### PR TITLE
Untitled

### DIFF
--- a/xwiki-platform-colibri/src/main/resources/colibri/edit.vm
+++ b/xwiki-platform-colibri/src/main/resources/colibri/edit.vm
@@ -49,7 +49,7 @@
   #template("xwikivars.vm")
   #template("layoutvars.vm")
   #template("htmlheader.vm")
-  #template("menuedit.vm")
+  #template("menuview.vm")
   #template("header.vm")
   #if($editor == 'wiki' || $editor == 'wysiwyg')
     <form id="edit" method="post" action="$doc.getURL('preview')" >


### PR DESCRIPTION
XWIKI-6407: Can't navigate to a space WebHome, when editing a page that doesn't have the parent set

Hi guys, can you take a look at this?

(testing pull requests on existing commis)
