### PR TITLE
XWIKI-6580: Without JS after adding an object you are redirected to wiki editor

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/editobject.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/editobject.vm
@@ -268,6 +268,7 @@
       ## CSRF prevention
       <input type="hidden" name="form_token" value="$!{services.csrf.getToken()}" />
       <input type="hidden" name="xcontinue" value="$doc.getURL($xcontext.action, $q)"/>
+      <input type="hidden" name="xredirect" value="$doc.getURL($xcontext.action, $q)"/>
       ## A submit button that captures "enter" on the form, placed before the "objectadd" submit button,
       ## to prevent from accidentally adding objects when pressing enter.
       #editActionButton('preview', 'preview')


### PR DESCRIPTION
XWIKI-6580: Without JS after adding an object you are redirected to wiki editor
Fixed.

Showing how Pull Request works...
