### PR TITLE
XWIKI-5887: The REST API allows to list wikis and spaces even when the wiki is protected

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/resources/spaces/SpacesResource.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/resources/spaces/SpacesResource.java
@@ -36,6 +36,7 @@ import org.xwiki.rest.model.jaxb.Spaces;
 
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.api.Document;
+import com.xpn.xwiki.api.XWiki;
 
 /**
  * @version $Id$
@@ -64,12 +65,16 @@ public class SpacesResource extends XWikiResource
                 String homeId = Utils.getPageId(wikiName, spaceName, "WebHome");
                 Document home = null;
 
-                if (Utils.getXWikiApi(componentManager).exists(homeId)) {
-                    home = Utils.getXWikiApi(componentManager).getDocument(homeId);
+                XWiki xwikiApi = Utils.getXWikiApi(componentManager);
+                if (xwikiApi.hasAccessLevel("view", homeId)) {
+                    if (xwikiApi.exists(homeId)) {
+                        home = Utils.getXWikiApi(componentManager).getDocument(homeId);
+                    }
+                    spaces.getSpaces()
+                        .add(
+                            DomainObjectFactory.createSpace(objectFactory, uriInfo.getBaseUri(), wikiName, spaceName,
+                                home));
                 }
-
-                spaces.getSpaces().add(
-                    DomainObjectFactory.createSpace(objectFactory, uriInfo.getBaseUri(), wikiName, spaceName, home));
             }
         } finally {
             Utils.getXWikiContext(componentManager).setDatabase(database);


### PR DESCRIPTION
XWIKI-5887: The REST API allows to list wikis and spaces even when the wiki is protected

Check that the user has "view" rights on the space WebHome before adding the space in the result.
