### PR TITLE
XWIKI-6755: XWiki.AdminRightsSheet imports rightsUI.vm template instead of actually containing it's code

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/src/main/resources/XWiki/AdminRightsSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/src/main/resources/XWiki/AdminRightsSheet.xml
@@ -22,9 +22,226 @@
 <minorEdit>false</minorEdit>
 <syntaxId>xwiki/2.0</syntaxId>
 <hidden>false</hidden>
-<content>{{velocity}}
+<content>{{velocity output='false'}}
 ### Administrate the rights in a wiki (globally or per space).
+#set ($formname = 'update')
+#set ($saveaction = 'save')
+########################
+## display the interface
+########################
+## inject the needed JS &amp; CSS files
+$xwiki.jsfx.use('js/xwiki/usersandgroups/usersandgroups.js', true)
+$xwiki.ssfx.use('js/xwiki/usersandgroups/usersandgroups.css', true)
+$xwiki.jsfx.use('js/xwiki/table/livetable.js', true)
+$xwiki.ssfx.use('js/xwiki/table/livetable.css', true)
+#set ($rightsLevels = {'view': 0, 'comment': 1, 'edit': 2, 'delete': 3, 'admin': 4, 'register': 5, 'programming': 6})
+#set ($levelsRights = $util.hashMap)
+#foreach ($r in $rightsLevels.keySet())
+  #set ($discard = $levelsRights.put($rightsLevels.get($r), $r))
+#end
+#set ($maxlevel = $rightsLevels.get('delete')) ## Default: view, comment, edit, delete
+#if($doc.fullName == 'XWiki.XWikiPreferences')
+  #if (("$!{request.editor}" == 'globaladmin') || "$!{editor}" == 'globaladmin')
+    #set ($clsname = 'XWiki.XWikiGlobalRights')
+    #if ($xcontext.database == 'xwiki')
+      #set ($maxlevel = $rightsLevels.get('programming')) ## base + admin, register, programming
+    #else
+      #set ($maxlevel = $rightsLevels.get('register')) ## base + admin, register
+    #end
+  #else
+    #set($clsname = 'XWiki.XWikiRights')
+  #end
+#elseif ($doc.name == 'WebPreferences')
+  #if ("$!{request.editor}" == 'spaceadmin' || "$!{editor}" == 'spaceadmin')
+    #set ($clsname = 'XWiki.XWikiGlobalRights')
+    #set ($maxlevel = $rightsLevels.get('admin')) ## base + admin
+  #else
+    #set ($clsname = 'XWiki.XWikiRights')
+  #end
+#else
+  #set ($clsname = 'XWiki.XWikiRights')
+#end
+
+## url to take the users and groups to display in the ajax-based table
+#set ($url = $doc.getURL('get', 'xpage=getusersandgroups'))
+#set ($saveUrl = $doc.getURL('edit', "form_token=$!{services.csrf.getToken()}&amp;xpage=saverights&amp;clsname=${clsname}&amp;fullname=XWiki.XWikiGuest&amp;uorg=users"))
+
+## get the rights for XWikiGuest
+#set($r = $util.arrayList)
+#foreach ($i in [0..$maxlevel])
+  #set ($discard = $r.add(0))
+#end
+#set ($guest = 'XWiki.XWikiGuest')
+#foreach ($obj in $doc.getObjects($clsname)) ## XWiki.XWikiGlobalRights or XWiki.XWikiRights
+  #set ($pers = "$!obj.getProperty('users').getValue()")
+  #if ($pers.matches("^(.*,)?${regextool.quote($guest)}(,.*)?$"))
+    #if ($obj.getProperty('allow').getValue() == 1)
+      #set ($rightValue = 1)
+    #else
+      #set ($rightValue = 2)
+    #end
+    #set ($specifiedRights = $!obj.getProperty('levels').getValue().split(','))
+    #foreach ($right in $specifiedRights)
+      #if ($maxlevel &gt;= $rightsLevels.get($right))
+        #set ($discard = $r.set($rightsLevels.get($right), $rightValue))
+      #end
+    #end
+  #end
+#end
+{{/velocity}}
+
+{{velocity}}
 {{html}}
-#template('rightsUI.vm')
+&lt;div id="xwikieditcontent"&gt;
+  #if ("$!editor" == 'rights')
+    ## Display a title if we're editing access rights for a particular page
+    &lt;div id="document-title"&gt;&lt;h1&gt;$msg.get('core.editors.rights.title', [$escapetool.xml($doc.displayTitle), $doc.getURL()])&lt;/h1&gt;&lt;/div&gt;
+  #end
+  &lt;table id="usersandgroupstable" class="xwiki-livetable#if("$!editor" != '') $editor#end"&gt;
+    &lt;tr&gt;
+      &lt;td class="xwiki-livetable-pagination" colspan="2"&gt;
+        &lt;span id="usersandgroupstable-limits" class="xwiki-livetable-limits"&gt;&lt;/span&gt;
+        &lt;span id="usersandgroupstable-ajax-loader" class="xwiki-livetable-loader"&gt;&lt;img src="$xwiki.getSkinFile('icons/xwiki/ajax-loader-large.gif')" alt="$msg.get('xe.livetable.loading')" title="" /&gt;$msg.get('xe.livetable.loading')&lt;/span&gt;
+        &lt;span class="pagination"&gt;
+          &lt;span id="usersandgroupstable-pagination-text" class="xwiki-livetable-pagination-text"&gt;$msg.get('xe.pagination.page')&lt;/span&gt;
+          &lt;span id="usersandgroupstable-pagination" class="xwiki-livetable-pagination-content" &gt;&lt;/span&gt;
+        &lt;/span&gt;
+      &lt;/td&gt;
+    &lt;/tr&gt;
+    &lt;tr&gt;
+      &lt;td class="xwiki-livetable-display-container"&gt;
+        &lt;table class="xwiki-livetable-display"&gt;
+          &lt;thead class="xwiki-livetable-display-header"&gt;
+            &lt;tr class="userorgroups-header"&gt;
+              ## Groups/Users switch
+              &lt;th scope="col" class="usersorgroupsnames"&gt;
+                &lt;label for="uorgg" class="hidden"&gt;$msg.get('rightsmanager.groups')&lt;/label&gt;
+                &lt;input type="radio" id="uorgg" name="uorg" value="groups" onclick="if(!$('unregistered').hasClassName('hidden')) $('unregistered').addClassName('hidden');" checked="checked" /&gt;$msg.get('rightsmanager.groups')&amp;nbsp;&amp;nbsp;
+                &lt;label for="uorgu" class="hidden"&gt;$msg.get('rightsmanager.users')&lt;/label&gt;
+                &lt;input type="radio" id="uorgu" name="uorg" value="users" onclick="if($('unregistered').hasClassName('hidden')) $('unregistered').removeClassName('hidden');" /&gt;$msg.get('rightsmanager.users')
+              &lt;/th&gt;
+              ## Column headers for each configurable access right
+              #foreach ($i in [0..$maxlevel])
+                &lt;th scope="col" class="rights"&gt;$msg.get("rightsmanager.${levelsRights.get($i)}")&lt;/th&gt;
+              #end
+            &lt;/tr&gt;
+            &lt;tr id="unregistered"&gt;
+              ## Rights for guests, statically displayed outside the livetable
+              &lt;td id="unreguser"&gt;$msg.get('rightsmanager.unregisteredusers')&lt;/td&gt;
+              #foreach ($i in [0..$maxlevel])
+                &lt;td class="rights" id="td${levelsRights.get($i)}"&gt;&lt;/td&gt;
+              #end
+            &lt;/tr&gt;
+            &lt;tr id="usersandgroupstable-filters"&gt;
+              ## Users/groups filter
+              &lt;td&gt;&lt;label for="name"&gt;$msg.get('rightsmanager.searchfilter')&lt;/label&gt;&lt;input id="name" name="name" type="text"/&gt;
+                #if(!$xcontext.isMainWiki()) #set($mainwk = false) #else #set($mainwk = true) #end
+                #if(!$mainwk) ## display the combobox only in a local wiki
+                  &lt;label for="wiki"&gt;$msg.get('rightsmanager.searchscope')&lt;/label&gt;
+                  &lt;select name="wiki" style="margin-left:10px;"&gt;
+                    &lt;option value="local" selected="selected"&gt;$msg.get('rightsmanager.local')&lt;/option&gt;
+                    &lt;option value="global"&gt;$msg.get('rightsmanager.global')&lt;/option&gt;
+                    &lt;option value="both"&gt;$msg.get('rightsmanager.both')&lt;/option&gt;
+                  &lt;/select&gt;
+                #else
+                  &lt;input type="hidden" name="wiki" value="local"/&gt;
+                #end
+                #set ($colsp = $maxlevel + 1)
+              &lt;/td&gt;
+              &lt;td colspan="$colsp"&gt;&lt;input type="hidden" name="clsname" value="$clsname" /&gt;&lt;/td&gt;
+            &lt;/tr&gt;
+          &lt;/thead&gt;
+          ## Livetable placeholder, will be filled in from Javascript
+          &lt;tbody id="usersandgroupstable-display" class="xwiki-livetable-display-body"&gt;&lt;tr&gt;&lt;td&gt;&amp;nbsp;&lt;/td&gt;&lt;/tr&gt;&lt;/tbody&gt;
+        &lt;/table&gt;
+      &lt;/td&gt;
+    &lt;/tr&gt;
+    ## Global settings: mandatory authentication for view/edit, captcha
+    #set ($guest_comment_captcha_prop = $doc.getObject('XWiki.XWikiPreferences').getxWikiClass().get('guest_comment_requires_captcha'))
+    #if ("$!request.editor" == 'globaladmin' || "$!editor" == 'globaladmin' || $guest_comment_captcha_prop)
+      &lt;tr&gt;
+        &lt;td&gt;
+          &lt;table&gt;
+          #if ("$!request.editor" == 'globaladmin' || "$!editor" == 'globaladmin')
+            #set ($auth_view = $doc.getObject('XWiki.XWikiPreferences').getProperty('authenticate_view').getValue())
+            #if ("$!auth_view" == '1')
+              #set ($view_icon = $xwiki.getSkinFile('js/xwiki/usersandgroups/img/allow-black.png'))
+              #set ($view_alt = 'yes')
+            #else
+              #set ($view_icon = $xwiki.getSkinFile('js/xwiki/usersandgroups/img/none.png'))
+              #set ($view_alt = 'no')
+            #end
+            &lt;tr&gt;&lt;td&gt;$msg.get('authenticate_view')&lt;/td&gt;&lt;td&gt;&lt;img id="authenticate_view" alt="$view_alt" src="${view_icon}" /&gt;&lt;/td&gt;&lt;/tr&gt;
+            #set ($auth_edit = $doc.getObject('XWiki.XWikiPreferences').getProperty('authenticate_edit').getValue())
+            #if ("$!auth_edit" == '1')
+              #set ($edit_icon = $xwiki.getSkinFile('js/xwiki/usersandgroups/img/allow-black.png'))
+              #set ($edit_alt = 'yes')
+            #else
+              #set ($edit_icon = $xwiki.getSkinFile('js/xwiki/usersandgroups/img/none.png'))
+              #set ($edit_alt = 'no')
+            #end
+            &lt;tr&gt;&lt;td&gt;$msg.get('authenticate_edit')&lt;/td&gt;&lt;td&gt;&lt;img id="authenticate_edit" alt="$edit_alt" src="${edit_icon}" /&gt;&lt;/td&gt;&lt;/tr&gt;
+          #end
+          #if ($guest_comment_captcha_prop)
+            ## If we are in globaladmin, we don't want to get the setting from XWiki.WebPreferences...
+            #if ("$!request.editor" == 'globaladmin' || "$!editor" == 'globaladmin')
+              #set ($guest_comment_requires_captcha = $xwiki.getXWikiPreferenceAsInt('guest_comment_requires_captcha', 0))
+            #else
+              #set ($guest_comment_requires_captcha = $xwiki.getSpacePreferenceAsInt('guest_comment_requires_captcha', 0))
+            #end
+            #if($guest_comment_requires_captcha == 1)
+              #set ($guest_comment_requires_captcha_icon = $xwiki.getSkinFile('js/xwiki/usersandgroups/img/allow-black.png'))
+              #set ($guest_comment_requires_captcha_alt = 'yes')
+            #else
+              #set ($guest_comment_requires_captcha_icon = $xwiki.getSkinFile('js/xwiki/usersandgroups/img/none.png'))
+              #set ($guest_comment_requires_captcha_alt = 'no')
+            #end
+            &lt;tr&gt;&lt;td&gt;$msg.get('rightsmanager.guestcommentrequirescaptcha')&lt;/td&gt;&lt;td&gt;&lt;img id="guest_comment_requires_captcha" alt="$guest_comment_requires_captcha_alt" src="$guest_comment_requires_captcha_icon" /&gt;&lt;/td&gt;&lt;/tr&gt;
+          #end
+          &lt;/table&gt;
+        &lt;/td&gt;
+      &lt;/tr&gt;
+    #end
+    &lt;/table&gt;
+
+    &lt;script type="text/javascript"&gt;
+    //&lt;![CDATA[
+(function() {
+  var startup = function() {
+    window.activeRights = [#foreach($i in [0..$maxlevel])"$levelsRights.get($i)",#end];
+    window.saveUrl = "$saveUrl";
+    saveUrl.replace(/&amp;amp;/g, "&amp;");
+    window.currentUser = "$!{escapetool.javascript($xcontext.user)}";
+    window.unregUser = "XWiki.XWikiGuest";
+    // the callback function is called from LiveTable with 3 arguments
+    var callback = function(row, i, table, idx) { return displayUsersAndGroups(row, i, table, idx, "$!{services.csrf.getToken()}") };
+    var ta = new XWiki.widgets.LiveTable("$url", "usersandgroupstable", callback, {"filtersNode": $('usersandgroupstable')});
+    #foreach($i in [0..$maxlevel])
+      var chbx${i} = new MSCheckbox($("td${levelsRights.get($i)}"), "${levelsRights.get($i)}", saveUrl, "${r.get($i)}");
+    #end
+    Event.observe(window, 'load', function() {
+      if($('uorgg').checked &amp;&amp; !$('unregistered').hasClassName('hidden')) {
+        $('unregistered').addClassName('hidden');
+      } else if($('uorgu').checked &amp;&amp; $('unregistered').hasClassName('hidden')) {
+        $('unregistered').removeClassName('hidden');
+      }
+    });
+    #if("$!editor" == 'globaladmin')
+      Event.observe($('authenticate_view'), 'click', setBooleanPropertyFromLiveCheckbox($('authenticate_view'), '$xwiki.getURL('XWiki.XWikiPreferences', 'save', "form_token=$!{services.csrf.getToken()}")', 'XWiki.XWikiPreferences', 0));
+      Event.observe($('authenticate_edit'), 'click', setBooleanPropertyFromLiveCheckbox($('authenticate_edit'), '$xwiki.getURL('XWiki.XWikiPreferences', 'save', "form_token=$!{services.csrf.getToken()}")', 'XWiki.XWikiPreferences', 0));
+    #end
+    #if($guest_comment_captcha_prop)
+      Event.observe($('guest_comment_requires_captcha'), 'click', setBooleanPropertyFromLiveCheckbox($('guest_comment_requires_captcha'), '$doc.getURL('save', "form_token=$!{services.csrf.getToken()}")', 'XWiki.XWikiPreferences', 0));
+    #end
+  }
+  if ((typeof(XWiki) != 'undefined') &amp;&amp; (typeof(XWiki.widgets) != 'undefined') &amp;&amp; (typeof(XWiki.widgets.LiveTable) != 'undefined')) {
+    startup();
+  } else {
+    document.observe('xwiki:dom:loading', startup);
+  }
+})();
+    //]]&gt;
+    &lt;/script&gt;
+&lt;/div&gt; ## xwikieditcontent
 {{/html}}
 {{/velocity}}</content></xwikidoc>


### PR DESCRIPTION
XWIKI-6755: XWiki.AdminRightsSheet imports rightsUI.vm template instead of actually containing it's code
- Pasted rightsUI.vm and minimised the use of the {{html}} macro by using it only in the section that produces html. First velocity section has been set to output='false'.
