### PR TITLE
XWIKI-6767: Livetable ajaxAction always using the url of the last ajax action from the list of actions.

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/macros.vm
@@ -1575,12 +1575,12 @@ function (row, i, table) {
             #if("$!colprop.ajaxActions.get($action)" == 'true')
               link.observe('click', function(event) {
                 event.stop();
-                new Ajax.Request(link.href, {
+                new Ajax.Request(this.href, {
                   onSuccess : function() {
                     $colprop.actionCallbacks.get($action)
                   }
                 });
-              });
+              }.bindAsEventListener(link));
             #end
             td.insert(link);
           }


### PR DESCRIPTION
XWIKI-6767: Livetable ajaxAction always using the url of the last ajax action from the list of actions.
- Using row.doc_${action}_url instead of link.href

Note: Sorry for the extra 4 commits. I can't seem to get rid of them. However, note that only one file is changed by this pull request, so the result should be ok. If you manage to exclude them it would be best.
