### PR TITLE
XWIKI-6797: Adding a new section (as space.page) under a category in the Administration (XWiki.AdminSheet) without specifying an icon does not use the default icon.

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/src/main/resources/XWiki/AdminSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/src/main/resources/XWiki/AdminSheet.xml
@@ -3231,6 +3231,8 @@ document.observe('xwiki:dom:loaded', function() {
         #set ($section.name = $sectionDoc.getDisplayTitle())
         #if ($sectionDoc.getAttachment('icon.png'))
           #set ($section.iconReference = "${sectionDoc}@icon.png")
+        #else
+          #set ($section.iconReference = 'XWiki.ConfigurableClass@DefaultAdminSectionIcon.png')
         #end
       #else
         #set ($sectionDoc = $xwiki.getDocument('XWiki.AdminSheet'))


### PR DESCRIPTION
XWIKI-6797: Adding a new section (as space.page) under a category in the Administration (XWiki.AdminSheet) without specifying an icon does not use the default icon.
- Added missing else clause.
