### PR TITLE
XWIKI-6804 Alternative to sendMessageFromTemplate that receives a map of parameters instead of a VelocityContext

### DIFF
--- a/xwiki-platform-core/xwiki-platform-mailsender/src/main/java/com/xpn/xwiki/plugin/mailsender/MailSender.java
+++ b/xwiki-platform-core/xwiki-platform-mailsender/src/main/java/com/xpn/xwiki/plugin/mailsender/MailSender.java
@@ -152,8 +152,8 @@ public interface MailSender
         String documentFullName, VelocityContext vcontext);
 
     /**
-     * Uses an XWiki document to build the message subject and context, based on variables stored in the
-     * VelocityContext. Sends the email.
+     * Uses an XWiki document to build the message subject and context, based on variables stored in a map.
+     * Sends the email.
      *
      * @param from Email sender
      * @param to Email recipient
@@ -167,5 +167,5 @@ public interface MailSender
      *         "error" key.
      */
     int sendMessageFromTemplate(String from, String to, String cc, String bcc, String language,
-        String documentFullName, Map parameters);
+        String documentFullName, Map<String, Object> parameters);
 }

--- a/xwiki-platform-core/xwiki-platform-mailsender/src/main/java/com/xpn/xwiki/plugin/mailsender/MailSenderPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-mailsender/src/main/java/com/xpn/xwiki/plugin/mailsender/MailSenderPlugin.java
@@ -637,7 +637,7 @@ public class MailSenderPlugin extends XWikiDefaultPlugin
     }
 
     /**
-     * Prepares a Mail Velocity context
+     * Prepares a Mail Velocity context based on a map of parameters
      *
      * @param fromAddr Mail from
      * @param toAddr Mail to
@@ -866,8 +866,8 @@ public class MailSenderPlugin extends XWikiDefaultPlugin
     }
 
     /**
-     * Uses an XWiki document to build the message subject and context, based on variables stored in the
-     * VelocityContext. Sends the email.
+     * Uses an XWiki document to build the message subject and context, based on variables stored in a map.
+     * Sends the email.
      *
      * @param templateDocFullName Full name of the template to be used (example: XWiki.MyEmailTemplate). The template
      *            needs to have an XWiki.Email object attached

--- a/xwiki-platform-core/xwiki-platform-mailsender/src/main/java/com/xpn/xwiki/plugin/mailsender/MailSenderPluginApi.java
+++ b/xwiki-platform-core/xwiki-platform-mailsender/src/main/java/com/xpn/xwiki/plugin/mailsender/MailSenderPluginApi.java
@@ -153,7 +153,7 @@ public class MailSenderPluginApi extends PluginApi<MailSenderPlugin> implements 
      * @see MailSender#sendMessageFromTemplate(String, String, String, String, String, String, java.util.Map)
      */
     public int sendMessageFromTemplate(String from, String to, String cc, String bcc, String language,
-        String documentFullName, Map parameters)
+        String documentFullName, Map<String, Object> parameters)
     {
         this.parameters = parameters;
         try {


### PR DESCRIPTION
XWIKI-6804 Alternative to sendMessageFromTemplate that receives a map of parameters instead of a VelocityContext

Added 
public int sendMessageFromTemplate(String from, String to, String cc, String bcc, String language,
        String documentFullName, Map parameters)
