### PR TITLE
XWIKI-6893: When passing a description String instead of property name, the Feed plugin renders it in syntax 1.0 instead of using the document's syntax

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/feed/SyndEntryDocumentSource.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/feed/SyndEntryDocumentSource.java
@@ -506,7 +506,7 @@ public class SyndEntryDocumentSource implements SyndEntrySource
     protected String parseString(String mapping, Document doc, XWikiContext context) throws XWikiException
     {
         if (isVelocityCode(mapping)) {
-            return doc.getRenderedContent(mapping.substring(1, mapping.length() - 1));
+            return doc.getRenderedContent(mapping.substring(1, mapping.length() - 1), doc.getSyntax().toIdString());
         } else {
             return mapping;
         }


### PR DESCRIPTION
XWIKI-6893: When passing a description String instead of property name, the Feed plugin renders it in syntax 1.0 instead of using the document's syntax
- Added document's syntax id for the internal rendering process
