### PR TITLE
XWIKI-6902: When creating a new wiki, use the XWikiDocument class to save the wiki descriptor and not the api.Document class

### DIFF
--- a/xwiki-platform-core/xwiki-platform-wiki-manager/xwiki-platform-wiki-manager-api/src/main/java/com/xpn/xwiki/plugin/wikimanager/WikiManager.java
+++ b/xwiki-platform-core/xwiki-platform-wiki-manager/xwiki-platform-wiki-manager-api/src/main/java/com/xpn/xwiki/plugin/wikimanager/WikiManager.java
@@ -455,10 +455,6 @@ public final class WikiManager
                 createWikiDatabase(newWikiName, context, templateWikiName == null);
 
                 // Save new wiki descriptor document.
-                // XXX: Because we are inside the platform and we have already done rights checking in the script service, we
-                // should use the un-checked XWikiDocument instance to avoid checking for the user's or the document's
-                // rights twice. Also, doing this, we allow the workspaceManager plugin to let normal users create a
-                // workspace (wiki). See XWIKI-6902
                 XWikiDocument wikiSuperXDocToSave = wikiSuperDocToSave.getDocument();
                 context.getWiki().saveDocument(wikiSuperXDocToSave, comment, context);
 


### PR DESCRIPTION
XWIKI-6902: When creating a new wiki, use the XWikiDocument class to save the wiki descriptor and not the api.Document class
- Used the core API to save the document.
