### PR TITLE
XWIKI-7145 : Livetable does not support column names with special characters and/or Unicode characters

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/macros.vm
@@ -1499,7 +1499,7 @@ ${Msz}Mb##
 function (row, i, table) {
   // This callback method code has been generated from velocity.
   var tr = new Element("tr");
-  if (row.doc_viewable) {
+  if (row["doc_viewable"]) {
   #foreach($colname in $collist)
     // $colname
     #set($colprop = $colprops.get($colname))
@@ -1516,10 +1516,10 @@ function (row, i, table) {
         var link = #if("$!colprop.link" != "editor") new Element("a"); #else new Element("span"); #end
         ## Automatic: the link url is in JSON results, with key column name + "_url"
         #if("$!colprop.link"=="auto")
-          link.href = (row.${jscolname}_url=="") ? row.doc_url : row.${jscolname}_url;
+          link.href = (row["${jscolname}_url"]=="") ? row["doc_url"] : row["${jscolname}_url"];
         #elseif($colprop.link=="field")
-          if (row.${jscolname}_url != "") {
-            link.href = row.${jscolname}_url;
+          if (row["${jscolname}_url"] != "") {
+            link.href = row["${jscolname}_url"];
           }
         ## Property editor
         #elseif($colprop.link=="editor")
@@ -1532,24 +1532,24 @@ function (row, i, table) {
             var tag = event.element().down("span");
             if (!tag)
              tag = event.element();
-            editProperty(row.doc_fullname, "${propClassName}", "${colname}", function(value) { tag.innerHTML = value});
+            editProperty(row["doc_fullname"], "${propClassName}", "${colname}", function(value) { tag.innerHTML = value});
           });
         ## Author
         #elseif($colprop.link == "author")
-          link.href = row.doc_author_url;
+          link.href = row["doc_author_url"];
         ## Space URL
         #elseif($colprop.link == "space")
-          link.href = row.doc_space_url;
+          link.href = row["doc_space_url"];
         ## Wiki URL
         #elseif($colprop.link == "wiki")
-          link.href = row.doc_wiki_url;
+          link.href = row["doc_wiki_url"];
         #else
-          link.href = row.doc_url;
+          link.href = row["doc_url"];
         #end
         #if($colprop.html && $colprop.html==true)
-          link.innerHTML = row.${jscolname};
+          link.innerHTML = row["${jscolname}"];
         #else
-          link.update(row.${jscolname});
+          link.update(row["${jscolname}"]);
         #end
         td.appendChild(link);
         tr.appendChild(td);
@@ -1557,7 +1557,7 @@ function (row, i, table) {
         var adminActions = ['admin', 'rename', 'rights'];
         var td = new Element("td", {'class' : 'actions'});
         #foreach($action in $colprop.get("actions"))
-          if (row.doc_has${action} || '${action}' == 'view' || (row.doc_has${action} === undefined && (row.doc_hasadmin || adminActions.indexOf('${action}') < 0))) {
+          if (row["doc_has${action}"] || '${action}' == 'view' || (row["doc_has${action}"] === undefined && (row["doc_hasadmin"] || adminActions.indexOf('${action}') < 0))) {
             #if($velocityCount > 1)
               td.insert(" ");
             #end
@@ -1568,7 +1568,7 @@ function (row, i, table) {
             #else
               #set($text = "$action")
             #end
-            var link = new Element("a", {"href": row.doc_${action}_url, "class":"action action${action}"}).update("$text");
+            var link = new Element("a", {"href": row["doc_${action}_url"], "class":"action action${action}"}).update("$text");
             #if("$!colprop.ajaxActions.get($action)" == 'true')
               link.observe('click', function(event) {
                 event.stop();
@@ -1587,9 +1587,9 @@ function (row, i, table) {
         #set($tdClass = "${jscolname} link$!{colprop.link} type$!{colprop.type}")
         var fieldel = new Element("td", {'class':"$tdClass"});
         #if($colprop.html && $colprop.html==true)
-          fieldel.innerHTML = row.${jscolname};
+          fieldel.innerHTML = row["${jscolname}"];
         #else
-          fieldel.update(row.${jscolname});
+          fieldel.update(row["${jscolname}"]);
         #end
         tr.appendChild(fieldel);
       #end
@@ -1597,7 +1597,7 @@ function (row, i, table) {
   #end
   }
   else {
-    var page = row.doc_fullname;
+    var page = row["doc_fullname"];
     var dp = page.indexOf(':');
     var p = page.indexOf('.');
     var space = (dp > 0) ? page.substring(dp + 1, p) : page.substring(0, p);


### PR DESCRIPTION
If we specify in the #livetable macro some column names which contain special characters (such as '.' for example) or Unicode characters, the livetable will not load the rows (although the JSON is loaded) because of a JS error. The inline JS script generated in macros.vm (#livetablecallback macro) creates for each table row some objects named 'row', which contain the respective JSON data. That data is accessed via the "dot" notation (row.<propname>) and this causes the JS to crash if the property name is not a valid JS object property name. We should instead use the "array" notation (row["<propname>"]) to make sure we don't have such conflicts, as no one can guarantee that the received JSON has "safe" column names.
