### PR TITLE
XWIKI-7172: Livetable doesn't show docs which don't have view rights for current user

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/macros.vm
@@ -1603,6 +1603,8 @@ function (row, i, table) {
     var space = (dp > 0) ? page.substring(dp + 1, p) : page.substring(0, p);
     var name = page.substring(p + 1);
     #foreach($colname in $collist)
+	  //$colname
+	  #set($colprop = $colprops.get($colname))
       #if("$!colprop.type"!="hidden")
         #if($colname.indexOf("doc.")==0)
          #set($jscolname = $colname.replaceAll("doc.", "doc_"))


### PR DESCRIPTION
In some isolated cases, when the last column of the livetable is set as hidden, the documents that would normally have to be returned from the livetable query are not displayed if they have doc_viewable = false in the JSON. They should appear without links, object property values or actions, but in this case they don't.

The bug is within #livetablecallback from macros.vm (around line 1600)
else {
    var page = row["doc_fullname"];
    var dp = page.indexOf(':');
    var p = page.indexOf('.');
    var space = (dp > 0) ? page.substring(dp + 1, p) : page.substring(0, p);
    var name = page.substring(p + 1);
    #foreach($colname in $collist)
      #if("$!colprop.type"!="hidden")
        ...
      #end
    #end
    $('${divid}-inaccessible-docs').removeClassName('hidden');
  }
  return tr;

The foreach loop here contains 
# if("$!colprop.type"!="hidden")

, but $colprop isn't initialized anywhere. It should be reinitialized at every iteration of the respective loop. Otherwise, it will have the value from other code that is executed before. Hence in my particular case it always had $colprop.type = "hidden", so that branch of code was never executed.
