### PR TITLE
XWIKI-7189

### DIFF
--- a/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-api/src/main/java/com/xpn/xwiki/plugin/scheduler/SchedulerPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-api/src/main/java/com/xpn/xwiki/plugin/scheduler/SchedulerPlugin.java
@@ -231,6 +231,7 @@ public class SchedulerPlugin extends XWikiDefaultPlugin
         XWikiServletRequestStub dummy = new XWikiServletRequestStub();
         dummy.setHost(context.getRequest().getHeader("x-forwarded-host"));
         dummy.setScheme(context.getRequest().getScheme());
+        dummy.setContextPath(context.getRequest().getContextPath());
         XWikiServletRequest request = new XWikiServletRequest(dummy);
         scontext.setRequest(request);
 

--- a/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-api/src/main/java/com/xpn/xwiki/plugin/scheduler/XWikiServletRequestStub.java
+++ b/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-api/src/main/java/com/xpn/xwiki/plugin/scheduler/XWikiServletRequestStub.java
@@ -52,13 +52,21 @@ public class XWikiServletRequestStub implements XWikiRequest
     /** The scheme used by the runtime instance. This is required for creating URLs from scheduled jobs. */
     private String scheme;
 
+    private String host;
+
+    /** The context path used by the runtime instance. This can be useful if a URL factory is created from within a scheduler job. */
+    private String contextPath;
+    
     public XWikiServletRequestStub()
     {
         this.host = "";
     }
 
-    private String host;
-
+    public void setContextPath(String contextPath)
+    {
+        this.contextPath = contextPath;
+    }
+    
     public void setHost(String host)
     {
         this.host = host;
@@ -189,7 +197,7 @@ public class XWikiServletRequestStub implements XWikiRequest
 
     public String getContextPath()
     {
-        return null;
+        return this.contextPath;
     }
 
     public String getQueryString()


### PR DESCRIPTION
URLs created by mailsender plugin called from a scheduler script can have a wrong context path
