### PR TITLE
XWIKI-7679: Separate Message Stream input from Activity Stream

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -1888,9 +1888,9 @@ xe.activity.action.publicMessage=posted the message
 xe.activity.messages.visibility=Visible to
 xe.activity.messages.visibility.targetName.tip=Name
 xe.activity.messages.submit=Share
-xe.activity.messages.submit.inProgress=Updating...
-xe.activity.messages.submit.failed=Failed to update: 
-xe.activity.messages.submit.success=Sent
+xe.activity.messages.submit.inProgress=Sending...
+xe.activity.messages.submit.failed=Failed to send message
+xe.activity.messages.submit.success=Message sent
 xe.activity.messages.follow=Follow
 xe.activity.messages.following=Following
 xe.activity.messages.unfollow=Unfollow
@@ -1900,6 +1900,7 @@ xe.activity.messages.unfollow.confirm=Are you sure you wish to stop following {0
 xe.activity.messages.delete=Delete this message
 xe.activity.messages.delete.confirm=Are you sure you wish to delete this message?
 xe.activity.messages.delete.failed=Failed to delete the message
+xe.activity.messages.delete.success=Message deleted
 
 ###timeAgo used by Recent Activity macro (XE 2.6RC1) and Activity macro
 timeAgo.minutesAgo={0,choice,0#few seconds|1#one minute|1<{0} minutes} ago


### PR DESCRIPTION
- Changed translations since they no longer reflect the current logic.

Note: Needed by https://github.com/xwiki/xwiki-enterprise/pull/22
