### PR TITLE
Add support for sorting a page's attachments via request parameter

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/attachmentsinline.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/attachmentsinline.vm
@@ -11,20 +11,20 @@ $xwiki.ssfx.use('js/xwiki/viewers/attachments.css', true)
 #end
 #set($showactions = 0)
 ### Determine attachment sorting
-#set($sortAttachBy = "$!{request.sortAttachBy}")
-#if($sortAttachBy == '')
+#set($sortAttachmentsBy = "$!{request.sortAttachmentsBy}")
+#if($sortAttachmentsBy == '')
   ### Default to sorting by filename, sort not requested.
-  #set($sortAttachBy = "filename")
+  #set($sortAttachmentsBy = "filename")
 #end
 ### Set attachment sorting direction
-#if($sortAttachBy == 'date')
+#if($sortAttachmentsBy == 'date')
   ### Sort the date descending
-  #set($sortAttachBy = "date:desc")
+  #set($sortAttachmentsBy = "date:desc")
 #else
   ### Sort everthing else ascending
-  #set($sortAttachBy = "${sortAttachBy}:asc")
+  #set($sortAttachmentsBy = "${sortAttachmentsBy}:asc")
 #end
-#set($attachments = $sorttool.sort($doc.attachmentList, "$sortAttachBy}"))
+#set($attachments = $sorttool.sort($doc.attachmentList, "$sortAttachmentsBy"))
 <div id="attachmentscontent" class="xwikiintracontent">
 <div id="attw">
 <div id="_attachments">

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/docextra.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/docextra.vm
@@ -45,12 +45,12 @@
     $xwiki.jsfx.use('js/xwiki/viewers/attachments.js', {'forceSkinAction': true, 'language': ${xcontext.language}})
     $xwiki.ssfx.use('js/xwiki/viewers/attachments.css', true)
     ### Support attachment sorting
-    #set($sortAttachBy = "$!{request.sortAttachBy}")
-    #if($sortAttachBy != '')
+    #set($sortAttachmentsBy = "$!{request.sortAttachmentsBy}")
+    #if($sortAttachmentsBy != '')
      ### Prepend request parameter
-     #set($sortAttachBy = "&sortAttachBy=${sortAttachBy}")    
+     #set($sortAttachmentsBy = "&sortAttachmentsBy=${sortAttachmentsBy}")    
     #end
-    #set ($discard = $docextras.add(['Attachments', 'attachments', $msg.get('docextra.attachments'), $doc.getAttachmentList().size(), "attachmentsinline.vm$!{sortAttachBy}", $msg.get('core.shortcuts.view.attachments')]))
+    #set ($discard = $docextras.add(['Attachments', 'attachments', $msg.get('docextra.attachments'), $doc.getAttachmentList().size(), "attachmentsinline.vm$!{sortAttachmentsBy}", $msg.get('core.shortcuts.view.attachments')]))
   #end
   #if ($showhistory)
     ## Pagination style


### PR DESCRIPTION
I modified attachmentsinline.vm to accept the request parameter "sortAttachBy", and it defaults to sorting by the filename. If the sortAttachBy is set to "date" then it will sort the attachments by descending, otherwise it sorts it ascending.

I also modified the docextra.vm to pass through the sortAttachBy request parameter to the attachmentsinline.vm ajax call if that parameter is set.

A dropdown <form> input could be implemented easily on top of this request parameter support, that allows the user to choose how they want to sort the page's attachments.
