### PR TITLE
XWIKI-8365: Office importer errors when starting 4.3 M1 Manager

### DIFF
--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -125,6 +125,24 @@
         <artifactId>xalan</artifactId>
         <version>2.7.1</version>
       </dependency>
+      <!-- Used by xwiki-platform-oldcore and xwiki-platform-captcha -->
+      <dependency>
+        <groupId>struts</groupId>
+        <artifactId>struts</artifactId>
+        <version>1.2.9</version>
+        <exclusions>
+          <!-- There is conflict with hibernate antlr-2.7.6 dependency -->
+          <exclusion>
+            <groupId>antlr</groupId>
+            <artifactId>antlr</artifactId>
+          </exclusion>
+          <!-- We use a more recent version of Xalan (see above) -->
+          <exclusion>
+            <groupId>xalan</groupId>
+            <artifactId>xalan</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
       <!-- Standard dependencies used in GWT modules -->
       <dependency>
         <groupId>com.google.gwt</groupId>

--- a/xwiki-platform-core/xwiki-platform-captcha/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-captcha/pom.xml
@@ -79,7 +79,6 @@
     <dependency>
       <groupId>struts</groupId>
       <artifactId>struts</artifactId>
-      <version>1.2.9</version>
     </dependency>
   </dependencies>
   <build>

--- a/xwiki-platform-core/xwiki-platform-oldcore/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-oldcore/pom.xml
@@ -190,14 +190,6 @@
     <dependency>
       <groupId>struts</groupId>
       <artifactId>struts</artifactId>
-      <version>1.2.9</version>
-      <exclusions>
-        <!-- There is conflict with hibernate antlr-2.7.6 dependency -->
-        <exclusion>
-          <groupId>antlr</groupId>
-          <artifactId>antlr</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <!-- Rendering -->


### PR DESCRIPTION
- Exclude Xalan from Struts dependencies because we use a newer version
