### PR TITLE
XWIKI-106: Cache issues with IE and proxy caches 

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Document.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Document.java
@@ -708,7 +708,7 @@ public class Document extends Api
      */
     public String getAttachmentURL(String filename)
     {
-        return this.doc.getAttachmentURL(filename, "download", getXWikiContext());
+        return this.doc.getAttachmentURL(filename, getXWikiContext());
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/DefaultDocumentAccessBridge.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/DefaultDocumentAccessBridge.java
@@ -606,12 +606,25 @@ public class DefaultDocumentAccessBridge implements DocumentAccessBridge
         String url;
         if (isFullURL) {
             XWikiContext xcontext = getContext();
-            url =
-                xcontext.getURLFactory().getURL(
-                    xcontext.getURLFactory().createAttachmentURL(attachmentReference.getName(),
-                        attachmentReference.getDocumentReference().getLastSpaceReference().getName(),
-                        attachmentReference.getDocumentReference().getName(), "download", queryString,
-                        attachmentReference.getDocumentReference().getWikiReference().getName(), xcontext), xcontext);
+            try{
+                XWikiDocument attachmentDocument = xcontext.getWiki().getDocument(
+                        attachmentReference.getDocumentReference(), xcontext);
+                XWikiAttachment attachment = attachmentDocument.getAttachment(attachmentReference.getName());
+                String attachmentVersion = (attachment != null) ? attachment.getVersion() : "1.1";
+                url =
+                    xcontext.getURLFactory().getURL(
+                        xcontext.getURLFactory().createAttachmentRevisionURL(attachmentReference.getName(),
+                            attachmentReference.getDocumentReference().getLastSpaceReference().getName(),
+                            attachmentReference.getDocumentReference().getName(), attachmentVersion, queryString,
+                            attachmentReference.getDocumentReference().getWikiReference().getName(), xcontext), xcontext);
+            }catch(XWikiException e){
+                url =
+                    xcontext.getURLFactory().getURL(
+                        xcontext.getURLFactory().createAttachmentURL(attachmentReference.getName(),
+                            attachmentReference.getDocumentReference().getLastSpaceReference().getName(),
+                            attachmentReference.getDocumentReference().getName(), "download", queryString,
+                            attachmentReference.getDocumentReference().getWikiReference().getName(), xcontext), xcontext);
+            }
         } else {
             XWikiContext xcontext = getContext();
             String documentReference =

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -1530,7 +1530,9 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
 
     public String getAttachmentURL(String filename, XWikiContext context)
     {
-        return getAttachmentURL(filename, "download", context);
+        XWikiAttachment attachment = getAttachment(filename);
+        String attachmentVersion = ( attachment != null ) ? attachment.getVersion() : "1.1";        
+        return getAttachmentRevisionURL(filename, attachmentVersion, context);
     }
 
     public String getAttachmentURL(String filename, String action, XWikiContext context)

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/attachmentslist.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/attachmentslist.vm
@@ -20,7 +20,7 @@
     <div class="attachment #if($velocityCount % 2 == 0) even #else odd #end">
     <span class="mime">#mimetypeimg($attach.getMimeType().toLowerCase() $attach.getFilename().toLowerCase())</span>
     <div class="information">
-    <span class="name"><a href="$doc.getAttachmentURL(${attach.filename}, 'download')"
+    <span class="name"><a href="$doc.getAttachmentURL(${attach.filename})"
       title="$msg.get('core.viewers.attachments.download')">$escapetool.xml($attach.filename)</a></span>
     <span class="xwikibuttonlinks">
     #if($hasEdit || $hasAdmin)


### PR DESCRIPTION
JIRA: http://jira.xwiki.org/browse/XWIKI-106

This commit replace the standard "download" action to the "downloadrev" action when you generate an attachment URL to avoid cache issue. If the file has changed, then the revision is not the same, and it will be reflected into the URL.
