### PR TITLE
XWiki 5406

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiAuthServiceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiAuthServiceImpl.java
@@ -180,6 +180,18 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
                 if (xwiki.Param("xwiki.authentication.validationKey") != null) {
                     persistent.setValidationKey(xwiki.Param("xwiki.authentication.validationKey"));
                 }
+                
+                if (xwiki.Param("xwiki.authentication.encryptionFileName") != null) {
+                    persistent.setEncryptionFile(xwiki.Param("xwiki.authentication.encryptionFileName"));
+                }
+                
+                if (xwiki.Param("xwiki.authentication.keyStorePassword") != null) {
+                    persistent.setKeyStorePassword(xwiki.Param("xwiki.authentication.keyStorePassword"));
+                }
+                
+                if (xwiki.Param("xwiki.authentication.encryptionKeyProtection") != null) {
+                    persistent.setEncryptionKeyProtection(xwiki.Param("xwiki.authentication.encryptionKeyProtection"));
+                }
 
                 sconfig.setPersistentLoginManager(persistent);
 


### PR DESCRIPTION
Changed the implementation of cookies for more security :
- Use AES/CBC and SHA-512 instead of DES/ECB and MD5.
- Automatically generate a random encryption key and store it in a keyStore (cf. XWIKI-542). 
  This should solve most of the issues listed in XWiki-5406 and also fix XWiki-542
