### PR TITLE
XWIKI-5338 : Registration possible without captcha

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/RegisterAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/RegisterAction.java
@@ -125,7 +125,7 @@ public class RegisterAction extends XWikiAction
                     return false;
                 }
             } catch (Exception e) {
-                LOGGER.warn("Cannot verify captcha answer : " + e.getMessage());
+                LOGGER.warn("Cannot verify captcha answer: {}", e.getMessage()); 
                 return false;
             }
         }


### PR DESCRIPTION
To fix this issue, I check the user captcha answer (if one is required) in registerAction. So it is no more possible to register a new user by posting directly to registerAction if the captcha feature is enbled. 
