### PR TITLE
XWIKI-9052 : Unregistered users can still see everything in the wiki even if right to view pages for Unregistered users is explicitly set to deny.

### DIFF
--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-bridge/src/main/java/org/xwiki/security/authorization/internal/XWikiCachingRightService.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-bridge/src/main/java/org/xwiki/security/authorization/internal/XWikiCachingRightService.java
@@ -341,9 +341,11 @@ public class XWikiCachingRightService implements XWikiRightService
         if (XWikiConstants.GUEST_USER.equals(user.getName())) {
             // Public users (not logged in) should be passed as null in the new API
             user = null;
-            if(needsAuth(Right.toRight(right), context)) {
-            	return false;
-            }
+        }
+        
+        // If authentication is needed, deny guest users.
+        if (user == null && needsAuth(Right.toRight(right), context)) {
+            return false;
         }
 
         return authorizationManager.hasAccess(Right.toRight(right), user, document);


### PR DESCRIPTION
In contrary to checkAccess, hasAccessLevel didn't check whether authentication is needed. 
The problem was that the REST API was relying on hasAccess level to know whether the current user had the right to access the ressources.
