### PR TITLE
XWiki-3492 : Registration issues when email-verification/authentication enabled

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/Registration.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/Registration.xml
@@ -471,20 +471,20 @@ $xwiki.get('ssfx').use('uicomponents/widgets/validation/livevalidation.css', tru
 #set($discard = $fields.add($field))
 ##
 ## The email address field, regex checked with an email pattern. Mandatory if registration uses email verification
-  #set($field = 
-    {'name' : 'register_email',
-      'label' : $services.localization.render('core.register.email'),
-      'params' : { 
-        'type' : 'text', 
-        'size' : '60' 
-      },
-      'validate' : {
-        'regex' : {
-          'pattern' : '/^([^@\s]+)@((?:[-a-zA-Z0-9]+\.)+[a-zA-Z]{2,})$/',
-          'failureMessage' : $services.localization.render('xe.admin.registration.invalidEmail')
-        }
+#set($field = 
+  {'name' : 'register_email',
+    'label' : $services.localization.render('core.register.email'),
+    'params' : { 
+      'type' : 'text', 
+      'size' : '60' 
+    },
+    'validate' : {
+      'regex' : {
+        'pattern' : '/^([^@\s]+)@((?:[-a-zA-Z0-9]+\.)+[a-zA-Z]{2,})$/',
+        'failureMessage' : $services.localization.render('xe.admin.registration.invalidEmail')
       }
-    })
+    }
+  })
 #if($xwiki.getXWikiPreferenceAsInt('use_email_verification', 0) == 1)
   #set($field.validate.mandatory = {'failureMessage' : $services.localization.render('core.validation.required.message')})
 #end


### PR DESCRIPTION
I just made the email field mandatory if email verification is enabled.
As I unfortunately didn't see that Sorin closed XWiki-8761 as a duplicate of XWiki-3492, my commit comment refers to the XWiki-8761.
