### PR TITLE
XWiki 9151 : XSS vulnerability in link syntax when using "path:" 

### DIFF
--- a/xwiki-platform-core/xwiki-platform-annotations/xwiki-platform-annotation-core/src/main/java/org/xwiki/annotation/internal/renderer/AnnotationMarkersXHTMLPrinter.java
+++ b/xwiki-platform-core/xwiki-platform-annotations/xwiki-platform-annotation-core/src/main/java/org/xwiki/annotation/internal/renderer/AnnotationMarkersXHTMLPrinter.java
@@ -27,8 +27,8 @@ import java.util.SortedMap;
 
 import org.xwiki.annotation.Annotation;
 import org.xwiki.annotation.renderer.AnnotationEvent;
+import org.xwiki.rendering.renderer.printer.DefaultXHTMLWikiPrinter;
 import org.xwiki.rendering.renderer.printer.WikiPrinter;
-import org.xwiki.rendering.renderer.printer.XHTMLWikiPrinter;
 
 /**
  * XHTML Printer to handle printing annotations markers in the rendered XHTML. It is able to generate the annotation
@@ -41,7 +41,7 @@ import org.xwiki.rendering.renderer.printer.XHTMLWikiPrinter;
  * @version $Id$
  * @since 2.3M1
  */
-public class AnnotationMarkersXHTMLPrinter extends XHTMLWikiPrinter
+public class AnnotationMarkersXHTMLPrinter extends DefaultXHTMLWikiPrinter
 {
 
     /**

--- a/xwiki-platform-core/xwiki-platform-annotations/xwiki-platform-annotation-core/src/main/java/org/xwiki/annotation/internal/renderer/AnnotationXHTMLChainingRenderer.java
+++ b/xwiki-platform-core/xwiki-platform-annotations/xwiki-platform-annotation-core/src/main/java/org/xwiki/annotation/internal/renderer/AnnotationXHTMLChainingRenderer.java
@@ -68,7 +68,7 @@ public class AnnotationXHTMLChainingRenderer extends XHTMLChainingRenderer imple
     public AnnotationXHTMLChainingRenderer(XHTMLLinkRenderer linkRenderer, XHTMLImageRenderer imageRenderer,
         ListenerChain listenerChain)
     {
-        super(linkRenderer, imageRenderer, listenerChain);
+        super(linkRenderer, imageRenderer, listenerChain, "default");
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -118,6 +118,8 @@ import org.xwiki.rendering.syntax.SyntaxFactory;
 import org.xwiki.rendering.transformation.TransformationContext;
 import org.xwiki.rendering.transformation.TransformationException;
 import org.xwiki.rendering.transformation.TransformationManager;
+import org.xwiki.security.authorization.AuthorizationManager;
+import org.xwiki.security.authorization.Right;
 import org.xwiki.velocity.VelocityManager;
 import org.xwiki.xml.XMLUtils;
 
@@ -7942,8 +7944,19 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
      */
     protected static String renderXDOM(XDOM content, Syntax targetSyntax) throws XWikiException
     {
+        /*boolean hasPR = false;
+        AuthorizationManager am = Utils.getComponent(AuthorizationManager.class);
+        if (am.hasAccess(Right.PROGRAM, this.getAuthorReference(), this.documentReference)) {
+            hasPR = true;
+        }*/
         try {
-            BlockRenderer renderer = Utils.getComponent(BlockRenderer.class, targetSyntax.toIdString());
+            BlockRenderer renderer;
+            String targetSyntaxId = targetSyntax.toIdString();
+            if("xhtml/1.0".equals(targetSyntaxId) || "annotatedxhtml/1.0".equals(targetSyntaxId)) {
+                renderer = Utils.getComponent(BlockRenderer.class, "secure" + targetSyntaxId);
+            } else {
+                renderer = Utils.getComponent(BlockRenderer.class, targetSyntaxId);
+            }
             WikiPrinter printer = new DefaultWikiPrinter();
             renderer.render(content, printer);
             return printer.toString();

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -7947,7 +7947,8 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
         try {
             BlockRenderer renderer;
             String targetSyntaxId = targetSyntax.toIdString();
-            if("xhtml/1.0".equals(targetSyntaxId) || "annotatedxhtml/1.0".equals(targetSyntaxId)) {
+            // If a secure renderer exists, let's use it.
+            if (Utils.getComponentManager().hasComponent(BlockRenderer.class, "secure" + targetSyntaxId)) {
                 renderer = Utils.getComponent(BlockRenderer.class, "secure" + targetSyntaxId);
             } else {
                 renderer = Utils.getComponent(BlockRenderer.class, targetSyntaxId);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -7944,11 +7944,6 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
      */
     protected static String renderXDOM(XDOM content, Syntax targetSyntax) throws XWikiException
     {
-        /*boolean hasPR = false;
-        AuthorizationManager am = Utils.getComponent(AuthorizationManager.class);
-        if (am.hasAccess(Right.PROGRAM, this.getAuthorReference(), this.documentReference)) {
-            hasPR = true;
-        }*/
         try {
             BlockRenderer renderer;
             String targetSyntaxId = targetSyntax.toIdString();

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/java/org/xwiki/rendering/internal/configuration/DefaultXWikiRenderingConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/java/org/xwiki/rendering/internal/configuration/DefaultXWikiRenderingConfiguration.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.rendering.internal.configuration;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
@@ -100,8 +101,8 @@ public class DefaultXWikiRenderingConfiguration implements XWikiRenderingConfigu
     }
     
     @Override
-    public String getXHTMLWikiPrinterHint()
+    public List<String> getExtraAttributes()
     {
-        return this.configuration.getProperty(PREFIX + "xhtmlWikiPrinter", "default");
+        return this.configuration.getProperty(PREFIX + "extraAttributes", new ArrayList<String>());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/java/org/xwiki/rendering/internal/configuration/DefaultXWikiRenderingConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/java/org/xwiki/rendering/internal/configuration/DefaultXWikiRenderingConfiguration.java
@@ -98,4 +98,10 @@ public class DefaultXWikiRenderingConfiguration implements XWikiRenderingConfigu
     {
         return this.configuration.getProperty(PREFIX + "transformations", Arrays.asList("macro", "icon"));
     }
+    
+    @Override
+    public String getXHTMLWikiPrinterHint()
+    {
+        return this.configuration.getProperty(PREFIX + "xhtmlWikiPrinter", "default");
+    }
 }

--- a/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.properties.vm
+++ b/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.properties.vm
@@ -141,6 +141,12 @@ environment.permanentDirectory=$xwikiPropertiesEnvironmentPermanentDirectory
 # rendering.interWikiDefinitions = wikipedia = http://en.wikipedia.org/wiki/
 # rendering.interWikiDefinitions = definition = http://www.yourdictionary.com/
 
+#-# [Since 5.1M2]
+#-# In order to prevent XSS attacks with the wiki syntax, you can switch to a more secure mode by setting the following 
+#-# parameter with "secure". In this case, non-authorized tags would be deleted, and values of src or href attributes
+#-# would have to start with "http", "/" (for internal links), "#" or "mailto".
+rendering.xhtmlWikiPrinter = default
+
 #-------------------------------------------------------------------------------------
 # Rendering Transformations
 #-------------------------------------------------------------------------------------

--- a/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.properties.vm
+++ b/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.properties.vm
@@ -141,11 +141,11 @@ environment.permanentDirectory=$xwikiPropertiesEnvironmentPermanentDirectory
 # rendering.interWikiDefinitions = wikipedia = http://en.wikipedia.org/wiki/
 # rendering.interWikiDefinitions = definition = http://www.yourdictionary.com/
 
-#-# [Since 5.1M2]
-#-# In order to prevent XSS attacks with the wiki syntax, you can switch to a more secure mode by setting the following 
-#-# parameter with "secure". In this case, non-authorized tags would be deleted, and values of src or href attributes
-#-# would have to start with "http", "/" (for internal links), "#" or "mailto".
-rendering.xhtmlWikiPrinter = default
+#-# [Since 5.1RC1]
+#-# In order to prevent XSS attacks, only a limited number of attributes can be used in the wiki syntax.
+#-# By default the only attributes authorized are : alt, class, height, id, name, rel, scope, style, target, title, width
+#-# You can add some (as a coma separated list) thanks to this property.
+# rendering.extraAttributes = 
 
 #-------------------------------------------------------------------------------------
 # Rendering Transformations


### PR DESCRIPTION
This should also solve XWiki-8593 : XSS in images and links using on\* parameter. See the xwiki-rendering corresponding pull request (https://github.com/xwiki/xwiki-rendering/pull/6).
