### PR TITLE
XWIKI-9357: Activity stream displays todays events two hours early

### DIFF
--- a/xwiki-platform-core/xwiki-platform-activitystream/xwiki-platform-activitystream-ui/src/main/resources/Main/Activity.xml
+++ b/xwiki-platform-core/xwiki-platform-activitystream/xwiki-platform-activitystream-ui/src/main/resources/Main/Activity.xml
@@ -1085,7 +1085,7 @@ $xwiki.ssx.use('Main.Activity')##
   #if ($mathtool.sub($eventTimeDiff.getDayOfYear(), 1) == 0 &amp;&amp;
       ($eventDateTime.isAfter($todayMidnight) ||
        $eventDateTime.isEqual($todayMidnight)))
-    #if ($mathtool.sub($eventTimeDiff.getHourOfDay(), 2) == 0)
+    #if ($eventTimeDiff.getHourOfDay() == 0)
       ##
       ## Few seconds ago
       ## ---------------------------------------------------------------
@@ -1094,7 +1094,7 @@ $xwiki.ssx.use('Main.Activity')##
       ##
       ## Number of minutes ago
       ## ---------------------------------------------------------------
-      #set ($hoursAgo = $eventTimeDiff.getHourOfDay() - 2)
+      #set ($hoursAgo = $eventTimeDiff.getHourOfDay())
       #set ($timeAgoMsg = $services.localization.render('timeAgo.hoursAgo', [$hoursAgo]))
     #end
     #set ($isToday = true)


### PR DESCRIPTION
I tried to fix this problem by removing a hard wired subtraction in two places; not sure why this is there in the first place
