### PR TITLE
XE-1315 : URI Based Reflected XSS on XWIKI 4.5.2

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/contentmenu.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/contentmenu.vm
@@ -7,18 +7,7 @@
 ##
 ## Let's clean the query string to avoid injections
 ##
-#set($cleanQueryString = '')
-#foreach($param in $request.getParameterNames())
-  #set($cleanParam = $!escapetool.url($param))
-  #foreach($value in $request.getParameterValues($param))
-    #set($cleanValue = $!escapetool.url($value))
-    #set($cleanQueryString = $cleanQueryString + $!cleanParam + '=' + $!cleanValue + '&amp;')
-  #end
-#end
-#if($cleanQueryString != '')
-  ## Remove the last "&amp;"
-  #set($cleanQueryString = $stringtool.substring($cleanQueryString, 0, -5))
-#end
+#set($cleanQueryString = $escapetool.url($request.getParameterMap()))
 #if($hasEdit && !$isReadOnly)
   ## Compute the default edit mode
   #set($editaction = $doc.getDefaultEditMode())


### PR DESCRIPTION
As Abhisek (who reported this issue) stressed, this issue is due to the injection of the request query string in some menus.
Note that this attack works only on certain browser when the security mode is switched off. To avoid it nonetheless, I clean the queryString, so that injection won't work, even with an insecure browser. Another solution would be to html escape the query string, but I thought the present solution was cleaner. 
