### PR TITLE
XWIKI-9302: The parameters specified in an "anchor" are encoded (fixed).

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiServletURLFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiServletURLFactory.java
@@ -233,6 +233,7 @@ public class XWikiServletURLFactory extends XWikiDefaultURLFactory
 
         if (!StringUtils.isEmpty(anchor)) {
             newpath.append("#");
+            // Don't encode the anchor part, regarding RFC 3986: http://tools.ietf.org/html/rfc3986#section-3.5
             newpath.append(anchor);
         }
 


### PR DESCRIPTION
Tests are OK.
JIRA issue: https://jira.xwiki.org/browse/XWIKI-9302
