### PR TITLE
XWIKI-6275: Removing the last member of a group removes the group as wel...

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/XWikiAdminGroup.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/XWikiAdminGroup.xml
@@ -68,6 +68,34 @@
     <className>XWiki.XWikiGroups</className>
     <guid>46d387f2-4d8d-446d-a618-8bfcb655ba18</guid>
     <property>
+      <member />
+    </property>
+  </object>
+  <object>
+    <class>
+      <name>XWiki.XWikiGroups</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <member>
+        <disabled>0</disabled>
+        <name>member</name>
+        <number>1</number>
+        <prettyName>Member</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </member>
+    </class>
+    <name>XWiki.XWikiAdminGroup</name>
+    <number>1</number>
+    <className>XWiki.XWikiGroups</className>
+    <guid>46d387f2-4d8d-446d-a618-8bfcb655ba18</guid>
+    <property>
       <member>XWiki.Admin</member>
     </property>
   </object>

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/XWikiAllGroup.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/XWikiAllGroup.xml
@@ -68,6 +68,34 @@
     <className>XWiki.XWikiGroups</className>
     <guid>2ab32578-80c7-484a-bc49-fab0b3570609</guid>
     <property>
+      <member/>
+    </property>
+  </object>
+  <object>
+    <class>
+      <name>XWiki.XWikiGroups</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <member>
+        <disabled>0</disabled>
+        <name>member</name>
+        <number>1</number>
+        <prettyName>Member</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </member>
+    </class>
+    <name>XWiki.XWikiAllGroup</name>
+    <number>1</number>
+    <className>XWiki.XWikiGroups</className>
+    <guid>2ab32578-80c7-484a-bc49-fab0b3570609</guid>
+    <property>
       <member>XWiki.Admin</member>
     </property>
   </object>


### PR DESCRIPTION
JIRA: http://jira.xwiki.org/browse/XWIKI-6275

As Denis said:

> When the UI create a new group, the UI put an empty user in the group so it get listed in the group list. If you 
> delete all member of such group, that empty member stay, and the group is kept. Groups imported from the 
> default UI does not have that empty member, and therefore, disappear."

So, I have added an empty user to XWikiAllGroup and XWikiAdminGroup, and now, when I delete XWIki.Admin in a subwiki, the groups are not removed as well.
