### PR TITLE
XWIKI-9414: Do not display "Subwikis directory" if there is no subwiki.

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/menuview.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/menuview.vm
@@ -150,7 +150,7 @@
 ##
 #set ($isAdminAppInstalled = $xwiki.exists('XWiki.AdminSheet'))
 #set ($canDeleteWorkspace = $isWorkspaceManagerAppInstalled && $services.workspace.canDeleteWorkspace($xcontext.user, $xcontext.database))
-#set ($displayWorkspaceDirectoryMenuEntry = $isWorkspaceManagerAppInstalled && $isMainWikiUser && $xcontext.isMainWiki() && $listtool.size($services.workspace.getWorkspaces())>1)
+#set ($displayWorkspaceDirectoryMenuEntry = $isWorkspaceManagerAppInstalled && $isMainWikiUser && $xcontext.isMainWiki() && $services.workspace.getWorkspaces().size()>1)
 #set ($displayWikiSubmenu = $hasWatch || $hasGlobalAdmin || $xwiki.exists('Main.AllDocs') || $displayWorkspaceDirectoryMenuEntry || $canDeleteWorkspace)
 #set ($wikiEntryId = 'tmWiki')
 #if ($isWorkspaceManagerAppInstalled)


### PR DESCRIPTION
Trivial implementation.

It could be better to check if there is a workspace where the user has an access, but I guess it would have a higher cost and this template.vm is used everywhere.
