### PR TITLE
XWIKI-7883: document.get(property) displays key not value for a property...

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/DBListClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/DBListClass.java
@@ -30,6 +30,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.ecs.xhtml.input;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xwiki.model.EntityType;
 import org.xwiki.query.Query;
 import org.xwiki.query.QueryManager;
 
@@ -111,7 +112,7 @@ public class DBListClass extends ListClass
                     // We create the query
                     Query query = queryManager.createQuery(hqlQuery, Query.HQL);
                     // The DBlist may come from an other wiki
-                    String wikiName = this.getObject().getDocumentReference().getWikiReference().getName();
+                    String wikiName = getReference().extractReference(EntityType.WIKI).getName();
                     query.setWiki(wikiName);
                     // We execute the query to create the list of values.
                     list = makeList(query.execute());


### PR DESCRIPTION
... of type database list which has key and value in multiwiki mode.
- Now, DBLIstClass#getDBList() executes the query on the good database.
- I have replaced xwiki.search() by QueryManager#createQuery() to not increase the technical debt.
- Bug fixed!
