### PR TITLE
XWIKI-9456: After the creation of a new (sub)wiki, the Distribution Wizard should not appear.

### DIFF
--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-distribution/src/main/java/org/xwiki/extension/distribution/internal/DistributionScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-distribution/src/main/java/org/xwiki/extension/distribution/internal/DistributionScriptService.java
@@ -64,23 +64,23 @@ public class DistributionScriptService implements ScriptService
     public static final String EXTENSIONERROR_KEY = "scriptservice.distribution.error";
 
     /**
-     * Provides safe objects for scripts.
-     */
-    @Inject
-    @SuppressWarnings("rawtypes")
-    private ScriptSafeProvider scriptProvider;
-
-    /**
      * The component used to get information about the current distribution.
      */
     @Inject
-    private DistributionManager distributionManager;
+    protected DistributionManager distributionManager;
 
     /**
      * Used to access current {@link XWikiContext}.
      */
     @Inject
-    private Provider<XWikiContext> xcontextProvider;
+    protected Provider<XWikiContext> xcontextProvider;
+
+    /**
+     * Provides safe objects for scripts.
+     */
+    @Inject
+    @SuppressWarnings("rawtypes")
+    private ScriptSafeProvider scriptProvider;
 
     /**
      * Used to access HTML renderer.


### PR DESCRIPTION
- Change some fields to "protected" in order to make it easier to extend.
- It's needed for the 5.2 migrator, and it can ve reverted for 5.3
- See: https://github.com/xwiki/xwiki-enterprise/pull/45
