### PR TITLE
XWIKI-7936: When you import a page, that have no attachment and overwrit...

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/Package.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/Package.java
@@ -800,9 +800,9 @@ public class Package
                     List<XWikiAttachment> newDocAttachments = doc.getDoc().getAttachmentList();
                     for (XWikiAttachment att : previousdoc.getAttachmentList())
                     {
-                        if (!newDocAttachments.contains(att))
+                        if (doc.getDoc().getAttachment(att.getFilename()) == null)
                         {
-                            // We add the attachement to new document
+                            // We add the attachment to new document
                             newDocAttachments.add(att);
                             // But then we add it in the "to remove list" of the document
                             // So the attachment will be removed from the database when XWiki#saveDocument


### PR DESCRIPTION
...e an existing page containing attachments, some errors appear with them.
- It happens when you import the document as a new version.
- We remove from the database all attachments that are not in the new version of the document.
