### PR TITLE
XWIKI-9500: Add Wiki icon missing from top menu when users is on a subwiki.

### DIFF
--- a/xwiki-platform-core/xwiki-platform-colibri/src/main/resources/colibri/colibri.css
+++ b/xwiki-platform-core/xwiki-platform-colibri/src/main/resources/colibri/colibri.css
@@ -1141,6 +1141,10 @@ div#xwikiobjects input[type="checkbox"], div#xwikiclassproperties input[type="ch
   background-image: url("$xwiki.getSkinFile('icons/silk/wrench.png')");
 }
 
+.actionmenu .tmCreateWiki{
+  background-image: url("$xwiki.getSkinFile('icons/silk/chart_organisation_add.png')");
+}
+
 .actionmenu .tmCreateSpace {
   background-image: url("$xwiki.getSkinFile('icons/silk/folder_add.png')");
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -830,6 +830,7 @@ core.menu.create=Add
 core.menu.create.page=Page
 core.menu.create.pageFromOffice=Page from Office
 core.menu.create.space=Space
+core.menu.create.wiki=Wiki
 core.menu.create.comment=Comment to Page
 core.menu.create.attachment=Attachment to Page
 core.menu.copy=Copy

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/menuview.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/menuview.vm
@@ -64,7 +64,7 @@
   #set ($hasPreviousMenuSection = false)
   #if ($hasCreateWorkspace)
     #set ($createWorkspaceDocumentReference = $services.model.createDocumentReference('xwiki', 'WorkspaceManager', 'CreateNewWorkspace'))
-    #submenuitem("$xwiki.getURL($createWorkspaceDocumentReference)" $services.localization.render('workspacemanager.menu.create') 'tmCreateWorkspace', '')
+    #submenuitem("$xwiki.getURL($createWorkspaceDocumentReference)" $services.localization.render('core.menu.create.wiki') 'tmCreateWiki', '')
     #set ($hasPreviousMenuSection = true)
   #end
   #if ($hasCreateSpace)

--- a/xwiki-platform-core/xwiki-platform-workspace/xwiki-platform-workspace-ui/src/main/resources/WorkspaceManager/Style.xml
+++ b/xwiki-platform-core/xwiki-platform-workspace/xwiki-platform-workspace-ui/src/main/resources/WorkspaceManager/Style.xml
@@ -107,10 +107,6 @@
   background-image: url("$xwiki.getSkinFile('icons/xwiki/logo-xs.png')");
 }
 
-.actionmenu #tmCreateWorkspace {
-  background-image: url("$xwiki.getSkinFile('icons/silk/chart_organisation_add.png')");
-}
-
 .actionmenu #tmMainWiki {
   background-image: url("$xwiki.getSkinFile('icons/silk/house.png')");
 }

--- a/xwiki-platform-core/xwiki-platform-workspace/xwiki-platform-workspace-ui/src/main/resources/WorkspaceManager/Translations.xml
+++ b/xwiki-platform-core/xwiki-platform-workspace/xwiki-platform-workspace-ui/src/main/resources/WorkspaceManager/Translations.xml
@@ -202,9 +202,6 @@ workspacemanager.browse._actions.viewInvitation=View Invitation
 workspacemanager.browse._actions.cancelJoinRequest=Cancel Request
 workspacemanager.browse._actions.leave=Leave
 workspacemanager.browse._actions.delete=Delete
-workspacemanager.menu.create=Wiki
-workspacemanager.menu.mainwiki.admin=Administer Main Wiki
-workspacemanager.menu.workspace.mainWiki=Main Wiki
 workspacemanager.menu.workspace.index=Wiki Index
 workspacemanager.menu.workspace.delete=Delete
 workspacemanager.menu.user.workspaces=Wikis
@@ -287,6 +284,9 @@ platform.workspace.wizard.step2.shortname=Members
 ## until 5.2
 #######################################
 platform.workspace.createNewWorkspaceLabel=Create a new Wiki
+workspacemanager.menu.create=Wiki
+workspacemanager.menu.mainwiki.admin=Administer Main Wiki
+workspacemanager.menu.workspace.mainWiki=Main Wiki
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend


### PR DESCRIPTION
- Moved icon from WorkspacesManager UI to Colibri
- Moved translation keys from WorkspacesManager UI to oldcore
