### PR TITLE
XWIKI-9501: Two Admin users are added when creating a new Workspace on a migrated main wiki.

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/XWikiAdminGroup.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/XWikiAdminGroup.xml
@@ -68,7 +68,7 @@
     <className>XWiki.XWikiGroups</className>
     <guid>46d387f2-4d8d-446d-a618-8bfcb655ba18</guid>
     <property>
-      <member />
+      <member>XWiki.Admin</member>
     </property>
   </object>
   <object>
@@ -96,7 +96,7 @@
     <className>XWiki.XWikiGroups</className>
     <guid>46d387f2-4d8d-446d-a618-8bfcb655ba18</guid>
     <property>
-      <member>XWiki.Admin</member>
+      <member />
     </property>
   </object>
   <object>

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/XWikiAllGroup.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/XWikiAllGroup.xml
@@ -68,7 +68,7 @@
     <className>XWiki.XWikiGroups</className>
     <guid>2ab32578-80c7-484a-bc49-fab0b3570609</guid>
     <property>
-      <member/>
+      <member>XWiki.Admin</member>
     </property>
   </object>
   <object>
@@ -96,7 +96,7 @@
     <className>XWiki.XWikiGroups</className>
     <guid>2ab32578-80c7-484a-bc49-fab0b3570609</guid>
     <property>
-      <member>XWiki.Admin</member>
+      <member/>
     </property>
   </object>
   <content/>


### PR DESCRIPTION
- Fixed. Has been introduced by XWIKI-6275. The member object that contains "XWiki.Admin" had a wrong number. Then EM was not able to merge groups the way we wanted.
