### PR TITLE
XWIKI-9176: New XWiki Syntax Guide

### DIFF
--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxDefinitionLists.de.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxDefinitionLists.de.xml
@@ -6,7 +6,7 @@
   <language>de</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxDefinitionLists.fr.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxDefinitionLists.fr.xml
@@ -6,7 +6,7 @@
   <language>fr</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxDefinitionLists.it.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxDefinitionLists.it.xml
@@ -6,7 +6,7 @@
   <language>it</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxDefinitionLists.lv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxDefinitionLists.lv.xml
@@ -6,7 +6,7 @@
   <language>lv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxDefinitionLists.sv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxDefinitionLists.sv.xml
@@ -6,7 +6,7 @@
   <language>sv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxEscapes.de.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxEscapes.de.xml
@@ -6,7 +6,7 @@
   <language>de</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxEscapes.fr.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxEscapes.fr.xml
@@ -6,7 +6,7 @@
   <language>fr</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxEscapes.it.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxEscapes.it.xml
@@ -6,7 +6,7 @@
   <language>it</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxEscapes.lv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxEscapes.lv.xml
@@ -6,7 +6,7 @@
   <language>lv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxEscapes.sv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxEscapes.sv.xml
@@ -6,7 +6,7 @@
   <language>sv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxGeneralRemarks.de.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxGeneralRemarks.de.xml
@@ -6,7 +6,7 @@
   <language>de</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxGeneralRemarks.fr.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxGeneralRemarks.fr.xml
@@ -6,7 +6,7 @@
   <language>fr</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxGeneralRemarks.it.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxGeneralRemarks.it.xml
@@ -6,7 +6,7 @@
   <language>it</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxGeneralRemarks.lv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxGeneralRemarks.lv.xml
@@ -6,7 +6,7 @@
   <language>lv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxGeneralRemarks.sv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxGeneralRemarks.sv.xml
@@ -6,7 +6,7 @@
   <language>sv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxGroups.de.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxGroups.de.xml
@@ -6,7 +6,7 @@
   <language>de</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxGroups.fr.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxGroups.fr.xml
@@ -6,7 +6,7 @@
   <language>fr</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxGroups.it.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxGroups.it.xml
@@ -6,7 +6,7 @@
   <language>it</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxGroups.lv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxGroups.lv.xml
@@ -6,7 +6,7 @@
   <language>lv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxGroups.sv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxGroups.sv.xml
@@ -6,7 +6,7 @@
   <language>sv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHTML.de.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHTML.de.xml
@@ -6,7 +6,7 @@
   <language>de</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHTML.fr.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHTML.fr.xml
@@ -6,7 +6,7 @@
   <language>fr</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHTML.it.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHTML.it.xml
@@ -6,7 +6,7 @@
   <language>it</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHTML.lv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHTML.lv.xml
@@ -6,7 +6,7 @@
   <language>lv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHTML.sv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHTML.sv.xml
@@ -6,7 +6,7 @@
   <language>sv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHeadings.de.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHeadings.de.xml
@@ -6,7 +6,7 @@
   <language>de</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHeadings.fr.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHeadings.fr.xml
@@ -6,7 +6,7 @@
   <language>fr</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHeadings.it.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHeadings.it.xml
@@ -6,7 +6,7 @@
   <language>it</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHeadings.lv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHeadings.lv.xml
@@ -6,7 +6,7 @@
   <language>lv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHeadings.sv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHeadings.sv.xml
@@ -6,7 +6,7 @@
   <language>sv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHorizontalLine.de.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHorizontalLine.de.xml
@@ -6,7 +6,7 @@
   <language>de</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHorizontalLine.fr.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHorizontalLine.fr.xml
@@ -6,7 +6,7 @@
   <language>fr</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHorizontalLine.it.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHorizontalLine.it.xml
@@ -6,7 +6,7 @@
   <language>it</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHorizontalLine.lv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHorizontalLine.lv.xml
@@ -6,7 +6,7 @@
   <language>lv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHorizontalLine.sv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHorizontalLine.sv.xml
@@ -6,7 +6,7 @@
   <language>sv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxImages.de.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxImages.de.xml
@@ -6,7 +6,7 @@
   <language>de</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxImages.fr.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxImages.fr.xml
@@ -6,7 +6,7 @@
   <language>fr</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxImages.it.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxImages.it.xml
@@ -6,7 +6,7 @@
   <language>it</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxImages.lv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxImages.lv.xml
@@ -6,7 +6,7 @@
   <language>lv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxImages.sv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxImages.sv.xml
@@ -6,7 +6,7 @@
   <language>sv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxIntroduction.de.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxIntroduction.de.xml
@@ -6,7 +6,7 @@
   <language>de</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxIntroduction.fr.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxIntroduction.fr.xml
@@ -6,7 +6,7 @@
   <language>fr</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxIntroduction.it.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxIntroduction.it.xml
@@ -6,7 +6,7 @@
   <language>it</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxIntroduction.lv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxIntroduction.lv.xml
@@ -6,7 +6,7 @@
   <language>lv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxIntroduction.sv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxIntroduction.sv.xml
@@ -6,7 +6,7 @@
   <language>sv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxLinks.de.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxLinks.de.xml
@@ -6,7 +6,7 @@
   <language>de</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxLinks.fr.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxLinks.fr.xml
@@ -6,7 +6,7 @@
   <language>fr</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxLinks.it.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxLinks.it.xml
@@ -6,7 +6,7 @@
   <language>it</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxLinks.lv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxLinks.lv.xml
@@ -6,7 +6,7 @@
   <language>lv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxLinks.sv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxLinks.sv.xml
@@ -6,7 +6,7 @@
   <language>sv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxLists.de.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxLists.de.xml
@@ -6,7 +6,7 @@
   <language>de</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxLists.fr.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxLists.fr.xml
@@ -6,7 +6,7 @@
   <language>fr</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxLists.it.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxLists.it.xml
@@ -6,7 +6,7 @@
   <language>it</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxLists.lv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxLists.lv.xml
@@ -6,7 +6,7 @@
   <language>lv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxLists.sv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxLists.sv.xml
@@ -6,7 +6,7 @@
   <language>sv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxMacros.de.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxMacros.de.xml
@@ -6,7 +6,7 @@
   <language>de</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxMacros.fr.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxMacros.fr.xml
@@ -6,7 +6,7 @@
   <language>fr</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxMacros.it.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxMacros.it.xml
@@ -6,7 +6,7 @@
   <language>it</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxMacros.lv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxMacros.lv.xml
@@ -6,7 +6,7 @@
   <language>lv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxMacros.sv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxMacros.sv.xml
@@ -6,7 +6,7 @@
   <language>sv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxNewLineLineBreaks.de.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxNewLineLineBreaks.de.xml
@@ -6,7 +6,7 @@
   <language>de</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxNewLineLineBreaks.fr.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxNewLineLineBreaks.fr.xml
@@ -6,7 +6,7 @@
   <language>fr</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxNewLineLineBreaks.it.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxNewLineLineBreaks.it.xml
@@ -6,7 +6,7 @@
   <language>it</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxNewLineLineBreaks.lv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxNewLineLineBreaks.lv.xml
@@ -6,7 +6,7 @@
   <language>lv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxNewLineLineBreaks.sv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxNewLineLineBreaks.sv.xml
@@ -6,7 +6,7 @@
   <language>sv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxOtherSyntaxes.de.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxOtherSyntaxes.de.xml
@@ -6,7 +6,7 @@
   <language>de</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxOtherSyntaxes.fr.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxOtherSyntaxes.fr.xml
@@ -6,7 +6,7 @@
   <language>fr</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxOtherSyntaxes.it.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxOtherSyntaxes.it.xml
@@ -6,7 +6,7 @@
   <language>it</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxOtherSyntaxes.lv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxOtherSyntaxes.lv.xml
@@ -6,7 +6,7 @@
   <language>lv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxOtherSyntaxes.sv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxOtherSyntaxes.sv.xml
@@ -6,7 +6,7 @@
   <language>sv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxParagraphs.de.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxParagraphs.de.xml
@@ -6,7 +6,7 @@
   <language>de</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxParagraphs.fr.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxParagraphs.fr.xml
@@ -6,7 +6,7 @@
   <language>fr</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxParagraphs.it.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxParagraphs.it.xml
@@ -6,7 +6,7 @@
   <language>it</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxParagraphs.lv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxParagraphs.lv.xml
@@ -6,7 +6,7 @@
   <language>lv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxParagraphs.sv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxParagraphs.sv.xml
@@ -6,7 +6,7 @@
   <language>sv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxParameters.de.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxParameters.de.xml
@@ -6,7 +6,7 @@
   <language>de</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxParameters.fr.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxParameters.fr.xml
@@ -6,7 +6,7 @@
   <language>fr</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxParameters.it.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxParameters.it.xml
@@ -6,7 +6,7 @@
   <language>it</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxParameters.lv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxParameters.lv.xml
@@ -6,7 +6,7 @@
   <language>lv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxParameters.sv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxParameters.sv.xml
@@ -6,7 +6,7 @@
   <language>sv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxQuotations.de.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxQuotations.de.xml
@@ -6,7 +6,7 @@
   <language>de</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxQuotations.fr.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxQuotations.fr.xml
@@ -6,7 +6,7 @@
   <language>fr</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxQuotations.it.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxQuotations.it.xml
@@ -6,7 +6,7 @@
   <language>it</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxQuotations.lv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxQuotations.lv.xml
@@ -6,7 +6,7 @@
   <language>lv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxQuotations.sv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxQuotations.sv.xml
@@ -6,7 +6,7 @@
   <language>sv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxScripts.de.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxScripts.de.xml
@@ -6,7 +6,7 @@
   <language>de</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxScripts.fr.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxScripts.fr.xml
@@ -6,7 +6,7 @@
   <language>fr</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxScripts.it.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxScripts.it.xml
@@ -6,7 +6,7 @@
   <language>it</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxScripts.lv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxScripts.lv.xml
@@ -6,7 +6,7 @@
   <language>lv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxScripts.sv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxScripts.sv.xml
@@ -6,7 +6,7 @@
   <language>sv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTables.de.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTables.de.xml
@@ -6,7 +6,7 @@
   <language>de</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTables.fr.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTables.fr.xml
@@ -6,7 +6,7 @@
   <language>fr</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTables.it.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTables.it.xml
@@ -6,7 +6,7 @@
   <language>it</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTables.lv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTables.lv.xml
@@ -6,7 +6,7 @@
   <language>lv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTables.sv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTables.sv.xml
@@ -6,7 +6,7 @@
   <language>sv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTextFormatting.de.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTextFormatting.de.xml
@@ -6,7 +6,7 @@
   <language>de</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTextFormatting.fr.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTextFormatting.fr.xml
@@ -6,7 +6,7 @@
   <language>fr</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTextFormatting.it.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTextFormatting.it.xml
@@ -6,7 +6,7 @@
   <language>it</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTextFormatting.lv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTextFormatting.lv.xml
@@ -6,7 +6,7 @@
   <language>lv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTextFormatting.sv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTextFormatting.sv.xml
@@ -6,7 +6,7 @@
   <language>sv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxVerbatim.de.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxVerbatim.de.xml
@@ -6,7 +6,7 @@
   <language>de</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxVerbatim.fr.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxVerbatim.fr.xml
@@ -6,7 +6,7 @@
   <language>fr</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxVerbatim.it.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxVerbatim.it.xml
@@ -6,7 +6,7 @@
   <language>it</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxVerbatim.lv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxVerbatim.lv.xml
@@ -6,7 +6,7 @@
   <language>lv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxVerbatim.sv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxVerbatim.sv.xml
@@ -6,7 +6,7 @@
   <language>sv</language>
   <defaultLanguage/>
   <translation>1</translation>
-  <parent/>
+  <parent>XWiki.XWikiSyntax</parent>
   <creator>xwiki:XWiki.Admin</creator>
   <author>xwiki:XWiki.Admin</author>
   <customClass/>


### PR DESCRIPTION
fix build by adding missing parents to translations, sorry
