### PR TITLE
XWIKI-9176: New XWiki Syntax Guide - fix tests

### DIFF
--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHeadings.de.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHeadings.de.xml
@@ -11,9 +11,9 @@
   <author>xwiki:XWiki.Admin</author>
   <customClass/>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <creationDate>1382871831000</creationDate>
-  <date>1382871831000</date>
-  <contentUpdateDate>1382871831000</contentUpdateDate>
+  <creationDate>1384507498000</creationDate>
+  <date>1384509658000</date>
+  <contentUpdateDate>1384509658000</contentUpdateDate>
   <version>1.1</version>
   <title>XWikiSyntaxHeadings</title>
   <defaultTemplate/>
@@ -38,14 +38,17 @@
 1.1.1.1.1 Ebene 5
 1.1.1.1.1.1 Ebene 6
 )))|(((
-{{html}}
-&lt;!-- Note: replace this with wiki syntax when http://jira.xwiki.org/jira/browse/XWIKI-4358 is implemented --&gt;
-&lt;h1 id="Hlevel1"&gt;&lt;span&gt;Ebene 1&lt;/span&gt;&lt;/h1&gt;&lt;p&gt;&amp;nbsp;&lt;/p&gt;&lt;h2 id="Hlevel2"&gt;&lt;span&gt;Ebene 2&lt;/span&gt;&lt;/h2&gt;&lt;h3 id="Hlevel3"&gt;&lt;span&gt;Ebene 3&lt;/span&gt;&lt;/h3&gt;&lt;h4 id="Hlevel4"&gt;&lt;span&gt;Ebene 4&lt;/span&gt;&lt;/h4&gt;&lt;h5 id="Hlevel5"&gt;&lt;span&gt;Ebene 5&lt;/span&gt;&lt;/h5&gt;&lt;h6 id="Hlevel6"&gt;&lt;span&gt;Ebene 6&lt;/span&gt;&lt;/h6&gt;
-{{/html}})))
+= Ebene 1 = 
+== Ebene 2 ==
+=== Ebene 3 ===
+==== Ebene 4 ====
+===== Ebene 5 =====
+====== Ebene 6 ======
+)))
 |Parametrisierte Überschrift|&lt;h1&gt;&lt;span style="color:blue"&gt;Überschrift&lt;/span&gt;&lt;/h1&gt;|(((
-{{html}}
-&lt;h1 id="Hheading" style="color:blue"&gt;&lt;span&gt;Überschrift&lt;/span&gt;&lt;/h1&gt;
-{{/html}})))
+(% style="color:blue" %)
+= Überschrift =
+)))
 |Überschrift mit XWiki Syntax|1.1.1 Überschrift mit *fett*|(((=== Überschrift mit **fett** ===)))
 
 === 2.0 Headings ===
@@ -59,13 +62,16 @@
 ===== Ebene 5 =====
 ====== Ebene 6 ======
 }}})))|(((
-{{html}}
-&lt;!-- Note: replace this with wiki syntax when http://jira.xwiki.org/jira/browse/XWIKI-4358 is implemented --&gt;
-&lt;h1 id="Hlevel1"&gt;&lt;span&gt;Ebene 1&lt;/span&gt;&lt;/h1&gt;&lt;p&gt;&amp;nbsp;&lt;/p&gt;&lt;h2 id="Hlevel2"&gt;&lt;span&gt;Ebene 2&lt;/span&gt;&lt;/h2&gt;&lt;h3 id="Hlevel3"&gt;&lt;span&gt;Ebene 3&lt;/span&gt;&lt;/h3&gt;&lt;h4 id="Hlevel4"&gt;&lt;span&gt;Ebene 4&lt;/span&gt;&lt;/h4&gt;&lt;h5 id="Hlevel5"&gt;&lt;span&gt;Ebene 5&lt;/span&gt;&lt;/h5&gt;&lt;h6 id="Hlevel6"&gt;&lt;span&gt;Ebene 6&lt;/span&gt;&lt;/h6&gt;
-{{/html}})))
+= Ebene 1 = 
+== Ebene 2 ==
+=== Ebene 3 ===
+==== Ebene 4 ====
+===== Ebene 5 =====
+====== Ebene 6 ======
+)))
 |Parametrisierte Überschrift|{{{(% style="color:blue" %)}}}\\= Überschrift =|(((
-{{html}}
-&lt;h1 id="Hheading" style="color:blue"&gt;&lt;span&gt;Überschrift&lt;/span&gt;&lt;/h1&gt;
-{{/html}})))
+(% style="color:blue" %)
+= Überschrift =
+)))
 |Überschrift mit XWiki Syntax|{{{=== Überschrift mit **fett** ===}}}|(((=== Überschrift mit **fett** ===)))</content>
 </xwikidoc>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHeadings.fr.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHeadings.fr.xml
@@ -11,9 +11,9 @@
   <author>xwiki:XWiki.Admin</author>
   <customClass/>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <creationDate>1382885828000</creationDate>
-  <date>1382885828000</date>
-  <contentUpdateDate>1382885828000</contentUpdateDate>
+  <creationDate>1384507496000</creationDate>
+  <date>1384509551000</date>
+  <contentUpdateDate>1384509551000</contentUpdateDate>
   <version>1.1</version>
   <title>XWikiSyntaxHeadings</title>
   <defaultTemplate/>
@@ -38,16 +38,17 @@
 1.1.1.1.1 niveau 5
 1.1.1.1.1.1 niveau 6
 )))|(((
-{{html}}
-&lt;!-- Note: replace this with wiki syntax when http://jira.xwiki.org/jira/browse/XWIKI-4358 is implemented --&gt;
-&lt;h1 id="Hlevel1"&gt;&lt;span&gt;niveau 1&lt;/span&gt;&lt;/h1&gt;&lt;p&gt;&amp;nbsp;&lt;/p&gt;&lt;h2 id="Hlevel2"&gt;&lt;span&gt;niveau 2&lt;/span&gt;&lt;/h2&gt;&lt;h3 id="Hlevel3"&gt;&lt;span&gt;niveau 3&lt;/span&gt;&lt;/h3&gt;&lt;h4 id="Hlevel4"&gt;&lt;span&gt;niveau 4&lt;/span&gt;&lt;/h4&gt;&lt;h5 id="Hlevel5"&gt;&lt;span&gt;niveau 5&lt;/span&gt;&lt;/h5&gt;&lt;h6 id="Hlevel6"&gt;&lt;span&gt;niveau 6&lt;/span&gt;&lt;/h6&gt;
-{{/html}}
+= niveau 1 = 
+== niveau 2 ==
+=== niveau 3 ===
+==== niveau 4 ====
+===== niveau 5 =====
+====== niveau 6 ======
 )))
 |Titres paramétrés|&lt;h1&gt;&lt;span style="color:blue"&gt;
 titre&lt;/span&gt;&lt;/h1&gt;|(((
-{{html}}
-&lt;h1 id="Hheading" style="color:blue"&gt;&lt;span&gt;titre&lt;/span&gt;&lt;/h1&gt;
-{{/html}}
+(% style="color:blue" %)
+= titre =
 )))
 |Titres en syntaxe wiki|1.1.1 Titre en *gras*|(((
 === Titre en **gras** ===
@@ -65,16 +66,17 @@ titre&lt;/span&gt;&lt;/h1&gt;|(((
 ===== niveau 5 =====
 ====== niveau 6 ======}}}
 )))|(((
-{{html}}
-&lt;!-- Note: replace this with wiki syntax when http://jira.xwiki.org/jira/browse/XWIKI-4358 is implemented --&gt;
-&lt;h1 id="Hlevel1"&gt;&lt;span&gt;niveau 1&lt;/span&gt;&lt;/h1&gt;&lt;p&gt;&amp;nbsp;&lt;/p&gt;&lt;h2 id="Hlevel2"&gt;&lt;span&gt;niveau 2&lt;/span&gt;&lt;/h2&gt;&lt;h3 id="Hlevel3"&gt;&lt;span&gt;niveau 3&lt;/span&gt;&lt;/h3&gt;&lt;h4 id="Hlevel4"&gt;&lt;span&gt;niveau 4&lt;/span&gt;&lt;/h4&gt;&lt;h5 id="Hlevel5"&gt;&lt;span&gt;niveau 5&lt;/span&gt;&lt;/h5&gt;&lt;h6 id="Hlevel6"&gt;&lt;span&gt;niveau 6&lt;/span&gt;&lt;/h6&gt;
-{{/html}}
+= niveau 1 = 
+== niveau 2 ==
+=== niveau 3 ===
+==== niveau 4 ====
+===== niveau 5 =====
+====== niveau 6 ======
 )))
 |Titres paramétrés|{{{(% style="color:blue" %)}}}
 ~= titre =|(((
-{{html}}
-&lt;h1 id="Hheading" style="color:blue"&gt;&lt;span&gt;titre&lt;/span&gt;&lt;/h1&gt;
-{{/html}}
+(% style="color:blue" %)
+= titre =
 )))
 |Titres en syntaxe wiki|{{{=== Titre en **gras** ===}}}|(((
 === Titre en **gras** ===

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHeadings.it.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHeadings.it.xml
@@ -11,9 +11,9 @@
   <author>xwiki:XWiki.Admin</author>
   <customClass/>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <creationDate>1382897887000</creationDate>
-  <date>1382897887000</date>
-  <contentUpdateDate>1382897887000</contentUpdateDate>
+  <creationDate>1384507497000</creationDate>
+  <date>1384509750000</date>
+  <contentUpdateDate>1384509750000</contentUpdateDate>
   <version>1.1</version>
   <title>XWikiSyntaxHeadings</title>
   <defaultTemplate/>
@@ -38,14 +38,17 @@
 1.1.1.1.1 livello 5
 1.1.1.1.1.1 livello 6
 )))|(((
-{{html}}
-&lt;!-- Nota: sostituire questo con sintassi xwiki se accade come http://jira.xwiki.org/jira/browse/XWIKI-4358 --&gt;
-&lt;h1 id="Hlevel1"&gt;&lt;span&gt;livello 1&lt;/span&gt;&lt;/h1&gt;&lt;p&gt;&amp;nbsp;&lt;/p&gt;&lt;h2 id="Hlevel2"&gt;&lt;span&gt;livello 2&lt;/span&gt;&lt;/h2&gt;&lt;h3 id="Hlevel3"&gt;&lt;span&gt;livello 3&lt;/span&gt;&lt;/h3&gt;&lt;h4 id="Hlevel4"&gt;&lt;span&gt;livello 4&lt;/span&gt;&lt;/h4&gt;&lt;h5 id="Hlevel5"&gt;&lt;span&gt;livello 5&lt;/span&gt;&lt;/h5&gt;&lt;h6 id="Hlevel6"&gt;&lt;span&gt;livello 6&lt;/span&gt;&lt;/h6&gt;
-{{/html}})))
+= livello 1 = 
+== livello 2 ==
+=== livello 3 ===
+==== livello 4 ====
+===== livello 5 =====
+====== livello 6 ======
+)))
 |Titoli con Parametri|&lt;h1&gt;&lt;span style="color:blue"&gt;titolo&lt;/span&gt;&lt;/h1&gt;|(((
-{{html}}
-&lt;h1 id="Hheader" style="color:blue"&gt;&lt;span&gt;titolo&lt;/span&gt;&lt;/h1&gt;
-{{/html}})))
+(% style="color:blue" %)
+= titolo =
+)))
 |Titoli con sintassi XWiki|1.1.1 Titolo con *grassetto*|(((=== Titolo con **grassetto** ===)))
 
 === 2.0 Headings ===
@@ -59,13 +62,16 @@
 ===== livello 5 =====
 ====== livello 6 ======
 }}})))|(((
-{{html}}
-&lt;!-- Nota: sostituire questo con sintassi xwiki se accade come http://jira.xwiki.org/jira/browse/XWIKI-4358 --&gt;
-&lt;h1 id="Hlevel1"&gt;&lt;span&gt;livello 1&lt;/span&gt;&lt;/h1&gt;&lt;p&gt;&amp;nbsp;&lt;/p&gt;&lt;h2 id="Hlevel2"&gt;&lt;span&gt;livello 2&lt;/span&gt;&lt;/h2&gt;&lt;h3 id="Hlevel3"&gt;&lt;span&gt;livello 3&lt;/span&gt;&lt;/h3&gt;&lt;h4 id="Hlevel4"&gt;&lt;span&gt;livello 4&lt;/span&gt;&lt;/h4&gt;&lt;h5 id="Hlevel5"&gt;&lt;span&gt;livello 5&lt;/span&gt;&lt;/h5&gt;&lt;h6 id="Hlevel6"&gt;&lt;span&gt;livello 6&lt;/span&gt;&lt;/h6&gt;
-{{/html}})))
+= livello 1 = 
+== livello 2 ==
+=== livello 3 ===
+==== livello 4 ====
+===== livello 5 =====
+====== livello 6 ======
+)))
 |Titoli con Parametri|{{{(% style="color:blue" %)}}}\\= titolo =|(((
-{{html}}
-&lt;h1 id="Hheader" style="color:blue"&gt;&lt;span&gt;titolo&lt;/span&gt;&lt;/h1&gt;
-{{/html}})))
+(% style="color:blue" %)
+= titolo =
+)))
 |Titoli con sintassi XWiki|{{{=== Titolo con **grassetto** ===}}}|(((=== Titolo con **grassetto** ===)))</content>
 </xwikidoc>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHeadings.lv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHeadings.lv.xml
@@ -11,9 +11,9 @@
   <author>xwiki:XWiki.Admin</author>
   <customClass/>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <creationDate>1382897917000</creationDate>
-  <date>1382897917000</date>
-  <contentUpdateDate>1382897917000</contentUpdateDate>
+  <creationDate>1384507502000</creationDate>
+  <date>1384509826000</date>
+  <contentUpdateDate>1384509826000</contentUpdateDate>
   <version>1.1</version>
   <title>XWikiSyntaxHeadings</title>
   <defaultTemplate/>
@@ -38,15 +38,16 @@
 1.1.1.1.1 5. līmenis
 1.1.1.1.1.1 6. līmenis
 )))|(((
-{{html}}
-&lt;!-- Note: replace this with wiki syntax when http://jira.xwiki.org/jira/browse/XWIKI-4358 is implemented --&gt;
-&lt;h1 id="Hlevel1"&gt;&lt;span&gt;1. līmenis&lt;/span&gt;&lt;/h1&gt;&lt;p&gt;&amp;nbsp;&lt;/p&gt;&lt;h2 id="Hlevel2"&gt;&lt;span&gt;2. līmenis&lt;/span&gt;&lt;/h2&gt;&lt;h3 id="Hlevel3"&gt;&lt;span&gt;3. līmenis&lt;/span&gt;&lt;/h3&gt;&lt;h4 id="Hlevel4"&gt;&lt;span&gt;4. līmenis&lt;/span&gt;&lt;/h4&gt;&lt;h5 id="Hlevel5"&gt;&lt;span&gt;5. līmenis&lt;/span&gt;&lt;/h5&gt;&lt;h6 id="Hlevel6"&gt;&lt;span&gt;6. līmenis&lt;/span&gt;&lt;/h6&gt;
-{{/html}}
+= 1. līmenis =
+== 2. līmenis ==
+=== 3. līmenis ===
+==== 4. līmenis ====
+===== 5. līmenis =====
+====== 6. līmenis ======
 )))
 |Virsraksts ar parametriem |&lt;h1&gt;&lt;span style="color:blue"&gt;virsraksts&lt;/span&gt;&lt;/h1&gt;|(((
-{{html}}
-&lt;h1 id="Hheader" style="color:blue"&gt;&lt;span&gt;virsraksts&lt;/span&gt;&lt;/h1&gt;
-{{/html}}
+(% style="color:blue" %)
+= virsraksts =
 )))
 |Virsraksts ar viki sintaksi|1.1.1 Virsraksts ar *treknrakstu*|(((
 === Virsraksts ar **treknrakstu** ===
@@ -66,16 +67,17 @@
 ====== 6. līmenis ======
 }}}
 )))|(((
-{{html}}
-&lt;!-- Note: replace this with wiki syntax when http://jira.xwiki.org/jira/browse/XWIKI-4358 is implemented --&gt;
-&lt;h1 id="Hlevel1"&gt;&lt;span&gt;1. līmenis&lt;/span&gt;&lt;/h1&gt;&lt;p&gt;&amp;nbsp;&lt;/p&gt;&lt;h2 id="Hlevel2"&gt;&lt;span&gt;2. līmenis&lt;/span&gt;&lt;/h2&gt;&lt;h3 id="Hlevel3"&gt;&lt;span&gt;3. līmenis&lt;/span&gt;&lt;/h3&gt;&lt;h4 id="Hlevel4"&gt;&lt;span&gt;4. līmenis&lt;/span&gt;&lt;/h4&gt;&lt;h5 id="Hlevel5"&gt;&lt;span&gt;5. līmenis&lt;/span&gt;&lt;/h5&gt;&lt;h6 id="Hlevel6"&gt;&lt;span&gt;6. līmenis&lt;/span&gt;&lt;/h6&gt;
-{{/html}}
+= 1. līmenis =
+== 2. līmenis ==
+=== 3. līmenis ===
+==== 4. līmenis ====
+===== 5. līmenis =====
+====== 6. līmenis ======
 )))
 |Virsraksts ar parametriem |{{{(% style="color:blue" %)}}}
 ~= virsraksts =|(((
-{{html}}
-&lt;h1 id="Hheader" style="color:blue"&gt;&lt;span&gt;virsraksts&lt;/span&gt;&lt;/h1&gt;
-{{/html}}
+(% style="color:blue" %)
+= virsraksts =
 )))
 |Virsraksts ar viki sintaksi|{{{=== Virsraksts ar **treknrakstu** ===}}}|(((
 === Virsraksts ar **treknrakstu** ===

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHeadings.sv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHeadings.sv.xml
@@ -11,9 +11,9 @@
   <author>xwiki:XWiki.Admin</author>
   <customClass/>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <creationDate>1382897933000</creationDate>
-  <date>1382897933000</date>
-  <contentUpdateDate>1382897933000</contentUpdateDate>
+  <creationDate>1384507496000</creationDate>
+  <date>1384509449000</date>
+  <contentUpdateDate>1384509449000</contentUpdateDate>
   <version>1.1</version>
   <title>XWikiSyntaxHeadings</title>
   <defaultTemplate/>
@@ -38,15 +38,16 @@
 1.1.1.1.1 nivå 5
 1.1.1.1.1.1 nivå 6
 )))|(((
-{{html}}
-&lt;!-- Note: replace this with wiki syntax when http://jira.xwiki.org/jira/browse/XWIKI-4358 is implemented --&gt;
-&lt;h1 id="Hlevel1"&gt;&lt;span&gt;nivå 1&lt;/span&gt;&lt;/h1&gt;&lt;p&gt;&amp;nbsp;&lt;/p&gt;&lt;h2 id="Hlevel2"&gt;&lt;span&gt;nivå 2&lt;/span&gt;&lt;/h2&gt;&lt;h3 id="Hlevel3"&gt;&lt;span&gt;nivå 3&lt;/span&gt;&lt;/h3&gt;&lt;h4 id="Hlevel4"&gt;&lt;span&gt;nivå 4&lt;/span&gt;&lt;/h4&gt;&lt;h5 id="Hlevel5"&gt;&lt;span&gt;nivå 5&lt;/span&gt;&lt;/h5&gt;&lt;h6 id="Hlevel6"&gt;&lt;span&gt;nivå 6&lt;/span&gt;&lt;/h6&gt;
-{{/html}}
+= nivå 1 = 
+== nivå 2 ==
+=== nivå 3 ===
+==== nivå 4 ====
+===== nivå 5 =====
+====== nivå 6 ======
 )))
 |Parametriserade rubriker|&lt;h1&gt;&lt;span style="color:blue"&gt;rubrik&lt;/span&gt;&lt;/h1&gt;|(((
-{{html}}
-&lt;h1 id="Hheader" style="color:blue"&gt;&lt;span&gt;rubrik&lt;/span&gt;&lt;/h1&gt;
-{{/html}}
+(% style="color:blue" %)
+= rubrik =
 )))
 |Rubriker med wikisyntax|1.1.1 Rubrik med *fetstil*|(((=== Rubrik med **fetstil** ===)))
 
@@ -68,9 +69,8 @@
 {{/html}}
 )))
 |Parametriserade rubriker|{{{(% style="color:blue" %)}}}\\= rubrik =|(((
-{{html}}
-&lt;h1 id="Hheader" style="color:blue"&gt;&lt;span&gt;rubrik&lt;/span&gt;&lt;/h1&gt;
-{{/html}}
+(% style="color:blue" %)
+= rubrik =
 )))
 |Rubriker med wikisyntax|{{{=== Rubrik med **fetstil** ===}}}|(((=== Rubrik med **fetstil** ===)))</content>
 </xwikidoc>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHeadings.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxHeadings.xml
@@ -11,12 +11,11 @@
   <author>xwiki:XWiki.Admin</author>
   <customClass/>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <creationDate>1300895617000</creationDate>
-  <date>1301497855000</date>
-  <contentUpdateDate>1301497855000</contentUpdateDate>
+  <creationDate>1384507498000</creationDate>
+  <date>1384508603000</date>
+  <contentUpdateDate>1384508603000</contentUpdateDate>
   <version>1.1</version>
   <title>XWikiSyntaxHeadings</title>
-  <template/>
   <defaultTemplate/>
   <validationScript/>
   <comment/>
@@ -118,14 +117,17 @@
 1.1.1.1.1 level 5
 1.1.1.1.1.1 level 6
 )))|(((
-{{html}}
-&lt;!-- Note: replace this with wiki syntax when http://jira.xwiki.org/jira/browse/XRENDERING-20 is implemented --&gt;
-&lt;h1 id="Hlevel1"&gt;&lt;span&gt;level 1&lt;/span&gt;&lt;/h1&gt;&lt;p&gt;&amp;nbsp;&lt;/p&gt;&lt;h2 id="Hlevel2"&gt;&lt;span&gt;level 2&lt;/span&gt;&lt;/h2&gt;&lt;h3 id="Hlevel3"&gt;&lt;span&gt;level 3&lt;/span&gt;&lt;/h3&gt;&lt;h4 id="Hlevel4"&gt;&lt;span&gt;level 4&lt;/span&gt;&lt;/h4&gt;&lt;h5 id="Hlevel5"&gt;&lt;span&gt;level 5&lt;/span&gt;&lt;/h5&gt;&lt;h6 id="Hlevel6"&gt;&lt;span&gt;level 6&lt;/span&gt;&lt;/h6&gt;
-{{/html}})))
-|Parameterized headings|&lt;h1&gt;&lt;span style="color:blue"&gt;heading&lt;/span&gt;&lt;/h1&gt;|(((
-{{html}}
-&lt;h1 id="Hheading" style="color:blue"&gt;&lt;span&gt;heading&lt;/span&gt;&lt;/h1&gt;
-{{/html}})))
+= level 1 = 
+== level 2 ==
+=== level 3 ===
+==== level 4 ====
+===== level 5 =====
+====== level 6 ======
+)))
+|Parameterized headings|&lt;h1&gt;&lt;span style="color:blue"&gt;Heading&lt;/span&gt;&lt;/h1&gt;|(((
+(% style="color:blue" %)
+= heading =
+)))
 |Headings with XWiki Syntax|1.1.1 Heading with *bold*|(((=== Heading with **bold** ===)))
 
 === 2.0 Headings ===
@@ -139,13 +141,16 @@
 ===== level 5 =====
 ====== level 6 ======
 }}})))|(((
-{{html}}
-&lt;!-- Note: replace this with wiki syntax when http://jira.xwiki.org/jira/browse/XRENDERING-20 is implemented --&gt;
-&lt;h1 id="Hlevel1"&gt;&lt;span&gt;level 1&lt;/span&gt;&lt;/h1&gt;&lt;p&gt;&amp;nbsp;&lt;/p&gt;&lt;h2 id="Hlevel2"&gt;&lt;span&gt;level 2&lt;/span&gt;&lt;/h2&gt;&lt;h3 id="Hlevel3"&gt;&lt;span&gt;level 3&lt;/span&gt;&lt;/h3&gt;&lt;h4 id="Hlevel4"&gt;&lt;span&gt;level 4&lt;/span&gt;&lt;/h4&gt;&lt;h5 id="Hlevel5"&gt;&lt;span&gt;level 5&lt;/span&gt;&lt;/h5&gt;&lt;h6 id="Hlevel6"&gt;&lt;span&gt;level 6&lt;/span&gt;&lt;/h6&gt;
-{{/html}})))
+= level 1 = 
+== level 2 ==
+=== level 3 ===
+==== level 4 ====
+===== level 5 =====
+====== level 6 ======
+)))
 |Parameterized headings|{{{(% style="color:blue" %)}}}\\= heading =|(((
-{{html}}
-&lt;h1 id="Hheading" style="color:blue"&gt;&lt;span&gt;heading&lt;/span&gt;&lt;/h1&gt;
-{{/html}})))
+(% style="color:blue" %)
+= heading =
+)))
 |Headings with XWiki Syntax|{{{=== Heading with **bold** ===}}}|(((=== Heading with **bold** ===)))</content>
 </xwikidoc>

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTables.de.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTables.de.xml
@@ -62,7 +62,7 @@ Wort 1 | Wort 2
 |Filterbare, sortierbare Tabelle|((({{{
 $xwiki.ssfx.use("js/xwiki/table/table.css")
 $xwiki.jsfx.use("js/xwiki/table/tablefilterNsort.js", true)
-&lt;table id="tableid" class="grid sortable filterable doOddEven"&gt;
+&lt;table id="table1id" class="grid sortable filterable doOddEven"&gt;
   &lt;tr class="sortHeader"&gt;
     &lt;th&gt;Titel 1&lt;/th&gt;
     &lt;th&gt;Titel 2&lt;/th&gt;
@@ -85,7 +85,7 @@ $xwiki.ssfx.use("js/xwiki/table/table.css")
 $xwiki.jsfx.use("js/xwiki/table/tablefilterNsort.js", true)
 {{/velocity}}
 
-(% class="grid sortable filterable doOddEven" id="tableid" %)
+(% class="grid sortable filterable doOddEven" id="table1id" %)
 (% class="sortHeader" %)|=Titel 1|=Titel 2
 |Zelle 11|Zelle 12
 |Zelle 21|Zelle 22

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTables.fr.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTables.fr.xml
@@ -69,7 +69,7 @@ yellow"&gt;Titre 2&lt;/td&gt;
 $xwiki.jsfx.use
 
 ("js/xwiki/table/tablefilterNsort.js", true)
-&lt;table id="tableid"
+&lt;table id="table1id"
 
 class="grid sortable filterable doOddEven"&gt;
  &lt;tr class="sortHeader"&gt;
@@ -92,7 +92,7 @@ $xwiki.jsfx.use("js/xwiki/table/tablefilterNsort.js", true)
 {{/velocity}}
 
 {{html}}
-&lt;table id="tableid" class="grid sortable filterable doOddEven"&gt;
+&lt;table id="table1id" class="grid sortable filterable doOddEven"&gt;
   &lt;tr class="sortHeader"&gt;
     &lt;th&gt;Titre1&lt;/th&gt;
     &lt;th&gt;Titre2&lt;/th&gt;

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTables.it.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTables.it.xml
@@ -62,7 +62,7 @@ Parola 1 | Parola 2
 |Tabella filtrabile ordinabile|((({{{
 $xwiki.ssfx.use("js/xwiki/table/table.css")
 $xwiki.jsfx.use("js/xwiki/table/tablefilterNsort.js", true)
-&lt;table id="tableid" class="grid sortable filterable doOddEven"&gt;
+&lt;table id="table1id" class="grid sortable filterable doOddEven"&gt;
 &lt;tr class="sortHeader"&gt;
 &lt;th&gt;Titolo1&lt;/th&gt;
 &lt;th&gt;Titolo2&lt;/th&gt;
@@ -85,7 +85,7 @@ $xwiki.ssfx.use("js/xwiki/table/table.css")
 $xwiki.jsfx.use("js/xwiki/table/tablefilterNsort.js", true)
 {{/velocity}}
 
-(% class="grid sortable filterable doOddEven" id="tableid" %)
+(% class="grid sortable filterable doOddEven" id="table1id" %)
 (% class="sortHeader" %)|=Titolo 1|=Titolo 2
 |Cella 11|Cella 12
 |Cella 21|Cella 22

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTables.lv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTables.lv.xml
@@ -63,7 +63,7 @@ Viki tabulas ļauj vienkāršā veidā attēlot saturu tabulas formā.
 {{{
 $xwiki.ssfx.use("js/xwiki/table/table.css")
 $xwiki.jsfx.use("js/xwiki/table/tablefilterNsort.js", true)
-&lt;table id="tableid" class="grid sortable filterable doOddEven"&gt;
+&lt;table id="table1id" class="grid sortable filterable doOddEven"&gt;
 &lt;tr class="sortHeader"&gt;
 &lt;th&gt;1. virsraksts&lt;/th&gt;
 &lt;th&gt;2. virsraksts&lt;/th&gt;
@@ -85,7 +85,7 @@ $xwiki.jsfx.use("js/xwiki/table/tablefilterNsort.js", true)
 {{/velocity}}
 
 {{html}}
-&lt;table id="tableid" class="grid sortable filterable doOddEven"&gt;
+&lt;table id="table1id" class="grid sortable filterable doOddEven"&gt;
 &lt;tr class="sortHeader"&gt;
 &lt;th&gt;1. virsraksts&lt;/th&gt;
 &lt;th&gt;2. virsraksts&lt;/th&gt;

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTables.sv.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTables.sv.xml
@@ -62,7 +62,7 @@ Ord 1 | Ord 2
 |Filtrerbar och sorterbar tabell|((({{{
 $xwiki.ssfx.use("js/xwiki/table/table.css")
 $xwiki.jsfx.use("js/xwiki/table/tablefilterNsort.js", true)
-&lt;table id="tableid" class="grid sortable filterable doOddEven"&gt;
+&lt;table id="table1id" class="grid sortable filterable doOddEven"&gt;
   &lt;tr class="sortHeader"&gt;
     &lt;th&gt;Titel1&lt;/th&gt;
     &lt;th&gt;Titel2&lt;/th&gt;
@@ -85,7 +85,7 @@ $xwiki.ssfx.use("js/xwiki/table/table.css")
 $xwiki.jsfx.use("js/xwiki/table/tablefilterNsort.js", true)
 {{/velocity}}
 
-(% class="grid sortable filterable doOddEven" id="tableid" %)
+(% class="grid sortable filterable doOddEven" id="table1id" %)
 (% class="sortHeader" %)|=Titel 1|=Titel 2
 |Cell 11|Cell 12
 |Cell 21|Cell 22

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTables.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntaxTables.xml
@@ -16,7 +16,6 @@
   <contentUpdateDate>1301497989000</contentUpdateDate>
   <version>1.1</version>
   <title>XWikiSyntaxTables</title>
-  <template/>
   <defaultTemplate/>
   <validationScript/>
   <comment/>
@@ -142,7 +141,7 @@ Word 1 | Word 2
 |Filterable Sortable table|((({{{
 $xwiki.ssfx.use("js/xwiki/table/table.css")
 $xwiki.jsfx.use("js/xwiki/table/tablefilterNsort.js", true)
-&lt;table id="tableid" class="grid sortable filterable doOddEven"&gt;
+&lt;table id="table1id" class="grid sortable filterable doOddEven"&gt;
   &lt;tr class="sortHeader"&gt;
     &lt;th&gt;Title 1&lt;/th&gt;
     &lt;th&gt;Title 2&lt;/th&gt;
@@ -165,7 +164,7 @@ $xwiki.ssfx.use("js/xwiki/table/table.css")
 $xwiki.jsfx.use("js/xwiki/table/tablefilterNsort.js", true)
 {{/velocity}}
 
-(% class="grid sortable filterable doOddEven" id="tableid" %)
+(% class="grid sortable filterable doOddEven" id="table1id" %)
 (% class="sortHeader" %)|=Title 1|=Title 2
 |Cell 11|Cell 12
 |Cell 21|Cell 22


### PR DESCRIPTION
avoid duplicated ids that make the HTMLValidatior tests fail
