### PR TITLE
XWIKI-9756: New XWiki Syntax guide lists every section twice

### DIFF
--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntax.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/XWiki/XWikiSyntax.xml
@@ -66,7 +66,7 @@
 #set($catCount = -1)
 #set($catName = "")
 #set($catChildren = [])
-#set($results = $services.query.xwql('from doc.object(XWiki.XWikiSyntaxClass) as syntax order by syntax.category, syntax.section').addFilter('currentlanguage').execute())
+#set($results = $services.query.xwql('from doc.object(XWiki.XWikiSyntaxClass) as syntax order by syntax.category, syntax.section').addFilter('currentlanguage').addFilter('unique').execute())
 
 #if($results.empty)
   No syntax sections found!


### PR DESCRIPTION
just in case a simple fix is good enough
