### PR TITLE
XWIKI-9738: Finalize migration from workspaces to the new wiki API.

### DIFF
--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-user/xwiki-platform-wiki-user-default/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-user/xwiki-platform-wiki-user-default/pom.xml
@@ -34,7 +34,7 @@
   <description>Default implementation for XWiki Platform - Wiki - User - API</description>
   <packaging>jar</packaging>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.13</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.15</xwiki.jacoco.instructionRatio>
   </properties>
   <dependencies>
     <dependency>
@@ -44,7 +44,7 @@
     </dependency>
     <dependency>
       <groupId>org.xwiki.platform</groupId>
-      <artifactId>xwiki-platform-wiki-default</artifactId>
+      <artifactId>xwiki-platform-wiki-api</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-user/xwiki-platform-wiki-user-default/src/test/java/org/xwiki/wiki/user/internal/WikiUserFromXEMMigrationTest.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-user/xwiki-platform-wiki-user-default/src/test/java/org/xwiki/wiki/user/internal/WikiUserFromXEMMigrationTest.java
@@ -58,7 +58,7 @@ public class WikiUserFromXEMMigrationTest
     @Rule
     public MockitoComponentMockingRule<WikiUserFromXEMMigration> mocker =
             new MockitoComponentMockingRule(WikiUserFromXEMMigration.class, HibernateDataMigration.class,
-                    "R530000WikiUserFromXEMMigration");
+                    "R530010WikiUserFromXEMMigration");
 
     private WikiDescriptorManager wikiDescriptorManager;
 
@@ -181,6 +181,35 @@ public class WikiUserFromXEMMigrationTest
         verify(xwiki, times(1)).saveDocument(memberGroupDoc, "Upgrade candidacies from the old Workspace Application" +
                 " to the new Wiki Application.", xcontext);
 
+    }
+
+    @Test
+    public void upgradeOldWorkspaceTemplate() throws Exception
+    {
+        // Mocks about the descriptor
+        when(wikiDescriptorManager.getCurrentWikiId()).thenReturn("workspacetemplate");
+        XWikiDocument oldDescriptorDocument = mock(XWikiDocument.class);
+        when(xwiki.getDocument(eq(new DocumentReference("mainWiki", XWiki.SYSTEM_SPACE, "XWikiServerWorkspacetemplate")),
+                any(XWikiContext.class))).thenReturn(oldDescriptorDocument);
+
+        // Mock about the workspace panel
+        when(xwiki.exists(eq(new DocumentReference("workspacetemplate", "Panels", "WorkspaceInformationPanel")),
+                any(XWikiContext.class))).thenReturn(true);
+
+        // Mocks about candidacies
+        DocumentReference memberGroupRef = new DocumentReference("workspacetemplate", XWiki.SYSTEM_SPACE,
+                "XWikiAllGroup");
+        XWikiDocument memberGroupDoc = mock(XWikiDocument.class);
+        when(xwiki.getDocument(eq(memberGroupRef), any(XWikiContext.class))).thenReturn(memberGroupDoc);
+
+        // Run
+        mocker.getComponentUnderTest().hibernateMigrate();
+
+        // Verify the user configuration is accurate
+        WikiUserConfiguration expectedConfiguration = new WikiUserConfiguration();
+        expectedConfiguration.setUserScope(UserScope.GLOBAL_ONLY);
+        expectedConfiguration.setMembershipType(MembershipType.INVITE);
+        verify(wikiUserConfigurationHelper).saveConfiguration(eq(expectedConfiguration), eq("workspacetemplate"));
     }
 
 }

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-workspaces-migrator/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-workspaces-migrator/pom.xml
@@ -34,7 +34,7 @@
   <description>Migrator to upgrade wikis modified by the old Workspaces Application</description>
   <packaging>jar</packaging>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.92</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.93</xwiki.jacoco.instructionRatio>
   </properties>
   <dependencies>
     <dependency>

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-workspaces-migrator/src/main/java/org/xwiki/wiki/workspacesmigrator/internal/WorkspacesMigration.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-workspaces-migrator/src/main/java/org/xwiki/wiki/workspacesmigrator/internal/WorkspacesMigration.java
@@ -26,6 +26,7 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.DocumentReference;
@@ -34,6 +35,8 @@ import org.xwiki.wiki.descriptor.WikiDescriptorManager;
 import com.xpn.xwiki.XWiki;
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.objects.BaseObject;
 import com.xpn.xwiki.store.migration.DataMigrationException;
 import com.xpn.xwiki.store.migration.XWikiDBVersion;
 import com.xpn.xwiki.store.migration.hibernate.AbstractHibernateDataMigration;
@@ -51,6 +54,8 @@ public class WorkspacesMigration extends AbstractHibernateDataMigration
 {
     private static final String WORKSPACE_CLASS_SPACE = "WorkspaceManager";
 
+    private static final String WORKSPACE_CLASS_PAGE = "WorkspaceClass";
+
     @Inject
     private WikiDescriptorManager wikiDescriptorManager;
 
@@ -66,16 +71,54 @@ public class WorkspacesMigration extends AbstractHibernateDataMigration
     @Override
     protected void hibernateMigrate() throws DataMigrationException, XWikiException
     {
-        String currentWiki = wikiDescriptorManager.getCurrentWikiId();
+        // Current wiki
+        String currentWikiId = wikiDescriptorManager.getCurrentWikiId();
 
         // Delete the search suggest config object
-        deleteSearchSuggestCustomConfig(currentWiki);
+        deleteSearchSuggestCustomConfig(currentWikiId);
 
-        // If it is not the main wiki
-        if (!currentWiki.equals(wikiDescriptorManager.getMainWikiId())) {
-            // Restore the document removed by WorkspaceManager.Install
-            restoreDeletedDocuments(currentWiki);
+        // If the wiki is a workspace
+        if (isWorkspace(currentWikiId)) {
+            // Restore the documents removed by WorkspaceManager.Install
+            restoreDeletedDocuments(currentWikiId);
         }
+    }
+
+    private boolean isWorkspace(String wikiId) throws DataMigrationException, XWikiException
+    {
+        // The main wiki is not a workspace
+        if (wikiId.equals(wikiDescriptorManager.getMainWikiId())) {
+            return false;
+        }
+
+        // Context, XWiki
+        XWikiContext context = getXWikiContext();
+        XWiki xwiki = context.getWiki();
+
+        // Get the old wiki descriptor
+        DocumentReference oldWikiDescriptorReference = new DocumentReference(wikiDescriptorManager.getMainWikiId(),
+                XWiki.SYSTEM_SPACE, String.format("XWikiServer%s", StringUtils.capitalize(wikiId)));
+        XWikiDocument oldWikiDescriptor = xwiki.getDocument(oldWikiDescriptorReference, context);
+
+        // Try to get the old workspace object
+        DocumentReference oldClassDocument = new DocumentReference(wikiDescriptorManager.getMainWikiId(),
+                WORKSPACE_CLASS_SPACE, WORKSPACE_CLASS_PAGE);
+        BaseObject oldObject = oldWikiDescriptor.getXObject(oldClassDocument);
+
+        return (oldObject != null) || isWorkspaceTemplate(wikiId);
+    }
+
+    private boolean isWorkspaceTemplate(String wikiId)
+    {
+        // Context, XWiki
+        XWikiContext context = getXWikiContext();
+        XWiki xwiki = context.getWiki();
+
+        // In the first version of the Workspace Application, workspacetemplate did not have the workspace object.
+        // We test for the existence of WorkspaceInformationPanel just to be sure that the workspacetemplate is a
+        // workspace.
+        return wikiId.equals("workspacetemplate") && xwiki.exists(new DocumentReference(wikiId,
+                "Panels", "WorkspaceInformationPanel"), context);
     }
 
     @Override


### PR DESCRIPTION
- Fix the build.
- Handle the case where workspacetemplate does not have the workspace object in the descriptor.
