### PR TITLE
XWIKI-9738: Finalize migration from workspaces to the new wiki API.

### DIFF
--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-user/xwiki-platform-wiki-user-default/src/main/java/org/xwiki/wiki/user/internal/WikiUserFromXEMMigration.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-user/xwiki-platform-wiki-user-default/src/main/java/org/xwiki/wiki/user/internal/WikiUserFromXEMMigration.java
@@ -123,10 +123,9 @@ public class WikiUserFromXEMMigration extends AbstractHibernateDataMigration
         XWiki xwiki = context.getWiki();
 
         // In the first version of the Workspace Application, workspacetemplate did not have the workspace object.
-        // We test for the existence of WorkspaceInformationPanel just to be sure that the workspacetemplate is a
-        // workspace.
+        // We test for the existence of XWiki.ManageWorkspace just to be sure that the workspacetemplate is a workspace.
         return wikiId.equals("workspacetemplate") && xwiki.exists(new DocumentReference(wikiId,
-                "Panels", "WorkspaceInformationPanel"), context);
+                "XWiki", "ManageWorkspace"), context);
     }
 
     private void saveConfiguration(WikiUserConfiguration configuration, String wikiId)

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-user/xwiki-platform-wiki-user-default/src/test/java/org/xwiki/wiki/user/internal/WikiUserFromXEMMigrationTest.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-user/xwiki-platform-wiki-user-default/src/test/java/org/xwiki/wiki/user/internal/WikiUserFromXEMMigrationTest.java
@@ -192,8 +192,8 @@ public class WikiUserFromXEMMigrationTest
         when(xwiki.getDocument(eq(new DocumentReference("mainWiki", XWiki.SYSTEM_SPACE, "XWikiServerWorkspacetemplate")),
                 any(XWikiContext.class))).thenReturn(oldDescriptorDocument);
 
-        // Mock about the workspace panel
-        when(xwiki.exists(eq(new DocumentReference("workspacetemplate", "Panels", "WorkspaceInformationPanel")),
+        // Mock about the workspace special page
+        when(xwiki.exists(eq(new DocumentReference("workspacetemplate", "XWiki", "ManageWorkspace")),
                 any(XWikiContext.class))).thenReturn(true);
 
         // Mocks about candidacies

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-workspaces-migrator/src/main/java/org/xwiki/wiki/workspacesmigrator/internal/WorkspacesMigration.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-workspaces-migrator/src/main/java/org/xwiki/wiki/workspacesmigrator/internal/WorkspacesMigration.java
@@ -115,10 +115,9 @@ public class WorkspacesMigration extends AbstractHibernateDataMigration
         XWiki xwiki = context.getWiki();
 
         // In the first version of the Workspace Application, workspacetemplate did not have the workspace object.
-        // We test for the existence of WorkspaceInformationPanel just to be sure that the workspacetemplate is a
-        // workspace.
+        // We test for the existence of XWiki.ManageWorkspace just to be sure that the workspacetemplate is a workspace.
         return wikiId.equals("workspacetemplate") && xwiki.exists(new DocumentReference(wikiId,
-                "Panels", "WorkspaceInformationPanel"), context);
+                "XWiki", "ManageWorkspace"), context);
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-workspaces-migrator/src/test/java/org/xwiki/wiki.workspacesmigrator.internal/WorkspaceMigrationTest.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-workspaces-migrator/src/test/java/org/xwiki/wiki.workspacesmigrator.internal/WorkspaceMigrationTest.java
@@ -127,10 +127,10 @@ public class WorkspaceMigrationTest
         when(xwiki.getDocument(eq(new DocumentReference("mainWiki", XWiki.SYSTEM_SPACE,
                 "XWikiServerWorkspacetemplate")), any(XWikiContext.class))).thenReturn(oldDescriptorDocument);
 
-        // Mock that the workspace panel exists
-        DocumentReference workspacePanelReference = new DocumentReference("workspacetemplate", "Panels",
-                "WorkspaceInformationPanel");
-        when(xwiki.exists(eq(workspacePanelReference), any(XWikiContext.class))).thenReturn(true);
+        // Mock that the workspace special page exists
+        DocumentReference workspacePageReference = new DocumentReference("workspacetemplate", "XWiki",
+                "ManageWorkspace");
+        when(xwiki.exists(eq(workspacePageReference), any(XWikiContext.class))).thenReturn(true);
 
         // Run
         mocker.getComponentUnderTest().hibernateMigrate();


### PR DESCRIPTION
- Test if XWiki.ManagerWorkspace exists instead of Panels.WorkspaceInformationPanel (might be better, there is less probability that the user has removed that technical page than a panel).
