### PR TITLE
XWIKI-9772: After an upgrade, XWikiServerClass has no sheet.

### DIFF
--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/main/java/org/xwiki/wiki/internal/descriptor/document/XWikiServerClassDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/main/java/org/xwiki/wiki/internal/descriptor/document/XWikiServerClassDocumentInitializer.java
@@ -279,7 +279,7 @@ public class XWikiServerClassDocumentInitializer extends AbstractMandatoryDocume
         // specified.
         if (this.classSheetBinder.getSheets(document).isEmpty()) {
             String wikiName = document.getDocumentReference().getWikiReference().getName();
-            DocumentReference sheet = new DocumentReference(wikiName, "WikiManager", "XWikiServerClassSheet");
+            DocumentReference sheet = new DocumentReference(wikiName, XWiki.SYSTEM_SPACE, "XWikiServerClassSheet");
             needsUpdate |= this.classSheetBinder.bind(document, sheet);
         }
 

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-mainwiki/src/main/resources/XWiki/XWikiServerClassSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-mainwiki/src/main/resources/XWiki/XWikiServerClassSheet.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <xwikidoc>
-  <web>WikiManager</web>
+  <web>XWiki</web>
   <name>XWikiServerClassSheet</name>
   <language/>
   <defaultLanguage/>


### PR DESCRIPTION
- Move XWikiServerClassSheet to the XWiki space.
