### PR TITLE
XWIKI-9673: Main wiki descriptor page XWiki.XWikiServerXwiki is missing after Wiki Manager installation.

### DIFF
--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-mainwiki/src/main/resources/XWiki/XWikiServerClassSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-mainwiki/src/main/resources/XWiki/XWikiServerClassSheet.xml
@@ -123,7 +123,7 @@
           &lt;/dd&gt;
         &lt;dt&gt;{{translation key="platform.wiki.sheet.prop.description"/}}:&lt;/dt&gt;
           &lt;dd&gt;
-            ## No &lt;p&gt; here because the "description" field contains its owns.
+            ## No &lt;p&gt; here because the "description" field contains its own.
             $doc.display("description", $firstalias)&lt;br/&gt;
             {{translation key="platform.wiki.sheet.desc.description"/}}
           &lt;/dd&gt;


### PR DESCRIPTION
- Fix HTML violation
