### PR TITLE
XWIKI-9905: Fix the list of members for subwikis

### DIFF
--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-mainwiki/src/main/resources/WikiManager/CreateWiki.xml
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-mainwiki/src/main/resources/WikiManager/CreateWiki.xml
@@ -1095,7 +1095,7 @@ return XWiki;
         #set ($discard = $globalMembers.add("${member}"))
       #end
       ## Add the members
-      #set($discard = $services.wiki.user.addMembers($globalMembers, $wikiDescriptor.id))
+      #set ($discard = $services.wiki.user.addMembers($globalMembers, $wikiDescriptor.id))
     #end
   #end
   ## Redirect to the new wiki's homepage.


### PR DESCRIPTION
- Add "xwiki:" in front of every member of the list if it's not already there

(see http://jira.xwiki.org/browse/XWIKI-9905)
