### PR TITLE
XWIKI-9970: Look at 'displayMainMenu' in edit mode

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/edit.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/edit.vm
@@ -60,7 +60,11 @@
   #template("xwikivars.vm")
   #template("layoutvars.vm")
   #template("htmlheader.vm")
-  #template("menuview.vm")
+  #if($displayMainMenu)
+    <div id="menuview">
+      #template("menuview.vm")
+    </div>
+  #end
   #template("header.vm")
   #if($editor == 'wiki' || $editor == 'wysiwyg')
     <form id="edit" method="post" action="$doc.getURL('preview')" class="withLock">


### PR DESCRIPTION
- The 'displayMainMenu' is now checked before loading the 'menuview.vm' in edit
  mode
