### PR TITLE
Edit + Save existing page-comments through a dedicated action)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiRightServiceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiRightServiceImpl.java
@@ -136,6 +136,7 @@ public class XWikiRightServiceImpl implements XWikiRightService
             actionMap.put("undelete", "undelete");
             actionMap.put("reset", "delete");
             actionMap.put("commentadd", "comment");
+            actionMap.put("commentsave", "comment");
             actionMap.put("register", "register");
             actionMap.put("redirect", "view");
             actionMap.put("admin", "admin");

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/CommentSaveAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/CommentSaveAction.java
@@ -1,0 +1,96 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xpn.xwiki.web;
+
+
+
+import com.xpn.xwiki.XWiki;
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.objects.classes.BaseClass;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Action used to edit+save an existing comment in a page, saves the comment
+ * object in the document, requires comment right but not edit right.
+ * 
+ * @version $Id$
+ */
+public class CommentSaveAction extends XWikiAction
+{
+    protected static final Logger LOGGER = LoggerFactory.getLogger(CommentSaveAction.class);
+
+    /** The name of the XWikiComments property identifying the author. */
+    private static final String AUTHOR_PROPERTY_NAME = "author";
+
+    /** The name of the space where user profiles are kept. */
+    private static final String USER_SPACE_PREFIX = "XWiki.";
+
+
+    @Override
+    public boolean action(XWikiContext context) throws XWikiException
+    {
+
+        LOGGER.info("Action! " + context.getAction());
+        // dit wil je:
+        // doc.readObjectsFromForm(EditForm eform, XWikiContext context) throws XWikiException
+
+        // CSRF prevention
+        if (!csrfTokenCheck(context)) {
+            return false;
+        }
+
+        XWiki xwiki = context.getWiki();
+        XWikiResponse response = context.getResponse();
+        XWikiDocument doc = context.getDoc();
+        EditForm eform = (EditForm) context.getForm();
+
+        // Make sure this class exists
+        BaseClass baseclass = xwiki.getCommentsClass(context);
+        if (doc.isNew()) {
+            return true;
+        } else {
+            doc.readObjectsFromForm(eform, context);
+            xwiki.saveDocument(doc, context.getMessageTool().get("core.comment.addComment"), true, context);
+        }
+        // If xpage is specified then allow the specified template to be parsed.
+        if (context.getRequest().get("xpage") != null) {
+            return true;
+        }
+        // forward to edit
+        String redirect = Utils.getRedirect("edit", context);
+        sendRedirect(response, redirect);
+        return false;
+    }
+
+    @Override
+    public String render(XWikiContext context) throws XWikiException
+    {
+        if (context.getDoc().isNew()) {
+            context.put("message", "nocommentwithnewdoc");
+            return "exception";
+        }
+        return "";
+    }
+
+}

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-bridge/src/main/java/org/xwiki/security/authorization/internal/XWikiCachingRightService.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-bridge/src/main/java/org/xwiki/security/authorization/internal/XWikiCachingRightService.java
@@ -93,6 +93,7 @@ public class XWikiCachingRightService implements XWikiRightService
             .putAction("undelete", Right.EDIT)
             .putAction("reset", Right.DELETE)
             .putAction("commentadd", Right.COMMENT)
+            .putAction("commentsave", Right.COMMENT)
             .putAction("redirect", Right.VIEW)
             .putAction("export", Right.VIEW)
             .putAction("import", Right.ADMIN)

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/WEB-INF/struts-config.xml
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/WEB-INF/struts-config.xml
@@ -36,6 +36,8 @@
                    type="com.xpn.xwiki.web.EditForm"/>
         <form-bean name="save"
                    type="com.xpn.xwiki.web.EditForm"/>
+        <form-bean name="commentsave"
+                   type="com.xpn.xwiki.web.EditForm"/>
         <form-bean name="saveandcontinue"
                    type="com.xpn.xwiki.web.EditForm"/>
         <form-bean name="rollback"
@@ -259,6 +261,12 @@
                 name="commentadd"
                 scope="request">
             <forward name="commentadd" path="/templates/edit.vm"/>
+        </action>
+        <action path="/commentsave/"
+                type="com.xpn.xwiki.web.CommentSaveAction"
+                name="commentsave"
+                scope="request">
+            <forward name="commentsave" path="/templates/edit.vm"/>
         </action>
 
         <action path="/objectsync/"

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/commentsinline.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/commentsinline.vm
@@ -154,7 +154,7 @@ $xwiki.ssfx.use('uicomponents/viewers/comments.css', true)
       <span class="commenttool comment-permalink"><a class="permalink" rel="nofollow" href="$doc.getURL('view', 'viewer=comments')#xwikicomment_${comment.number}" title="$services.localization.render('core.viewers.comments.permalink')">$services.localization.render('core.viewers.comments.permalink')</a></span>
       #if($xwiki.hasAccessLevel('comment'))
         <span class="commenttool commentreply"><a class="commentreply" rel="nofollow" href="$xredirect.replaceAll('&?replyto=\d++', '')&amp;replyto=${comment.number}#xwikicomment_${comment.number}" title="$services.localization.render('core.viewers.comments.reply')"#if("$!replyTo" == "${comment.number}") style="display: none;"#end>$services.localization.render('core.viewers.comments.reply')</a></span>
-        #if($comment.author == $xcontext.user && $hasEdit)
+        #if($comment.author == $xcontext.user)
           <span class="commenttool commentedit"><a class="edit" rel="nofollow" href="$doc.getURL('view', "viewer=comments&amp;number=${comment.number}&amp;xredirect=$xredirect")" title="$services.localization.render('core.viewers.comments.edit')">$services.localization.render('core.viewers.comments.edit')</a></span>
         #end
       #end
@@ -243,7 +243,7 @@ $xwiki.ssfx.use('uicomponents/viewers/comments.css', true)
 ##
 #macro(displayEditCommentForm $comment)
   #if (${comment.author} == ${xcontext.user})
-  <form action="$doc.getURL('save')" method="post" class="edit-xcomment reply">
+  <form action="$doc.getURL('commentsave')" method="post" class="edit-xcomment reply">
     <div id="xwikicomment_${comment.number}" class="xwikicomment#if($comment.getProperty('author').value == $doc.creator) commentByCreator#end">
     <div class="commentavatar">#if("$!comment.replyto" == '')#mediumUserAvatar($comment.author)#{else}#smallUserAvatar($comment.author)#end</div>
     <div class="commentheader">
@@ -263,7 +263,7 @@ $xwiki.ssfx.use('uicomponents/viewers/comments.css', true)
       <input type="hidden" name="xredirect" value="$xredirect">
     </div>
     <div>
-      <span class="buttonwrapper"><input type="submit" name="action_save" class="button" value="$services.localization.render('core.viewers.comments.edit.save')"/></span>
+      <span class="buttonwrapper"><input type="submit" name="action_commentsave" class="button" value="$services.localization.render('core.viewers.comments.edit.save')"/></span>
       <span class="buttonwrapper"><a class="cancel secondary button" href="$doc.getURL('view', 'viewer=comments')">$services.localization.render('core.viewers.comments.edit.cancel')</a></span>
     </div>
 


### PR DESCRIPTION
I propose a dedicated action CommentSaveAction similar to CommantAddAction to allow users without edit-right to edit and save their own comments.

With the existing action CommentAdd people with comment-right could already add comments to xwiki-pages without the need to have edit-right. In practise it is counter-intuitive for them to lack the ability to change comments they created themselves. 