### PR TITLE
XWIKI-10297_PageHistoryResourceImpl.java

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PageHistoryResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PageHistoryResourceImpl.java
@@ -53,6 +53,7 @@ public class PageHistoryResourceImpl extends XWikiResource implements PageHistor
         try {
             Utils.getXWikiContext(componentManager).setDatabase(wikiName);
 
+            // Note that the query is made to work with Oracle which treats empty strings as null.
             String query = String.format("select doc.space, doc.name, rcs.id, rcs.date, rcs.author, rcs.comment"
                 + " from XWikiRCSNodeInfo as rcs, XWikiDocument as doc where rcs.id.docId = doc.id and"
                 + " doc.space = :space and doc.name = :name and (doc.language = '' or doc.language is null)"


### PR DESCRIPTION
Getting the history of a page on oracle does not work. This patch fixes the problem.
