### PR TITLE
XWIKI-10309: Phishing Through URL Redirection

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiServletResponse.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiServletResponse.java
@@ -77,6 +77,13 @@ public class XWikiServletResponse implements XWikiResponse
             LOGGER.warn("Possible HTTP Response Splitting attack, attempting to redirect to [{}]", redirect);
             return;
         }
+        if (redirect.matches("[a-z0-9]+://.*")) {
+            // Full URL, check that the hostname matches
+            if (!redirect.matches("[a-z0-9]+://" + Utils.getContext().getRequest().getServerName() + "[:/].*")) {
+                LOGGER.warn("Possible phishing attack, attempting to redirect to [{}]", redirect);
+                return;
+            }
+        }
         this.httpStatus = SC_FOUND;
         this.response.sendRedirect(redirect);
     }


### PR DESCRIPTION
I'm not sure this is safe:
- is there any page that uses `xredirect` to redirect to a different wiki?
- is there any chance that `xredirect` uses a full URL that has a different host than what XWiki believes was requested, for example an IP vs. name, or `localhost` seen behind a proxy?
