### PR TITLE
XWIKI-10432: "floating box" no longer floats

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/src/main/resources/flamingo/less/misc.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/src/main/resources/flamingo/less/misc.less
@@ -161,3 +161,11 @@ table {
     }
   }
 }
+
+//FIX: floating box
+div.floatinginfobox {
+    background-color: #F3F3F3;
+    float: right;
+    margin: 0.66em 0 1em 1em;
+    padding: 10px;
+}


### PR DESCRIPTION
Floating box is not displayed correctly on flamingo skin, because CSS instruction (div.floatinginfobox) missing.
Cf.: http://jira.xwiki.org/browse/XWIKI-10432
