### PR TITLE
XWIKI-10606: Filter in Livetable macro does not work under MSSQL database

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/main/resources/XWiki/LiveTableResultsMacros.xml
+++ b/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/main/resources/XWiki/LiveTableResultsMacros.xml
@@ -572,7 +572,7 @@
   #if("$!filterValue" != '')
     #set($discard = $tablelist.add($tableAlias))
     #if($colname.startsWith('doc.'))
-      #set($whereSql = "${whereSql} and upper(str(${safe_colname.replace('_','.')})) like upper(?)")
+      #set($whereSql = "${whereSql} and upper(${safe_colname.replace('_','.')}) like upper(?)")
       #set($discard = $whereParams.add("%${filterValue}%"))
     #elseif($propType == 'NumberClass' || $propType == 'BooleanClass')
       #livetable_getTableName($colname)


### PR DESCRIPTION
The str() call does not work on MS SQL. However the code works also without the str call.
