### PR TITLE
XWIKI-10690

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/src/main/resources/flamingo/menus/create.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/src/main/resources/flamingo/menus/create.vm
@@ -7,7 +7,7 @@
 ## - and the wiki application has been installed.
 ## (in the future the last condition will be removed since we will use the Distribution Wizard for wiki creation)
 #set ($displayCreateWiki = $isWikiAPIAvailable && $isWikiUIAvailable && $hasCreateWiki)
-#set ($displayCreateSubmenu = $hasCreateSpace || $hasCreatePage || $hasComment || $displayCreateWiki)
+#set ($displayCreateSubmenu = $hasCreateSpace || $hasCreatePage || $displayCreateWiki)
 #if ($displayCreateSubmenu)
   #xwikicreatemenuentrystart('' $services.localization.render('core.menu.create') 'tmCreate' 'hasIcon' 'plus')
   #if ($displayCreateWiki)


### PR DESCRIPTION
when a user is only allowed to add Comment on a page, the submenu of "create" button is empty.
