### PR TITLE
Missing translation in export menu in flamingo skin

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -885,7 +885,6 @@ core.menu.export.odt=Export as ODT
 core.menu.export.rtf=Export as RTF
 core.menu.export.html=Export as HTML
 core.menu.export.xar=Export as XAR
-core.menu.export.cancel=Cancel
 core.menu.watchlist.add=Watch
 core.menu.watchlist.remove=Unwatch
 core.menu.watchlist.add.document=Watch document


### PR DESCRIPTION
Missing multi language parameter for export menu of flamingo skin.
