### PR TITLE
XWIKI-11020: Gallery widget sets invalid dimensions for container element in maximized mode

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/widgets/gallery/gallery.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/widgets/gallery/gallery.js
@@ -150,7 +150,7 @@ XWiki.Gallery = Class.create({
     var width = dimensions.width - 20;
     var height = dimensions.height - 20;
     if (!this._isIE6()) {
-      this.container.setStyle({width: width + 'px', height: height + 'px'});
+      this.container.setStyle({width: dimensions.width + 'px', height: dimensions.height + 'px'});
     }
     this.currentImage.up().setStyle({height: height + 'px', lineHeight: height + 'px'});
     // Remove width reserved for the navigation arrows.


### PR DESCRIPTION
dimensions.width / dimensions.height should be used for the main container in maximized mode to avoid empty borders
