### PR TITLE
    XWIKI-11006 : The icon from annotation is not well displayed if you annotate a title

### DIFF
--- a/xwiki-platform-core/xwiki-platform-annotations/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Style.xml
+++ b/xwiki-platform-core/xwiki-platform-annotations/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Style.xml
@@ -302,7 +302,7 @@ AABJRU5ErkJggg==
   width: 10px;
   vertical-align: baseline;
   ##margin: -19px -14px 3px -2px;
-  margin: -15px -7px 5px -3px;
+  margin: -15px -7px 0.6em -3px;
   z-index: 1;
   position: relative;
   cursor: pointer;


### PR DESCRIPTION
My proposal is to use the "em" measurement unit, since it is relative to the current font size. The value 0.6 seems to be the best fit for the positioning issue of the annotation icon.
