### PR TITLE
Remove redondancy in the API

### DIFF
--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-rest/xwiki-platform-wiki-rest-default/src/main/java/org/xwiki/wiki/rest/internal/DefaultWikiManagerREST.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-rest/xwiki-platform-wiki-rest-default/src/main/java/org/xwiki/wiki/rest/internal/DefaultWikiManagerREST.java
@@ -23,7 +23,6 @@ import java.net.URI;
 
 import javax.inject.Inject;
 import javax.ws.rs.POST;
-import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
@@ -58,7 +57,6 @@ import com.xpn.xwiki.XWikiContext;
  * @version $Id$
  */
 @Component("org.xwiki.wiki.rest.internal.DefaultWikiManagerREST")
-@Path("/wikimanager")
 public class DefaultWikiManagerREST extends XWikiResource implements WikiManagerREST
 {
     @Inject


### PR DESCRIPTION
Just remove a redundancy in the declaration of API paths (REST service `xwiki-platform-wiki` module)  since it's already defined in the [`xwiki-platform-wiki-rest-api`](https://github.com/xwiki/xwiki-platform/blob/master/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-rest/xwiki-platform-wiki-rest-api/src/main/java/org/xwiki/wiki/rest/WikiManagerREST.java#L35) module