### PR TITLE
Fix the deprecated uses of @Component

### DIFF
--- a/xwiki-platform-core/xwiki-platform-annotations/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/representations/FormUrlEncodedAnnotationAddRequestReader.java
+++ b/xwiki-platform-core/xwiki-platform-annotations/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/representations/FormUrlEncodedAnnotationAddRequestReader.java
@@ -22,6 +22,7 @@ package org.xwiki.annotation.rest.internal.representations;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.core.MediaType;
@@ -38,7 +39,8 @@ import org.xwiki.component.annotation.Component;
  * @version $Id$
  * @since 2.3M1
  */
-@Component("org.xwiki.annotation.rest.internal.representations.FormUrlEncodedAnnotationAddRequestReader")
+@Component
+@Named("org.xwiki.annotation.rest.internal.representations.FormUrlEncodedAnnotationAddRequestReader")
 @Provider
 @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 @Singleton

--- a/xwiki-platform-core/xwiki-platform-annotations/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/representations/FormUrlEncodedAnnotationRequestReader.java
+++ b/xwiki-platform-core/xwiki-platform-annotations/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/representations/FormUrlEncodedAnnotationRequestReader.java
@@ -22,6 +22,7 @@ package org.xwiki.annotation.rest.internal.representations;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.core.MediaType;
@@ -35,7 +36,8 @@ import org.xwiki.component.annotation.Component;
  * @version $Id$
  * @since 2.3M1
  */
-@Component("org.xwiki.annotation.rest.internal.representations.FormUrlEncodedAnnotationRequestReader")
+@Component
+@Named("org.xwiki.annotation.rest.internal.representations.FormUrlEncodedAnnotationRequestReader")
 @Provider
 @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 @Singleton

--- a/xwiki-platform-core/xwiki-platform-annotations/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/representations/FormUrlEncodedAnnotationUpdateRequestReader.java
+++ b/xwiki-platform-core/xwiki-platform-annotations/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/representations/FormUrlEncodedAnnotationUpdateRequestReader.java
@@ -22,6 +22,7 @@ package org.xwiki.annotation.rest.internal.representations;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.core.MediaType;
@@ -38,7 +39,8 @@ import org.xwiki.component.annotation.Component;
  * @version $Id$
  * @since 2.3M1
  */
-@Component("org.xwiki.annotation.rest.internal.representations.FormUrlEncodedAnnotationUpdateRequestReader")
+@Component
+@Named("org.xwiki.annotation.rest.internal.representations.FormUrlEncodedAnnotationUpdateRequestReader")
 @Provider
 @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 @Singleton

--- a/xwiki-platform-core/xwiki-platform-captcha/src/main/java/org/xwiki/captcha/internal/velocity/VelocityXWikiCaptchaService.java
+++ b/xwiki-platform-core/xwiki-platform-captcha/src/main/java/org/xwiki/captcha/internal/velocity/VelocityXWikiCaptchaService.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.captcha.internal.velocity;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
@@ -32,7 +33,8 @@ import org.xwiki.captcha.CaptchaVerifierNotFoundException;
  * @version $Id$
  * @since 2.2M2
  */
-@Component("velocity")
+@Component
+@Named("velocity")
 @Singleton
 public class VelocityXWikiCaptchaService extends DefaultXWikiCaptchaService
 {

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-annotation/src/main/java/org/xwiki/annotation/internal/AnnotationVelocityContextInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-annotation/src/main/java/org/xwiki/annotation/internal/AnnotationVelocityContextInitializer.java
@@ -20,6 +20,7 @@
 package org.xwiki.annotation.internal;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.apache.velocity.VelocityContext;
@@ -37,7 +38,8 @@ import org.xwiki.velocity.VelocityContextInitializer;
  * @since 2.3M1
  * @deprecated starting with 3.0RC1 use directly the Annotation Script Service from scripts
  */
-@Component("annotations")
+@Component
+@Named("annotations")
 @Singleton
 @Deprecated
 public class AnnotationVelocityContextInitializer implements VelocityContextInitializer

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/ExtensionUpdaterListener.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/ExtensionUpdaterListener.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
@@ -37,7 +38,8 @@ import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.objects.BaseObject;
 
-@Component("ExtensionUpdaterListener")
+@Component
+@Named("ExtensionUpdaterListener")
 @Singleton
 public class ExtensionUpdaterListener implements EventListener
 {

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/ExtensionRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/ExtensionRESTResource.java
@@ -20,6 +20,7 @@
 
 package org.xwiki.repository.internal.resources;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -37,7 +38,8 @@ import com.xpn.xwiki.doc.XWikiDocument;
  * @version $Id$
  * @since 3.2M3
  */
-@Component("org.xwiki.repository.internal.resources.ExtensionRESTResource")
+@Component
+@Named("org.xwiki.repository.internal.resources.ExtensionRESTResource")
 @Path(Resources.EXTENSION)
 @Singleton
 public class ExtensionRESTResource extends AbstractExtensionRESTResource

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/ExtensionVersionFileRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/ExtensionVersionFileRESTResource.java
@@ -26,6 +26,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -75,7 +76,8 @@ import com.xpn.xwiki.objects.BaseObject;
  * @version $Id$
  * @since 3.2M3
  */
-@Component("org.xwiki.repository.internal.resources.ExtensionVersionFileRESTResource")
+@Component
+@Named("org.xwiki.repository.internal.resources.ExtensionVersionFileRESTResource")
 @Path(Resources.EXTENSION_VERSION_FILE)
 @Singleton
 public class ExtensionVersionFileRESTResource extends AbstractExtensionRESTResource

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/ExtensionVersionRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/ExtensionVersionRESTResource.java
@@ -20,6 +20,7 @@
 
 package org.xwiki.repository.internal.resources;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -37,7 +38,8 @@ import com.xpn.xwiki.doc.XWikiDocument;
  * @version $Id$
  * @since 3.2M3
  */
-@Component("org.xwiki.repository.internal.resources.ExtensionVersionRESTResource")
+@Component
+@Named("org.xwiki.repository.internal.resources.ExtensionVersionRESTResource")
 @Path(Resources.EXTENSION_VERSION)
 @Singleton
 public class ExtensionVersionRESTResource extends AbstractExtensionRESTResource

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/ExtensionVersionsRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/ExtensionVersionsRESTResource.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -47,7 +48,8 @@ import org.xwiki.repository.Resources;
  * @version $Id$
  * @since 3.2M3
  */
-@Component("org.xwiki.repository.internal.resources.ExtensionVersionsRESTResource")
+@Component
+@Named("org.xwiki.repository.internal.resources.ExtensionVersionsRESTResource")
 @Path(Resources.EXTENSION_VERSIONS)
 @Singleton
 public class ExtensionVersionsRESTResource extends AbstractExtensionRESTResource

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/ExtensionsRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/ExtensionsRESTResource.java
@@ -20,6 +20,7 @@
 
 package org.xwiki.repository.internal.resources;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -36,7 +37,8 @@ import org.xwiki.repository.Resources;
  * @version $Id$
  * @since 3.2M3
  */
-@Component("org.xwiki.repository.internal.resources.ExtensionsRESTResource")
+@Component
+@Named("org.xwiki.repository.internal.resources.ExtensionsRESTResource")
 @Path(Resources.EXTENSIONS)
 @Singleton
 public class ExtensionsRESTResource extends AbstractExtensionRESTResource

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/RepositoryRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/RepositoryRESTResource.java
@@ -20,6 +20,7 @@
 
 package org.xwiki.repository.internal.resources;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -32,7 +33,8 @@ import org.xwiki.repository.Resources;
  * @version $Id$
  * @since 7.1RC1
  */
-@Component("org.xwiki.repository.internal.resources.RepositoryRESTResource")
+@Component
+@Named("org.xwiki.repository.internal.resources.RepositoryRESTResource")
 @Path(Resources.ENTRYPOINT)
 @Singleton
 public class RepositoryRESTResource extends AbstractExtensionRESTResource

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/SearchRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/SearchRESTResource.java
@@ -23,6 +23,7 @@ package org.xwiki.repository.internal.resources;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -49,7 +50,8 @@ import org.xwiki.repository.internal.XWikiRepositoryModel;
  * @version $Id$
  * @since 3.2M3
  */
-@Component("org.xwiki.repository.internal.resources.SearchRESTResource")
+@Component
+@Named("org.xwiki.repository.internal.resources.SearchRESTResource")
 @Path(Resources.SEARCH)
 @Singleton
 public class SearchRESTResource extends AbstractExtensionRESTResource

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/exceptions/XWikiRestExceptionMapper.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/exceptions/XWikiRestExceptionMapper.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.rest.internal.exceptions;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -39,7 +40,8 @@ import com.xpn.xwiki.XWikiException;
  * @version $Id$
  * @since 4.3M2
  */
-@Component("org.xwiki.rest.internal.exceptions.XWikiRestExceptionMapper")
+@Component
+@Named("org.xwiki.rest.internal.exceptions.XWikiRestExceptionMapper")
 @Provider
 @Singleton
 public class XWikiRestExceptionMapper implements ExceptionMapper<XWikiRestException>, XWikiRestComponent

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/representations/comments/FormUrlEncodedCommentReader.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/representations/comments/FormUrlEncodedCommentReader.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
@@ -46,7 +47,8 @@ import org.xwiki.rest.model.jaxb.ObjectFactory;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.representations.comments.FormUrlEncodedCommentReader")
+@Component
+@Named("org.xwiki.rest.internal.representations.comments.FormUrlEncodedCommentReader")
 @Provider
 @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 @Singleton

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/representations/comments/TextPlainCommentReader.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/representations/comments/TextPlainCommentReader.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.WebApplicationException;
@@ -39,7 +40,8 @@ import org.xwiki.rest.model.jaxb.ObjectFactory;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.representations.comments.TextPlainCommentReader")
+@Component
+@Named("org.xwiki.rest.internal.representations.comments.TextPlainCommentReader")
 @Provider
 @Consumes(MediaType.TEXT_PLAIN)
 @Singleton

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/representations/objects/FormUrlEncodedObjectReader.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/representations/objects/FormUrlEncodedObjectReader.java
@@ -25,6 +25,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Enumeration;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
@@ -48,7 +49,8 @@ import org.xwiki.rest.model.jaxb.Property;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.representations.objects.FormUrlEncodedObjectReader")
+@Component
+@Named("org.xwiki.rest.internal.representations.objects.FormUrlEncodedObjectReader")
 @Provider
 @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 @Singleton

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/representations/objects/FormUrlEncodedPropertyReader.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/representations/objects/FormUrlEncodedPropertyReader.java
@@ -25,6 +25,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Enumeration;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
@@ -47,7 +48,8 @@ import org.xwiki.rest.model.jaxb.Property;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.representations.objects.FormUrlEncodedPropertyReader")
+@Component
+@Named("org.xwiki.rest.internal.representations.objects.FormUrlEncodedPropertyReader")
 @Provider
 @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 @Singleton

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/representations/objects/TextPlainPropertyReader.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/representations/objects/TextPlainPropertyReader.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.WebApplicationException;
@@ -39,7 +40,8 @@ import org.xwiki.rest.model.jaxb.Property;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.representations.objects.TextPlainPropertyReader")
+@Component
+@Named("org.xwiki.rest.internal.representations.objects.TextPlainPropertyReader")
 @Provider
 @Consumes(MediaType.TEXT_PLAIN)
 @Singleton

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/representations/pages/FormUrlEncodedPageReader.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/representations/pages/FormUrlEncodedPageReader.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
@@ -46,7 +47,8 @@ import org.xwiki.rest.model.jaxb.Page;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.representations.pages.FormUrlEncodedPageReader")
+@Component
+@Named("org.xwiki.rest.internal.representations.pages.FormUrlEncodedPageReader")
 @Provider
 @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 @Singleton

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/representations/pages/TextPlainPageReader.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/representations/pages/TextPlainPageReader.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.WebApplicationException;
@@ -39,7 +40,8 @@ import org.xwiki.rest.model.jaxb.Page;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.representations.pages.TextPlainPageReader")
+@Component
+@Named("org.xwiki.rest.internal.representations.pages.TextPlainPageReader")
 @Provider
 @Consumes(MediaType.TEXT_PLAIN)
 @Singleton

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/representations/tags/FormUrlEncodedTagsReader.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/representations/tags/FormUrlEncodedTagsReader.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.Consumes;
@@ -48,7 +49,8 @@ import org.xwiki.rest.model.jaxb.Tags;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.representations.tags.FormUrlEncodedTagsReader")
+@Component
+@Named("org.xwiki.rest.internal.representations.tags.FormUrlEncodedTagsReader")
 @Provider
 @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 @Singleton

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/representations/tags/TextPlainTagsReader.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/representations/tags/TextPlainTagsReader.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
+import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.WebApplicationException;
@@ -40,7 +41,8 @@ import org.xwiki.rest.model.jaxb.Tags;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.representations.tags.TextPlainTagsReader")
+@Component
+@Named("org.xwiki.rest.internal.representations.tags.TextPlainTagsReader")
 @Provider
 @Consumes(MediaType.TEXT_PLAIN)
 @Singleton

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/ModificationsResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/ModificationsResourceImpl.java
@@ -23,6 +23,8 @@ import java.sql.Timestamp;
 import java.util.Date;
 import java.util.List;
 
+import javax.inject.Named;
+
 import org.xwiki.component.annotation.Component;
 import org.xwiki.query.Query;
 import org.xwiki.query.QueryException;
@@ -39,7 +41,8 @@ import com.xpn.xwiki.doc.rcs.XWikiRCSNodeId;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.ModificationsResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.ModificationsResourceImpl")
 public class ModificationsResourceImpl extends XWikiResource implements ModificationsResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/RootResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/RootResourceImpl.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.rest.internal.resources;
 
+import javax.inject.Named;
+
 import org.xwiki.component.annotation.Component;
 import org.xwiki.rest.XWikiResource;
 import org.xwiki.rest.internal.DomainObjectFactory;
@@ -29,7 +31,8 @@ import org.xwiki.rest.resources.RootResource;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.RootResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.RootResourceImpl")
 public class RootResourceImpl extends XWikiResource implements RootResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/SyntaxesResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/SyntaxesResourceImpl.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.rest.internal.resources;
 
+import javax.inject.Named;
+
 import org.xwiki.component.annotation.Component;
 import org.xwiki.rest.XWikiResource;
 import org.xwiki.rest.internal.Utils;
@@ -28,7 +30,8 @@ import org.xwiki.rest.resources.SyntaxesResource;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.SyntaxesResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.SyntaxesResourceImpl")
 public class SyntaxesResourceImpl extends XWikiResource implements SyntaxesResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/attachments/AttachmentAtPageVersionResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/attachments/AttachmentAtPageVersionResourceImpl.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.rest.internal.resources.attachments;
 
+import javax.inject.Named;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -34,7 +35,8 @@ import com.xpn.xwiki.api.Document;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.attachments.AttachmentAtPageVersionResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.attachments.AttachmentAtPageVersionResourceImpl")
 public class AttachmentAtPageVersionResourceImpl extends XWikiResource implements AttachmentAtPageVersionResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/attachments/AttachmentHistoryResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/attachments/AttachmentHistoryResourceImpl.java
@@ -23,6 +23,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.inject.Named;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 
@@ -42,7 +43,8 @@ import com.xpn.xwiki.api.Document;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.attachments.AttachmentHistoryResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.attachments.AttachmentHistoryResourceImpl")
 public class AttachmentHistoryResourceImpl extends XWikiResource implements AttachmentHistoryResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/attachments/AttachmentResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/attachments/AttachmentResourceImpl.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.rest.internal.resources.attachments;
 
+import javax.inject.Named;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -37,7 +38,8 @@ import com.xpn.xwiki.doc.XWikiDocument;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.attachments.AttachmentResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.attachments.AttachmentResourceImpl")
 public class AttachmentResourceImpl extends BaseAttachmentsResource implements AttachmentResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/attachments/AttachmentVersionResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/attachments/AttachmentVersionResourceImpl.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.rest.internal.resources.attachments;
 
+import javax.inject.Named;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -34,7 +35,8 @@ import com.xpn.xwiki.api.Document;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.attachments.AttachmentVersionResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.attachments.AttachmentVersionResourceImpl")
 public class AttachmentVersionResourceImpl extends XWikiResource implements AttachmentVersionResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/attachments/AttachmentsAtPageVersionResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/attachments/AttachmentsAtPageVersionResourceImpl.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.rest.internal.resources.attachments;
 
+import javax.inject.Named;
+
 import org.xwiki.component.annotation.Component;
 import org.xwiki.rest.XWikiRestException;
 import org.xwiki.rest.internal.resources.BaseAttachmentsResource;
@@ -31,7 +33,8 @@ import com.xpn.xwiki.api.Document;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.attachments.AttachmentsAtPageVersionResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.attachments.AttachmentsAtPageVersionResourceImpl")
 public class AttachmentsAtPageVersionResourceImpl extends BaseAttachmentsResource implements
         AttachmentsAtPageVersionResource
 {

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/attachments/AttachmentsResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/attachments/AttachmentsResourceImpl.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.util.Enumeration;
 
+import javax.inject.Named;
 import javax.mail.BodyPart;
 import javax.mail.Header;
 import javax.mail.Multipart;
@@ -44,7 +45,8 @@ import com.xpn.xwiki.api.Document;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.attachments.AttachmentsResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.attachments.AttachmentsResourceImpl")
 public class AttachmentsResourceImpl extends BaseAttachmentsResource implements AttachmentsResource
 {
     private static String FORM_FILENAME_FIELD = "filename";

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/ClassPropertiesResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/ClassPropertiesResourceImpl.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.rest.internal.resources.classes;
 
+import javax.inject.Named;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 
@@ -39,7 +40,8 @@ import com.xpn.xwiki.XWikiException;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.classes.ClassPropertiesResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.classes.ClassPropertiesResourceImpl")
 public class ClassPropertiesResourceImpl extends XWikiResource implements ClassPropertiesResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/ClassPropertyResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/ClassPropertyResourceImpl.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.rest.internal.resources.classes;
 
+import javax.inject.Named;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 
@@ -39,7 +40,8 @@ import com.xpn.xwiki.XWikiException;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.classes.ClassPropertyResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.classes.ClassPropertyResourceImpl")
 public class ClassPropertyResourceImpl extends XWikiResource implements ClassPropertyResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/ClassResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/ClassResourceImpl.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.rest.internal.resources.classes;
 
+import javax.inject.Named;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 
@@ -35,7 +36,8 @@ import com.xpn.xwiki.XWikiException;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.classes.ClassResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.classes.ClassResourceImpl")
 public class ClassResourceImpl extends XWikiResource implements ClassResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/ClassesResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/ClassesResourceImpl.java
@@ -22,6 +22,8 @@ package org.xwiki.rest.internal.resources.classes;
 import java.util.Collections;
 import java.util.List;
 
+import javax.inject.Named;
+
 import org.xwiki.component.annotation.Component;
 import org.xwiki.rest.XWikiResource;
 import org.xwiki.rest.XWikiRestException;
@@ -36,7 +38,8 @@ import com.xpn.xwiki.XWikiException;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.classes.ClassesResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.classes.ClassesResourceImpl")
 public class ClassesResourceImpl extends XWikiResource implements ClassesResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/comments/CommentResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/comments/CommentResourceImpl.java
@@ -21,6 +21,7 @@ package org.xwiki.rest.internal.resources.comments;
 
 import java.util.Vector;
 
+import javax.inject.Named;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 
@@ -38,7 +39,8 @@ import com.xpn.xwiki.api.Document;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.comments.CommentResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.comments.CommentResourceImpl")
 public class CommentResourceImpl extends XWikiResource implements CommentResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/comments/CommentVersionResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/comments/CommentVersionResourceImpl.java
@@ -21,6 +21,7 @@ package org.xwiki.rest.internal.resources.comments;
 
 import java.util.Vector;
 
+import javax.inject.Named;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 
@@ -38,7 +39,8 @@ import com.xpn.xwiki.api.Document;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.comments.CommentVersionResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.comments.CommentVersionResourceImpl")
 public class CommentVersionResourceImpl extends XWikiResource implements CommentVersionResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/comments/CommentsResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/comments/CommentsResourceImpl.java
@@ -22,6 +22,7 @@ package org.xwiki.rest.internal.resources.comments;
 import java.util.Date;
 import java.util.Vector;
 
+import javax.inject.Named;
 import javax.ws.rs.core.Response;
 
 import org.xwiki.component.annotation.Component;
@@ -41,7 +42,8 @@ import com.xpn.xwiki.api.Document;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.comments.CommentsResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.comments.CommentsResourceImpl")
 public class CommentsResourceImpl extends XWikiResource implements CommentsResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/comments/CommentsVersionResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/comments/CommentsVersionResourceImpl.java
@@ -21,6 +21,8 @@ package org.xwiki.rest.internal.resources.comments;
 
 import java.util.Vector;
 
+import javax.inject.Named;
+
 import org.xwiki.component.annotation.Component;
 import org.xwiki.rest.XWikiResource;
 import org.xwiki.rest.XWikiRestException;
@@ -36,7 +38,8 @@ import com.xpn.xwiki.api.Document;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.comments.CommentsVersionResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.comments.CommentsVersionResourceImpl")
 public class CommentsVersionResourceImpl extends XWikiResource implements CommentsVersionResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/objects/AllObjectsForClassNameResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/objects/AllObjectsForClassNameResourceImpl.java
@@ -21,6 +21,8 @@ package org.xwiki.rest.internal.resources.objects;
 
 import java.util.List;
 
+import javax.inject.Named;
+
 import org.xwiki.component.annotation.Component;
 import org.xwiki.query.Query;
 import org.xwiki.rest.XWikiResource;
@@ -38,7 +40,8 @@ import com.xpn.xwiki.objects.BaseObject;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.objects.AllObjectsForClassNameResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.objects.AllObjectsForClassNameResourceImpl")
 public class AllObjectsForClassNameResourceImpl extends XWikiResource implements AllObjectsForClassNameResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/objects/ObjectAtPageVersionResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/objects/ObjectAtPageVersionResourceImpl.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.rest.internal.resources.objects;
 
+import javax.inject.Named;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 
@@ -37,7 +38,8 @@ import com.xpn.xwiki.doc.XWikiDocument;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.objects.ObjectAtPageVersionResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.objects.ObjectAtPageVersionResourceImpl")
 public class ObjectAtPageVersionResourceImpl extends XWikiResource implements ObjectAtPageVersionResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/objects/ObjectPropertiesAtPageVersionResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/objects/ObjectPropertiesAtPageVersionResourceImpl.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.rest.internal.resources.objects;
 
+import javax.inject.Named;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 
@@ -41,7 +42,8 @@ import com.xpn.xwiki.doc.XWikiDocument;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.objects.ObjectPropertiesAtPageVersionResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.objects.ObjectPropertiesAtPageVersionResourceImpl")
 public class ObjectPropertiesAtPageVersionResourceImpl extends XWikiResource implements
         ObjectPropertiesAtPageVersionResource
 {

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/objects/ObjectPropertiesResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/objects/ObjectPropertiesResourceImpl.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.rest.internal.resources.objects;
 
+import javax.inject.Named;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 
@@ -39,7 +40,8 @@ import com.xpn.xwiki.api.Document;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.objects.ObjectPropertiesResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.objects.ObjectPropertiesResourceImpl")
 
 public class ObjectPropertiesResourceImpl extends BaseObjectsResource implements ObjectPropertiesResource
 {

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/objects/ObjectPropertyAtPageVersionResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/objects/ObjectPropertyAtPageVersionResourceImpl.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.rest.internal.resources.objects;
 
+import javax.inject.Named;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 
@@ -41,7 +42,8 @@ import com.xpn.xwiki.doc.XWikiDocument;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.objects.ObjectPropertyAtPageVersionResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.objects.ObjectPropertyAtPageVersionResourceImpl")
 public class ObjectPropertyAtPageVersionResourceImpl extends XWikiResource implements
         ObjectPropertyAtPageVersionResource
 {

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/objects/ObjectPropertyResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/objects/ObjectPropertyResourceImpl.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.rest.internal.resources.objects;
 
+import javax.inject.Named;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -42,7 +43,8 @@ import com.xpn.xwiki.doc.XWikiDocument;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.objects.ObjectPropertyResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.objects.ObjectPropertyResourceImpl")
 public class ObjectPropertyResourceImpl extends XWikiResource implements ObjectPropertyResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/objects/ObjectResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/objects/ObjectResourceImpl.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.rest.internal.resources.objects;
 
+import javax.inject.Named;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -37,7 +38,8 @@ import com.xpn.xwiki.api.Document;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.objects.ObjectResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.objects.ObjectResourceImpl")
 public class ObjectResourceImpl extends BaseObjectsResource implements ObjectResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/objects/ObjectsAtPageVersionResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/objects/ObjectsAtPageVersionResourceImpl.java
@@ -21,6 +21,8 @@ package org.xwiki.rest.internal.resources.objects;
 
 import java.util.List;
 
+import javax.inject.Named;
+
 import org.xwiki.component.annotation.Component;
 import org.xwiki.rest.XWikiRestException;
 import org.xwiki.rest.internal.DomainObjectFactory;
@@ -35,7 +37,8 @@ import com.xpn.xwiki.api.Document;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.objects.ObjectsAtPageVersionResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.objects.ObjectsAtPageVersionResourceImpl")
 public class ObjectsAtPageVersionResourceImpl extends BaseObjectsResource implements ObjectsAtPageVersionResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/objects/ObjectsForClassNameResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/objects/ObjectsForClassNameResourceImpl.java
@@ -21,6 +21,8 @@ package org.xwiki.rest.internal.resources.objects;
 
 import java.util.List;
 
+import javax.inject.Named;
+
 import org.xwiki.component.annotation.Component;
 import org.xwiki.rest.XWikiRestException;
 import org.xwiki.rest.internal.DomainObjectFactory;
@@ -35,7 +37,8 @@ import com.xpn.xwiki.api.Document;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.objects.ObjectsForClassNameResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.objects.ObjectsForClassNameResourceImpl")
 public class ObjectsForClassNameResourceImpl extends BaseObjectsResource implements ObjectsForClassNameResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/objects/ObjectsResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/objects/ObjectsResourceImpl.java
@@ -21,6 +21,7 @@ package org.xwiki.rest.internal.resources.objects;
 
 import java.util.List;
 
+import javax.inject.Named;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -45,7 +46,8 @@ import com.xpn.xwiki.objects.classes.BaseClass;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.objects.ObjectsResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.objects.ObjectsResourceImpl")
 public class ObjectsResourceImpl extends BaseObjectsResource implements ObjectsResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PageChildrenResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PageChildrenResourceImpl.java
@@ -21,6 +21,8 @@ package org.xwiki.rest.internal.resources.pages;
 
 import java.util.List;
 
+import javax.inject.Named;
+
 import org.xwiki.component.annotation.Component;
 import org.xwiki.query.Query;
 import org.xwiki.rest.XWikiResource;
@@ -35,7 +37,8 @@ import com.xpn.xwiki.api.Document;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.pages.PageChildrenResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.pages.PageChildrenResourceImpl")
 public class PageChildrenResourceImpl extends XWikiResource implements PageChildrenResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PageHistoryResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PageHistoryResourceImpl.java
@@ -23,6 +23,8 @@ import java.sql.Timestamp;
 import java.util.Date;
 import java.util.List;
 
+import javax.inject.Named;
+
 import org.xwiki.component.annotation.Component;
 import org.xwiki.query.Query;
 import org.xwiki.query.QueryException;
@@ -39,7 +41,8 @@ import com.xpn.xwiki.doc.rcs.XWikiRCSNodeId;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.pages.PageHistoryResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.pages.PageHistoryResourceImpl")
 public class PageHistoryResourceImpl extends XWikiResource implements PageHistoryResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PageResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PageResourceImpl.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.rest.internal.resources.pages;
 
+import javax.inject.Named;
 import javax.ws.rs.core.Response;
 
 import org.xwiki.component.annotation.Component;
@@ -34,7 +35,8 @@ import com.xpn.xwiki.api.Document;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.pages.PageResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.pages.PageResourceImpl")
 public class PageResourceImpl extends ModifiablePageResource implements PageResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PageTagsResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PageTagsResourceImpl.java
@@ -22,6 +22,7 @@ package org.xwiki.rest.internal.resources.pages;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.inject.Named;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -46,7 +47,8 @@ import com.xpn.xwiki.objects.classes.BaseClass;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.pages.PageTagsResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.pages.PageTagsResourceImpl")
 public class PageTagsResourceImpl extends ModifiablePageResource implements PageTagsResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PageTranslationHistoryResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PageTranslationHistoryResourceImpl.java
@@ -23,6 +23,8 @@ import java.sql.Timestamp;
 import java.util.Date;
 import java.util.List;
 
+import javax.inject.Named;
+
 import org.xwiki.component.annotation.Component;
 import org.xwiki.query.Query;
 import org.xwiki.query.QueryException;
@@ -39,7 +41,8 @@ import com.xpn.xwiki.doc.rcs.XWikiRCSNodeId;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.pages.PageTranslationHistoryResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.pages.PageTranslationHistoryResourceImpl")
 public class PageTranslationHistoryResourceImpl extends XWikiResource implements PageTranslationHistoryResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PageTranslationResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PageTranslationResourceImpl.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.rest.internal.resources.pages;
 
+import javax.inject.Named;
 import javax.ws.rs.core.Response;
 
 import org.xwiki.component.annotation.Component;
@@ -34,7 +35,8 @@ import com.xpn.xwiki.api.Document;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.pages.PageTranslationResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.pages.PageTranslationResourceImpl")
 public class PageTranslationResourceImpl extends ModifiablePageResource implements PageTranslationResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PageTranslationVersionResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PageTranslationVersionResourceImpl.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.rest.internal.resources.pages;
 
+import javax.inject.Named;
+
 import org.xwiki.component.annotation.Component;
 import org.xwiki.rest.XWikiResource;
 import org.xwiki.rest.XWikiRestException;
@@ -33,7 +35,8 @@ import com.xpn.xwiki.api.Document;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.pages.PageTranslationVersionResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.pages.PageTranslationVersionResourceImpl")
 public class PageTranslationVersionResourceImpl extends XWikiResource implements PageTranslationVersionResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PageTranslationsResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PageTranslationsResourceImpl.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.rest.internal.resources.pages;
 
+import javax.inject.Named;
+
 import org.xwiki.component.annotation.Component;
 import org.xwiki.rest.XWikiResource;
 import org.xwiki.rest.XWikiRestException;
@@ -32,7 +34,8 @@ import com.xpn.xwiki.api.Document;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.pages.PageTranslationsResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.pages.PageTranslationsResourceImpl")
 public class PageTranslationsResourceImpl extends XWikiResource implements PageTranslationsResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PageVersionResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PageVersionResourceImpl.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.rest.internal.resources.pages;
 
+import javax.inject.Named;
+
 import org.xwiki.component.annotation.Component;
 import org.xwiki.rest.XWikiResource;
 import org.xwiki.rest.XWikiRestException;
@@ -33,7 +35,8 @@ import com.xpn.xwiki.api.Document;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.pages.PageVersionResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.pages.PageVersionResourceImpl")
 public class PageVersionResourceImpl extends XWikiResource implements PageVersionResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PagesResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PagesResourceImpl.java
@@ -22,6 +22,8 @@ package org.xwiki.rest.internal.resources.pages;
 import java.util.List;
 import java.util.regex.Pattern;
 
+import javax.inject.Named;
+
 import org.xwiki.component.annotation.Component;
 import org.xwiki.query.Query;
 import org.xwiki.query.QueryFilter;
@@ -37,7 +39,8 @@ import com.xpn.xwiki.api.Document;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.pages.PagesResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.pages.PagesResourceImpl")
 public class PagesResourceImpl extends XWikiResource implements PagesResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/spaces/SpaceAttachmentsResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/spaces/SpaceAttachmentsResourceImpl.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.rest.internal.resources.spaces;
 
+import javax.inject.Named;
+
 import org.xwiki.component.annotation.Component;
 import org.xwiki.rest.XWikiRestException;
 import org.xwiki.rest.internal.resources.BaseAttachmentsResource;
@@ -28,7 +30,8 @@ import org.xwiki.rest.resources.spaces.SpaceAttachmentsResource;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.spaces.SpaceAttachmentsResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.spaces.SpaceAttachmentsResourceImpl")
 public class SpaceAttachmentsResourceImpl extends BaseAttachmentsResource implements SpaceAttachmentsResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/spaces/SpaceResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/spaces/SpaceResourceImpl.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.rest.internal.resources.spaces;
 
+import javax.inject.Named;
+
 import org.xwiki.component.annotation.Component;
 import org.xwiki.rest.XWikiResource;
 import org.xwiki.rest.XWikiRestException;
@@ -33,7 +35,8 @@ import com.xpn.xwiki.api.Document;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.spaces.SpaceResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.spaces.SpaceResourceImpl")
 public class SpaceResourceImpl extends XWikiResource implements SpaceResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/spaces/SpaceSearchResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/spaces/SpaceSearchResourceImpl.java
@@ -21,6 +21,8 @@ package org.xwiki.rest.internal.resources.spaces;
 
 import java.util.List;
 
+import javax.inject.Named;
+
 import org.xwiki.component.annotation.Component;
 import org.xwiki.rest.XWikiRestException;
 import org.xwiki.rest.internal.Utils;
@@ -28,7 +30,8 @@ import org.xwiki.rest.internal.resources.BaseSearchResult;
 import org.xwiki.rest.model.jaxb.SearchResults;
 import org.xwiki.rest.resources.spaces.SpaceSearchResource;
 
-@Component("org.xwiki.rest.internal.resources.spaces.SpaceSearchResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.spaces.SpaceSearchResourceImpl")
 public class SpaceSearchResourceImpl extends BaseSearchResult implements SpaceSearchResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/spaces/SpacesResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/spaces/SpacesResourceImpl.java
@@ -21,6 +21,8 @@ package org.xwiki.rest.internal.resources.spaces;
 
 import java.util.List;
 
+import javax.inject.Named;
+
 import org.xwiki.component.annotation.Component;
 import org.xwiki.query.QueryFilter;
 import org.xwiki.rest.XWikiResource;
@@ -36,7 +38,8 @@ import com.xpn.xwiki.api.XWiki;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.spaces.SpacesResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.spaces.SpacesResourceImpl")
 public class SpacesResourceImpl extends XWikiResource implements SpacesResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/tags/PagesForTagsResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/tags/PagesForTagsResourceImpl.java
@@ -22,6 +22,8 @@ package org.xwiki.rest.internal.resources.tags;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.inject.Named;
+
 import org.xwiki.component.annotation.Component;
 import org.xwiki.query.Query;
 import org.xwiki.query.QueryException;
@@ -35,7 +37,8 @@ import org.xwiki.rest.resources.tags.PagesForTagsResource;
 
 import com.xpn.xwiki.api.Document;
 
-@Component("org.xwiki.rest.internal.resources.tags.PagesForTagsResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.tags.PagesForTagsResourceImpl")
 public class PagesForTagsResourceImpl extends XWikiResource implements PagesForTagsResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/tags/TagsResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/tags/TagsResourceImpl.java
@@ -22,6 +22,8 @@ package org.xwiki.rest.internal.resources.tags;
 import java.util.Collections;
 import java.util.List;
 
+import javax.inject.Named;
+
 import org.xwiki.component.annotation.Component;
 import org.xwiki.query.Query;
 import org.xwiki.query.QueryException;
@@ -35,7 +37,8 @@ import org.xwiki.rest.model.jaxb.Tags;
 import org.xwiki.rest.resources.tags.PagesForTagsResource;
 import org.xwiki.rest.resources.tags.TagsResource;
 
-@Component("org.xwiki.rest.internal.resources.tags.TagsResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.tags.TagsResourceImpl")
 public class TagsResourceImpl extends XWikiResource implements TagsResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/wikis/WikiAttachmentsResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/wikis/WikiAttachmentsResourceImpl.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.rest.internal.resources.wikis;
 
+import javax.inject.Named;
+
 import org.xwiki.component.annotation.Component;
 import org.xwiki.rest.XWikiRestException;
 import org.xwiki.rest.internal.resources.BaseAttachmentsResource;
@@ -28,7 +30,8 @@ import org.xwiki.rest.resources.wikis.WikiAttachmentsResource;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.wikis.WikiAttachmentsResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.wikis.WikiAttachmentsResourceImpl")
 public class WikiAttachmentsResourceImpl extends BaseAttachmentsResource implements WikiAttachmentsResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/wikis/WikiPagesResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/wikis/WikiPagesResourceImpl.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.inject.Named;
 import javax.ws.rs.core.UriBuilder;
 
 import org.xwiki.component.annotation.Component;
@@ -46,7 +47,8 @@ import com.xpn.xwiki.doc.XWikiDocument;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.wikis.WikiPagesResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.wikis.WikiPagesResourceImpl")
 public class WikiPagesResourceImpl extends XWikiResource implements WikiPagesResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/wikis/WikiResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/wikis/WikiResourceImpl.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
+import javax.inject.Named;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
@@ -43,7 +44,8 @@ import com.xpn.xwiki.plugin.packaging.PackageAPI;
  *
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.wikis.WikiResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.wikis.WikiResourceImpl")
 public class WikiResourceImpl extends XWikiResource implements WikiResource
 {
     /**

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/wikis/WikiSearchQueryResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/wikis/WikiSearchQueryResourceImpl.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.rest.internal.resources.wikis;
 
+import javax.inject.Named;
+
 import org.xwiki.component.annotation.Component;
 import org.xwiki.rest.XWikiRestException;
 import org.xwiki.rest.internal.Utils;
@@ -26,7 +28,8 @@ import org.xwiki.rest.internal.resources.BaseSearchResult;
 import org.xwiki.rest.model.jaxb.SearchResults;
 import org.xwiki.rest.resources.wikis.WikiSearchQueryResource;
 
-@Component("org.xwiki.rest.internal.resources.wikis.WikiSearchQueryResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.wikis.WikiSearchQueryResourceImpl")
 public class WikiSearchQueryResourceImpl extends BaseSearchResult implements WikiSearchQueryResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/wikis/WikiSearchResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/wikis/WikiSearchResourceImpl.java
@@ -21,6 +21,8 @@ package org.xwiki.rest.internal.resources.wikis;
 
 import java.util.List;
 
+import javax.inject.Named;
+
 import org.xwiki.component.annotation.Component;
 import org.xwiki.rest.XWikiRestException;
 import org.xwiki.rest.internal.Utils;
@@ -28,7 +30,8 @@ import org.xwiki.rest.internal.resources.BaseSearchResult;
 import org.xwiki.rest.model.jaxb.SearchResults;
 import org.xwiki.rest.resources.wikis.WikiSearchResource;
 
-@Component("org.xwiki.rest.internal.resources.wikis.WikiSearchResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.wikis.WikiSearchResourceImpl")
 public class WikiSearchResourceImpl extends BaseSearchResult implements WikiSearchResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/wikis/WikisResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/wikis/WikisResourceImpl.java
@@ -20,6 +20,7 @@
 package org.xwiki.rest.internal.resources.wikis;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.EntityType;
@@ -45,7 +46,8 @@ import org.xwiki.wiki.user.WikiUserManager;
 /**
  * @version $Id$
  */
-@Component("org.xwiki.rest.internal.resources.wikis.WikisResourceImpl")
+@Component
+@Named("org.xwiki.rest.internal.resources.wikis.WikisResourceImpl")
 public class WikisResourceImpl extends XWikiResource implements WikisResource
 {
     @Inject

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-rest/src/main/java/org/xwiki/search/solr/internal/rest/WikisSearchQueryResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-rest/src/main/java/org/xwiki/search/solr/internal/rest/WikisSearchQueryResourceImpl.java
@@ -35,7 +35,8 @@ import org.xwiki.rest.resources.wikis.WikisSearchQueryResource;
  * @version $Id$
  * @since 6.4M1
  */
-@Component("org.xwiki.search.solr.internal.rest.WikisSearchQueryResourceImpl")
+@Component
+@Named("org.xwiki.search.solr.internal.rest.WikisSearchQueryResourceImpl")
 public class WikisSearchQueryResourceImpl extends BaseSearchResult implements WikisSearchQueryResource
 {
     private static final String MULTIWIKI_QUERY_TEMPLATE_INFO =

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-rest/xwiki-platform-wiki-rest-default/src/main/java/org/xwiki/wiki/rest/internal/DefaultWikiManagerREST.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-rest/xwiki-platform-wiki-rest-default/src/main/java/org/xwiki/wiki/rest/internal/DefaultWikiManagerREST.java
@@ -22,6 +22,7 @@ package org.xwiki.wiki.rest.internal;
 import java.net.URI;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
@@ -57,7 +58,8 @@ import com.xpn.xwiki.XWikiContext;
  * @since 5.4RC1
  * @version $Id$
  */
-@Component("org.xwiki.wiki.rest.internal.DefaultWikiManagerREST")
+@Component
+@Named("org.xwiki.wiki.rest.internal.DefaultWikiManagerREST")
 @Path("/wikimanager")
 public class DefaultWikiManagerREST extends XWikiResource implements WikiManagerREST
 {


### PR DESCRIPTION
There was a few deprecated used of `@Component("something")` instead of 

```
@Component
@Named("something")
```