### PR TITLE
XWIKI-11917 : Remove debugging modal when rating an extension, on a sub-wiki

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/DefaultRatingsManager.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/DefaultRatingsManager.java
@@ -55,7 +55,7 @@ public class DefaultRatingsManager extends AbstractRatingsManager
     protected DocumentReferenceResolver<String> userReferenceResolver;
 
     @Inject
-    @Named("local")
+    @Named("compactwiki")
     protected EntityReferenceSerializer<String> entityReferenceSerializer;
 
     @Inject

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/SeparatePageRatingsManager.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/SeparatePageRatingsManager.java
@@ -67,7 +67,7 @@ public class SeparatePageRatingsManager extends AbstractRatingsManager
     protected DocumentReferenceResolver<String> userReferenceResolver;
 
     @Inject
-    @Named("local")
+    @Named("compactwiki")
     protected EntityReferenceSerializer<String> entityReferenceSerializer;
 
     /**


### PR DESCRIPTION
The bug consisted in the fact that all users were serialized to their local representation (spage.page) and this proved to be an issue when serializing a global user acting on a subwiki due to the fact that the serialized user document would not contain the main wiki prefix (space.page instead of mainWikiID:space.page)