### PR TITLE
XWIKI-10118: Allow multiple column layouts on single page

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-container/src/main/java/org/xwiki/rendering/internal/macro/container/ColumnsLayoutManager.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-container/src/main/java/org/xwiki/rendering/internal/macro/container/ColumnsLayoutManager.java
@@ -73,7 +73,10 @@ public class ColumnsLayoutManager implements LayoutManager
             return;
         }
 
-        ssfx.use("uicomponents/container/columns.css");
+        Map<String, Object> skinxParams = new HashMap<String, Object>();
+        skinxParams.put("forceSkinAction", true);
+
+        ssfx.use("uicomponents/container/columns.css", skinxParams);
 
         // add styles to all columns inside
         for (int i = 0; i < count; i++) {

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-container/src/main/java/org/xwiki/rendering/internal/macro/container/ColumnsLayoutManager.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-container/src/main/java/org/xwiki/rendering/internal/macro/container/ColumnsLayoutManager.java
@@ -73,10 +73,7 @@ public class ColumnsLayoutManager implements LayoutManager
             return;
         }
 
-        Map<String, Object> skinxParams = new HashMap<String, Object>();
-        skinxParams.put("forceSkinAction", true);
-        skinxParams.put("columns", count);
-        ssfx.use("uicomponents/container/columns.css", skinxParams);
+        ssfx.use("uicomponents/container/columns.css");
 
         // add styles to all columns inside
         for (int i = 0; i < count; i++) {
@@ -100,7 +97,7 @@ public class ColumnsLayoutManager implements LayoutManager
         Map<String, String> clearFloatsParams = new HashMap<String, String>();
         clearFloatsParams.put(CLASS_ATTRIBUTE, "clearfloats");
         String oldClass = container.getParameter(CLASS_ATTRIBUTE);
-        String newClass = "container-columns";
+        String newClass = "container-columns container-columns-" + count;
         container.setParameter(CLASS_ATTRIBUTE, StringUtils.isEmpty(oldClass) ? newClass : oldClass + " " + newClass);
         container.addChild(new GroupBlock(clearFloatsParams));
     }

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/container/columns.css
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/container/columns.css
@@ -1,16 +1,14 @@
-/* Get the number of columns from the request parameter. */
-#set ($columns = "$!request.columns")
-#set ($columnsNumber = $mathtool.toInteger($columns))
-#if (!$columnsNumber || $columnsNumber <= 0)
-  #set ($columnsNumber = 1)
+#set ($maxColumns = "$!request.maxColumns")
+#set ($maxColumnsNumber = $mathtool.toInteger($maxColumns))
+#if (!$maxColumnsNumber || $maxColumnsNumber <= 0)
+  #set ($maxColumnsNumber = 50)
 #end
 /* Don't fill 100% because IE doesn't fit things properly in. */
 #set($columnsTotalWidth = 99)
 /* 1.5% padding right to all the columns except last one. */
 #set($columnPadding = 0.75)
-/* Compute the percent of the screen width of a column. Round so that the java upper rounding doesn't screw IE, and because 2 decimals should be enough for everyone. */
-#set($rawComputedColumnWidth = (($columnsTotalWidth - $columnPadding * 2 * ($columnsNumber - 1)) / $columnsNumber))
-#set($computedColumnWidth = $mathtool.roundTo(2, $rawComputedColumnWidth))
+
+/* Render generic css first */
 
 /* FIXME: this style should not be here, it's style for the container overall, not for the columns layout. For the moment
    it's here to minimize the number of requested css, since there are no other container rules at the moment (like
@@ -21,9 +19,6 @@
 
 .container-columns .column {
   float: left;
-  width: $computedColumnWidth%;
-  padding-right: $columnPadding%;
-  padding-left: $columnPadding%;
 }
 
 /* Responsiveness, upon the same limit than Twitter Bootstrap (768px) */
@@ -47,3 +42,16 @@
 .container-columns .last-column {
   padding-right: 0;
 }
+
+
+/* Generate column-specific css classes */
+#foreach($columns in [1..$maxColumnsNumber])
+  /* Compute the percent of the screen width of a column. Round so that the java upper rounding doesn't screw IE, and because 2 decimals should be enough for everyone. */
+  #set($rawComputedColumnWidth = (($columnsTotalWidth - $columnPadding * 2 * ($columns - 1)) / $columns))
+  #set($computedColumnWidth = $mathtool.roundTo(2, $rawComputedColumnWidth))
+  .container-columns-$column .column{
+    width: $computedColumnWidth%;
+    padding-right: $columnPadding%;
+    padding-left: $columnPadding%;
+  }
+#end

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/container/columns.css
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/container/columns.css
@@ -49,7 +49,7 @@
   /* Compute the percent of the screen width of a column. Round so that the java upper rounding doesn't screw IE, and because 2 decimals should be enough for everyone. */
   #set($rawComputedColumnWidth = (($columnsTotalWidth - $columnPadding * 2 * ($columns - 1)) / $columns))
   #set($computedColumnWidth = $mathtool.roundTo(2, $rawComputedColumnWidth))
-  .container-columns-$column .column{
+  .container-columns-$columns .column{
     width: $computedColumnWidth%;
     padding-right: $columnPadding%;
     padding-left: $columnPadding%;


### PR DESCRIPTION
Sets different class to every container which represents column numbers. By default limit is 50 columns (can be increased/decreased by explicitly specifying number of max columns as ssfx parameter).


Fixed by Tieto Czech s.r.o., Lukas Raska, lukas.raska@tieto.com
