### PR TITLE
XWIKI-12660: With xwiki.showviewaction=0 and url.standard.hideViewAct…

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-oldcore/pom.xml
@@ -396,6 +396,11 @@
     </dependency>
     <dependency>
       <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-url-scheme-standard</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
       <artifactId>xwiki-platform-display-api</artifactId>
       <version>${project.version}</version>
     </dependency>


### PR DESCRIPTION
…ion=true, requests for nested document gets mapped to UnknownAction.

This fix computes the action path using the same method as in org.xwiki.url.internal.standard.entity.AbstractEntityResourceReferenceResolver

I'm not sure about the xmlrpc special case.  But hasn't xmlrpc supporb been dropped?
