### PR TITLE
XWIKI-12851:Extra "Edit Section" buttons displayed on Blog Archives p…

### DIFF
--- a/xwiki-platform-core/xwiki-platform-blog/xwiki-platform-blog-ui/src/main/resources/Blog/Archive.xml
+++ b/xwiki-platform-core/xwiki-platform-blog/xwiki-platform-blog-ui/src/main/resources/Blog/Archive.xml
@@ -46,7 +46,6 @@
   <content>{{include reference="Blog.BlogCode"/}}
 
 {{velocity filter="none"}}
-{{html clean="false" wiki="true"}}
 ##
 ##
 ##
@@ -172,6 +171,5 @@
     #displayBlogMonthArchive($blogDoc $year $month)
   #end
 #end
-{{/html}}
 {{/velocity}}</content>
 </xwikidoc>


### PR DESCRIPTION
* These section editing buttons are displayed because of the html macro with wiki=true,  after verification there is no need to use the html macro here