### PR TITLE
XWIKI-13128: LESS compiler can output sourcemaps

### DIFF
--- a/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/LESSConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/LESSConfiguration.java
@@ -47,4 +47,13 @@ public class LESSConfiguration
     {
         return configurationSource.getProperty(CONFIGURATION_PREFIX + "maximumSimultaneousCompilations", 4);
     }
+
+    /**
+     *
+     * @return whether the LESS compiler should generate inline sourcemaps.
+     */
+    public boolean isGenerateInlineSourceMaps()
+    {
+        return configurationSource.getProperty(CONFIGURATION_PREFIX + "generateInlineSourceMaps",false);
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/LESSConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/LESSConfiguration.java
@@ -54,6 +54,6 @@ public class LESSConfiguration
      */
     public boolean isGenerateInlineSourceMaps()
     {
-        return configurationSource.getProperty(CONFIGURATION_PREFIX + "generateInlineSourceMaps",false);
+        return configurationSource.getProperty(CONFIGURATION_PREFIX + "generateInlineSourceMaps", false);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/compiler/CachedLESSCompiler.java
+++ b/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/compiler/CachedLESSCompiler.java
@@ -105,7 +105,7 @@ public class CachedLESSCompiler implements CachedCompilerInterface<String>, Init
 
             // Compile the LESS code
             if (useLESS) {
-                return less4JCompiler.compile(lessCode, skin);
+                return less4JCompiler.compile(lessCode, skin, lessConfiguration.isGenerateInlineSourceMaps());
             }
 
             // Otherwise return the raw LESS code

--- a/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/compiler/DefaultLESSCompiler.java
+++ b/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/compiler/DefaultLESSCompiler.java
@@ -61,14 +61,14 @@ public class DefaultLESSCompiler extends AbstractCachedCompiler<String> implemen
 
     @Override
     public String compile(LESSResourceReference lessResourceReference, boolean includeSkinStyle, boolean useVelocity,
-        boolean force) throws LESSCompilerException
+                          boolean force) throws LESSCompilerException
     {
         return super.getResult(lessResourceReference, includeSkinStyle, useVelocity, force);
     }
 
     @Override
     public String compile(LESSResourceReference lessResourceReference, boolean includeSkinStyle, boolean useVelocity,
-        String skin, boolean force) throws LESSCompilerException
+                         String skin, boolean force) throws LESSCompilerException
     {
         return super.getResult(lessResourceReference, includeSkinStyle, useVelocity, skin, force);
     }

--- a/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/compiler/less4j/Less4jCompiler.java
+++ b/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/compiler/less4j/Less4jCompiler.java
@@ -59,7 +59,6 @@ public class Less4jCompiler
         LessCompiler lessCompiler = new DefaultLessCompiler();
         LessCompiler.Configuration options = new LessCompiler.Configuration();
         options.setCompressing(true);
-        //LessCompiler.SourceMapConfiguration smopts = options.getSourceMapConfiguration();
         options.getSourceMapConfiguration().setInline(inlineSourceMap);
         options.getSourceMapConfiguration().setIncludeSourcesContent(true);
         LessSource lessSource = 

--- a/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/compiler/less4j/Less4jCompiler.java
+++ b/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/compiler/less4j/Less4jCompiler.java
@@ -51,6 +51,7 @@ public class Less4jCompiler
      * Compile the LESS code and get the included files from the skin templates.
      * @param lessCode code to compile
      * @param skin skin holding the templates
+     * @param inlineSourceMap whether to create inline sourcemaps in the generated css
      * @return the results of the LESS compilation
      * @throws Less4jException if problems occur
      */

--- a/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/compiler/less4j/Less4jCompiler.java
+++ b/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/compiler/less4j/Less4jCompiler.java
@@ -54,11 +54,14 @@ public class Less4jCompiler
      * @return the results of the LESS compilation
      * @throws Less4jException if problems occur
      */
-    public String compile(String lessCode, String skin) throws Less4jException
+    public String compile(String lessCode, String skin, boolean inlineSourceMap) throws Less4jException
     {
         LessCompiler lessCompiler = new DefaultLessCompiler();
         LessCompiler.Configuration options = new LessCompiler.Configuration();
         options.setCompressing(true);
+        //LessCompiler.SourceMapConfiguration smopts = options.getSourceMapConfiguration();
+        options.getSourceMapConfiguration().setInline(inlineSourceMap);
+        options.getSourceMapConfiguration().setIncludeSourcesContent(true);
         LessSource lessSource = 
             new CustomContentLESSSource(lessCode, templateManager, skinManager.getSkin(skin));
         LessCompiler.CompilationResult lessResult = lessCompiler.compile(lessSource, options);

--- a/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/test/java/org/xwiki/lesscss/internal/LESSConfigurationTest.java
+++ b/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/test/java/org/xwiki/lesscss/internal/LESSConfigurationTest.java
@@ -1,0 +1,64 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.lesscss.internal;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.xwiki.configuration.ConfigurationSource;
+import org.xwiki.test.mockito.MockitoComponentMockingRule;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test class for {@link org.xwiki.lesscss.internal.LESSConfiguration}.
+ *
+ */
+public class LESSConfigurationTest {
+
+    @Rule
+    public MockitoComponentMockingRule<LESSConfiguration> mocker =
+            new MockitoComponentMockingRule<>(LESSConfiguration.class);
+
+    private ConfigurationSource xwikiPropertiesSource;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        this.xwikiPropertiesSource = this.mocker.getInstance(ConfigurationSource.class);
+    }
+
+    @Test
+    public void maxSimultaneousCompilations() throws Exception
+    {
+        when(xwikiPropertiesSource.getProperty("lesscss.maximumSimultaneousCompilations",4)).thenReturn(4);
+        int i = mocker.getComponentUnderTest().getMaximumSimultaneousCompilations();
+        assertTrue(i == 4);
+    }
+
+    @Test
+    public void generateSourceMaps() throws Exception
+    {
+        when(xwikiPropertiesSource.getProperty("lesscss.generateInlineSourceMaps", false)).thenReturn(true);
+        boolean b  = mocker.getComponentUnderTest().isGenerateInlineSourceMaps();
+        assertTrue(b == true);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/test/java/org/xwiki/lesscss/internal/LESSConfigurationTest.java
+++ b/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/test/java/org/xwiki/lesscss/internal/LESSConfigurationTest.java
@@ -26,6 +26,7 @@ import org.xwiki.configuration.ConfigurationSource;
 import org.xwiki.test.mockito.MockitoComponentMockingRule;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
 
 /**
@@ -51,7 +52,7 @@ public class LESSConfigurationTest {
     {
         when(xwikiPropertiesSource.getProperty("lesscss.maximumSimultaneousCompilations",4)).thenReturn(4);
         int i = mocker.getComponentUnderTest().getMaximumSimultaneousCompilations();
-        assertTrue(i == 4);
+        assertEquals(4,i);
     }
 
     @Test
@@ -59,6 +60,6 @@ public class LESSConfigurationTest {
     {
         when(xwikiPropertiesSource.getProperty("lesscss.generateInlineSourceMaps", false)).thenReturn(true);
         boolean b  = mocker.getComponentUnderTest().isGenerateInlineSourceMaps();
-        assertTrue(b == true);
+        assertTrue(b);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/test/java/org/xwiki/lesscss/internal/compiler/CachedLESSCompilerTest.java
+++ b/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/test/java/org/xwiki/lesscss/internal/compiler/CachedLESSCompilerTest.java
@@ -89,6 +89,7 @@ public class CachedLESSCompilerTest
         when(xcontext.getDoc()).thenReturn(mockDocument);
 
         when(lessConfiguration.getMaximumSimultaneousCompilations()).thenReturn(1);
+        when(lessConfiguration.isGenerateInlineSourceMaps()).thenReturn(false);
     }
 
     @Test
@@ -99,7 +100,8 @@ public class CachedLESSCompilerTest
         when(resource.getContent(eq("skin2"))).thenReturn("Some LESS content");
         when(xwiki.evaluateVelocity(eq("Some LESS content"), eq("SomeContextDocument"))).
             thenReturn("Some Velocity-rendered LESS content");
-        when(less4jCompiler.compile(eq("Some Velocity-rendered LESS content"), eq("skin2")))
+        when(less4jCompiler.compile(eq("Some Velocity-rendered LESS content"), eq("skin2"),
+                eq(false)))
             .thenReturn("output");
 
         // Tests
@@ -116,7 +118,8 @@ public class CachedLESSCompilerTest
         // Mocks
         LESSResourceReference resource = mock(LESSSkinFileResourceReference.class);
         when(resource.getContent(eq("skin2"))).thenReturn("Some LESS content");
-        when(less4jCompiler.compile(eq("Some LESS content"), eq("skin2"))).thenReturn("output");
+        when(less4jCompiler.compile(eq("Some LESS content"), eq("skin2"),
+                eq(false))).thenReturn("output");
 
         // Tests
         assertEquals("output", mocker.getComponentUnderTest().compute(resource, false, false, true, "skin2"));
@@ -154,7 +157,8 @@ public class CachedLESSCompilerTest
                 .thenReturn("@import (reference) \"style.less.vm\";\n"
                         +"Some Velocity-rendered LESS content");
         when(less4jCompiler.compile(eq("@import (reference) \"style.less.vm\";\n"
-            +"Some Velocity-rendered LESS content"), eq("skin")))
+            +"Some Velocity-rendered LESS content"), eq("skin"),
+                eq(false)))
                 .thenReturn("output");
 
         // Tests
@@ -171,7 +175,8 @@ public class CachedLESSCompilerTest
         when(xwiki.evaluateVelocity(eq("Some LESS content"), eq("SomeContextDocument"))).
                 thenReturn("Some Velocity-rendered LESS content");
         Less4jException lessCompilerException = mock(Less4jException.class);
-        when(less4jCompiler.compile(eq("Some Velocity-rendered LESS content"), eq("skin"))).
+        when(less4jCompiler.compile(eq("Some Velocity-rendered LESS content"), eq("skin"),
+                eq(false))).
             thenThrow(lessCompilerException);
 
         // Tests

--- a/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/test/java/org/xwiki/lesscss/internal/compiler/less4j/Less4jCompilerTest.java
+++ b/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/test/java/org/xwiki/lesscss/internal/compiler/less4j/Less4jCompilerTest.java
@@ -107,9 +107,7 @@ public class Less4jCompilerTest
         IOUtils.copy(new FileInputStream(getClass().getResource("/style3.less").getFile()), source);
         String result = mocker.getComponentUnderTest().compile(source.toString(), "skin", false);
 
-	// Now with sourcemaps.
-        StringWriter source2 = new StringWriter();
-        IOUtils.copy(new FileInputStream(getClass().getResource("/style3.less").getFile()), source2);
+	    // Now with sourcemaps.
         String result2 = mocker.getComponentUnderTest().compile(source.toString(), "skin", true);
 
         // Verify

--- a/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/test/java/org/xwiki/lesscss/internal/compiler/less4j/Less4jCompilerTest.java
+++ b/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/test/java/org/xwiki/lesscss/internal/compiler/less4j/Less4jCompilerTest.java
@@ -20,6 +20,8 @@
 package org.xwiki.lesscss.internal.compiler.less4j;
 
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.StringReader;
 import java.io.StringWriter;
 
 import org.apache.commons.io.IOUtils;
@@ -37,6 +39,7 @@ import org.xwiki.test.mockito.MockitoComponentMockingRule;
 import com.github.sommeri.less4j.Less4jException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -102,12 +105,24 @@ public class Less4jCompilerTest
         // Test
         StringWriter source = new StringWriter();
         IOUtils.copy(new FileInputStream(getClass().getResource("/style3.less").getFile()), source);
-        String result = mocker.getComponentUnderTest().compile(source.toString(), "skin");
-        
+        String result = mocker.getComponentUnderTest().compile(source.toString(), "skin", false);
+
+
+        StringWriter source2 = new StringWriter();
+        IOUtils.copy(new FileInputStream(getClass().getResource("/style3.less").getFile()), source2);
+        String result2 = mocker.getComponentUnderTest().compile(source.toString(), "skin", true);
+
+        //StringReader s2 = new StringReader(result2);
+        //IOUtils.copy(s2, new FileOutputStream("/var/tmp/style3.css_inl"));
+
         // Verify
         StringWriter expected = new StringWriter();
         IOUtils.copy(new FileInputStream(getClass().getResource("/style3.css").getFile()), expected);
         assertEquals(expected.toString(), result);
+
+        //StringWriter expected2 = new StringWriter();
+        //IOUtils.copy(new FileInputStream(getClass().getResource("/style3_inl.css").getFile()), expected2);
+        assertTrue(result2.contains("/*# sourceMappingURL=data:application/json;base64,"));
     }
 
     @Test
@@ -123,7 +138,7 @@ public class Less4jCompilerTest
         try {
             StringWriter source = new StringWriter();
             IOUtils.copy(new FileInputStream(getClass().getResource("/style3.less").getFile()), source);
-            mocker.getComponentUnderTest().compile(source.toString(), "skin");
+            mocker.getComponentUnderTest().compile(source.toString(), "skin", false);
         } catch (Less4jException e) {
             caughtException = e;
         }

--- a/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/test/java/org/xwiki/lesscss/internal/compiler/less4j/Less4jCompilerTest.java
+++ b/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/test/java/org/xwiki/lesscss/internal/compiler/less4j/Less4jCompilerTest.java
@@ -107,21 +107,16 @@ public class Less4jCompilerTest
         IOUtils.copy(new FileInputStream(getClass().getResource("/style3.less").getFile()), source);
         String result = mocker.getComponentUnderTest().compile(source.toString(), "skin", false);
 
-
+	// Now with sourcemaps.
         StringWriter source2 = new StringWriter();
         IOUtils.copy(new FileInputStream(getClass().getResource("/style3.less").getFile()), source2);
         String result2 = mocker.getComponentUnderTest().compile(source.toString(), "skin", true);
-
-        //StringReader s2 = new StringReader(result2);
-        //IOUtils.copy(s2, new FileOutputStream("/var/tmp/style3.css_inl"));
 
         // Verify
         StringWriter expected = new StringWriter();
         IOUtils.copy(new FileInputStream(getClass().getResource("/style3.css").getFile()), expected);
         assertEquals(expected.toString(), result);
 
-        //StringWriter expected2 = new StringWriter();
-        //IOUtils.copy(new FileInputStream(getClass().getResource("/style3_inl.css").getFile()), expected2);
         assertTrue(result2.contains("/*# sourceMappingURL=data:application/json;base64,"));
     }
 

--- a/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.properties.vm
+++ b/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.properties.vm
@@ -734,7 +734,7 @@ extension.oldflavors=$oldFlavor.trim()
 #-# The default is:
 # lesscss.maximumSimultaneousCompilations = 4
 
-#-# [Since 8.0M]
+#-# [Since 8.0RC1]
 #-# Generate sourcemaps inline in the CSS files.
 #-#
 #-# The default is:

--- a/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.properties.vm
+++ b/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.properties.vm
@@ -734,5 +734,11 @@ extension.oldflavors=$oldFlavor.trim()
 #-# The default is:
 # lesscss.maximumSimultaneousCompilations = 4
 
+#-# [Since 8.0M]
+#-# Generate sourcemaps inline in the CSS files.
+#-#
+#-# The default is:
+# lesscss.generateInlineSourceMaps = false
+
 
 $!xwikiPropertiesAdditionalProperties


### PR DESCRIPTION
Let the LESS compiler output sourcemaps inline in the CSS files.
