### PR TITLE
XWIKI-13347: Rename CopyStatusPage.java to CopyOrRenameStatusPage.java

### DIFF
--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -475,7 +475,7 @@
                     "packages": {
                       "regex": true,
                       "include": ["org\\.xwiki\\..*"],
-                      "exclude": ["org\\.xwiki\\..*\\.internal(\\..*)?", "org\\.xwiki\\..*\\.test(\\..*)?"]
+                      "exclude": ["org\\.xwiki\\..*\\.internal(\\..*)?", "org\\.xwiki\\..*\\.test(\\..*)?", "org\\.xwiki\\..*\\.po(\\..*)?"]
                     }
                   }
                 },


### PR DESCRIPTION
* fixed failing build of xwiki-platform-test-ui