### PR TITLE
XWIKI-13395 : The DBList field always propses the blog introduction f…

### DIFF
--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/DBList.xml
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/DBList.xml
@@ -51,7 +51,7 @@
     <validationScript/>
     <databaseList>
       <cache>0</cache>
-      <classname>Blog.BlogPostClass</classname>
+      <classname></classname>
       <customDisplay/>
       <disabled>0</disabled>
       <displayType>select</displayType>


### PR DESCRIPTION
…irst in AWM

Remove this class example since It's not a good idea to have an example document from another application here this can lead to confusion.
This can make sense only if AWM had a dependency on the blog
