### PR TITLE
XWIKI-13142: Display and Include macros should handle XWiki.RedirectClass objects

### DIFF
--- a/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-macro/src/test/java/org/xwiki/rendering/internal/macro/DisplayMacroTest.java
+++ b/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-macro/src/test/java/org/xwiki/rendering/internal/macro/DisplayMacroTest.java
@@ -39,6 +39,7 @@ import org.xwiki.display.internal.DocumentDisplayer;
 import org.xwiki.display.internal.DocumentDisplayerParameters;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.DocumentReferenceResolver;
+import org.xwiki.model.reference.SpaceReference;
 import org.xwiki.rendering.block.Block;
 import org.xwiki.rendering.block.MacroBlock;
 import org.xwiki.rendering.block.MetaDataBlock;
@@ -210,9 +211,14 @@ public class DisplayMacroTest extends AbstractComponentTestCase
         getMockery().checking(new Expectations()
         {
             {
+                DocumentReference reference = new DocumentReference("wiki", "space", "page");
                 allowing(mockDocumentReferenceResolver).resolve("wiki:space.page", macroContext.getCurrentMacroBlock());
-                will(returnValue(new DocumentReference("wiki", "space", "page")));
-
+                will(returnValue(reference));
+                allowing(mockSetup.bridge).getProperty(reference,
+                        new DocumentReference("RedirectClass",
+                                new SpaceReference("XWiki", reference.getWikiReference())),
+                        "location");
+                will(returnValue(null));
                 allowing(mockSetup.bridge).isDocumentViewable(with(any(DocumentReference.class)));
                 will(returnValue(true));
                 allowing(mockSetup.bridge).getDocument(with(any(DocumentReference.class)));
@@ -353,6 +359,11 @@ public class DisplayMacroTest extends AbstractComponentTestCase
                 allowing(mockDocumentReferenceResolver).resolve(with(resolve),
                     with(IsArray.array(any(MacroBlock.class))));
                 will(returnValue(reference));
+                allowing(mockSetup.bridge).getProperty(reference,
+                        new DocumentReference("RedirectClass",
+                                new SpaceReference("XWiki", reference.getWikiReference())),
+                        "location");
+                will(returnValue(null));
                 allowing(mockSetup.bridge).getDocument(reference);
                 will(returnValue(mockDocument));
                 allowing(mockDocument).getSyntax();

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
@@ -20,6 +20,7 @@
 package org.xwiki.rendering.internal.macro.include;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Stack;
 
@@ -46,6 +47,7 @@ import org.xwiki.rendering.macro.MacroExecutionException;
 import org.xwiki.rendering.macro.include.IncludeMacroParameters;
 import org.xwiki.rendering.macro.include.IncludeMacroParameters.Context;
 import org.xwiki.rendering.transformation.MacroTransformationContext;
+import org.xwiki.text.StringUtils;
 
 /**
  * @version $Id$
@@ -138,7 +140,7 @@ public class IncludeMacro extends AbstractMacro<IncludeMacroParameters>
         throws MacroExecutionException
     {
         // Step 1: Perform checks.
-        if (parameters.getReference() == null) {
+        if (StringUtils.isBlank(parameters.getReference())) {
             throw new MacroExecutionException(
                 "You must specify a 'reference' parameter pointing to the entity to include.");
         }
@@ -271,13 +273,28 @@ public class IncludeMacro extends AbstractMacro<IncludeMacroParameters>
     private DocumentReference resolve(MacroBlock block, IncludeMacroParameters parameters)
         throws MacroExecutionException
     {
+        // We have already checked previously that the reference is not empty
         String reference = parameters.getReference();
 
-        if (reference == null) {
-            throw new MacroExecutionException(
-                "You must specify a 'reference' parameter pointing to the entity to include.");
+        // Parse that reference to get the real document reference
+        DocumentReference documentReference = macroDocumentReferenceResolver.resolve(reference, block);
+
+        // But the document might have a redirect object
+        DocumentReference redirectClass = new DocumentReference(documentReference.getWikiReference().getName(),
+                "XWiki", "RedirectClass");
+        Object redirectLocation = documentAccessBridge.getProperty(documentReference, redirectClass, "location");
+        HashSet<String> visitedLocations = new HashSet<>();
+        // While we end-up on a document that have a redirect object, follow that redirection
+        while (redirectLocation != null) {
+            reference = (String) redirectLocation;
+            if (!visitedLocations.add(reference)) {
+                throw new MacroExecutionException(String.format("Infinite redirection recursion: [%s].",
+                        parameters.getReference()));
+            }
+            documentReference = macroDocumentReferenceResolver.resolve(reference, block);
+            redirectLocation = documentAccessBridge.getProperty(documentReference, redirectClass, "location");
         }
 
-        return this.macroDocumentReferenceResolver.resolve(reference, block);
+        return documentReference;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/IncludeMacroTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/IncludeMacroTest.java
@@ -38,6 +38,7 @@ import org.xwiki.display.internal.DocumentDisplayer;
 import org.xwiki.display.internal.DocumentDisplayerParameters;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.DocumentReferenceResolver;
+import org.xwiki.model.reference.SpaceReference;
 import org.xwiki.rendering.block.Block;
 import org.xwiki.rendering.block.MacroBlock;
 import org.xwiki.rendering.block.MacroMarkerBlock;
@@ -249,10 +250,16 @@ public class IncludeMacroTest extends AbstractComponentTestCase
         getMockery().checking(new Expectations()
         {
             {
+                DocumentReference reference = new DocumentReference("wiki", "space", "page");
                 allowing(mockDocumentReferenceResolver).resolve("wiki:space.page", macroContext.getCurrentMacroBlock());
-                will(returnValue(new DocumentReference("wiki", "space", "page")));
+                will(returnValue(reference));
+                allowing(mockSetup.bridge).getProperty(reference,
+                        new DocumentReference("RedirectClass",
+                                new SpaceReference("XWiki", reference.getWikiReference())),
+                        "location");
+                will(returnValue(null));
                 allowing(mockDocumentReferenceResolver).resolve("space.page", includeMacroMarker);
-                will(returnValue(new DocumentReference("wiki", "space", "page")));
+                will(returnValue(reference));
             }
         });
 
@@ -291,9 +298,14 @@ public class IncludeMacroTest extends AbstractComponentTestCase
         getMockery().checking(new Expectations()
         {
             {
+                DocumentReference reference = new DocumentReference("wiki", "space", "page");
                 allowing(mockDocumentReferenceResolver).resolve("wiki:space.page", macroContext.getCurrentMacroBlock());
-                will(returnValue(new DocumentReference("wiki", "space", "page")));
-
+                will(returnValue(reference));
+                allowing(mockSetup.bridge).getProperty(reference,
+                        new DocumentReference("RedirectClass",
+                                new SpaceReference("XWiki", reference.getWikiReference())),
+                        "location");
+                will(returnValue(null));
                 allowing(mockSetup.bridge).isDocumentViewable(with(any(DocumentReference.class)));
                 will(returnValue(true));
                 allowing(mockSetup.bridge).getDocument(with(any(DocumentReference.class)));
@@ -353,6 +365,11 @@ public class IncludeMacroTest extends AbstractComponentTestCase
             {
                 oneOf(mockDocumentReferenceResolver).resolve("relativePage", macroContext.getCurrentMacroBlock());
                 will(returnValue(resolvedReference));
+                allowing(mockSetup.bridge).getProperty(resolvedReference,
+                        new DocumentReference("RedirectClass",
+                                new SpaceReference("XWiki", resolvedReference.getWikiReference())),
+                        "location");
+                will(returnValue(null));
                 oneOf(mockSetup.bridge).isDocumentViewable(resolvedReference);
                 will(returnValue(true));
                 oneOf(mockSetup.bridge).getDocument(resolvedReference);
@@ -392,6 +409,11 @@ public class IncludeMacroTest extends AbstractComponentTestCase
             {
                 oneOf(mockDocumentReferenceResolver).resolve("document", macroContext.getCurrentMacroBlock());
                 will(returnValue(resolvedReference));
+                allowing(mockSetup.bridge).getProperty(resolvedReference,
+                        new DocumentReference("RedirectClass",
+                                new SpaceReference("XWiki", resolvedReference.getWikiReference())),
+                        "location");
+                will(returnValue(null));
                 oneOf(mockSetup.bridge).isDocumentViewable(resolvedReference);
                 will(returnValue(true));
                 oneOf(mockSetup.bridge).getDocument(resolvedReference);
@@ -425,6 +447,11 @@ public class IncludeMacroTest extends AbstractComponentTestCase
             {
                 oneOf(mockDocumentReferenceResolver).resolve("document", macroContext.getCurrentMacroBlock());
                 will(returnValue(resolvedReference));
+                allowing(mockSetup.bridge).getProperty(resolvedReference,
+                        new DocumentReference("RedirectClass",
+                                new SpaceReference("XWiki", resolvedReference.getWikiReference())),
+                        "location");
+                will(returnValue(null));
                 oneOf(mockSetup.bridge).isDocumentViewable(resolvedReference);
                 will(returnValue(true));
                 oneOf(mockSetup.bridge).getDocument(resolvedReference);
@@ -468,6 +495,11 @@ public class IncludeMacroTest extends AbstractComponentTestCase
                 allowing(mockDocumentReferenceResolver).resolve(with(resolve),
                     with(IsArray.array(any(MacroBlock.class))));
                 will(returnValue(reference));
+                allowing(mockSetup.bridge).getProperty(reference,
+                        new DocumentReference("RedirectClass",
+                                new SpaceReference("XWiki", reference.getWikiReference())),
+                        "location");
+                will(returnValue(null));
                 allowing(mockSetup.bridge).getDocument(reference);
                 will(returnValue(mockDocument));
                 allowing(mockDocument).getSyntax();


### PR DESCRIPTION
I open a PR because:
* I'm not sure it's the correct fix
* there is duplicated code
* I have not written test (even if I tried with the old mock system that we should replace anyway)
* I'm not sure it's needed since we have http://jira.xwiki.org/browse/XWIKI-4906

However, it does the job, and I will deploy this patch for some clients that have the problem.

(I don't have a lot of time to work on it)