### PR TITLE
XWIKI-13483  After page rename, the old page redirects wrongly to Main.WebHome

### DIFF
--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultModelBridge.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultModelBridge.java
@@ -83,7 +83,10 @@ public class DefaultModelBridge implements ModelBridge
     private QueryManager queryManager;
 
     /**
-     * Used to serialize a space reference in order to query the child documents.
+     * Used to serialize a space reference in order to query the child documents and to serialize the redirect location.
+     * 
+     * @see #createRedirect(DocumentReference, DocumentReference)
+     * @see #getDocumentReferences(SpaceReference)
      */
     @Inject
     @Named("local")
@@ -213,7 +216,7 @@ public class DefaultModelBridge implements ModelBridge
             try {
                 XWikiDocument oldDocument = xcontext.getWiki().getDocument(oldReference, xcontext);
                 int number = oldDocument.createXObject(redirectClassReference, xcontext);
-                String location = this.compactEntityReferenceSerializer.serialize(newReference, oldReference);
+                String location = this.localEntityReferenceSerializer.serialize(newReference);
                 oldDocument.getXObject(redirectClassReference, number).setStringValue("location", location);
                 oldDocument.setHidden(true);
                 xcontext.getWiki().saveDocument(oldDocument, "Create automatic redirect.", xcontext);

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultModelBridge.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultModelBridge.java
@@ -84,8 +84,6 @@ public class DefaultModelBridge implements ModelBridge
 
     /**
      * Used to serialize a space reference in order to query the child documents.
-     * 
-     * @see #getDocumentReferences(SpaceReference)
      */
     @Inject
     @Named("local")

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultModelBridge.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultModelBridge.java
@@ -83,9 +83,8 @@ public class DefaultModelBridge implements ModelBridge
     private QueryManager queryManager;
 
     /**
-     * Used to serialize a space reference in order to query the child documents and to serialize the redirect location.
+     * Used to serialize a space reference in order to query the child documents.
      * 
-     * @see #createRedirect(DocumentReference, DocumentReference)
      * @see #getDocumentReferences(SpaceReference)
      */
     @Inject
@@ -98,8 +97,7 @@ public class DefaultModelBridge implements ModelBridge
      * @see #createRedirect(DocumentReference, DocumentReference)
      */
     @Inject
-    @Named("compact")
-    private EntityReferenceSerializer<String> compactEntityReferenceSerializer;
+    private EntityReferenceSerializer<String> defaultEntityReferenceSerializer;
 
     /**
      * Used to resolve the references of child documents.
@@ -216,7 +214,7 @@ public class DefaultModelBridge implements ModelBridge
             try {
                 XWikiDocument oldDocument = xcontext.getWiki().getDocument(oldReference, xcontext);
                 int number = oldDocument.createXObject(redirectClassReference, xcontext);
-                String location = this.localEntityReferenceSerializer.serialize(newReference);
+                String location = this.defaultEntityReferenceSerializer.serialize(newReference);
                 oldDocument.getXObject(redirectClassReference, number).setStringValue("location", location);
                 oldDocument.setHidden(true);
                 xcontext.getWiki().saveDocument(oldDocument, "Create automatic redirect.", xcontext);


### PR DESCRIPTION
* I replaced the use of the compact serializer with the local serializer in order to get the full name of the new reference instead of 'WebHome'.