### PR TITLE
XWIKI-12314 : Improper redirect when you cancel the request for adding a new user

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/Registration.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/Registration.xml
@@ -483,7 +483,7 @@
         ##
         &lt;input class="button" type="submit" value="$services.localization.render('save')" onclick="window.lb.lbSaveForm();"/&gt;
         &lt;/span&gt;#* End ButtonWrapper then start another...*#&lt;span class="buttonwrapper"&gt;
-        &lt;input class="button secondary" type="submit" value="$services.localization.render("cancel")" onclick="Form.disable(window.lb.form); window.lb.lbClose();"/&gt;
+        &lt;input class="button secondary" type="submit" value="$services.localization.render("cancel")" onclick="window.lb.lbClose();"/&gt;
       #else
         ## Not using the LightBox
         &lt;input type="submit" value="$services.localization.render('core.register.submit')" class="button"/&gt;


### PR DESCRIPTION
* Form.disable(window.lb.form) was performing an unusual action by redirecting to another page displaying the same form, while its own purpose was to close the pop-up window just like the "x" button is doing