### PR TITLE
XWIKI-13560 : Translation key xe.blog.code.blogcategories displayed when editing a blog post in the object editor

### DIFF
--- a/xwiki-platform-core/xwiki-platform-blog/xwiki-platform-blog-ui/src/main/resources/Blog/BlogPostClass.xml
+++ b/xwiki-platform-core/xwiki-platform-blog/xwiki-platform-blog-ui/src/main/resources/Blog/BlogPostClass.xml
@@ -67,7 +67,7 @@
       <separators/>
       <size>1</size>
       <sort>value</sort>
-      <sql/>
+      <sql>select doc.name from XWikiDocument doc, BaseObject as obj where doc.fullName = obj.name and obj.className = 'Blog.CategoryClass' and  doc.fullName not in ('Blog.CategoryTemplate', 'Blog.Categories')</sql>
       <tooltip/>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>

--- a/xwiki-platform-core/xwiki-platform-blog/xwiki-platform-blog-ui/src/main/resources/Blog/Categories.xml
+++ b/xwiki-platform-core/xwiki-platform-blog/xwiki-platform-blog-ui/src/main/resources/Blog/Categories.xml
@@ -119,7 +119,7 @@ $xwiki.jsx.use('Blog.ManageCategories')##
       <description/>
     </property>
     <property>
-      <name>xe.blog.code.blogcategories</name>
+      <name>Blog categories</name>
     </property>
   </object>
   <object>


### PR DESCRIPTION
* the `name` field of the `Blog.CategoryClass` class has no reason to be translation key since it's not rendered
* added `hql` statement in order to exclude `Blog.CategoryTemplate` from the list of displayed `Categories` in object mode.
* `Blog.Categories` should be also excluded from here since it's not displayed in inline mode nor in panels.