### PR TITLE
XWIKI-13274 : Subpages don't inherit properly space rating configuration

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/AbstractRatingsManager.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/AbstractRatingsManager.java
@@ -76,6 +76,16 @@ public abstract class AbstractRatingsManager implements RatingsManager
     }
 
     /**
+     * Gets the ratings configuration component.
+     *
+     * @return the ratingsConfiguration representing the RatingsConfiguration component.
+     */
+    protected RatingsConfiguration getRatingsConfiguration()
+    {
+        return ratingsConfiguration;
+    }
+
+    /**
      * Retrieves the XWiki context from the current execution context.
      * 
      * @return the XWiki context

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/SeparatePageRatingsManager.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/SeparatePageRatingsManager.java
@@ -73,9 +73,6 @@ public class SeparatePageRatingsManager extends AbstractRatingsManager
     @Named("compactwiki")
     protected EntityReferenceSerializer<String> entityReferenceSerializer;
 
-    @Inject
-    private RatingsConfiguration ratingsConfiguration;
-
     /**
      * SeparatePageRatingsManager constructor.
      */
@@ -95,7 +92,7 @@ public class SeparatePageRatingsManager extends AbstractRatingsManager
         String ratingsSpaceName = getXWiki().Param("xwiki.ratings.separatepagemanager.spacename", "");
         ratingsSpaceName =
             getXWiki().getXWikiPreference("ratings_separatepagemanager_spacename", ratingsSpaceName, getXWikiContext());
-        return ratingsConfiguration.getConfigurationParameter(documentRef,
+        return getRatingsConfiguration().getConfigurationParameter(documentRef,
             RatingsManager.RATINGS_CONFIG_CLASS_FIELDNAME_STORAGE_SPACE, ratingsSpaceName);
     }
 
@@ -111,7 +108,7 @@ public class SeparatePageRatingsManager extends AbstractRatingsManager
         result =
             getXWiki().getXWikiPreference("ratings_separatepagemanager_ratingsspaceforeachspace", result,
                 getXWikiContext());
-        return (ratingsConfiguration.getConfigurationParameter(documentRef,
+        return (getRatingsConfiguration().getConfigurationParameter(documentRef,
             RatingsManager.RATINGS_CONFIG_CLASS_FIELDNAME_STORAGE_SEPARATE_SPACES, result) == "1");
     }
 


### PR DESCRIPTION
* Fixed the NPE : RatingsConfiguration component was injected in both SeparatePageRatingsManager and it's superclass AbstractRatingsManager.
