### PR TITLE
XWIKI-13727 : Ratings app is unusable on XWiki 7.4.5

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-ui/src/main/resources/XWiki/Ratings.xml
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-ui/src/main/resources/XWiki/Ratings.xml
@@ -446,20 +446,22 @@ position: relative;
     </class>
     <property>
       <content>{{velocity}}
-#set($canView = $services.security.authorization.hasAccess("view", "XWiki.RatingsMacros"))
+#set($canView = $services.security.authorization.hasAccess('view', 'XWiki.RatingsMacros'))
 #if($canView)
   {{include reference='XWiki.RatingsMacros'/}}
-  #set($configurationClass = 'XWiki.RatingsConfigClass')
+#end
+{{/velocity}}
+{{velocity}}
+#if($canView)
   #set($configurationDoc = $services.ratings.getConfigurationDocument($doc.documentReference))
-  #set($configurationObj = $configurationDoc.getObject($configurationClass))
+  #set($configurationObj = $configurationDoc.getObject('XWiki.RatingsConfigClass'))
   ##
   #set($displayRatings = $configurationObj.getProperty('displayRatings').value == 1)
   #set($excludedPages  = $stringtool.split($configurationObj.getProperty('excludedPages').value, ','))
   #set($excludedPages  = $stringtool.stripAll($excludedPages))
   ##
-  ##
   #if($displayRatings &amp;&amp; !$excludedPages.contains($doc.name))
-    #displayFullRating($doc.getDocumentReference() "")
+    #displayFullRating($doc.getDocumentReference() '')
   #end
 #end
 {{/velocity}}</content>


### PR DESCRIPTION
* this commit is to fix the same issue for XWiki 8.3
* this could be applied also for XWiki 7.4.5 only if the fix for http://jira.xwiki.org/browse/XWIKI-13274 will be also applied