### PR TITLE
XWIKI-13786: Accessibility problem with rights management's checkboxes states.

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/usersandgroups/usersandgroups.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/usersandgroups/usersandgroups.js
@@ -53,8 +53,14 @@ MSCheckbox = Class.create({
       "$xwiki.getSkinFile('js/xwiki/usersandgroups/img/allow.png')",
       "$xwiki.getSkinFile('js/xwiki/usersandgroups/img/deny1.png')"
     ];
+    // TODO: set the labels
     this.labels = ['','',''];
-
+    // Alts are the messages describing the checkbox images
+    this.alts = [
+      '--',
+      '$escapetool.javascript($services.localization.render("allow_1"))',
+      '$escapetool.javascript($services.localization.render("allow_0"))'
+    ];
     this.draw(this.state);
     this.attachEvents();
   },
@@ -71,6 +77,7 @@ MSCheckbox = Class.create({
     //add new image
     var img = document.createElement('img');
     img.src = this.images[state];
+    img.alt = this.alts[state];
     this.domNode.appendChild(img);
     //add label
     if (this.labels[state] != '') {


### PR DESCRIPTION
I open this PR because I don't really know if we should re-use the "labels" fields of the `MSCheckbox` class instead of creating the `alts` one.

Anyway, if we decide to display the labels in the rights editor, we would still need to add an "alt" attribute to the images. That is the best practice and the only choice to be accessible and HTML5 valid (even if our validation tool do not detect this error because it's some HTML code generated by javascript).
