### PR TITLE
XWIKI-14260: Exporting as PDF Level 1 pages, with Header option selected, displays the title of the page 2 times

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/pdfheader.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/pdfheader.vm
@@ -1,6 +1,10 @@
 #set ($title = "$!{pdfdoc.display('title', 'rendered', '', $pdfobj)}")
 #if ($title == '')
-  $!{escapetool.xml($doc.space)} - $!{escapetool.xml($tdoc.plainTitle)}
+  #if ($doc.space != $tdoc.plainTitle)
+    $!{escapetool.xml($doc.space)} - $!{escapetool.xml($tdoc.plainTitle)}
+  #else
+    $!{escapetool.xml($doc.space)}
+  #end
 #else
   $escapetool.xml($title)
 #end


### PR DESCRIPTION
Fix bug by displaying the title only once if it’s the same as the space

When a PDF is exported from a page which has the same title as its space name, this code prevents the document title and the document space (which are, in this case, the same) to be printed twice.
