### PR TITLE
XWIKI-14304: Visually separate document tabs from content

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
@@ -114,7 +114,7 @@
       }
     }
   }
-  
+
   // Only right panels
   &.hideleft {
     &.panel-right-width-Small {
@@ -164,14 +164,14 @@
       }
     }
   }
-  
+
   // No Panels
   &.hidelefthideright {
     .main {
       .make-md-column(12, @main-padding);
     }
   }
-  
+
   &.panel-left-width-Small {
     #leftPanels {
       .make-md-column(1);
@@ -219,10 +219,25 @@
 }
 
 .main {
+  background-color: @body-bg;
+}
+
+#body.main { // Rule for WYSIWYG frame body.main
   background-color: @xwiki-page-content-bg;
-   div& { // Do not apply on WYSIWYG body.main
-    box-shadow: 0 1px 2px @xwiki-border-color;
-  }
+}
+
+#contentcolumn .main {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+#xwikieditor .main {
+  background-color: @xwiki-page-content-bg;
+  box-shadow: 0 1px 2px @xwiki-border-color;
+}
+
+#xwikieditcontent .main {
+  background-color: @xwiki-page-content-bg;
 }
 
 .main,
@@ -252,15 +267,6 @@
   }
 }
 
-#xdocFooter {
-  .clearfix;
-  border-bottom-left-radius: @border-radius-base;
-  border-bottom-right-radius: @border-radius-base;
-  box-shadow: 0px 1px 1px @xwiki-border-color;
-  margin: (@grid-gutter-width / 2) 0;
-  padding: @breadcrumb-padding-vertical @breadcrumb-padding-horizontal;
-}
-
 #xdocAuthors {
   text-align: right;
 }
@@ -273,11 +279,50 @@
   text-align: center;
   position: relative;
   z-index: 2;
-  
+
   a {
     color: @navbar-default-link-color;
     &:hover {
       color: @navbar-default-link-hover-color;
     }
   }
+}
+
+#mainContentArea,
+#xdocFooter,
+#docextrapanes {
+  background-color: @xwiki-page-content-bg;
+  box-shadow: 0 1px 2px @xwiki-border-color;
+  margin: 0 -@grid-gutter-width;
+  padding: @line-height-computed @grid-gutter-width;
+}
+
+#docextrapanes {
+  border-top: 1px solid @xwiki-border-color;
+  border-top-left-radius: @border-radius-base;
+  border-top-right-radius: @border-radius-base;
+  margin-top: -1px;
+}
+
+#xdocFooter {
+  .clearfix;
+  border-bottom-left-radius: @border-radius-base;
+  border-bottom-right-radius: @border-radius-base;
+  margin-bottom: floor((@grid-gutter-width / 2));
+  padding-top: 0;
+}
+
+// Tabbar =====================================================================
+
+.xwikitabbar { // Used by: AllDocs, DocExtra
+  .nav;
+  .nav-tabs;
+  margin: 0;
+  margin-left: -(floor((@grid-gutter-width / 2)));
+}
+
+.xwikitabbar > li.active > a {
+  border-top-color: fade((@xwiki-border-color), 70%);
+  border-left-color: fade((@xwiki-border-color), 70%);
+  border-right-color: fade((@xwiki-border-color), 70%);
 }

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/misc.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/misc.less
@@ -4,7 +4,7 @@
 
 // Left menu2 =================================================================
 .leftmenu2 {
-  background-color: #F0F0EE; 
+  background-color: #F0F0EE;
   padding: 5px;
   a {
     img {
@@ -13,18 +13,10 @@
   }
 }
 
-// Tabbar =====================================================================
-
-.xwikitabbar { // Used by: AllDocs, DocExtra
-  .nav;
-  .nav-tabs;
-  margin: 0;
-}
-
 // Labels =====================================================================
 
 .language {
-  &-translation, 
+  &-translation,
   &-default {
     .label;
     .label-default;
@@ -83,7 +75,7 @@
     }
     .gridBody {
       overflow: hidden; // IE11
-    } 
+    }
     table {
       width: auto;
     }
@@ -122,7 +114,7 @@
 // FIX: Administration: Panel Wizard
 .xwikitabbar {
   #panelEditorSteps& { // PROBLEM: Mapping and usage
-    &>li { 
+    &>li {
       float: none;
       display: inline-block;
     }
@@ -156,13 +148,13 @@
 // FIX: WYSIWYG
 .gwt-MenuBar-horizontal { // PROBLEM: General styling reset
   table {
-    width: auto; 
+    width: auto;
   }
 }
 
 .gwt-MenuBarPopup, // PROBLEM: General styling reset
 .gwt-PopupPanel {
-  & table { 
+  & table {
     margin-bottom: 0;
     td {
       padding: 0;

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/print.css
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/print.css
@@ -55,8 +55,6 @@
 
 #xdocFooter, #docextrapanes {
   border: 0;
-  padding-left: 10px;
-  padding-right: 10px;
 }
 
 #xwikicontent a , #xdocFooter a, #docextrapanes .commentauthor a, #breadcrumbs a {
@@ -77,6 +75,13 @@
   box-shadow: none;
   float: none !important;
   overflow: visible !important;
+}
+
+#mainContentArea, #xdocFooter, #docextrapanes {
+  margin: 0;
+  padding-left: 0;
+  padding-right: 0;
+  box-shadow: none;
 }
 
 /* Remove shortcuts */


### PR DESCRIPTION
- Moved background color from .main to content containing containers
- Tested on editors, viewers, actions and print preview

Result: 
<img width="1273" alt="after" src="https://cloud.githubusercontent.com/assets/629552/26555259/e97cf89a-449c-11e7-92e9-84d580a6a171.png">