### PR TITLE
XWIKI-14348: Allow registration of custom events in wiki pages

### DIFF
--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/pom.xml
@@ -68,6 +68,11 @@
       <artifactId>xwiki-platform-template-api</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-observation-api</artifactId>
+      <version>${commons.version}</version>
+    </dependency>
     <!-- Test Dependencies -->
     <dependency>
       <groupId>org.xwiki.commons</groupId>

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-default/src/main/java/org/xwiki/eventstream/internal/UntypedRecordableEventDescriptorComponentBuilder.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-default/src/main/java/org/xwiki/eventstream/internal/UntypedRecordableEventDescriptorComponentBuilder.java
@@ -31,9 +31,9 @@ import org.xwiki.component.wiki.WikiComponent;
 import org.xwiki.component.wiki.WikiComponentException;
 import org.xwiki.component.wiki.internal.bridge.WikiBaseObjectComponentBuilder;
 import org.xwiki.eventstream.EventStreamException;
-import org.xwiki.model.EntityType;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
+import org.xwiki.model.reference.LocalDocumentReference;
 import org.xwiki.security.authorization.AuthorizationManager;
 import org.xwiki.security.authorization.Right;
 
@@ -63,9 +63,7 @@ public class UntypedRecordableEventDescriptorComponentBuilder implements WikiBas
     @Override
     public EntityReference getClassReference()
     {
-        return new EntityReference(
-                UntypedRecordableEventDescriptorComponentBuilder.BOUNDED_XOBJECT_CLASS,
-                EntityType.OBJECT);
+        return new LocalDocumentReference(Arrays.asList("XWiki", "EventStream", "Code"), "EventClass");
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-default/src/test/java/org/xwiki/eventstream/internal/UntypedRecordableEventDescriptorComponentBuilderTest.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-default/src/test/java/org/xwiki/eventstream/internal/UntypedRecordableEventDescriptorComponentBuilderTest.java
@@ -90,7 +90,7 @@ public class UntypedRecordableEventDescriptorComponentBuilderTest
     @Test
     public void testClassReference() throws Exception
     {
-        assertEquals(UntypedRecordableEventDescriptorComponentBuilder.BOUNDED_XOBJECT_CLASS,
+        assertEquals("EventClass",
                 this.mocker.getComponentUnderTest().getClassReference().getName());
     }
 


### PR DESCRIPTION
This pull request fixes two bugs : 
* The first one (9c515fc) was due to a missing dependency in `xwiki-platform-eventstream-api` which triggered the errors available here : http://ci.xwiki.org/job/xwiki-platform_Quality/4226/console (_Failed to lookup component [role = [interface org.xwiki.observation.EventListener] hint = [Untyped Event Listener]]_).
My guess is that the maven build has been able to succeed because the dependency added here (`xwiki-commons-observation-api`) is also a dependency of `xwiki-commons-tool-test-component`, which is present of the `pom.xml` of `xwiki-platform-eventstream-api`, but with the scope `test`.

* The second commit (b45c588) fixes a bug that provoked in-page events to not be registered at application startup time.