### PR TITLE
XWIKI-14119: Be able to add notifications types from a wiki pages

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/pom.xml
@@ -76,7 +76,11 @@
       <artifactId>xwiki-platform-scheduler-api</artifactId>
       <version>${project.version}</version>
     </dependency>
-
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-component-wiki</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.xwiki.commons</groupId>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/src/main/java/org/xwiki/notifications/internal/DefaultNotificationRenderer.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/src/main/java/org/xwiki/notifications/internal/DefaultNotificationRenderer.java
@@ -20,6 +20,7 @@
 package org.xwiki.notifications.internal;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
@@ -43,6 +44,7 @@ import org.xwiki.text.StringUtils;
 public class DefaultNotificationRenderer implements NotificationRenderer
 {
     @Inject
+    @Named("wiki")
     private ComponentManager componentManager;
 
     @Inject

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-default/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-default/pom.xml
@@ -30,6 +30,9 @@
   <artifactId>xwiki-platform-notifications-default</artifactId>
   <name>XWiki Platform - Notifications - Default bridge</name>
   <description>Default bridge to oldcore for the Notifications API module.</description>
+  <properties>
+    <xwiki.jacoco.instructionRatio>0.21</xwiki.jacoco.instructionRatio>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.xwiki.platform</groupId>
@@ -40,6 +43,13 @@
       <groupId>org.xwiki.platform</groupId>
       <artifactId>xwiki-platform-oldcore</artifactId>
       <version>${project.version}</version>
+    </dependency>
+    <!-- Test Dependencies -->
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-tool-test-component</artifactId>
+      <version>${commons.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-default/src/main/java/org/xwiki/notifications/internal/NotificationDisplayerComponent.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-default/src/main/java/org/xwiki/notifications/internal/NotificationDisplayerComponent.java
@@ -1,0 +1,185 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.notifications.internal;
+
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.script.ScriptContext;
+
+import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.component.wiki.WikiComponent;
+import org.xwiki.component.wiki.WikiComponentScope;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.EntityReference;
+import org.xwiki.notifications.CompositeEvent;
+import org.xwiki.notifications.NotificationDisplayer;
+import org.xwiki.notifications.NotificationException;
+import org.xwiki.rendering.block.Block;
+import org.xwiki.script.ScriptContextManager;
+import org.xwiki.template.Template;
+import org.xwiki.template.TemplateManager;
+import org.xwiki.text.StringUtils;
+
+import com.xpn.xwiki.objects.BaseObject;
+import com.xpn.xwiki.objects.BaseObjectReference;
+
+/**
+ * This class is meant to be instanciated and then registered to the Component Manager by the
+ * {@link NotificationDisplayerComponentBuilder} component every time a document containing a
+ * NotificationDisplayerClass is added, updated or deleted.
+ *
+ * @version $Id$
+ * @since 9.5RC1
+ */
+public class NotificationDisplayerComponent implements WikiComponent, NotificationDisplayer
+{
+    private static final String EVENT_BINDING_NAME = "event";
+
+    private TemplateManager templateManager;
+
+    private ScriptContextManager scriptContextManager;
+
+    private ComponentManager componentManager;
+
+    private BaseObjectReference objectReference;
+
+    private DocumentReference authorReference;
+
+    private String notificationTemplate;
+
+    private String eventType;
+
+    /**
+     * Constructs a new {@link NotificationDisplayerComponent}.
+     *
+     * @param objectReference the reference to the template XObject
+     * @param authorReference the author reference of the document
+     * @param templateManager the {@link TemplateManager} to use
+     * @param scriptContextManager the {@link ScriptContextManager} to use
+     * @param componentManager the {@link ComponentManager} to use
+     * @param baseObject the XObject which has the required properties to instantiate the component
+     * @throws NotificationException if the properties of the given BaseObject could not be loaded
+     */
+    public NotificationDisplayerComponent(BaseObjectReference objectReference, DocumentReference authorReference,
+            TemplateManager templateManager, ScriptContextManager scriptContextManager,
+            ComponentManager componentManager, BaseObject baseObject) throws NotificationException
+    {
+        this.objectReference = objectReference;
+        this.authorReference = authorReference;
+        this.templateManager = templateManager;
+        this.scriptContextManager = scriptContextManager;
+        this.componentManager = componentManager;
+        this.setProperties(baseObject);
+    }
+
+    /**
+     * Set the object attributes by extracting their values from the given BaseObject.
+     *
+     * @param baseObject the XObject that should contain the parameters
+     * @throws NotificationException if an error occured while extracting the parameters from the base object
+     */
+    private void setProperties(BaseObject baseObject) throws NotificationException
+    {
+        try {
+            this.notificationTemplate = baseObject.getStringValue(
+                    NotificationDisplayerDocumentInitializer.NOTIFICATION_TEMPLATE);
+            this.eventType = baseObject.getStringValue(NotificationDisplayerDocumentInitializer.EVENT_TYPE);
+        } catch (Exception e) {
+            throw new NotificationException(
+                    String.format("Unable to extract the parameters from the [%s] NotificationDisplayerClass.",
+                            baseObject), e);
+        }
+    }
+
+    @Override
+    public Block renderNotification(CompositeEvent eventNotification) throws NotificationException
+    {
+        try {
+            // Allow the template to access the event during its execution
+            scriptContextManager.getCurrentScriptContext().setAttribute(EVENT_BINDING_NAME, eventNotification,
+                    ScriptContext.ENGINE_SCOPE);
+
+            // If we have no template defined, fallback on the default displayer
+            if (StringUtils.isBlank(this.notificationTemplate)) {
+                return ((NotificationDisplayer) this.componentManager.getInstance(NotificationDisplayer.class))
+                        .renderNotification(eventNotification);
+            }
+
+            // Render the template
+            Template customTemplate = templateManager.createStringTemplate(
+                    this.notificationTemplate,
+                    this.getAuthorReference());
+
+            return templateManager.getXDOM(customTemplate);
+
+        } catch (Exception e) {
+            throw new NotificationException(
+                    String.format("Unable to render notification template for the [%s].", this.eventType), e);
+        } finally {
+            // Unbind the event from the current script context
+            scriptContextManager.getCurrentScriptContext().removeAttribute(EVENT_BINDING_NAME,
+                    ScriptContext.ENGINE_SCOPE);
+        }
+    }
+
+    @Override
+    public List<String> getSupportedEvents()
+    {
+        return Arrays.asList(this.eventType);
+    }
+
+    @Override
+    public DocumentReference getDocumentReference()
+    {
+        return (DocumentReference) this.objectReference.getParent();
+    }
+
+    @Override
+    public EntityReference getEntityReference()
+    {
+        return this.objectReference;
+    }
+
+    @Override
+    public DocumentReference getAuthorReference()
+    {
+        return this.authorReference;
+    }
+
+    @Override
+    public Type getRoleType()
+    {
+        return NotificationDisplayer.class;
+    }
+
+    @Override
+    public String getRoleHint()
+    {
+        return this.eventType;
+    }
+
+    @Override
+    public WikiComponentScope getScope()
+    {
+        return WikiComponentScope.WIKI;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-default/src/main/java/org/xwiki/notifications/internal/NotificationDisplayerComponentBuilder.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-default/src/main/java/org/xwiki/notifications/internal/NotificationDisplayerComponentBuilder.java
@@ -1,0 +1,114 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.notifications.internal;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.component.wiki.WikiComponent;
+import org.xwiki.component.wiki.WikiComponentException;
+import org.xwiki.component.wiki.internal.bridge.WikiBaseObjectComponentBuilder;
+import org.xwiki.model.EntityType;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.EntityReference;
+import org.xwiki.notifications.NotificationException;
+import org.xwiki.script.ScriptContextManager;
+import org.xwiki.security.authorization.AuthorizationManager;
+import org.xwiki.security.authorization.Right;
+import org.xwiki.template.TemplateManager;
+
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.objects.BaseObject;
+
+/**
+ * This component allows the definition of a {@link org.xwiki.notifications.NotificationDisplayer} in wiki pages.
+ * It uses {@link UntypedRecordableEvent#getEventType} to be bound to a specific event type.
+ *
+ * @version $Id$
+ * @since 9.5RC1
+ */
+@Component
+@Named(NotificationDisplayerDocumentInitializer.XCLASS_NAME)
+@Singleton
+public class NotificationDisplayerComponentBuilder implements WikiBaseObjectComponentBuilder
+{
+    @Inject
+    private TemplateManager templateManager;
+
+    @Inject
+    private ScriptContextManager scriptContextManager;
+
+    @Inject
+    private ComponentManager componentManager;
+
+    @Inject
+    private AuthorizationManager authorizationManager;
+
+    @Override
+    public EntityReference getClassReference()
+    {
+        return new EntityReference(
+                NotificationDisplayerDocumentInitializer.XCLASS_NAME,
+                EntityType.OBJECT);
+    }
+
+    @Override
+    public List<WikiComponent> buildComponents(BaseObject baseObject) throws WikiComponentException
+    {
+        try {
+            // Check that the document owner is allowed to build the components
+            XWikiDocument parentDocument = baseObject.getOwnerDocument();
+            this.checkRights(parentDocument.getDocumentReference(), parentDocument.getAuthorReference());
+
+            // Instantiate the component
+            return Arrays.asList(
+                    new NotificationDisplayerComponent(
+                            baseObject.getReference(), parentDocument.getAuthorReference(),
+                            this.templateManager, this.scriptContextManager, this.componentManager, baseObject));
+        } catch (Exception e) {
+            throw new WikiComponentException(String.format(
+                    "Unable to build the NotificationDisplayerComponent wiki component "
+                            + "for [%s].", baseObject), e);
+        }
+    }
+
+    /**
+     * Ensure that the given author has the administrative rights in the current context.
+     *
+     * @param documentReference the working entity
+     * @param authorReference the author that should have its rights checked
+     * @throws NotificationException if the author rights are not sufficient
+     */
+    private void checkRights(DocumentReference documentReference, DocumentReference authorReference)
+            throws NotificationException
+    {
+        if (!this.authorizationManager.hasAccess(Right.ADMIN, authorReference, documentReference.getWikiReference()))
+        {
+            throw new NotificationException(
+                    "Registering custom Notification Displayers requires wiki administration rights.");
+        }
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-default/src/main/java/org/xwiki/notifications/internal/NotificationDisplayerDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-default/src/main/java/org/xwiki/notifications/internal/NotificationDisplayerDocumentInitializer.java
@@ -1,0 +1,81 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.notifications.internal;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.model.reference.LocalDocumentReference;
+
+import com.xpn.xwiki.doc.AbstractMandatoryClassInitializer;
+import com.xpn.xwiki.objects.classes.BaseClass;
+import com.xpn.xwiki.objects.classes.TextAreaClass;
+
+/**
+ * Define the NotificationDisplayerClass XObjects.
+ *
+ * @version $Id$
+ * @since 9.6RC1
+ */
+@Component
+@Named(NotificationDisplayerDocumentInitializer.XCLASS_NAME)
+@Singleton
+public class NotificationDisplayerDocumentInitializer extends AbstractMandatoryClassInitializer
+{
+    /**
+     * The name of the XObject class that should be bound used.
+     */
+    public static final String XCLASS_NAME = "XWiki.Notifications.Code.NotificationDisplayerClass";
+
+    /**
+     * The name of the event type property in the XObject.
+     */
+    public static final String EVENT_TYPE = "eventType";
+
+    /**
+     * The name of the notification template property in the XObject.
+     */
+    public static final String NOTIFICATION_TEMPLATE = "notificationTemplate";
+
+    /**
+     * The name of the space where the class is located.
+     */
+    private static final List<String> SPACE_PATH = Arrays.asList("XWiki", "Notifications", "Code");
+
+    /**
+     * Default constructor.
+     */
+    public NotificationDisplayerDocumentInitializer()
+    {
+        super(new LocalDocumentReference(SPACE_PATH, "NotificationDisplayerClass"));
+    }
+
+    @Override
+    protected void createClass(BaseClass xclass)
+    {
+        xclass.addTextField(EVENT_TYPE, "Event type", 64);
+        xclass.addTextAreaField(NOTIFICATION_TEMPLATE, "Notification template",
+                40, 3, TextAreaClass.ContentType.VELOCITY_CODE);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-default/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-default/src/main/resources/META-INF/components.txt
@@ -1,1 +1,3 @@
 org.xwiki.notifications.internal.DefaultModelBridge
+org.xwiki.notifications.internal.NotificationDisplayerComponentBuilder
+org.xwiki.notifications.internal.NotificationDisplayerDocumentInitializer

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-default/src/test/java/org/xwiki/notifications/internal/NotificationDisplayerComponentBuilderTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-default/src/test/java/org/xwiki/notifications/internal/NotificationDisplayerComponentBuilderTest.java
@@ -1,0 +1,74 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.notifications.internal;
+
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.DocumentReferenceResolver;
+import org.xwiki.query.Query;
+import org.xwiki.query.QueryManager;
+import org.xwiki.test.mockito.MockitoComponentMockingRule;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link NotificationDisplayerComponentBuilder}.
+ *
+ * @version $Id$
+ * @since 9.5RC1
+ */
+public class NotificationDisplayerComponentBuilderTest
+{
+    @Rule
+    public final MockitoComponentMockingRule<NotificationDisplayerComponentBuilder> mocker =
+            new MockitoComponentMockingRule<>(NotificationDisplayerComponentBuilder.class);
+
+    private QueryManager queryManager;
+
+    private DocumentReferenceResolver<String> documentReferenceResolver;
+
+    private DocumentReference event1;
+    private DocumentReference event2;
+    private DocumentReference event3;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        queryManager = mocker.registerMockComponent(QueryManager.class);
+
+        documentReferenceResolver = mocker.registerMockComponent(DocumentReferenceResolver.class);
+        Query query = mock(Query.class);
+        when(queryManager.createQuery(any(), any())).thenReturn(query);
+        when(query.execute()).thenReturn(Arrays.asList("e1", "e2", "e3"));
+
+        event1 = mock(DocumentReference.class);
+        event2 = mock(DocumentReference.class);
+        event3 = mock(DocumentReference.class);
+
+        when(this.documentReferenceResolver.resolve("e1")).thenReturn(event1);
+        when(this.documentReferenceResolver.resolve("e2")).thenReturn(event2);
+        when(this.documentReferenceResolver.resolve("e3")).thenReturn(event3);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-default/src/test/java/org/xwiki/notifications/internal/NotificationDisplayerComponentTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-default/src/test/java/org/xwiki/notifications/internal/NotificationDisplayerComponentTest.java
@@ -1,0 +1,135 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.notifications.internal;
+
+import javax.script.ScriptContext;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.component.wiki.WikiComponentScope;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.notifications.CompositeEvent;
+import org.xwiki.notifications.NotificationDisplayer;
+import org.xwiki.script.ScriptContextManager;
+import org.xwiki.template.Template;
+import org.xwiki.template.TemplateManager;
+
+import com.xpn.xwiki.objects.BaseObject;
+import com.xpn.xwiki.objects.BaseObjectReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link NotificationDisplayerComponent}.
+ *
+ * @version $Id$
+ * @since 9.5RC1
+ */
+public class NotificationDisplayerComponentTest
+{
+    private BaseObjectReference objectReference;
+
+    private DocumentReference authorReference;
+
+    private TemplateManager templateManager;
+
+    private ScriptContextManager scriptContextManager;
+
+    private ComponentManager componentManager;
+
+    private NotificationDisplayer defaultNotificationDisplayer;
+
+    private NotificationDisplayerComponent componentUnderTest;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        this.objectReference = mock(BaseObjectReference.class);
+        this.authorReference = mock(DocumentReference.class);
+
+        this.templateManager = mock(TemplateManager.class);
+        when(this.templateManager.createStringTemplate(any(), any())).thenReturn(mock(Template.class));
+
+        this.scriptContextManager = mock(ScriptContextManager.class);
+        ScriptContext scriptContext = mock(ScriptContext.class);
+        when(this.scriptContextManager.getCurrentScriptContext()).thenReturn(scriptContext);
+
+        this.componentManager = mock(ComponentManager.class);
+        this.defaultNotificationDisplayer = mock(DefaultNotificationDisplayer.class);
+        when(this.componentManager.getInstance(NotificationDisplayer.class)).thenReturn(defaultNotificationDisplayer);
+    }
+
+    private void instantiateComponent(BaseObject baseObject) throws Exception
+    {
+        componentUnderTest = new NotificationDisplayerComponent(objectReference, authorReference, templateManager,
+                scriptContextManager, componentManager, baseObject);
+    }
+
+    private BaseObject mockBaseObject(String notificationTemplate, String eventType) throws Exception
+    {
+        BaseObject baseObject = mock(BaseObject.class);
+        when(baseObject.getStringValue(NotificationDisplayerDocumentInitializer.NOTIFICATION_TEMPLATE))
+                .thenReturn(notificationTemplate);
+        when(baseObject.getStringValue(NotificationDisplayerDocumentInitializer.EVENT_TYPE))
+                .thenReturn(eventType);
+        return baseObject;
+    }
+
+    @Test
+    public void parameters() throws Exception
+    {
+        this.instantiateComponent(this.mockBaseObject("Notification Template", "Event Type"));
+
+        assertEquals("Event Type", componentUnderTest.getSupportedEvents().get(0));
+        assertEquals(this.authorReference, componentUnderTest.getAuthorReference());
+        assertEquals(NotificationDisplayer.class, componentUnderTest.getRoleType());
+        assertEquals("Event Type", componentUnderTest.getRoleHint());
+        assertEquals(WikiComponentScope.WIKI, componentUnderTest.getScope());
+        assertEquals(this.objectReference, componentUnderTest.getEntityReference());
+    }
+
+    @Test
+    public void renderNotificationWithBlankTemplate() throws Exception
+    {
+        this.instantiateComponent(this.mockBaseObject("", "Event Type"));
+
+        CompositeEvent compositeEvent = mock(CompositeEvent.class);
+        this.componentUnderTest.renderNotification(compositeEvent);
+
+        verify(defaultNotificationDisplayer, times(1)).renderNotification(compositeEvent);
+    }
+
+    @Test
+    public void renderNotificationWithTemplate() throws Exception
+    {
+        this.instantiateComponent(this.mockBaseObject("Some Template", "Event Type"));
+
+        CompositeEvent compositeEvent = mock(CompositeEvent.class);
+        this.componentUnderTest.renderNotification(compositeEvent);
+
+        verify(templateManager, times(1)).getXDOM(any(Template.class));
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-default/src/test/java/org/xwiki/notifications/internal/NotificationDisplayerDocumentInitializerTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-default/src/test/java/org/xwiki/notifications/internal/NotificationDisplayerDocumentInitializerTest.java
@@ -1,0 +1,51 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.notifications.internal;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.xwiki.test.mockito.MockitoComponentMockingRule;
+
+import com.xpn.xwiki.objects.classes.BaseClass;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for {@link NotificationDisplayerDocumentInitializer}.
+ *
+ * @version $Id$
+ * @since 9.6RC1
+ */
+public class NotificationDisplayerDocumentInitializerTest
+{
+    @Rule
+    public final MockitoComponentMockingRule<NotificationDisplayerDocumentInitializer> mocker =
+            new MockitoComponentMockingRule<>(NotificationDisplayerDocumentInitializer.class);
+
+    @Test
+    public void testCreateClass() throws Exception
+    {
+        BaseClass testXClass = new BaseClass();
+
+        this.mocker.getComponentUnderTest().createClass(testXClass);
+
+        assertEquals(2, testXClass.getFieldList().size());
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-pageobjects/src/main/java/org/xwiki/platform/notifications/test/po/NotificationsTrayPage.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-pageobjects/src/main/java/org/xwiki/platform/notifications/test/po/NotificationsTrayPage.java
@@ -181,6 +181,21 @@ public class NotificationsTrayPage  extends ViewPage
     }
 
     /**
+     * Get the raw content of a notification.
+     *
+     * @param notificationNumber index of the notification in the list
+     * @return the notification raw content
+     */
+    public String getNotificationRawContent(int notificationNumber)
+    {
+        if (notificationNumber < 0 || notificationNumber >= this.getNotificationsCount()) {
+            throw new IndexOutOfBoundsException();
+        }
+
+        return this.getNotifications().get(notificationNumber).getText();
+    }
+
+    /**
      * Mark a notification as read.
      *
      * @param notificationNumber index of the notification in the list


### PR DESCRIPTION
* Add NotificationDisplayerComponent Wiki Component
* NotificationDisplayerComponentBuilder Component
* NotificationDisplayerDocumentInitializer Component
* Add unit tests in xwiki-platform-notifications-default
* Add functionnal tests