### PR TITLE
XWIKI-14507: Allow actions in the event stream to be observed

### DIFF
--- a/xwiki-platform-core/xwiki-platform-activitystream/xwiki-platform-activitystream-api/src/main/java/com/xpn/xwiki/plugin/activitystream/eventstreambridge/BridgeEventStream.java
+++ b/xwiki-platform-core/xwiki-platform-activitystream/xwiki-platform-activitystream-api/src/main/java/com/xpn/xwiki/plugin/activitystream/eventstreambridge/BridgeEventStream.java
@@ -81,7 +81,7 @@ public class BridgeEventStream implements EventStream
             XWikiContext context = getXWikiContext();
             ActivityStreamPlugin plugin = getPlugin(context);
             plugin.getActivityStream().addActivityEvent(eventConverter.convertEventToActivity(e), context);
-            this.sendEventStreamEvent(new EventStreamAddedEvent(e));
+            this.sendEventStreamEvent(new EventStreamAddedEvent(), e);
         } catch (ActivityStreamException ex) {
             // Unlikely; nothing we can do
         }
@@ -94,20 +94,20 @@ public class BridgeEventStream implements EventStream
             XWikiContext context = getXWikiContext();
             ActivityStreamPlugin plugin = getPlugin(context);
             plugin.getActivityStream().deleteActivityEvent(eventConverter.convertEventToActivity(e), context);
-            this.sendEventStreamEvent(new EventStreamDeletedEvent(e));
+            this.sendEventStreamEvent(new EventStreamDeletedEvent(), e);
         } catch (ActivityStreamException ex) {
             // Unlikely; nothing we can do
         }
     }
 
-    private void sendEventStreamEvent(AbstractEventStreamEvent eventStreamEvent)
+    private void sendEventStreamEvent(AbstractEventStreamEvent eventStreamEvent, Event event)
     {
         // In order to avoid infinite loop caused by observation events triggering event stream events that are
         // themselves triggering new observation events …, we add a new property to the execution context. Therefore,
         // an observation event declared out of an event stream event can only be triggered once.
         if (!this.execution.getContext().hasProperty(EVENT_LOOP_CONTEXT_LOCK_PROPERTY)) {
             this.execution.getContext().newProperty(EVENT_LOOP_CONTEXT_LOCK_PROPERTY).declare();
-            this.observationManager.notify(eventStreamEvent, eventStreamEvent.getEvent());
+            this.observationManager.notify(eventStreamEvent, event);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-activitystream/xwiki-platform-activitystream-api/src/main/java/com/xpn/xwiki/plugin/activitystream/eventstreambridge/BridgeEventStream.java
+++ b/xwiki-platform-core/xwiki-platform-activitystream/xwiki-platform-activitystream-api/src/main/java/com/xpn/xwiki/plugin/activitystream/eventstreambridge/BridgeEventStream.java
@@ -31,6 +31,9 @@ import org.xwiki.context.Execution;
 import org.xwiki.eventstream.Event;
 import org.xwiki.eventstream.EventGroup;
 import org.xwiki.eventstream.EventStream;
+import org.xwiki.eventstream.events.EventStreamAddedEvent;
+import org.xwiki.eventstream.events.EventStreamDeletedEvent;
+import org.xwiki.observation.ObservationManager;
 import org.xwiki.query.Query;
 import org.xwiki.query.QueryException;
 import org.xwiki.query.QueryManager;
@@ -61,6 +64,9 @@ public class BridgeEventStream implements EventStream
     @Inject
     private EventConverter eventConverter;
 
+    @Inject
+    private ObservationManager observationManager;
+
     @Override
     public void addEvent(Event e)
     {
@@ -68,6 +74,7 @@ public class BridgeEventStream implements EventStream
             XWikiContext context = getXWikiContext();
             ActivityStreamPlugin plugin = getPlugin(context);
             plugin.getActivityStream().addActivityEvent(eventConverter.convertEventToActivity(e), context);
+            this.observationManager.notify(new EventStreamAddedEvent(e), e);
         } catch (ActivityStreamException ex) {
             // Unlikely; nothing we can do
         }
@@ -80,6 +87,7 @@ public class BridgeEventStream implements EventStream
             XWikiContext context = getXWikiContext();
             ActivityStreamPlugin plugin = getPlugin(context);
             plugin.getActivityStream().deleteActivityEvent(eventConverter.convertEventToActivity(e), context);
+            this.observationManager.notify(new EventStreamDeletedEvent(e), e);
         } catch (ActivityStreamException ex) {
             // Unlikely; nothing we can do
         }

--- a/xwiki-platform-core/xwiki-platform-activitystream/xwiki-platform-activitystream-api/src/main/java/com/xpn/xwiki/plugin/activitystream/eventstreambridge/BridgeEventStream.java
+++ b/xwiki-platform-core/xwiki-platform-activitystream/xwiki-platform-activitystream-api/src/main/java/com/xpn/xwiki/plugin/activitystream/eventstreambridge/BridgeEventStream.java
@@ -58,7 +58,7 @@ public class BridgeEventStream implements EventStream
      * Used to provide a key to a property in the current execution context that avoids stepping into a loop when
      * triggering new events.
      */
-    private static final String EVENT_CONTEXT_LOCK_PROPERTY = "eventContextProperty";
+    private static final String EVENT_LOOP_CONTEXT_LOCK_PROPERTY = "eventLoopContextLockProperty";
 
     /** Needed for accessing the current request context. */
     @Inject
@@ -105,8 +105,8 @@ public class BridgeEventStream implements EventStream
         // In order to avoid infinite loop caused by observation events triggering event stream events that are
         // themselves triggering new observation events …, we add a new property to the execution context. Therefore,
         // an observation event declared out of an event stream event can only be triggered once.
-        if (!this.execution.getContext().hasProperty(EVENT_CONTEXT_LOCK_PROPERTY)) {
-            this.execution.getContext().newProperty(EVENT_CONTEXT_LOCK_PROPERTY).declare();
+        if (!this.execution.getContext().hasProperty(EVENT_LOOP_CONTEXT_LOCK_PROPERTY)) {
+            this.execution.getContext().newProperty(EVENT_LOOP_CONTEXT_LOCK_PROPERTY).declare();
             this.observationManager.notify(eventStreamEvent, eventStreamEvent.getEvent());
         }
     }

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/events/AbstractEventStreamEvent.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/events/AbstractEventStreamEvent.java
@@ -53,4 +53,10 @@ public abstract class AbstractEventStreamEvent implements org.xwiki.observation.
     {
         return this.event;
     }
+
+    @Override
+    public boolean matches(Object o)
+    {
+        return (this.getClass().isInstance(o) && ((AbstractEventStreamEvent) o).getEvent().equals(this.event));
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/events/AbstractEventStreamEvent.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/events/AbstractEventStreamEvent.java
@@ -22,7 +22,7 @@ package org.xwiki.eventstream.events;
 import org.xwiki.eventstream.Event;
 
 /**
- * Groups every event regarding the {@link org.xwiki.eventstream.EventStream}.
+ * Abstract method for every event that is related to the {@link org.xwiki.eventstream.EventStream}.
  * When an event that extends an {@link AbstractEventStreamEvent} is triggered, it should also be triggered
  * with the corresponding event stream event as the source object.
  *

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/events/AbstractEventStreamEvent.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/events/AbstractEventStreamEvent.java
@@ -19,8 +19,6 @@
  */
 package org.xwiki.eventstream.events;
 
-import org.xwiki.eventstream.Event;
-
 /**
  * Abstract class for every event that is related to the {@link org.xwiki.eventstream.EventStream}.
  *
@@ -29,29 +27,9 @@ import org.xwiki.eventstream.Event;
  */
 public abstract class AbstractEventStreamEvent implements org.xwiki.observation.event.Event
 {
-    protected Event event;
-
-    /**
-     * Constructs a new {@link AbstractEventStreamEvent}.
-     *
-     * @param event the event stream event that is related to this particular event.
-     */
-    public AbstractEventStreamEvent(Event event)
-    {
-        this.event = event;
-    }
-
-    /**
-     * @return the event related to the event stream.
-     */
-    public Event getEvent()
-    {
-        return this.event;
-    }
-
     @Override
     public boolean matches(Object o)
     {
-        return (this.getClass().isInstance(o) && ((AbstractEventStreamEvent) o).getEvent().equals(this.event));
+        return (this.getClass().isInstance(o));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/events/AbstractEventStreamEvent.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/events/AbstractEventStreamEvent.java
@@ -1,0 +1,56 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.eventstream.events;
+
+import org.xwiki.eventstream.Event;
+
+/**
+ * Groups every event regarding the {@link org.xwiki.eventstream.EventStream}.
+ * When an event that extends an {@link AbstractEventStreamEvent} is triggered, it should also be triggered
+ * with the corresponding event stream event as the source object.
+ *
+ * Here, we require a reference to an event stream event in order to correctly implement
+ * {@link org.xwiki.observation.event.Event#matches(Object)}.
+ *
+ * @since 9.6RC1
+ * @version $Id$
+ */
+public abstract class AbstractEventStreamEvent implements org.xwiki.observation.event.Event
+{
+    protected Event event;
+
+    /**
+     * Constructs a new {@link AbstractEventStreamEvent}.
+     *
+     * @param event the event stream event that is related to this particular event.
+     */
+    public AbstractEventStreamEvent(Event event)
+    {
+        this.event = event;
+    }
+
+    /**
+     * @return the event related to the event stream.
+     */
+    public Event getEvent()
+    {
+        return this.event;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/events/AbstractEventStreamEvent.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/events/AbstractEventStreamEvent.java
@@ -22,12 +22,7 @@ package org.xwiki.eventstream.events;
 import org.xwiki.eventstream.Event;
 
 /**
- * Abstract method for every event that is related to the {@link org.xwiki.eventstream.EventStream}.
- * When an event that extends an {@link AbstractEventStreamEvent} is triggered, it should also be triggered
- * with the corresponding event stream event as the source object.
- *
- * Here, we require a reference to an event stream event in order to correctly implement
- * {@link org.xwiki.observation.event.Event#matches(Object)}.
+ * Abstract class for every event that is related to the {@link org.xwiki.eventstream.EventStream}.
  *
  * @since 9.6RC1
  * @version $Id$

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/events/EventStreamAddedEvent.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/events/EventStreamAddedEvent.java
@@ -47,10 +47,4 @@ public class EventStreamAddedEvent extends AbstractEventStreamEvent
     {
         super(event);
     }
-
-    @Override
-    public boolean matches(Object o)
-    {
-        return (o instanceof EventStreamAddedEvent && ((EventStreamAddedEvent) o).getEvent().equals(this.event));
-    }
 }

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/events/EventStreamAddedEvent.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/events/EventStreamAddedEvent.java
@@ -19,32 +19,16 @@
  */
 package org.xwiki.eventstream.events;
 
-import org.xwiki.eventstream.Event;
-
 /**
  * Event triggered when a new event is registered inside of the {@link org.xwiki.eventstream.EventStream}. This event
  * contains a reference to the actual event that has been registered in the event stream.
+ *
+ * This event also send the following parameters:
+ * source: the event inserted in the event stream that triggered this event
  *
  * @since 9.6RC1
  * @version $Id$
  */
 public class EventStreamAddedEvent extends AbstractEventStreamEvent
 {
-    /**
-     * Constructs a new {@link EventStreamAddedEvent}.
-     */
-    public EventStreamAddedEvent()
-    {
-        super(null);
-    }
-
-    /**
-     * Constructs a new {@link EventStreamAddedEvent}.
-     *
-     * @param event the event stream event related to this particular event
-     */
-    public EventStreamAddedEvent(Event event)
-    {
-        super(event);
-    }
 }

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/events/EventStreamAddedEvent.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/events/EventStreamAddedEvent.java
@@ -32,6 +32,14 @@ public class EventStreamAddedEvent extends AbstractEventStreamEvent
 {
     /**
      * Constructs a new {@link EventStreamAddedEvent}.
+     */
+    public EventStreamAddedEvent()
+    {
+        super(null);
+    }
+
+    /**
+     * Constructs a new {@link EventStreamAddedEvent}.
      *
      * @param event the event stream event related to this particular event
      */

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/events/EventStreamAddedEvent.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/events/EventStreamAddedEvent.java
@@ -1,0 +1,48 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.eventstream.events;
+
+import org.xwiki.eventstream.Event;
+
+/**
+ * Event triggered when a new event is registered inside of the {@link org.xwiki.eventstream.EventStream}. This event
+ * contains a reference to the actual event that has been registered in the event stream.
+ *
+ * @since 9.6RC1
+ * @version $Id$
+ */
+public class EventStreamAddedEvent extends AbstractEventStreamEvent
+{
+    /**
+     * Constructs a new {@link EventStreamAddedEvent}.
+     *
+     * @param event the event stream event related to this particular event
+     */
+    public EventStreamAddedEvent(Event event)
+    {
+        super(event);
+    }
+
+    @Override
+    public boolean matches(Object o)
+    {
+        return (o instanceof EventStreamAddedEvent && ((EventStreamAddedEvent) o).getEvent().equals(this.event));
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/events/EventStreamDeletedEvent.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/events/EventStreamDeletedEvent.java
@@ -19,31 +19,15 @@
  */
 package org.xwiki.eventstream.events;
 
-import org.xwiki.eventstream.Event;
-
 /**
  * Event triggered when an event is deleted from the {@link org.xwiki.eventstream.EventStream}.
+ *
+ * This event also send the following parameters:
+ * source: the event removed from the event stream that triggered this event
  *
  * @since 9.6RC1
  * @version $Id$
  */
 public class EventStreamDeletedEvent extends AbstractEventStreamEvent
 {
-    /**
-     * Constructs a new {@link EventStreamDeletedEvent}.
-     */
-    public EventStreamDeletedEvent()
-    {
-        super(null);
-    }
-
-    /**
-     * Constructs a new {@link EventStreamDeletedEvent}.
-     *
-     * @param event the event stream event related to this particular event
-     */
-    public EventStreamDeletedEvent(Event event)
-    {
-        super(event);
-    }
 }

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/events/EventStreamDeletedEvent.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/events/EventStreamDeletedEvent.java
@@ -31,6 +31,14 @@ public class EventStreamDeletedEvent extends AbstractEventStreamEvent
 {
     /**
      * Constructs a new {@link EventStreamDeletedEvent}.
+     */
+    public EventStreamDeletedEvent()
+    {
+        super(null);
+    }
+
+    /**
+     * Constructs a new {@link EventStreamDeletedEvent}.
      *
      * @param event the event stream event related to this particular event
      */

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/events/EventStreamDeletedEvent.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/events/EventStreamDeletedEvent.java
@@ -46,10 +46,4 @@ public class EventStreamDeletedEvent extends AbstractEventStreamEvent
     {
         super(event);
     }
-
-    @Override
-    public boolean matches(Object o)
-    {
-        return (o instanceof EventStreamDeletedEvent && ((EventStreamDeletedEvent) o).getEvent().equals(this.event));
-    }
 }

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/events/EventStreamDeletedEvent.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/events/EventStreamDeletedEvent.java
@@ -1,0 +1,47 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.eventstream.events;
+
+import org.xwiki.eventstream.Event;
+
+/**
+ * Event triggered when an event is deleted from the {@link org.xwiki.eventstream.EventStream}.
+ *
+ * @since 9.6RC1
+ * @version $Id$
+ */
+public class EventStreamDeletedEvent extends AbstractEventStreamEvent
+{
+    /**
+     * Constructs a new {@link EventStreamDeletedEvent}.
+     *
+     * @param event the event stream event related to this particular event
+     */
+    public EventStreamDeletedEvent(Event event)
+    {
+        super(event);
+    }
+
+    @Override
+    public boolean matches(Object o)
+    {
+        return (o instanceof EventStreamDeletedEvent && ((EventStreamDeletedEvent) o).getEvent().equals(this.event));
+    }
+}


### PR DESCRIPTION
* Add EventStreamAddedEvent and EventStreamDeletedEvent
* Update the BridgeEventStream to trigger those events when needed
* Update BridgeEventStream in order to avoid loops between observation events and event stream events