### PR TITLE
XWIKI-12990: Displaying a livetable list filter for a non-static list field is not scalable

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/macros.vm
@@ -277,25 +277,33 @@
                 #set($class = $xwiki.getDocument($propClassName).getxWikiClass())
                 #set($list = '')
                 #set($list = $class.get($colname).getListValues())
-                <select id="xwiki-livetable-${htmlLiveTableId}-filter-${velocityCount}" name='${colname}'
-                #if("$!colprop.type" == 'multilist')
-                  #set($ok = $xwiki.jsfx.use('js/xwiki/table/livetablemulti.js', true))
-                  #set($ok = $xwiki.linkx.use($services.webjars.url('bootstrap-select', 'css/bootstrap-select.css'), {'type': 'text/css', 'rel': 'stylesheet'}))
-                  class='xwiki-livetable-multilist' multiple='multiple'>
+                #if ($list.size() > 1000)
+                  ## default to a text filter if the list is too large
+                  <input id="xwiki-livetable-${htmlLiveTableId}-filter-${velocityCount}" name="${colname}" type="text"
+                  #if("$!colprop.size" != '') size="${colprop.size}"
+                  title="$escapetool.xml($services.localization.render('platform.livetable.filtersTitle',
+                  [$services.localization.render("${transprefix}${colname}")]))"#end />
                 #else
-                  ><option value=''>$services.localization.render('platform.livetable.selectAll')</option>
-                  <option disabled='disabled'>────</option>
-                #end
-                #set($map = $class.get($colname).getMapValues())
-                #foreach($listitem in $list)
-                  #set ($l10n_key = "${propClassName}_${colname}_${listitem}")
-                  #set ($l10n_value = $services.localization.render($l10n_key))
-                  #if ($l10n_value == $l10n_key)
-                    #set ($l10n_value = $map.get($listitem).getValue())
+                  <select id="xwiki-livetable-${htmlLiveTableId}-filter-${velocityCount}" name='${colname}'
+                  #if("$!colprop.type" == 'multilist')
+                    #set($ok = $xwiki.jsfx.use('js/xwiki/table/livetablemulti.js', true))
+                    #set($ok = $xwiki.linkx.use($services.webjars.url('bootstrap-select', 'css/bootstrap-select.css'), {'type': 'text/css', 'rel': 'stylesheet'}))
+                    class='xwiki-livetable-multilist' multiple='multiple'>
+                  #else
+                    ><option value=''>$services.localization.render('platform.livetable.selectAll')</option>
+                    <option disabled='disabled'>────</option>
                   #end
-                  <option value="$listitem">$l10n_value</option>
+                  #set($map = $class.get($colname).getMapValues())
+                  #foreach($listitem in $list)
+                    #set ($l10n_key = "${propClassName}_${colname}_${listitem}")
+                    #set ($l10n_value = $services.localization.render($l10n_key))
+                    #if ($l10n_value == $l10n_key)
+                      #set ($l10n_value = $map.get($listitem).getValue())
+                    #end
+                    <option value="$listitem">$l10n_value</option>
+                  #end
+                  </select>
                 #end
-                </select>
                 </td>
               #elseif("$!colprop.type" == 'boolean' && $isFilterable)
                 <td class="xwiki-livetable-display-header-filter">


### PR DESCRIPTION
When we display lists that are too big, it causes a loop to run for hours. Instead, we can use a text filter as a fallback if there are too many items (proposed solution 2).

JIRA: https://jira.xwiki.org/browse/XWIKI-12990