### PR TITLE
XWIKI-11162: Allow quickly switching the type of user (simple / advanced) without moving away from the current page

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/shortcuts.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/shortcuts.vm
@@ -75,6 +75,33 @@
     shortcut.add("$services.localization.render('core.shortcuts.view.code')", function() {
       location.href = $('tmViewSource').href;
     }, {'type': 'keypress', 'propagate': false, 'disable_in_input': true });
+
+    var developerShortcutsRestCall = function(restUrl) {
+        const req = new XMLHttpRequest();
+
+        req.onreadystatechange = function(event) {
+            if (this.readyState === XMLHttpRequest.DONE) {
+                if (this.status === 200) {
+                    // Reload the page to apply the user modifications
+                    location.reload()
+                } else {
+                    new XWiki.widgets.Notification("$escapetool.javascript($services.localization.render('core.shortcuts.developper.user.ajax.error'))", 'error');
+                }
+            }
+        };
+
+        req.open('PUT', restUrl, true);
+        req.send(null);
+    };
+
+    // Append developper shortcuts for toggeling userType and hiddenDocuments in the current user profile
+    shortcut.add("$services.localization.render('core.shortcuts.developer.user.type')", function() {
+        developerShortcutsRestCall('/rest/currentuser/properties/usertype/next');
+    }, {'type': 'keypress', 'propagate': false, 'disable_in_input': true });
+
+    shortcut.add("$services.localization.render('core.shortcuts.developer.user.displayHiddenDocs')", function () {
+        developerShortcutsRestCall('/rest/currentuser/properties/displayHiddenDocuments/next');
+    }, {'type': 'keypress', 'propagate': false, 'disable_in_input': true });
   //]]>
   </script>
 #end

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -717,6 +717,11 @@ core.shortcuts.edit.preview=Alt+P
 core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
+### Developer shortcuts
+core.shortcuts.developer.user.type=Alt+Shift+A
+core.shortcuts.developer.user.displayHiddenDocs=Alt+Shift+H
+core.shortcuts.developper.user.ajax.error=Unable to update current user properties
+
 ### Create
 core.create.pageTitle=Create Page
 


### PR DESCRIPTION
* Add developer shortcuts to flamingo shortcuts