### PR TITLE
XWIKI-14649: Delete UI announces success immediately regardless of the actual result (for big terminal pages)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/delete.js
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/delete.js
@@ -190,7 +190,7 @@ require(['jquery', 'xwiki-meta', 'tree'], function($, xm) {
           handleQuestion();
           return;
         }
-        if (data.progress.offset < 1) {
+        if (data.state != 'FINISHED') {
           setTimeout(getProgressStatus, 1000);
         } else {
           whenTerminated();


### PR DESCRIPTION
Changed the condition for operation finished in delete.js, to check the actual state of the job and not its progress