### PR TITLE
XWIKI-14763: Use the document's locale to find the title

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-rest/src/main/java/org/xwiki/search/solr/internal/rest/SOLRSearchSource.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-rest/src/main/java/org/xwiki/search/solr/internal/rest/SOLRSearchSource.java
@@ -183,11 +183,7 @@ public class SOLRSearchSource extends AbstractSearchSource
                 Locale docLocale = LocaleUtils.toLocale((String) document.get(FieldUtils.DOCUMENT_LOCALE));
                 Locale locale = LocaleUtils.toLocale((String) document.get(FieldUtils.LOCALE));
 
-                List<String> titles = (List<String>) document.get(FieldUtils.getFieldName(FieldUtils.TITLE, locale));
-
-                searchResult.setTitle(titles == null || titles.isEmpty() ?
-                    null :
-                    titles.get(0));
+                searchResult.setTitle((String) document.getFirstValue(FieldUtils.getFieldName(FieldUtils.TITLE, locale)));
 
                 List<String> spaces = Utils.getSpacesHierarchy(documentReference.getLastSpaceReference());
 

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-rest/src/main/java/org/xwiki/search/solr/internal/rest/SOLRSearchSource.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-rest/src/main/java/org/xwiki/search/solr/internal/rest/SOLRSearchSource.java
@@ -136,7 +136,7 @@ public class SOLRSearchSource extends AbstractSearchSource
         // Boost
         // FIXME: take it from configuration
         query.bindValue("qf",
-            "title_^10.0 name^10.0 doccontent^2.0 objcontent^0.4 filename^0.4 attcontent^0.4 doccontentraw^0.4 "
+            "title^10.0 name^10.0 doccontent^2.0 objcontent^0.4 filename^0.4 attcontent^0.4 doccontentraw^0.4 "
                 + "author_display^0.08 creator_display^0.08 " + "comment^0.016 attauthor_display^0.016 space^0.016");
 
         // Order


### PR DESCRIPTION
The search result's title field is empty because it's multi-lingual field.
This causes the title in solr search results to be null. So use the locale
field to look up the correct title field to populate the search result with.

Jira: https://jira.xwiki.org/browse/XWIKI-14763