### PR TITLE
XWIKI-14808: Replace OpenJS Keyboard JS with Keypress JS for handling keyboard shortcuts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
     <restlet.version>2.3.10</restlet.version>
     <tika.version>1.14</tika.version>
     <pdfbox.version>2.0.7</pdfbox.version>
+    <keypress.version>2.1.3</keypress.version>
 
     <!-- By default check that unit tests don't output anything to the console -->
     <xwiki.surefire.captureconsole.skip>false</xwiki.surefire.captureconsole.skip>
@@ -277,6 +278,12 @@
         <groupId>org.webjars</groupId>
         <artifactId>bootstrap</artifactId>
         <version>${bootstrap.version}</version>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.webjars.bower</groupId>
+        <artifactId>Keypress</artifactId>
+        <version>${keypress.version}</version>
         <scope>runtime</scope>
       </dependency>
 

--- a/xwiki-platform-core/xwiki-platform-annotations/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Script.xml
+++ b/xwiki-platform-core/xwiki-platform-annotations/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Script.xml
@@ -1429,12 +1429,8 @@ XWiki.Annotation = Class.create({
   },
 
   registerShortcuts : function(annotationShorcuts, method) {
-    var eventType = 'keypress';
-    if (Prototype.Browser.IE || Prototype.Browser.WebKit || browser.isIE11up) {
-      eventType = 'keyup';
-    }
     for (var i = 0; i &lt; annotationShorcuts.size(); ++i) {
-      shortcut.add(annotationShorcuts[i], method.bindAsEventListener(this), {type: eventType});
+      shortcut.add(annotationShorcuts[i], method.bindAsEventListener(this));
     }
   },
   unregisterShortcuts : function(annotationShorcuts) {

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/pom.xml
@@ -91,6 +91,11 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <groupId>org.webjars.bower</groupId>
+      <artifactId>Keypress</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.webjars</groupId>
       <artifactId>respond</artifactId>
       <version>1.4.2</version>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/docextra.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/docextra.vm
@@ -122,7 +122,7 @@
         ##
         #if ($keyboardShortcutsEnabled && "$!extraShortcut" != "")
           shortcut.remove("$extraShortcut");
-          shortcut.add("$extraShortcut", function() { XWiki.displayDocExtra("${extraAnchor}", "${extraTemplate}", true); }, { 'type':'keypress', 'propagate':false, 'disable_in_input':true });
+          shortcut.add("$extraShortcut", function() { XWiki.displayDocExtra("${extraAnchor}", "${extraTemplate}", true); }, { 'disable_in_input':true });
         #end
       #end
       document.observe("dom:loaded", extraInit, false);

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_content.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_content.vm
@@ -381,24 +381,24 @@
   <script type="text/javascript">
   //<![CDATA[
     #if ($hasEdit && !$isReadOnly)
-      shortcut.add("$services.localization.render('core.shortcuts.view.edit')",function() { location.href=$('tmEdit').down('a').href; }, { 'type':'keypress', 'propagate':false, 'disable_in_input':true });
+      shortcut.add("$services.localization.render('core.shortcuts.view.edit')",function() { location.href=$('tmEdit').down('a').href; }, { 'disable_in_input':true });
       #if($isAdvancedUser)
-        shortcut.add("$services.localization.render('core.shortcuts.view.wiki')",function() { location.href=$('tmEditWiki').href; }, { 'type':'keypress', 'propagate':false, 'disable_in_input':true });
-        shortcut.add("$services.localization.render('core.shortcuts.view.wysiwyg')",function() { location.href=$('tmEditWysiwyg').href; }, { 'type':'keypress', 'propagate':false, 'disable_in_input':true });
-        shortcut.add("$services.localization.render('core.shortcuts.view.inline')",function() { location.href=$('tmEditInline').href; }, { 'type':'keypress', 'propagate':false, 'disable_in_input':true });
-        shortcut.add("$services.localization.render('core.shortcuts.view.rights')",function() { var editRights = $('tmEditRights'); location.href= editRights ? editRights.href : "$xwiki.getURL($spacePreferencesDocumentReference, 'admin', 'category=1')";}, { 'type':'keypress', 'propagate':false, 'disable_in_input':true });
-        shortcut.add("$services.localization.render('core.shortcuts.view.objects')",function() { location.href=$('tmEditObject').href; }, { 'type':'keypress', 'propagate':false, 'disable_in_input':true });
+        shortcut.add("$services.localization.render('core.shortcuts.view.wiki')",function() { location.href=$('tmEditWiki').href; }, { 'disable_in_input':true });
+        shortcut.add("$services.localization.render('core.shortcuts.view.wysiwyg')",function() { location.href=$('tmEditWysiwyg').href; }, { 'disable_in_input':true });
+        shortcut.add("$services.localization.render('core.shortcuts.view.inline')",function() { location.href=$('tmEditInline').href; }, { 'disable_in_input':true });
+        shortcut.add("$services.localization.render('core.shortcuts.view.rights')",function() { var editRights = $('tmEditRights'); location.href= editRights ? editRights.href : "$xwiki.getURL($spacePreferencesDocumentReference, 'admin', 'category=1')";}, { 'disable_in_input':true });
+        shortcut.add("$services.localization.render('core.shortcuts.view.objects')",function() { location.href=$('tmEditObject').href; }, { 'disable_in_input':true });
         #if($hasAdmin)
-          shortcut.add("$services.localization.render('core.shortcuts.view.class')",function() { location.href=$('tmEditClass').href; }, { 'type':'keypress', 'propagate':false, 'disable_in_input':true });
+          shortcut.add("$services.localization.render('core.shortcuts.view.class')",function() { location.href=$('tmEditClass').href; }, { 'disable_in_input':true });
         #end
       #end
     #end
     #if ($canDelete && $displayAdminMenu)
-      shortcut.add("$services.localization.render('core.shortcuts.view.delete')",function() { location.href=$('tmActionDelete').href; }, { 'type':'keypress', 'propagate':false, 'disable_in_input':true });
-      shortcut.add("$services.localization.render('core.shortcuts.view.rename')",function() { location.href=$('tmActionRename').href; }, { 'type':'keypress', 'propagate':false, 'disable_in_input':true });
+      shortcut.add("$services.localization.render('core.shortcuts.view.delete')",function() { location.href=$('tmActionDelete').href; }, { 'disable_in_input':true });
+      shortcut.add("$services.localization.render('core.shortcuts.view.rename')",function() { location.href=$('tmActionRename').href; }, { 'disable_in_input':true });
     #end
     #if ($canView && $displayMoreActionsMenu)
-      shortcut.add("$services.localization.render('core.shortcuts.view.code')", function() { location.href = $('tmViewSource').href; }, {'type': 'keypress', 'propagate': false, 'disable_in_input': true });
+      shortcut.add("$services.localization.render('core.shortcuts.view.code')", function() { location.href = $('tmViewSource').href; }, { 'disable_in_input': true });
     #end
   //]]>
   </script>

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -719,9 +719,9 @@ core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
-core.shortcuts.developer.user.type=x x x a
+core.shortcuts.developer.user.type=x+x+x+a
 core.shortcuts.developer.user.type.error=Unable to update the current user type
-core.shortcuts.developer.user.displayHiddenDocs=x x x h
+core.shortcuts.developer.user.displayHiddenDocs=x+x+x+h
 core.shortcuts.developer.user.displayHiddenDocs.error=Unable to toggle the current user hidden documents property
 core.shortcuts.developer.user.ajax.inprogress=Performing REST request...
 core.shortcuts.developer.user.ajax.success=REST Request successful!
@@ -1138,7 +1138,7 @@ core.viewers.jump.dialog.actions.view.tooltip=View page (Enter, Meta+V)
 core.viewers.jump.dialog.actions.view.shortcuts='Enter', 'Meta+V'
 core.viewers.jump.dialog.actions.edit=Edit
 core.viewers.jump.dialog.actions.edit.tooltip=Edit page in the default editor (Meta+E)
-core.viewers.jump.dialog.actions.edit.shortcuts='Meta+E'
+core.viewers.jump.dialog.actions.edit.shortcuts='meta e'
 core.viewers.jump.dialog.invalidNameError=Invalid page name. Valid names have the following format: Space.Page
 core.viewers.jump.suggest.noResults=No pages found
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -1138,7 +1138,7 @@ core.viewers.jump.dialog.actions.view.tooltip=View page (Enter, Meta+V)
 core.viewers.jump.dialog.actions.view.shortcuts='Enter', 'Meta+V'
 core.viewers.jump.dialog.actions.edit=Edit
 core.viewers.jump.dialog.actions.edit.tooltip=Edit page in the default editor (Meta+E)
-core.viewers.jump.dialog.actions.edit.shortcuts='meta e'
+core.viewers.jump.dialog.actions.edit.shortcuts='Meta+E'
 core.viewers.jump.dialog.invalidNameError=Invalid page name. Valid names have the following format: Space.Page
 core.viewers.jump.suggest.noResults=No pages found
 

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/actionbuttons/actionButtons.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/actionbuttons/actionButtons.js
@@ -61,7 +61,7 @@ actionButtons.EditActions = Class.create({
       if (targetButtons.size() > 0) {
         shortcut.add(shortcuts[key], function() {
           this.click();
-        }.bind(targetButtons.first()), {'propagate' : false} );
+        }.bind(targetButtons.first()));
       }
     }
   },

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/xwiki.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/xwiki.js
@@ -994,7 +994,10 @@ shortcut = new Object({
             // If no options are defined, create a blank array
             opt = (opt) ? opt : [];
 
-            var combination = shortcut._format_shortcut_combination(shortcut_combination);
+            var shortcut_descriptor = {
+                "keys": shortcut._format_shortcut_combination(shortcut_combination),
+                "is_solitary": true
+            };
 
             // CSS selector that should be used by the listener holding the shortcut
             var listener_target = ('target' in opt) ? opt['target'] : document;
@@ -1007,23 +1010,24 @@ shortcut = new Object({
 
             if ('type' in opt && Object.values(shortcut.type).indexOf(opt['type']) > -1) {
                 switch (opt['type']) {
-                    case shortcut.type.SIMPLE:
-                        listener.simple_combo(combination, callback);
-                        break;
                     case shortcut.type.COUNTING:
-                        listener.counting_combo(combination, callback);
+                        shortcut_descriptor["is_counting"] = true;
+                        shortcut_descriptor["is_unordered"] = false;
                         break;
                     case shortcut.type.SEQUENCE:
-                        listener.sequence_combo(combination, callback);
+                        shortcut_descriptor["is_sequence"] = true;
+                        shortcut_descriptor["is_exclusive"] = true;
                         break;
                 }
+
+                listener.register_combo(shortcut_descriptor);
             } else {
                 if ('type' in opt) {
                     console.warn('The parameter [' + opt['type'] + '] for the shortcut [' + combination
-                                 + '] type deprecated.');
+                        + '] type deprecated.');
                 }
 
-                listener.simple_combo(combination, callback);
+                listener.register_combo(shortcut_descriptor);
             }
 
             // Log deprecation warnings for opt parameters

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/xwiki.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/xwiki.js
@@ -943,235 +943,164 @@ function checkAdvancedContent(message) {
 }
 
 /**
- * Keyboard Shortcuts.
- * Version: 2.01.A
- * URL: http://www.openjs.com/scripts/events/keyboard_shortcuts/
- * Author: Binny VA
- * License : BSD
+ * Manage the keyboards shortcuts.
+ * This object interfaces with the bundled Keypress JS library.
  */
-shortcut = {
-        'all_shortcuts':{},//All the shortcuts are stored in this array
-        'add': function(shortcut_combination,callback,opt) {
-            //Provide a set of default options
-            var default_options = {
-                    'type':'keydown',
-                    'propagate':false,
-                    'disable_in_input':false,
-                    'target':document,
-                    'keycode':false
+shortcut = new Object({
+
+    /**
+     * @returns {Array} of registered shortcuts
+     */
+    all_shortcuts: function() {
+        var shortcuts = [];
+
+        Object.values(this._listeners).forEach(function(group, index) {
+            Object.values(group).forEach(function(listener, index2) {
+                shortcuts = shortcuts.concat(listener.get_registered_combos());
+            })
+        });
+
+        return shortcuts;
+    },
+
+    /**
+     * Type of shortcut that can be registered.
+     */
+    type: new Object({
+        SIMPLE: 'simple',
+        COUNTING: 'counting',
+        SEQUENCE: 'sequence'
+    }),
+
+    /**
+     * Add a new shortcut.
+     *
+     * The opt parameter should be a map of optional parameters used while registering the shortcut.
+     * <ul>
+     *     <li>target: A DOM element in which the shortcut should be listened (defaults to the whole document)</li>
+     *     <li>disable_in_input: If true, the shortcut will not be listened when an input
+     *     or textarea field is selected (default: false)</li>
+     *     <li>type: The type (shortcut.type) that should be used (default: SIMPLE)</li>
+     * </ul>
+     *
+     * @param shortcut_combination {string} the shortcut that should trigger the callback
+     * @param callback the function triggered by the shortcut
+     * @param opt optional associative array defining parameters for registering the shortcut
+     */
+    add: function(shortcut_combination, callback, opt) {
+        // Require Keypress JS to be fully loaded before registering the shortcut.
+        require(["$services.webjars.url('org.webjars.bower:Keypress', 'keypress.js')", 'jquery'], function(keypress) {
+
+            // If no options are defined, create a blank array
+            opt = (opt) ? opt : [];
+
+            var combination = shortcut._format_shortcut_combination(shortcut_combination);
+
+            // CSS selector that should be used by the listener holding the shortcut
+            var listener_target = ('target' in opt) ? opt['target'] : document;
+
+            // Get the group in which we should store the listener
+            var listener_group = ('disable_in_input' in opt && opt['disable_in_input'])
+                ? shortcut._listeners.disabled_in_inputs : shortcut._listeners.enabled_in_inputs;
+
+            var listener = shortcut._get_or_create_listener(listener_target, listener_group, keypress);
+
+            if ('type' in opt && Object.values(shortcut.type).indexOf(opt['type']) > -1) {
+                switch (opt['type']) {
+                    case shortcut.type.SIMPLE:
+                        listener.simple_combo(combination, callback);
+                        break;
+                    case shortcut.type.COUNTING:
+                        listener.counting_combo(combination, callback);
+                        break;
+                    case shortcut.type.SEQUENCE:
+                        listener.sequence_combo(combination, callback);
+                        break;
+                }
+            } else {
+                if ('type' in opt) {
+                    console.warn('The parameter [' + opt['type'] + '] for the shortcut [' + combination
+                                 + '] type deprecated.');
+                }
+
+                listener.simple_combo(combination, callback);
             }
-            if(!opt) opt = default_options;
-            else {
-                for(var dfo in default_options) {
-                    if(typeof opt[dfo] == 'undefined') opt[dfo] = default_options[dfo];
+
+            // Log deprecation warnings for opt parameters
+            var allowedOptParameters = ['target', 'disable_in_input', 'type'];
+            Object.keys(opt).forEach(function (key) {
+                if (allowedOptParameters.indexOf(key) === -1) {
+                    console.warn('The parameter [' + key + '] for the shortcut [' + combination + '] is deprecated.');
                 }
+            });
+        });
+    },
+
+    /**
+     * Remove the given shortcut combination from every known listener.
+     *
+     * @param shortcut_combination a string representing the shortcut combination to remove
+     */
+    remove: function(shortcut_combination) {
+        var combination = shortcut._format_shortcut_combination(shortcut_combination);
+
+        Object.values(this._listeners).forEach(function(group, index) {
+            Object.values(group).forEach(function(listener, index2) {
+                listener.unregister_combo(combination);
+            });
+        });
+    },
+
+    /**
+     * Map of every Keypress JS shortcut listeners.
+     *
+     * @private
+     */
+    _listeners: {
+        disabled_in_inputs: {},
+        enabled_in_inputs: {}
+    },
+
+    /**
+     * Check if a Keypress JS listener exists for the given target in the given group, if not, create it.
+     *
+     * @param target the DOM element that should be targeted by the listener
+     * @param group the group (either disabled_in_inputs or enabled_in_inputs) in which the listener belongs
+     * @param keypress a reference to the Keypress JS API
+     * @returns {*} The Keypress JS listener
+     * @private
+     */
+    _get_or_create_listener: function(target, group, keypress) {
+        if (target in group) {
+            return group[target];
+        } else {
+            var newListener = new keypress.Listener(target);
+
+            if (group === this._listeners.disabled_in_inputs) {
+                // Disable the created listener when focus goes on an input or textarea field
+                jQuery(document)
+                    .on('focus', 'input, textarea',
+                        function() { newListener.stop_listening(); })
+                    .on('blur', 'input, textarea',
+                        function() { newListener.listen(); });
             }
 
-            var ele = opt.target
-            if(typeof opt.target == 'string') ele = document.getElementById(opt.target);
-            var ths = this;
-            shortcut_combination = shortcut_combination.toLowerCase();
-
-            //The function to be called at keypress
-            var func = function(e) {
-                e = e || window.event;
-
-                if(opt['disable_in_input']) { //Don't enable shortcut keys in Input, Textarea fields
-                    var element;
-                    if(e.target) element=e.target;
-                    else if(e.srcElement) element=e.srcElement;
-                    if(element.nodeType==3) element=element.parentNode;
-                    if(element.tagName == 'INPUT' || element.tagName == 'TEXTAREA' || element.tagName == 'SELECT') {
-                        return;
-                    }
-                }
-
-                //Find Which key is pressed
-                var code = 0;
-                if (e.keyCode) code = e.keyCode;
-                else if (e.which) code = e.which;
-                var character = String.fromCharCode(code).toLowerCase();
-
-                if(code == 188) character=","; //If the user presses , when the type is onkeydown
-                if(code == 190) character="."; //If the user presses , when the type is onkeydown
-
-                var keys = shortcut_combination.split("+");
-                //Key Pressed - counts the number of valid keypresses - if it is same as the number of keys, the shortcut function is invoked
-                var kp = 0;
-
-                //Work around for stupid Shift key bug created by using lowercase - as a result the shift+num combination was broken
-                var shift_nums = {
-                        "`":"~",
-                        "1":"!",
-                        "2":"@",
-                        "3":"#",
-                        "4":"$",
-                        "5":"%",
-                        "6":"^",
-                        "7":"&",
-                        "8":"*",
-                        "9":"(",
-                        "0":")",
-                        "-":"_",
-                        "=":"+",
-                        ";":":",
-                        "'":"\"",
-                        ",":"<",
-                        ".":">",
-                        "/":"?",
-                        "\\":"|"
-                }
-                //Special Keys - and their codes
-                var special_keys = {
-                        'esc':27,
-                        'escape':27,
-                        'tab':9,
-                        'space':32,
-                        'return':13,
-                        'enter':13,
-                        'backspace':8,
-
-                        'scrolllock':145,
-                        'scroll_lock':145,
-                        'scroll':145,
-                        'capslock':20,
-                        'caps_lock':20,
-                        'caps':20,
-                        'numlock':144,
-                        'num_lock':144,
-                        'num':144,
-
-                        'pause':19,
-                        'break':19,
-
-                        'insert':45,
-                        'home':36,
-                        'delete':46,
-                        'end':35,
-
-                        'pageup':33,
-                        'page_up':33,
-                        'pu':33,
-
-                        'pagedown':34,
-                        'page_down':34,
-                        'pd':34,
-
-                        'left':37,
-                        'up':38,
-                        'right':39,
-                        'down':40,
-
-                        'f1':112,
-                        'f2':113,
-                        'f3':114,
-                        'f4':115,
-                        'f5':116,
-                        'f6':117,
-                        'f7':118,
-                        'f8':119,
-                        'f9':120,
-                        'f10':121,
-                        'f11':122,
-                        'f12':123
-                }
-
-                var modifiers = {
-                        shift: { wanted:false, pressed:false},
-                        ctrl : { wanted:false, pressed:false},
-                        alt  : { wanted:false, pressed:false},
-                        meta : { wanted:false, pressed:false}   //Meta is Mac specific
-                };
-                if(e.ctrlKey)   modifiers.ctrl.pressed = true;
-                if(e.shiftKey)  modifiers.shift.pressed = true;
-                if(e.altKey)    modifiers.alt.pressed = true;
-                if(e.metaKey)   modifiers.meta.pressed = true;
-
-                for(var i=0; k=keys[i],i<keys.length; i++) {
-                    //Modifiers
-                    if(k == 'ctrl' || k == 'control') {
-                        kp++;
-                        modifiers.ctrl.wanted = true;
-
-                    } else if(k == 'shift') {
-                        kp++;
-                        modifiers.shift.wanted = true;
-
-                    } else if(k == 'alt') {
-                        kp++;
-                        modifiers.alt.wanted = true;
-                    } else if(k == 'meta') {
-                        kp++;
-                        modifiers.meta.wanted = true;
-                    } else if(k.length > 1) { //If it is a special key
-                        if(special_keys[k] == code) kp++;
-
-                    } else if(opt['keycode']) {
-                        if(opt['keycode'] == code) kp++;
-
-                    } else { //The special keys did not match
-                        if(character == k) kp++;
-                        else {
-                            if(shift_nums[character] && e.shiftKey) { //Stupid Shift key bug created by using lowercase
-                                character = shift_nums[character];
-                                if(character == k) kp++;
-                            }
-                        }
-                    }
-                }
-
-                if(kp == keys.length &&
-                        modifiers.ctrl.pressed == modifiers.ctrl.wanted &&
-                        modifiers.shift.pressed == modifiers.shift.wanted &&
-                        modifiers.alt.pressed == modifiers.alt.wanted &&
-                        modifiers.meta.pressed == modifiers.meta.wanted) {
-                    callback(e);
-
-                    if(!opt['propagate']) { //Stop the event
-                        //e.cancelBubble is supported by IE - this will kill the bubbling process.
-                        e.cancelBubble = true;
-                        e.returnValue = false;
-
-                        // XWIKI : added to force Alt+key events not to be propagated to IE7
-                        if (document.all && !window.opera && window.XMLHttpRequest) {
-                            e.keyCode = 0;
-                        }
-
-                        //e.stopPropagation works in Firefox.
-                        if (e.stopPropagation) {
-                            e.stopPropagation();
-                            e.preventDefault();
-                        }
-                        return false;
-                    }
-                }
-            }
-            this.all_shortcuts[shortcut_combination] = {
-                    'callback':func,
-                    'target':ele,
-                    'event': opt['type']
-            };
-            //Attach the function with the event
-            if(ele.addEventListener) ele.addEventListener(opt['type'], func, false);
-            else if(ele.attachEvent) ele.attachEvent('on'+opt['type'], func);
-            else ele['on'+opt['type']] = func;
-        },
-
-        //Remove the shortcut - just specify the shortcut and I will remove the binding
-        'remove':function(shortcut_combination) {
-            shortcut_combination = shortcut_combination.toLowerCase();
-            var binding = this.all_shortcuts[shortcut_combination];
-            delete(this.all_shortcuts[shortcut_combination])
-            if(!binding) return;
-            var type = binding['event'];
-            var ele = binding['target'];
-            var callback = binding['callback'];
-
-            if(ele.detachEvent) ele.detachEvent('on'+type, callback);
-            else if(ele.removeEventListener) ele.removeEventListener(type, callback, false);
-            else ele['on'+type] = false;
+            group[target] = newListener;
+            return newListener;
         }
-}
+    },
+
+    /**
+     * Format the given combination to match the format accepted by Keypress JS while allowing backward compatibility
+     * with the previous OpenJS shortcut syntax.
+     *
+     * @returns {string} the formatted combination
+     * @private
+     */
+    _format_shortcut_combination: function(combination) {
+        return combination.toLowerCase().replace(/\+/g, ' ');
+    }
+});
 
 /**
  * Browser Detect


### PR DESCRIPTION
* Add (again) the Keypress JS library
* Fix regression that was overriding browser shortcuts
* Allow sequence shortcuts to be triggered without triggering combo shortcuts