### PR TITLE
Added Solr sloppy phrase matching capability and config

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/AbstractSolrMetadataExtractor.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/AbstractSolrMetadataExtractor.java
@@ -440,6 +440,8 @@ public abstract class AbstractSolrMetadataExtractor implements SolrMetadataExtra
                 // Index the raw value that is saved in the database. This is most probably a string so we'll be able to
                 // perform exact matches on this value.
                 setPropertyValue(solrDocument, property, new TypedValue(rawValue), locale);
+                // This should allow tags to be matched in a case insensitive manner from Solr
+                setPropertyValue(solrDocument, property, new TypedValue(rawValue, TypedValue.TEXT), locale);
                 ListItem valueInfo = knownValues.get(rawValue);
                 if (valueInfo != null && valueInfo.getValue() != null && !valueInfo.getValue().equals(rawValue)) {
                     // Index the display value as text (based on the given locale). This is the text seen by the user

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/AbstractSolrMetadataExtractor.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/AbstractSolrMetadataExtractor.java
@@ -440,8 +440,6 @@ public abstract class AbstractSolrMetadataExtractor implements SolrMetadataExtra
                 // Index the raw value that is saved in the database. This is most probably a string so we'll be able to
                 // perform exact matches on this value.
                 setPropertyValue(solrDocument, property, new TypedValue(rawValue), locale);
-                // This should allow tags to be matched in a case insensitive manner from Solr
-                setPropertyValue(solrDocument, property, new TypedValue(rawValue, TypedValue.TEXT), locale);
                 ListItem valueInfo = knownValues.get(rawValue);
                 if (valueInfo != null && valueInfo.getValue() != null && !valueInfo.getValue().equals(rawValue)) {
                     // Index the display value as text (based on the given locale). This is the text seen by the user

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/Main/SolrSearchConfig.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/Main/SolrSearchConfig.xml
@@ -40,6 +40,10 @@
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
   <content>{{velocity output="false"}}
+#set ($supportedLocales = $xwiki.getXWikiPreference('languages').split('\s*[|, ]\s*'))
+{{/velocity}}    
+    
+{{velocity output="false"}}
 #set ($__defaultSolrConfig = {
   'queryFields': {
     'DOCUMENT': 'title^10.0 name^10.0
@@ -51,14 +55,60 @@
     'OBJECT': 'objcontent',
     'OBJECT_PROPERTY': 'propertyvalue'
   },
-  'phraseFields': 'title_en^200.0 title__^200.0
-                   filename^45.0 
-                   doccontent_en^40.0 doccontent__^40.0
-                   attcontent_en^35.0 attcontent__^35.0 
-                   comment^25.0
-                   author_display^20.0 creator_display^20.0  attauthor_display^20.0'
-  ,
-  'phraseFieldSlop': '10',
+  'phraseFields': {
+    'DOCUMENT': "#expandField('title' '^400.0')
+                 #expandField('doccontent' '^80.0')
+                 filename^90.0 #expandField('attcontent' '^70.0')
+                 comment^50.0
+                 author_display^40.0 creator_display^40.0 attauthor_display^20.0",
+    'ATTACHMENT': "filename^90.0 #expandField('attcontent' '^70.0') attauthor_display^40.0",
+    'OBJECT': 'objcontent^10.0',
+    'OBJECT_PROPERTY': 'propertyvalue^10.0',
+    ''        : "#expandField('title' '^400.0')
+                 #expandField('doccontent' '^80.0')
+                 filename^90.0 #expandField('attcontent' '^70.0')
+                 author_display^40.0 creator_display^40.0
+                 comment^50.0 attauthor_display^20.0
+                 objcontent^10.0 propertyvalue^10.0"
+  },
+  'bigramPhraseFields': {
+    'DOCUMENT': "#expandField('title' '^200.0')
+                 #expandField('doccontent' '^40.0')
+                 filename^45.0 #expandField('attcontent' '^35.0')
+                 comment^25.0 
+                 author_display^20.0 creator_display^20.0 attauthor_display^10.0",
+    'ATTACHMENT': "filename^45.0 #expandField('attcontent' '^35.0') attauthor_display^20.0",
+    'OBJECT': 'objcontent^5.0',
+    'OBJECT_PROPERTY': 'propertyvalue^5.0',
+    ''        : "#expandField('title' '^200.0')
+                 #expandField('doccontent' '^40.0')
+                 filename^45.0 #expandField('attcontent' '^35.0')
+                 author_display^20.0 creator_display^20.0
+                 comment^25.0 attauthor_display^10.0
+                 objcontent^5.0 propertyvalue^5.0"
+  },
+  'trigramPhraseFields': {
+    'DOCUMENT': "#expandField('title' '^300.0')
+                 #expandField('doccontent' '^60.0')
+                 filename^67.5 #expandField('attcontent' '^52.5')
+                 comment^37.5 
+                 author_display^30.0 creator_display^30.0 attauthor_display^15.0",
+    'ATTACHMENT': "filename^67.5 #expandField('attcontent' '^52.5') attauthor_display^30.0",
+    'OBJECT': 'objcontent^7.5',
+    'OBJECT_PROPERTY': 'propertyvalue^7.5',
+    ''        : "#expandField('title' '^300.0')
+                 #expandField('doccontent' '^60.0')
+                 filename^67.5 #expandField('attcontent' '^52.5')
+                 author_display^30.0 creator_display^30.0
+                 comment^37.5 attauthor_display^15.0
+                 objcontent^7.5 propertyvalue^7.5"
+  },
+  'phraseFieldSlop': '15',
+  'bigramPhraseFieldSlop': '5',
+  'trigramPhraseFieldSlop': '10',
+  'boostQuery': ['property.XWiki.TagClass.tags_string','^1000.0'],
+  'tieBreaker': '0.1',
+  'minShouldMatch': '2',
   'sortFields': {
     'DOCUMENT': {
       'score': 'desc',
@@ -163,5 +213,13 @@
   #set ($discard = $__defaultSolrConfig.putAll($solrConfig))
 #end
 #set ($solrConfig = $__defaultSolrConfig)
+
+#macro (expandField $fieldName $fieldBoost)
+  ${fieldName}__${fieldBoost} ##
+  #foreach ($locale in $supportedLocales)
+    ${fieldName}_${locale}${fieldBoost} ##
+  #end
+#end
+    
 {{/velocity}}</content>
 </xwikidoc>

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/Main/SolrSearchConfig.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/Main/SolrSearchConfig.xml
@@ -106,7 +106,6 @@
   'phraseFieldSlop': '15',
   'bigramPhraseFieldSlop': '5',
   'trigramPhraseFieldSlop': '10',
-  'boostQuery': ['property.XWiki.TagClass.tags_string','^1000.0'],
   'tieBreaker': '0.1',
   'minShouldMatch': '2',
   'sortFields': {

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/Main/SolrSearchConfig.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/Main/SolrSearchConfig.xml
@@ -58,6 +58,7 @@
                    comment^25.0
                    author_display^20.0 creator_display^20.0  attauthor_display^20.0'
   ,
+  'phraseFieldSlop': '10',
   'sortFields': {
     'DOCUMENT': {
       'score': 'desc',

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/Main/SolrSearchConfig.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/Main/SolrSearchConfig.xml
@@ -51,6 +51,13 @@
     'OBJECT': 'objcontent',
     'OBJECT_PROPERTY': 'propertyvalue'
   },
+  'phraseFields': 'title_en^200.0 title__^200.0
+                   filename^45.0 
+                   doccontent_en^40.0 doccontent__^40.0
+                   attcontent_en^35.0 attcontent__^35.0 
+                   comment^25.0
+                   author_display^20.0 creator_display^20.0  attauthor_display^20.0'
+  ,
   'sortFields': {
     'DOCUMENT': {
       'score': 'desc',

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/Main/SolrSearchMacros.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/Main/SolrSearchMacros.xml
@@ -658,7 +658,7 @@ $services.localization.render('core.users.unknownUser')##
   #end
   #if ("$!phraseFieldsBoost" != '')
     #set ($discard = $query.bindValue('pf', $phraseFieldsBoost))
-    #set ($discard = $query.bindValue('ps', '10'))
+    #set ($discard = $query.bindValue('ps', $solrConfig.phraseFieldSlop))
   #end
 #end
 

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/Main/SolrSearchMacros.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/Main/SolrSearchMacros.xml
@@ -617,6 +617,13 @@ $services.localization.render('core.users.unknownUser')##
   #set ($discard = $query.setLimit($rows))
   #set ($discard = $query.setOffset($start))
   #set ($discard = $query.bindValue('sort', "${sort} ${sortOrder}"))
+  #set ($discard = $query.bindValue('tie', $solrConfig.tieBreaker))
+  #set ($discard = $query.bindValue('mm', $solrConfig.minShouldMatch))
+  ## Little rudimentary but this should impart higher relevance to
+  ## documents with tags matching the search terms. Will only match single word tags at the moment
+  #set ($fieldName = $solrConfig.boostQuery[0])
+  #set ($fieldBoost = $solrConfig.boostQuery[1])
+  #set ($discard = $query.bindValue('bq', "${fieldName}:(${queryString})${fieldBoost}"))    
   #setQueryFields($query)
   #setPhraseFields($query)
   #setFacetFields($query)
@@ -648,17 +655,51 @@ $services.localization.render('core.users.unknownUser')##
 #end
     
 #macro (setPhraseFields $query)
+  ## Set the main phrase field parameter boosts so that queries with all search terms
+  ## in close proximity have high relevance
   #if ($solrConfig.phraseFields.substring(0, 0) == '')
-    ## If the value of the 'queryFields' parameter is a string then it means that the same query fields are used for
-    ## all result types.
+    ## If the value of the 'phraseFields' parameter is a string then it means that the
+    ## same query fields are used for all result types.
     #set ($phraseFieldsBoost = $solrConfig.phraseFields)
   #else
-    ## There are different query fields for each result type.
-    #set ($phraseFieldsBoost = $solrConfig.phraseFields.get($type))
+    ## There are different phrase fields for each result type.
+    ## Including type = null, which will result from all facets being deselected
+    #set ($phraseFieldsBoost = $solrConfig.phraseFields.get("$!type"))
   #end
   #if ("$!phraseFieldsBoost" != '')
     #set ($discard = $query.bindValue('pf', $phraseFieldsBoost))
     #set ($discard = $query.bindValue('ps', $solrConfig.phraseFieldSlop))
+  #end
+  ## Set the bigram phrase field parameter boosts so that queries with groups of two
+  ## search terms in close proximity have high relevance
+  #if ($solrConfig.bigramPhraseFields.substring(0, 0) == '')
+    ## If the value of the 'bigramPhraseFields' parameter is a string then it means that the
+    ## same query fields are used for all result types.
+    #set ($bigramPhraseFieldsBoost = $solrConfig.bigramPhraseFields)
+  #else
+    ## There are different phrase fields for each result type.
+    ## Including type = null, which will result from all facets being deselected
+    #set ($bigramPhraseFieldsBoost = $solrConfig.bigramPhraseFields.get("$!type"))
+  #end
+  #if ("$!bigramPhraseFieldsBoost" != '')
+    #set ($discard = $query.bindValue('pf2', $bigramPhraseFieldsBoost))
+    #set ($discard = $query.bindValue('ps2', $solrConfig.bigramPhraseFieldSlop))
+  #end
+  ## Set the trigram phrase field parameter boosts so that queries with groups of three
+  ## search terms in close proximity have high relevance.
+  ## Generally (pf boost) > (pf3 boost) > (pf2 boost)
+  #if ($solrConfig.trigramPhraseFields.substring(0, 0) == '')
+    ## If the value of the 'trigramPhraseFields' parameter is a string then it means that the
+    ## same query fields are used for all result types.
+    #set ($trigramPhraseFieldsBoost = $solrConfig.trigramPhraseFields)
+  #else
+    ## There are different phrase fields for each result type.
+    ## including type = null, which will result from all facets being deselected
+    #set ($trigramPhraseFieldsBoost = $solrConfig.trigramPhraseFields.get("$!type"))
+  #end
+  #if ("$!trigramPhraseFieldsBoost" != '')
+    #set ($discard = $query.bindValue('pf3', $trigramPhraseFieldsBoost))
+    #set ($discard = $query.bindValue('ps3', $solrConfig.trigramPhraseFieldSlop))
   #end
 #end
 

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/Main/SolrSearchMacros.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/Main/SolrSearchMacros.xml
@@ -618,12 +618,7 @@ $services.localization.render('core.users.unknownUser')##
   #set ($discard = $query.setOffset($start))
   #set ($discard = $query.bindValue('sort', "${sort} ${sortOrder}"))
   #set ($discard = $query.bindValue('tie', $solrConfig.tieBreaker))
-  #set ($discard = $query.bindValue('mm', $solrConfig.minShouldMatch))
-  ## Little rudimentary but this should impart higher relevance to
-  ## documents with tags matching the search terms. Will only match single word tags at the moment
-  #set ($fieldName = $solrConfig.boostQuery[0])
-  #set ($fieldBoost = $solrConfig.boostQuery[1])
-  #set ($discard = $query.bindValue('bq', "${fieldName}:(${queryString})${fieldBoost}"))    
+  #set ($discard = $query.bindValue('mm', $solrConfig.minShouldMatch))  
   #setQueryFields($query)
   #setPhraseFields($query)
   #setFacetFields($query)

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/Main/SolrSearchMacros.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/Main/SolrSearchMacros.xml
@@ -618,6 +618,7 @@ $services.localization.render('core.users.unknownUser')##
   #set ($discard = $query.setOffset($start))
   #set ($discard = $query.bindValue('sort', "${sort} ${sortOrder}"))
   #setQueryFields($query)
+  #setPhraseFields($query)
   #setFacetFields($query)
   #setFilterQuery($query)
   #setHighlightQuery($query)
@@ -643,6 +644,21 @@ $services.localization.render('core.users.unknownUser')##
   #end
   #if ("$!boost" != '')
     #set ($discard = $query.bindValue('qf', $boost))
+  #end
+#end
+    
+#macro (setPhraseFields $query)
+  #if ($solrConfig.phraseFields.substring(0, 0) == '')
+    ## If the value of the 'queryFields' parameter is a string then it means that the same query fields are used for
+    ## all result types.
+    #set ($phraseFieldsBoost = $solrConfig.phraseFields)
+  #else
+    ## There are different query fields for each result type.
+    #set ($phraseFieldsBoost = $solrConfig.phraseFields.get($type))
+  #end
+  #if ("$!phraseFieldsBoost" != '')
+    #set ($discard = $query.bindValue('pf', $phraseFieldsBoost))
+    #set ($discard = $query.bindValue('ps', '10'))
   #end
 #end
 


### PR DESCRIPTION
I find this works well in my XWiki instance however I think I should set the "locale" rather than hard code the language to English. Wasn't sure how to achieve this so open to comment.

Also tried to boost by tag object independently of others but couldn't get this to work. Does the database schema need updating to allow this?