### PR TITLE
XWIKI-11038 : title in desc

### DIFF
--- a/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.cfg.vm
+++ b/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.cfg.vm
@@ -363,7 +363,7 @@ xwiki.authentication.logoutpage=(/|/[^/]+/|/wiki/[^/]+/)logout/*
 # xwiki.hidelogin=false
 
 #-# HTTP status code to sent when the authentication failed.
-xwiki.authentication.unauthorized_code=200
+xwiki.authentication.unauthorized_code=403
 
 #-# Used by some authenticators (like com.xpn.xwiki.user.impl.xwiki.AppServerTrustedAuthServiceImpl)
 #-# to indicate that the users should be created. In this kind of authenticator the user are not created by default.

--- a/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.cfg.vm
+++ b/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.cfg.vm
@@ -363,7 +363,7 @@ xwiki.authentication.logoutpage=(/|/[^/]+/|/wiki/[^/]+/)logout/*
 # xwiki.hidelogin=false
 
 #-# HTTP status code to sent when the authentication failed.
-xwiki.authentication.unauthorized_code=403
+# xwiki.authentication.unauthorized_code=403
 
 #-# Used by some authenticators (like com.xpn.xwiki.user.impl.xwiki.AppServerTrustedAuthServiceImpl)
 #-# to indicate that the users should be created. In this kind of authenticator the user are not created by default.


### PR DESCRIPTION
"xwiki.authentication.unauthorized_code has a bad default value and is not taken into account"
not sure if this is an issue, could not understand what Thomas said, "Note that I just tested to fail the login and got 403 so additionally it's not really fully taken into account (I don't really see the point of making it configurable anyway)".