### PR TITLE
XWIKI-13640: Overflow issue in the UI of the Distribution Wizard

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/job/job.css
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/job/job.css
@@ -95,4 +95,5 @@
   line-height: inherit;
   margin: 0;
   min-width: 100px;
+  overflow-wrap: break-word;
 }


### PR DESCRIPTION
Resolves XWIKI-13640. Pushes text onto new line, removing need for any scrollbars. Tested on both extension manager and distribution wizard.  