### PR TITLE
XWIKI-14983 issue. obsolescence of the supplied documentation

### DIFF
--- a/xwiki-platform-tools/xwiki-platform-tool-jetty/xwiki-platform-tool-jetty-resources/src/main/resources/start_xwiki.bat
+++ b/xwiki-platform-tools/xwiki-platform-tool-jetty/xwiki-platform-tool-jetty-resources/src/main/resources/start_xwiki.bat
@@ -27,7 +27,7 @@ REM     e.g. to increase the memory allocated to the JVM to 1GB, use
 REM       set XWIKI_OPTS=-Xmx1024m
 REM   JETTY_OPTS - optional parameters passed to Jetty's start.jar. For example to list the configuration that will
 REM       execute, try setting it to "--list-config". See
-REM       http://www.eclipse.org/jetty/documentation/9.2.3.v20140905/start-jar.html for more options.
+REM       http://www.eclipse.org/jetty/documentation/current/start-jar.html for more options.
 REM   JETTY_PORT - the port on which to start Jetty, 8080 by default
 REM   JETTY_STOP_PORT - the port on which Jetty listens for a Stop command, 8079 by default
 REM -------------------------------------------------------------------------

--- a/xwiki-platform-tools/xwiki-platform-tool-jetty/xwiki-platform-tool-jetty-resources/src/main/resources/start_xwiki.sh
+++ b/xwiki-platform-tools/xwiki-platform-tool-jetty/xwiki-platform-tool-jetty-resources/src/main/resources/start_xwiki.sh
@@ -26,7 +26,7 @@
 #       JVM to 1GB, use set XWIKI_OPTS=-Xmx1024m
 #   JETTY_OPTS - optional parameters passed to Jetty's start.jar. For example to list the configuration that will
 #       execute, try setting it to "--list-config". See
-#       http://www.eclipse.org/jetty/documentation/9.2.3.v20140905/start-jar.html for more options.
+#       http://www.eclipse.org/jetty/documentation/current/start-jar.html for more options.
 #   JETTY_PORT - the port on which to start Jetty.
 #   JETTY_STOP_PORT - the port on which Jetty listens for a Stop command.
 # ----------------------------------------------------------------------------------------------------------------

--- a/xwiki-platform-tools/xwiki-platform-tool-jetty/xwiki-platform-tool-jetty-resources/src/main/resources/start_xwiki_debug.bat
+++ b/xwiki-platform-tools/xwiki-platform-tool-jetty/xwiki-platform-tool-jetty-resources/src/main/resources/start_xwiki_debug.bat
@@ -27,7 +27,7 @@ REM     e.g. to increase the memory allocated to the JVM to 1GB, use
 REM       set XWIKI_OPTS=-Xmx1024m
 REM   JETTY_OPTS - optional parameters passed to Jetty's start.jar. For example to list the configuration that will
 REM       execute, try setting it to "--list-config". See
-REM       http://www.eclipse.org/jetty/documentation/9.2.3.v20140905/start-jar.html for more options.
+REM       http://www.eclipse.org/jetty/documentation/current/start-jar.html for more options.
 REM   JETTY_PORT - the port on which to start Jetty, 8080 by default
 REM   JETTY_STOP_PORT - the port on which Jetty listens for a Stop command, 8079 by default
 REM -------------------------------------------------------------------------

--- a/xwiki-platform-tools/xwiki-platform-tool-jetty/xwiki-platform-tool-jetty-resources/src/main/resources/start_xwiki_debug.sh
+++ b/xwiki-platform-tools/xwiki-platform-tool-jetty/xwiki-platform-tool-jetty-resources/src/main/resources/start_xwiki_debug.sh
@@ -25,7 +25,7 @@
 #   XWIKI_OPTS - parameters passed to the Java VM when running XWiki e.g. to increase the memory allocated to the
 #       JVM to 1GB, use set XWIKI_OPTS=-Xmx1024m
 #   JETTY_OPTS - optional parameters passed to Jetty's start.jar. See
-#       http://www.eclipse.org/jetty/documentation/9.2.3.v20140905/start-jar.html for options.
+#       http://www.eclipse.org/jetty/documentation/current/start-jar.html for options.
 #   JETTY_PORT - the port on which to start Jetty.
 #   JETTY_STOP_PORT - the port on which Jetty listens for a Stop command.
 # ----------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
I suggest updating the documentation link.
The link now sends a 404 error.
XWIKI-14983 issue. obsolescence of the supplied documentation