### PR TITLE
XWIKI-14811: Bad layout when using a font larger than the default one

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/extension/extension.css
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/extension/extension.css
@@ -475,3 +475,71 @@ ul.collapsible.document-tree {
   font-weight: normal;
   padding-right: .3em;
 }
+
+@media screen and (min-width: 675px) {
+    .extension-header .extension-status {
+        margin: 0 1em;
+    }
+  .dependency-item{
+       height: 7.407vw;
+  }
+  .dependency-item .extension-status {
+       padding-top: 2.962vw;
+  }
+}
+
+@media screen and (min-width: 620px) {
+
+  .dependency-item{
+       height: 12.407vw;
+  }
+  .dependency-item .extension-status {
+       padding-top: 3.962vw;
+  }
+}
+@media screen and (min-width: 475px) {
+
+  .dependency-item{
+       height: 14.407vw;
+  }
+  .dependency-item .extension-status {
+       padding-top: 3.962vw;
+  }
+}
+@media screen and (min-width: 431px) {
+
+  .dependency-item{
+       height: 20.407vw;
+  }
+  .dependency-item .extension-status {
+       padding-top: 3.962vw;
+       padding-left: 5.962vw;
+  }
+}
+@media screen and (min-width: 420px) {
+
+  .dependency-item{
+       height: 27.407vw;
+  }
+  .dependency-item .extension-status {
+       padding-top: 4.962vw;
+  }
+}
+@media screen and (min-width: 357px) {
+
+  .dependency-item{
+       height: 43.407vw;
+  }
+  .dependency-item .extension-status {
+       padding-top: 5.962vw;
+  }
+}
+@media screen and (min-width: 357px) {
+
+  .dependency-item{
+       height: 43.407vw;
+  }
+  .dependency-item .extension-status {
+       padding-top: 5.962vw;
+  }
+}

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/extension/extension.css
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/extension/extension.css
@@ -489,7 +489,9 @@ ul.collapsible.document-tree {
 }
 
 @media screen and (min-width: 620px) {
-
+    .extension-header .extension-status {
+        margin: 0 1em;
+    }
   .dependency-item{
        height: 12.407vw;
   }
@@ -498,7 +500,9 @@ ul.collapsible.document-tree {
   }
 }
 @media screen and (min-width: 475px) {
-
+    .extension-header .extension-status {
+        margin: 0 1em;
+    }
   .dependency-item{
        height: 14.407vw;
   }
@@ -507,7 +511,9 @@ ul.collapsible.document-tree {
   }
 }
 @media screen and (min-width: 431px) {
-
+    .extension-header .extension-status {
+        margin: 0 1em;
+    }
   .dependency-item{
        height: 20.407vw;
   }
@@ -517,7 +523,9 @@ ul.collapsible.document-tree {
   }
 }
 @media screen and (min-width: 420px) {
-
+    .extension-header .extension-status {
+        margin: 0 1em;
+    }
   .dependency-item{
        height: 27.407vw;
   }
@@ -526,7 +534,9 @@ ul.collapsible.document-tree {
   }
 }
 @media screen and (min-width: 357px) {
-
+    .extension-header .extension-status {
+        margin: 0 1em;
+    }
   .dependency-item{
        height: 43.407vw;
   }
@@ -535,7 +545,9 @@ ul.collapsible.document-tree {
   }
 }
 @media screen and (min-width: 357px) {
-
+    .extension-header .extension-status {
+        margin: 0 1em;
+    }
   .dependency-item{
        height: 43.407vw;
   }


### PR DESCRIPTION
This image shows the effect of the changes
![before and after](https://user-images.githubusercontent.com/20560218/36063330-84b97f2c-0e73-11e8-8bfc-8120882a1523.jpg)

Resolves this issue: https://jira.xwiki.org/browse/XWIKI-14811

Didn't go lower than the last media query as the next width down was so small that almost no devices use it.
