### PR TITLE
XWIKI-15091: AbstractWikiReferenceExtractor fails to extract a wiki reference …

### DIFF
--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-schemes/xwiki-platform-url-scheme-standard/src/main/java/org/xwiki/url/internal/standard/AbstractWikiReferenceExtractor.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-schemes/xwiki-platform-url-scheme-standard/src/main/java/org/xwiki/url/internal/standard/AbstractWikiReferenceExtractor.java
@@ -34,6 +34,8 @@ import org.xwiki.wiki.manager.WikiManagerException;
  */
 public abstract class AbstractWikiReferenceExtractor implements WikiReferenceExtractor
 {
+    private static final String XWIKI_CONTEXT = "xwikicontext";
+
     @Inject
     private StandardURLConfiguration configuration;
 
@@ -70,7 +72,7 @@ public abstract class AbstractWikiReferenceExtractor implements WikiReferenceExt
         // Note: We also support not having an Execution Context available. This allows this code to work at request
         // initialization time, when no Context has been set up yet. In the future, we need to move the Context init
         // as the first thing along with Database initialization.
-        if (this.execution.getContext() == null) {
+        if (this.execution.getContext() == null || !this.execution.getContext().hasProperty(XWIKI_CONTEXT)) {
             return null;
         }
 
@@ -86,7 +88,7 @@ public abstract class AbstractWikiReferenceExtractor implements WikiReferenceExt
         // Note: We also support not having an Execution Context available. This allows this code to work at request
         // initialization time, when no Context has been set up yet. In the future, we need to move the Context init
         // as the first thing along with Database initialization.
-        if (this.execution.getContext() == null) {
+        if (this.execution.getContext() == null || !this.execution.getContext().hasProperty(XWIKI_CONTEXT)) {
             return null;
         }
 

--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-schemes/xwiki-platform-url-scheme-standard/src/test/java/org/xwiki/url/internal/standard/DomainWikiReferenceExtractorTest.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-schemes/xwiki-platform-url-scheme-standard/src/test/java/org/xwiki/url/internal/standard/DomainWikiReferenceExtractorTest.java
@@ -146,7 +146,9 @@ public class DomainWikiReferenceExtractorTest
     {
         // Simulate a configured Execution Context
         Execution execution = mocker.getInstance(Execution.class);
-        when(execution.getContext()).thenReturn(new ExecutionContext());
+        ExecutionContext executionContext = new ExecutionContext();
+        executionContext.setProperty("xwikicontext", true);
+        when(execution.getContext()).thenReturn(executionContext);
 
         StandardURLConfiguration urlConfiguration = mocker.getInstance(StandardURLConfiguration.class);
         when(urlConfiguration.getWikiNotFoundBehavior()).thenReturn(wikiNotFoundBehavior);

--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-schemes/xwiki-platform-url-scheme-standard/src/test/java/org/xwiki/url/internal/standard/PathWikiReferenceExtractorTest.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-schemes/xwiki-platform-url-scheme-standard/src/test/java/org/xwiki/url/internal/standard/PathWikiReferenceExtractorTest.java
@@ -133,7 +133,9 @@ public class PathWikiReferenceExtractorTest
     {
         // Simulate a configured Execution Context
         Execution execution = mocker.getInstance(Execution.class);
-        when(execution.getContext()).thenReturn(new ExecutionContext());
+        ExecutionContext executionContext = new ExecutionContext();
+        executionContext.setProperty("xwikicontext", true);
+        when(execution.getContext()).thenReturn(executionContext);
 
         StandardURLConfiguration urlConfiguration = mocker.getInstance(StandardURLConfiguration.class);
         when(urlConfiguration.getWikiNotFoundBehavior()).thenReturn(wikiNotFoundBehavior);


### PR DESCRIPTION
… if the XWiki Context isn't correctly initialized

Check if the XWikiContext is present in the ExecutionContext before trying to use the WikiDescriptorManager