### PR TITLE
XWIKI-14892: Displays revisions in the URL 

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/historyinline.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/historyinline.vm
@@ -49,10 +49,9 @@ $xwiki.ssfx.use('uicomponents/pagination/pagination.css', true)##
 ##
 ##
     #set ($formname = 'historyform')
-    <form id="$formname" action="$doc.getURL('view', "viewer=changes&amp;$docvariant")" method="post">
+    <form id="$formname" action="$doc.getURL('view', "viewer=changes&amp;$docvariant")" method="get">
       <div id="_history">
       ## CSRF prevention
-      <input type="hidden" name="form_token" value="$!{services.csrf.getToken()}" />
       <input type="hidden" name="language" value="$!xcontext.locale" />
       <table class="table table-striped table-hover responsive-table">
         <caption class="sr-only">$services.localization.render('core.viewers.history.summary', [$escapetool.xml($doc.displayTitle), $versions.get($mathtool.sub($versions.size(), 1)), $versions.get(0)])</caption>


### PR DESCRIPTION
This PR fixes [XWIKI-14892](https://jira.xwiki.org/browse/XWIKI-14892) and shows both revision numbers in the URL when comparing history versions.
Please review ASAP :)
![screen shot 2018-05-07 at 6 16 37 pm](https://user-images.githubusercontent.com/26062692/39702504-b4b70ac6-5222-11e8-8eb3-4f185fb1bbd2.png)
