### PR TITLE
XWIKI-14892: Displays changes in the URL

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/historyinline.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/historyinline.vm
@@ -49,10 +49,9 @@ $xwiki.ssfx.use('uicomponents/pagination/pagination.css', true)##
 ##
 ##
     #set ($formname = 'historyform')
-    <form id="$formname" action="$doc.getURL('view', "viewer=changes&amp;$docvariant")" method="post">
+    <form id="$formname" action="$doc.getURL('view', "viewer=changes&amp;$docvariant")" method="get">
       <div id="_history">
       ## CSRF prevention
-      <input type="hidden" name="form_token" value="$!{services.csrf.getToken()}" />
       <input type="hidden" name="language" value="$!xcontext.locale" />
       <table class="table table-striped table-hover responsive-table">
         <caption class="sr-only">$services.localization.render('core.viewers.history.summary', [$escapetool.xml($doc.displayTitle), $versions.get($mathtool.sub($versions.size(), 1)), $versions.get(0)])</caption>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/historyinline.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/historyinline.vm
@@ -49,10 +49,11 @@ $xwiki.ssfx.use('uicomponents/pagination/pagination.css', true)##
 ##
 ##
     #set ($formname = 'historyform')
-    <form id="$formname" action="$doc.getURL('view', "viewer=changes&amp;$docvariant")" method="get">
+    <form id="$formname" action="$doc.getURL('view', "$docvariant")" method="get">
       <div id="_history">
       ## CSRF prevention
       <input type="hidden" name="language" value="$!xcontext.locale" />
+      <input type="hidden" name="viewer" value="changes" />
       <table class="table table-striped table-hover responsive-table">
         <caption class="sr-only">$services.localization.render('core.viewers.history.summary', [$escapetool.xml($doc.displayTitle), $versions.get($mathtool.sub($versions.size(), 1)), $versions.get(0)])</caption>
 ## Print the table header
@@ -157,10 +158,12 @@ $xwiki.ssfx.use('uicomponents/pagination/pagination.css', true)##
         #if ($xwiki.hasMinorEdit())
           #if ("$!request.showminor" != 'true')
             <input class="btn btn-default" type="submit" name="viewminorversions" value="$services.localization.render('core.viewers.history.showMinorEdits')"
-              onclick="document.forms.${formname}.action='$tdoc.getURL('view', "viewer=history&amp;showminor=true&amp;$docvariant")'; if (document.forms.${formname}.onsubmit) document.forms.${formname}.onsubmit();" />
+              onclick="document.forms.${formname}.action='$tdoc.getURL('view', "$docvariant")'; if (document.forms.${formname}.onsubmit) document.forms.${formname}.onsubmit();" />
           #else
+          <input type="hidden" name="showminor" value="true" />
+          <input type="hidden" name="viewer" value="history" />
             <input class="btn btn-default" type="submit" name="hideminorversions" value="$services.localization.render('core.viewers.history.hideMinorEdits')"
-              onclick="document.forms.${formname}.action='$tdoc.getURL('view', "viewer=history&amp;$docvariant")'; if (document.forms.${formname}.onsubmit) document.forms.${formname}.onsubmit();" />
+              onclick="document.forms.${formname}.action='$tdoc.getURL('view', "$docvariant")'; if (document.forms.${formname}.onsubmit) document.forms.${formname}.onsubmit();" />
           #end
         #end
       </div>


### PR DESCRIPTION
This PR fixes XWIKI-14892 and shows both revision numbers in the URL when comparing history versions.
The following changes have been made:
- Hidden inputs have been added for viewer params for showing history revisions
- Csrf param has been removed
- The method has been changed from post to get
- Hidden inputs have been added for showminor and viewer params for displaying minor edits
- The changes have been tested and work fine.
Please review ASAP :)