### PR TITLE
XWIKI-15321: XWQL "in element()" expression create duplicates results…

### DIFF
--- a/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-xwql/src/main/java/org/xwiki/query/xwql/internal/hql/PropertyPrinter.java
+++ b/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-xwql/src/main/java/org/xwiki/query/xwql/internal/hql/PropertyPrinter.java
@@ -20,10 +20,7 @@
 package org.xwiki.query.xwql.internal.hql;
 
 import org.xwiki.query.internal.jpql.node.APath;
-import org.xwiki.query.internal.jpql.node.PGroupbyItem;
-import org.xwiki.query.internal.jpql.node.POrderbyItem;
 import org.xwiki.query.internal.jpql.node.PPath;
-import org.xwiki.query.internal.jpql.node.PSelectExpression;
 import org.xwiki.query.internal.jpql.node.TId;
 import org.xwiki.query.xwql.internal.QueryContext.PropertyInfo;
 
@@ -55,10 +52,7 @@ public class PropertyPrinter
                     String s = prop.alias + "." + prop.getValueField();
                     // Takes the elements of the list instead of the list itself
                     // Note that we couldn't use 'elements(list)' statement when using 'group by' and 'order by'
-                    if (className.endsWith("DBStringListProperty") && p.parent() != null && (
-                        p.parent() instanceof PSelectExpression ||
-                        p.parent().parent() instanceof POrderbyItem ||
-                        p.parent().parent() instanceof PGroupbyItem)) {
+                    if (className.endsWith("DBStringListProperty")) {
                         s = prop.alias + prop.getValueField();
                     }
                     p.replaceBy(new APath(new TId(s)));

--- a/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-xwql/src/main/java/org/xwiki/query/xwql/internal/hql/TreePrinter.java
+++ b/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-xwql/src/main/java/org/xwiki/query/xwql/internal/hql/TreePrinter.java
@@ -132,9 +132,10 @@ public class TreePrinter extends DepthFirstAdapter
     @Override
     public void caseACollectionMemberExpression(ACollectionMemberExpression node)
     {
-        // "member of" fails on HQL, so use "in elements()"
-        builder.append(" in elements(");
+        // "member of" fails on HQL, so use "="
+        // this works only for a property of DBStringListProperty (relational storage)
+        builder.append(" = ");
         node.getPath().apply(this);
-        builder.append(" )");
+        builder.append(" ");
     }
 }


### PR DESCRIPTION
… with DBStringListProperty classes

Note that the non relational static lists are not working correctly as of now and their use should probably be deprecated at the expense of relational static lists.