### PR TITLE
XWIKI-15283: Vertical scroll bar randomly appears

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/headers.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/headers.less
@@ -4,8 +4,8 @@
 
 .edit_section {
   display: block;
-  height: 24px;
-  line-height: 24px;
+  height: @font-size-h1;
+  line-height: @font-size-h1;
   margin: -@font-size-h1 0 0;
   overflow: hidden;
   position: relative;


### PR DESCRIPTION
See https://jira.xwiki.org/browse/XWIKI-15283

*Before:*
![image](https://user-images.githubusercontent.com/2213999/41412144-5dff4baa-6fdf-11e8-9858-e0f540101202.png)

*After:*
![image](https://user-images.githubusercontent.com/2213999/41412188-78cb5492-6fdf-11e8-9a60-156ba9140af4.png)

Note that the section titles (h1 and h2) now appear with the h1 height.