### PR TITLE
XWIKI-15366: Make the sticky save bar have a smoother transition

### DIFF
--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserSheet.xml
@@ -272,6 +272,7 @@ Object.extend(XWiki, {
       this.tabsContainer.select('.category-tab.current').each(function (activeTab) {
         this.updateCategoryFields(activeTab.id);
         document.fire('xwiki:profile:switchedCategory', {'category' : activeTab.id});
+        document.fire('xwiki:dom:refresh');
       }.bind(this));
       this.handleCancelAction();
 
@@ -302,6 +303,7 @@ Object.extend(XWiki, {
         this.updateURL(tabName);
       }
       document.fire('xwiki:profile:switchedCategory', {'category' : tab});
+      document.fire('xwiki:dom:refresh');
     },
 
     updateCategoryFields : function (category) {

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/actionbuttons/actionButtons.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/actionbuttons/actionButtons.js
@@ -382,7 +382,7 @@ require(['jquery'], function ($) {
   $placeholder.height(0);
   $placeholder.insertBefore($container);
 
-  $(window).on("scroll resize load click xwiki:profile:switchedCategory", function() {
+  $(window).on("scroll resize load click xwiki:dom:refresh", function() {
     var isFullScreen = $('.fullScreenWrapper').length > 0
     // Show the element and make the gap where the save bar should fit.
     $placeholder.height($container.height());

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/actionbuttons/actionButtons.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/actionbuttons/actionButtons.js
@@ -375,20 +375,28 @@ return XWiki;
 require(['jquery'], function ($) {
   var $container = $('.sticky-buttons');
   if ($container.length == 0) return;
-  // Use the placeholder to get the initial container position
-  var $placeholder = $('<span></span>');
+  // Use the placeholder to save the initial container position and make a gap to place
+  // the sticky save bar once it reaches its initial position.
+  var $placeholder = $('<div></div>');
+  // Hide the element while keeping its offset.
+  $placeholder.height(0);
   $placeholder.insertBefore($container);
 
   $(window).on("scroll resize load click xwiki:profile:switchedCategory", function() {
     var isFullScreen = $('.fullScreenWrapper').length > 0
-    var position = $placeholder.offset().top;
+    // Show the element and make the gap where the save bar should fit.
+    $placeholder.height($container.height());
+    var position = $placeholder.offset().top + $placeholder.height();
 
     if (!isFullScreen && $(window).height() + $(window).scrollTop() < position) {
       $container.addClass('sticky-buttons-fixed');
+      // The width of the parent element is not inherited when the position is fixed
       $container.innerWidth($container.parent().width());
     } else {
       $container.removeClass('sticky-buttons-fixed');
       $container.innerWidth('');
+      // Hide the element while keeping its offset.
+      $placeholder.height(0);
     }
   });
 });

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/editors/dataeditors.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/editors/dataeditors.js
@@ -134,6 +134,7 @@ editors.XDataEditors = Class.create({
               },
               onComplete : function() {
                 item.disabled = false;
+                document.fire('xwiki:dom:refresh');
               },
               // IE converts 204 status code into 1223...
               on1223 : function(response) {


### PR DESCRIPTION
See https://jira.xwiki.org/browse/XWIKI-15366

*Before:*
![sticky-02](https://user-images.githubusercontent.com/2213999/41524225-07e9eec2-72dd-11e8-8531-653f7e5fa1ac.gif)

*After:*
![sticky-01](https://user-images.githubusercontent.com/2213999/41524222-04156a2e-72dd-11e8-8502-6f53a0ff56ef.gif)

**Other issue:**
The issue has already been solved for the following screenshot but there was other pages where it happened.
*Before:*
![image](https://user-images.githubusercontent.com/2213999/41483226-9ad17eb4-70d8-11e8-8f45-6416c49f272d.png)

*After:*
![image](https://user-images.githubusercontent.com/2213999/41483246-abe299a4-70d8-11e8-8a62-955aba5da19a.png)