### PR TITLE
XWIKI-15398: Move WikiMacroBindingInitializer as a public interface

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-api/src/main/java/org/xwiki/rendering/internal/macro/wikibridge/DefaultWikiMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-api/src/main/java/org/xwiki/rendering/internal/macro/wikibridge/DefaultWikiMacro.java
@@ -44,6 +44,7 @@ import org.xwiki.rendering.macro.descriptor.MacroDescriptor;
 import org.xwiki.rendering.macro.descriptor.ParameterDescriptor;
 import org.xwiki.rendering.macro.parameter.MacroParameterException;
 import org.xwiki.rendering.macro.wikibridge.WikiMacro;
+import org.xwiki.rendering.macro.wikibridge.WikiMacroBindingInitializer;
 import org.xwiki.rendering.macro.wikibridge.WikiMacroExecutionFinishedEvent;
 import org.xwiki.rendering.macro.wikibridge.WikiMacroExecutionStartsEvent;
 import org.xwiki.rendering.macro.wikibridge.WikiMacroParameters;
@@ -189,7 +190,7 @@ public class DefaultWikiMacro implements WikiMacro, NestedScriptMacroEnabled
                 this.componentManager.getInstanceList(WikiMacroBindingInitializer.class);
 
             for (WikiMacroBindingInitializer bindingInitializer : bindingInitializers) {
-                bindingInitializer.initialize(this.macroDocumentReference, parameters, macroContent, context,
+                bindingInitializer.initialize(this, parameters, macroContent, context,
                     macroBinding);
             }
         } catch (ComponentLookupException e) {

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-api/src/main/java/org/xwiki/rendering/macro/wikibridge/WikiMacroBindingInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-api/src/main/java/org/xwiki/rendering/macro/wikibridge/WikiMacroBindingInitializer.java
@@ -17,18 +17,16 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.xwiki.rendering.internal.macro.wikibridge;
+package org.xwiki.rendering.macro.wikibridge;
 
 import java.util.Map;
 
 import org.xwiki.component.annotation.Role;
-import org.xwiki.model.reference.DocumentReference;
-import org.xwiki.rendering.macro.wikibridge.WikiMacroParameters;
 import org.xwiki.rendering.transformation.MacroTransformationContext;
 
 /**
  * Initialize the binding provided to the script macros. Called before executing each wiki macro is executed.
- * 
+ *
  * @version $Id$
  * @since 2.5M1
  */
@@ -37,13 +35,13 @@ public interface WikiMacroBindingInitializer
 {
     /**
      * Initialize the binding provided to the script macros.
-     * 
-     * @param macroDocumentReference the reference of the document containing the wiki macro
+     *
+     * @param wikiMacro the wiki macro
      * @param parameters the parameters of the macro
      * @param macroContent the content of the macro
      * @param context the macro execution context
      * @param macroBinding the binding map to fill
      */
-    void initialize(DocumentReference macroDocumentReference, WikiMacroParameters parameters, String macroContent,
+    void initialize(WikiMacro wikiMacro, WikiMacroParameters parameters, String macroContent,
         MacroTransformationContext context, Map<String, Object> macroBinding);
 }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/CoreWikiMacroBindingInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/CoreWikiMacroBindingInitializer.java
@@ -29,7 +29,8 @@ import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.context.Execution;
 import org.xwiki.model.reference.DocumentReference;
-import org.xwiki.rendering.internal.macro.wikibridge.WikiMacroBindingInitializer;
+import org.xwiki.rendering.macro.wikibridge.WikiMacro;
+import org.xwiki.rendering.macro.wikibridge.WikiMacroBindingInitializer;
 import org.xwiki.rendering.macro.wikibridge.WikiMacroParameters;
 import org.xwiki.rendering.transformation.MacroTransformationContext;
 
@@ -39,7 +40,7 @@ import com.xpn.xwiki.doc.XWikiDocument;
 
 /**
  * Provide old core related wiki macro bindings.
- * 
+ *
  * @version $Id$
  * @since 2.5M1
  */
@@ -75,9 +76,10 @@ public class CoreWikiMacroBindingInitializer implements WikiMacroBindingInitiali
     }
 
     @Override
-    public void initialize(DocumentReference macroDocumentReference, WikiMacroParameters parameters,
-        String macroContent, MacroTransformationContext context, Map<String, Object> macroBinding)
+    public void initialize(WikiMacro wikiMacro, WikiMacroParameters parameters, String macroContent,
+        MacroTransformationContext context, Map<String, Object> macroBinding)
     {
+        DocumentReference macroDocumentReference = wikiMacro.getDocumentReference();
         try {
             XWikiDocument document = getContext().getWiki().getDocument(macroDocumentReference, getContext());
             macroBinding.put(MACRO_DOC_KEY, document.newDocument(getContext()));


### PR DESCRIPTION
* Move the WikiMacroBindingInitializer class out of the internal package.
* Change the related imports.
* Use the WikiMacro as parameter of the initialize method instead
  of its DocumentReference.

See https://jira.xwiki.org/browse/XWIKI-15398