### PR TITLE
XWIKI-15398: Move WikiMacroBindingInitializer as a public interface

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-api/src/main/java/org/xwiki/rendering/macro/wikibridge/WikiMacroBindingInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-api/src/main/java/org/xwiki/rendering/macro/wikibridge/WikiMacroBindingInitializer.java
@@ -23,14 +23,16 @@ import java.util.Map;
 
 import org.xwiki.component.annotation.Role;
 import org.xwiki.rendering.transformation.MacroTransformationContext;
+import org.xwiki.stability.Unstable;
 
 /**
  * Initialize the binding provided to the script macros. Called before executing each wiki macro is executed.
  *
  * @version $Id$
- * @since 2.5M1
+ * @since 10.6RC1
  */
 @Role
+@Unstable
 public interface WikiMacroBindingInitializer
 {
     /**


### PR DESCRIPTION
* Change the since version.
* Add the Unstable annotation.