### PR TITLE
XWIKI-15400: Missing translation for save shortcut

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -711,7 +711,7 @@ core.shortcuts.view.rename=F2
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ xe.wikimacrobridge.macroDescription=Description
 xe.wikimacrobridge.macroVisibility=Visibility
 xe.wikimacrobridge.macroPage=Macro page
 xe.wikimacrobridge.noWikiMacro=There are no wiki macro defined in this wiki yet.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_bg.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_bg.properties
@@ -711,7 +711,7 @@
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ xe.index.trash.attachments.actions=
 ### Missing: xe.wikimacrobridge.macroVisibility=Visibility
 ### Missing: xe.wikimacrobridge.macroPage=Macro page
 ### Missing: xe.wikimacrobridge.noWikiMacro=There are no wiki macro defined in this wiki yet.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_ca.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_ca.properties
@@ -711,7 +711,7 @@ core.shortcuts.view.rename=F2
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ platform.index.attachments.type=Tipus
 ### Missing: xe.wikimacrobridge.macroVisibility=Visibility
 ### Missing: xe.wikimacrobridge.macroPage=Macro page
 ### Missing: xe.wikimacrobridge.noWikiMacro=There are no wiki macro defined in this wiki yet.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_cs.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_cs.properties
@@ -711,7 +711,7 @@ core.shortcuts.view.rename=F2
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ xe.wikimacrobridge.macroDescription=Popis
 xe.wikimacrobridge.macroVisibility=Viditelnost
 xe.wikimacrobridge.macroPage=Str\u00E1nka macra
 xe.wikimacrobridge.noWikiMacro=V t\u00E9to wiki nejsou zat\u00EDm \u017E\u00E1dn\u00E1 makra
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_da.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_da.properties
@@ -711,7 +711,7 @@ core.shortcuts.view.rename=F2
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ xe.wikimacrobridge.macroDescription=Beskrivelse
 xe.wikimacrobridge.macroVisibility=Synlighed
 xe.wikimacrobridge.macroPage=Makro-side
 xe.wikimacrobridge.noWikiMacro=Der er endnu ikke defineret nogen wiki-makroer.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_de.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_de.properties
@@ -711,7 +711,7 @@ core.shortcuts.view.rename=F2
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ xe.wikimacrobridge.macroDescription=Beschreibung
 xe.wikimacrobridge.macroVisibility=Sichtbarkeit
 xe.wikimacrobridge.macroPage=Makroseite
 xe.wikimacrobridge.noWikiMacro=Es sind in diesem Wiki noch keine Wiki Makros definiert worden.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_el.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_el.properties
@@ -711,7 +711,7 @@
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ xe.index.trash.attachments.actions=
 ### Missing: xe.wikimacrobridge.macroVisibility=Visibility
 ### Missing: xe.wikimacrobridge.macroPage=Macro page
 ### Missing: xe.wikimacrobridge.noWikiMacro=There are no wiki macro defined in this wiki yet.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_es.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_es.properties
@@ -711,7 +711,7 @@ core.shortcuts.view.rename=F2
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ xe.wikimacrobridge.macroDescription=Descripci\u00F3n
 xe.wikimacrobridge.macroVisibility=Visibilidad
 xe.wikimacrobridge.macroPage=P\u00E1gina de macro
 xe.wikimacrobridge.noWikiMacro=Todav\u00EDa no ha una macro wiki definida en este wiki.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_fa.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_fa.properties
@@ -711,7 +711,7 @@
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ xe.index.trash.attachments.actions=
 ### Missing: xe.wikimacrobridge.macroVisibility=Visibility
 ### Missing: xe.wikimacrobridge.macroPage=Macro page
 ### Missing: xe.wikimacrobridge.noWikiMacro=There are no wiki macro defined in this wiki yet.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_fr.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_fr.properties
@@ -711,7 +711,7 @@ core.shortcuts.view.rename=F2
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ xe.wikimacrobridge.macroDescription=Description
 xe.wikimacrobridge.macroVisibility=Visibilit\u00E9
 xe.wikimacrobridge.macroPage=Page d'une macro
 xe.wikimacrobridge.noWikiMacro=Il n'y a pas encore de macros d\u00E9finies dans ce wiki
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_gl.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_gl.properties
@@ -711,7 +711,7 @@ core.shortcuts.view.rename=F2
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ platform.index.attachments.type=Tipo
 ### Missing: xe.wikimacrobridge.macroVisibility=Visibility
 ### Missing: xe.wikimacrobridge.macroPage=Macro page
 ### Missing: xe.wikimacrobridge.noWikiMacro=There are no wiki macro defined in this wiki yet.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_hi.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_hi.properties
@@ -711,7 +711,7 @@ core.shortcuts.view.delete=Delete
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ createblogpost=\u092C\u094D\u0932\u0949\u0917 \u0926\u0930\u094D\u091C \u0915\u0
 ### Missing: xe.wikimacrobridge.macroVisibility=Visibility
 ### Missing: xe.wikimacrobridge.macroPage=Macro page
 ### Missing: xe.wikimacrobridge.noWikiMacro=There are no wiki macro defined in this wiki yet.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_hr.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_hr.properties
@@ -711,7 +711,7 @@ core.shortcuts.view.rename=F2
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ xe.wikimacrobridge.macroDescription=Opis
 xe.wikimacrobridge.macroVisibility=Vidljivost
 xe.wikimacrobridge.macroPage=Makro stranica
 xe.wikimacrobridge.noWikiMacro=U ovom wikiju jo\u0161 nema definiranih wiki makroa.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_hu.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_hu.properties
@@ -711,7 +711,7 @@ core.shortcuts.view.delete=Delete
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ admin.elements=Oldal elemek
 ### Missing: xe.wikimacrobridge.macroVisibility=Visibility
 ### Missing: xe.wikimacrobridge.macroPage=Macro page
 ### Missing: xe.wikimacrobridge.noWikiMacro=There are no wiki macro defined in this wiki yet.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_id.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_id.properties
@@ -711,7 +711,7 @@
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ xe.index.trash.attachments.actions=
 ### Missing: xe.wikimacrobridge.macroVisibility=Visibility
 ### Missing: xe.wikimacrobridge.macroPage=Macro page
 ### Missing: xe.wikimacrobridge.noWikiMacro=There are no wiki macro defined in this wiki yet.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_it.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_it.properties
@@ -711,7 +711,7 @@ core.shortcuts.view.rename=F2
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ xe.wikimacrobridge.macroDescription=Descrizione
 xe.wikimacrobridge.macroVisibility=Visibilit\u00E0
 xe.wikimacrobridge.macroPage=Pagina della Macro
 xe.wikimacrobridge.noWikiMacro=Non ci sono ancora delle macro wiki definite in questo wiki.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_km.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_km.properties
@@ -711,7 +711,7 @@
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ xe.index.trash.attachments.actions=
 ### Missing: xe.wikimacrobridge.macroVisibility=Visibility
 ### Missing: xe.wikimacrobridge.macroPage=Macro page
 ### Missing: xe.wikimacrobridge.noWikiMacro=There are no wiki macro defined in this wiki yet.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_kn.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_kn.properties
@@ -711,7 +711,7 @@ edithtmlcontent=WYSIWYG \u0CB8\u0C82\u0CAA\u0CBE\u0CA6\u0CBF\u0CB8\u0CC1
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ xe.index.trash.attachments.actions=
 ### Missing: xe.wikimacrobridge.macroVisibility=Visibility
 ### Missing: xe.wikimacrobridge.macroPage=Macro page
 ### Missing: xe.wikimacrobridge.noWikiMacro=There are no wiki macro defined in this wiki yet.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_ko.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_ko.properties
@@ -711,7 +711,7 @@ Editing=\uC218\uC815
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ admin.configuration.description=\uC704\uD0A4\uC758 \uC77C\uBC18\uC801\uC778 \uC1
 ### Missing: xe.wikimacrobridge.macroVisibility=Visibility
 ### Missing: xe.wikimacrobridge.macroPage=Macro page
 ### Missing: xe.wikimacrobridge.noWikiMacro=There are no wiki macro defined in this wiki yet.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_lt.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_lt.properties
@@ -711,7 +711,7 @@ Error=Klaida
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ xe.index.trash.attachments.actions=
 ### Missing: xe.wikimacrobridge.macroVisibility=Visibility
 ### Missing: xe.wikimacrobridge.macroPage=Macro page
 ### Missing: xe.wikimacrobridge.noWikiMacro=There are no wiki macro defined in this wiki yet.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_lv.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_lv.properties
@@ -711,7 +711,7 @@ core.shortcuts.view.rename=F2
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ xe.wikimacrobridge.macroDescription=Apraksts
 xe.wikimacrobridge.macroVisibility=Redzam\u012Bba
 xe.wikimacrobridge.macroPage=Makrosa lapa
 xe.wikimacrobridge.noWikiMacro=\u0160aj\u0101 viki v\u0113l nav defin\u0113ts viki makross
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_mr.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_mr.properties
@@ -711,7 +711,7 @@
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ xe.index.trash.attachments.actions=
 ### Missing: xe.wikimacrobridge.macroVisibility=Visibility
 ### Missing: xe.wikimacrobridge.macroPage=Macro page
 ### Missing: xe.wikimacrobridge.noWikiMacro=There are no wiki macro defined in this wiki yet.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_nl.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_nl.properties
@@ -711,7 +711,7 @@ core.shortcuts.view.rename=F2
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ xe.wikimacrobridge.macroDescription=Omschrijving
 xe.wikimacrobridge.macroVisibility=Zichtbaarheid
 xe.wikimacrobridge.macroPage=Macro pagina
 xe.wikimacrobridge.noWikiMacro=Er is nog geen macro gedefinieerd in deze wiki.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_no.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_no.properties
@@ -711,7 +711,7 @@ core.shortcuts.view.rename=F2
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ core.menu.actions=Handlinger
 ### Missing: xe.wikimacrobridge.macroVisibility=Visibility
 ### Missing: xe.wikimacrobridge.macroPage=Macro page
 ### Missing: xe.wikimacrobridge.noWikiMacro=There are no wiki macro defined in this wiki yet.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_pl.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_pl.properties
@@ -711,7 +711,7 @@ core.shortcuts.view.delete=Delete
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ platform.index.attachments.type=Typ
 ### Missing: xe.wikimacrobridge.macroVisibility=Visibility
 ### Missing: xe.wikimacrobridge.macroPage=Macro page
 ### Missing: xe.wikimacrobridge.noWikiMacro=There are no wiki macro defined in this wiki yet.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_pt.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_pt.properties
@@ -711,7 +711,7 @@ core.shortcuts.view.delete=Delete
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ platform.index.attachments.type=Tipo
 ### Missing: xe.wikimacrobridge.macroVisibility=Visibility
 ### Missing: xe.wikimacrobridge.macroPage=Macro page
 ### Missing: xe.wikimacrobridge.noWikiMacro=There are no wiki macro defined in this wiki yet.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_pt_BR.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_pt_BR.properties
@@ -711,7 +711,7 @@ core.shortcuts.view.rename=F2
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ xe.wikimacrobridge.macroDescription=Descri\u00E7\u00E3o
 xe.wikimacrobridge.macroVisibility=Visibilidade
 xe.wikimacrobridge.macroPage=P\u00E1gina da macro
 xe.wikimacrobridge.noWikiMacro=N\u00E3o existe defini\u00E7\u00E3o de macro para essa wiki ainda.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_ro.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_ro.properties
@@ -711,7 +711,7 @@ core.shortcuts.view.rename=F2
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ platform.index.attachments.type=Tip
 ### Missing: xe.wikimacrobridge.macroVisibility=Visibility
 ### Missing: xe.wikimacrobridge.macroPage=Macro page
 ### Missing: xe.wikimacrobridge.noWikiMacro=There are no wiki macro defined in this wiki yet.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_ru.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_ru.properties
@@ -711,7 +711,7 @@ core.shortcuts.view.rename=F2
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ xe.wikimacrobridge.macroDescription=\u041E\u043F\u0438\u0441\u0430\u043D\u0438\u
 xe.wikimacrobridge.macroVisibility=\u0412\u0438\u0434\u0438\u043C\u043E\u0441\u0442\u044C
 xe.wikimacrobridge.macroPage=\u0421\u0442\u0440\u0430\u043D\u0438\u0446\u0430-\u043C\u0430\u043A\u0440\u043E\u0441
 xe.wikimacrobridge.noWikiMacro=Wiki-\u043C\u0430\u043A\u0440\u043E\u0441 \u0435\u0449\u0435 \u043D\u0435 \u043E\u043F\u0440\u0435\u0434\u0435\u043B\u0435\u043D \u0432 wiki.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_si.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_si.properties
@@ -711,7 +711,7 @@
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ xe.index.trash.attachments.actions=
 ### Missing: xe.wikimacrobridge.macroVisibility=Visibility
 ### Missing: xe.wikimacrobridge.macroPage=Macro page
 ### Missing: xe.wikimacrobridge.noWikiMacro=There are no wiki macro defined in this wiki yet.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_sk.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_sk.properties
@@ -711,7 +711,7 @@ core.shortcuts.view.rename=F2
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ xe.wikimacrobridge.macroDescription=Popis
 xe.wikimacrobridge.macroVisibility=Vidite\u013Enos\u0165
 xe.wikimacrobridge.macroPage=Macro str\u00E1nka
 ### Missing: xe.wikimacrobridge.noWikiMacro=There are no wiki macro defined in this wiki yet.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_sl.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_sl.properties
@@ -711,7 +711,7 @@
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ xe.index.trash.attachments.actions=
 ### Missing: xe.wikimacrobridge.macroVisibility=Visibility
 ### Missing: xe.wikimacrobridge.macroPage=Macro page
 ### Missing: xe.wikimacrobridge.noWikiMacro=There are no wiki macro defined in this wiki yet.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_sv.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_sv.properties
@@ -711,7 +711,7 @@ core.shortcuts.view.rename=F2
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ xe.wikimacrobridge.macroDescription=Beskrivning
 xe.wikimacrobridge.macroVisibility=Synlighet
 xe.wikimacrobridge.macroPage=Makrosida
 xe.wikimacrobridge.noWikiMacro=Det finns \u00E4nnu inga wikimakron i den h\u00E4r wikin.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_tr.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_tr.properties
@@ -711,7 +711,7 @@ core.shortcuts.view.rename=F2
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ xe.wikimacrobridge.macroDescription=A\u00E7\u0131klama
 xe.wikimacrobridge.macroVisibility=G\u00F6r\u00FCn\u00FCrl\u00FCk
 xe.wikimacrobridge.macroPage=Makro sayfas\u0131
 xe.wikimacrobridge.noWikiMacro=Hen\u00FCz bu wiki tan\u0131mlanm\u0131\u015F hi\u00E7bir wiki makro vard\u0131r .
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_uk.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_uk.properties
@@ -711,7 +711,7 @@ core.shortcuts.view.rename=F2
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ core.menu.moreactions=\u0411\u0456\u043B\u044C\u0448\u0435 \u0434\u0456\u0439
 ### Missing: xe.wikimacrobridge.macroVisibility=Visibility
 ### Missing: xe.wikimacrobridge.macroPage=Macro page
 ### Missing: xe.wikimacrobridge.noWikiMacro=There are no wiki macro defined in this wiki yet.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_vi.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_vi.properties
@@ -711,7 +711,7 @@ core.shortcuts.view.rename=F2
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ platform.index.attachments.type=Lo\u1EA1i
 ### Missing: xe.wikimacrobridge.macroVisibility=Visibility
 ### Missing: xe.wikimacrobridge.macroPage=Macro page
 ### Missing: xe.wikimacrobridge.noWikiMacro=There are no wiki macro defined in this wiki yet.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_zh.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_zh.properties
@@ -711,7 +711,7 @@ core.shortcuts.view.rename=F2
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ platform.index.attachments.type=\u7C7B\u578B
 ### Missing: xe.wikimacrobridge.macroVisibility=Visibility
 ### Missing: xe.wikimacrobridge.macroPage=Macro page
 ### Missing: xe.wikimacrobridge.noWikiMacro=There are no wiki macro defined in this wiki yet.
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_zh_TW.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources_zh_TW.properties
@@ -711,7 +711,7 @@ core.shortcuts.view.rename=F2
 core.shortcuts.edit.cancel=Alt+C
 core.shortcuts.edit.backtoedit=Alt+B
 core.shortcuts.edit.preview=Alt+P
-core.shortcuts.edit.saveandcontinue=Alt+Shift+S
+core.shortcuts.edit.save=Alt+Shift+S
 core.shortcuts.edit.saveandview=Alt+S
 
 ### Developer shortcuts
@@ -5197,6 +5197,11 @@ xe.wikimacrobridge.macroDescription=\u5DE8\u96C6\u8AAA\u660E
 ### Missing: xe.wikimacrobridge.macroVisibility=Visibility
 xe.wikimacrobridge.macroPage=\u5DE8\u96C6\u9801\u9762
 xe.wikimacrobridge.noWikiMacro=\u6B64 wiki \u5C1A\u672A\u5B9A\u7FA9\u4EFB\u4F55 wiki \u5DE8\u96C6
+
+#######################################
+## until 10.6-rc-1
+#######################################
+core.shortcuts.edit.saveandcontinue=Alt+Shift+S
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend


### PR DESCRIPTION
* Add missing translation.
* Move the old translation to the deprecated section.

See https://jira.xwiki.org/browse/XWIKI-15400