### PR TITLE
XWIKI-15406: Parsed LESS code in SSX objects always produces the same…

### DIFF
--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/web/sx/SxDocumentSource.java
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/web/sx/SxDocumentSource.java
@@ -138,7 +138,8 @@ public class SxDocumentSource implements SxSource
                     LESSResourceReference lessResourceReference =
                         lessResourceReferenceFactory.createReferenceForXObjectProperty(objectPropertyReference);
                     try {
-                        sxContent = lessCompiler.compile(lessResourceReference, true, (parse == 1), false);
+                        // We don't use cache here because it should be managed by the browser using cache policy.
+                        sxContent = lessCompiler.compile(lessResourceReference, true, (parse == 1), true);
                     } catch (LESSCompilerException e) {
                         // Set the error message in a CSS comment to help the developer understand why its SSX is not
                         // working (it will work only if the CSS minifier is not used).

--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/web/sx/SxDocumentSource.java
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/web/sx/SxDocumentSource.java
@@ -139,7 +139,7 @@ public class SxDocumentSource implements SxSource
                         lessResourceReferenceFactory.createReferenceForXObjectProperty(objectPropertyReference);
                     try {
                         sxContent = lessCompiler.compile(lessResourceReference, true, (parse == 1),
-                            CachePolicy.FORBID.equals(getCachePolicy()));
+                            CachePolicy.FORBID == getCachePolicy());
                     } catch (LESSCompilerException e) {
                         // Set the error message in a CSS comment to help the developer understand why its SSX is not
                         // working (it will work only if the CSS minifier is not used).

--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/web/sx/SxDocumentSource.java
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/web/sx/SxDocumentSource.java
@@ -138,8 +138,8 @@ public class SxDocumentSource implements SxSource
                     LESSResourceReference lessResourceReference =
                         lessResourceReferenceFactory.createReferenceForXObjectProperty(objectPropertyReference);
                     try {
-                        // We don't use cache here because it should be managed by the browser using cache policy.
-                        sxContent = lessCompiler.compile(lessResourceReference, true, (parse == 1), true);
+                        sxContent = lessCompiler.compile(lessResourceReference, true, (parse == 1),
+                            CachePolicy.FORBID.equals(getCachePolicy()));
                     } catch (LESSCompilerException e) {
                         // Set the error message in a CSS comment to help the developer understand why its SSX is not
                         // working (it will work only if the CSS minifier is not used).


### PR DESCRIPTION
… CSS, even with 'no caching' set

* Disable LESS caching for SSX when the cache policy is set to "no caching".

See https://jira.xwiki.org/browse/XWIKI-15406.