### PR TITLE
XWIKI-15434: Create a displayer for the Page field that supports autocomplete

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editobject.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editobject.vm
@@ -225,6 +225,7 @@
         ## Output the SkinExtension hooks to allow field displayers to pull JavaScript/CSS resources.
         ## The object editor will move these 'includes' (link/script tags) in the head of the HTML page.
         ## Note that we need to pull the JavaScript/CSS only once, for the first object of a given type.
+        <!-- com.xpn.xwiki.plugin.skinx.LinkExtensionPlugin -->
         #skinExtensionHooks
         #displayClass($class)
       #else

--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-api/src/main/java/org/xwiki/icon/IconManager.java
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-api/src/main/java/org/xwiki/icon/IconManager.java
@@ -115,13 +115,13 @@ public interface IconManager
     String renderHTML(String iconName, String iconSetName, boolean fallback) throws IconException;
 
     /**
-     * Generate metadata of an icon.
-     * <p> It can contain useful information such as:
+     * Generates metadata of an icon.
+     * <p> The map can contain useful information such as:
      * <ul>
-     * <li> The icon set name
-     * <li> The icon set type name
-     * <li> The icon url if defined
-     * <li> The icon css class if defined
+     * <li> The icon set name ({@value META_DATA_ICON_SET_NAME})
+     * <li> The icon set type name ({@value META_DATA_ICON_SET_TYPE})
+     * <li> The icon url if defined ({@value META_DATA_URL})
+     * <li> The icon css class if defined ({@value META_DATA_CSS_CLASS})
      * </ul>
      *
      * @param iconName name of the icon
@@ -135,13 +135,13 @@ public interface IconManager
     }
 
     /**
-     * Generate metadata of an icon.
-     * <p> It can contain useful information such as:
+     * Generates metadata of an icon.
+     * <p> The map can contain useful information such as:
      * <ul>
-     * <li> The icon set name
-     * <li> The icon set type name
-     * <li> The icon url if defined
-     * <li> The icon css class if defined
+     * <li> The icon set name ({@value META_DATA_ICON_SET_NAME})
+     * <li> The icon set type name ({@value META_DATA_ICON_SET_TYPE})
+     * <li> The icon url if defined ({@value META_DATA_URL})
+     * <li> The icon css class if defined ({@value META_DATA_CSS_CLASS})
      * </ul>
      *
      * @param iconName name of the icon
@@ -156,13 +156,13 @@ public interface IconManager
     }
 
     /**
-     * Generate metadata of an icon.
-     * <p> It can contain useful information such as:
+     * Generates metadata of an icon.
+     * <p> The map can contain useful information such as:
      * <ul>
-     * <li> The icon set name
-     * <li> The icon set type name
-     * <li> The icon url if defined
-     * <li> The icon css class if defined
+     * <li> The icon set name ({@value META_DATA_ICON_SET_NAME})
+     * <li> The icon set type name ({@value META_DATA_ICON_SET_TYPE})
+     * <li> The icon url if defined ({@value META_DATA_URL})
+     * <li> The icon css class if defined ({@value META_DATA_CSS_CLASS})
      * </ul>
      *
      * @param iconName name of the icon

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/DefaultPageQueryBuilder.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/DefaultPageQueryBuilder.java
@@ -65,6 +65,7 @@ public class DefaultPageQueryBuilder implements QueryBuilder<PageClass>
         Query query;
         if (StringUtils.isEmpty(pageClass.getSql())) {
             query = this.implicitlyAllowedValuesQueryBuilder.build(pageClass);
+            // We don't need the viewable filter here as the query builder already adds its own viewable filter.
             query.addFilter(this.documentFilter);
         } else {
             query = this.explicitlyAllowedValuesQueryBuilder.build(pageClass);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/DefaultPageQueryBuilder.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/DefaultPageQueryBuilder.java
@@ -1,0 +1,77 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xpn.xwiki.internal.objects.classes;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.query.Query;
+import org.xwiki.query.QueryBuilder;
+import org.xwiki.query.QueryException;
+import org.xwiki.query.QueryFilter;
+import org.xwiki.text.StringUtils;
+
+import com.xpn.xwiki.objects.classes.DBListClass;
+import com.xpn.xwiki.objects.classes.PageClass;
+
+/**
+ * Builds a query that returns the values allowed for a Page property.
+ *
+ * @version $Id$
+ * @since 10.6RC1
+ */
+@Component
+@Singleton
+public class DefaultPageQueryBuilder implements QueryBuilder<PageClass>
+{
+    @Inject
+    @Named("explicitlyAllowedValues")
+    private QueryBuilder<DBListClass> explicitlyAllowedValuesQueryBuilder;
+
+    @Inject
+    @Named("implicitlyAllowedValues")
+    private QueryBuilder<PageClass> implicitlyAllowedValuesQueryBuilder;
+
+    @Inject
+    @Named("document")
+    private QueryFilter documentFilter;
+
+    @Inject
+    @Named("viewable")
+    private QueryFilter viewableFilter;
+
+    @Override
+    public Query build(PageClass pageClass) throws QueryException
+    {
+        Query query;
+        if (StringUtils.isEmpty(pageClass.getSql())) {
+            query = this.implicitlyAllowedValuesQueryBuilder.build(pageClass);
+            query.addFilter(this.documentFilter);
+        } else {
+            query = this.explicitlyAllowedValuesQueryBuilder.build(pageClass);
+            query.addFilter(this.documentFilter);
+            query.addFilter(this.viewableFilter);
+        }
+
+        return query;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/DefaultPageQueryBuilder.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/DefaultPageQueryBuilder.java
@@ -37,7 +37,7 @@ import com.xpn.xwiki.objects.classes.PageClass;
  * Builds a query that returns the values allowed for a Page property.
  *
  * @version $Id$
- * @since 10.6RC1
+ * @since 10.6
  */
 @Component
 @Singleton

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/ImplicitlyAllowedValuesPageQueryBuilder.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/ImplicitlyAllowedValuesPageQueryBuilder.java
@@ -36,7 +36,7 @@ import com.xpn.xwiki.objects.classes.PageClass;
  * Builds a query from the meta data of a Page property.
  *
  * @version $Id$
- * @since 10.6RC1
+ * @since 10.6
  */
 @Component
 @Named("implicitlyAllowedValues")

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/ImplicitlyAllowedValuesPageQueryBuilder.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/ImplicitlyAllowedValuesPageQueryBuilder.java
@@ -1,0 +1,60 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xpn.xwiki.internal.objects.classes;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.query.Query;
+import org.xwiki.query.QueryBuilder;
+import org.xwiki.query.QueryException;
+import org.xwiki.text.StringUtils;
+
+import com.xpn.xwiki.objects.classes.DBListClass;
+import com.xpn.xwiki.objects.classes.PageClass;
+
+/**
+ * Builds a query from the meta data of a Page property.
+ *
+ * @version $Id$
+ * @since 10.6RC1
+ */
+@Component
+@Named("implicitlyAllowedValues")
+@Singleton
+public class ImplicitlyAllowedValuesPageQueryBuilder implements QueryBuilder<PageClass>
+{
+    @Inject
+    @Named("implicitlyAllowedValues")
+    private QueryBuilder<DBListClass> implicitlyAllowedValuesQueryBuilder;
+
+    @Override
+    public Query build(PageClass pageClass) throws QueryException
+    {
+        DBListClass dbListClass = (DBListClass) pageClass.clone();
+        if (StringUtils.isEmpty(dbListClass.getIdField())) {
+            dbListClass.setIdField("doc.fullName");
+        }
+
+        return implicitlyAllowedValuesQueryBuilder.build(dbListClass);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/ImplicitlyAllowedValuesPageQueryBuilder.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/ImplicitlyAllowedValuesPageQueryBuilder.java
@@ -54,6 +54,9 @@ public class ImplicitlyAllowedValuesPageQueryBuilder implements QueryBuilder<Pag
         if (StringUtils.isEmpty(dbListClass.getIdField())) {
             dbListClass.setIdField("doc.fullName");
         }
+        if (StringUtils.isEmpty(dbListClass.getValueField())) {
+            dbListClass.setValueField("doc.title");
+        }
 
         return implicitlyAllowedValuesQueryBuilder.build(dbListClass);
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/META-INF/components.txt
@@ -97,9 +97,11 @@ com.xpn.xwiki.internal.model.DefaultLegacySpaceResolver
 com.xpn.xwiki.internal.namespace.DefaultNamespaceContextExecutor
 com.xpn.xwiki.internal.objects.classes.DefaultDBListQueryBuilder
 com.xpn.xwiki.internal.objects.classes.DefaultGroupsQueryBuilder
+com.xpn.xwiki.internal.objects.classes.DefaultPageQueryBuilder
 com.xpn.xwiki.internal.objects.classes.DefaultUsersQueryBuilder
 com.xpn.xwiki.internal.objects.classes.ExplicitlyAllowedValuesDBListQueryBuilder
 com.xpn.xwiki.internal.objects.classes.ImplicitlyAllowedValuesDBListQueryBuilder
+com.xpn.xwiki.internal.objects.classes.ImplicitlyAllowedValuesPageQueryBuilder
 com.xpn.xwiki.internal.objects.classes.UsedValuesListQueryBuilder
 com.xpn.xwiki.internal.objects.classes.ViewableAllowedDBListValueFilter
 com.xpn.xwiki.internal.objects.classes.XClassMigratorListener

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/objects/classes/DefaultPageQueryBuilderTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/objects/classes/DefaultPageQueryBuilderTest.java
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.when;
  * Unit tests for {@link DefaultPageQueryBuilder}.
  *
  * @version $Id$
- * @since 10.6RC1
+ * @since 10.6
  */
 @ComponentTest
 public class DefaultPageQueryBuilderTest

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/objects/classes/DefaultPageQueryBuilderTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/objects/classes/DefaultPageQueryBuilderTest.java
@@ -1,0 +1,74 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xpn.xwiki.internal.objects.classes;
+
+import javax.inject.Named;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.query.Query;
+import org.xwiki.query.QueryBuilder;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import com.xpn.xwiki.objects.classes.DBListClass;
+import com.xpn.xwiki.objects.classes.PageClass;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link DefaultPageQueryBuilder}.
+ *
+ * @version $Id$
+ * @since 10.6RC1
+ */
+@ComponentTest
+public class DefaultPageQueryBuilderTest
+{
+    @InjectMockComponents
+    private DefaultPageQueryBuilder queryBuilder;
+
+    @MockComponent
+    @Named("explicitlyAllowedValues")
+    private QueryBuilder<DBListClass> explicitlyAllowedValuesQueryBuilder;
+
+    @MockComponent
+    @Named("implicitlyAllowedValues")
+    private QueryBuilder<PageClass> implicitlyAllowedValuesQueryBuilder;
+
+    @Test
+    public void build() throws Exception
+    {
+        PageClass pageClass = new PageClass();
+
+        Query explicitlyAllowedValuesQuery = mock(Query.class, "explicit");
+        when(this.explicitlyAllowedValuesQueryBuilder.build(pageClass)).thenReturn(explicitlyAllowedValuesQuery);
+
+        Query implicitlyAllowedValuesQuery = mock(Query.class, "implicit");
+        when(this.implicitlyAllowedValuesQueryBuilder.build(pageClass)).thenReturn(implicitlyAllowedValuesQuery);
+
+        assertSame(implicitlyAllowedValuesQuery, this.queryBuilder.build(pageClass));
+
+        pageClass.setSql("test");
+        assertSame(explicitlyAllowedValuesQuery, this.queryBuilder.build(pageClass));
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/objects/classes/ImplicitlyAllowedValuesPageQueryBuilderTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/objects/classes/ImplicitlyAllowedValuesPageQueryBuilderTest.java
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.when;
  * Unit tests for {@link ImplicitlyAllowedValuesPageQueryBuilder}.
  *
  * @version $Id$
- * @since 10.6RC1
+ * @since 10.6
  */
 @ComponentTest
 public class ImplicitlyAllowedValuesPageQueryBuilderTest

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/objects/classes/ImplicitlyAllowedValuesPageQueryBuilderTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/objects/classes/ImplicitlyAllowedValuesPageQueryBuilderTest.java
@@ -1,0 +1,61 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xpn.xwiki.internal.objects.classes;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+
+import com.xpn.xwiki.objects.classes.DBListClass;
+import com.xpn.xwiki.objects.classes.PageClass;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link ImplicitlyAllowedValuesPageQueryBuilder}.
+ *
+ * @version $Id$
+ * @since 10.6RC1
+ */
+@ComponentTest
+public class ImplicitlyAllowedValuesPageQueryBuilderTest
+{
+    @InjectMockComponents
+    private ImplicitlyAllowedValuesPageQueryBuilder queryBuilder;
+
+    @Test
+    public void build() throws Exception
+    {
+        PageClass pageClass = mock(PageClass.class);
+        DBListClass dbListClass = mock(DBListClass.class);
+        when(pageClass.clone()).thenReturn(dbListClass);
+
+        this.queryBuilder.build(pageClass);
+        verify(dbListClass).setIdField("doc.fullName");
+
+        when(dbListClass.getIdField()).thenReturn("doc.name");
+        this.queryBuilder.build(pageClass);
+        // The method shouldn't be called once more when the id field is defined
+        verify(dbListClass, times(1)).setIdField("doc.fullName");
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-model/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-model/pom.xml
@@ -31,7 +31,8 @@
   <name>XWiki Platform - REST - Model</name>
   <description>The (JAXB) model for XML resource representations served by the REST module.</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.02</xwiki.jacoco.instructionRatio>
+    <!-- The jacoco instruction ratio precision is higher here because the jaxb2 plugin generates classes that are not excluded in the analysis. -->
+    <xwiki.jacoco.instructionRatio>0.0292</xwiki.jacoco.instructionRatio>
   </properties>
   <dependencies>
     <!-- Test dependencies. -->

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-model/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-model/pom.xml
@@ -20,7 +20,8 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.xwiki.platform</groupId>
@@ -31,7 +32,10 @@
   <name>XWiki Platform - REST - Model</name>
   <description>The (JAXB) model for XML resource representations served by the REST module.</description>
   <properties>
-    <!-- The jacoco instruction ratio precision is higher here because the jaxb2 plugin generates classes that are not excluded in the analysis. -->
+    <!--
+      The jacoco instruction ratio precision is higher here because the jaxb2 plugin generates classes
+      that are not excluded in the analysis.
+    -->
     <xwiki.jacoco.instructionRatio>0.0292</xwiki.jacoco.instructionRatio>
   </properties>
   <dependencies>

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-model/src/main/java/org/xwiki/rest/model/jaxb/MapAdapter.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-model/src/main/java/org/xwiki/rest/model/jaxb/MapAdapter.java
@@ -29,7 +29,7 @@ import javax.xml.bind.annotation.adapters.XmlAdapter;
  * output format is XML and as a JSON object when the output format is JSON. This adapter allows us to use
  * {@link java.util.Map} in the REST resource that retrieves the class property values, while the XML serialization will
  * be done using the schema-generated {@link Map}.
- * 
+ *
  * @version $Id$
  * @since 9.8RC1
  */
@@ -42,7 +42,15 @@ public class MapAdapter extends XmlAdapter<Map, java.util.Map<String, java.lang.
             return null;
         } else {
             Map output = new Map();
-            input.forEach((key, value) -> output.getEntries().add(new MapEntry().withKey(key).withValue(value)));
+            for (String key : input.keySet()) {
+                java.lang.Object value = input.get(key);
+                if (value instanceof java.util.Map) {
+                    java.util.Map<String, java.lang.Object> nestedMap = new HashMap<>();
+                    ((java.util.Map<?, ?>) value).forEach((k, v) -> nestedMap.put(k.toString(), v));
+                    value = marshal(nestedMap);
+                }
+                output.getEntries().add(new MapEntry().withKey(key).withValue(value));
+            }
             return output;
         }
     }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-model/src/main/java/org/xwiki/rest/model/jaxb/MapAdapter.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-model/src/main/java/org/xwiki/rest/model/jaxb/MapAdapter.java
@@ -42,8 +42,9 @@ public class MapAdapter extends XmlAdapter<Map, java.util.Map<String, java.lang.
             return null;
         } else {
             Map output = new Map();
-            for (String key : input.keySet()) {
-                java.lang.Object value = input.get(key);
+            for (java.util.Map.Entry<String, java.lang.Object> entry : input.entrySet()) {
+                String key = entry.getKey();
+                java.lang.Object value = entry.getValue();
                 if (value instanceof java.util.Map) {
                     java.util.Map<String, java.lang.Object> nestedMap = new HashMap<>();
                     ((java.util.Map<?, ?>) value).forEach((k, v) -> nestedMap.put(k.toString(), v));

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-model/src/test/java/org/xwiki/rest/model/jaxb/MapAdapterTest.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-model/src/test/java/org/xwiki/rest/model/jaxb/MapAdapterTest.java
@@ -23,11 +23,13 @@ import java.util.LinkedHashMap;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Unit tests for {@link MapAdapter}.
- * 
+ *
  * @version $Id$
  * @since 9.8RC1
  */
@@ -39,13 +41,25 @@ public class MapAdapterTest
         java.util.Map<String, java.lang.Object> input = new LinkedHashMap<>();
         input.put("label", "News");
         input.put("count", 7);
+        java.util.Map<java.lang.Object, java.lang.Object> nestedMap = new LinkedHashMap<>();
+        nestedMap.put("test", 1);
+        nestedMap.put(8, "test");
+        input.put("nested map", nestedMap);
 
         Map output = new MapAdapter().marshal(input);
-        assertEquals(2, output.getEntries().size());
+        assertEquals(3, output.getEntries().size());
         assertEquals("label", output.getEntries().get(0).getKey());
         assertEquals("News", output.getEntries().get(0).getValue());
         assertEquals("count", output.getEntries().get(1).getKey());
         assertEquals(7, output.getEntries().get(1).getValue());
+        assertEquals("nested map", output.getEntries().get(2).getKey());
+        assertTrue(output.getEntries().get(2).getValue() instanceof Map);
+        Map value = (Map) output.getEntries().get(2).getValue();
+        assertEquals(2, value.getEntries().size());
+        assertEquals("test", value.getEntries().get(0).getKey());
+        assertEquals(1, value.getEntries().get(0).getValue());
+        assertEquals("8", value.getEntries().get(1).getKey());
+        assertEquals("test", value.getEntries().get(1).getValue());
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/pom.xml
@@ -169,6 +169,11 @@
       <artifactId>jaxb2-fluent-api</artifactId>
       <version>3.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-icon-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/AbstractClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/AbstractClassPropertyValuesProvider.java
@@ -43,7 +43,7 @@ import com.xpn.xwiki.objects.PropertyInterface;
 
 /**
  * Base class for {@link ClassPropertyValuesProvider} implementations.
- * 
+ *
  * @param <T> the property type
  * @version $Id$
  * @since 9.8
@@ -55,6 +55,12 @@ public abstract class AbstractClassPropertyValuesProvider<T> implements ClassPro
     protected static final String META_DATA_COUNT = "count";
 
     protected static final String META_DATA_ICON = "icon";
+
+    protected static final String META_DATA_HINT = "hint";
+
+    protected static final String META_DATA_ICON_META_DATA = "iconMetaData";
+
+    protected static final String META_DATA_URL = "url";
 
     @Inject
     protected Provider<XWikiContext> xcontextProvider;

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/AbstractClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/AbstractClassPropertyValuesProvider.java
@@ -58,8 +58,6 @@ public abstract class AbstractClassPropertyValuesProvider<T> implements ClassPro
 
     protected static final String META_DATA_HINT = "hint";
 
-    protected static final String META_DATA_ICON_META_DATA = "iconMetaData";
-
     protected static final String META_DATA_URL = "url";
 
     @Inject

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/AbstractDocumentListClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/AbstractDocumentListClassPropertyValuesProvider.java
@@ -24,6 +24,8 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import org.slf4j.Logger;
+import org.xwiki.icon.IconManager;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReferenceSerializer;
 import org.xwiki.model.reference.WikiReference;
@@ -50,6 +52,12 @@ public abstract class AbstractDocumentListClassPropertyValuesProvider<T extends 
     extends AbstractListClassPropertyValuesProvider<T>
 {
     @Inject
+    protected Logger logger;
+
+    @Inject
+    protected IconManager iconManager;
+
+    @Inject
     @Named("compact")
     private EntityReferenceSerializer<String> compactSerializer;
 
@@ -62,10 +70,7 @@ public abstract class AbstractDocumentListClassPropertyValuesProvider<T extends 
     private QueryFilter viewableFilter;
 
     /**
-     * A map with an icon css class / url or with {@link org.xwiki.icon.IconManager#getMetaData icon metadata}.
-     *
-     * <p>The entries of this map are meant to be added to the metadata of the
-     * {@link #getValueFromQueryResult values of the query result}.
+     * A map sharing the same keys as the {@link org.xwiki.icon.IconManager#getMetaData icon metadata}.
      *
      * @param documentReference document reference used to generate the icon
      * @return a map with icon related information
@@ -99,7 +104,7 @@ public abstract class AbstractDocumentListClassPropertyValuesProvider<T extends 
             value.setValue(this.compactSerializer.serialize(documentReference, wikiReference));
             value.getMetaData().put(META_DATA_LABEL,
                 getLabel(documentReference, value.getMetaData().get(META_DATA_LABEL)));
-            value.getMetaData().putAll(getIcon(documentReference));
+            value.getMetaData().put(META_DATA_ICON, getIcon(documentReference));
             value.getMetaData().put(META_DATA_URL, getURL(documentReference));
             value.getMetaData().put(META_DATA_HINT, getHint(documentReference));
         }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/AbstractUsersAndGroupsClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/AbstractUsersAndGroupsClassPropertyValuesProvider.java
@@ -23,7 +23,6 @@ import java.util.Iterator;
 
 import javax.inject.Inject;
 
-import org.slf4j.Logger;
 import org.xwiki.query.Query;
 import org.xwiki.query.QueryBuilder;
 import org.xwiki.rest.model.jaxb.PropertyValue;
@@ -36,7 +35,7 @@ import com.xpn.xwiki.objects.classes.ListClass;
 /**
  * Base class for {@link ClassPropertyValuesProvider} implementations that work with list of users and groups
  * properties.
- * 
+ *
  * @param <T> the property type
  * @version $Id$
  * @since 9.8
@@ -44,9 +43,6 @@ import com.xpn.xwiki.objects.classes.ListClass;
 public abstract class AbstractUsersAndGroupsClassPropertyValuesProvider<T extends ListClass>
     extends AbstractDocumentListClassPropertyValuesProvider<T>
 {
-    @Inject
-    protected Logger logger;
-
     @Inject
     protected WikiDescriptorManager wikiDescriptorManager;
 

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/GroupsClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/GroupsClassPropertyValuesProvider.java
@@ -19,6 +19,9 @@
  */
 package org.xwiki.rest.internal.resources.classes;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -41,7 +44,7 @@ import com.xpn.xwiki.objects.classes.GroupsClass;
 
 /**
  * Provides values for the "List of Groups" type of properties.
- * 
+ *
  * @version $Id$
  * @since 9.8
  */
@@ -81,23 +84,27 @@ public class GroupsClassPropertyValuesProvider extends AbstractUsersAndGroupsCla
     }
 
     @Override
-    protected String getIcon(DocumentReference groupReference)
+    protected Map<String, Object> getIcon(DocumentReference groupReference)
     {
+        Map<String, Object> icon = new HashMap<>();
         XWikiContext xcontext = this.xcontextProvider.get();
         try {
             XWikiDocument groupProfileDocument = xcontext.getWiki().getDocument(groupReference, xcontext);
             XWikiAttachment avatarAttachment = getFirstImageAttachment(groupProfileDocument, xcontext);
             if (avatarAttachment != null) {
-                return xcontext.getWiki().getURL(avatarAttachment.getReference(), "download",
-                    "width=30&height=30&keepAspectRatio=true", null, xcontext);
+                icon.put(META_DATA_ICON, xcontext.getWiki().getURL(avatarAttachment.getReference(), "download",
+                    "width=30&height=30&keepAspectRatio=true", null, xcontext));
             }
         } catch (XWikiException e) {
             this.logger.warn(
                 "Failed to read the avatar of group [{}]. Root cause is [{}]. Using the default avatar instead.",
                 groupReference.getName(), ExceptionUtils.getRootCauseMessage(e));
         }
+        if (!icon.containsKey(META_DATA_ICON)) {
+            icon.put(META_DATA_ICON, xcontext.getWiki().getSkinFile("icons/xwiki/noavatargroup.png", true, xcontext));
+        }
 
-        return xcontext.getWiki().getSkinFile("icons/xwiki/noavatargroup.png", true, xcontext);
+        return icon;
     }
 
     private XWikiAttachment getFirstImageAttachment(XWikiDocument document, XWikiContext xcontext)

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/PageClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/PageClassPropertyValuesProvider.java
@@ -53,7 +53,7 @@ import com.xpn.xwiki.objects.classes.PageClass;
  * Provides values for Page properties.
  *
  * @version $Id$
- * @since 10.6RC1
+ * @since 10.6
  */
 @Component
 @Named("Page")

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/PageClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/PageClassPropertyValuesProvider.java
@@ -99,11 +99,7 @@ public class PageClassPropertyValuesProvider extends AbstractDocumentListClassPr
         try {
             XWikiContext xcontext = this.xcontextProvider.get();
             XWikiDocument document;
-            if (XWiki.DEFAULT_SPACE_HOMEPAGE.equals(entityReference.getName())) {
-                document = xcontext.getWiki().getDocument(entityReference.getParent(), xcontext);
-            } else {
-                document = xcontext.getWiki().getDocument(entityReference, xcontext);
-            }
+            document = xcontext.getWiki().getDocument(entityReference, xcontext);
             label = document.getRenderedTitle(Syntax.PLAIN_1_0, xcontext);
         } catch (XWikiException e) {
             this.logger.error("Error while loading the document [{}]. Root cause is [{}]", entityReference,

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/PageClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/PageClassPropertyValuesProvider.java
@@ -98,7 +98,12 @@ public class PageClassPropertyValuesProvider extends AbstractDocumentListClassPr
         String label;
         try {
             XWikiContext xcontext = this.xcontextProvider.get();
-            XWikiDocument document = xcontext.getWiki().getDocument(entityReference, xcontext);
+            XWikiDocument document;
+            if (XWiki.DEFAULT_SPACE_HOMEPAGE.equals(entityReference.getName())) {
+                document = xcontext.getWiki().getDocument(entityReference.getParent(), xcontext);
+            } else {
+                document = xcontext.getWiki().getDocument(entityReference, xcontext);
+            }
             label = document.getRenderedTitle(Syntax.PLAIN_1_0, xcontext);
         } catch (XWikiException e) {
             this.logger.error("Error while loading the document [{}]. Root cause is [{}]", entityReference,

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/PageClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/PageClassPropertyValuesProvider.java
@@ -1,0 +1,157 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rest.internal.resources.classes;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.icon.IconException;
+import org.xwiki.icon.IconManager;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.EntityReference;
+import org.xwiki.model.reference.WikiReference;
+import org.xwiki.query.QueryBuilder;
+import org.xwiki.rendering.syntax.Syntax;
+import org.xwiki.rest.model.jaxb.PropertyValue;
+import org.xwiki.rest.model.jaxb.PropertyValues;
+import org.xwiki.security.authorization.AuthorExecutor;
+
+import com.xpn.xwiki.XWiki;
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.objects.classes.PageClass;
+
+/**
+ * Provides values for Page properties.
+ *
+ * @version $Id$
+ * @since 10.6RC1
+ */
+@Component
+@Named("Page")
+@Singleton
+public class PageClassPropertyValuesProvider extends AbstractDocumentListClassPropertyValuesProvider<PageClass>
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(PageClassPropertyValuesProvider.class);
+
+    @Inject
+    private QueryBuilder<PageClass> allowedValuesQueryBuilder;
+
+    @Inject
+    private AuthorExecutor authorExecutor;
+
+    @Inject
+    private IconManager iconManager;
+
+    @Override
+    protected Class<PageClass> getPropertyType()
+    {
+        return PageClass.class;
+    }
+
+    @Override
+    protected PropertyValues getAllowedValues(PageClass pageClass, int limit, String filter) throws Exception
+    {
+        // Execute the query with the rights of the class last author because the query may not be safe.
+        return this.authorExecutor.call(() -> getValues(
+            this.allowedValuesQueryBuilder.build(pageClass), limit, filter, pageClass
+        ), pageClass.getOwnerDocument().getAuthorReference());
+    }
+
+    @Override
+    protected PropertyValue getValueFromQueryResult(Object result, PageClass propertyDefinition)
+    {
+        PropertyValue value = super.getValueFromQueryResult(result, propertyDefinition);
+        // Get the document reference if it exists from the result as the parent method serialized it in the value
+        DocumentReference documentReference = (
+            (Supplier<DocumentReference>) () -> {
+                if (result instanceof Object[]) {
+                    Object[] row = (Object[]) result;
+                    if (row.length > 0 && row[0] instanceof DocumentReference) {
+                        return (DocumentReference) row[0];
+                    }
+                } else if (result instanceof DocumentReference) {
+                    return (DocumentReference) result;
+                }
+                return null;
+            }
+        ).get();
+
+        if (value != null && documentReference != null) {
+            value.getMetaData().put(META_DATA_HINT, getHint(documentReference));
+        }
+        return value;
+    }
+
+    @Override
+    protected Map<String, Object> getIcon(DocumentReference documentReference)
+    {
+        Map<String, Object> icon = new HashMap<>();
+        try {
+            icon.put(META_DATA_ICON_META_DATA, iconManager.getMetaData("page"));
+        } catch (IconException e) {
+            e.printStackTrace();
+        }
+
+        return icon;
+    }
+
+    @Override
+    protected String getLabel(DocumentReference documentReference, Object currentLabel)
+    {
+        String label = currentLabel == null ? "" : currentLabel.toString().trim();
+        if (label.isEmpty()) {
+            try {
+                XWikiContext xcontext = this.xcontextProvider.get();
+                XWikiDocument document = xcontext.getWiki().getDocument(documentReference, xcontext);
+                label = document.getRenderedTitle(Syntax.PLAIN_1_0, xcontext);
+            } catch (XWikiException e) {
+                LOGGER.error("Error while loading the document [{}]", documentReference,
+                    ExceptionUtils.getRootCause(e));
+                label = super.getLabel(documentReference, currentLabel);
+            }
+        }
+        return label;
+    }
+
+    @Override
+    protected String getHint(DocumentReference documentReference)
+    {
+        EntityReference parentSpace = documentReference.getParent();
+        if (XWiki.DEFAULT_SPACE_HOMEPAGE.equals(documentReference.getName())) {
+            parentSpace = parentSpace.getParent();
+        }
+        return parentSpace.getReversedReferenceChain().stream()
+            .filter(entityReference -> !(entityReference instanceof WikiReference))
+            .map(EntityReference::getName)
+            .collect(Collectors.joining(" / "));
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/UsersClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/UsersClassPropertyValuesProvider.java
@@ -19,6 +19,9 @@
  */
 package org.xwiki.rest.internal.resources.classes;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -38,7 +41,7 @@ import com.xpn.xwiki.objects.classes.UsersClass;
 
 /**
  * Provides values for the "List of Users" type of properties.
- * 
+ *
  * @version $Id$
  * @since 9.8
  */
@@ -80,23 +83,27 @@ public class UsersClassPropertyValuesProvider extends AbstractUsersAndGroupsClas
     }
 
     @Override
-    protected String getIcon(DocumentReference userReference)
+    protected Map<String, Object> getIcon(DocumentReference userReference)
     {
+        Map<String, Object> icon = new HashMap<>();
         XWikiContext xcontext = this.xcontextProvider.get();
         try {
             XWikiDocument userProfileDocument = xcontext.getWiki().getDocument(userReference, xcontext);
             String avatar = userProfileDocument.getStringValue("avatar");
             XWikiAttachment avatarAttachment = userProfileDocument.getAttachment(avatar);
             if (avatarAttachment != null && avatarAttachment.isImage(xcontext)) {
-                return xcontext.getWiki().getURL(avatarAttachment.getReference(), "download",
-                    "width=30&height=30&keepAspectRatio=true", null, xcontext);
+                icon.put(META_DATA_ICON, xcontext.getWiki().getURL(avatarAttachment.getReference(), "download",
+                    "width=30&height=30&keepAspectRatio=true", null, xcontext));
             }
         } catch (XWikiException e) {
             this.logger.warn(
                 "Failed to read the avatar of user [{}]. Root cause is [{}]. Using the default avatar instead.",
                 userReference.getName(), ExceptionUtils.getRootCauseMessage(e));
         }
+        if (!icon.containsKey(META_DATA_ICON)) {
+            icon.put(META_DATA_ICON, xcontext.getWiki().getSkinFile("icons/xwiki/noavatar.png", true, xcontext));
+        }
 
-        return xcontext.getWiki().getSkinFile("icons/xwiki/noavatar.png", true, xcontext);
+        return icon;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/UsersClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/UsersClassPropertyValuesProvider.java
@@ -28,6 +28,9 @@ import javax.inject.Singleton;
 
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.xwiki.component.annotation.Component;
+import org.xwiki.icon.IconException;
+import org.xwiki.icon.IconManager;
+import org.xwiki.icon.IconType;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.query.QueryBuilder;
 import org.xwiki.rest.model.jaxb.PropertyValues;
@@ -50,6 +53,8 @@ import com.xpn.xwiki.objects.classes.UsersClass;
 @Singleton
 public class UsersClassPropertyValuesProvider extends AbstractUsersAndGroupsClassPropertyValuesProvider<UsersClass>
 {
+    private static final String DEFAULT_ICON_NAME = "user";
+
     @Inject
     private WikiUserManager wikiUserManager;
 
@@ -92,16 +97,22 @@ public class UsersClassPropertyValuesProvider extends AbstractUsersAndGroupsClas
             String avatar = userProfileDocument.getStringValue("avatar");
             XWikiAttachment avatarAttachment = userProfileDocument.getAttachment(avatar);
             if (avatarAttachment != null && avatarAttachment.isImage(xcontext)) {
-                icon.put(META_DATA_ICON, xcontext.getWiki().getURL(avatarAttachment.getReference(), "download",
-                    "width=30&height=30&keepAspectRatio=true", null, xcontext));
+                icon.put(IconManager.META_DATA_URL, xcontext.getWiki().getURL(avatarAttachment.getReference(),
+                    "download", "width=30&height=30&keepAspectRatio=true", null, xcontext));
+                icon.put(IconManager.META_DATA_ICON_SET_TYPE, IconType.IMAGE.name());
             }
         } catch (XWikiException e) {
             this.logger.warn(
                 "Failed to read the avatar of user [{}]. Root cause is [{}]. Using the default avatar instead.",
                 userReference.getName(), ExceptionUtils.getRootCauseMessage(e));
         }
-        if (!icon.containsKey(META_DATA_ICON)) {
-            icon.put(META_DATA_ICON, xcontext.getWiki().getSkinFile("icons/xwiki/noavatar.png", true, xcontext));
+        if (!icon.containsKey(IconManager.META_DATA_URL)) {
+            try {
+                icon = this.iconManager.getMetaData(DEFAULT_ICON_NAME);
+            } catch (IconException e) {
+                this.logger.warn("Error getting the icon [{}]. Root cause is [{}].", DEFAULT_ICON_NAME,
+                    ExceptionUtils.getRootCause(e));
+            }
         }
 
         return icon;

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/resources/META-INF/components.txt
@@ -56,6 +56,7 @@ org.xwiki.rest.internal.resources.classes.ClassPropertyValuesResourceImpl
 org.xwiki.rest.internal.resources.classes.DBListClassPropertyValuesProvider
 org.xwiki.rest.internal.resources.classes.DefaultClassPropertyValuesProvider
 org.xwiki.rest.internal.resources.classes.GroupsClassPropertyValuesProvider
+org.xwiki.rest.internal.resources.classes.PageClassPropertyValuesProvider
 org.xwiki.rest.internal.resources.classes.UsersClassPropertyValuesProvider
 org.xwiki.rest.internal.resources.search.HQLSearchSource
 org.xwiki.rest.internal.resources.search.XWQLSearchSource

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/AbstractListClassPropertyValuesProviderTest.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/AbstractListClassPropertyValuesProviderTest.java
@@ -21,6 +21,7 @@ package org.xwiki.rest.internal.resources.classes;
 
 import java.util.Arrays;
 
+import javax.inject.Named;
 import javax.inject.Provider;
 
 import org.xwiki.component.manager.ComponentManager;
@@ -32,6 +33,7 @@ import org.xwiki.query.QueryBuilder;
 import org.xwiki.query.QueryParameter;
 import org.xwiki.rest.resources.classes.ClassPropertyValuesProvider;
 import org.xwiki.test.junit5.mockito.InjectComponentManager;
+import org.xwiki.test.junit5.mockito.MockComponent;
 
 import com.xpn.xwiki.XWiki;
 import com.xpn.xwiki.XWikiContext;
@@ -61,6 +63,8 @@ public abstract class AbstractListClassPropertyValuesProviderTest
 
     protected XWikiDocument classDocument = mock(XWikiDocument.class);
 
+    @MockComponent
+    @Named("usedValues")
     protected QueryBuilder<ListClass> usedValuesQueryBuilder;
 
     @InjectComponentManager
@@ -103,10 +107,6 @@ public abstract class AbstractListClassPropertyValuesProviderTest
             when(allowedValuesQueryBuilder.build(definition)).thenReturn(this.allowedValuesQuery);
 
             if (definition instanceof ListClass) {
-                DefaultParameterizedType usedValuesQueryBuilderType =
-                    new DefaultParameterizedType(null, QueryBuilder.class, ListClass.class);
-                this.usedValuesQueryBuilder =
-                    this.componentManager.getInstance(usedValuesQueryBuilderType, "usedValues");
                 when(this.usedValuesQueryBuilder.build((ListClass) definition)).thenReturn(this.usedValuesQuery);
             }
         }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/AbstractListClassPropertyValuesProviderTest.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/AbstractListClassPropertyValuesProviderTest.java
@@ -63,6 +63,8 @@ public abstract class AbstractListClassPropertyValuesProviderTest
 
     protected XWikiDocument classDocument = mock(XWikiDocument.class);
 
+    protected XWiki xwiki = mock(XWiki.class);
+
     @MockComponent
     @Named("usedValues")
     protected QueryBuilder<ListClass> usedValuesQueryBuilder;
@@ -73,12 +75,11 @@ public abstract class AbstractListClassPropertyValuesProviderTest
     public void configure() throws Exception
     {
         Provider<XWikiContext> xcontextProvider = this.componentManager.getInstance(XWikiContext.TYPE_PROVIDER);
-        XWiki xwiki = mock(XWiki.class);
         BaseClass xclass = mock(BaseClass.class);
         DocumentReference authorReference = new DocumentReference("wiki", "Users", "Alice");
 
         when(xcontextProvider.get()).thenReturn(this.xcontext);
-        when(this.xcontext.getWiki()).thenReturn(xwiki);
+        when(this.xcontext.getWiki()).thenReturn(this.xwiki);
         when(this.classDocument.getXClass()).thenReturn(xclass);
         when(this.classDocument.getDocumentReference()).thenReturn(this.classReference);
         when(this.classDocument.getAuthorReference()).thenReturn(authorReference);

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/GroupsClassPropertyValuesProviderTest.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/GroupsClassPropertyValuesProviderTest.java
@@ -30,6 +30,7 @@ import org.xwiki.rendering.syntax.Syntax;
 import org.xwiki.rest.model.jaxb.PropertyValues;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
 import org.xwiki.wiki.descriptor.WikiDescriptorManager;
 import org.xwiki.wiki.user.UserScope;
 import org.xwiki.wiki.user.WikiUserManager;
@@ -55,6 +56,7 @@ public class GroupsClassPropertyValuesProviderTest extends AbstractListClassProp
     @InjectMockComponents
     private GroupsClassPropertyValuesProvider provider;
 
+    @MockComponent
     private WikiUserManager wikiUserManager;
 
     private ClassPropertyReference propertyReference = new ClassPropertyReference("band", this.classReference);
@@ -67,8 +69,6 @@ public class GroupsClassPropertyValuesProviderTest extends AbstractListClassProp
         addProperty(this.propertyReference.getName(), new GroupsClass(), true);
         when(this.xcontext.getWiki().getSkinFile("icons/xwiki/noavatargroup.png", true, this.xcontext))
             .thenReturn("url/to/noavatar.png");
-
-        this.wikiUserManager = this.componentManager.getInstance(WikiUserManager.class);
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/GroupsClassPropertyValuesProviderTest.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/GroupsClassPropertyValuesProviderTest.java
@@ -20,6 +20,7 @@
 package org.xwiki.rest.internal.resources.classes;
 
 import java.util.Arrays;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,6 +41,7 @@ import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.objects.classes.GroupsClass;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -102,10 +104,13 @@ public class GroupsClassPropertyValuesProviderTest extends AbstractListClassProp
         assertEquals(2, values.getPropertyValues().size());
 
         assertEquals("Developers", values.getPropertyValues().get(0).getMetaData().get("label"));
-        assertEquals("url/to/noavatar.png", values.getPropertyValues().get(0).getMetaData().get("icon"));
+        assertTrue(values.getPropertyValues().get(0).getMetaData().get("icon") instanceof Map);
 
         assertEquals("Administrators", values.getPropertyValues().get(1).getMetaData().get("label"));
-        assertEquals("url/to/admins/image", values.getPropertyValues().get(1).getMetaData().get("icon"));
+        assertTrue(values.getPropertyValues().get(1).getMetaData().get("icon") instanceof Map);
+        Map icon = (Map) values.getPropertyValues().get(1).getMetaData().get("icon");
+        assertEquals("url/to/admins/image", icon.get("url"));
+        assertEquals("IMAGE", icon.get("iconSetType"));
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/PageClassPropertyValuesProviderTest.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/PageClassPropertyValuesProviderTest.java
@@ -38,8 +38,8 @@ import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
 
-import com.xpn.xwiki.objects.classes.DBListClass;
 import com.xpn.xwiki.objects.classes.DateClass;
+import com.xpn.xwiki.objects.classes.PageClass;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -53,18 +53,18 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * Unit tests for {@link DBListClassPropertyValuesProvider}.
+ * Unit tests for {@link PageClassPropertyValuesProvider}.
  *
  * @version $Id$
- * @since 9.8RC1
+ * @since 10.6RC1
  */
 @ComponentTest
-public class DBListClassPropertyValuesProviderTest extends AbstractListClassPropertyValuesProviderTest
+public class PageClassPropertyValuesProviderTest extends AbstractListClassPropertyValuesProviderTest
 {
-    @InjectMockComponents
-    private DBListClassPropertyValuesProvider provider;
+    private PageClass pageClass = new PageClass();
 
-    private DBListClass dbListClass = new DBListClass();
+    @InjectMockComponents
+    private PageClassPropertyValuesProvider provider;
 
     @MockComponent
     private EntityReferenceSerializer<String> entityReferenceSerializer;
@@ -77,7 +77,7 @@ public class DBListClassPropertyValuesProviderTest extends AbstractListClassProp
     {
         super.configure();
 
-        addProperty("category", this.dbListClass, true);
+        addProperty("category", this.pageClass, true);
         addProperty("date", new DateClass(), false);
 
         when(this.xcontext.getWiki().getDocument(new ClassPropertyReference("status", this.classReference),
@@ -103,14 +103,14 @@ public class DBListClassPropertyValuesProviderTest extends AbstractListClassProp
         Throwable exception = assertThrows(XWikiRestException.class, () -> {
             this.provider.getValues(propertyReference, 0);
         });
-        assertEquals(exception.getMessage(), "This [status reference] is not a [DBListClass] property.");
+        assertEquals(exception.getMessage(), "This [status reference] is not a [PageClass] property.");
     }
 
     @Test
     public void getValuesAllowed() throws Exception
     {
         ClassPropertyReference propertyReference = new ClassPropertyReference("category", this.classReference);
-        DocumentReference authorReference = this.dbListClass.getOwnerDocument().getAuthorReference();
+        DocumentReference authorReference = this.pageClass.getOwnerDocument().getAuthorReference();
         PropertyValues values = new PropertyValues();
         when(this.authorExecutor.call(any(), eq(authorReference))).thenReturn(values);
 
@@ -123,7 +123,7 @@ public class DBListClassPropertyValuesProviderTest extends AbstractListClassProp
     public void getValuesMixedWithoutUsed() throws Exception
     {
         ClassPropertyReference propertyReference = new ClassPropertyReference("category", this.classReference);
-        DocumentReference authorReference = this.dbListClass.getOwnerDocument().getAuthorReference();
+        DocumentReference authorReference = this.pageClass.getOwnerDocument().getAuthorReference();
         PropertyValues values = new PropertyValues();
         values.getPropertyValues().add(new PropertyValue());
         when(this.authorExecutor.call(any(), eq(authorReference))).thenReturn(values);
@@ -138,7 +138,7 @@ public class DBListClassPropertyValuesProviderTest extends AbstractListClassProp
     public void getValuesMixedWithUsed() throws Exception
     {
         ClassPropertyReference propertyReference = new ClassPropertyReference("category", this.classReference);
-        DocumentReference authorReference = this.dbListClass.getOwnerDocument().getAuthorReference();
+        DocumentReference authorReference = this.pageClass.getOwnerDocument().getAuthorReference();
 
         PropertyValues values = new PropertyValues();
         PropertyValue red = new PropertyValue();
@@ -150,7 +150,7 @@ public class DBListClassPropertyValuesProviderTest extends AbstractListClassProp
 
         Query query = mock(Query.class);
         QueryParameter queryParameter = mock(QueryParameter.class);
-        when(this.usedValuesQueryBuilder.build(dbListClass)).thenReturn(query);
+        when(this.usedValuesQueryBuilder.build(pageClass)).thenReturn(query);
         when(query.bindValue("text")).thenReturn(queryParameter);
         when(queryParameter.anyChars()).thenReturn(queryParameter);
         when(queryParameter.literal("bar")).thenReturn(queryParameter);

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/PageClassPropertyValuesProviderTest.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/PageClassPropertyValuesProviderTest.java
@@ -21,12 +21,14 @@ package org.xwiki.rest.internal.resources.classes;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.EntityReference;
+import org.xwiki.model.reference.SpaceReference;
+import org.xwiki.model.reference.WikiReference;
 import org.xwiki.query.Query;
 import org.xwiki.rendering.syntax.Syntax;
 import org.xwiki.rest.model.jaxb.PropertyValues;
@@ -35,12 +37,11 @@ import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
 
 import com.xpn.xwiki.XWiki;
+import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.objects.classes.PageClass;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.xwiki.rest.internal.resources.classes.AbstractClassPropertyValuesProvider.META_DATA_ICON;
@@ -66,50 +67,74 @@ public class PageClassPropertyValuesProviderTest extends AbstractListClassProper
         super.configure();
 
         when(this.pageClass.getOwnerDocument()).thenReturn(this.classDocument);
-        when(this.xcontext.getWiki().getDocument(any(DocumentReference.class), eq(this.xcontext)))
-            .thenReturn(this.classDocument);
-        when(this.classDocument.getRenderedTitle(Syntax.PLAIN_1_0, this.xcontext)).thenReturn("Document");
     }
 
     @Test
     public void getValues() throws Exception
     {
-        List<String> spaces = Arrays.asList("space1", "space2");
-        DocumentReference documentReference = new DocumentReference("wiki", spaces, "page");
+        WikiReference wikiRef = new WikiReference("wiki");
+        SpaceReference space1Ref = new SpaceReference("space1", wikiRef);
+        SpaceReference space2Ref = new SpaceReference("space2", space1Ref);
+        EntityReference pageRef = new DocumentReference("page", space2Ref);
+
+        XWikiDocument space1Doc = mock(XWikiDocument.class);
+        XWikiDocument space2Doc = mock(XWikiDocument.class);
+        XWikiDocument pageDoc = mock(XWikiDocument.class);
+        when(this.xwiki.getDocument(space1Ref, this.xcontext)).thenReturn(space1Doc);
+        when(this.xwiki.getDocument(space2Ref, this.xcontext)).thenReturn(space2Doc);
+        when(this.xwiki.getDocument(pageRef, this.xcontext)).thenReturn(pageDoc);
+        when(space1Doc.getRenderedTitle(Syntax.PLAIN_1_0, this.xcontext)).thenReturn("Space 1");
+        when(space2Doc.getRenderedTitle(Syntax.PLAIN_1_0, this.xcontext)).thenReturn("Space 2");
+        when(pageDoc.getRenderedTitle(Syntax.PLAIN_1_0, this.xcontext)).thenReturn("Page");
 
         Query query = mock(Query.class);
-        when(query.execute()).thenReturn(Collections.singletonList(documentReference));
+        when(query.execute()).thenReturn(Collections.singletonList(pageRef));
 
         PropertyValues values = this.provider.getValues(query, 3, "", this.pageClass);
         assertEquals(1, values.getPropertyValues().size());
 
         Map<String, Object> metadata = values.getPropertyValues().get(0).getMetaData();
-        assertEquals("space1 / space2", metadata.get("hint"));
-        assertEquals("Document", metadata.get("label"));
+        assertEquals("Space 1 / Space 2", metadata.get("hint"));
+        assertEquals("Page", metadata.get("label"));
         assertTrue(metadata.containsKey(META_DATA_ICON));
     }
 
     @Test
     public void getValuesWithNonTerminalPage() throws Exception
     {
-        List<String> spaces = Arrays.asList("space1", "space2");
-        DocumentReference documentReference1 = new DocumentReference("wiki", spaces, "page");
-        DocumentReference documentReference2 = new DocumentReference("wiki", spaces, XWiki.DEFAULT_SPACE_HOMEPAGE);
+        WikiReference wikiRef = new WikiReference("wiki");
+        SpaceReference space1Ref = new SpaceReference("space1", wikiRef);
+        SpaceReference space2Ref = new SpaceReference("space2", space1Ref);
+        EntityReference page1Ref = new DocumentReference("page", space2Ref);
+        EntityReference page2Ref = new DocumentReference(XWiki.DEFAULT_SPACE_HOMEPAGE, space2Ref);
+
+        XWikiDocument space1Doc = mock(XWikiDocument.class);
+        XWikiDocument space2Doc = mock(XWikiDocument.class);
+        XWikiDocument page1Doc = mock(XWikiDocument.class);
+        XWikiDocument page2Doc = mock(XWikiDocument.class);
+        when(this.xwiki.getDocument(space1Ref, this.xcontext)).thenReturn(space1Doc);
+        when(this.xwiki.getDocument(space2Ref, this.xcontext)).thenReturn(space2Doc);
+        when(this.xwiki.getDocument(page1Ref, this.xcontext)).thenReturn(page1Doc);
+        when(this.xwiki.getDocument(page2Ref, this.xcontext)).thenReturn(page2Doc);
+        when(space1Doc.getRenderedTitle(Syntax.PLAIN_1_0, this.xcontext)).thenReturn("Space 1");
+        when(space2Doc.getRenderedTitle(Syntax.PLAIN_1_0, this.xcontext)).thenReturn("Space 2");
+        when(page1Doc.getRenderedTitle(Syntax.PLAIN_1_0, this.xcontext)).thenReturn("Page 1");
+        when(page2Doc.getRenderedTitle(Syntax.PLAIN_1_0, this.xcontext)).thenReturn("Page 2");
 
         Query query = mock(Query.class);
-        when(query.execute()).thenReturn(Arrays.asList(documentReference1, documentReference2));
+        when(query.execute()).thenReturn(Arrays.asList(page1Ref, page2Ref));
 
         PropertyValues values = this.provider.getValues(query, 3, "", this.pageClass);
         assertEquals(2, values.getPropertyValues().size());
 
         Map<String, Object> metadata = values.getPropertyValues().get(0).getMetaData();
-        assertEquals("space1 / space2", metadata.get("hint"));
-        assertEquals("Document", metadata.get("label"));
+        assertEquals("Space 1 / Space 2", metadata.get("hint"));
+        assertEquals("Page 1", metadata.get("label"));
         assertTrue(metadata.containsKey(META_DATA_ICON));
 
         metadata = values.getPropertyValues().get(1).getMetaData();
-        assertEquals("space1", metadata.get("hint"));
-        assertEquals("Document", metadata.get("label"));
+        assertEquals("Space 1", metadata.get("hint"));
+        assertEquals("Space 2", metadata.get("label"));
         assertTrue(metadata.containsKey(META_DATA_ICON));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/PageClassPropertyValuesProviderTest.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/PageClassPropertyValuesProviderTest.java
@@ -100,7 +100,7 @@ public class PageClassPropertyValuesProviderTest extends AbstractListClassProper
     }
 
     @Test
-    public void getValuesWithNonTerminalPage() throws Exception
+    public void getValuesWithTerminalPage() throws Exception
     {
         WikiReference wikiRef = new WikiReference("wiki");
         SpaceReference space1Ref = new SpaceReference("space1", wikiRef);
@@ -113,7 +113,7 @@ public class PageClassPropertyValuesProviderTest extends AbstractListClassProper
         XWikiDocument page1Doc = mock(XWikiDocument.class);
         XWikiDocument page2Doc = mock(XWikiDocument.class);
         when(this.xwiki.getDocument(space1Ref, this.xcontext)).thenReturn(space1Doc);
-        when(this.xwiki.getDocument(space2Ref, this.xcontext)).thenReturn(space2Doc);
+        when(this.xwiki.getDocument(space2Ref, this.xcontext)).thenReturn(page2Doc);
         when(this.xwiki.getDocument(page1Ref, this.xcontext)).thenReturn(page1Doc);
         when(this.xwiki.getDocument(page2Ref, this.xcontext)).thenReturn(page2Doc);
         when(space1Doc.getRenderedTitle(Syntax.PLAIN_1_0, this.xcontext)).thenReturn("Space 1");
@@ -128,13 +128,13 @@ public class PageClassPropertyValuesProviderTest extends AbstractListClassProper
         assertEquals(2, values.getPropertyValues().size());
 
         Map<String, Object> metadata = values.getPropertyValues().get(0).getMetaData();
-        assertEquals("Space 1 / Space 2", metadata.get("hint"));
+        assertEquals("Space 1 / Page 2", metadata.get("hint"));
         assertEquals("Page 1", metadata.get("label"));
         assertTrue(metadata.containsKey(META_DATA_ICON));
 
         metadata = values.getPropertyValues().get(1).getMetaData();
         assertEquals("Space 1", metadata.get("hint"));
-        assertEquals("Space 2", metadata.get("label"));
+        assertEquals("Page 2", metadata.get("label"));
         assertTrue(metadata.containsKey(META_DATA_ICON));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/PageClassPropertyValuesProviderTest.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/PageClassPropertyValuesProviderTest.java
@@ -43,7 +43,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.xwiki.rest.internal.resources.classes.AbstractClassPropertyValuesProvider.META_DATA_ICON_META_DATA;
+import static org.xwiki.rest.internal.resources.classes.AbstractClassPropertyValuesProvider.META_DATA_ICON;
 
 /**
  * Unit tests for {@link PageClassPropertyValuesProvider}.
@@ -86,7 +86,7 @@ public class PageClassPropertyValuesProviderTest extends AbstractListClassProper
         Map<String, Object> metadata = values.getPropertyValues().get(0).getMetaData();
         assertEquals("space1 / space2", metadata.get("hint"));
         assertEquals("Document", metadata.get("label"));
-        assertTrue(metadata.containsKey(META_DATA_ICON_META_DATA));
+        assertTrue(metadata.containsKey(META_DATA_ICON));
     }
 
     @Test
@@ -105,11 +105,11 @@ public class PageClassPropertyValuesProviderTest extends AbstractListClassProper
         Map<String, Object> metadata = values.getPropertyValues().get(0).getMetaData();
         assertEquals("space1 / space2", metadata.get("hint"));
         assertEquals("Document", metadata.get("label"));
-        assertTrue(metadata.containsKey(META_DATA_ICON_META_DATA));
+        assertTrue(metadata.containsKey(META_DATA_ICON));
 
         metadata = values.getPropertyValues().get(1).getMetaData();
         assertEquals("space1", metadata.get("hint"));
         assertEquals("Document", metadata.get("label"));
-        assertTrue(metadata.containsKey(META_DATA_ICON_META_DATA));
+        assertTrue(metadata.containsKey(META_DATA_ICON));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/PageClassPropertyValuesProviderTest.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/PageClassPropertyValuesProviderTest.java
@@ -49,7 +49,7 @@ import static org.xwiki.rest.internal.resources.classes.AbstractClassPropertyVal
  * Unit tests for {@link PageClassPropertyValuesProvider}.
  *
  * @version $Id$
- * @since 10.6RC1
+ * @since 10.6
  */
 @ComponentTest
 public class PageClassPropertyValuesProviderTest extends AbstractListClassPropertyValuesProviderTest

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/UsersClassPropertyValuesProviderTest.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/UsersClassPropertyValuesProviderTest.java
@@ -22,6 +22,7 @@ package org.xwiki.rest.internal.resources.classes;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,6 +44,7 @@ import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.objects.classes.UsersClass;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -124,13 +126,16 @@ public class UsersClassPropertyValuesProviderTest extends AbstractListClassPrope
         assertEquals("Users.Alice", values.getPropertyValues().get(0).getValue());
         assertEquals("Alice One", values.getPropertyValues().get(0).getMetaData().get("label"));
         assertEquals(3L, values.getPropertyValues().get(0).getMetaData().get("count"));
-        assertEquals("url/to/noavatar.png", values.getPropertyValues().get(0).getMetaData().get("icon"));
+        assertTrue(values.getPropertyValues().get(0).getMetaData().get("icon") instanceof Map);
         assertEquals("url/to/alice", values.getPropertyValues().get(0).getMetaData().get("url"));
 
         assertEquals("Users.Bob", values.getPropertyValues().get(1).getValue());
         assertEquals("Bob", values.getPropertyValues().get(1).getMetaData().get("label"));
         assertEquals(17L, values.getPropertyValues().get(1).getMetaData().get("count"));
-        assertEquals("url/to/bob/avatar", values.getPropertyValues().get(1).getMetaData().get("icon"));
+        assertTrue(values.getPropertyValues().get(1).getMetaData().get("icon") instanceof Map);
+        Map icon = (Map) values.getPropertyValues().get(1).getMetaData().get("icon");
+        assertEquals("url/to/bob/avatar", icon.get("url"));
+        assertEquals("IMAGE", icon.get("iconSetType"));
         assertEquals("url/to/bob", values.getPropertyValues().get(1).getMetaData().get("url"));
 
         verify(this.allowedValuesQuery, never()).setWiki(any(String.class));

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/UsersClassPropertyValuesProviderTest.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/UsersClassPropertyValuesProviderTest.java
@@ -33,6 +33,7 @@ import org.xwiki.query.QueryFilter;
 import org.xwiki.rest.model.jaxb.PropertyValues;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
 import org.xwiki.wiki.descriptor.WikiDescriptorManager;
 import org.xwiki.wiki.user.UserScope;
 import org.xwiki.wiki.user.WikiUserManager;
@@ -61,6 +62,7 @@ public class UsersClassPropertyValuesProviderTest extends AbstractListClassPrope
     @InjectMockComponents
     private UsersClassPropertyValuesProvider provider;
 
+    @MockComponent
     private WikiUserManager wikiUserManager;
 
     private ClassPropertyReference propertyReference = new ClassPropertyReference("owner", this.classReference);
@@ -73,8 +75,6 @@ public class UsersClassPropertyValuesProviderTest extends AbstractListClassPrope
         addProperty(this.propertyReference.getName(), new UsersClass(), true);
         when(this.xcontext.getWiki().getSkinFile("icons/xwiki/noavatar.png", true, this.xcontext))
             .thenReturn("url/to/noavatar.png");
-
-        this.wikiUserManager = this.componentManager.getInstance(WikiUserManager.class);
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/suggest/suggestPropertyValues.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/suggest/suggestPropertyValues.js
@@ -58,7 +58,9 @@ define('xwiki-suggestPropertyValues', ['jquery', 'xwiki-selectize'], function($)
       value: propertyValue.value,
       label: metaData.label,
       icon: metaData.icon,
-      url: metaData.url
+      url: metaData.url,
+      hint: metaData.hint,
+      iconMetaData: metaData.iconMetaData
     };
   };
 

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/suggest/suggestPropertyValues.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/suggest/suggestPropertyValues.js
@@ -59,8 +59,7 @@ define('xwiki-suggestPropertyValues', ['jquery', 'xwiki-selectize'], function($)
       label: metaData.label,
       icon: metaData.icon,
       url: metaData.url,
-      hint: metaData.hint,
-      iconMetaData: metaData.iconMetaData
+      hint: metaData.hint
     };
   };
 

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/suggest/xwiki.selectize.css
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/suggest/xwiki.selectize.css
@@ -40,6 +40,9 @@ a.xwiki-selectize-option-label {
   color: inherit;
   text-decoration: none;
 }
+em.xwiki-selectize-option-hint {
+  display: block;
+}
 
 /* Live Table Filter */
 .xwiki-livetable-display-header-filter .selectize-input {

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/suggest/xwiki.selectize.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/suggest/xwiki.selectize.js
@@ -36,20 +36,31 @@ define('xwiki-selectize', ['jquery', 'selectize', 'xwiki-events-bridge'], functi
     '</div>'
   ].join('');
 
-  var renderOption = function(option) {
+  var renderCommon = function(option) {
     var output = $(optionTemplate);
     var value = (option && typeof option === 'object') ? option.value : option;
     output.attr('data-value', value);
+    var iconMetaData = option && option.iconMetaData;
+    if (typeof iconMetaData !== 'object') {
+      iconMetaData = {};
+    }
     var icon = option && option.icon;
-    if (typeof icon === 'string') {
+    if (typeof icon === 'string' && icon !== '') {
       if (icon.indexOf('/') >= 0 || icon.indexOf('.') >= 0) {
         // The icon is specified by its path.
-        var image = $('<img class="xwiki-selectize-option-icon" alt="" />').attr('src', icon);
-        output.find('.xwiki-selectize-option-icon').replaceWith(image);
+        iconMetaData.iconSetType = 'IMAGE';
+        iconMetaData.url = icon;
       } else {
         // The icon is specified by its CSS class.
-        output.find('.xwiki-selectize-option-icon').addClass(icon);
+        iconMetaData.iconSetType = 'FONT';
+        iconMetaData.cssClass = icon;
       }
+    }
+    if (iconMetaData.iconSetType === 'IMAGE') {
+      var image = $('<img class="xwiki-selectize-option-icon" alt="" />').attr('src', iconMetaData.url);
+      output.find('.xwiki-selectize-option-icon').replaceWith(image);
+    } else if (iconMetaData.iconSetType === 'FONT') {
+      output.find('.xwiki-selectize-option-icon').addClass(iconMetaData.cssClass);
     } else {
       output.find('.xwiki-selectize-option-icon').remove();
     }
@@ -65,6 +76,24 @@ define('xwiki-selectize', ['jquery', 'selectize', 'xwiki-events-bridge'], functi
     output.find('.xwiki-selectize-option-label').text(label);
     return output;
   };
+
+  var renderOption = function(option) {
+    var output = renderCommon(option);
+    var hint = option && option.hint;
+    if (typeof hint === 'string' && hint !== '') {
+      output.append('<em class="xwiki-selectize-option-hint">' + hint + '</em>');
+    }
+    return output;
+  }
+
+  var renderItem = function(option) {
+    var output = renderCommon(option);
+    var hint = option && option.hint;
+    if (typeof hint === 'string' && hint !== '') {
+      output.attr('title', hint);
+    }
+    return output;
+  }
 
   var defaultSettings = {
     // Copying the CSS classes from the form field to the dropdown can have unexpected side effects if those classes are
@@ -87,7 +116,7 @@ define('xwiki-selectize', ['jquery', 'selectize', 'xwiki-events-bridge'], functi
     persist: false,
     preload: 'focus',
     render: {
-      item: renderOption,
+      item: renderItem,
       option: renderOption,
       option_create: function(data, escapeHTML) {
         // TODO: Use translation key here.

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/suggest/xwiki.selectize.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/suggest/xwiki.selectize.js
@@ -40,29 +40,23 @@ define('xwiki-selectize', ['jquery', 'selectize', 'xwiki-events-bridge'], functi
     var output = $(optionTemplate);
     var value = (option && typeof option === 'object') ? option.value : option;
     output.attr('data-value', value);
-    var iconMetaData = option && option.iconMetaData;
-    if (typeof iconMetaData !== 'object') {
-      iconMetaData = {};
-    }
     var icon = option && option.icon;
-    if (typeof icon === 'string' && icon !== '') {
-      if (icon.indexOf('/') >= 0 || icon.indexOf('.') >= 0) {
-        // The icon is specified by its path.
-        iconMetaData.iconSetType = 'IMAGE';
-        iconMetaData.url = icon;
-      } else {
-        // The icon is specified by its CSS class.
-        iconMetaData.iconSetType = 'FONT';
-        iconMetaData.cssClass = icon;
+    if (typeof icon === 'object') {
+      // Set the icon set type in case it was missing.
+      if (!icon.iconSetType && icon.url) {
+        icon.iconSetType = 'IMAGE';
+      } else if (!icon.iconSetType && icon.cssClass) {
+          icon.iconSetType = 'FONT';
       }
-    }
-    if (iconMetaData.iconSetType === 'IMAGE') {
-      var image = $('<img class="xwiki-selectize-option-icon" alt="" />').attr('src', iconMetaData.url);
-      output.find('.xwiki-selectize-option-icon').replaceWith(image);
-    } else if (iconMetaData.iconSetType === 'FONT') {
-      output.find('.xwiki-selectize-option-icon').addClass(iconMetaData.cssClass);
-    } else {
-      output.find('.xwiki-selectize-option-icon').remove();
+      // Render the icon depending on the icon set type.
+      if (icon.iconSetType === 'IMAGE') {
+        var image = $('<img class="xwiki-selectize-option-icon" alt="" />').attr('src', icon.url);
+        output.find('.xwiki-selectize-option-icon').replaceWith(image);
+      } else if (icon.iconSetType === 'FONT') {
+        output.find('.xwiki-selectize-option-icon').addClass(icon.cssClass);
+      } else {
+        output.find('.xwiki-selectize-option-icon').remove();
+      }
     }
     var url = option && option.url;
     if (typeof url === 'string') {

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/displayer_page.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/displayer_page.vm
@@ -1,0 +1,1 @@
+#template('displayer_dblist.vm')


### PR DESCRIPTION
## Changes
* DefaultPageQueryBuilder, ImplicitlyAllowedValuesPageQueryBuilder
* Add support to nested maps serialization in MapAdapter.
* Improve AbstractDocumentListClassPropertyValuesProvider
  * Add icon and hint metadata to the property values.
  * Make the getIcon method return a map with icon related information.
  * Replace the document name with the parent space name when the
   document is WebHome in the getLabel method.
* Create a Page class property values provider.
* Display icons in the selectize when an icon metadata is passed.
* Create a displayer for the Page class.
* Add related tests
* Increase jacoco threshold

## Jira
https://jira.xwiki.org/browse/XWIKI-15434

## Example
![autocomplete-07](https://user-images.githubusercontent.com/2213999/42454554-1a120eea-8390-11e8-838e-126ef84870bf.gif)

## Could be enhanced
* Search pages with the shown label name (e.g. "Sandbox Test Page 1").
* Support for the `wiki:` prefix / search through sub-wikis.
* Show also the name of the document in the hint?