### PR TITLE
XWIKI-11283 : Missing "Actions" column name on the History table

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/historyinline.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/historyinline.vm
@@ -70,12 +70,11 @@ $xwiki.ssfx.use('uicomponents/pagination/pagination.css', true)##
           #if($xwiki.hasEditComment())
             <th scope="col">$services.localization.render('core.viewers.history.comment')</th>
           #end
-  ## Editors see the Revert button.
-          #if($hasEdit && !$hasAdmin)
-            <th scope="col"></th>
-  ## Admins see the Revert and Delete buttons.
-          #elseif($hasAdmin)
-            <th scope="col" colspan="2"></th>
+  ## Editors see the Revert button. Admins see the Revert and Delete buttons.
+          #if ($hasEdit)
+            <th scope="col" #if($hasAdmin)colspan="2"#end>
+              $services.localization.render('core.viewers.history.actions')
+            </th>
           #end
           </tr>
         </thead>

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -1087,6 +1087,7 @@ core.viewers.attachments.mime.vcard=vCard
 core.viewers.attachments.mime.exe=Windows Executable
 core.viewers.attachments.mime.attachment=Attachment
 
+core.viewers.history.actions=Actions
 core.viewers.history.title=History of <a href="{1}">{0}</a>
 core.viewers.history.summary=History of {0} &mdash; revisions from {1} to {2}
 core.viewers.history.from=From


### PR DESCRIPTION
* add the "Action" title for the column name
* simplified the condition on the title display because the administration rights imply the edit rights 