### PR TITLE
XWIKI-11277: The fields from "Job name" and "Job cron expression" have not the same size

### DIFF
--- a/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-ui/src/main/resources/XWiki/SchedulerJobSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-ui/src/main/resources/XWiki/SchedulerJobSheet.xml
@@ -44,7 +44,7 @@
   #set ($class = $obj.xWikiClass)
   #set ($prettyName = $class.get($propName).translatedPrettyName)
   &lt;dt&gt;
-    &lt;label for="${class.getName()}_${obj.number}_${propName}"&gt;$prettyName&lt;/label&gt;
+    &lt;label#if ($xcontext.action == 'edit')) for="${class.getName()}_${obj.number}_${propName}"#end&gt;$prettyName&lt;/label&gt;
     #if ($propName == 'script')
       &lt;span class='xHint'&gt;
         $services.localization.render('xe.scheduler.job.scriptexplanation')


### PR DESCRIPTION
The problem was that I added the "for" attribute in the view mode where there is no input, so no id matching the "for" value.
Previous PR: https://github.com/xwiki/xwiki-platform/pull/767