### PR TITLE
XWIKI-8587: Add a Document field type that has a picker associated which suggests document names

### DIFF
--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test-pageobjects/src/main/java/org/xwiki/appwithinminutes/test/po/SuggestClassFieldEditPane.java
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test-pageobjects/src/main/java/org/xwiki/appwithinminutes/test/po/SuggestClassFieldEditPane.java
@@ -23,19 +23,20 @@ import org.openqa.selenium.WebElement;
 import org.xwiki.test.ui.po.SuggestInputElement;
 
 /**
- * Represents the pane used to edit a 'User' class field.
+ * Represents the pane used to edit a class field with a suggest.
+ * Example of class fields: User and Page.
  * 
  * @version $Id$
  * @since 4.5
  */
-public class UserClassFieldEditPane extends ClassFieldEditPane
+public class SuggestClassFieldEditPane extends ClassFieldEditPane
 {
     /**
      * Creates a new instance.
      * 
      * @param fieldName the name of the date field
      */
-    public UserClassFieldEditPane(String fieldName)
+    public SuggestClassFieldEditPane(String fieldName)
     {
         super(fieldName);
     }
@@ -54,9 +55,9 @@ public class UserClassFieldEditPane extends ClassFieldEditPane
     }
 
     /**
-     * @return the user picker
+     * @return the picker
      */
-    public SuggestInputElement getUserPicker()
+    public SuggestInputElement getPicker()
     {
         return new SuggestInputElement(getDefaultValueInput());
     }

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/SuggestInputElement.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/SuggestInputElement.java
@@ -44,27 +44,42 @@ public class SuggestInputElement extends BaseElement
             this.suggestion = suggestion;
         }
 
+        /**
+         * @return the value of this suggestion
+         */
         public String getValue()
         {
             return this.suggestion.getAttribute("data-value");
         }
 
+        /**
+         * @return the label of this suggestion
+         */
         public String getLabel()
         {
             return this.suggestion.findElement(By.className("xwiki-selectize-option-label")).getText();
         }
 
+        /**
+         * @return the icon class or src attribute of this suggestion
+         */
         public String getIcon()
         {
             WebElement icon = this.suggestion.findElement(By.className("xwiki-selectize-option-icon"));
             return "img".equals(icon.getTagName()) ? icon.getAttribute("src") : icon.getAttribute("class");
         }
 
+        /**
+         * @return the url of this suggestion
+         */
         public String getURL()
         {
             return this.suggestion.findElement(By.className("xwiki-selectize-option-label")).getAttribute("href");
         }
 
+        /**
+         * @return the hint of this suggestion
+         */
         public String getHint()
         {
             return this.suggestion.findElement(By.className("xwiki-selectize-option-hint")).getText();
@@ -82,6 +97,9 @@ public class SuggestInputElement extends BaseElement
             getDriver().getKeyboard().sendKeys(Keys.BACK_SPACE);
         }
 
+        /**
+         * Selects this suggestion.
+         */
         public void select()
         {
             this.suggestion.click();
@@ -106,35 +124,65 @@ public class SuggestInputElement extends BaseElement
         getDriver().waitUntilCondition(driver -> !this.container.getAttribute("class").contains("loading"));
     }
 
+    /**
+     * @return the actual text input
+     */
     private WebElement getTextInput()
     {
         return getDriver().findElementWithoutWaiting(this.container, By.cssSelector(".selectize-input > input"));
     }
 
+    /**
+     * Clicks on the text input.
+     *
+     * @return the current suggest input element
+     */
     public SuggestInputElement click()
     {
+        // On single selects, the text input isn't visible until the container is focused.
         this.container.click();
+        this.getTextInput().click();
         return this;
     }
 
+    /**
+     * Removes the typed text.
+     *
+     * @return the current suggest input element
+     */
     public SuggestInputElement clear()
     {
         getTextInput().clear();
         return this;
     }
 
+    /**
+     * Removes all the selected elements.
+     *
+     * @return the current suggest input element
+     */
     public SuggestInputElement clearSelectedSuggestions()
     {
         getSelectedSuggestions().forEach(SuggestionElement::delete);
         return this;
     }
 
+    /**
+     * Sends the given sequence of keys to the input.
+     *
+     * @return the current suggest input element
+     */
     public SuggestInputElement sendKeys(CharSequence... keysToSend)
     {
         getTextInput().sendKeys(keysToSend);
         return this;
     }
 
+    /**
+     * Waits until the suggestions have been loaded.
+     *
+     * @return the current suggest input element
+     */
     public SuggestInputElement waitForSuggestions()
     {
         // Wait for the suggestions to be fetched from the server and for the suggestion drop down list to be visible.
@@ -144,6 +192,9 @@ public class SuggestInputElement extends BaseElement
         return this;
     }
 
+    /**
+     * @return a list of all the suggestion elements
+     */
     public List<SuggestionElement> getSuggestions()
     {
         return getDriver()
@@ -151,6 +202,11 @@ public class SuggestInputElement extends BaseElement
             .map(SuggestionElement::new).collect(Collectors.toList());
     }
 
+    /**
+     * Selects an element by clicking on the suggestion with the given position.
+     *
+     * @return the current suggest input element
+     */
     public SuggestInputElement selectByIndex(int index)
     {
         getDriver().findElementWithoutWaiting(
@@ -161,6 +217,11 @@ public class SuggestInputElement extends BaseElement
         return this;
     }
 
+    /**
+     * Selects an element by clicking on the suggestion with the given value.
+     *
+     * @return the current suggest input element
+     */
     public SuggestInputElement selectByValue(String value)
     {
         getDriver().findElementWithoutWaiting(
@@ -171,6 +232,11 @@ public class SuggestInputElement extends BaseElement
         return this;
     }
 
+    /**
+     * Selects an element by clicking on the suggestion with the given label.
+     *
+     * @return the current suggest input element
+     */
     public SuggestInputElement selectByVisibleText(String text)
     {
         getDriver().findElementWithoutWaiting(
@@ -181,6 +247,11 @@ public class SuggestInputElement extends BaseElement
         return this;
     }
 
+    /**
+     * Selects and creates an element with the input text.
+     *
+     * @return the current suggest input element
+     */
     public SuggestInputElement selectTypedText()
     {
         getDriver().findElementWithoutWaiting(By.cssSelector(".selectize-dropdown.active .create")).click();
@@ -188,7 +259,10 @@ public class SuggestInputElement extends BaseElement
         return this;
     }
 
-    public List<String> getValue()
+    /**
+     * @return list of all the values of the selected elements.
+     */
+    public List<String> getValues()
     {
         if ("select".equals(this.originalInput.getTagName())) {
             return new Select(this.originalInput).getAllSelectedOptions().stream()
@@ -198,12 +272,20 @@ public class SuggestInputElement extends BaseElement
         }
     }
 
+    /**
+     * @return list of suggestion elements found in the suggestion panel
+     */
     public List<SuggestionElement> getSelectedSuggestions()
     {
         return getDriver().findElementsWithoutWaiting(this.container, By.className("xwiki-selectize-option")).stream()
             .map(SuggestionElement::new).collect(Collectors.toList());
     }
 
+    /**
+     * Hides the suggestions panel.
+     *
+     * @return the current suggest input element
+     */
     public SuggestInputElement hideSuggestions()
     {
         getTextInput().sendKeys(Keys.ESCAPE);

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/PageClassFieldTest.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/PageClassFieldTest.java
@@ -1,0 +1,264 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.test.ui.appwithinminutes;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebElement;
+import org.xwiki.appwithinminutes.test.po.ApplicationClassEditPage;
+import org.xwiki.appwithinminutes.test.po.SuggestClassFieldEditPane;
+import org.xwiki.test.ui.po.InlinePage;
+import org.xwiki.test.ui.po.SuggestInputElement;
+import org.xwiki.test.ui.po.SuggestInputElement.SuggestionElement;
+import org.xwiki.xclass.test.po.ClassSheetPage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Special class editor tests that address only the Page class field type.
+ *
+ * @version $Id$
+ * @since 10.6
+ */
+public class PageClassFieldTest extends AbstractClassEditorTest
+{
+    @Before
+    @Override
+    public void setUp() throws Exception
+    {
+        String className = getTestClassName();
+        getUtil().deleteSpace(className);
+        getUtil().createPage(className, "pageclassfieldpage1", "Content", className + " Page 1");
+        getUtil().createPage(className, "pageclassfieldpage2", "Content", className + " Page 2");
+        getUtil().createPage(Arrays.asList(className, "space"), "pageclassfieldtesthome", "Content",
+            className + " TestHome");
+        getUtil().gotoPage(className, getTestMethodName(), "edit",
+            "editor=inline&template=AppWithinMinutes.ClassTemplate&title=" + getTestMethodName() + " Class");
+        editor = new ApplicationClassEditPage();
+    }
+
+    @Test
+    public void testSuggestions() throws Exception
+    {
+        String className = getTestClassName();
+        SuggestInputElement pagePicker = new SuggestClassFieldEditPane(editor.addField("Page").getName()).getPicker();
+
+        // Make sure the picker is ready.
+        pagePicker.click().waitForSuggestions();
+
+        List<SuggestionElement> suggestions =
+            pagePicker.sendKeys(className, " pag").waitForSuggestions().getSuggestions();
+        assertEquals(2, suggestions.size());
+        assertEquals(className + " Page 1", suggestions.get(0).getLabel());
+        assertEquals(className, suggestions.get(0).getHint());
+        assertEquals(className + " Page 2", suggestions.get(1).getLabel());
+        assertEquals(className, suggestions.get(1).getHint());
+
+        suggestions = pagePicker.sendKeys(" 1").waitForSuggestions().getSuggestions();
+        assertEquals(1, suggestions.size());
+        assertEquals(className + " Page 1", suggestions.get(0).getLabel());
+
+        suggestions = pagePicker.clear().sendKeys(className).waitForSuggestions().getSuggestions();
+        assertEquals(3, suggestions.size());
+        assertEquals(className + " Page 1", suggestions.get(0).getLabel());
+        assertEquals(className, suggestions.get(0).getHint());
+        assertEquals(className + " Page 2", suggestions.get(1).getLabel());
+        assertEquals(className, suggestions.get(1).getHint());
+        assertEquals(className + " TestHome", suggestions.get(2).getLabel());
+        assertEquals(className + " / space", suggestions.get(2).getHint());
+    }
+
+    @Test
+    public void testSingleSelection()
+    {
+        String className = getTestClassName();
+        SuggestInputElement pagePicker = new SuggestClassFieldEditPane(editor.addField("Page").getName()).getPicker();
+
+        // Make sure the picker is ready.
+        pagePicker.click().waitForSuggestions();
+
+        // Use the keyboard.
+        List<SuggestionElement> selectedPages = pagePicker.sendKeys(className).waitForSuggestions().sendKeys(Keys.ENTER)
+            .getSelectedSuggestions();
+        assertEquals(1, selectedPages.size());
+        assertEquals(className + " Page 1", selectedPages.get(0).getLabel());
+        assertEquals(Collections.singletonList(className + ".pageclassfieldpage1"), pagePicker.getValues());
+
+        // Use the mouse. Since we have single selection by default, the previously selected page should be replaced.
+        selectedPages = pagePicker.click().selectByVisibleText(className + " Page 2").getSelectedSuggestions();
+        assertEquals(1, selectedPages.size());
+        assertEquals(className + " Page 2", selectedPages.get(0).getLabel());
+        assertEquals(Collections.singletonList(className + ".pageclassfieldpage2"), pagePicker.getValues());
+
+        // Delete the selected page.
+        selectedPages.get(0).delete();
+        assertEquals(0, pagePicker.getSelectedSuggestions().size());
+        assertEquals(Collections.singletonList(""), pagePicker.getValues());
+    }
+
+    @Test
+    public void testMultipleSelection()
+    {
+        String className = getTestClassName();
+        SuggestClassFieldEditPane pageField = new SuggestClassFieldEditPane(editor.addField("Page").getName());
+        pageField.openConfigPanel();
+        pageField.setMultipleSelect(true);
+        pageField.closeConfigPanel();
+        SuggestInputElement pagePicker = pageField.getPicker();
+
+        // Make sure the picker is ready.
+        pagePicker.click().waitForSuggestions();
+
+        // Select 2 pages.
+        List<SuggestionElement> selectedPages = pagePicker.sendKeys(className).waitForSuggestions().sendKeys(Keys.ENTER)
+            .sendKeys(Keys.ENTER).getSelectedSuggestions();
+        assertEquals(2, selectedPages.size());
+        assertEquals(className + " Page 1", selectedPages.get(0).getLabel());
+        assertEquals(className + " Page 2", selectedPages.get(1).getLabel());
+        assertEquals(Arrays.asList(className + ".pageclassfieldpage1", className + ".pageclassfieldpage2"),
+            pagePicker.getValues());
+
+        // Delete the first selected page.
+        selectedPages.get(0).delete();
+
+        // Select another page.
+        pagePicker.sendKeys(className, " testhome").waitForSuggestions().sendKeys(Keys.ENTER);
+        selectedPages = pagePicker.getSelectedSuggestions();
+        assertEquals(2, selectedPages.size());
+        assertEquals(className + " TestHome", selectedPages.get(0).getLabel());
+        assertEquals(className + " Page 2", selectedPages.get(1).getLabel());
+        assertEquals(Arrays.asList(className + ".space.pageclassfieldtesthome", className + ".pageclassfieldpage2"),
+            pagePicker.getValues());
+
+        // Clear the list of selected pages.
+        pagePicker.clearSelectedSuggestions();
+        assertEquals(0, pagePicker.getSelectedSuggestions().size());
+        assertTrue(pagePicker.getValues().isEmpty());
+    }
+
+    @Test
+    public void testSaveAndInitialSelection()
+    {
+        String className = getTestClassName();
+        SuggestInputElement pagePicker = new SuggestClassFieldEditPane(editor.addField("Page").getName()).getPicker();
+        // Make sure the picker is ready.
+        pagePicker.click().waitForSuggestions();
+        pagePicker.sendKeys(className).waitForSuggestions().sendKeys(Keys.ENTER);
+        editor.clickSaveAndView().edit();
+
+        SuggestClassFieldEditPane pageField = new SuggestClassFieldEditPane("page1");
+        pagePicker = pageField.getPicker();
+        List<SuggestionElement> selectedPages = pagePicker.getSelectedSuggestions();
+        assertEquals(1, selectedPages.size());
+        assertEquals(className + " Page 1", selectedPages.get(0).getLabel());
+        assertEquals(Collections.singletonList(className + ".pageclassfieldpage1"), pagePicker.getValues());
+
+        // Enable multiple selection.
+        pageField.openConfigPanel();
+        pageField.setMultipleSelect(true);
+        pageField.closeConfigPanel();
+
+        // Re-take the page picker because the display has been reloaded.
+        pagePicker = pageField.getPicker();
+
+        // Select one more page.
+        pagePicker.click().waitForSuggestions().sendKeys(className).waitForSuggestions().sendKeys(Keys.ENTER);
+        editor.clickSaveAndContinue();
+        editor.clickCancel().edit();
+
+        pagePicker = new SuggestClassFieldEditPane("page1").getPicker();
+        selectedPages = pagePicker.getSelectedSuggestions();
+        assertEquals(2, selectedPages.size());
+        assertEquals(className + " Page 1", selectedPages.get(0).getLabel());
+        assertEquals(className + " Page 2", selectedPages.get(1).getLabel());
+        assertEquals(Arrays.asList(className + ".pageclassfieldpage1", className + ".pageclassfieldpage2"),
+            pagePicker.getValues());
+
+        // We should be able to input free text also.
+        pagePicker.click().waitForSuggestions().sendKeys("foobar").waitForSuggestions().selectTypedText();
+        editor.clickSaveAndContinue();
+        editor.clickCancel().edit();
+
+        pagePicker = new SuggestClassFieldEditPane("page1").getPicker();
+        selectedPages = pagePicker.getSelectedSuggestions();
+        assertEquals(3, selectedPages.size());
+        assertEquals("foobar", selectedPages.get(2).getLabel());
+        assertEquals(Arrays.asList(className + ".pageclassfieldpage1", className + ".pageclassfieldpage2", "foobar"),
+            pagePicker.getValues());
+
+        // Delete the fake page.
+        selectedPages.get(2).delete();
+        assertEquals(2, pagePicker.getSelectedSuggestions().size());
+
+        // Delete all selected pages.
+        pagePicker.clearSelectedSuggestions();
+        editor.clickSaveAndContinue();
+        editor.clickCancel().edit();
+
+        pagePicker = new SuggestClassFieldEditPane("page1").getPicker();
+        assertEquals(0, pagePicker.getSelectedSuggestions().size());
+        assertTrue(pagePicker.getValues().isEmpty());
+    }
+
+
+    @Test
+    public void testApplicationEntry()
+    {
+        String className = getTestClassName();
+        // Create the application class.
+        SuggestInputElement pagePicker = new SuggestClassFieldEditPane(editor.addField("Page").getName()).getPicker();
+        // Make sure the picker is ready.
+        pagePicker.click().waitForSuggestions();
+        pagePicker.sendKeys(className).waitForSuggestions().sendKeys(Keys.ENTER);
+        editor.clickSaveAndView();
+
+        // Create the application entry.
+        ClassSheetPage classSheetPage = new ClassSheetPage();
+        InlinePage entryEditPage = classSheetPage.createNewDocument(className, getTestMethodName() + "Entry");
+
+        // Assert the initial value.
+        String id = className + "." + getTestMethodName() + "_0_page1";
+        pagePicker = new SuggestInputElement(getDriver().findElement(By.id(id)));
+        List<SuggestionElement> selectedPages = pagePicker.getSelectedSuggestions();
+        assertEquals(1, selectedPages.size());
+        assertEquals(className + " Page 1", selectedPages.get(0).getLabel());
+        assertEquals(Collections.singletonList(className + ".pageclassfieldpage1"), pagePicker.getValues());
+
+        // Make sure the picker is ready.
+        pagePicker.click().waitForSuggestions();
+        pagePicker.sendKeys(className).waitForSuggestions().sendKeys(Keys.ENTER);
+        // Change the selected page.
+        pagePicker.clearSelectedSuggestions().sendKeys(className, " testh").waitForSuggestions().sendKeys(Keys.ENTER);
+        // We wait for the page to load because Selenium doesn't do it all the time when Save & View is clicked.
+        entryEditPage.clickSaveAndView().waitUntilPageIsLoaded();
+
+        // Assert the view mode.
+        List<WebElement> pages = getDriver().findElements(By.cssSelector("#xwikicontent a"));
+        assertEquals(1, pages.size());
+        assertEquals(className + " TestHome", pages.get(0).getText());
+    }
+}

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/UserClassFieldTest.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/UserClassFieldTest.java
@@ -30,7 +30,7 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
-import org.xwiki.appwithinminutes.test.po.UserClassFieldEditPane;
+import org.xwiki.appwithinminutes.test.po.SuggestClassFieldEditPane;
 import org.xwiki.test.ui.po.InlinePage;
 import org.xwiki.test.ui.po.SuggestInputElement;
 import org.xwiki.test.ui.po.SuggestInputElement.SuggestionElement;
@@ -61,7 +61,7 @@ public class UserClassFieldTest extends AbstractClassEditorTest
     @Test
     public void testSuggestions()
     {
-        SuggestInputElement userPicker = new UserClassFieldEditPane(editor.addField("User").getName()).getUserPicker();
+        SuggestInputElement userPicker = new SuggestClassFieldEditPane(editor.addField("User").getName()).getPicker();
 
         // The suggestions should be case-insensitive. Match the last name.
         List<SuggestionElement> suggestions = userPicker.sendKeys("mOr").waitForSuggestions().getSuggestions();
@@ -149,42 +149,42 @@ public class UserClassFieldTest extends AbstractClassEditorTest
     @Test
     public void testSingleSelection()
     {
-        SuggestInputElement userPicker = new UserClassFieldEditPane(editor.addField("User").getName()).getUserPicker();
+        SuggestInputElement userPicker = new SuggestClassFieldEditPane(editor.addField("User").getName()).getPicker();
 
         // Use the keyboard.
         userPicker.sendKeys("mor").waitForSuggestions().sendKeys(Keys.ARROW_DOWN, Keys.ENTER);
         List<SuggestionElement> selectedUsers = userPicker.getSelectedSuggestions();
         Assert.assertEquals(1, selectedUsers.size());
         assertUserSuggestion(selectedUsers.get(0), "Eduard Moraru", "Enygma2002");
-        Assert.assertEquals(Collections.singletonList("XWiki.Enygma2002"), userPicker.getValue());
+        Assert.assertEquals(Collections.singletonList("XWiki.Enygma2002"), userPicker.getValues());
 
         // Use the mouse. Since we have single selection by default, the previously selected user should be replaced.
         selectedUsers = userPicker.click().selectByVisibleText("Thomas Mortagne").getSelectedSuggestions();
         Assert.assertEquals(1, selectedUsers.size());
         assertUserSuggestion(selectedUsers.get(0), "Thomas Mortagne");
-        Assert.assertEquals(Collections.singletonList("XWiki.tmortagne"), userPicker.getValue());
+        Assert.assertEquals(Collections.singletonList("XWiki.tmortagne"), userPicker.getValues());
 
         // Delete the selected user.
         selectedUsers.get(0).delete();
         Assert.assertEquals(0, userPicker.getSelectedSuggestions().size());
-        Assert.assertEquals(Collections.singletonList(""), userPicker.getValue());
+        Assert.assertEquals(Collections.singletonList(""), userPicker.getValues());
 
         // When there is only one suggestion, Enter key should select it.
         userPicker.sendKeys("admin").waitForSuggestions().sendKeys(Keys.ENTER);
         selectedUsers = userPicker.getSelectedSuggestions();
         Assert.assertEquals(1, selectedUsers.size());
         assertUserSuggestion(selectedUsers.get(0), "Administrator", "Admin", "fa-user");
-        Assert.assertEquals(Collections.singletonList("XWiki.Admin"), userPicker.getValue());
+        Assert.assertEquals(Collections.singletonList("XWiki.Admin"), userPicker.getValues());
     }
 
     @Test
     public void testMultipleSelection()
     {
-        UserClassFieldEditPane userField = new UserClassFieldEditPane(editor.addField("User").getName());
+        SuggestClassFieldEditPane userField = new SuggestClassFieldEditPane(editor.addField("User").getName());
         userField.openConfigPanel();
         userField.setMultipleSelect(true);
         userField.closeConfigPanel();
-        SuggestInputElement userPicker = userField.getUserPicker();
+        SuggestInputElement userPicker = userField.getPicker();
 
         // Select 2 users.
         userPicker.sendKeys("tmortagne").waitForSuggestions().sendKeys(Keys.ENTER);
@@ -193,7 +193,7 @@ public class UserClassFieldTest extends AbstractClassEditorTest
         Assert.assertEquals(2, selectedUsers.size());
         assertUserSuggestion(selectedUsers.get(0), "Thomas Mortagne");
         assertUserSuggestion(selectedUsers.get(1), "Eduard Moraru", "Enygma2002");
-        Assert.assertEquals(Arrays.asList("XWiki.tmortagne", "XWiki.Enygma2002"), userPicker.getValue());
+        Assert.assertEquals(Arrays.asList("XWiki.tmortagne", "XWiki.Enygma2002"), userPicker.getValues());
 
         // Delete the first selected user.
         selectedUsers.get(0).delete();
@@ -204,27 +204,27 @@ public class UserClassFieldTest extends AbstractClassEditorTest
         Assert.assertEquals(2, selectedUsers.size());
         assertUserSuggestion(selectedUsers.get(0), "Administrator", "Admin", "fa-user");
         assertUserSuggestion(selectedUsers.get(1), "Eduard Moraru", "Enygma2002");
-        Assert.assertEquals(Arrays.asList("XWiki.Admin", "XWiki.Enygma2002"), userPicker.getValue());
+        Assert.assertEquals(Arrays.asList("XWiki.Admin", "XWiki.Enygma2002"), userPicker.getValues());
 
         // Clear the list of selected users.
         userPicker.clearSelectedSuggestions();
         Assert.assertEquals(0, userPicker.getSelectedSuggestions().size());
-        Assert.assertTrue(userPicker.getValue().isEmpty());
+        Assert.assertTrue(userPicker.getValues().isEmpty());
     }
 
     @Test
     public void testSaveAndInitialSelection()
     {
-        SuggestInputElement userPicker = new UserClassFieldEditPane(editor.addField("User").getName()).getUserPicker();
+        SuggestInputElement userPicker = new SuggestClassFieldEditPane(editor.addField("User").getName()).getPicker();
         userPicker.sendKeys("thomas").waitForSuggestions().sendKeys(Keys.ENTER);
         editor.clickSaveAndView().edit();
 
-        UserClassFieldEditPane userField = new UserClassFieldEditPane("user1");
-        userPicker = userField.getUserPicker();
+        SuggestClassFieldEditPane userField = new SuggestClassFieldEditPane("user1");
+        userPicker = userField.getPicker();
         List<SuggestionElement> selectedUsers = userPicker.getSelectedSuggestions();
         Assert.assertEquals(1, selectedUsers.size());
         assertUserSuggestion(selectedUsers.get(0), "Thomas Mortagne");
-        Assert.assertEquals(Collections.singletonList("XWiki.tmortagne"), userPicker.getValue());
+        Assert.assertEquals(Collections.singletonList("XWiki.tmortagne"), userPicker.getValues());
 
         // Enable multiple selection.
         userField.openConfigPanel();
@@ -232,30 +232,30 @@ public class UserClassFieldTest extends AbstractClassEditorTest
         userField.closeConfigPanel();
 
         // Re-take the user picker because the display has been reloaded.
-        userPicker = userField.getUserPicker();
+        userPicker = userField.getPicker();
 
         // Select one more user.
         userPicker.sendKeys("admin").waitForSuggestions().sendKeys(Keys.ENTER);
         editor.clickSaveAndContinue();
         editor.clickCancel().edit();
 
-        userPicker = new UserClassFieldEditPane("user1").getUserPicker();
+        userPicker = new SuggestClassFieldEditPane("user1").getPicker();
         selectedUsers = userPicker.getSelectedSuggestions();
         Assert.assertEquals(2, selectedUsers.size());
         assertUserSuggestion(selectedUsers.get(0), "Thomas Mortagne");
         assertUserSuggestion(selectedUsers.get(1), "Administrator", "Admin", "fa-user");
-        Assert.assertEquals(Arrays.asList("XWiki.tmortagne", "XWiki.Admin"), userPicker.getValue());
+        Assert.assertEquals(Arrays.asList("XWiki.tmortagne", "XWiki.Admin"), userPicker.getValues());
 
         // We should be able to input free text also.
         userPicker.sendKeys("foobar").waitForSuggestions().selectTypedText();
         editor.clickSaveAndContinue();
         editor.clickCancel().edit();
 
-        userPicker = new UserClassFieldEditPane("user1").getUserPicker();
+        userPicker = new SuggestClassFieldEditPane("user1").getPicker();
         selectedUsers = userPicker.getSelectedSuggestions();
         Assert.assertEquals(3, selectedUsers.size());
         assertUserSuggestion(selectedUsers.get(2), "foobar", "foobar", null);
-        Assert.assertEquals(Arrays.asList("XWiki.tmortagne", "XWiki.Admin", "foobar"), userPicker.getValue());
+        Assert.assertEquals(Arrays.asList("XWiki.tmortagne", "XWiki.Admin", "foobar"), userPicker.getValues());
 
         // Delete the fake user.
         selectedUsers.get(2).delete();
@@ -266,16 +266,16 @@ public class UserClassFieldTest extends AbstractClassEditorTest
         editor.clickSaveAndContinue();
         editor.clickCancel().edit();
 
-        userPicker = new UserClassFieldEditPane("user1").getUserPicker();
+        userPicker = new SuggestClassFieldEditPane("user1").getPicker();
         Assert.assertEquals(0, userPicker.getSelectedSuggestions().size());
-        Assert.assertTrue(userPicker.getValue().isEmpty());
+        Assert.assertTrue(userPicker.getValues().isEmpty());
     }
 
     @Test
     public void testApplicationEntry()
     {
         // Create the application class.
-        SuggestInputElement userPicker = new UserClassFieldEditPane(editor.addField("User").getName()).getUserPicker();
+        SuggestInputElement userPicker = new SuggestClassFieldEditPane(editor.addField("User").getName()).getPicker();
         userPicker.sendKeys("thomas").waitForSuggestions().sendKeys(Keys.ENTER);
         editor.clickSaveAndView();
 
@@ -289,7 +289,7 @@ public class UserClassFieldTest extends AbstractClassEditorTest
         List<SuggestionElement> selectedUsers = userPicker.getSelectedSuggestions();
         Assert.assertEquals(1, selectedUsers.size());
         assertUserSuggestion(selectedUsers.get(0), "Thomas Mortagne");
-        Assert.assertEquals(Collections.singletonList("XWiki.tmortagne"), userPicker.getValue());
+        Assert.assertEquals(Collections.singletonList("XWiki.tmortagne"), userPicker.getValues());
 
         // Change the selected user.
         userPicker.clearSelectedSuggestions().sendKeys("eduard").waitForSuggestions().sendKeys(Keys.ENTER);


### PR DESCRIPTION
## Changes

* Add functional tests for the AWM Page class field.
* Add documentation on some public methods.
* Rename the UserClassFieldEditPane class to SuggestClassFieldEditPane as it could be generalized.

## Notes

* It seems that inserting text in the selectize element, before having the initial values added to the suggestions, doesn't update the suggestion list but keeps the initial list.
  *Workaround*: `pagePicker.click().waitForSuggestions();` this makes sure the initial values have been loaded.
* The `SuggestInputElement#click` method didn't worked as expected on multiselect inputs having selected suggestions as a click was made on one of those selected suggestions.
  *Workaround*: perform the click on the text input. Had to also click on the suggest input before to make sure it also works for single selects.
  (i.e. `this.container.click();` then `this.getTextInput().click();`)