### PR TITLE
XWIKI-15454: Wrong suggest input size in object edition

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editclass.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editclass.vm
@@ -134,7 +134,7 @@ $xwiki.jsfx.use('js/xwiki/editors/dataeditors.js', true)##
 #classSwitcher()
 ##
 ##
-<form id="$formname" method="post" action="$doc.getURL('preview')" class="withLock">
+<form id="$formname" method="post" action="$doc.getURL('preview')" class="withLock xform">
 <div id="xwikieditcontent" class="clear">
 ##
 ##

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
@@ -18,14 +18,6 @@
   margin: 0;
   position: static;
 }
-/* Basic form elements styling */
-#xwikiobjects input, #xwikiobjects textarea,
-#xwikiobjects select, #xwikiobjects .selectize-input,
-#xwikiclassproperties input, #xwikiclassproperties textarea,
-#xwikiclassproperties select, #xwikiclassproperties .selectize-input {
-  border: 1px solid $theme.borderColor;
-  width: 90%;
-}
 div#xwikiobjects input[type="checkbox"], div#xwikiclassproperties input[type="checkbox"],
 div#xwikiobjects input[type="radio"], div#xwikiclassproperties input[type="radio"] {
   width: auto;

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
@@ -20,7 +20,9 @@
 }
 /* Basic form elements styling */
 #xwikiobjects input, #xwikiobjects textarea,
-#xwikiclassproperties input, #xwikiclassproperties textarea {
+#xwikiobjects select, #xwikiobjects .selectize-input,
+#xwikiclassproperties input, #xwikiclassproperties textarea,
+#xwikiclassproperties select, #xwikiclassproperties .selectize-input {
   border: 1px solid $theme.borderColor;
   width: 90%;
 }


### PR DESCRIPTION
### Issue

https://jira.xwiki.org/browse/XWIKI-15454

### Changes

* Use the xform and skin css rules for the editor inputs.

### Screenshots
*Before:*
![image-2018-07-20-14-40-03-958](https://user-images.githubusercontent.com/2213999/43003250-2adf1606-8c2c-11e8-886b-10500afea076.png)

*After:*
![image](https://user-images.githubusercontent.com/2213999/43003286-47bb3eb2-8c2c-11e8-9c00-64d92509bedc.png)