### PR TITLE
XWIKI-15467: Loading icon remains stuck when you Share a page by email using an email address

### DIFF
--- a/xwiki-platform-core/xwiki-platform-sharepage/xwiki-platform-sharepage-ui/src/main/resources/XWiki/SharePage.xml
+++ b/xwiki-platform-core/xwiki-platform-sharepage/xwiki-platform-sharepage-ui/src/main/resources/XWiki/SharePage.xml
@@ -179,6 +179,7 @@ require(['jquery', 'xwiki-suggestUsers'], function($) {
   };
 
   var initShareStatus = function() {
+    modal.find('.modal-body').removeClass('loading');
     modal.find('.share-backlink').attr('data-dismiss', 'modal');
   };
 


### PR DESCRIPTION
### Issue

https://jira.xwiki.org/browse/XWIKI-15467

### Changes

* Remove the loading icon of the share page modal after status init.