### PR TITLE
XWIKI-15462: Messages sent to multiple users are received only by the first added user

### DIFF
--- a/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-ui/src/main/resources/Main/MessageSenderMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-ui/src/main/resources/Main/MessageSenderMacro.xml
@@ -649,14 +649,14 @@ return XWiki;
             &lt;div class="message-target message-target-user#if ($defaultTarget != 'user') hidden#end"&gt;
               #set ($discard = $userPickerParams.put('class', 'targetName'))
               #set ($userPickerParams.disabled = $inEditMode || $defaultTarget != 'user')
-              #userPicker(true, $userPickerParams)
+              #userPicker(false, $userPickerParams)
             &lt;/div&gt;
           #end
           #if ($possibleTargets.contains('group'))
             &lt;div class="message-target message-target-group#if ($defaultTarget != 'group') hidden#end"&gt;
               #set ($discard = $userPickerParams.put('class', 'targetName'))
               #set ($userPickerParams.disabled = $inEditMode || $defaultTarget != 'group')
-              #groupPicker(true, $userPickerParams)
+              #groupPicker(false, $userPickerParams)
             &lt;/div&gt;
           #end
           &lt;div class="message-target message-target-default"&gt;


### PR DESCRIPTION
### Issue

https://jira.xwiki.org/browse/XWIKI-15462

### Changes

* Set the user and group pickers of the Message Sender Macro back to single-select inputs.