### PR TITLE
XWIKI-15474: Toggles aren't saved in the UI when changing the page of the Filters

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/table/livetable.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/table/livetable.js
@@ -127,7 +127,6 @@ XWiki.widgets.LiveTable = Class.create({
     this.handler = handler || function(){};
     this.totalRows = -1;
     this.fetchedRows = new Array();
-    this.renderedRows = new Array();
     this.getUrl = url;
     this.sendReqNo = 0;
     this.recvReqNo = 0;
@@ -304,21 +303,22 @@ XWiki.widgets.LiveTable = Class.create({
 
     for (var i = off; i <= f; i++) {
       if (this.fetchedRows[i]) {
-        if (this.renderedRows[i] === undefined) {
-          this.renderedRows[i] = this.handler(this.fetchedRows[i], i, this);
+        var elem = this.fetchedRows[i].livetableRenderedRow;
+        if (elem === undefined) {
+          this.fetchedRows[i].livetableRenderedRow = this.handler(this.fetchedRows[i], i, this);
+          elem = this.fetchedRows[i].livetableRenderedRow;
+          var memo = {
+            "data": this.fetchedRows[i],
+            "row":elem,
+            "table":this,
+            "tableId":this.domNodeName
+          };
+          // 1. Named event (for code interested by that table only)
+          document.fire("xwiki:livetable:" + this.domNodeName + ":newrow", memo);
+          // 2. Generic event (for code potentially interested in any livetable)
+          document.fire("xwiki:livetable:newrow", memo);
         }
-        var elem = this.renderedRows[i];
         this.displayNode.appendChild(elem);
-        var memo = {
-          "data": this.fetchedRows[i],
-          "row":elem,
-          "table":this,
-          "tableId":this.domNodeName
-        };
-        // 1. Named event (for code interested by that table only)
-        document.fire("xwiki:livetable:" + this.domNodeName + ":newrow", memo);
-        // 2. Generic event (for code potentially interested in any livetable)
-        document.fire("xwiki:livetable:newrow", memo);
       }
     }
     if (this.paginator) this.paginator.refreshPagination();

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/table/livetable.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/table/livetable.js
@@ -127,6 +127,7 @@ XWiki.widgets.LiveTable = Class.create({
     this.handler = handler || function(){};
     this.totalRows = -1;
     this.fetchedRows = new Array();
+    this.renderedRows = new Array();
     this.getUrl = url;
     this.sendReqNo = 0;
     this.recvReqNo = 0;
@@ -303,7 +304,10 @@ XWiki.widgets.LiveTable = Class.create({
 
     for (var i = off; i <= f; i++) {
       if (this.fetchedRows[i]) {
-        var elem = this.handler(this.fetchedRows[i], i, this);
+        if (this.renderedRows[i] === undefined) {
+          this.renderedRows[i] = this.handler(this.fetchedRows[i], i, this);
+        }
+        var elem = this.renderedRows[i];
         this.displayNode.appendChild(elem);
         var memo = {
           "data": this.fetchedRows[i],


### PR DESCRIPTION
### Issue

https://jira.xwiki.org/browse/XWIKI-15474

### Changes

* Cache livetable row elements.

### Result

*Before:*
![fix-livetable-cache-before](https://user-images.githubusercontent.com/2213999/43596106-a6477d9a-967e-11e8-823a-d3e06ab53354.gif)

*After:*
![fix-livetable-cache-after](https://user-images.githubusercontent.com/2213999/43596114-aa4bfa6a-967e-11e8-92a0-e0d7fa01e2e1.gif)