### PR TITLE
XWIKI-15452: Use auto-suggestion on xproperties that can support it

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/ConfigurableClass.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/ConfigurableClass.xml
@@ -485,17 +485,29 @@ $doc.dropPermissions()##
       <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
     </codeToExecute>
     <configurationClass>
+      <cache>0</cache>
+      <classname/>
       <customDisplay/>
       <disabled>0</disabled>
+      <displayType>input</displayType>
+      <hint/>
+      <idField/>
+      <multiSelect>0</multiSelect>
       <name>configurationClass</name>
       <number>3</number>
-      <picker>0</picker>
+      <picker>1</picker>
       <prettyName>configurationClass</prettyName>
       <size>30</size>
+      <relationalStorage>0</relationalStorage>
+      <separator> </separator>
+      <separators/>
+      <sort>none</sort>
+      <sql/>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      <valueField/>
+      <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
     </configurationClass>
     <configureGlobally>
       <customDisplay/>

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/Registration.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/Registration.xml
@@ -907,16 +907,29 @@
     <nameField/>
     <validationScript/>
     <defaultRedirect>
+      <cache>0</cache>
+      <classname/>
+      <customDisplay/>
       <disabled>0</disabled>
+      <displayType>input</displayType>
+      <hint/>
+      <idField/>
+      <multiSelect>0</multiSelect>
       <name>defaultRedirect</name>
       <number>7</number>
-      <picker>0</picker>
+      <picker>1</picker>
       <prettyName>Redirect here after registration</prettyName>
       <size>30</size>
+      <relationalStorage>0</relationalStorage>
+      <separator> </separator>
+      <separators/>
+      <sort>none</sort>
+      <sql/>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      <valueField/>
+      <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
     </defaultRedirect>
     <heading>
       <disabled>0</disabled>

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/TemplateProviderClass.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/TemplateProviderClass.xml
@@ -172,17 +172,29 @@
       <classType>com.xpn.xwiki.objects.classes.DBListClass</classType>
     </spaces>
     <template>
+      <cache>0</cache>
+      <classname/>
       <customDisplay/>
       <disabled>0</disabled>
+      <displayType>input</displayType>
+      <hint/>
+      <idField/>
+      <multiSelect>0</multiSelect>
       <name>template</name>
       <number>2</number>
-      <picker>0</picker>
+      <picker>1</picker>
       <prettyName>template</prettyName>
       <size>30</size>
+      <relationalStorage>0</relationalStorage>
+      <separator> </separator>
+      <separators/>
+      <sort>none</sort>
+      <sql/>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      <valueField/>
+      <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
     </template>
     <terminal>
       <customDisplay/>

--- a/xwiki-platform-core/xwiki-platform-annotations/xwiki-platform-annotation-io/src/main/java/org/xwiki/annotation/internal/AnnotationClassDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-annotations/xwiki-platform-annotation-io/src/main/java/org/xwiki/annotation/internal/AnnotationClassDocumentInitializer.java
@@ -81,7 +81,7 @@ public class AnnotationClassDocumentInitializer extends AbstractMandatoryClassIn
             ContentType.PURE_TEXT);
         xclass.addTextAreaField(Annotation.ORIGINAL_SELECTION_FIELD, "Original Selection", 40, 5,
             ContentType.PURE_TEXT);
-        xclass.addTextField(Annotation.TARGET_FIELD, "Target", 30);
+        xclass.addPageField(Annotation.TARGET_FIELD, "Target", 30);
         xclass.addTextField(Annotation.STATE_FIELD, "State", 30);
     }
 

--- a/xwiki-platform-core/xwiki-platform-annotations/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/AnnotationClass.xml
+++ b/xwiki-platform-core/xwiki-platform-annotations/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/AnnotationClass.xml
@@ -166,16 +166,25 @@
       <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
     </state>
     <target>
+      <cache>0</cache>
+      <classname/>
+      <customDisplay/>
       <disabled>0</disabled>
       <name>target</name>
       <number>7</number>
-      <picker>0</picker>
+      <picker>1</picker>
       <prettyName>Target</prettyName>
       <size>30</size>
+      <relationalStorage>0</relationalStorage>
+      <separator> </separator>
+      <separators/>
+      <sort>none</sort>
+      <sql/>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      <valueField/>
+      <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
     </target>
   </class>
 </xwikidoc>

--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/LiveTableClass.xml
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/LiveTableClass.xml
@@ -50,17 +50,29 @@
     <nameField/>
     <validationScript/>
     <class>
+      <cache>0</cache>
+      <classname/>
       <customDisplay/>
       <disabled>0</disabled>
+      <displayType>input</displayType>
+      <hint/>
+      <idField/>
+      <multiSelect>0</multiSelect>
       <name>class</name>
       <number>1</number>
-      <picker>0</picker>
+      <picker>1</picker>
       <prettyName>Class</prettyName>
       <size>30</size>
+      <relationalStorage>0</relationalStorage>
+      <separator> </separator>
+      <separators/>
+      <sort>none</sort>
+      <sql/>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      <valueField/>
+      <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
     </class>
     <columns>
       <customDisplay/>
@@ -76,17 +88,29 @@
       <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
     </columns>
     <dataSpace>
+      <cache>0</cache>
+      <classname/>
       <customDisplay/>
       <disabled>0</disabled>
+      <displayType>input</displayType>
+      <hint/>
+      <idField/>
+      <multiSelect>0</multiSelect>
       <name>dataSpace</name>
       <number>4</number>
-      <picker>0</picker>
+      <picker>1</picker>
       <prettyName>Data Location</prettyName>
       <size>30</size>
+      <relationalStorage>0</relationalStorage>
+      <separator> </separator>
+      <separators/>
+      <sort>none</sort>
+      <sql/>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      <valueField/>
+      <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
     </dataSpace>
     <description>
       <customDisplay/>

--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/MetadataClass.xml
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/MetadataClass.xml
@@ -50,17 +50,29 @@
     <nameField/>
     <validationScript/>
     <dataSpaceName>
+      <cache>0</cache>
+      <classname/>
       <customDisplay/>
       <disabled>0</disabled>
+      <displayType>input</displayType>
+      <hint/>
+      <idField/>
+      <multiSelect>0</multiSelect>
       <name>dataSpaceName</name>
       <number>1</number>
-      <picker>0</picker>
+      <picker>1</picker>
       <prettyName>Data Space Name</prettyName>
       <size>30</size>
+      <relationalStorage>0</relationalStorage>
+      <separator> </separator>
+      <separators/>
+      <sort>none</sort>
+      <sql/>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      <valueField/>
+      <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
     </dataSpaceName>
   </class>
   <object>

--- a/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/FeedPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/FeedPlugin.java
@@ -712,7 +712,7 @@ public class FeedPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfa
         }
 
         needsUpdate |= bclass.addTextField("title", "Title", 80);
-        needsUpdate |= bclass.addTextField("author", "Author", 40);
+        needsUpdate |= bclass.addUsersField("author", "Author", 40, false);
         needsUpdate |= bclass.addTextField("feedurl", "Feed URL", 80);
         needsUpdate |= bclass.addTextField("feedname", "Feed Name", 40);
         needsUpdate |= bclass.addTextField("url", "URL", 80);

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/commentsinline.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/commentsinline.vm
@@ -149,7 +149,7 @@ $xwiki.ssfx.use('uicomponents/viewers/comments.css', true)
     <div class="commentavatar">#if("$!comment.replyto" == '')#largeUserAvatar($comment.author)#{else}#mediumUserAvatar($comment.author)#end</div>
     <div class="commentheader">
       <div>
-      <span class="commentauthor">$!xwiki.getUserName($doc.display('author', 'view', $comment))</span>##
+      <span class="commentauthor">$!xwiki.getUserName($comment.getValue('author'))</span>##
       #set($date = $comment.getProperty('date').value)
 ## Don't indent, otherwise the comma will be misplaced
 #if($date), <span class="commentdate">$!xwiki.formatDate($date)</span>#end
@@ -266,7 +266,7 @@ $xwiki.ssfx.use('uicomponents/viewers/comments.css', true)
     <div class="commentavatar">#if("$!comment.replyto" == '')#largeUserAvatar($comment.author)#{else}#mediumUserAvatar($comment.author)#end</div>
     <div class="commentheader">
       <div>
-      <span class="commentauthor">$!xwiki.getUserName($doc.display('author', 'view', $comment))</span>##
+      <span class="commentauthor">$!xwiki.getUserName($comment.getValue('author'))</span>##
 ## Don't indent, otherwise the comma will be misplaced
 #set($date = $comment.getProperty('date').value)##
 #if($date), <span class="commentdate">$!xwiki.formatDate($date)</span>#end

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editclass.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editclass.vm
@@ -85,7 +85,16 @@ $xwiki.jsfx.use('js/xwiki/editors/dataeditors.js', true)##
               <dd></dd>
             #else
               <dt><label for="${field.name}_$classprop">${escapetool.xml($propDef.getPrettyName())} $!{propertyDetails.get($classprop)}</label></dt>
-              <dd>$doc.displayEdit($propDef, "${field.name}_" , $field)</dd>
+              #if($propDef.type == 'PageClass')
+                #set ($pagePickerParams = {
+                  'id': "${field.name}_${propDef.name}",
+                  'name': "${field.name}_${propDef.name}",
+                  'value': $field.getProperty($propDef.name).value
+                })
+                <dd>#pagePicker(false $pagePickerParams)</dd>
+              #else
+                <dd>$doc.displayEdit($propDef, "${field.name}_" , $field)</dd>
+              #end
             #end
           #end
         #end

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/macros.vm
@@ -422,6 +422,15 @@
       class="suggest-propertyValues" multiple="multiple" size="1"
       data-className="$!escapetool.xml($xproperty.className)" data-propertyName="$!escapetool.xml($xproperty.name)">
     </select>
+  #elseif ($filterType == 'page')
+    #set ($discard = $xwiki.linkx.use($services.webjars.url('selectize.js', 'css/selectize.bootstrap3.css'),
+      {'type': 'text/css', 'rel': 'stylesheet'}))
+    #set ($discard = $xwiki.ssfx.use('uicomponents/suggest/xwiki.selectize.css', true))
+    #set ($discard = $xwiki.jsfx.use('uicomponents/suggest/suggestPages.js',
+      {'forceSkinAction' : true, 'language' : $xcontext.locale}))
+    <select id="xwiki-livetable-${htmlLiveTableId}-filter-$velocityCount" name="$!escapetool.xml($column)"
+      class="suggest-pages" multiple="multiple" size="1">
+    </select>
   #end
 #end
 

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/XWiki/DeletedDocuments.xml
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/XWiki/DeletedDocuments.xml
@@ -46,7 +46,7 @@ $xwiki.jsx.use('XWiki.DeletedDocuments')##
 ##
 #set($columns = ["ddoc.fullName", "ddoc.title", "ddoc.date", "ddoc.deleter", 'ddoc.batchId', 'actions'])
 #set($columnsProperties = {
-    'ddoc.fullName'  : { 'type' : 'text', 'size' : 10 },
+    'ddoc.fullName'  : { 'type' : 'page', 'size' : 10 },
     'ddoc.title'     : { 'type' : 'text', 'filterable' : false, 'sortable' : false },
     'ddoc.date'      : { 'type' : 'date'},
     'ddoc.deleter'   : { 'type' : 'text', 'size' : 10 },

--- a/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/main/resources/Invitation/InvitationMailClass.xml
+++ b/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/main/resources/Invitation/InvitationMailClass.xml
@@ -114,14 +114,29 @@
       <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
     </recipient>
     <sendingUser>
+      <cache>0</cache>
+      <classname/>
+      <customDisplay/>
       <disabled>0</disabled>
+      <displayType>input</displayType>
+      <hint/>
+      <idField/>
+      <multiSelect>0</multiSelect>
       <name>sendingUser</name>
       <number>3</number>
-      <picker>0</picker>
+      <picker>1</picker>
       <prettyName>sendingUser</prettyName>
       <size>30</size>
+      <relationalStorage>0</relationalStorage>
+      <separator> </separator>
+      <separators/>
+      <sort>none</sort>
+      <sql/>
       <unmodifiable>0</unmodifiable>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      <validationMessage/>
+      <validationRegExp/>
+      <valueField/>
+      <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
     </sendingUser>
     <sentDate>
       <dateFormat>dd/MM/yyyy</dateFormat>

--- a/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/main/resources/Invitation/WebHome.xml
+++ b/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/main/resources/Invitation/WebHome.xml
@@ -529,28 +529,54 @@ $xwiki.get('ssx').use($config.get('commonPage'))
       <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
     </commonPage>
     <emailClass>
+      <cache>0</cache>
+      <classname/>
+      <customDisplay/>
       <disabled>0</disabled>
+      <displayType>input</displayType>
+      <hint/>
+      <idField/>
+      <multiSelect>0</multiSelect>
       <name>emailClass</name>
       <number>5</number>
-      <picker>0</picker>
+      <picker>1</picker>
       <prettyName>Email message XClass</prettyName>
       <size>30</size>
+      <relationalStorage>0</relationalStorage>
+      <separator> </separator>
+      <separators/>
+      <sort>none</sort>
+      <sql/>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      <valueField/>
+      <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
     </emailClass>
     <emailContainer>
+      <cache>0</cache>
+      <classname/>
+      <customDisplay/>
       <disabled>0</disabled>
+      <displayType>input</displayType>
+      <hint/>
+      <idField/>
+      <multiSelect>0</multiSelect>
       <name>emailContainer</name>
       <number>9</number>
-      <picker>0</picker>
+      <picker>1</picker>
       <prettyName>Document containing email XObjects</prettyName>
       <size>30</size>
+      <relationalStorage>0</relationalStorage>
+      <separator> </separator>
+      <separators/>
+      <sort>none</sort>
+      <sql/>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      <valueField/>
+      <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
     </emailContainer>
     <emailRegex>
       <disabled>0</disabled>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/DefaultModelBridge.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/DefaultModelBridge.java
@@ -52,6 +52,7 @@ import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.objects.BaseObject;
+import com.xpn.xwiki.objects.classes.UsersClass;
 
 /**
  * Default implementation for {@link ModelBridge}.
@@ -64,17 +65,17 @@ import com.xpn.xwiki.objects.BaseObject;
 public class DefaultModelBridge implements ModelBridge
 {
     private static final SpaceReference NOTIFICATION_CODE_SPACE = new SpaceReference("Code",
-            new SpaceReference("Notifications",
-                    new SpaceReference("XWiki", new WikiReference("xwiki"))
-            )
+        new SpaceReference("Notifications",
+            new SpaceReference("XWiki", new WikiReference("xwiki"))
+        )
     );
 
     private static final DocumentReference NOTIFICATION_FILTER_PREFERENCE_CLASS = new DocumentReference(
-            "NotificationFilterPreferenceClass", NOTIFICATION_CODE_SPACE
+        "NotificationFilterPreferenceClass", NOTIFICATION_CODE_SPACE
     );
 
     private static final DocumentReference TOGGLEABLE_FILTER_PREFERENCE_CLASS = new DocumentReference(
-            "ToggleableFilterPreferenceClass", NOTIFICATION_CODE_SPACE
+        "ToggleableFilterPreferenceClass", NOTIFICATION_CODE_SPACE
     );
 
     private static final String FIELD_FILTER_NAME = "filterName";
@@ -111,13 +112,13 @@ public class DefaultModelBridge implements ModelBridge
 
     @Override
     public Set<NotificationFilterPreference> getFilterPreferences(DocumentReference user)
-            throws NotificationException
+        throws NotificationException
     {
         XWikiContext context = contextProvider.get();
         XWiki xwiki = context.getWiki();
 
-        final DocumentReference notificationFilterPreferenceClass
-                = NOTIFICATION_FILTER_PREFERENCE_CLASS.setWikiReference(user.getWikiReference());
+        final DocumentReference notificationFilterPreferenceClass = NOTIFICATION_FILTER_PREFERENCE_CLASS
+            .setWikiReference(user.getWikiReference());
 
         Set<NotificationFilterPreference> preferences = new HashSet<>();
 
@@ -128,10 +129,10 @@ public class DefaultModelBridge implements ModelBridge
                 for (BaseObject obj : preferencesObj) {
                     if (obj != null) {
                         Map<NotificationFilterProperty, List<String>> filterPreferenceProperties =
-                                createNotificationFilterPropertiesMap(obj);
+                            createNotificationFilterPropertiesMap(obj);
 
                         NotificationFilterType filterType = NotificationFilterType.valueOf(
-                                obj.getStringValue(FIELD_FILTER_TYPE).toUpperCase());
+                            obj.getStringValue(FIELD_FILTER_TYPE).toUpperCase());
 
                         Set<NotificationFormat> filterFormats = new HashSet<>();
                         for (String format : (List<String>) obj.getListValue(FIELD_FILTER_FORMATS)) {
@@ -139,9 +140,8 @@ public class DefaultModelBridge implements ModelBridge
                         }
 
                         // Create the new filter preference and add it to the list of preferences
-                        DefaultNotificationFilterPreference notificationFilterPreference
-                                = new DefaultNotificationFilterPreference(
-                                        obj.getStringValue(FILTER_PREFERENCE_NAME));
+                        DefaultNotificationFilterPreference notificationFilterPreference =
+                            new DefaultNotificationFilterPreference(obj.getStringValue(FILTER_PREFERENCE_NAME));
 
                         notificationFilterPreference.setProviderHint("userProfile");
                         notificationFilterPreference.setFilterName(obj.getStringValue(FIELD_FILTER_NAME));
@@ -158,8 +158,8 @@ public class DefaultModelBridge implements ModelBridge
             }
         } catch (Exception e) {
             throw new NotificationException(
-                    String.format("Failed to get the notification preferences scope for the user [%s].",
-                            user), e);
+                String.format("Failed to get the notification preferences scope for the user [%s].", user), e
+            );
         }
 
         return preferences;
@@ -170,17 +170,17 @@ public class DefaultModelBridge implements ModelBridge
         Map<NotificationFilterProperty, List<String>> filterPreferenceProperties = new HashMap<>();
 
         filterPreferenceProperties.put(NotificationFilterProperty.APPLICATION,
-                obj.getListValue(FIELD_APPLICATIONS));
+            obj.getListValue(FIELD_APPLICATIONS));
         filterPreferenceProperties.put(NotificationFilterProperty.EVENT_TYPE,
-                obj.getListValue(FIELD_EVENT_TYPES));
+            obj.getListValue(FIELD_EVENT_TYPES));
         filterPreferenceProperties.put(NotificationFilterProperty.PAGE,
-                obj.getListValue(FIELD_PAGES));
+            obj.getListValue(FIELD_PAGES));
         filterPreferenceProperties.put(NotificationFilterProperty.SPACE,
-                obj.getListValue(FIELD_SPACES));
+            obj.getListValue(FIELD_SPACES));
         filterPreferenceProperties.put(NotificationFilterProperty.WIKI,
-                obj.getListValue(FIELD_WIKIS));
+            obj.getListValue(FIELD_WIKIS));
         filterPreferenceProperties.put(NotificationFilterProperty.USER,
-                obj.getListValue(FIELD_USERS));
+            UsersClass.getListFromString(obj.getStringValue(FIELD_USERS)));
         return filterPreferenceProperties;
     }
 
@@ -191,19 +191,19 @@ public class DefaultModelBridge implements ModelBridge
         XWiki xwiki = context.getWiki();
 
         final DocumentReference notificationPreferencesScopeClass
-                = TOGGLEABLE_FILTER_PREFERENCE_CLASS.setWikiReference(user.getWikiReference());
+            = TOGGLEABLE_FILTER_PREFERENCE_CLASS.setWikiReference(user.getWikiReference());
 
         Map<String, Boolean> filterStatus = new HashMap<>();
 
         try {
             XWikiDocument doc = xwiki.getDocument(user, context);
             for (NotificationFilter filter : componentManager.<NotificationFilter>getInstanceList(
-                    NotificationFilter.class)) {
+                NotificationFilter.class)) {
                 if (filter instanceof ToggleableNotificationFilter) {
                     ToggleableNotificationFilter toggleableFilter = (ToggleableNotificationFilter) filter;
                     boolean status = toggleableFilter.isEnabledByDefault();
                     BaseObject obj = doc.getXObject(notificationPreferencesScopeClass, FIELD_FILTER_NAME,
-                            filter.getName());
+                        filter.getName());
                     if (obj != null) {
                         status = obj.getIntValue(FIELD_IS_ENABLED, status ? 1 : 0) != 0;
                     }
@@ -212,8 +212,8 @@ public class DefaultModelBridge implements ModelBridge
             }
         } catch (Exception e) {
             throw new NotificationException(
-                    String.format("Failed to get the toggleable filters preferences for the user [%s].",
-                            user), e);
+                String.format("Failed to get the toggleable filters preferences for the user [%s].", user), e
+            );
         }
 
         return filterStatus;
@@ -225,8 +225,8 @@ public class DefaultModelBridge implements ModelBridge
         XWikiContext context = contextProvider.get();
         XWiki xwiki = context.getWiki();
 
-        final DocumentReference notificationFilterPreferenceClass
-                = NOTIFICATION_FILTER_PREFERENCE_CLASS.setWikiReference(user.getWikiReference());
+        final DocumentReference notificationFilterPreferenceClass = NOTIFICATION_FILTER_PREFERENCE_CLASS
+            .setWikiReference(user.getWikiReference());
         boolean shouldSave = false;
 
         try {
@@ -235,7 +235,8 @@ public class DefaultModelBridge implements ModelBridge
             if (preferencesObj != null) {
                 for (BaseObject obj : preferencesObj) {
                     if (obj != null
-                            && StringUtils.equals(filterPreferenceName, obj.getStringValue(FILTER_PREFERENCE_NAME))) {
+                        && StringUtils.equals(filterPreferenceName, obj.getStringValue(FILTER_PREFERENCE_NAME)))
+                    {
                         doc.removeXObject(obj);
                         shouldSave = true;
                     }
@@ -246,20 +247,19 @@ public class DefaultModelBridge implements ModelBridge
             }
         } catch (Exception e) {
             throw new NotificationException(
-                    String.format("Failed to delete filters [%s] for user [%s].", filterPreferenceName, user), e);
+                String.format("Failed to delete filters [%s] for user [%s].", filterPreferenceName, user), e);
         }
-
     }
 
     @Override
     public void setFilterPreferenceEnabled(DocumentReference user, String filterPreferenceName, boolean enabled)
-            throws NotificationException
+        throws NotificationException
     {
         XWikiContext context = contextProvider.get();
         XWiki xwiki = context.getWiki();
 
-        final DocumentReference notificationFilterPreferenceClass
-                = NOTIFICATION_FILTER_PREFERENCE_CLASS.setWikiReference(user.getWikiReference());
+        final DocumentReference notificationFilterPreferenceClass = NOTIFICATION_FILTER_PREFERENCE_CLASS
+            .setWikiReference(user.getWikiReference());
         boolean shouldSave = false;
 
         try {
@@ -268,8 +268,9 @@ public class DefaultModelBridge implements ModelBridge
             if (preferencesObj != null) {
                 for (BaseObject obj : preferencesObj) {
                     if (obj != null
-                            && StringUtils.equals(filterPreferenceName, obj.getStringValue(FILTER_PREFERENCE_NAME))
-                            && (obj.getIntValue(FIELD_IS_ENABLED) != 0) != enabled) {
+                        && StringUtils.equals(filterPreferenceName, obj.getStringValue(FILTER_PREFERENCE_NAME))
+                        && (obj.getIntValue(FIELD_IS_ENABLED) != 0) != enabled)
+                    {
                         obj.setIntValue(FIELD_IS_ENABLED, enabled ? 1 : 0);
                         shouldSave = true;
                     }
@@ -278,18 +279,18 @@ public class DefaultModelBridge implements ModelBridge
             if (shouldSave) {
                 // Make this change a minor edit so it's not displayed, by default, in notifications
                 xwiki.saveDocument(doc, String.format("%s filter preference [%s].",
-                        enabled ? "Enable" : "Disable", filterPreferenceName), true, context);
+                    enabled ? "Enable" : "Disable", filterPreferenceName), true, context);
             }
         } catch (Exception e) {
             throw new NotificationException(
-                    String.format("Failed to update enabled state filters [%s] for user [%s].",
-                            filterPreferenceName, user), e);
+                String.format("Failed to update enabled state filters [%s] for user [%s].",
+                    filterPreferenceName, user), e);
         }
     }
 
     @Override
     public void saveFilterPreferences(DocumentReference user,
-            Collection<NotificationFilterPreference> filterPreferences) throws NotificationException
+        Collection<NotificationFilterPreference> filterPreferences) throws NotificationException
     {
         if (user == null) {
             return;
@@ -297,15 +298,15 @@ public class DefaultModelBridge implements ModelBridge
 
         // Convert the collection of preferences to save to a Map sorted by filter names
         Map<String, NotificationFilterPreference> toSave = filterPreferences.stream().collect(
-                Collectors.toMap(NotificationFilterPreference::getFilterPreferenceName, Function.identity())
+            Collectors.toMap(NotificationFilterPreference::getFilterPreferenceName, Function.identity())
         );
 
         // Usual XWiki objects
         XWikiContext context = contextProvider.get();
         XWiki xwiki = context.getWiki();
 
-        final DocumentReference notificationFilterPreferenceClass
-                = NOTIFICATION_FILTER_PREFERENCE_CLASS.setWikiReference(user.getWikiReference());
+        final DocumentReference notificationFilterPreferenceClass = NOTIFICATION_FILTER_PREFERENCE_CLASS
+            .setWikiReference(user.getWikiReference());
 
         try {
             XWikiDocument doc = xwiki.getDocument(user, context);
@@ -319,8 +320,7 @@ public class DefaultModelBridge implements ModelBridge
             xwiki.saveDocument(doc, "Save notification filter preferences.", true, context);
         } catch (Exception e) {
             throw new NotificationException(
-                    String.format("Failed to save the notification preferences scope for the user [%s].", user),
-                    e
+                String.format("Failed to save the notification preferences scope for the user [%s].", user), e
             );
         }
     }
@@ -332,8 +332,8 @@ public class DefaultModelBridge implements ModelBridge
         XWikiContext context = contextProvider.get();
         XWiki xwiki = context.getWiki();
 
-        final DocumentReference notificationFilterPreferenceClass
-                = NOTIFICATION_FILTER_PREFERENCE_CLASS.setWikiReference(user.getWikiReference());
+        final DocumentReference notificationFilterPreferenceClass = NOTIFICATION_FILTER_PREFERENCE_CLASS
+            .setWikiReference(user.getWikiReference());
 
         try {
             XWikiDocument doc = xwiki.getDocument(user, context);
@@ -353,12 +353,11 @@ public class DefaultModelBridge implements ModelBridge
             if (needSave) {
                 // Make this change a minor edit so it's not displayed, by default, in notifications
                 xwiki.saveDocument(doc, "Save notification filter preferences starting date.", true,
-                        context);
+                    context);
             }
         } catch (Exception e) {
             throw new NotificationException(
-                    String.format("Failed to save the notification preferences starting date for the user [%s].", user),
-                    e
+                String.format("Failed to save the notification preferences starting date for the user [%s].", user), e
             );
         }
     }
@@ -371,7 +370,7 @@ public class DefaultModelBridge implements ModelBridge
      * @param doc the document on which the objects are located
      */
     private void updateExistingObjects(Map<String, NotificationFilterPreference> toSave,
-            DocumentReference notificationFilterPreferenceClass, XWikiDocument doc)
+        DocumentReference notificationFilterPreferenceClass, XWikiDocument doc)
     {
         // Get existing objects
         List<BaseObject> preferencesObj = doc.getXObjects(notificationFilterPreferenceClass);
@@ -407,12 +406,11 @@ public class DefaultModelBridge implements ModelBridge
      * @param notificationFilterPreferenceClass class of the XObjects
      * @param doc the document on which the objects are located
      * @param context XWiki Context
-     *
      * @throws XWikiException if error happens
      */
     private void createNewObjects(Map<String, NotificationFilterPreference> toSave,
-            DocumentReference notificationFilterPreferenceClass, XWikiDocument doc, XWikiContext context)
-                throws XWikiException
+        DocumentReference notificationFilterPreferenceClass, XWikiDocument doc, XWikiContext context)
+        throws XWikiException
     {
         for (NotificationFilterPreference filterPreference : toSave.values()) {
             int objNumber = doc.createXObject(notificationFilterPreferenceClass, context);
@@ -423,6 +421,7 @@ public class DefaultModelBridge implements ModelBridge
 
     /**
      * Fill the values of the given XObject with the values of the given filter preference.
+     *
      * @param filterPreference the filter preference to save
      * @param obj the object to fill
      */
@@ -434,19 +433,19 @@ public class DefaultModelBridge implements ModelBridge
         obj.setIntValue(FIELD_IS_ACTIVE, filterPreference.isActive() ? 1 : 0);
         obj.setStringValue(FIELD_FILTER_TYPE, filterPreference.getFilterType().name().toLowerCase());
         obj.setDBStringListValue(FIELD_FILTER_FORMATS,
-                toCollectionOfStrings(filterPreference.getFilterFormats()));
+            toCollectionOfStrings(filterPreference.getFilterFormats()));
         obj.setDBStringListValue(FIELD_APPLICATIONS,
-                filterPreference.getProperties(NotificationFilterProperty.APPLICATION));
+            filterPreference.getProperties(NotificationFilterProperty.APPLICATION));
         obj.setDBStringListValue(FIELD_EVENT_TYPES,
-                filterPreference.getProperties(NotificationFilterProperty.EVENT_TYPE));
+            filterPreference.getProperties(NotificationFilterProperty.EVENT_TYPE));
         obj.setDBStringListValue(FIELD_PAGES,
-                filterPreference.getProperties(NotificationFilterProperty.PAGE));
+            filterPreference.getProperties(NotificationFilterProperty.PAGE));
         obj.setDBStringListValue(FIELD_SPACES,
-                filterPreference.getProperties(NotificationFilterProperty.SPACE));
+            filterPreference.getProperties(NotificationFilterProperty.SPACE));
         obj.setDBStringListValue(FIELD_WIKIS,
-                filterPreference.getProperties(NotificationFilterProperty.WIKI));
+            filterPreference.getProperties(NotificationFilterProperty.WIKI));
         obj.setDBStringListValue(FIELD_USERS,
-                filterPreference.getProperties(NotificationFilterProperty.USER));
+            filterPreference.getProperties(NotificationFilterProperty.USER));
         obj.setDateValue(FIELD_STARTING_DATE, filterPreference.getStartingDate());
     }
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/NotificationFilterPreferenceDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/NotificationFilterPreferenceDocumentInitializer.java
@@ -82,10 +82,8 @@ public class NotificationFilterPreferenceDocumentInitializer extends AbstractMan
                 true, StringUtils.EMPTY, INPUT, SEPARATORS);
         xclass.addStaticListField("eventTypes", "Event types", 64, true,
                 true, StringUtils.EMPTY, INPUT, SEPARATORS);
-        xclass.addStaticListField("users", "Users", 10, true, true,
-                StringUtils.EMPTY, INPUT, SEPARATORS);
-        xclass.addStaticListField("pages", "Pages", 64, true,
-                true, StringUtils.EMPTY, INPUT, SEPARATORS);
+        xclass.addUsersField("users", "Users", 10, true, true);
+        xclass.addPageField("pages", "Pages", 64, true);
         xclass.addStaticListField("spaces", "Spaces", 64, true,
                 true, StringUtils.EMPTY, INPUT, SEPARATORS);
         xclass.addStaticListField("wikis", "Wikis", 64, true,

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/RedirectClassDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/RedirectClassDocumentInitializer.java
@@ -57,6 +57,6 @@ public class RedirectClassDocumentInitializer extends AbstractMandatoryClassInit
     @Override
     protected void createClass(BaseClass xclass)
     {
-        xclass.addTextField("location", "Location", 30);
+        xclass.addPageField("location", "Location", 30);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiCommentsDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiCommentsDocumentInitializer.java
@@ -82,7 +82,7 @@ public class XWikiCommentsDocumentInitializer extends AbstractMandatoryClassInit
     @Override
     protected void createClass(BaseClass xclass)
     {
-        xclass.addTextField("author", "Author", 30);
+        xclass.addUsersField("author", "Author", 30, false);
         xclass.addTextAreaField("highlight", "Highlighted Text", 40, 2);
         xclass.addNumberField("replyto", "Reply To", 5, "integer");
         xclass.addDateField("date", "Date");

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiPreferencesDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiPreferencesDocumentInitializer.java
@@ -50,28 +50,28 @@ public class XWikiPreferencesDocumentInitializer extends AbstractMandatoryClassI
 {
     /**
      * The name of the initialized document.
-     * 
+     *
      * @since 9.4RC1
      */
     public static final String NAME = "XWikiPreferences";
 
     /**
      * The local reference of the initialized document as String.
-     * 
+     *
      * @since 9.4RC1
      */
     public static final String LOCAL_REFERENCE_STRING = XWiki.SYSTEM_SPACE + '.' + NAME;
 
     /**
      * The local reference of the initialized document as String.
-     * 
+     *
      * @since 9.4RC1
      */
     public static final LocalDocumentReference LOCAL_REFERENCE = new LocalDocumentReference(XWiki.SYSTEM_SPACE, NAME);
 
     /**
      * A regex to match any object reference with initialized class.
-     * 
+     *
      * @since 9.4RC1
      */
     public static final RegexEntityReference OBJECT_REFERENCE = BaseObjectReference.any(LOCAL_REFERENCE_STRING);
@@ -104,14 +104,14 @@ public class XWikiPreferencesDocumentInitializer extends AbstractMandatoryClassI
     {
         xclass.setCustomMapping("internal");
 
-        xclass.addTextField("parent", "Parent Space", 30);
+        xclass.addPageField("parent", "Parent Space", 30);
         xclass.addBooleanField("multilingual", "Multi-Lingual", "yesno");
         xclass.addTextField("default_language", "Default Language", 5);
         xclass.addBooleanField("authenticate_edit", "Authenticated Edit", "yesno");
         xclass.addBooleanField("authenticate_view", "Authenticated View", "yesno");
         xclass.addBooleanField("auth_active_check", "Authentication Active Check", "yesno");
 
-        xclass.addTextField("skin", "Skin", 30);
+        xclass.addPageField("skin", "Skin", 30);
         xclass.addDBListField("colorTheme", "Color theme",
             "select doc.fullName, doc.title from XWikiDocument as doc, BaseObject as theme "
                 + "where doc.fullName=theme.name and (theme.className='ColorThemes.ColorThemeClass' "
@@ -174,14 +174,15 @@ public class XWikiPreferencesDocumentInitializer extends AbstractMandatoryClassI
         xclass.addBooleanField("backlinks", "Activate the backlinks", "yesno");
 
         // New fields for the XWiki 1.0 skin
-        xclass.addTextField("leftPanels", "Panels displayed on the left", 60);
-        xclass.addTextField("rightPanels", "Panels displayed on the right", 60);
+        String sql = "select obj.name from BaseObject as obj where obj.className = 'Panels.PanelClass'";
+        xclass.addPageField("leftPanels", "Panels displayed on the left", 60, true, false, sql);
+        xclass.addPageField("rightPanels", "Panels displayed on the right", 60, true, false, sql);
         xclass.addBooleanField("showLeftPanels", "Display the left panel column", "yesno");
         xclass.addBooleanField("showRightPanels", "Display the right panel column", "yesno");
         xclass.addStaticListField("leftPanelsWidth", "Width of the left panel column", "---|Small|Medium|Large");
         xclass.addStaticListField("rightPanelsWidth", "Width of the right panel column", "---|Small|Medium|Large");
         xclass.addTextField("languages", "Supported languages", 30);
-        xclass.addTextField("documentBundles", "Internationalization Document Bundles", 60);
+        xclass.addPageField("documentBundles", "Internationalization Document Bundles", 60);
         xclass.addTimezoneField(TIMEZONE_FIELD, "Time Zone", 30);
 
         // Only used by LDAP authentication service

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiUsersDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiUsersDocumentInitializer.java
@@ -92,7 +92,7 @@ public class XWikiUsersDocumentInitializer extends AbstractMandatoryClassInitial
         xclass.addTimezoneField(TIMEZONE_FIELD, "Time Zone", 30);
 
         // New fields for the XWiki 1.0 skin
-        xclass.addTextField("skin", "skin", 30);
+        xclass.addPageField("skin", "skin", 30);
         xclass.addTextField("avatar", "Avatar", 30);
         xclass.addTextField("phone", "Phone", 30);
         xclass.addTextAreaField("address", "Address", 40, 3);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BaseClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BaseClass.java
@@ -521,7 +521,7 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
 
     public boolean addTextField(String fieldName, String fieldPrettyName, int size)
     {
-        if (get(fieldName) == null) {
+        if (!(getField(fieldName) instanceof StringClass)) {
             StringClass text_class = new StringClass();
             text_class.setName(fieldName);
             text_class.setPrettyName(fieldPrettyName);
@@ -542,7 +542,7 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
 
     public boolean addPasswordField(String fieldName, String fieldPrettyName, int size, String storageType)
     {
-        if (get(fieldName) == null) {
+        if (!(get(fieldName) instanceof PasswordClass)) {
             PasswordClass passwordClass = new PasswordClass();
             passwordClass.setName(fieldName);
             passwordClass.setPrettyName(fieldPrettyName);
@@ -561,7 +561,7 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
 
     public boolean addEmailField(String fieldName, String fieldPrettyName, int size)
     {
-        if (get(fieldName) == null) {
+        if (!(getField(fieldName) instanceof EmailClass)) {
             EmailClass emailClass = new EmailClass();
             emailClass.setName(fieldName);
             emailClass.setPrettyName(fieldPrettyName);
@@ -577,7 +577,7 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
 
     public boolean addTimezoneField(String fieldName, String fieldPrettyName, int size)
     {
-        if (get(fieldName) == null) {
+        if (!(getField(fieldName) instanceof TimezoneClass)) {
             TimezoneClass timezoneClass = new TimezoneClass();
             timezoneClass.setName(fieldName);
             timezoneClass.setPrettyName(fieldPrettyName);
@@ -606,7 +606,7 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
      */
     public boolean addBooleanField(String fieldName, String fieldPrettyName, String formType, String displayType, Boolean def)
     {
-        if (get(fieldName) == null) {
+        if (!(getField(fieldName) instanceof BooleanClass)) {
             BooleanClass booleanClass = new BooleanClass();
             booleanClass.setName(fieldName);
             booleanClass.setPrettyName(fieldPrettyName);
@@ -652,12 +652,31 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
      */
     public boolean addUsersField(String fieldName, String fieldPrettyName, int size, boolean multiSelect)
     {
-        if (get(fieldName) == null) {
+        // Set relational storage to false to keep backward compatibility
+        return addUsersField(fieldName, fieldPrettyName, size, multiSelect, false);
+    }
+
+    /**
+     * Adds a users field to the class.
+     *
+     * @param fieldName the field name
+     * @param fieldPrettyName the shown name
+     * @param size size of the input
+     * @param multiSelect specifies if there can be several values
+     * @param relationalStorage specifies how the values are being stored
+     * @return true if the field has been added
+     * @since 10.7RC1
+     */
+    public boolean addUsersField(String fieldName, String fieldPrettyName, int size, boolean multiSelect,
+        boolean relationalStorage)
+    {
+        if (!(getField(fieldName) instanceof UsersClass)) {
             UsersClass users_class = new UsersClass();
             users_class.setName(fieldName);
             users_class.setPrettyName(fieldPrettyName);
             users_class.setSize(size);
             users_class.setMultiSelect(multiSelect);
+            users_class.setRelationalStorage(relationalStorage);
             users_class.setObject(this);
             put(fieldName, users_class);
 
@@ -674,7 +693,7 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
 
     public boolean addLevelsField(String fieldName, String fieldPrettyName, int size)
     {
-        if (get(fieldName) == null) {
+        if (!(getField(fieldName) instanceof LevelsClass)) {
             LevelsClass levels_class = new LevelsClass();
             levels_class.setName(fieldName);
             levels_class.setPrettyName(fieldPrettyName);
@@ -696,7 +715,7 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
 
     public boolean addGroupsField(String fieldName, String fieldPrettyName, int size)
     {
-        if (get(fieldName) == null) {
+        if (!(getField(fieldName) instanceof GroupsClass)) {
             GroupsClass groups_class = new GroupsClass();
             groups_class.setName(fieldName);
             groups_class.setPrettyName(fieldPrettyName);
@@ -851,7 +870,7 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
     public boolean addStaticListField(String fieldName, String fieldPrettyName, int size, boolean multiSelect,
         boolean relationalStorage, String values, String displayType, String separators)
     {
-        if (get(fieldName) == null) {
+        if (!(getField(fieldName) instanceof StaticListClass)) {
             StaticListClass list_class = new StaticListClass();
             list_class.setName(fieldName);
             list_class.setPrettyName(fieldPrettyName);
@@ -877,7 +896,7 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
 
     public boolean addNumberField(String fieldName, String fieldPrettyName, int size, String type)
     {
-        if (get(fieldName) == null) {
+        if (!(getField(fieldName) instanceof NumberClass)) {
             NumberClass number_class = new NumberClass();
             number_class.setName(fieldName);
             number_class.setPrettyName(fieldPrettyName);
@@ -904,7 +923,7 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
 
     public boolean addDateField(String fieldName, String fieldPrettyName, String dformat, int emptyIsToday)
     {
-        if (get(fieldName) == null) {
+        if (!(getField(fieldName) instanceof DateClass)) {
             DateClass date_class = new DateClass();
             date_class.setName(fieldName);
             date_class.setPrettyName(fieldPrettyName);
@@ -937,7 +956,7 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
     public boolean addDBListField(String fieldName, String fieldPrettyName, int size, boolean multiSelect,
         boolean relationalStorage, String sql)
     {
-        if (get(fieldName) == null) {
+        if (!(getField(fieldName) instanceof DBListClass)) {
             DBListClass list_class = new DBListClass();
             list_class.setName(fieldName);
             list_class.setPrettyName(fieldPrettyName);
@@ -971,7 +990,7 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
     public boolean addDBTreeListField(String fieldName, String fieldPrettyName, int size, boolean multiSelect,
         boolean relationalStorage, String sql)
     {
-        if (get(fieldName) == null) {
+        if (!(getField(fieldName) instanceof DBTreeListClass)) {
             DBTreeListClass list_class = new DBTreeListClass();
             list_class.setName(fieldName);
             list_class.setPrettyName(fieldPrettyName);
@@ -981,6 +1000,91 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
             list_class.setSql(sql);
             list_class.setObject(this);
             put(fieldName, list_class);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Adds a page field to the class.
+     * <p>The input has no multiselect by default.
+     *
+     * @param fieldName the field name
+     * @param fieldPrettyName the shown name
+     * @param size size of the input
+     * @return true if the field has been added
+     * @since 10.7RC1
+     */
+    public boolean addPageField(String fieldName, String fieldPrettyName, int size)
+    {
+        return addPageField(fieldName, fieldPrettyName, size, false);
+    }
+
+    /**
+     * Adds a page field to the class.
+     *
+     * @param fieldName the field name
+     * @param fieldPrettyName the shown name
+     * @param size size of the input
+     * @param multiSelect specifies if there can be several values
+     * @return true if the field has been added
+     * @since 10.7RC1
+     */
+    public boolean addPageField(String fieldName, String fieldPrettyName, int size, boolean multiSelect)
+    {
+        return addPageField(fieldName, fieldPrettyName, size, multiSelect, multiSelect, "");
+    }
+
+    /**
+     * Adds a page field to the class.
+     *
+     * @param fieldName the field name
+     * @param fieldPrettyName the shown name
+     * @param size size of the input
+     * @param multiSelect specifies if there can be several values
+     * @param relationalStorage specifies how the values are being stored
+     * @param sql the optional sql query used for the autosuggest
+     * @return true if the field has been added
+     * @since 10.7RC1
+     */
+    public boolean addPageField(String fieldName, String fieldPrettyName, int size, boolean multiSelect,
+        boolean relationalStorage, String sql)
+    {
+        return addPageField(fieldName, fieldPrettyName, size, multiSelect, relationalStorage, sql,
+            ListClass.DISPLAYTYPE_INPUT, true);
+    }
+
+    /**
+     * Adds a page field to the class.
+     *
+     * @param fieldName the field name
+     * @param fieldPrettyName the shown name
+     * @param size size of the input
+     * @param multiSelect specifies if there can be several values
+     * @param relationalStorage specifies how the values are being stored
+     * @param sql the optional sql query used for the autosuggest
+     * @param displayType the display type
+     * @param hasPicker enables the autosuggest
+     * @return true if the field has been added
+     * @since 10.7RC1
+     */
+    public boolean addPageField(String fieldName, String fieldPrettyName, int size, boolean multiSelect,
+        boolean relationalStorage, String sql, String displayType, boolean hasPicker)
+    {
+        if (!(getField(fieldName) instanceof PageClass)) {
+            PageClass pageClass = new PageClass();
+            pageClass.setName(fieldName);
+            pageClass.setPrettyName(fieldPrettyName);
+            pageClass.setSize(size);
+            pageClass.setMultiSelect(multiSelect);
+            pageClass.setSql(sql);
+            pageClass.setRelationalStorage(relationalStorage);
+            pageClass.setDisplayType(displayType);
+            pageClass.setPicker(hasPicker);
+            pageClass.setObject(this);
+            put(fieldName, pageClass);
 
             return true;
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
@@ -135,7 +135,7 @@ public abstract class ListClass extends PropertyClass
 
     /**
      * @return a string of separator characters used to split/deserialize an input string coming from the UI (filled by
-     *         the user) that represents a serialized list
+     * the user) that represents a serialized list
      * @see #displayEdit(StringBuffer, String, String, BaseCollection, XWikiContext)
      * @see #fromString(String)
      */
@@ -150,7 +150,7 @@ public abstract class ListClass extends PropertyClass
 
     /**
      * @param separators a string of characters used to split/deserialize an input string coming from the UI (filled by
-     *            the user) that represents a serialized list
+     * the user) that represents a serialized list
      */
     public void setSeparators(String separators)
     {
@@ -229,7 +229,7 @@ public abstract class ListClass extends PropertyClass
 
     /**
      * @return a string (usually just 1 character long) used to join this list's items when displaying it in the UI in
-     *         view mode.
+     * view mode.
      * @see #displayView(StringBuffer, String, String, BaseCollection, XWikiContext)
      */
     public String getSeparator()
@@ -239,7 +239,7 @@ public abstract class ListClass extends PropertyClass
 
     /**
      * @param separator a string (usually just 1 character long) used to join this list's items when displaying it in
-     *            the UI in view mode.
+     * the UI in view mode.
      */
     public void setSeparator(String separator)
     {
@@ -261,10 +261,9 @@ public abstract class ListClass extends PropertyClass
     /**
      * @param value the string holding a serialized list
      * @param separators the separator characters (given as a string) used to delimit the list's items inside the input
-     *            string. These separators can also be present, in escaped ({@value #SEPARATOR_ESCAPE}) form, inside
-     *            list items
+     * string. These separators can also be present, in escaped ({@value #SEPARATOR_ESCAPE}) form, inside list items
      * @param withMap set to true if the list's values contain map entries (key=value pairs) that should also be parsed.
-     *            Only the keys are extracted from such list items
+     * Only the keys are extracted from such list items
      * @return the list that was stored in the input string
      */
     public static List<String> getListFromString(String value, String separators, boolean withMap)
@@ -318,7 +317,7 @@ public abstract class ListClass extends PropertyClass
      *
      * @param list the list to serialize
      * @return a string representing a serialized list, delimited by the first separator character (from the ones inside
-     *         the separators string). Separators inside list items are safely escaped ({@value #SEPARATOR_ESCAPE}).
+     * the separators string). Separators inside list items are safely escaped ({@value #SEPARATOR_ESCAPE}).
      * @see #getStringFromList(List, String)
      */
     public static String getStringFromList(List<String> list)
@@ -329,10 +328,10 @@ public abstract class ListClass extends PropertyClass
     /**
      * @param list the list to serialize
      * @param separators the separator characters (given as a string) used when the list was populated with values. The
-     *            list's items can contain these separators in plain/unescaped form. The first separator character will
-     *            be used to join the list in the output.
+     * list's items can contain these separators in plain/unescaped form. The first separator character will be used to
+     * join the list in the output.
      * @return a string representing a serialized list, delimited by the first separator character (from the ones inside
-     *         the separators string). Separators inside list items are safely escaped ({@value #SEPARATOR_ESCAPE}).
+     * the separators string). Separators inside list items are safely escaped ({@value #SEPARATOR_ESCAPE}).
      */
     public static String getStringFromList(List<String> list, String separators)
     {
@@ -387,8 +386,8 @@ public abstract class ListClass extends PropertyClass
      *
      * @param property a property to be used in an form input
      * @return the text value to be used in an form input. If a {@link ListProperty} is passed, the list's separators
-     *         defined by {@link #getSeparators()} are escaped for each list item and the items are joined by the first
-     *         separator
+     * defined by {@link #getSeparators()} are escaped for each list item and the items are joined by the first
+     * separator
      * @see #getStringFromList(List, String)
      */
     public String toFormString(BaseProperty property)
@@ -542,12 +541,12 @@ public abstract class ListClass extends PropertyClass
      * Search for an internationalizable display text for the current value. The value can be either a simple string, or
      * a value=name pair selected from the database.
      *
-     * @see #getDisplayValue(String, String, Map, XWikiContext)
      * @param rawvalue The internal value, or a value=name pair.
      * @param name The name of the ListProperty.
      * @param map The value=name mapping specified in the "values" parameter of the property.
      * @param context The request context.
      * @return The text that should be displayed, representing a human-understandable name for the internal value.
+     * @see #getDisplayValue(String, String, Map, XWikiContext)
      */
     protected String getDisplayValue(Object rawvalue, String name, Map<String, ListItem> map, XWikiContext context)
     {
@@ -844,6 +843,17 @@ public abstract class ListClass extends PropertyClass
 
         // Fallback on default ListProperty merging
         super.mergeProperty(currentProperty, previousProperty, newProperty, configuration, context, mergeResult);
+    }
+
+    @Override
+    public BaseProperty fromValue(Object value)
+    {
+        if (value instanceof String) {
+            return this.fromString((String) value);
+        }
+        BaseProperty property = newProperty();
+        property.setValue(value);
+        return property;
     }
 
     protected <T extends EntityReference> void mergeNotOrderedListProperty(BaseProperty<T> currentProperty,

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/meta/DBListMetaClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/meta/DBListMetaClass.java
@@ -25,6 +25,8 @@ import javax.inject.Singleton;
 import org.xwiki.component.annotation.Component;
 
 import com.xpn.xwiki.objects.classes.DBListClass;
+import com.xpn.xwiki.objects.classes.ListClass;
+import com.xpn.xwiki.objects.classes.PageClass;
 import com.xpn.xwiki.objects.classes.PropertyClassInterface;
 import com.xpn.xwiki.objects.classes.StringClass;
 import com.xpn.xwiki.objects.classes.TextAreaClass;
@@ -55,10 +57,12 @@ public class DBListMetaClass extends ListMetaClass
         sqlClass.setRows(5);
         safeput(sqlClass.getName(), sqlClass);
 
-        StringClass classNameClass = new StringClass(this);
+        PageClass classNameClass = new PageClass(this);
         classNameClass.setName("classname");
         classNameClass.setPrettyName("XWiki Class Name");
         classNameClass.setSize(20);
+        classNameClass.setDisplayType(ListClass.DISPLAYTYPE_INPUT);
+        classNameClass.setMultiSelect(false);
         safeput(classNameClass.getName(), classNameClass);
 
         StringClass idFieldClass = new StringClass(this);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -3137,7 +3137,7 @@ XWiki.TagClass_tags=Tags
 ### XWiki.WatchListClass (watchlist plugin)
 XWiki.WatchListClass_interval=Email notifications interval
 XWiki.WatchListClass_spaces=Space list, comma separated
-XWiki.WatchListClass_documents=Page list, comma separated
+XWiki.WatchListClass_documents=Page list
 XWiki.WatchListClass_query=Query (HQL)
 XWiki.WatchListClass_automaticwatch=Automatic page watching
 XWiki.WatchListClass_automaticwatch_default=Default

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-api/src/main/java/org/xwiki/panels/internal/AbstractPanelsUIExtensionManager.java
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-api/src/main/java/org/xwiki/panels/internal/AbstractPanelsUIExtensionManager.java
@@ -26,7 +26,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.manager.ComponentLookupException;
 import org.xwiki.component.manager.ComponentManager;
@@ -84,19 +83,19 @@ public abstract class AbstractPanelsUIExtensionManager implements UIExtensionMan
      *
      * @return a comma separated list of panel IDs
      */
-    protected abstract String getConfiguration();
+    protected abstract List<String> getConfiguration();
 
     @Override
     public List<UIExtension> get(String extensionPointId)
     {
         List<UIExtension> panels = new ArrayList<UIExtension>();
 
-        String panelConfigurationString = getConfiguration();
+        List<String> panelConfiguration = getConfiguration();
 
         // Verify that there's a panel configuration property defined, and if not don't return any panel extension.
-        if (!StringUtils.isEmpty(panelConfigurationString)) {
+        if (!panelConfiguration.isEmpty()) {
             List<String> panelSerializedReferences = new ArrayList<String>();
-            for (String serializedReference : getConfiguration().split(",")) {
+            for (String serializedReference : panelConfiguration) {
                 panelSerializedReferences.add(serializer.serialize(resolver.resolve(serializedReference.trim())));
             }
 

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-api/src/main/java/org/xwiki/panels/internal/LeftPanelsUIExtensionManager.java
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-api/src/main/java/org/xwiki/panels/internal/LeftPanelsUIExtensionManager.java
@@ -19,8 +19,11 @@
  */
 package org.xwiki.panels.internal;
 
+import java.util.List;
+
 import javax.inject.Named;
 import javax.inject.Singleton;
+
 import org.xwiki.component.annotation.Component;
 
 /**
@@ -35,7 +38,7 @@ import org.xwiki.component.annotation.Component;
 public class LeftPanelsUIExtensionManager extends AbstractPanelsUIExtensionManager
 {
     @Override
-    protected String getConfiguration()
+    protected List<String> getConfiguration()
     {
         return this.configurationSource.getProperty("leftPanels");
     }

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-api/src/main/java/org/xwiki/panels/internal/RightPanelsUIExtensionManager.java
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-api/src/main/java/org/xwiki/panels/internal/RightPanelsUIExtensionManager.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.panels.internal;
 
+import java.util.List;
+
 import javax.inject.Named;
 import javax.inject.Singleton;
 
@@ -36,7 +38,7 @@ import org.xwiki.component.annotation.Component;
 public class RightPanelsUIExtensionManager extends AbstractPanelsUIExtensionManager
 {
     @Override
-    protected String getConfiguration()
+    protected List<String> getConfiguration()
     {
         return this.configurationSource.getProperty("rightPanels");
     }

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/PanelsCode/NavigationConfigurationClass.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/PanelsCode/NavigationConfigurationClass.xml
@@ -77,17 +77,17 @@
       <number>2</number>
       <picker>1</picker>
       <prettyName>Exclusions</prettyName>
+      <size>1</size>
       <relationalStorage>1</relationalStorage>
       <separator> </separator>
       <separators/>
-      <size>1</size>
       <sort>none</sort>
       <sql>select doc.fullName, space.name from XWikiDocument doc, XWikiSpace space where doc.space = space.reference and space.parent is null and doc.translation = 0 and doc.name = 'WebHome' order by space.name</sql>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
       <valueField/>
-      <classType>com.xpn.xwiki.objects.classes.DBListClass</classType>
+      <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
     </exclusions>
     <inclusions>
       <cache>0</cache>
@@ -102,17 +102,17 @@
       <number>3</number>
       <picker>1</picker>
       <prettyName>Inclusions</prettyName>
+      <size>1</size>
       <relationalStorage>1</relationalStorage>
       <separator> </separator>
       <separators/>
-      <size>1</size>
       <sort>none</sort>
       <sql>select doc.fullName, space.name from XWikiDocument doc, XWikiSpace space where doc.space = space.reference and space.parent is null and doc.translation = 0 and doc.name = 'WebHome' order by space.name</sql>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
       <valueField/>
-      <classType>com.xpn.xwiki.objects.classes.DBListClass</classType>
+      <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
     </inclusions>
   </class>
   <object>

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/SearchSuggestSourceClass.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/SearchSuggestSourceClass.xml
@@ -145,17 +145,29 @@
       <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
     </resultsNumber>
     <url>
+      <cache>0</cache>
+      <classname/>
       <customDisplay/>
       <disabled>0</disabled>
+      <displayType>input</displayType>
+      <hint/>
+      <idField/>
+      <multiSelect>0</multiSelect>
       <name>url</name>
       <number>3</number>
-      <picker>0</picker>
+      <picker>1</picker>
       <prettyName>Service</prettyName>
+      <relationalStorage>0</relationalStorage>
+      <separator> </separator>
+      <separators/>
       <size>30</size>
+      <sort>none</sort>
+      <sql/>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      <valueField/>
+      <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
     </url>
   </class>
   <object>

--- a/xwiki-platform-core/xwiki-platform-sheet/xwiki-platform-sheet-ui/src/main/resources/XWiki/ClassSheetBinding.xml
+++ b/xwiki-platform-core/xwiki-platform-sheet/xwiki-platform-sheet-ui/src/main/resources/XWiki/ClassSheetBinding.xml
@@ -50,17 +50,29 @@
     <nameField/>
     <validationScript/>
     <sheet>
+      <cache>0</cache>
+      <classname/>
       <customDisplay/>
       <disabled>0</disabled>
+      <displayType>input</displayType>
+      <hint/>
+      <idField/>
+      <multiSelect>0</multiSelect>
       <name>sheet</name>
       <number>1</number>
-      <picker>0</picker>
+      <picker>1</picker>
       <prettyName>Sheet</prettyName>
       <size>30</size>
+      <relationalStorage>0</relationalStorage>
+      <separator> </separator>
+      <separators/>
+      <sort>none</sort>
+      <sql/>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      <valueField/>
+      <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
     </sheet>
   </class>
 </xwikidoc>

--- a/xwiki-platform-core/xwiki-platform-sheet/xwiki-platform-sheet-ui/src/main/resources/XWiki/DocumentSheetBinding.xml
+++ b/xwiki-platform-core/xwiki-platform-sheet/xwiki-platform-sheet-ui/src/main/resources/XWiki/DocumentSheetBinding.xml
@@ -50,17 +50,29 @@
     <nameField/>
     <validationScript/>
     <sheet>
+      <cache>0</cache>
+      <classname/>
       <customDisplay/>
       <disabled>0</disabled>
+      <displayType>input</displayType>
+      <hint/>
+      <idField/>
+      <multiSelect>0</multiSelect>
       <name>sheet</name>
       <number>1</number>
-      <picker>0</picker>
+      <picker>1</picker>
       <prettyName>Sheet</prettyName>
       <size>30</size>
+      <relationalStorage>0</relationalStorage>
+      <separator> </separator>
+      <separators/>
+      <sort>none</sort>
+      <sql/>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      <valueField/>
+      <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
     </sheet>
   </class>
 </xwikidoc>

--- a/xwiki-platform-core/xwiki-platform-watchlist/xwiki-platform-watchlist-api/src/main/java/org/xwiki/watchlist/internal/documents/WatchListClassDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-watchlist/xwiki-platform-watchlist-api/src/main/java/org/xwiki/watchlist/internal/documents/WatchListClassDocumentInitializer.java
@@ -127,8 +127,8 @@ public class WatchListClassDocumentInitializer extends AbstractMandatoryClassIni
         // Watched elements properties
         addWatchedElementField(xclass, WIKIS_PROPERTY, "Wiki List");
         addWatchedElementField(xclass, SPACES_PROPERTY, "Space List");
-        addWatchedElementField(xclass, DOCUMENTS_PROPERTY, "Document List");
-        addWatchedElementField(xclass, USERS_PROPERTY, "User List");
+        xclass.addPageField(DOCUMENTS_PROPERTY, "Document List", 80, true);
+        xclass.addUsersField(USERS_PROPERTY, "User List", 80);
 
         // Automatic watching property
         String automaticWatchValues = String.format("%s%s%s", AUTOMATICWATCH_DEFAULT_VALUE, ListClass.DEFAULT_SEPARATOR,

--- a/xwiki-platform-core/xwiki-platform-watchlist/xwiki-platform-watchlist-api/src/main/java/org/xwiki/watchlist/internal/documents/WatchListJobClassDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-watchlist/xwiki-platform-watchlist-api/src/main/java/org/xwiki/watchlist/internal/documents/WatchListJobClassDocumentInitializer.java
@@ -83,7 +83,7 @@ public class WatchListJobClassDocumentInitializer extends AbstractMandatoryClass
     @Override
     protected void createClass(BaseClass xclass)
     {
-        xclass.addTextField(TEMPLATE_FIELD, "Document holding the notification message template to use", 80);
+        xclass.addPageField(TEMPLATE_FIELD, "Document holding the notification message template to use", 80);
         xclass.addDateField(LAST_FIRE_TIME_FIELD, "Last notifier fire time", "dd/MM/yyyy HH:mm:ss", 1);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/suggest/suggestPages.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/suggest/suggestPages.js
@@ -1,0 +1,66 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+require.config({
+  paths: {
+    'xwiki-selectize': "$xwiki.getSkinFile('uicomponents/suggest/xwiki.selectize.js', true)" +
+      "?v=$escapetool.url($xwiki.version)"
+  }
+});
+
+define('xwiki-suggestPages', ['jquery', 'xwiki-selectize'], function($, utils) {
+  'use strict';
+
+  var getSelectizeOptions = function(select) {
+    return {
+      create: true,
+      load: function(text, callback) {
+        loadPages(text).done(callback).fail(callback);
+      }
+    }
+  };
+
+  var loadPages = function(text) {
+    // ${request.contextPath}/rest/wikis/query/
+    var pages = $.getJSON(XWiki.currentDocument.getURL('get'), {
+      'xpage': 'pagesuggest',
+      'input': text,
+      'limit': 10,
+      'media': 'json'
+    });
+
+    return pages;
+  };
+
+  $.fn.suggestPages = function() {
+    return this.each(function() {
+      $(this).xwikiSelectize(getSelectizeOptions($(this)));
+    });
+  };
+});
+
+require(['jquery', 'xwiki-suggestPages', 'xwiki-events-bridge'], function($) {
+  var init = function(event, data) {
+    var container = $((data && data.elements) || document);
+    container.find('.suggest-pages').suggestPages();
+  };
+
+  $(document).on('xwiki:dom:loaded xwiki:dom:updated', init);
+  XWiki.domIsLoaded && init();
+});

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/comments2.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/comments2.vm
@@ -14,7 +14,7 @@
 <div class="xwikidatatitle">
 <a href="" onclick="showhide('xwikicommentscontent'); return false">$services.localization.render('comments')</a>:
 $!comments.size() $services.localization.render('comments') #if($comments.size()>0) $services.localization.render('by')
-$!xwiki.getUserName($doc.display('author','view',$comments.get(0))) ...
+$!xwiki.getUserName($comments.get(0).getValue('author')) ...
 #end
 </div>
 </div>
@@ -24,7 +24,7 @@ $!xwiki.getUserName($doc.display('author','view',$comments.get(0))) ...
 #foreach($comment in $comments)
 #set($count=$count+1)
 <div id="xwikicomment_${count}" class="xwikicomment" >
-$!xwiki.getUserName($doc.display('author','view',$comment))
+$!xwiki.getUserName($comment.getValue('author'))
 #set($date = $doc.display("date","view",$comment))
 #if($date != "")
 $date

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/exportinline.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/exportinline.vm
@@ -19,7 +19,14 @@
     <label for="author">$services.localization.render('export_author')</label>
     <span class="xHint">$services.localization.render('administration.section.export.author.hint')</span>
   </dt>
-  <dd><input type="text" name="author" id="author" value="$xcontext.user"/></dd>
+  <dd>
+  #set ($userPickerParams = {
+      'id': 'author',
+      'name': 'author',
+      'value': $xcontext.user
+      })
+  #userPicker(false $userPickerParams)
+  </dd>
   <dt>
     <label for="version">$services.localization.render('export_version')</label>
     <span class="xHint">$services.localization.render('administration.section.export.version.hint')</span>

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/macros.vm
@@ -1572,6 +1572,15 @@ $Msz MB##
       class="suggest-propertyValues" multiple="multiple" size="1"
       data-className="$!escapetool.xml($xproperty.className)" data-propertyName="$!escapetool.xml($xproperty.name)">
     </select>
+  #elseif ($filterType == 'page')
+    #set ($discard = $xwiki.linkx.use($services.webjars.url('selectize.js', 'css/selectize.bootstrap3.css'),
+      {'type': 'text/css', 'rel': 'stylesheet'}))
+    #set ($discard = $xwiki.ssfx.use('uicomponents/suggest/xwiki.selectize.css', true))
+    #set ($discard = $xwiki.jsfx.use('uicomponents/suggest/suggestPages.js',
+      {'forceSkinAction' : true, 'language' : $xcontext.locale}))
+    <select id="xwiki-livetable-${htmlLiveTableId}-filter-$velocityCount" name="$!escapetool.xml($column)"
+      class="suggest-pages" multiple="multiple" size="1">
+    </select>
   #end
 #end
 
@@ -2289,14 +2298,20 @@ function (row, i, table) {
 $string##
 #end
 
+#**
+ * Pulls all the JavaScript and CSS resources needed by pickers.
+ *#
+#macro (picker_import)
+  #set ($discard = $xwiki.linkx.use($services.webjars.url('selectize.js', 'css/selectize.bootstrap3.css'),
+    {'type': 'text/css', 'rel': 'stylesheet'}))
+  #set ($discard = $xwiki.ssfx.use('uicomponents/suggest/xwiki.selectize.css', true))
+#end
 
 #**
  * Pulls all the JavaScript and CSS resources needed by the user and group picker.
  *#
 #macro (userPicker_import)
-  #set ($discard = $xwiki.linkx.use($services.webjars.url('selectize.js', 'css/selectize.bootstrap3.css'),
-    {'type': 'text/css', 'rel': 'stylesheet'}))
-  #set ($discard = $xwiki.ssfx.use('uicomponents/suggest/xwiki.selectize.css', true))
+  #picker_import
   #set ($discard = $xwiki.jsfx.use('uicomponents/suggest/suggestUsersAndGroups.js',
     {'forceSkinAction': true, 'language': $xcontext.locale}))
 #end
@@ -2321,6 +2336,31 @@ $string##
   #userPicker_input($multiSelect $parameters)
 #end
 
+
+#**
+* Pulls all the JavaScript and CSS resources needed by the page picker.
+*#
+#macro (pagePicker_import)
+  #picker_import
+  #set ($discard = $xwiki.jsfx.use('uicomponents/suggest/suggestPages.js',
+    {'forceSkinAction': true, 'language': $xcontext.locale}))
+#end
+
+#macro (pagePicker_input $multiSelect $parameters)
+  #if ($multiSelect)
+    #set ($discard = $parameters.put('multiple', 'multiple'))
+  #end
+  #suggestInput($parameters)
+#end
+
+#macro (pagePicker $multiSelect $parameters)
+  #pagePicker_import
+  #if ("$!parameters" == "")
+    #set ($parameters = {})
+  #end
+  #set ($discard = $parameters.put('class', "$!parameters.get('class') suggest-pages"))
+  #pagePicker_input($multiSelect $parameters)
+#end
 
 #**
  * Displays the given title (i.e. the title of the sheet) if the condition is true. Otherwise displays the title of the

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/pagesuggest.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/pagesuggest.vm
@@ -1,0 +1,85 @@
+#macro (suggestPages)
+  #set ($input = "$!request.input.toLowerCase()")
+  #set ($statement = "where lower(doc.fullName) like :input or lower(doc.title) like :input")
+  #if ($request.wiki == 'global')
+    #set ($wikiReference = $services.model.createWikiReference($xcontext.mainWikiName))
+  #else
+    #set ($wikiReference = $doc.documentReference.wikiReference)
+  #end
+  #set ($query = $services.query.xwql($statement).setWiki($wikiReference.name).addFilter('unique'))
+  #set ($query = $query.setLimit(10).bindValue('input', "%$input%"))
+  #set ($rawResults = $query.execute())
+  #displayResults($rawResults $wikiReference)
+#end
+##
+#macro (displayResults $rawResults $wikiReference)
+  #set ($results = [])
+  #foreach ($result in $rawResults)
+    #addResultData($result $results $wikiReference)
+  #end
+  #if ($request.media == 'json')
+    #displayResultsJSON($results)
+  #else
+    #displayResultsXML($results)
+  #end
+#end
+##
+#macro (getLabel $reference)
+  #set ($doc = $xwiki.getDocument($reference))
+  #set ($res = $doc.plainTitle)
+  #if ("$!res" == "")
+    #set ($res = $doc.name)
+  #end
+#end
+##
+#macro (addResultData $result $results $wikiReference)
+  #set ($reference = $services.model.resolveDocument($result, $wikiReference))
+  #getLabel($reference)
+  #set ($label = $res)
+  #set ($icon = $services.icon.getMetaData('page_white'))
+  #set ($hint = "")
+  #foreach ($ref in $reference.reversedReferenceChain)
+    #if ($ref.type != "WIKI" && $ref.name != "WebHome" && $foreach.hasNext)
+      #if ("$!hint" != "")
+        #set ($hint = "$hint / ")
+      #end
+      #getLabel($ref)
+      #set ($hint = "$hint $res")
+    #end
+  #end
+  #set ($discard = $results.add({
+    'value': $services.model.serialize($reference, 'compactwiki'),
+    'label': $label,
+    'icon': $icon,
+    'url': $xwiki.getURL($reference),
+    'hint': $hint
+  }))
+#end
+##
+#macro (displayResultsXML $results)
+  #set ($discard = $response.setContentType('text/xml'))
+  <?xml version="1.0" encoding="UTF-8"?>
+  <results>
+    #foreach ($result in $results)
+      #set ($icon = $result.icon.url)
+      #if ("$!icon" == '')
+        #set ($icon = $result.icon.cssClass)
+      #end
+      <rs id="$escapetool.xml($result.url)" icon="$!escapetool.xml($icon)"
+        info="$escapetool.xml($result.label)">$escapetool.xml($result.value)</rs>
+    #end
+  </results>
+#end
+##
+#macro (displayResultsJSON $results)
+  #set ($discard = $response.setContentType('application/json'))
+  $jsontool.serialize($results)
+#end
+##
+#if ($request.exactMatch == 'true' && "$!request.input" != '')
+  ## This is normally used for loading the initial selection.
+  #set ($rawResults = [$request.input])
+  #displayResults($rawResults)
+#else
+  #suggestPages()
+#end

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/main/java/org/xwiki/wiki/internal/descriptor/document/XWikiServerClassDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/main/java/org/xwiki/wiki/internal/descriptor/document/XWikiServerClassDocumentInitializer.java
@@ -264,7 +264,7 @@ public class XWikiServerClassDocumentInitializer extends AbstractMandatoryClassI
         xclass.addStaticListField(FIELD_LANGUAGE, FIELDPN_LANGUAGE, FIELDL_LANGUAGE);
         xclass.addBooleanField(FIELD_SECURE, FIELDPN_SECURE, FIELDFT_SECURE, FIELDDT_SECURE, DEFAULT_SECURE);
         xclass.addNumberField(FIELD_PORT, FIELDPN_PORT, 4, FIELDT_PORT);
-        xclass.addTextField(FIELD_HOMEPAGE, FIELDPN_HOMEPAGE, 30);
+        xclass.addPageField(FIELD_HOMEPAGE, FIELDPN_HOMEPAGE, 30);
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-common/src/main/resources/WikiManager/AdminWikiDescriptorSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-common/src/main/resources/WikiManager/AdminWikiDescriptorSheet.xml
@@ -124,7 +124,12 @@
               #else
                 #set ($homepage = '')
               #end
-              &lt;input id='homepage' name='homepage' type='text' size='30' class='suggestDocuments' value="$!{escapetool.xml($homepage)}" /&gt;
+              #set ($pagePickerParams = {
+                'id': 'homepage',
+                'name': 'homepage',
+                'value': $!{escapetool.xml($homepage)}
+              })
+              #pagePicker(false $pagePickerParams)
             &lt;/dd&gt;
 
             ## Only show the owner change form element if the current user is the current owner or a global admin (has edit on the wiki's descriptor document).

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-user/xwiki-platform-wiki-user-default/src/main/java/org/xwiki/wiki/user/internal/WikiCandidateMemberClassInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-user/xwiki-platform-wiki-user-default/src/main/java/org/xwiki/wiki/user/internal/WikiCandidateMemberClassInitializer.java
@@ -166,12 +166,12 @@ public class WikiCandidateMemberClassInitializer extends AbstractMandatoryClassI
     @Override
     protected void createClass(BaseClass xclass)
     {
-        xclass.addTextField(FIELD_USER, FIELDPN_USERNAME, 30);
+        xclass.addUsersField(FIELD_USER, FIELDPN_USERNAME, 30, false);
         xclass.addDateField(FIELD_DATE_OF_CREATION, FIELDPN_DATE);
         xclass.addTextAreaField(FIELD_USER_COMMENT, FIELDPN_USERCOMMENT, 40, 3);
         xclass.addStaticListField(FIELD_STATUS, FIELDPN_STATUS, FIELDL_STATUS);
         xclass.addDateField(FIELD_DATE_OF_CLOSURE, FIELDPN_RESOLUTIONDATE);
-        xclass.addTextField(FIELD_ADMIN, FIELDPN_REVIEWER, 30);
+        xclass.addUsersField(FIELD_ADMIN, FIELDPN_REVIEWER, 30, false);
         xclass.addTextAreaField(FIELD_ADMIN_COMMENT, FIELDPN_REVIEWERCOMMENT, 40, 3);
         xclass.addTextAreaField(FIELD_ADMIN_PRIVATE_COMMENT, FIELDPN_REVIEWERPRIVATECOMMENT, 40, 3);
         xclass.addStaticListField(FIELD_TYPE, FIELDPN_TYPE, FIELDL_TYPE);

--- a/xwiki-platform-distribution/xwiki-platform-distribution-ui/xwiki-platform-distribution-ui-admin-user/src/main/resources/XWiki/Admin.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-ui/xwiki-platform-distribution-ui-admin-user/src/main/resources/XWiki/Admin.xml
@@ -72,18 +72,29 @@
       </automaticwatch>
       <documents>
         <cache>0</cache>
+        <classname/>
+        <customDisplay/>
         <disabled>0</disabled>
-        <displayType>input</displayType>
+        <hint/>
+        <idField/>
         <multiSelect>1</multiSelect>
         <name>documents</name>
         <number>4</number>
+        <picker>1</picker>
         <prettyName>Document List</prettyName>
         <relationalStorage>1</relationalStorage>
         <separator> </separator>
         <size>80</size>
+        <relationalStorage>1</relationalStorage>
+        <separator> </separator>
+        <separators/>
+        <sort>none</sort>
         <sql/>
         <unmodifiable>0</unmodifiable>
-        <classType>com.xpn.xwiki.objects.classes.DBListClass</classType>
+        <validationMessage/>
+        <validationRegExp/>
+        <valueField/>
+        <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
       </documents>
       <interval>
         <cache>0</cache>
@@ -123,13 +134,14 @@
         <multiSelect>1</multiSelect>
         <name>users</name>
         <number>5</number>
+        <picker>1</picker>
         <prettyName>User List</prettyName>
         <relationalStorage>1</relationalStorage>
         <separator> </separator>
         <size>80</size>
         <sql/>
         <unmodifiable>0</unmodifiable>
-        <classType>com.xpn.xwiki.objects.classes.DBListClass</classType>
+        <classType>com.xpn.xwiki.objects.classes.UsersClass</classType>
       </users>
       <wikis>
         <cache>0</cache>
@@ -517,13 +529,29 @@
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </phone>
       <skin>
+        <cache>0</cache>
+        <classname/>
+        <customDisplay/>
         <disabled>0</disabled>
+        <displayType>input</displayType>
+        <hint/>
+        <idField/>
+        <multiSelect>0</multiSelect>
         <name>skin</name>
         <number>19</number>
+        <picker>1</picker>
         <prettyName>skin</prettyName>
         <size>30</size>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators/>
+        <sort>none</sort>
+        <sql/>
         <unmodifiable>0</unmodifiable>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+        <validationMessage/>
+        <validationRegExp/>
+        <valueField/>
+        <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
       </skin>
       <timezone>
         <customDisplay>{{velocity}}


### PR DESCRIPTION
### Issue

https://jira.xwiki.org/browse/XWIKI-15452
http://design.xwiki.org/xwiki/bin/view/Proposal/AutocompleteOnReference

### Changes

* Introduce a generic page picker.
* Use the Page / User property on these fields:
  * XWiki.SearchSuggestSourceClass
    * Service
  * Global Administration: Export
    * Author
  * XWiki.DeletedDocuments
    * Livetable: page type
  * Class editor (Lists)
    * XWiki Class Name
  * XWiki.XWikiUsers
    * Skin
  * XWiki.XWikiServerClass
    * Home page
  * WikiManager.AdminWikiDescriptorSheet (Global Administration: Descriptor)
    * Home page
  * XWiki.XWikiPreferences
    * Parent Space
    * Skin
    * Right/Left panels
    * Internationalization Document Bundles
  * XWiki.XWikiComments
    * Author (also fix how comment authors are being displayed)
    * Target
  * XWiki.WatchListJobClass
    * Template
  * XWiki.WatchListClass
    * Documents
    * Users
  * XWiki.Notifications.Code.NotificationFilterPreferenceClass
    * Users
    * Pages
  * XWiki.TemplateProviderClass
    * Template
  * XWiki.RedirectClass
    * Location
  * XWiki.Registration
    * Default redirect
  * XWiki.FeedEntryClass
    * Author
  * XWiki.ConfigurableClass
    * Configuration class
  * XWiki.DocumentSheetBinding
    * Sheet
  * XWiki.ClassSheetBinding
    * Sheet
  * AppWithinMinutes.MetadataClass
    * Data space name
  * AppWithinMinutes.LiveTableClass
    * Class
    * Data space
  * WikiManager.WikiCandidateMemberClass
    * User Name
    * Reviewer
  * PanelsCode.NavigationConfigurationClass
    * Inclusions
    * Exclusions
  * Invitation.WebHome
    * Email Class
    * Email Container
  * Invitation.InvitationMailClass
    * Sending User

### Notes

This PR is meant to add an autocomplete support to most of the inputs listed in [this design page](http://design.xwiki.org/xwiki/bin/view/Proposal/AutocompleteOnReference).

Here is a list of tasks, from the design page, that have not (or partially) been taken care of:
1. [Template: Docextra](https://design.xwiki.org/xwiki/bin/view/Proposal/AutocompleteOnReference#HTemplate:Docextra)
    Out of scope.
2. [XWiki.XWikiUsers](https://design.xwiki.org/xwiki/bin/view/Proposal/AutocompleteOnReference#HClass:XWiki.XWikiUsers)
    We might need another picker to suggest attachments on the Avatar field.
3. [App: Page Index](https://design.xwiki.org/xwiki/bin/view/Proposal/AutocompleteOnReference#HApp:PageIndex)
    *Deleted Pages*: the search input of the *Page* column doesn't suggest deleted documents.
    *Deleted Attachments*: suggest attachments problem.
4. [XWiki.XWikiPreferences](https://design.xwiki.org/xwiki/bin/view/Proposal/AutocompleteOnReference#HClass:XWiki.XWikiPreferences2BAdministration:Look26Feel-Themes2CPanels)
    The page picker hasn't been implemented for the *Skin* field of the Administration page (see the screenshot of the design page).
5. [XWiki.XWikiGroups](https://design.xwiki.org/xwiki/bin/view/Proposal/AutocompleteOnReference#HClass:XWiki.XWikiGroups)
    The Member property can take either a User or a Group entity.
6. No suggest for *Wiki* and *Space* properties for:
    * [XWiki.WatchListClass](https://design.xwiki.org/xwiki/bin/view/Proposal/AutocompleteOnReference#HClass:XWiki.WatchListClass)
    * [XWiki.Notifications.Code.NotificationFilterPreferenceClass](https://design.xwiki.org/xwiki/bin/view/Proposal/AutocompleteOnReference#HClass:XWiki.Notifications.Code.NotificationFilterPreferenceClass)
    * [XWiki.TemplateProviderClass](https://design.xwiki.org/xwiki/bin/view/Proposal/AutocompleteOnReference#HClass:XWiki.TemplateProviderClass)
7. [TourCode.TourClass + TourCode.StepClass](https://design.xwiki.org/xwiki/bin/view/Proposal/AutocompleteOnReference#HClass:TourCode.TourClass2BTourCode.StepClass2BApp:Tour)
    Need to make the change directly in the [tour application](https://github.com/xwiki-contrib/application-tour).
8. [Create, Copy, Rename - Advanced](https://design.xwiki.org/xwiki/bin/view/Proposal/AutocompleteOnReference#HCreate2CCopy2CRename-Advanced)
    Need to recreate or change the location picker.
9. [Inputs inside WYSIWYG macros](https://design.xwiki.org/xwiki/bin/view/Proposal/AutocompleteOnReference#HWYIWYGMacros)
    Requires a different work from what was done here. Another PR will be made.

Some page properties might need a custom SQL query (to apply a filter):
* *Skin* properties? (e.g. XWiki.XWikiPreferences > Skin)
* *Space* properties? (e.g. XWiki.XWikiPreferences > Parent Space)

The [json/xml response](https://github.com/xwiki/xwiki-platform/blob/a196061711ff91fc9f7e2f038e464709a3b55b43/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/pagesuggest.vm) generated by the generic page picker has been implemented in the same way as [the one for users and groups](https://github.com/xwiki/xwiki-platform/blob/master/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/uorgsuggest.vm). Using the REST API on [`wikis/query`](https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/Features/XWikiRESTfulAPI#H2Fwikis2Fquery3Fq3D7Bquery7D26wikis3DwikiList5B26distinct3D7Btrue2Cfalse7D5D5B26order3D7Basc2Cdesc7D5D5B26start3Dn5D5B26number3Dn5D5B26prettyNames3D7Btrue2Cfalse7D5D) would have create inconsistencies between the results of the generic page picker and the ones of the page picker used for property values ([`/wikis/{wikiName}/classes/{className}/properties/{property}/values`](https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/Features/XWikiRESTfulAPI#H2Fwikis2F7BwikiName7D2Fclasses2F7BclassName7D2Fproperties2F7Bproperty7D2Fvalues)). I think it would have been better to have a common / generic API instead of duplicating code.

Another point is that an input from the class editor now support the autocomplete. A problem will occur if a user tries, for instance, to create a Page property inside an empty class. The related input will be shown like this:
![image](https://user-images.githubusercontent.com/2213999/43718346-ac3151d6-998a-11e8-9b0b-a2f4a317df59.png)
instead of
![image](https://user-images.githubusercontent.com/2213999/43718590-63ff649c-998b-11e8-9967-01e71bf67526.png)

The problem is that the javascript file (`suggestPages.js`) is not fetched by the AJAX call once the created property is displayed. It would be nice to use the [same mechanism](https://github.com/xwiki/xwiki-platform/blob/master/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/editors/dataeditors.js#L159-L176) as the object editor.

Edit: Also can't properly look for the Main.WebHome page on the page picker.