### PR TITLE
XWIKI-15492: XWiki.ClassSheet generates sheets which double escape the special characters in the document titles upon usage of the sheet

### DIFF
--- a/xwiki-platform-core/xwiki-platform-xclass/xwiki-platform-xclass-ui/src/main/resources/XWiki/ClassSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-xclass/xwiki-platform-xclass-ui/src/main/resources/XWiki/ClassSheet.xml
@@ -233,7 +233,7 @@
           ## FIXME: Use a dedicated escape tool method when XCOMMONS-405 is implemented.
           #set ($sheetContent = $escapetool.xml($sheetContent).replaceAll("\n", '&amp;#10;'))
           &lt;input type="hidden" name="content" value="$sheetContent"/&gt;
-          &lt;input type="hidden" name="title" value="${escapetool.h}if(${escapetool.d}doc.name == '$escapetool.xml($defaultClassSheetReference.name)')$escapetool.xml($className) Sheet${escapetool.h}{else}${escapetool.d}services.display.title(${escapetool.d}doc, {'displayerHint': 'default'})${escapetool.h}end"/&gt;
+          &lt;input type="hidden" name="title" value="${escapetool.h}if(${escapetool.d}doc.name == '$escapetool.xml($defaultClassSheetReference.name)')$escapetool.xml($className) Sheet${escapetool.h}{else}${escapetool.d}services.display.title(${escapetool.d}doc, {'displayerHint': 'default', 'outputSyntaxId': 'plain/1.0'})${escapetool.h}end"/&gt;
           &lt;span class="buttonwrapper"&gt;&lt;input type="submit" value="Create the sheet" class="button"/&gt;&lt;/span&gt;
         &lt;/div&gt;
       &lt;/form&gt;


### PR DESCRIPTION
### Issue

https://jira.xwiki.org/browse/XWIKI-15492

### Change

* Avoid escaping html entities twice.