### PR TITLE
XWIKI-15452: Use auto-suggestion on xproperties that can support it

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/SearchSuggestSourceClass.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/SearchSuggestSourceClass.xml
@@ -145,17 +145,29 @@
       <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
     </resultsNumber>
     <url>
+      <cache>0</cache>
+      <classname/>
       <customDisplay/>
       <disabled>0</disabled>
+      <displayType>input</displayType>
+      <hint/>
+      <idField/>
+      <multiSelect>0</multiSelect>
       <name>url</name>
       <number>3</number>
-      <picker>0</picker>
+      <picker>1</picker>
       <prettyName>Service</prettyName>
+      <relationalStorage>0</relationalStorage>
+      <separator> </separator>
+      <separators/>
       <size>30</size>
+      <sort>none</sort>
+      <sql/>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      <valueField/>
+      <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
     </url>
   </class>
   <object>


### PR DESCRIPTION
### Issue

https://jira.xwiki.org/browse/XWIKI-15452

### Change

* Use a Page field on the Service property of the Search Suggest class.

### Result

![image](https://user-images.githubusercontent.com/2213999/44527877-6a3ff500-a6e8-11e8-91ae-827cf86b6edb.png)

### Note

This change was taken from #803.
The page picker used is the default one and does not include hidden pages (even though the user enabled it, since https://github.com/xwiki/xwiki-platform/commit/be171e02c8d60025a652307f116bdbb0c65d77c3#diff-6f2ffb743b760b87c60b2a806239c4ffR72).
There is also no sql filters regarding the suggested page list (which means all pages of the wiki are suggested).