### PR TITLE
XWIKI-15536: Error while performing certain requests on the Search resources REST API

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-rest/src/main/java/org/xwiki/search/solr/internal/rest/SOLRSearchSource.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-rest/src/main/java/org/xwiki/search/solr/internal/rest/SOLRSearchSource.java
@@ -194,9 +194,8 @@ public class SOLRSearchSource extends AbstractSearchSource
                                 spaces, searchResult.getPageName()).toString();
                 } else {
                     searchResult.setLanguage(docLocale.toString());
-                    pageUri =
-                        Utils.createURI(uriInfo.getBaseUri(), PageTranslationResource.class, spaces,
-                                searchResult.getPageName(), docLocale).toString();
+                    pageUri = Utils.createURI(uriInfo.getBaseUri(), PageTranslationResource.class,
+                        searchResult.getWiki(), spaces, searchResult.getPageName(), docLocale).toString();
                 }
 
                 Link pageLink = new Link();


### PR DESCRIPTION
### Issue

https://jira.xwiki.org/browse/XWIKI-15536

### Change

* Add missing path element (wiki) when creating the URI of a translated page in the rest Solr Search.