### PR TITLE
XWIKI-15452: Use auto-suggestion on xproperties that can support it

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminThemesSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminThemesSheet.xml
@@ -211,7 +211,7 @@ $xwiki.jsx.use('XWiki.AdminThemesSheet')
    */
   var customizeSkin = new CustomizeButton(
     $('label.skin a'),
-    $('input[name="XWiki.XWikiPreferences_0_skin"]'),
+    $('select[name="XWiki.XWikiPreferences_0_skin"]'),
     'view'
   );
 });

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/commentsinline.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/commentsinline.vm
@@ -141,15 +141,16 @@ $xwiki.ssfx.use('uicomponents/viewers/comments.css', true)
   #if ("$!commentSelection" != "")
     #set($isAnnotation = true)
   #end
+  #set ($commentAuthor = $comment.getValue('author'))
   ## An empty comment author means that the comment author is a guest.
   ## This variable should be true only for an authenticate user that matches the comment author.
   ## We don't allow guests to be edit or delete comments because we can't know if they are the comment author.
-  #set ($isUserComment = $comment.author != '' && $services.model.resolveDocument($comment.author, 'user') == $xcontext.userReference)
+  #set ($isUserComment = $commentAuthor != '' && $services.model.resolveDocument($commentAuthor, 'user') == $xcontext.userReference)
   <div id="xwikicomment_${comment.number}" class="xwikicomment  #if($comment.getProperty('author').value == $doc.creator) commentByCreator#end#if($isAnnotation) annotation#end">
-    <div class="commentavatar">#if("$!comment.replyto" == '')#largeUserAvatar($comment.author)#{else}#mediumUserAvatar($comment.author)#end</div>
+    <div class="commentavatar">#if("$!comment.replyto" == '')#largeUserAvatar($commentAuthor)#{else}#mediumUserAvatar($commentAuthor)#end</div>
     <div class="commentheader">
       <div>
-      <span class="commentauthor">$!xwiki.getUserName($comment.getValue('author'))</span>##
+      <span class="commentauthor">$!xwiki.getUserName($commentAuthor)</span>##
       #set($date = $comment.getProperty('date').value)
 ## Don't indent, otherwise the comma will be misplaced
 #if($date), <span class="commentdate">$!xwiki.formatDate($date)</span>#end
@@ -260,13 +261,14 @@ $xwiki.ssfx.use('uicomponents/viewers/comments.css', true)
 ##
 ##
 #macro(displayEditCommentForm $comment)
-  #if($services.model.resolveDocument($comment.author, 'current') == $xcontext.userReference || $hasAdmin)
+  #set ($commentAuthor = $comment.getValue('author'))
+  #if($services.model.resolveDocument($commentAuthor, 'current') == $xcontext.userReference || $hasAdmin)
   <form action="$doc.getURL('commentsave')" method="post" class="edit-xcomment reply">
-    <div id="xwikicomment_${comment.number}" class="xwikicomment#if($comment.getProperty('author').value == $doc.creator) commentByCreator#end">
-    <div class="commentavatar">#if("$!comment.replyto" == '')#largeUserAvatar($comment.author)#{else}#mediumUserAvatar($comment.author)#end</div>
+    <div id="xwikicomment_${comment.number}" class="xwikicomment#if($commentAuthor == $doc.creator) commentByCreator#end">
+    <div class="commentavatar">#if("$!comment.replyto" == '')#largeUserAvatar($commentAuthor)#{else}#mediumUserAvatar($commentAuthor)#end</div>
     <div class="commentheader">
       <div>
-      <span class="commentauthor">$!xwiki.getUserName($comment.getValue('author'))</span>##
+      <span class="commentauthor">$!xwiki.getUserName($commentAuthor)</span>##
 ## Don't indent, otherwise the comma will be misplaced
 #set($date = $comment.getProperty('date').value)##
 #if($date), <span class="commentdate">$!xwiki.formatDate($date)</span>#end

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/editor/ObjectEditPane.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/editor/ObjectEditPane.java
@@ -71,10 +71,10 @@ public class ObjectEditPane extends FormElement
     }
 
     /**
-     * @param userPropertyName the name of a property of type List of Users
-     * @return a user picker for a property of type List of Users
+     * @param userPropertyName the name of a property
+     * @return a {@link SuggestInputElement suggest input} for the given property
      */
-    public SuggestInputElement getUserPicker(String userPropertyName)
+    public SuggestInputElement getSuggestInput(String userPropertyName)
     {
         return new SuggestInputElement(
             getDriver().findElementWithoutWaiting(getForm(), byPropertyName(userPropertyName)));

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-selenium/src/test/it/org/xwiki/test/selenium/AdministrationTest.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-selenium/src/test/it/org/xwiki/test/selenium/AdministrationTest.java
@@ -21,12 +21,14 @@ package org.xwiki.test.selenium;
 
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 import org.xwiki.administration.test.po.AdministrationMenu;
 import org.xwiki.model.reference.LocalDocumentReference;
 import org.xwiki.rest.model.jaxb.Page;
 import org.xwiki.test.selenium.framework.AbstractXWikiTestCase;
 import org.xwiki.test.ui.TestUtils;
+import org.xwiki.test.ui.po.SuggestInputElement;
 
 import static org.junit.Assert.*;
 
@@ -232,7 +234,9 @@ public class AdministrationTest extends AbstractXWikiTestCase
         clickButtonAndContinue("//input[@name='action_objectadd']");
         setFieldValue("XWiki.ConfigurableClass_1_displayInSection", "TestSection2");
         setFieldValue("XWiki.ConfigurableClass_1_heading", "Some Other Heading");
-        setFieldValue("XWiki.ConfigurableClass_1_configurationClass", space + "." + page);
+        SuggestInputElement configurationSuggest = new SuggestInputElement(getDriver()
+            .findElementById("XWiki.ConfigurableClass_1_configurationClass"));
+        configurationSuggest.sendKeys(space + "." + page).waitForSuggestions().sendKeys(Keys.ENTER);
         getSelenium().uncheck("XWiki.ConfigurableClass_1_configureGlobally");
         // Set propertiesToShow so that each config only shows half of the properties.
         setFieldValue("XWiki.ConfigurableClass_1_propertiesToShow", "TextArea, Select");
@@ -408,7 +412,9 @@ public class AdministrationTest extends AbstractXWikiTestCase
         expandObject("XWiki.ConfigurableClass", 0);
         setFieldValue("XWiki.ConfigurableClass_0_codeToExecute", codeToExecute);
         setFieldValue("XWiki.ConfigurableClass_0_heading", heading);
-        setFieldValue("XWiki.ConfigurableClass_0_configurationClass", "");
+        SuggestInputElement configurationSuggest = new SuggestInputElement(getDriver()
+            .findElementById("XWiki.ConfigurableClass_0_configurationClass"));
+        configurationSuggest.clear();
         clickEditSaveAndView();
 
         Page restPage = getUtil().rest().get(new LocalDocumentReference("XWiki", "ConfigurableClass"));
@@ -453,7 +459,9 @@ public class AdministrationTest extends AbstractXWikiTestCase
         createConfigurableApplication(space, page, "TestSection1", true);
         open(space, page, "edit", "editor=object");
         expandObject("XWiki.ConfigurableClass", 0);
-        setFieldValue("XWiki.ConfigurableClass_0_configurationClass", "");
+        SuggestInputElement configurationSuggest = new SuggestInputElement(getDriver()
+            .findElementById("XWiki.ConfigurableClass_0_configurationClass"));
+        configurationSuggest.clear();
         setFieldValue("XWiki.ConfigurableClass_0_codeToExecute", test);
         clickEditSaveAndView();
 
@@ -482,7 +490,9 @@ public class AdministrationTest extends AbstractXWikiTestCase
         getSelenium().select("classname", "value=XWiki.ConfigurableClass");
         clickButtonAndContinue("//input[@name='action_objectadd']");
         setFieldValue("XWiki.ConfigurableClass_1_displayInSection", "TestSection1");
-        setFieldValue("XWiki.ConfigurableClass_1_configurationClass", space + "." + page);
+        SuggestInputElement configurationSuggest = new SuggestInputElement(getDriver()
+            .findElementById("XWiki.ConfigurableClass_1_configurationClass"));
+        configurationSuggest.sendKeys(space + "." + page).waitForSuggestions().sendKeys(Keys.ENTER);
         setFieldValue("XWiki.ConfigurableClass_1_propertiesToShow", "TextArea, Select");
         setFieldValue("XWiki.ConfigurableClass_1_codeToExecute", test);
         getSelenium().check("XWiki.ConfigurableClass_1_configureGlobally");
@@ -644,7 +654,9 @@ public class AdministrationTest extends AbstractXWikiTestCase
 
         setFieldValue("XWiki.ConfigurableClass_0_displayInSection", section);
         setFieldValue("XWiki.ConfigurableClass_0_heading", "Some Heading");
-        setFieldValue("XWiki.ConfigurableClass_0_configurationClass", space + "." + page);
+        SuggestInputElement configurationSuggest = new SuggestInputElement(getDriver()
+            .findElementById("XWiki.ConfigurableClass_0_configurationClass"));
+        configurationSuggest.sendKeys(space + "." + page).waitForSuggestions().sendKeys(Keys.ENTER);
         
         // Unfold the XWiki.ConfigurableClass object so that we can modify its properties
         WebElement configurableClassObj = getDriver().findElement(By.id("xobject_XWiki.ConfigurableClass_0"));

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/src/test/it/org/xwiki/test/ui/EditObjectsTest.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/src/test/it/org/xwiki/test/ui/EditObjectsTest.java
@@ -340,12 +340,12 @@ public class EditObjectsTest extends AbstractTest
         ObjectEditPage objectEditor = ObjectEditPage.gotoPage(getTestClassName(), getTestMethodName());
         ObjectEditPane object = objectEditor.addObject(className);
         object.openDatePicker("date").setDay("15").close();
-        object.getUserPicker("author").sendKeys("ad").waitForSuggestions().selectByVisibleText("Administrator");
+        object.getSuggestInput("author").sendKeys("ad").waitForSuggestions().selectByVisibleText("Administrator");
 
         // Save, edit again and check the values.
         object = objectEditor.clickSaveAndView().editObjects().getObjectsOfClass(className).get(0);
         Assert.assertEquals("15", object.openDatePicker("date").getDay());
-        SuggestionElement author = object.getUserPicker("author").getSelectedSuggestions().get(0);
+        SuggestionElement author = object.getSuggestInput("author").getSelectedSuggestions().get(0);
         Assert.assertEquals("Administrator", author.getLabel());
         Assert.assertEquals("XWiki.Admin", author.getValue());
     }

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/src/test/it/org/xwiki/test/ui/PreviewTest.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/src/test/it/org/xwiki/test/ui/PreviewTest.java
@@ -23,8 +23,10 @@ import static org.junit.Assert.*;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.openqa.selenium.Keys;
 import org.xwiki.model.reference.LocalDocumentReference;
 import org.xwiki.test.ui.po.InlinePage;
+import org.xwiki.test.ui.po.SuggestInputElement;
 import org.xwiki.test.ui.po.editor.ClassEditPage;
 import org.xwiki.test.ui.po.editor.ObjectEditPage;
 import org.xwiki.test.ui.po.editor.ObjectEditPane;
@@ -74,8 +76,9 @@ public class PreviewTest extends AbstractTest
         // Bind the class to the sheet.
         ObjectEditPage objectEditor = ObjectEditPage.gotoPage(getTestClassName(), getTestMethodName() + "Class");
         ObjectEditPane objectEditPane = objectEditor.addObject("XWiki.ClassSheetBinding");
-        objectEditPane.setFieldValue(objectEditPane.byPropertyName("sheet"), getTestClassName() + "."
-            + getTestMethodName() + "Sheet");
+        SuggestInputElement sheetPicker = objectEditPane.getSuggestInput("sheet");
+        sheetPicker.sendKeys(getTestClassName() + "." + getTestMethodName() + "Sheet").waitForSuggestions()
+            .sendKeys(Keys.ENTER);
         objectEditor.clickSaveAndContinue();
 
         // Create the template.


### PR DESCRIPTION
### Issue

https://jira.xwiki.org/browse/XWIKI-15452

### Changes

* Fix selector for the XWikiPreferences Skin input.
* Use the value of the author property instead of its display for comments.
* Rename the getUserPicker method as it can be used for other suggest inputs.
* Fix some failing tests.