### PR TITLE
misc: Fix pseudo-tested method in xwiki-platform-resource-default

### DIFF
--- a/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-default/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-default/pom.xml
@@ -32,8 +32,8 @@
   <packaging>jar</packaging>
   <description>Default implementation of the Resource API and some default Resources</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.73</xwiki.jacoco.instructionRatio>
-    <xwiki.pitest.mutationThreshold>62</xwiki.pitest.mutationThreshold>
+    <xwiki.jacoco.instructionRatio>0.76</xwiki.jacoco.instructionRatio>
+    <xwiki.pitest.mutationThreshold>70</xwiki.pitest.mutationThreshold>
     <!-- Name to display by the Extension Manager -->
     <xwiki.extension.name>Default Resource Implementation</xwiki.extension.name>
   </properties>

--- a/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-default/src/main/java/org/xwiki/resource/internal/entity/DefaultEntityResourceActionLister.java
+++ b/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-default/src/main/java/org/xwiki/resource/internal/entity/DefaultEntityResourceActionLister.java
@@ -71,21 +71,27 @@ public class DefaultEntityResourceActionLister implements EntityResourceActionLi
     @Named("context")
     private Provider<ComponentManager> contextComponentManagerProvider;
 
-    @Override
-    public void initialize() throws InitializationException
+    protected SAXBuilder createSAXBuilder()
     {
-        // Parse the Struts config file (struts-config.xml) to extract all available actions
-        List<String> actionNames = new ArrayList<>();
         SAXBuilder builder = new SAXBuilder();
 
         // Make sure we don't require an Internet Connection to parse the Struts config file!
         builder.setEntityResolver(new EntityResolver() {
             @Override public InputSource resolveEntity(String publicId, String systemId)
-                throws SAXException, IOException
+                    throws SAXException, IOException
             {
                 return new InputSource(new StringReader(""));
             }
         });
+
+        return builder;
+    }
+
+    @Override
+    public void initialize() throws InitializationException
+    {
+        // Parse the Struts config file (struts-config.xml) to extract all available actions
+        List<String> actionNames = new ArrayList<>();
 
         // Step 1: Get a stream on the Struts config file if it exists
         InputStream strutsConfigStream = this.environment.getResourceAsStream(getStrutsConfigResource());
@@ -94,7 +100,7 @@ public class DefaultEntityResourceActionLister implements EntityResourceActionLi
             // Step 2: Parse the Strust config file, looking for action names
             Document document;
             try {
-                document = builder.build(strutsConfigStream);
+                document = createSAXBuilder().build(strutsConfigStream);
             } catch (JDOMException | IOException e) {
                 throw new InitializationException(
                     String.format("Failed to parse Struts Config file [%s]", getStrutsConfigResource()), e);

--- a/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-default/src/test/java/org/xwiki/resource/internal/MainResourceReferenceHandlerManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-default/src/test/java/org/xwiki/resource/internal/MainResourceReferenceHandlerManagerTest.java
@@ -21,14 +21,15 @@ package org.xwiki.resource.internal;
 
 import java.util.Arrays;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xwiki.component.manager.ComponentManager;
 import org.xwiki.component.util.DefaultParameterizedType;
 import org.xwiki.resource.ResourceReference;
 import org.xwiki.resource.ResourceReferenceHandler;
 import org.xwiki.resource.ResourceReferenceHandlerChain;
 import org.xwiki.resource.ResourceType;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.mockito.MockitoComponentMockingRule;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -42,14 +43,14 @@ import static org.mockito.Mockito.*;
  * @version $Id$
  * @since 6.1M2
  */
+@ComponentTest
 public class MainResourceReferenceHandlerManagerTest
 {
-    @Rule
-    public MockitoComponentMockingRule<MainResourceReferenceHandlerManager> componentManager =
-        new MockitoComponentMockingRule<>(MainResourceReferenceHandlerManager.class);
+    @InjectMockComponents
+    public MainResourceReferenceHandlerManager handlerManager;
 
     @Test
-    public void handleWithOrder() throws Exception
+    public void handleWithOrder(ComponentManager componentManager) throws Exception
     {
         // First Handler component will lower priority
         ResourceReferenceHandler testHandler = mock(ResourceReferenceHandler.class, "handler1");
@@ -61,7 +62,7 @@ public class MainResourceReferenceHandlerManagerTest
         // We return 1 to mean that the second Handler has a higher priority than the first Handler
         when(beforeTestHandler.compareTo(testHandler)).thenReturn(-1);
 
-        ComponentManager contextComponentManager = this.componentManager.getInstance(ComponentManager.class, "context");
+        ComponentManager contextComponentManager = componentManager.getInstance(ComponentManager.class, "context");
         when(contextComponentManager.<ResourceReferenceHandler>getInstanceList(
             new DefaultParameterizedType(null, ResourceReferenceHandler.class, ResourceType.class)))
                 .thenReturn(Arrays.asList(testHandler, beforeTestHandler));
@@ -69,7 +70,7 @@ public class MainResourceReferenceHandlerManagerTest
         ResourceReference reference = mock(ResourceReference.class);
         when(reference.getType()).thenReturn(new ResourceType("test"));
 
-        this.componentManager.getComponentUnderTest().handle(reference);
+        handlerManager.handle(reference);
 
         // Verify that the second Action is called (since it has a higher priority).
         verify(beforeTestHandler).handle(same(reference), any(ResourceReferenceHandlerChain.class));

--- a/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-default/src/test/java/org/xwiki/resource/internal/MainResourceReferenceHandlerManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-default/src/test/java/org/xwiki/resource/internal/MainResourceReferenceHandlerManagerTest.java
@@ -32,6 +32,8 @@ import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.mockito.MockitoComponentMockingRule;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
@@ -47,7 +49,7 @@ import static org.mockito.Mockito.*;
 public class MainResourceReferenceHandlerManagerTest
 {
     @InjectMockComponents
-    public MainResourceReferenceHandlerManager handlerManager;
+    private MainResourceReferenceHandlerManager handlerManager;
 
     @Test
     public void handleWithOrder(ComponentManager componentManager) throws Exception
@@ -74,5 +76,23 @@ public class MainResourceReferenceHandlerManagerTest
 
         // Verify that the second Action is called (since it has a higher priority).
         verify(beforeTestHandler).handle(same(reference), any(ResourceReferenceHandlerChain.class));
+    }
+
+    @Test
+    public void matches()
+    {
+        ResourceReferenceHandler resourceReferenceHandler1 = mock(ResourceReferenceHandler.class);
+        ResourceReferenceHandler resourceReferenceHandler2 = mock(ResourceReferenceHandler.class);
+        ResourceType resourceType1 = new ResourceType("test1");
+        ResourceType resourceType2 = new ResourceType("test2");
+
+        when(resourceReferenceHandler1.getSupportedResourceReferences()).thenReturn(Arrays.asList(resourceType1));
+        when(resourceReferenceHandler2.getSupportedResourceReferences()).thenReturn(Arrays.asList(resourceType1, resourceType2));
+
+        assertTrue(handlerManager.matches(resourceReferenceHandler1, resourceType1));
+        assertFalse(handlerManager.matches(resourceReferenceHandler1, resourceType2));
+
+        assertTrue(handlerManager.matches(resourceReferenceHandler2, resourceType1));
+        assertTrue(handlerManager.matches(resourceReferenceHandler2, resourceType2));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-default/src/test/java/org/xwiki/resource/internal/entity/DefaultEntityResourceActionListerTest.java
+++ b/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-default/src/test/java/org/xwiki/resource/internal/entity/DefaultEntityResourceActionListerTest.java
@@ -19,11 +19,18 @@
  */
 package org.xwiki.resource.internal.entity;
 
+import java.io.IOException;
+import java.io.StringReader;
+
 import javax.inject.Provider;
 
+import org.jdom2.input.SAXBuilder;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xwiki.component.manager.ComponentLookupException;
 import org.xwiki.component.manager.ComponentManager;
 import org.xwiki.component.util.DefaultParameterizedType;
 import org.xwiki.environment.Environment;
@@ -31,6 +38,8 @@ import org.xwiki.resource.ResourceReferenceHandler;
 import org.xwiki.resource.entity.EntityResourceAction;
 import org.xwiki.test.mockito.MockitoComponentMockingRule;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.mockito.Mockito.*;
@@ -66,5 +75,12 @@ public class DefaultEntityResourceActionListerTest
             EntityResourceAction.class), "testaction");
 
         assertThat(this.mocker.getComponentUnderTest().listActions(), hasItems("view", "edit", "get", "testaction"));
+    }
+
+    @Test
+    public void createSAXBuilder() throws Exception
+    {
+        SAXBuilder saxBuilder = this.mocker.getComponentUnderTest().createSAXBuilder();
+        assertNotNull(saxBuilder.getEntityResolver().resolveEntity("foo", "bar"));
     }
 }


### PR DESCRIPTION
 * Refactor one test to use JUnit 5
 * Add a more exhaustive test on MainResourceReferenceHandlerManager
 * Extract a method and add a test for DefaultEntityResourceActionLister