### PR TITLE
misc: Fix pseudo-tested method in xwiki-platform-url-api

### DIFF
--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-api/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-api/pom.xml
@@ -34,8 +34,8 @@
   <properties>
     <!-- The reason for this low TPC value is because this module is tested using integration tests in the various
          URL Scheme modules -->
-    <xwiki.jacoco.instructionRatio>0.33</xwiki.jacoco.instructionRatio>
-    <xwiki.pitest.mutationThreshold>36</xwiki.pitest.mutationThreshold>
+    <xwiki.jacoco.instructionRatio>0.40</xwiki.jacoco.instructionRatio>
+    <xwiki.pitest.mutationThreshold>43</xwiki.pitest.mutationThreshold>
     <!-- Name to display by the Extension Manager -->
     <xwiki.extension.name>URL API</xwiki.extension.name>
   </properties>

--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-api/src/main/java/org/xwiki/url/ExtendedURL.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-api/src/main/java/org/xwiki/url/ExtendedURL.java
@@ -179,7 +179,7 @@ public class ExtendedURL implements Cloneable
         return this.parameters;
     }
 
-    private Map<String, List<String>> extractParameters(URI uri)
+    protected Map<String, List<String>> extractParameters(URI uri)
     {
         Map<String, List<String>> uriParameters;
         if (uri.getQuery() != null) {

--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-api/src/test/java/org/xwiki/url/ExtendedURLTest.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-api/src/test/java/org/xwiki/url/ExtendedURLTest.java
@@ -31,8 +31,12 @@ import org.xwiki.resource.CreateResourceReferenceException;
 
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -44,6 +48,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 public class ExtendedURLTest
 {
+    @Test
+    public void extractParameters() throws Exception
+    {
+        URL url = new URL("http://localhost:8080/xwiki/?foo=bar&toto&foo=baz");
+        ExtendedURL extendedURL = new ExtendedURL(url, null);
+        Map<String, List<String>> parameters = extendedURL.extractParameters(url.toURI());
+        assertThat(parameters, hasEntry(is("foo"), hasItems("bar", "baz")));
+        assertThat(parameters, hasEntry(is("toto"), is(empty())));
+    }
+
     @Test
     public void withoutPrefix() throws Exception
     {
@@ -110,6 +124,13 @@ public class ExtendedURLTest
         ExtendedURL extendedURL1 = new ExtendedURL(new URL("http://localhost:8080/some/path"), null);
         ExtendedURL extendedURL2 = new ExtendedURL(new URL("http://localhost:8080/some/path"), null);
         assertEquals(extendedURL1, extendedURL2);
+
+        ExtendedURL extendedURL3 = new ExtendedURL(new URL("http://localhost:8080/some/path"), "some");
+        ExtendedURL extendedURL4 = new ExtendedURL(new URL("http://localhost:8080/some"), null);
+
+        assertNotEquals(extendedURL1, extendedURL3);
+        assertNotEquals(extendedURL1, extendedURL4);
+        assertNotEquals(extendedURL3, extendedURL4);
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-api/src/test/java/org/xwiki/url/ExtendedURLTest.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-api/src/test/java/org/xwiki/url/ExtendedURLTest.java
@@ -26,12 +26,15 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xwiki.resource.CreateResourceReferenceException;
 
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for {@link ExtendedURL}.
@@ -95,12 +98,10 @@ public class ExtendedURLTest
     public void withInvalidPrefix() throws Exception
     {
         URL url = new URL("http://localhost:8080/some/path");
-        try {
+        Throwable exception = assertThrows(CreateResourceReferenceException.class, () -> {
             new ExtendedURL(url, "/xwiki");
-            fail("Should have thrown an exception here");
-        } catch (CreateResourceReferenceException e) {
-            assertEquals("URL Path [/some/path] doesn't start with [/xwiki]", e.getMessage());
-        }
+        });
+        assertEquals("URL Path [/some/path] doesn't start with [/xwiki]", exception.getMessage());
     }
 
     @Test
@@ -114,13 +115,11 @@ public class ExtendedURLTest
     @Test
     public void invalidURL() throws Exception
     {
-        try {
+        Throwable exception = assertThrows(CreateResourceReferenceException.class, () -> {
             // Invalid URL since the space in the page name isn't encoded.
             new ExtendedURL(new URL("http://host/xwiki/bin/view/space/page name"), null);
-            fail("Should have thrown an exception here");
-        } catch (CreateResourceReferenceException expected) {
-            assertEquals("Invalid URL [http://host/xwiki/bin/view/space/page name]", expected.getMessage());
-        }
+        });
+        assertEquals("Invalid URL [http://host/xwiki/bin/view/space/page name]", exception.getMessage());
     }
 
     @Test


### PR DESCRIPTION
 * Make `extractParameters` protected to be tested
 * Add a new test for extractParameters
 * Add new assertion for equality test
 * Fix thresholds
 * Refactor to JUnit5