### PR TITLE
XWIKI-15605: Auto-suggest control doesn't display correctly hidden pages

### DIFF
--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -398,6 +398,19 @@
                     "old": "parameter void org.xwiki.notifications.filters.watch.WatchedUserReference::<init>(java.lang.String, org.xwiki.notifications.filters.internal.user.EventUserFilterPreferencesGetter, ===org.xwiki.notifications.filters.NotificationFilterManager===)",
                     "new": "parameter void org.xwiki.notifications.filters.watch.WatchedUserReference::<init>(java.lang.String, org.xwiki.notifications.filters.internal.user.EventUserFilterPreferencesGetter, ===org.xwiki.notifications.filters.NotificationFilterPreferenceManager===)",
                     "justification": "Young API"
+                  },
+                  {
+                    "code": "java.method.numberOfParametersChanged",
+                    "old": "method org.xwiki.rest.model.jaxb.PropertyValues org.xwiki.rest.resources.classes.ClassPropertyValuesResource::getClassPropertyValues(java.lang.String, java.lang.String, java.lang.String, java.lang.Integer, java.util.List<java.lang.String>) throws org.xwiki.rest.XWikiRestException",
+                    "new": "method org.xwiki.rest.model.jaxb.PropertyValues org.xwiki.rest.resources.classes.ClassPropertyValuesResource::getClassPropertyValues(java.lang.String, java.lang.String, java.lang.String, java.lang.Integer, java.util.List<java.lang.String>, java.lang.Boolean) throws org.xwiki.rest.XWikiRestException",
+                    "package": "org.xwiki.rest.resources.classes",
+                    "classQualifiedName": "org.xwiki.rest.resources.classes.ClassPropertyValuesResource",
+                    "classSimpleName": "ClassPropertyValuesResource",
+                    "methodName": "getClassPropertyValues",
+                    "oldArchive": "org.xwiki.platform:xwiki-platform-rest-api:jar:10.7",
+                    "newArchive": "org.xwiki.platform:xwiki-platform-rest-api:jar:10.9-SNAPSHOT",
+                    "elementKind": "method",
+                    "justification": "Add an optional parameter to a REST API end point"
                   }
                 ]
               }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-api/src/main/java/org/xwiki/rest/resources/classes/ClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-api/src/main/java/org/xwiki/rest/resources/classes/ClassPropertyValuesProvider.java
@@ -22,6 +22,7 @@ package org.xwiki.rest.resources.classes;
 import org.xwiki.component.annotation.Role;
 import org.xwiki.model.reference.ClassPropertyReference;
 import org.xwiki.rest.XWikiRestException;
+import org.xwiki.rest.model.jaxb.PropertyValue;
 import org.xwiki.rest.model.jaxb.PropertyValues;
 import org.xwiki.stability.Unstable;
 
@@ -52,11 +53,11 @@ public interface ClassPropertyValuesProvider
      *
      * @param propertyReference the property to provide the value for
      * @param rawValue raw value used to resolve the property value
-     * @return the property value based on the raw value
+     * @return the property value based on the raw value or null if the raw value is empty
      * @throws XWikiRestException if retrieving the property value fails
      * @since 10.9RC1
      */
-    default PropertyValues getValue(ClassPropertyReference propertyReference, Object rawValue)
+    default PropertyValue getValue(ClassPropertyReference propertyReference, Object rawValue)
         throws XWikiRestException {
         throw new UnsupportedOperationException();
     }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-api/src/main/java/org/xwiki/rest/resources/classes/ClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-api/src/main/java/org/xwiki/rest/resources/classes/ClassPropertyValuesProvider.java
@@ -49,7 +49,7 @@ public interface ClassPropertyValuesProvider
         throws XWikiRestException;
 
     /**
-     * Provides the document specified by the filter as a property value.
+     * Resolves the given raw value into a {@link PropertyValue} of the specified class property.
      *
      * @param propertyReference the property to provide the value for
      * @param rawValue raw value used to resolve the property value

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-api/src/main/java/org/xwiki/rest/resources/classes/ClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-api/src/main/java/org/xwiki/rest/resources/classes/ClassPropertyValuesProvider.java
@@ -46,4 +46,16 @@ public interface ClassPropertyValuesProvider
      */
     PropertyValues getValues(ClassPropertyReference propertyReference, int limit, Object... filterParameters)
         throws XWikiRestException;
+
+    /**
+     * Provides the document specified by the filter as a property value.
+     *
+     * @param propertyReference the property to provide the value for
+     * @param filterParameters parameters used to get the document
+     * @return the value based on the filter
+     * @throws XWikiRestException if retrieving the property value fails
+     * @since 10.8
+     */
+    PropertyValues getValue(ClassPropertyReference propertyReference, Object... filterParameters)
+        throws XWikiRestException;
 }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-api/src/main/java/org/xwiki/rest/resources/classes/ClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-api/src/main/java/org/xwiki/rest/resources/classes/ClassPropertyValuesProvider.java
@@ -51,11 +51,13 @@ public interface ClassPropertyValuesProvider
      * Provides the document specified by the filter as a property value.
      *
      * @param propertyReference the property to provide the value for
-     * @param filterParameters parameters used to get the document
-     * @return the value based on the filter
+     * @param rawValue raw value used to resolve the property value
+     * @return the property value based on the raw value
      * @throws XWikiRestException if retrieving the property value fails
-     * @since 10.8
+     * @since 10.9RC1
      */
-    PropertyValues getValue(ClassPropertyReference propertyReference, Object... filterParameters)
-        throws XWikiRestException;
+    default PropertyValues getValue(ClassPropertyReference propertyReference, Object rawValue)
+        throws XWikiRestException {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-api/src/main/java/org/xwiki/rest/resources/classes/ClassPropertyValuesResource.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-api/src/main/java/org/xwiki/rest/resources/classes/ClassPropertyValuesResource.java
@@ -47,6 +47,7 @@ public interface ClassPropertyValuesResource
         @PathParam("className") String className,
         @PathParam("propertyName") String propertyName,
         @QueryParam("limit") @DefaultValue("100") Integer limit,
-        @QueryParam("fp") List<String> filterParameters
+        @QueryParam("fp") List<String> filterParameters,
+        @QueryParam("exactMatch") @DefaultValue("false") Boolean isExactMatch
     ) throws XWikiRestException;
 }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/AbstractClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/AbstractClassPropertyValuesProvider.java
@@ -93,16 +93,10 @@ public abstract class AbstractClassPropertyValuesProvider<T> implements ClassPro
     }
 
     @Override
-    public PropertyValues getValue(ClassPropertyReference propertyReference, Object rawValue)
+    public PropertyValue getValue(ClassPropertyReference propertyReference, Object rawValue)
         throws XWikiRestException
     {
-        PropertyValues propertyValues = new PropertyValues();
-        PropertyValue value = this.getValueFromQueryResult(rawValue, getPropertyDefinition(propertyReference));
-        if (value != null) {
-            propertyValues.getPropertyValues().add(value);
-        }
-
-        return propertyValues;
+        return this.getValueFromQueryResult(rawValue, getPropertyDefinition(propertyReference));
     }
 
     @SuppressWarnings("unchecked")

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/AbstractClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/AbstractClassPropertyValuesProvider.java
@@ -26,10 +26,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
 
-import org.xwiki.model.EntityType;
 import org.xwiki.model.reference.ClassPropertyReference;
-import org.xwiki.model.reference.DocumentReference;
-import org.xwiki.model.reference.DocumentReferenceResolver;
 import org.xwiki.model.reference.EntityReferenceSerializer;
 import org.xwiki.query.Query;
 import org.xwiki.query.QueryException;
@@ -70,9 +67,6 @@ public abstract class AbstractClassPropertyValuesProvider<T> implements ClassPro
     protected EntityReferenceSerializer<String> entityReferenceSerializer;
 
     @Inject
-    protected DocumentReferenceResolver<String> documentReferenceResolver;
-
-    @Inject
     @Named("text")
     private QueryFilter textFilter;
 
@@ -99,27 +93,15 @@ public abstract class AbstractClassPropertyValuesProvider<T> implements ClassPro
     }
 
     @Override
-    public PropertyValues getValue(ClassPropertyReference propertyReference, Object... filterParameters)
+    public PropertyValues getValue(ClassPropertyReference propertyReference, Object rawValue)
         throws XWikiRestException
     {
-        String filter = "";
-        if (filterParameters.length > 0 && filterParameters[0] != null) {
-            filter = filterParameters[0].toString();
-        }
-        if (StringUtils.isEmpty(filter)) {
-            return new PropertyValues();
+        PropertyValues propertyValues = new PropertyValues();
+        PropertyValue value = this.getValueFromQueryResult(rawValue, getPropertyDefinition(propertyReference));
+        if (value != null) {
+            propertyValues.getPropertyValues().add(value);
         }
 
-        PropertyValues propertyValues = new PropertyValues();
-        DocumentReference documentReference = documentReferenceResolver.resolve(filter, EntityType.DOCUMENT);
-        if (documentReference != null) {
-            PropertyValue value =
-                this.getValueFromQueryResult(documentReference, getPropertyDefinition(propertyReference));
-            if (value != null) {
-                value.setValue(filter);
-                propertyValues.getPropertyValues().add(value);
-            }
-        }
         return propertyValues;
     }
 

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/AbstractDocumentListClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/AbstractDocumentListClassPropertyValuesProvider.java
@@ -75,10 +75,10 @@ public abstract class AbstractDocumentListClassPropertyValuesProvider<T extends 
     private QueryFilter viewableFilter;
 
     @Inject
-    protected DocumentReferenceResolver<String> documentReferenceResolver;
+    private DocumentReferenceResolver<String> documentReferenceResolver;
 
     @Override
-    public PropertyValues getValue(ClassPropertyReference propertyReference, Object rawValue)
+    public PropertyValue getValue(ClassPropertyReference propertyReference, Object rawValue)
         throws XWikiRestException
     {
         String reference = "";
@@ -86,20 +86,17 @@ public abstract class AbstractDocumentListClassPropertyValuesProvider<T extends 
             reference = rawValue.toString();
         }
         if (StringUtils.isEmpty(reference)) {
-            return new PropertyValues();
+            return null;
         }
 
-        PropertyValues propertyValues = new PropertyValues();
         DocumentReference documentReference = documentReferenceResolver.resolve(reference, EntityType.DOCUMENT);
-        if (documentReference != null) {
-            PropertyValue value =
-                this.getValueFromQueryResult(documentReference, getPropertyDefinition(propertyReference));
-            if (value != null) {
-                value.setValue(reference);
-                propertyValues.getPropertyValues().add(value);
-            }
+        PropertyValue propertyValue =
+            this.getValueFromQueryResult(documentReference, getPropertyDefinition(propertyReference));
+        if (propertyValue != null) {
+            propertyValue.setValue(reference);
         }
-        return propertyValues;
+
+        return propertyValue;
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/AbstractDocumentListClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/AbstractDocumentListClassPropertyValuesProvider.java
@@ -90,8 +90,7 @@ public abstract class AbstractDocumentListClassPropertyValuesProvider<T extends 
         }
 
         DocumentReference documentReference = documentReferenceResolver.resolve(reference, EntityType.DOCUMENT);
-        PropertyValue propertyValue =
-            this.getValueFromQueryResult(documentReference, getPropertyDefinition(propertyReference));
+        PropertyValue propertyValue = super.getValue(propertyReference, documentReference);
         if (propertyValue != null) {
             propertyValue.setValue(reference);
         }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/AbstractDocumentListClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/AbstractDocumentListClassPropertyValuesProvider.java
@@ -24,14 +24,19 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.xwiki.icon.IconManager;
+import org.xwiki.model.EntityType;
+import org.xwiki.model.reference.ClassPropertyReference;
 import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.DocumentReferenceResolver;
 import org.xwiki.model.reference.EntityReferenceSerializer;
 import org.xwiki.model.reference.WikiReference;
 import org.xwiki.query.Query;
 import org.xwiki.query.QueryException;
 import org.xwiki.query.QueryFilter;
+import org.xwiki.rest.XWikiRestException;
 import org.xwiki.rest.model.jaxb.PropertyValue;
 import org.xwiki.rest.model.jaxb.PropertyValues;
 import org.xwiki.rest.resources.classes.ClassPropertyValuesProvider;
@@ -68,6 +73,34 @@ public abstract class AbstractDocumentListClassPropertyValuesProvider<T extends 
     @Inject
     @Named("viewable")
     private QueryFilter viewableFilter;
+
+    @Inject
+    protected DocumentReferenceResolver<String> documentReferenceResolver;
+
+    @Override
+    public PropertyValues getValue(ClassPropertyReference propertyReference, Object rawValue)
+        throws XWikiRestException
+    {
+        String reference = "";
+        if (rawValue != null) {
+            reference = rawValue.toString();
+        }
+        if (StringUtils.isEmpty(reference)) {
+            return new PropertyValues();
+        }
+
+        PropertyValues propertyValues = new PropertyValues();
+        DocumentReference documentReference = documentReferenceResolver.resolve(reference, EntityType.DOCUMENT);
+        if (documentReference != null) {
+            PropertyValue value =
+                this.getValueFromQueryResult(documentReference, getPropertyDefinition(propertyReference));
+            if (value != null) {
+                value.setValue(reference);
+                propertyValues.getPropertyValues().add(value);
+            }
+        }
+        return propertyValues;
+    }
 
     /**
      * A map sharing the same keys as the {@link org.xwiki.icon.IconManager#getMetaData icon metadata}.

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/ClassPropertyValuesResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/ClassPropertyValuesResourceImpl.java
@@ -67,7 +67,7 @@ public class ClassPropertyValuesResourceImpl extends XWikiResource implements Cl
 
     @Override
     public PropertyValues getClassPropertyValues(String wikiName, String className, String propertyName, Integer limit,
-        List<String> filterParameters) throws XWikiRestException
+        List<String> filterParameters, Boolean isExactMatch) throws XWikiRestException
     {
         DocumentReference classReference = this.resolver.resolve(className, new WikiReference(wikiName));
         ClassPropertyReference classPropertyReference = new ClassPropertyReference(propertyName, classReference);
@@ -84,8 +84,13 @@ public class ClassPropertyValuesResourceImpl extends XWikiResource implements Cl
         propertyLink.setHref(propertyURI.toString());
         propertyLink.setRel(Relations.PROPERTY);
 
-        PropertyValues propertyValues =
-            this.propertyValuesProvider.getValues(classPropertyReference, limit, filterParameters.toArray());
+        PropertyValues propertyValues;
+        if (isExactMatch) {
+            propertyValues = this.propertyValuesProvider.getValue(classPropertyReference, filterParameters.toArray());
+        } else {
+            propertyValues = this.propertyValuesProvider
+                .getValues(classPropertyReference, limit, filterParameters.toArray());
+        }
         propertyValues.getLinks().add(propertyLink);
 
         return propertyValues;

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/ClassPropertyValuesResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/ClassPropertyValuesResourceImpl.java
@@ -37,6 +37,7 @@ import org.xwiki.rest.XWikiResource;
 import org.xwiki.rest.XWikiRestException;
 import org.xwiki.rest.internal.Utils;
 import org.xwiki.rest.model.jaxb.Link;
+import org.xwiki.rest.model.jaxb.PropertyValue;
 import org.xwiki.rest.model.jaxb.PropertyValues;
 import org.xwiki.rest.resources.classes.ClassPropertyResource;
 import org.xwiki.rest.resources.classes.ClassPropertyValuesProvider;
@@ -87,9 +88,9 @@ public class ClassPropertyValuesResourceImpl extends XWikiResource implements Cl
         PropertyValues propertyValues = new PropertyValues();
         if (isExactMatch) {
             for (String filterParameter : filterParameters) {
-                PropertyValues values =  this.propertyValuesProvider.getValue(classPropertyReference, filterParameter);
-                if (values != null) {
-                    propertyValues.getPropertyValues().addAll(values.getPropertyValues());
+                PropertyValue value =  this.propertyValuesProvider.getValue(classPropertyReference, filterParameter);
+                if (value != null) {
+                    propertyValues.getPropertyValues().add(value);
                 }
             }
         } else {

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/ClassPropertyValuesResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/ClassPropertyValuesResourceImpl.java
@@ -84,9 +84,14 @@ public class ClassPropertyValuesResourceImpl extends XWikiResource implements Cl
         propertyLink.setHref(propertyURI.toString());
         propertyLink.setRel(Relations.PROPERTY);
 
-        PropertyValues propertyValues;
+        PropertyValues propertyValues = new PropertyValues();
         if (isExactMatch) {
-            propertyValues = this.propertyValuesProvider.getValue(classPropertyReference, filterParameters.toArray());
+            for (String filterParameter : filterParameters) {
+                PropertyValues values =  this.propertyValuesProvider.getValue(classPropertyReference, filterParameter);
+                if (values != null) {
+                    propertyValues.getPropertyValues().addAll(values.getPropertyValues());
+                }
+            }
         } else {
             propertyValues = this.propertyValuesProvider
                 .getValues(classPropertyReference, limit, filterParameters.toArray());

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/DefaultClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/DefaultClassPropertyValuesProvider.java
@@ -30,6 +30,7 @@ import org.xwiki.component.manager.ComponentManager;
 import org.xwiki.model.reference.ClassPropertyReference;
 import org.xwiki.model.reference.EntityReferenceSerializer;
 import org.xwiki.rest.XWikiRestException;
+import org.xwiki.rest.model.jaxb.PropertyValue;
 import org.xwiki.rest.model.jaxb.PropertyValues;
 import org.xwiki.rest.resources.classes.ClassPropertyValuesProvider;
 
@@ -69,7 +70,7 @@ public class DefaultClassPropertyValuesProvider implements ClassPropertyValuesPr
     }
 
     @Override
-    public PropertyValues getValue(ClassPropertyReference propertyReference, Object rawValue)
+    public PropertyValue getValue(ClassPropertyReference propertyReference, Object rawValue)
         throws XWikiRestException
     {
         return getDedicatedProvider(getPropertyType(propertyReference)).getValue(propertyReference, rawValue);

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/DefaultClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/DefaultClassPropertyValuesProvider.java
@@ -68,6 +68,13 @@ public class DefaultClassPropertyValuesProvider implements ClassPropertyValuesPr
             filterParameters);
     }
 
+    @Override
+    public PropertyValues getValue(ClassPropertyReference propertyReference, Object... filterParameters)
+        throws XWikiRestException
+    {
+        return getDedicatedProvider(getPropertyType(propertyReference)).getValue(propertyReference, filterParameters);
+    }
+
     private ClassPropertyValuesProvider getDedicatedProvider(String propertyType) throws XWikiRestException
     {
         try {

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/DefaultClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/DefaultClassPropertyValuesProvider.java
@@ -69,10 +69,10 @@ public class DefaultClassPropertyValuesProvider implements ClassPropertyValuesPr
     }
 
     @Override
-    public PropertyValues getValue(ClassPropertyReference propertyReference, Object... filterParameters)
+    public PropertyValues getValue(ClassPropertyReference propertyReference, Object rawValue)
         throws XWikiRestException
     {
-        return getDedicatedProvider(getPropertyType(propertyReference)).getValue(propertyReference, filterParameters);
+        return getDedicatedProvider(getPropertyType(propertyReference)).getValue(propertyReference, rawValue);
     }
 
     private ClassPropertyValuesProvider getDedicatedProvider(String propertyType) throws XWikiRestException

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/ClassPropertyValuesResourceImplTest.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/ClassPropertyValuesResourceImplTest.java
@@ -115,7 +115,7 @@ public class ClassPropertyValuesResourceImplTest
     public void getClassPropertyValuesUnauthorized() throws Exception
     {
         try {
-            this.resource.getClassPropertyValues("wiki", "Path.To.Class", "status", 6, Arrays.asList("text"));
+            this.resource.getClassPropertyValues("wiki", "Path.To.Class", "status", 6, Arrays.asList("text"), false);
             fail();
         } catch (WebApplicationException expected) {
             assertEquals(Status.UNAUTHORIZED.getStatusCode(), expected.getResponse().getStatus());
@@ -128,7 +128,7 @@ public class ClassPropertyValuesResourceImplTest
         when(this.authorization.hasAccess(Right.VIEW, this.propertyReference)).thenReturn(true);
 
         try {
-            this.resource.getClassPropertyValues("wiki", "Path.To.Class", "status", 6, Arrays.asList("text"));
+            this.resource.getClassPropertyValues("wiki", "Path.To.Class", "status", 6, Arrays.asList("text"), false);
             fail();
         } catch (WebApplicationException expected) {
             assertEquals(Status.NOT_FOUND.getStatusCode(), expected.getResponse().getStatus());
@@ -146,7 +146,8 @@ public class ClassPropertyValuesResourceImplTest
         when(propertyValuesProvider.getValues(this.propertyReference, 6, "one", "two")).thenReturn(values);
 
         assertSame(values,
-            this.resource.getClassPropertyValues("wiki", "Path.To.Class", "status", 6, Arrays.asList("one", "two")));
+            this.resource.getClassPropertyValues("wiki", "Path.To.Class", "status", 6, Arrays.asList("one", "two"),
+                false));
 
         assertEquals(1, values.getLinks().size());
         Link propertyLink = values.getLinks().get(0);

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/suggest/suggestPropertyValues.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/suggest/suggestPropertyValues.js
@@ -35,20 +35,27 @@ define('xwiki-suggestPropertyValues', ['jquery', 'xwiki-selectize'], function($)
       'properties', encodeURIComponent(select.attr('data-propertyName')),
       'values'
     ].join('/');
-    return {
-      create: true,
-      load: function(text, callback) {
-        $.getJSON(loadURL, {
-          'fp': text,
-          'limit': 10
-        }).then(function(response) {
+
+    var getLoad = function(getOptions) {
+      return function(text, callback) {
+        $.getJSON(loadURL, getOptions(text)).then(function(response) {
           if (response && $.isArray(response.propertyValues)) {
             return response.propertyValues.map(getSuggestion);
           } else {
             return [];
           }
         }).done(callback).fail(callback);
-      }
+      };
+    }
+
+    return {
+      create: true,
+      load: getLoad(function(text) {
+        return { 'fp': text, 'limit': 10 }
+      }),
+      loadSelected: getLoad(function(text) {
+        return { 'fp': text, 'exactMatch': true }
+      })
     };
   };
 

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/suggest/suggestUsersAndGroups.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/suggest/suggestUsersAndGroups.js
@@ -75,7 +75,13 @@ define('xwiki-suggestUsers', ['jquery', 'xwiki-selectize-utils', 'xwiki-selectiz
       load: function(text, callback) {
         loadUsers(select.attr('data-userScope'), {
           'input': text,
-          'limit': 10
+          'limit': 10,
+        }).done(callback).fail(callback);
+      },
+      loadSelected: function(text, callback) {
+        loadUsers(select.attr('data-userScope'), {
+          'input': text,
+          'exactMatch': true
         }).done(callback).fail(callback);
       }
     };
@@ -127,6 +133,12 @@ define('xwiki-suggestGroups', ['jquery', 'xwiki-selectize-utils', 'xwiki-selecti
         loadGroups(select.attr('data-userScope'), {
           'input': text,
           'limit': 10
+        }).done(callback).fail(callback);
+      },
+      loadSelected: function(text, callback) {
+        loadGroups(select.attr('data-userScope'), {
+          'input': text,
+          'exactMatch': true
         }).done(callback).fail(callback);
       }
     };

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/suggest/xwiki.selectize.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/suggest/xwiki.selectize.js
@@ -161,8 +161,14 @@ define('xwiki-selectize', ['jquery', 'selectize', 'xwiki-events-bridge'], functi
 
   var loadSelectedValue = function(selectize, value) {
     var deferred = $.Deferred();
-    if (value && typeof selectize.settings.load === 'function') {
-      selectize.settings.load(value, function(options) {
+    var load;
+    if (typeof selectize.settings.loadSelected === 'function') {
+      load = selectize.settings.loadSelected;
+    } else {
+      load = selectize.settings.load;
+    }
+    if (value && typeof load === 'function') {
+      load(value, function(options) {
         $.isArray(options) && options.forEach(function(option) {
           var value = option[selectize.settings.valueField];
           if (selectize.options.hasOwnProperty(value)) {

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/uorgsuggest.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/uorgsuggest.vm
@@ -59,9 +59,14 @@
       'url': $avatarURL.url
     })
   #end
-  ## Use the local reference as value if possible (see XWIKI-10046).
+  #if ($request.exactMatch == 'true' && "$!request.input" != '')
+    #set ($value = $result)
+  #else
+    ## Use the local reference as value if possible (see XWIKI-10046).
+    #set ($value = $services.model.serialize($reference, 'compactwiki'))
+  #end
   #set ($discard = $results.add({
-    'value': $services.model.serialize($reference, 'compactwiki'),
+    'value': $value,
     'label': $label,
     'icon': $icon,
     'url': $xwiki.getURL($reference)


### PR DESCRIPTION
### Issue

https://jira.xwiki.org/browse/XWIKI-15605

### Changes

* Add an optional parameter to the ClassPropertyValuesResource API to get the exact match value.
* Add a getValue method to the ClassPropertyValuesProvider to get the exact match value.
* Use the exact match parameter when fetching selected items in the property suggest picker.
* Use the exact match query for selected values in users or groups suggest picker.