### PR TITLE
XWIKI-15604: All Menu entries have Page name "WebHome" in the LiveTable

### DIFF
--- a/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/WebHome.xml
+++ b/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/WebHome.xml
@@ -38,7 +38,7 @@
   <hidden>false</hidden>
   <content>{{velocity}}
 #set ($columnsProperties = {
-  'doc.name': {"type":"text","size":10,"link":"view"},
+  'doc.location': {},
   'doc.date': {"type":"date","size":10},
   'doc.author': {"type":"text","size":10,"link":"author"},
   '_actions': {"sortable":false,"filterable":false,"html":true,"actions":["edit","delete"]}
@@ -52,7 +52,7 @@
   'selectedColumn': 'doc.name',
   'defaultOrder': 'asc'
 })
-#set ($columns = ['doc.name', 'doc.date', 'doc.author', '_actions'])
+#set ($columns = ['doc.location', 'doc.date', 'doc.author', '_actions'])
 #livetable('menu' $columns $columnsProperties $options)
 {{/velocity}}</content>
   <object>


### PR DESCRIPTION
Bring back the changes from: https://github.com/xwiki/xwiki-platform/commit/17b8b60c1b6d9b3a6cf8385165b76fd88b261040#diff-ae8a5758f70d31be40578af6c17189b5