### PR TITLE
XWIKI-14314: Jobs waiting conflict when leaving the page during action

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/delete.js
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/delete.js
@@ -12,6 +12,12 @@ require.config({
   }
 });
 require(['jquery', 'xwiki-meta', 'tree'], function($, xm) {
+  // prevent the user from leaving the delete
+  $(window).on("beforeunload", function(e) {
+    e.preventDefault();
+    e.returnValue = "";
+  });
+
   $(document).ready(function() {
     var progressBar = $('#delete-progress-bar');
     var jobId = progressBar.data('job-id');
@@ -108,6 +114,10 @@ require(['jquery', 'xwiki-meta', 'tree'], function($, xm) {
         // Called when the user click on "delete"
         $('.btConfirmDelete').click(function(event){
           event.preventDefault();
+
+          // we don't ask again the user to confirm he's leaving the page
+          $(window).off("beforeunload");
+
           /*jshint camelcase:false */
 	        // Get the selection
           var selectedNodes = $('.deleteTree').jstree().get_selected(true);
@@ -139,6 +149,9 @@ require(['jquery', 'xwiki-meta', 'tree'], function($, xm) {
         // Called when the user click on "cancel"
         $('.btCancelDelete').click( function(event) {
           event.preventDefault();
+
+          // we don't ask again the user to confirm he's leaving the page
+          $(window).off("beforeunload");
           $('.btConfirmDelete').prop('disabled', 'disabled');
           var notif = new XWiki.widgets.Notification(
             "$escapetool.javascript($services.localization.render('core.delete.warningExtensions.canceling'))",

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/job/job.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/job/job.js
@@ -32,6 +32,12 @@ require.config({
 
 require(['jquery', 'xwiki-meta', 'JobRunner'], function($, xm, JobRunner) {
   'use strict';
+  // prevent the user from leaving the job
+  $(window).on("beforeunload", function(e) {
+    e.preventDefault();
+    e.returnValue = "";
+  });
+
   var updateProgress = function(jobUI, job) {
     var percent = Math.floor((job.progress.offset || 0) * 100);
     jobUI.find('.ui-progress-bar').css('width', percent + '%');
@@ -144,6 +150,9 @@ require(['jquery', 'xwiki-meta', 'JobRunner'], function($, xm, JobRunner) {
   var onQuestionAnswer = function(event) {
     // Disable standard form behavior
     event.preventDefault();
+
+    // we don't ask again the user to confirm he's leaving the page
+    $(window).off("beforeunload");
 
     var button = $(this);
 


### PR DESCRIPTION
  * Add a confirm dialog to prevent users leaving a pending job in
delete/rename/move

For the record, we cannot specify the text in the confirm dialog as stated in https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload#Notes