### PR TITLE
XWIKI-15671: Navigation tree not showing after theme change

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminThemesSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminThemesSheet.xml
@@ -181,7 +181,7 @@ $xwiki.jsx.use('XWiki.AdminThemesSheet')
       var inputValue = self.input.val();
       // We consider a color theme or a skin must be written with an absolute reference, so if there is no "dot", the
       // value is wrong.
-      if (inputValue.indexOf('.') &gt; 0) {
+      if (typeof inputValue === 'string' &amp;&amp; inputValue.indexOf('.') &gt; 0) {
         // TODO: verify that the page exists (?)
         var pageReference = XWiki.Model.resolve(inputValue, XWiki.EntityType.DOCUMENT);
         var url = new XWiki.Document(pageReference).getURL(self.action);


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XWIKI-15671

## Resolution

 * Fix Javascript issue in AdminThemesSheet to avoid JS race condition