### PR TITLE
XWIKI-15715: XWiki.XWikiComments document is saved twice at during each startup

### DIFF
--- a/xwiki-platform-core/xwiki-platform-annotations/xwiki-platform-annotation-io/src/main/java/org/xwiki/annotation/internal/AnnotationClassDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-annotations/xwiki-platform-annotation-io/src/main/java/org/xwiki/annotation/internal/AnnotationClassDocumentInitializer.java
@@ -71,7 +71,7 @@ public class AnnotationClassDocumentInitializer extends AbstractMandatoryClassIn
     @Override
     protected void createClass(BaseClass xclass)
     {
-        xclass.addTextField(Annotation.AUTHOR_FIELD, "Author", 30);
+        xclass.addUsersField(Annotation.AUTHOR_FIELD, "Author", 30, false);
         xclass.addDateField(Annotation.DATE_FIELD, "Date");
 
         xclass.addTextAreaField(Annotation.SELECTION_FIELD, "Selection", 40, 5, ContentType.PURE_TEXT);


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XWIKI-15715

## Change

* Use a User field on the Author property of the AnnotationClass class.