### PR TITLE
XWIKI-15724: ClassCastException when specifying the escape character and using like

### DIFF
--- a/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/EscapeLikeParametersQuery.java
+++ b/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/EscapeLikeParametersQuery.java
@@ -161,8 +161,8 @@ public class EscapeLikeParametersQuery extends WrappingQuery
         {
             if (expr.getEscape() == null) {
                 expr.setEscape("!");
-                expr.accept(new XWikiLikeExpressionVisitor());
             }
+            expr.accept(new XWikiLikeExpressionVisitor());
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/test/java/org/xwiki/query/internal/EscapeLikeParametersFilterTest.java
+++ b/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/test/java/org/xwiki/query/internal/EscapeLikeParametersFilterTest.java
@@ -27,7 +27,8 @@ import org.xwiki.query.Query;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -171,6 +172,110 @@ public class EscapeLikeParametersFilterTest
         // The test is here, we verify that the bang character has been escaped from the like value since it's an
         // escape character
         assertEquals("%some!!thing%", filteredQuery.getNamedParameters().get("likeValue"));
+    }
 
+    @Test
+    public void namedParametersLikeAPICustomEscape()
+    {
+        String statement = "select doc.fullName from XWikiDocument doc where "
+            + "doc.fullName like :fullName escape '/' and doc.author like :author escape '!'";
+        Query query = mock(Query.class);
+        when(query.getLanguage()).thenReturn(Query.HQL);
+        when(query.getStatement()).thenReturn(statement);
+
+        Map<String, Object> parameters = new LinkedHashMap<>();
+        parameters.put("fullName", new DefaultQueryParameter(null).literal("Foo//Bar"));
+        parameters.put("author", new DefaultQueryParameter(null).like("Bar!").anychar());
+
+        when(query.getNamedParameters()).thenReturn(parameters);
+
+        Query filteredQuery = this.filter.filterQuery(query);
+        String modifiedStatement = "SELECT doc.fullName FROM XWikiDocument doc WHERE "
+            + "doc.fullName LIKE :fullName ESCAPE '/' AND doc.author LIKE :author ESCAPE '!'";
+        assertEquals(modifiedStatement, filteredQuery.getStatement());
+
+        assertTrue(filteredQuery.getPositionalParameters().isEmpty());
+
+        Map<String, Object> expectedMap = new LinkedHashMap<>();
+        expectedMap.put("author", "Bar!!_");
+
+        // Limitation, only standard '!' is currently escaped automatically
+        expectedMap.put("fullName", "Foo//Bar");
+
+        assertEquals(expectedMap, filteredQuery.getNamedParameters());
+    }
+
+    @Test
+    public void positionalParametersLikeAPICustomEscape()
+    {
+        String statement = "select doc.fullName from XWikiDocument doc where "
+            + "doc.fullName like ? and doc.author like ? escape '!'";
+        Query query = mock(Query.class);
+        when(query.getLanguage()).thenReturn(Query.HQL);
+        when(query.getStatement()).thenReturn(statement);
+
+        Map<Integer, Object> parameters = new LinkedHashMap<>();
+        parameters.put(0, new DefaultQueryParameter(null).literal("Foo!"));
+        parameters.put(1, new DefaultQueryParameter(null).like("Bar!").anychar());
+
+        when(query.getPositionalParameters()).thenReturn(parameters);
+
+        Query filteredQuery = this.filter.filterQuery(query);
+        String modifiedStatement = "SELECT doc.fullName FROM XWikiDocument doc WHERE "
+            + "doc.fullName LIKE ? ESCAPE '!' AND doc.author LIKE ? ESCAPE '!'";
+        assertEquals(modifiedStatement, filteredQuery.getStatement());
+
+        assertTrue(filteredQuery.getNamedParameters().isEmpty());
+
+        Map<Integer, Object> expectedMap = new LinkedHashMap<>();
+        expectedMap.put(0, "Foo!!");
+        expectedMap.put(1, "Bar!!_");
+
+        assertEquals(expectedMap, filteredQuery.getPositionalParameters());
+    }
+
+    @Test
+    public void positionalAndNamedParameters()
+    {
+        String statement = "select doc.fullName from XWikiDocument doc where "
+            + "doc.fullName like :fullName escape '/' and "
+            + "doc.author like ? or "
+            + "doc.version = :version and "
+            + "doc.space like ? escape '!'";
+
+        Query query = mock(Query.class);
+        when(query.getLanguage()).thenReturn(Query.HQL);
+        when(query.getStatement()).thenReturn(statement);
+
+        Map<String, Object> namedParameters = new LinkedHashMap<>();
+        namedParameters.put("fullName", new DefaultQueryParameter(null).literal("Space//Content").anyChars());
+        namedParameters.put("version", "1.1");
+        when(query.getNamedParameters()).thenReturn(namedParameters);
+
+        Map<Integer, Object> positionalParameters = new LinkedHashMap<>();
+        positionalParameters.put(0, new DefaultQueryParameter(null).like("Bar!"));
+        positionalParameters.put(1, new DefaultQueryParameter(null).like("%Foo!%"));
+        when(query.getPositionalParameters()).thenReturn(positionalParameters);
+
+        Query filteredQuery = this.filter.filterQuery(query);
+        String modifiedStatement = "SELECT doc.fullName FROM XWikiDocument doc WHERE "
+            + "doc.fullName LIKE :fullName ESCAPE '/' AND "
+            + "doc.author LIKE ? ESCAPE '!' OR "
+            + "doc.version = :version AND "
+            + "doc.space LIKE ? ESCAPE '!'";
+
+        assertEquals(modifiedStatement, filteredQuery.getStatement());
+
+        Map<String, Object> expectedNamedMap = new LinkedHashMap<>();
+        expectedNamedMap.put("fullName", "Space//Content%");
+        expectedNamedMap.put("version", "1.1");
+
+        assertEquals(expectedNamedMap, filteredQuery.getNamedParameters());
+
+        Map<Integer, Object> expectedPositionalMap = new LinkedHashMap<>();
+        expectedPositionalMap.put(0, "Bar!!");
+        expectedPositionalMap.put(1, "%Foo!!%");
+
+        assertEquals(expectedPositionalMap, filteredQuery.getPositionalParameters());
     }
 }


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XWIKI-15724

## Solution

The expression should always be visited in `EscapeLikeParametersQuery` in order to be converted later.


## Test

Unit tests added in EscapeLikeParametersFilterTest