### PR TITLE
XWIKI-15718 #headerglobalsearchinput is missing the label

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/QuickSearchUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/QuickSearchUIX.xml
@@ -242,7 +242,7 @@
     #set ($discard = $xwiki.jsx.use('XWiki.QuickSearchUIX'))
     &lt;li&gt;
       &lt;form class="navbar-form globalsearch globalsearch-close form-inline" id="globalsearch" action="#if($xwiki.exists('Main.Search'))$xwiki.getURL('Main.Search')#else$xwiki.getURL('Main.WebSearch')#end"&gt;
-        &lt;label class="hidden" for="text"&gt;$services.localization.render('search')&lt;/label&gt;
+        &lt;label class="hidden" for="headerglobalsearchinput"&gt;$services.localization.render('search')&lt;/label&gt;
         &lt;input type="text" name="text" placeholder="$services.localization.render('panels.search.inputText')" id="headerglobalsearchinput" /&gt;
         &lt;button type="submit" class="btn" title="$services.localization.render('search')"&gt;$services.icon.renderHTML('search')&lt;/button&gt;
       &lt;/form&gt;

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/QuickSearchUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/QuickSearchUIX.xml
@@ -242,6 +242,7 @@
     #set ($discard = $xwiki.jsx.use('XWiki.QuickSearchUIX'))
     &lt;li&gt;
       &lt;form class="navbar-form globalsearch globalsearch-close form-inline" id="globalsearch" action="#if($xwiki.exists('Main.Search'))$xwiki.getURL('Main.Search')#else$xwiki.getURL('Main.WebSearch')#end"&gt;
+        &lt;label class="hidden" for="text"&gt;$services.localization.render('search')&lt;/label&gt;
         &lt;input type="text" name="text" placeholder="$services.localization.render('panels.search.inputText')" id="headerglobalsearchinput" /&gt;
         &lt;button type="submit" class="btn" title="$services.localization.render('search')"&gt;$services.icon.renderHTML('search')&lt;/button&gt;
       &lt;/form&gt;


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XWIKI-15718

## Change

* Add missing label to an input for accessibility purpose.