### PR TITLE
XWIKI-15726: Headings hierarchy is broken when using Bootstrap .modal-title and .panel-title

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminGroupsSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminGroupsSheet.xml
@@ -46,9 +46,9 @@
           &lt;button type="button" class="close" data-dismiss="modal" aria-label="Close"&gt;
             &lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;
           &lt;/button&gt;
-          &lt;h4 class="modal-title" id="createGroupModal-label"&gt;
+          &lt;div class="modal-title" id="createGroupModal-label"&gt;
             $escapetool.xml($services.localization.render('rightsmanager.creategroup'))
-          &lt;/h4&gt;
+          &lt;/div&gt;
         &lt;/div&gt;
         &lt;div class="modal-body"&gt;
           &lt;div class="hidden"&gt;
@@ -93,9 +93,9 @@
           &lt;button type="button" class="close" data-dismiss="modal" aria-label="Close"&gt;
             &lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;
           &lt;/button&gt;
-          &lt;h4 class="modal-title" id="editGroupModal-label"&gt;
+          &lt;div class="modal-title" id="editGroupModal-label"&gt;
             $escapetool.xml($services.localization.render('xe.admin.groups.editGroup'))
-          &lt;/h4&gt;
+          &lt;/div&gt;
         &lt;/div&gt;
         &lt;div class="modal-body"&gt;&lt;/div&gt;
       &lt;/div&gt;
@@ -112,9 +112,9 @@
           &lt;button type="button" class="close" data-dismiss="modal" aria-label="Close"&gt;
             &lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;
           &lt;/button&gt;
-          &lt;h4 class="modal-title" id="deleteGroupModal-label"&gt;
+          &lt;div class="modal-title" id="deleteGroupModal-label"&gt;
             $escapetool.xml($services.localization.render('xe.admin.groups.deleteGroup'))
-          &lt;/h4&gt;
+          &lt;/div&gt;
         &lt;/div&gt;
         &lt;div class="modal-body"&gt;
           #set ($message = $escapetool.xml($services.localization.render('rightsmanager.confirmdeletegroup')))

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminUsersSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminUsersSheet.xml
@@ -94,9 +94,9 @@
           &lt;button type="button" class="close" data-dismiss="modal" aria-label="Close"&gt;
             &lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;
           &lt;/button&gt;
-          &lt;h4 class="modal-title" id="createUserModal-label"&gt;
+          &lt;div class="modal-title" id="createUserModal-label"&gt;
             $escapetool.xml($services.localization.render('rightsmanager.addnewuser'))
-          &lt;/h4&gt;
+          &lt;/div&gt;
         &lt;/div&gt;
         &lt;div class="modal-body"&gt;&lt;/div&gt;
         &lt;div class="modal-footer"&gt;
@@ -121,9 +121,9 @@
           &lt;button type="button" class="close" data-dismiss="modal" aria-label="Close"&gt;
             &lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;
           &lt;/button&gt;
-          &lt;h4 class="modal-title" id="editUserModal-label"&gt;
+          &lt;div class="modal-title" id="editUserModal-label"&gt;
             $escapetool.xml($services.localization.render('xe.admin.users.editUser'))
-          &lt;/h4&gt;
+          &lt;/div&gt;
         &lt;/div&gt;
         &lt;div class="modal-body"&gt;&lt;/div&gt;
         &lt;div class="modal-footer"&gt;
@@ -148,9 +148,9 @@
           &lt;button type="button" class="close" data-dismiss="modal" aria-label="Close"&gt;
             &lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;
           &lt;/button&gt;
-          &lt;h4 class="modal-title" id="deleteUserModal-label"&gt;
+          &lt;div class="modal-title" id="deleteUserModal-label"&gt;
             $escapetool.xml($services.localization.render('xe.admin.users.deleteUser'))
-          &lt;/h4&gt;
+          &lt;/div&gt;
         &lt;/div&gt;
         &lt;div class="modal-body"&gt;
           #set ($message = $escapetool.xml($services.localization.render('rightsmanager.confirmdeleteuser')))

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/TemplateProviderMacros.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/TemplateProviderMacros.xml
@@ -95,7 +95,7 @@
           &lt;button type="button" class="close" data-dismiss="modal" aria-label="Close"&gt;
             &lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;
           &lt;/button&gt;
-          &lt;h4 class="modal-title"&gt;$services.localization.render('core.documentPicker.title')&lt;/h4&gt;
+          &lt;div class="modal-title"&gt;$services.localization.render('core.documentPicker.title')&lt;/div&gt;
         &lt;/div&gt;
         &lt;div class="modal-body"&gt;
           #documentTree({

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/attachment_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/attachment_macros.vm
@@ -128,7 +128,7 @@
       <div class="modal-content">
         <div class="modal-header">
           <button type="button" class="close" data-dismiss="modal">&times;</button>
-          <h4 class="modal-title">$services.localization.render('core.viewers.attachments.delete')</h4>
+          <div class="modal-title">$services.localization.render('core.viewers.attachments.delete')</div>
         </div>
         <div class="modal-body">
           <div>$services.localization.render('core.viewers.attachments.delete.confirm')</div>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/commentsinline.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/commentsinline.vm
@@ -302,7 +302,7 @@ $xwiki.ssfx.use('uicomponents/viewers/comments.css', true)
       <div class="modal-content">
         <div class="modal-header">
           <button type="button" class="close" data-dismiss="modal">&times;</button>
-          <h4 class="modal-title">$services.localization.render('core.viewers.comments.permalink')</h4>
+          <div class="modal-title">$services.localization.render('core.viewers.comments.permalink')</div>
         </div>
         <div class="modal-body">
           <div class="input-group">
@@ -329,7 +329,7 @@ $xwiki.ssfx.use('uicomponents/viewers/comments.css', true)
       <div class="modal-content">
         <div class="modal-header">
           <button type="button" class="close" data-dismiss="modal">&times;</button>
-          <h4 class="modal-title">$services.localization.render('core.viewers.comments.delete')</h4>
+          <div class="modal-title">$services.localization.render('core.viewers.comments.delete')</div>
         </div>
         <div class="modal-body">
           <div>$services.localization.render('core.viewers.comments.delete.confirm')</div>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/export_modal.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/export_modal.vm
@@ -26,11 +26,11 @@
 #macro (displayOfficeFormats $exportExtensions)
   <div class="panel panel-default">
     <div class="panel-heading" role="tab" id="exportModalHeadingOffice">
-      <h4 class="panel-title">
+      <div class="panel-title">
         <a role="button" data-toggle="collapse" data-parent="#exportModelAccordion" href="#exportModelOfficeCollapse" aria-expanded="true" aria-controls="exportModelOfficeCollapse">
           $escapetool.xml($services.localization.render('core.exporter.headings.officeFormats'))
         </a>
-      </h4>
+      </div>
     </div>
     <div id="exportModelOfficeCollapse" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="exportModalHeadingOffice">
       <div class="panel-body">
@@ -52,11 +52,11 @@
 #macro (displayOtherFormats $exportExtensions)
   <div class="panel panel-default">
     <div class="panel-heading" role="tab" id="exportModalHeadingOther">
-      <h4 class="panel-title">
+      <div class="panel-title">
         <a class="collapsed" role="button" data-toggle="collapse" data-parent="#exportModelAccordion" href="#exportModelOtherCollapse" aria-expanded="false" aria-controls="exportModelOtherCollapse">
           $escapetool.xml($services.localization.render('core.exporter.headings.otherFormats'))
         </a>
-      </h4>
+      </div>
     </div>
     <div id="exportModelOtherCollapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="exportModalHeadingOther">
       <form id="export-form" method="post" class="panel-body">

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/export_modal.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/export_modal.vm
@@ -9,7 +9,7 @@
       <div class="modal-content">
         <div class="modal-header">
           <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-          <h4 class="modal-title" id="exportModalLabel">$services.localization.render('core.menu.export')</h4>
+          <div class="modal-title" id="exportModalLabel">$services.localization.render('core.menu.export')</div>
         </div>
         <div class="modal-body">
           <div class="panel-group" id="exportModelAccordion" role="tablist" aria-multiselectable="true">

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/modals.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/modals.less
@@ -1,0 +1,4 @@
+.modal-title {
+  // Using the font-size of H4, but using normal divs because of WCAG headings hierarchy rule
+  font-size: ceil((@font-size-base * 1.424));
+}

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/style.less.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/style.less.vm
@@ -22,6 +22,7 @@
 @import "layout";
 @import "livetable";
 @import "messages";
+@import "modals";
 @import "misc";
 @import "panels";
 @import "tables";

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/macros.vm
@@ -14,7 +14,7 @@
 #macro(xwikimessageboxstart $title $message)
     <div class="centered panel panel-default xwikimessage">
      <div class="panel-heading">
-      <h3 class="panel-title">$title</h3>
+      <div class="panel-title">$title</div>
      </div>
      <div class="panel-body">
       <p class="xwikimessage">$message</p>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsFiltersPreferencesMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsFiltersPreferencesMacro.xml
@@ -968,7 +968,7 @@ require(['jquery', 'AddNotificationFilterPreferenceLivetable', 'bootstrap', 'boo
     &lt;div class="modal-content"&gt;
       &lt;div class="modal-header"&gt;
         &lt;button type="button" class="close" data-dismiss="modal" aria-label="Close"&gt;&lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;&lt;/button&gt;
-        &lt;h4 class="modal-title"&gt;$escapetool.xml($services.localization.render('notifications.settings.addFilter'))&lt;/h4&gt;
+        &lt;div class="modal-title"&gt;$escapetool.xml($services.localization.render('notifications.settings.addFilter'))&lt;/div&gt;
       &lt;/div&gt;
       &lt;div class="modal-body"&gt;
         &lt;div class="xform"&gt;

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/PanelsCode/NavigationConfigurationSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/PanelsCode/NavigationConfigurationSheet.xml
@@ -74,9 +74,9 @@
   {{html clean="false"}}
   &lt;div class="panel panel-info"&gt;
     &lt;div class="panel-heading"&gt;
-      &lt;h3 class="panel-title"&gt;
+      &lt;div class="panel-title"&gt;
         $escapetool.xml($services.localization.render('platform.panels.navigation.configuration.excludedPages'))
-      &lt;/h3&gt;
+      &lt;/div&gt;
     &lt;/div&gt;
     &lt;div class="panel-body"&gt;
       &lt;p class="xHint"&gt;

--- a/xwiki-platform-core/xwiki-platform-sharepage/xwiki-platform-sharepage-ui/src/main/resources/XWiki/SharePage.xml
+++ b/xwiki-platform-core/xwiki-platform-sharepage/xwiki-platform-sharepage-ui/src/main/resources/XWiki/SharePage.xml
@@ -137,9 +137,9 @@ require(['jquery', 'xwiki-suggestUsers'], function($) {
                 '"&gt;' +
               '&lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;' +
             '&lt;/button&gt;' +
-            '&lt;h4 class="modal-title"&gt;' +
+            '&lt;div class="modal-title"&gt;' +
               $jsontool.serialize($services.localization.render('core.viewers.share.dialogTitle')) +
-            '&lt;/h4&gt;' +
+            '&lt;/div&gt;' +
           '&lt;/div&gt;' +
           '&lt;div class="modal-body"&gt;&lt;/div&gt;' +
         '&lt;/div&gt;' +

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/job/question/OverwriteQuestion.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/job/question/OverwriteQuestion.vm
@@ -40,11 +40,11 @@
 
 <div class="panel panel-warning overwriteQuestion xform">
   <div class="panel-heading">
-    <h3 class="panel-title">
+    <div class="panel-title">
       $services.icon.renderHTML('warning')
       $escapetool.xml($services.localization.render('job.question.OverwriteQuestion.title',
         [$destinationDocument.plainTitle]))
-    </h3>
+    </div>
   </div>
   <div class="panel-body">
     <p>

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/locationPicker_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/locationPicker_macros.vm
@@ -185,7 +185,7 @@
           <button type="button" class="close" data-dismiss="modal" aria-label="Close">
             <span aria-hidden="true">&times;</span>
           </button>
-          <h4 class="modal-title">$services.localization.render('core.documentPicker.title')</h4>
+          <div class="modal-title">$services.localization.render('core.documentPicker.title')</div>
         </div>
         <div class="modal-body">
           #set ($showWikis = $options.wiki && $displayWikiFields)

--- a/xwiki-platform-tools/xwiki-platform-tool-standards-validator/src/test/resources/xwiki-invalid.html
+++ b/xwiki-platform-tools/xwiki-platform-tool-standards-validator/src/test/resources/xwiki-invalid.html
@@ -390,7 +390,7 @@ window.docgeturl = "/xwiki/bin/get/Main/WebHome";
       <div class="modal-content">
         <div class="modal-header">
           <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-          <h4 class="modal-title" id="exportModalLabel">Export</h4>
+          <div class="modal-title" id="exportModalLabel">Export</div>
         </div>
         <div class="modal-body">
           <a href="/xwiki/bin/view/Main/?xpage=pdfoptions&amp;qs=" class="btn btn-primary">Export as PDF</a>

--- a/xwiki-platform-tools/xwiki-platform-tool-standards-validator/src/test/resources/xwiki-valid.html
+++ b/xwiki-platform-tools/xwiki-platform-tool-standards-validator/src/test/resources/xwiki-valid.html
@@ -393,7 +393,7 @@ window.docgeturl = "/xwiki/bin/get/Main/WebHome";
       <div class="modal-content">
         <div class="modal-header">
           <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-          <h4 class="modal-title" id="exportModalLabel">Export</h4>
+          <div class="modal-title" id="exportModalLabel">Export</div>
         </div>
         <div class="modal-body">
           <a href="/xwiki/bin/view/Main/?xpage=pdfoptions&amp;qs=" class="btn btn-primary">Export as PDF</a>


### PR DESCRIPTION
- Adding styling for .modal-title for the font-size property
- Replace headings usage for .modal-title and .panel-title in order to comply with WCAG rules