### PR TITLE
XWIKI-15444: Export UI does not export child pages if there are many (and tree has pagination)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/export_modal.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/export_modal.vm
@@ -59,7 +59,7 @@
       </div>
     </div>
     <div id="exportModelOtherCollapse" class="panel-collapse collapse" role="tabpanel" aria-labelledby="exportModalHeadingOther">
-      <form id="export-form" method="post" class="panel-body">
+      <div class="panel-body">
         #if ($doc.name == 'WebHome')
           #set ($discard = $xwiki.jsfx.use('uicomponents/exporter/exporter.js', {'forceSkinAction': true}))
           <div class="row">
@@ -97,7 +97,7 @@
         #foreach ($exportExtension in $exportExtensions)
           $services.rendering.render($exportExtension.execute(), 'html/5.0')
         #end
-      </form>
+      </div>
     </div>
   </div>
 #end

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-pageobjects/src/main/java/org/xwiki/flamingo/sking/test/po/ExportModal.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-pageobjects/src/main/java/org/xwiki/flamingo/sking/test/po/ExportModal.java
@@ -50,7 +50,7 @@ public class ExportModal extends BaseModal
     public OtherFormatPane openOtherFormatPane()
     {
         getDriver().findElementByLinkText(OTHER_FORMAT_PANE_LINK).click();
-        getDriver().waitUntilElementIsVisible(By.id((OtherFormatPane.FORM_ID)));
+        getDriver().waitUntilElementIsVisible(By.cssSelector("#exportModelOtherCollapse .panel-body"));
         return new OtherFormatPane();
     }
 

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-pageobjects/src/main/java/org/xwiki/flamingo/sking/test/po/OtherFormatPane.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-pageobjects/src/main/java/org/xwiki/flamingo/sking/test/po/OtherFormatPane.java
@@ -35,12 +35,7 @@ import org.xwiki.tree.test.po.TreeElement;
  */
 public class OtherFormatPane extends BaseElement
 {
-    /**
-     * ID of the main form used in the Other Format Pane.
-     * It can be used to detect if the pane is opened.
-     */
-    static final String FORM_ID = "export-form";
-
+    private static final String FORM_ID = "export-form";
     private static final String CONTAINER_TREE_CLASS = "exportModalTreeContainer";
     private static final String TREE_CLASS = "xtree";
     private static final String XAR_EXPORT_LINK_TEXT = "Export as XAR";

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/exporter/exporter.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/exporter/exporter.js
@@ -99,8 +99,6 @@ require([
    */
   require(['tree'], function () {
     $(document).ready(function () {
-      var form = $('#export-form');
-
       /**
        * Save the default url
        */
@@ -305,9 +303,15 @@ require([
             return arrayOfNames.map(function (name) { return encodeURIComponent(name); }).join("&");
           };
 
-          // we clean the form from old hidden pages (in case we click several times on the export button)
-          $("input[name='pages']").remove();
-          $("input[name='excludes']").remove();
+          // in case an old form was already existing
+          // we could remove it after the submit, but it's easier that way for testing
+          $('#export-form').remove();
+
+          var form = $('<form id="export-form" />').appendTo("body");
+          form.attr({
+            action: url.serialize(),
+            method: 'post'
+          });
 
           // create on the fly the hidden inputs
           for (var pages in exportPages) {
@@ -323,9 +327,6 @@ require([
               value: aggregatePageNames(exportPages[pages])
             }).appendTo(form);
           }
-
-          // put the right action for the form
-          form.attr('action', url.serialize());
           form.submit();
         });
       });


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XWIKI-15444

## Solution

  * Form is now created on the fly to avoid nested form

## Tests

All dedicated tests running.
