### PR TITLE
XWIKI-15761: Improve look and feel of default pdf export

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/xhtml2fo.xsl
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/xhtml2fo.xsl
@@ -76,9 +76,9 @@ WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING O
         <xsl:attribute name="text-align"><xsl:value-of select="$text-align"/></xsl:attribute>
         <xsl:attribute name="font-family">
           <xsl:choose>
-            <xsl:when test="starts-with($language, 'ja')">FreeSerif, IPAMincho, AR PL UMing CN, serif</xsl:when>
-            <xsl:when test="starts-with($language, 'ko') or starts-with($language, 'kr')">FreeSerif, Baekmuk Gulim, AR PL UMing CN, serif</xsl:when>
-            <xsl:otherwise>FreeSerif, AR PL UMing CN, serif</xsl:otherwise>
+            <xsl:when test="starts-with($language, 'ja')">FreeSans, IPAMincho, AR PL UMing CN, sans-serif</xsl:when>
+            <xsl:when test="starts-with($language, 'ko') or starts-with($language, 'kr')">FreeSans, Baekmuk Gulim, AR PL UMing CN, sans-serif</xsl:when>
+            <xsl:otherwise>FreeSans, AR PL UMing CN, sans-serif</xsl:otherwise>
           </xsl:choose>
         </xsl:attribute>
         <!-- specified on fo:root to change the properties' initial values -->

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/pdfcover.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/pdfcover.vm
@@ -1,5 +1,6 @@
-<div style="text-align: center; width: 100%;">
-<h1>
+<div style="width: 100%;">
+<hr style="border-width: 0.25pt"/>
+<h1 style="text-align: left;">
 #set ($title = "$!pdfdoc.display('title', 'rendered', '', $pdfobj)")
 #if ($title == '')
   $escapetool.xml($!tdoc.plainTitle)
@@ -7,9 +8,12 @@
   $escapetool.xml($title)
 #end
 </h1>
+<div>
+  <p style="text-align: left;" class="author">${services.localization.render('lastmodifiedby')} $!xwiki.getUserName($tdoc.author, false)</p>
+</div>
+<div>
+  <p style="text-align: left;" class="date">${services.localization.render('lastmodifiedon')} $!xwiki.formatDate($tdoc.date)</p>
+</div>
 <br />
-<br />
-<p class="author">$!xwiki.getUserName($tdoc.author, false)</p>
-<br />
-<p class="date">$!xwiki.formatDate($tdoc.date)</p>
+<hr style="border-width: 0.25pt"/>
 </div>

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/pdffooter.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/pdffooter.vm
@@ -1,1 +1,2 @@
+<hr style="border-width: 0.25pt"/>
 $msg.Page <span class="page-number"></span> / <span class="page-total"></span> - $services.localization.render('lastmodifiedby') $xwiki.getUserName($tdoc.author, false) $services.localization.render('lastmodifiedon') $!xwiki.formatDate($tdoc.date)

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/pdfheader.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/pdfheader.vm
@@ -1,10 +1,19 @@
 #set ($title = "$!{pdfdoc.display('title', 'rendered', '', $pdfobj)}")
 #if ($title == '')
-  #if ($doc.space != $tdoc.plainTitle)
-    $!{escapetool.xml($doc.space)} - $!{escapetool.xml($tdoc.plainTitle)}
+  #set($pdfHeaderParentLabel = '')
+  #if ($doc.name == 'WebHome')
+    ## document is terminal, the parent is the previous last space in the list
+    #if($doc.documentReference.parent.parent && $doc.documentReference.parent.parent.type == 'SPACE')
+      #set($pdfHeaderParentRef = $doc.documentReference.parent.parent)
+      #set($pdfHeaderParentLabel = $xwiki.getDocument($pdfHeaderParentRef).plainTitle)
+    #end
   #else
-    $!{escapetool.xml($doc.space)}
+    ## document is not terminal, the parent is the last space in the list
+    #set($pdfHeaderParentRef = $doc.documentReference.getParent())
+    #set($pdfHeaderParentLabel = $xwiki.getDocument($pdfHeaderParentRef).plainTitle)
   #end
+  #if($pdfHeaderParentLabel != '')$pdfHeaderParentLabel - #{end}$tdoc.plainTitle
 #else
   $escapetool.xml($title)
 #end
+<hr style="border-width: 0.25pt"/>

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/pdfheader.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/pdfheader.vm
@@ -3,7 +3,7 @@
   #set($pdfHeaderParentLabel = '')
   #if ($doc.name == 'WebHome')
     ## document is terminal, the parent is the previous last space in the list
-    #if($doc.documentReference.parent.parent && $doc.documentReference.parent.parent.type == 'SPACE')
+    #if("$!doc.documentReference.parent.parent.type" == 'SPACE')
       #set($pdfHeaderParentRef = $doc.documentReference.parent.parent)
       #set($pdfHeaderParentLabel = $xwiki.getDocument($pdfHeaderParentRef).plainTitle)
     #end


### PR DESCRIPTION
* Changed default font to sans fonts
* Added thin lines between doc header, doc footer and page content text
* Fixed the document pdfheader to display document titles instead of document space name
* Polished the document cover to display title and document metadata to the left and repeat the thin separator lines to preserve the same look and feel as the pages