### PR TITLE
Recover username and pasword for global users from subwikis

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/ForgotUsername.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/ForgotUsername.xml
@@ -49,6 +49,10 @@
 
 #else
   #set($results = $services.query.hql(", BaseObject obj, StringProperty prop where obj.name = doc.fullName and obj.className = 'XWiki.XWikiUsers' and prop.id.id = obj.id and prop.id.name = 'email' and LOWER(prop.value) = ?").bindValues([$email.toLowerCase()]).execute())
+  ## If local user does not exist check global user
+  #if($results.size() == 0)
+    #set($results = $services.query.hql(", BaseObject obj, StringProperty prop where obj.name = doc.fullName and obj.className = 'XWiki.XWikiUsers' and prop.id.id = obj.id and prop.id.name = 'email' and LOWER(prop.value) = ?").bindValues([$email.toLowerCase()]).setWiki('xwiki').execute())
+  #end
   #if($results.size() == 0)
     {{translation key="xe.admin.forgotUsername.error.noAccount"/}}
 

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/ForgotUsername.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/ForgotUsername.xml
@@ -48,10 +48,11 @@
 {{/html}}
 
 #else
-  #set($results = $services.query.hql(", BaseObject obj, StringProperty prop where obj.name = doc.fullName and obj.className = 'XWiki.XWikiUsers' and prop.id.id = obj.id and prop.id.name = 'email' and LOWER(prop.value) = ?").bindValues([$email.toLowerCase()]).execute())
+  #set($query = $services.query.hql(", BaseObject obj, StringProperty prop where obj.name = doc.fullName and obj.className = 'XWiki.XWikiUsers' and prop.id.id = obj.id and prop.id.name = 'email' and LOWER(prop.value) = ?").bindValues([$email.toLowerCase()]))
+  #set($results = $query.execute())
   ## If local user does not exist check global user
-  #if($results.size() == 0)
-    #set($results = $services.query.hql(", BaseObject obj, StringProperty prop where obj.name = doc.fullName and obj.className = 'XWiki.XWikiUsers' and prop.id.id = obj.id and prop.id.name = 'email' and LOWER(prop.value) = ?").bindValues([$email.toLowerCase()]).setWiki('xwiki').execute())
+  #if($results.size() == 0 &amp;&amp; ${xcontext.database} != ${xcontext.mainWikiName})
+    #set($results = $query.setWiki("${xcontext.mainWikiName}").execute())
   #end
   #if($results.size() == 0)
     {{translation key="xe.admin.forgotUsername.error.noAccount"/}}

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/ResetPassword.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/ResetPassword.xml
@@ -73,6 +73,15 @@ u = user account sent in the form
   ## Check if the user exists and has a valid email address configured in his profile
   #set ($userObj = '')
   #set ($userObj = $userDoc.getObject('XWiki.XWikiUsers'))
+  ## If local user does not exist check global user
+  #if (!$userObj)
+    #if ($userName.indexOf('.') != -1)
+      #set ($userDoc = $xwiki.getDocumentAsAuthor("xwiki:${userName}"))
+    #else
+      #set ($userDoc = $xwiki.getDocumentAsAuthor("xwiki:XWiki.${userName}"))
+    #end
+    #set ($userObj = $userDoc.getObject('XWiki.XWikiUsers'))
+  #end
   #if (!$userObj)
 
     {{warning}}$services.localization.render('xe.admin.passwordReset.error.noUser', ["//${escapetool.xml($userName)}//"]){{/warning}}

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/ResetPassword.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/ResetPassword.xml
@@ -74,11 +74,11 @@ u = user account sent in the form
   #set ($userObj = '')
   #set ($userObj = $userDoc.getObject('XWiki.XWikiUsers'))
   ## If local user does not exist check global user
-  #if (!$userObj)
+  #if (!$userObj &amp;&amp; ${xcontext.database} != ${xcontext.mainWikiName})
     #if ($userName.indexOf('.') != -1)
-      #set ($userDoc = $xwiki.getDocumentAsAuthor("xwiki:${userName}"))
+      #set ($userDoc = $xwiki.getDocumentAsAuthor("${xcontext.mainWikiName}:${userName}"))
     #else
-      #set ($userDoc = $xwiki.getDocumentAsAuthor("xwiki:XWiki.${userName}"))
+      #set ($userDoc = $xwiki.getDocumentAsAuthor("${xcontext.mainWikiName}:XWiki.${userName}"))
     #end
     #set ($userObj = $userDoc.getObject('XWiki.XWikiUsers'))
   #end


### PR DESCRIPTION
[XWIKI-15682: Global users can't recover their password from a subwiki](https://jira.xwiki.org/browse/XWIKI-15682)
[XWIKI-15681: Global users can't recover their login from a subwiki](https://jira.xwiki.org/browse/XWIKI-15681)

- pull request for both issues since they are related and should behave similarly
- fix aims to mimic the behaviour of the login action (first local user then global, if local does not exist)