### PR TITLE
Stable 10.8.x

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R1008010XWIKI10092DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R1008010XWIKI10092DataMigration.java
@@ -115,7 +115,7 @@ public class R1008010XWIKI10092DataMigration extends AbstractHibernateDataMigrat
         // Note that we count only the expected properties (those declared by the class).
         Query query = session.createQuery("select obj from BaseObject as obj, BaseProperty as prop "
             + "where obj.id = prop.id.id and obj.className = :className and prop.id.name in :expectedProperties "
-            + "group by obj, BaseObject having count(prop) < :expectedPropertyCount");
+            + "group by obj, obj.number, obj.name, obj.className, obj.guid having count(prop) < :expectedPropertyCount");
         query.setString("className", className);
         query.setParameterList("expectedProperties", expectedProperties);
         query.setLong("expectedPropertyCount", Integer.valueOf(expectedProperties.size()).longValue());

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R1008010XWIKI10092DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R1008010XWIKI10092DataMigration.java
@@ -115,7 +115,7 @@ public class R1008010XWIKI10092DataMigration extends AbstractHibernateDataMigrat
         // Note that we count only the expected properties (those declared by the class).
         Query query = session.createQuery("select obj from BaseObject as obj, BaseProperty as prop "
             + "where obj.id = prop.id.id and obj.className = :className and prop.id.name in :expectedProperties "
-            + "group by obj having count(prop) < :expectedPropertyCount");
+            + "group by obj, BaseObject having count(prop) < :expectedPropertyCount");
         query.setString("className", className);
         query.setParameterList("expectedProperties", expectedProperties);
         query.setLong("expectedPropertyCount", Integer.valueOf(expectedProperties.size()).longValue());


### PR DESCRIPTION
XWIKI-15771:  Schema update failing using MSSQL as columns must use agg functions or be included in the group by.

Since this is not dynamic any new columns added or removed would break the query.