### PR TITLE
XWIKI-15653: Prevent users from deleting/moving/renaming pages containing XClass

### DIFF
--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-selenium/src/test/it/org/xwiki/test/selenium/AllDocsTest.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-selenium/src/test/it/org/xwiki/test/selenium/AllDocsTest.java
@@ -130,7 +130,7 @@ public class AllDocsTest extends AbstractXWikiTestCase
         waitForTextPresent("//span[@class='xwiki-livetable-pagination-content']", "1");
         clickLinkWithLocator("//tbody/tr/td/a[text()='delete']");
         clickLinkWithLocator("//button[contains(@class, 'confirm')]");
-        assertTextPresent("The page has been deleted.");
+        assertTextPresent("Done.");
         open("Main", "AllDocs");
         getSelenium().focus("doc.location");
         getSelenium().typeKeys("doc.location", "actions");


### PR DESCRIPTION
  * Fix delete message in AllDocsTest after refactoring