### PR TITLE
XWIKI-15693: Remove inline styling from WikiManager.CreateWiki

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/flavor/picker.css
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/flavor/picker.css
@@ -85,6 +85,10 @@
   clear: both;
 }
 
+.xwiki-flavor-picker-filter {
+  margin-bottom: 2px;
+}
+
 .skin-colibri .xwiki-flavor-picker-option {
   width: 47%;
 }

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/flavor/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/flavor/macros.vm
@@ -18,7 +18,7 @@
   #set ($discard = $xwiki.jsfx.use('uicomponents/flavor/picker.js' , {'forceSkinAction': true, 'version': $environmentVersion}))
   <div class="xwiki-flavor-picker $!cssClass" data-namespace="$escapetool.xml($namespace)">
     ## Filter
-    <input type="text" id="${escapetool.xml($fieldName)}_filter" class="xwiki-flavor-picker-filter" placeholder="$escapetool.xml($services.localization.render('flavor.picker.filterPlaceHolder'))" style="margin-bottom: 2px;"/>
+    <input type="text" id="${escapetool.xml($fieldName)}_filter" class="xwiki-flavor-picker-filter" placeholder="$escapetool.xml($services.localization.render('flavor.picker.filterPlaceHolder'))" />
     ## Results
     <div class="ui-progress-background hidden" id="xwiki-flavor-picker-progress-background">
       <div class="ui-progress-bar green" id="xwiki-flavor-picker-progress-bar"/>


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XWIKI-15693

## Solution 

 * Remove inline style from macros.vm and put it in picker.css