### PR TITLE
XWIKI-15691: Inline styling is not allowed in XWiki.XWikiSyntaxGroups

### DIFF
--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards/src/test/it/org/xwiki/test/webstandards/CustomDutchWebGuidelinesValidator.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards/src/test/it/org/xwiki/test/webstandards/CustomDutchWebGuidelinesValidator.java
@@ -128,7 +128,8 @@ public class CustomDutchWebGuidelinesValidator extends HTML5DutchWebGuidelinesVa
             && !isPage("XWiki", "XWikiSyntaxParagraphs") && !isPage("XWiki", "XWikiSyntaxMacros")
             && !isPage("XWiki", "XWikiSyntaxDefinitionLists") && !isPage("XWiki", "XWikiSyntaxHeadings")
             && !isPage("XWiki", "XWikiSyntaxLists") && !isPage("XWiki", "XWikiSyntaxParameters")
-            && !isPage("Panels", "PanelWizard") && !isPage("XWiki", "Treeview") && !isPage("Invitation", "WebHome")) {
+            && !isPage("XWiki", "XWikiSyntaxGroups") && !isPage("XWiki", "Treeview")
+            && !isPage("Panels", "PanelWizard") && !isPage("Invitation", "WebHome")) {
             // Usage of the style attribute is strictly forbidden in the other spaces.
 
             assertTrue(Type.ERROR, "rpd9s1.attr", getElement(ELEM_BODY).getElementsByAttribute(STYLE).isEmpty());


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XWIKI-15691

## Solution 

 * Add XWiki.XWikiSyntaxGroups in the list of exceptions