### PR TITLE
XWIKI-15576: Page filter on the livetable

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/macros.vm
@@ -427,6 +427,17 @@
       class="suggest-propertyValues" multiple="multiple" size="1"
       data-className="$!escapetool.xml($xproperty.className)" data-propertyName="$!escapetool.xml($xproperty.name)">
     </select>
+  #elseif ($filterType == 'page')
+    #set ($discard = $xwiki.linkx.use($services.webjars.url('selectize.js', 'css/selectize.bootstrap3.css'),
+      {'type': 'text/css', 'rel': 'stylesheet'}))
+    #set ($discard = $xwiki.ssfx.use('uicomponents/suggest/xwiki.selectize.css', true))
+    #set ($discard = $xwiki.jsfx.use('uicomponents/suggest/suggestPages.js',
+      {'forceSkinAction' : true, 'language' : $xcontext.locale}))
+    <select id="xwiki-livetable-${htmlLiveTableId}-filter-$velocityCount" name="$!escapetool.xml($column)"
+      #if ("$!columnProperties.size" != '')size="$!escapetool.xml($columnProperties.size)"#end
+      #if ("$!columnProperties.multiple" != '')multiple="$!escapetool.xml($columnProperties.multiple)"#end
+      class="suggest-pages">
+    </select>
   #end
 #end
 

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/XWiki/DeletedDocuments.xml
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/XWiki/DeletedDocuments.xml
@@ -43,7 +43,7 @@ $xwiki.jsx.use('XWiki.DeletedDocuments')##
 ##
 #set($columns = ["ddoc.fullName", "ddoc.title", "ddoc.date", "ddoc.deleter", 'ddoc.batchId', 'actions'])
 #set($columnsProperties = {
-    'ddoc.fullName'  : { 'type' : 'text', 'size' : 10 },
+    'ddoc.fullName'  : { 'type' : 'page', 'size' : 10 },
     'ddoc.title'     : { 'type' : 'text', 'filterable' : false, 'sortable' : false },
     'ddoc.date'      : { 'type' : 'date'},
     'ddoc.deleter'   : { 'type' : 'text', 'size' : 10 },

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/macros.vm
@@ -1603,6 +1603,17 @@ $Msz MB##
       class="suggest-propertyValues" multiple="multiple" size="1"
       data-className="$!escapetool.xml($xproperty.className)" data-propertyName="$!escapetool.xml($xproperty.name)">
     </select>
+  #elseif ($filterType == 'page')
+    #set ($discard = $xwiki.linkx.use($services.webjars.url('selectize.js', 'css/selectize.bootstrap3.css'),
+      {'type': 'text/css', 'rel': 'stylesheet'}))
+    #set ($discard = $xwiki.ssfx.use('uicomponents/suggest/xwiki.selectize.css', true))
+    #set ($discard = $xwiki.jsfx.use('uicomponents/suggest/suggestPages.js',
+      {'forceSkinAction' : true, 'language' : $xcontext.locale}))
+    <select id="xwiki-livetable-${htmlLiveTableId}-filter-$velocityCount" name="$!escapetool.xml($column)"
+      #if ("$!columnProperties.size" != '')size="$!escapetool.xml($columnProperties.size)"#end
+      #if ("$!columnProperties.multiple" != '')multiple="$!escapetool.xml($columnProperties.multiple)"#end
+      class="suggest-pages">
+    </select>
   #end
 #end
 


### PR DESCRIPTION
### Issue

https://jira.xwiki.org/browse/XWIKI-15576

### Changes

* Add a page filter type on the livetable.
* Use the page filter type for the Deleted Documents table.

### Notes

Some limitations:
* The input will not suggest deleted pages
* If the `multiple` attribute is set, only the first element will be used to make the filter

### Results

![livetable](https://user-images.githubusercontent.com/2213999/47915622-bd31e780-dea3-11e8-878e-77c13b0d046f.gif)