### PR TITLE
XWIKI-15794: The default exported wiki XAR package name is 'XWiki.XWikiPreferences' instead of 'backup'

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/ExportAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/ExportAction.java
@@ -81,6 +81,15 @@ public class ExportAction extends XWikiAction
     private static String PAGE_SEPARATOR = "&";
 
     /**
+     * Define the different format supported by the export.
+     */
+    private enum EXPORT_FORMAT {
+        XAR,
+        HTML,
+        OTHER
+    }
+
+    /**
      * Manage the arguments of the export and provides them in an object to simplify their usage in the different
      * methods.
      *
@@ -104,7 +113,7 @@ public class ExportAction extends XWikiAction
          */
         private String description;
 
-        ExportArguments(XWikiContext context, String format) throws XWikiException
+        ExportArguments(XWikiContext context, EXPORT_FORMAT format) throws XWikiException
         {
             XWikiRequest request = context.getRequest();
 
@@ -115,10 +124,8 @@ public class ExportAction extends XWikiAction
             String[] pages = request.getParameterValues("pages");
             String[] excludes = request.getParameterValues("excludes");
 
-            if (StringUtils.isBlank(name)) {
-                if (!format.equals("xar")) {
-                    this.name = context.getDoc().getFullName();
-                }
+            if (StringUtils.isBlank(name) && !format.equals(EXPORT_FORMAT.XAR)) {
+                this.name = context.getDoc().getFullName();
             }
 
             this.exportPages = new LinkedHashMap<>();
@@ -201,7 +208,7 @@ public class ExportAction extends XWikiAction
      */
     private String exportHTML(XWikiContext context) throws XWikiException, IOException
     {
-        ExportArguments exportArguments = new ExportArguments(context, "html");
+        ExportArguments exportArguments = new ExportArguments(context, EXPORT_FORMAT.HTML);
 
         Collection<DocumentReference> pageList = resolvePages(exportArguments, context);
         if (pageList.isEmpty()) {
@@ -418,7 +425,7 @@ public class ExportAction extends XWikiAction
         String licence = request.get("licence");
         String version = request.get("version");
 
-        ExportArguments exportArguments = new ExportArguments(context, "xar");
+        ExportArguments exportArguments = new ExportArguments(context, EXPORT_FORMAT.XAR);
 
         boolean all = exportArguments.exportPages.isEmpty();
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/ExportAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/ExportAction.java
@@ -104,19 +104,22 @@ public class ExportAction extends XWikiAction
          */
         private String description;
 
-        ExportArguments(XWikiContext context) throws XWikiException
+        ExportArguments(XWikiContext context, String format) throws XWikiException
         {
             XWikiRequest request = context.getRequest();
 
             this.description = request.get("description");
 
             this.name = request.get("name");
-            if (StringUtils.isBlank(name)) {
-                this.name = context.getDoc().getFullName();
-            }
 
             String[] pages = request.getParameterValues("pages");
             String[] excludes = request.getParameterValues("excludes");
+
+            if (StringUtils.isBlank(name)) {
+                if (!format.equals("xar")) {
+                    this.name = context.getDoc().getFullName();
+                }
+            }
 
             this.exportPages = new LinkedHashMap<>();
 
@@ -198,7 +201,7 @@ public class ExportAction extends XWikiAction
      */
     private String exportHTML(XWikiContext context) throws XWikiException, IOException
     {
-        ExportArguments exportArguments = new ExportArguments(context);
+        ExportArguments exportArguments = new ExportArguments(context, "html");
 
         Collection<DocumentReference> pageList = resolvePages(exportArguments, context);
         if (pageList.isEmpty()) {
@@ -415,7 +418,7 @@ public class ExportAction extends XWikiAction
         String licence = request.get("licence");
         String version = request.get("version");
 
-        ExportArguments exportArguments = new ExportArguments(context);
+        ExportArguments exportArguments = new ExportArguments(context, "xar");
 
         boolean all = exportArguments.exportPages.isEmpty();
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/ExportAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/ExportAction.java
@@ -83,7 +83,8 @@ public class ExportAction extends XWikiAction
     /**
      * Define the different format supported by the export.
      */
-    private enum EXPORT_FORMAT {
+    private enum ExportFormat
+    {
         XAR,
         HTML,
         OTHER
@@ -113,7 +114,7 @@ public class ExportAction extends XWikiAction
          */
         private String description;
 
-        ExportArguments(XWikiContext context, EXPORT_FORMAT format) throws XWikiException
+        ExportArguments(XWikiContext context, ExportFormat format) throws XWikiException
         {
             XWikiRequest request = context.getRequest();
 
@@ -124,7 +125,7 @@ public class ExportAction extends XWikiAction
             String[] pages = request.getParameterValues("pages");
             String[] excludes = request.getParameterValues("excludes");
 
-            if (StringUtils.isBlank(name) && !format.equals(EXPORT_FORMAT.XAR)) {
+            if (StringUtils.isBlank(name) && !format.equals(ExportFormat.XAR)) {
                 this.name = context.getDoc().getFullName();
             }
 
@@ -208,7 +209,7 @@ public class ExportAction extends XWikiAction
      */
     private String exportHTML(XWikiContext context) throws XWikiException, IOException
     {
-        ExportArguments exportArguments = new ExportArguments(context, EXPORT_FORMAT.HTML);
+        ExportArguments exportArguments = new ExportArguments(context, ExportFormat.HTML);
 
         Collection<DocumentReference> pageList = resolvePages(exportArguments, context);
         if (pageList.isEmpty()) {
@@ -425,7 +426,7 @@ public class ExportAction extends XWikiAction
         String licence = request.get("licence");
         String version = request.get("version");
 
-        ExportArguments exportArguments = new ExportArguments(context, EXPORT_FORMAT.XAR);
+        ExportArguments exportArguments = new ExportArguments(context, ExportFormat.XAR);
 
         boolean all = exportArguments.exportPages.isEmpty();
 


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XWIKI-15794

## Solution

  * Fix the name of the xar package when no name is given.