### PR TITLE
[Misc] Ignore overlays files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ nbproject
 .clover
 *~
 **/overlays/*.info
+xwiki-platform-distribution/xwiki-platform-distribution-war/overlays/


### PR DESCRIPTION
We have to exclude this kind of folders, so it would be nice to make the rule more generic. We probably shouldn't exclude all overlays folders as it would bring a limitation but we should exclude the ones that are generated in war modules.