### PR TITLE
XWIKI-15852: NPE on the propertyValues REST API end point when a document cannot be viewed

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/PageClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/PageClassPropertyValuesProvider.java
@@ -95,19 +95,26 @@ public class PageClassPropertyValuesProvider extends AbstractDocumentListClassPr
 
     private String getLabel(EntityReference entityReference)
     {
-        String label;
+        String label = null;
         try {
             XWikiContext xcontext = this.xcontextProvider.get();
-            XWikiDocument document;
-            document = xcontext.getWiki().getDocument(entityReference, xcontext).getTranslatedDocument(xcontext);
-            label = document.getRenderedTitle(Syntax.PLAIN_1_0, xcontext);
+            XWikiDocument document = xcontext.getWiki().getDocument(entityReference, xcontext);
+            if (document != null) {
+                document = document.getTranslatedDocument(xcontext);
+            }
+            if (document != null) {
+                label = document.getRenderedTitle(Syntax.PLAIN_1_0, xcontext);
+            }
         } catch (XWikiException e) {
             this.logger.error("Error while loading the document [{}]. Root cause is [{}]", entityReference,
                 ExceptionUtils.getRootCause(e));
-            if (entityReference instanceof DocumentReference) {
-                label = super.getLabel((DocumentReference) entityReference, "");
-            } else {
-                label = entityReference.getName();
+        } finally {
+            if (label == null) {
+                if (entityReference instanceof DocumentReference) {
+                    label = super.getLabel((DocumentReference) entityReference, "");
+                } else {
+                    label = entityReference.getName();
+                }
             }
         }
         return label;


### PR DESCRIPTION
### Issue

https://jira.xwiki.org/browse/XWIKI-15852

### Change

* Add checks for NPE.

### Note

The fix is not very sexy, would be great if someone could make suggestions.