### PR TITLE
XWIKI-15880: Create a button to delete all from the recycle bin

### DIFF
--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/Index/Translations.xml
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/Index/Translations.xml
@@ -44,6 +44,7 @@ index.spacesMacro.spaceAdministration.alt=Administer Space
 index.spacesMacro.createSpace.link=Create a new space
 index.spacesMacro.createSpace.defaultSpaceName=Space name
 index.spacesMacro.createSpace.submit=Create
+index.deletedDocuments.deleteAll=Delete all
 </content>
   <object>
     <name>Index.Translations</name>

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/XWiki/DeletedDocuments.xml
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/XWiki/DeletedDocuments.xml
@@ -356,12 +356,18 @@ XWiki.index.trash.documents.confirmDeleteAll = function(event) {
   } else {
     new XWiki.widgets.ConfirmedAjaxRequest(
       /* Ajax request URL */
-      this.href = "$xwiki.getURL($doc.fullName, 'delete', '&amp;confirm=1&amp;emptybin=true')" + "&amp;form_token=$!{services.csrf.getToken()}" + (Prototype.Browser.Opera ? "" : "&amp;ajax=1"),
+      this.href = XWiki.currentDocument.getURL('delete'),
       /* Ajax request parameters */
       {
+        parameters : {
+          'confirm': 1,
+          'emptybin': 'true',
+          'form_token': "$!{services.csrf.getToken()}",
+          'ajax': 1
+        },
         onCreate : function() {
           // Disable the button, to avoid a cascade of clicks from impatient users
-          this.addClassName('disabled');;
+          this.addClassName('disabled');
         }.bind(this),
         onSuccess : function() {
           // Update the livetable
@@ -390,11 +396,11 @@ document.observe('xwiki:dom:loaded', function() {
 
 // we need to wait the complete display of the livetable to get the number of rows
 document.observe('xwiki:livetable:documentsTrash:displayComplete', function() {
-  var actionAllContainer = $('documentsTrash').
-      getElementsBySelector('td.xwiki-livetable-display-header-filter:last-child')[0];
-
   // avoid to get multiple times the button
   if (!$('trashAllDeleted')) {
+    var actionAllContainer = $('documentsTrash').
+    getElementsBySelector('td.xwiki-livetable-display-header-filter:last-child')[0];
+
     var trashAll = new Element('a', {
       'id': 'trashAllDeleted',
       'class': 'btn btn-danger',

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/XWiki/DeletedDocuments.xml
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/XWiki/DeletedDocuments.xml
@@ -389,10 +389,22 @@ XWiki.index.trash.documents.confirmDeleteAll = function(event) {
 document.observe('xwiki:dom:loaded', function() {
   if ($('documentsTrash')) {
     $('documentsTrash').up('.hidden').removeClassName('hidden');
-    var actionAllContainer = $('documentsTrash').getElementsBySelector('td.xwiki-livetable-display-header-filter:nth-child(6)')[0];
+  }
+});
 
+// we need to wait the complete display of the livetable to get the number of rows
+document.observe('xwiki:livetable:displayComplete', function() {
+  if ($('documentsTrash')) {
+    var actionAllContainer = $('documentsTrash').getElementsBySelector('td.xwiki-livetable-display-header-filter:last-child')[0];
     var trashAllDisabled = (trashDocumentsLivetable.totalRows > 0) ? false : true;
+
+    // avoid to get multiple times the button
+    if ($('trashAllDeleted')) {
+      $('trashAllDeleted').remove();
+    }
+
     var trashAll = new Element('a', {
+        'id': 'trashAllDeleted',
         'class':'btn btn-danger',
         'href':'#',
         'disabled': trashAllDisabled

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/XWiki/DeletedDocuments.xml
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/XWiki/DeletedDocuments.xml
@@ -350,7 +350,7 @@ XWiki.index.trash.documents.confirmDelete = function(event, table, rowIdx) {
  */
 XWiki.index.trash.documents.confirmDeleteAll = function(event) {
   event.stop();
-  if (this.disabled) {
+  if (this.hasClassName('disabled')) {
     // Do nothing if the button was already clicked and it's waiting for a response from the server.
     return;
   } else {
@@ -361,16 +361,12 @@ XWiki.index.trash.documents.confirmDeleteAll = function(event) {
       {
         onCreate : function() {
           // Disable the button, to avoid a cascade of clicks from impatient users
-          this.disabled = true;
+          this.addClassName('disabled');;
         }.bind(this),
         onSuccess : function() {
           // Update the livetable
           trashDocumentsLivetable.refresh();
-        }.bindAsEventListener(this),
-        onComplete : function() {
-          // In the end: re-enable the button
-          this.disabled = false;
-        }.bind(this)
+        }.bindAsEventListener(this)
       },
       /* Interaction parameters */
       {
@@ -394,29 +390,21 @@ document.observe('xwiki:dom:loaded', function() {
 
 // we need to wait the complete display of the livetable to get the number of rows
 document.observe('xwiki:livetable:documentsTrash:displayComplete', function() {
-  if ($('documentsTrash')) {
-    var actionAllContainer = $('documentsTrash').
-        getElementsBySelector('td.xwiki-livetable-display-header-filter:last-child')[0];
+  var actionAllContainer = $('documentsTrash').
+      getElementsBySelector('td.xwiki-livetable-display-header-filter:last-child')[0];
 
-    if (trashDocumentsLivetable.totalRows > 0) {
-      var trashAllClass = 'btn btn-danger';
-    } else {
-      var trashAllClass = 'btn btn-danger disabled';
-    }
-
-    // avoid to get multiple times the button
-    if ($('trashAllDeleted')) {
-      $('trashAllDeleted').writeAttribute('class', trashAllClass);
-    } else {
-      var trashAll = new Element('a', {
-          'id': 'trashAllDeleted',
-          'class': trashAllClass,
-          'href':'#'
-          }).update('$services.localization.render('index.deletedDocuments.deleteAll')');
-      actionAllContainer.insert(trashAll);
-      trashAll.observe('click', XWiki.index.trash.documents.confirmDeleteAll.bindAsEventListener(trashAll));
-    }
+  // avoid to get multiple times the button
+  if (!$('trashAllDeleted')) {
+    var trashAll = new Element('a', {
+      'id': 'trashAllDeleted',
+      'class': 'btn btn-danger',
+      'href':'#'
+    }).update("$services.localization.render('index.deletedDocuments.deleteAll')");
+    actionAllContainer.insert(trashAll);
+    trashAll.observe('click', XWiki.index.trash.documents.confirmDeleteAll.bindAsEventListener(trashAll));
   }
+
+  $('trashAllDeleted').toggleClassName('disabled', trashDocumentsLivetable.totalRows &lt;= 0);
 });
       </code>
     </property>

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/XWiki/DeletedDocuments.xml
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/XWiki/DeletedDocuments.xml
@@ -356,12 +356,12 @@ XWiki.index.trash.documents.confirmDeleteAll = function(event) {
   } else {
     new XWiki.widgets.ConfirmedAjaxRequest(
       /* Ajax request URL */
-      this.href = XWiki.currentDocument.getURL('delete'),
+      XWiki.currentDocument.getURL('delete'),
       /* Ajax request parameters */
       {
         parameters : {
           'confirm': 1,
-          'emptybin': 'true',
+          'emptybin': true,
           'form_token': "$!{services.csrf.getToken()}",
           'ajax': 1
         },
@@ -399,7 +399,7 @@ document.observe('xwiki:livetable:documentsTrash:displayComplete', function() {
   // avoid to get multiple times the button
   if (!$('trashAllDeleted')) {
     var actionAllContainer = $('documentsTrash').
-    getElementsBySelector('td.xwiki-livetable-display-header-filter:last-child')[0];
+      getElementsBySelector('td.xwiki-livetable-display-header-filter:last-child')[0];
 
     var trashAll = new Element('a', {
       'id': 'trashAllDeleted',

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/XWiki/DeletedDocuments.xml
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/XWiki/DeletedDocuments.xml
@@ -393,25 +393,28 @@ document.observe('xwiki:dom:loaded', function() {
 });
 
 // we need to wait the complete display of the livetable to get the number of rows
-document.observe('xwiki:livetable:displayComplete', function() {
+document.observe('xwiki:livetable:documentsTrash:displayComplete', function() {
   if ($('documentsTrash')) {
-    var actionAllContainer = $('documentsTrash').getElementsBySelector('td.xwiki-livetable-display-header-filter:last-child')[0];
-    var trashAllDisabled = (trashDocumentsLivetable.totalRows > 0) ? false : true;
+    var actionAllContainer = $('documentsTrash').
+        getElementsBySelector('td.xwiki-livetable-display-header-filter:last-child')[0];
+
+    if (trashDocumentsLivetable.totalRows > 0) {
+      var trashAllClass = 'btn btn-danger';
+    } else {
+      var trashAllClass = 'btn btn-danger disabled';
+    }
 
     // avoid to get multiple times the button
     if ($('trashAllDeleted')) {
-      $('trashAllDeleted').remove();
-    }
-
-    var trashAll = new Element('a', {
-        'id': 'trashAllDeleted',
-        'class':'btn btn-danger',
-        'href':'#',
-        'disabled': trashAllDisabled
-        }).update('Delete all');
-    actionAllContainer.insert(trashAll);
-    if (!trashAllDisabled) {
-        trashAll.observe('click', XWiki.index.trash.documents.confirmDeleteAll.bindAsEventListener(trashAll));
+      $('trashAllDeleted').writeAttribute('class', trashAllClass);
+    } else {
+      var trashAll = new Element('a', {
+          'id': 'trashAllDeleted',
+          'class': trashAllClass,
+          'href':'#'
+          }).update('$services.localization.render('index.deletedDocuments.deleteAll')');
+      actionAllContainer.insert(trashAll);
+      trashAll.observe('click', XWiki.index.trash.documents.confirmDeleteAll.bindAsEventListener(trashAll));
     }
   }
 });

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/XWiki/DeletedDocuments.xml
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/XWiki/DeletedDocuments.xml
@@ -53,7 +53,8 @@ $xwiki.jsx.use('XWiki.DeletedDocuments')##
 #set($options = {
     'url'               : "$xwiki.getURL('XWiki.DeletedDocumentsJSON', 'view', 'list=1&amp;xpage=plain&amp;outputSyntax=plain')",
     'callback'          : 'XWiki.index.trash.documents.displayEntry',
-    'translationPrefix' : 'platform.index.trashDocuments.'
+    'translationPrefix' : 'platform.index.trashDocuments.',
+    'javascriptName'    : 'trashDocumentsLivetable'
   })##
 ##
 ##
@@ -341,6 +342,46 @@ XWiki.index.trash.documents.confirmDelete = function(event, table, rowIdx) {
       );
   }
 }
+
+/**
+ * Event listener, called when clicking the "delete all" button.
+ *
+ * @param event the link activation event
+ */
+XWiki.index.trash.documents.confirmDeleteAll = function(event) {
+  event.stop();
+  if (this.disabled) {
+    // Do nothing if the button was already clicked and it's waiting for a response from the server.
+    return;
+  } else {
+    new XWiki.widgets.ConfirmedAjaxRequest(
+      /* Ajax request URL */
+      this.href = "$xwiki.getURL($doc.fullName, 'delete', '&amp;confirm=1&amp;emptybin=true')" + "&amp;form_token=$!{services.csrf.getToken()}" + (Prototype.Browser.Opera ? "" : "&amp;ajax=1"),
+      /* Ajax request parameters */
+      {
+        onCreate : function() {
+          // Disable the button, to avoid a cascade of clicks from impatient users
+          this.disabled = true;
+        }.bind(this),
+        onSuccess : function() {
+          // Update the livetable
+          trashDocumentsLivetable.refresh();
+        }.bindAsEventListener(this),
+        onComplete : function() {
+          // In the end: re-enable the button
+          this.disabled = false;
+        }.bind(this)
+      },
+      /* Interaction parameters */
+      {
+         confirmationText: "$services.localization.render('core.recyclebin.completelyDeleteConfirm')",
+         progressMessageText : "$services.localization.render('platform.index.trashDocumentsDeleteInProgress')",
+         successMessageText : "$services.localization.render('platform.index.trashDocumentsDeleteDone')",
+         failureMessageText : "$services.localization.render('platform.index.trashDocumentsDeleteFailed')"
+      }
+      );
+  }
+}
 /*
  * The livetable is hidden when javascript is disabled, so that an alternative &lt;noscript&gt; table is displayed.
  * Re-display it when the document loads and Javascript is available.
@@ -348,8 +389,21 @@ XWiki.index.trash.documents.confirmDelete = function(event, table, rowIdx) {
 document.observe('xwiki:dom:loaded', function() {
   if ($('documentsTrash')) {
     $('documentsTrash').up('.hidden').removeClassName('hidden');
+    var actionAllContainer = $('documentsTrash').getElementsBySelector('td.xwiki-livetable-display-header-filter:nth-child(6)')[0];
+
+    var trashAllDisabled = (trashDocumentsLivetable.totalRows > 0) ? false : true;
+    var trashAll = new Element('a', {
+        'class':'btn btn-danger',
+        'href':'#',
+        'disabled': trashAllDisabled
+        }).update('Delete all');
+    actionAllContainer.insert(trashAll);
+    if (!trashAllDisabled) {
+        trashAll.observe('click', XWiki.index.trash.documents.confirmDeleteAll.bindAsEventListener(trashAll));
+    }
   }
-});</code>
+});
+      </code>
     </property>
     <property>
       <name/>


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XWIKI-15880

## Solution

  * Add the button inside the livetable
  * Wait for user confirmation
  * Refresh the livetable once it's done

## Limitations

  * I only supported the button for the livetable, not for the "noscript" part of the view
  * For now the confirmation message displayed is the same as for single document deletion

## Preview

![peek 26-11-2018 15-27](https://user-images.githubusercontent.com/1478232/49020078-e5a1be80-f18f-11e8-9d1d-8b1987f09ade.gif)
