### PR TITLE
XWIKI-15666: Validation check broken for 2 consecutive line breaks on translation pages

### DIFF
--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards/src/test/it/org/xwiki/test/webstandards/CustomDutchWebGuidelinesValidator.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards/src/test/it/org/xwiki/test/webstandards/CustomDutchWebGuidelinesValidator.java
@@ -76,6 +76,20 @@ public class CustomDutchWebGuidelinesValidator extends HTML5DutchWebGuidelinesVa
     }
 
     /**
+     * @return true if it's a translation document.
+     */
+    private boolean isTranslationDocument()
+    {
+        if (target instanceof DocumentReferenceTarget) {
+            DocumentReferenceTarget documentReferenceTarget = (DocumentReferenceTarget) target;
+
+            return documentReferenceTarget.getDocumentReference().getName().contains("Translations");
+        } else {
+            return false;
+        }
+    }
+
+    /**
      * Use the p (paragraph) element to indicate paragraphs. Do not use the br (linebreak) element to separate
      * paragraphs.
      */
@@ -83,7 +97,7 @@ public class CustomDutchWebGuidelinesValidator extends HTML5DutchWebGuidelinesVa
     public void validateRpd3s4()
     {
         if (!isPage("XWiki", "XWikiSyntax") && !isPage("XWiki", "XWikiSyntaxParagraphs")
-            && !isPage("XWiki", "XWikiSyntaxGeneralRemarks")) {
+            && !isPage("XWiki", "XWikiSyntaxGeneralRemarks") && !isTranslationDocument()) {
             super.validateRpd3s4();
         }
     }

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards/src/test/it/org/xwiki/test/webstandards/CustomDutchWebGuidelinesValidator.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards/src/test/it/org/xwiki/test/webstandards/CustomDutchWebGuidelinesValidator.java
@@ -96,6 +96,9 @@ public class CustomDutchWebGuidelinesValidator extends HTML5DutchWebGuidelinesVa
     @Override
     public void validateRpd3s4()
     {
+        // Exclude translation documents as they are using plain syntax and line breaking are then translated with
+        // potentially multiple br tags. Now those translations pages are not supposed to be watched by the users,
+        // so we can ignore them.
         if (!isPage("XWiki", "XWikiSyntax") && !isPage("XWiki", "XWikiSyntaxParagraphs")
             && !isPage("XWiki", "XWikiSyntaxGeneralRemarks") && !isTranslationDocument()) {
             super.validateRpd3s4();


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XWIKI-15666

## Solution

  * Ignore translations pages for checking rule Rpd3s4