### PR TITLE
 XWIKI-15883: Selected page versions range cannot be deleted anymore from History tab

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/HistoryPane.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/HistoryPane.java
@@ -133,6 +133,23 @@ public class HistoryPane extends BaseElement
         return new HistoryPane();
     }
 
+
+    private void selectVersions(String fromVersion, String toVersion)
+    {
+        String versionXPath = ".//input[@name = 'rev%s' and @value = '%s']";
+        getDriver().findElementWithoutWaiting(pane, By.xpath(String.format(versionXPath, 1, fromVersion))).click();
+        getDriver().findElementWithoutWaiting(pane, By.xpath(String.format(versionXPath, 2, toVersion))).click();
+    }
+
+    public HistoryPane deleteRangeVersions(String fromVersion, String toVersion)
+    {
+        getDriver().makeConfirmDialogSilent(true);
+        this.selectVersions(fromVersion, toVersion);
+        getDriver().findElementWithoutWaiting(pane, By.xpath(".//input[@name = 'deleteVersions']")).click();
+
+        return new HistoryPane();
+    }
+
     /**
      * Selects the specified document versions and clicks the button to compare them.
      * 
@@ -142,9 +159,7 @@ public class HistoryPane extends BaseElement
      */
     public ComparePage compare(String fromVersion, String toVersion)
     {
-        String versionXPath = ".//input[@name = 'rev%s' and @value = '%s']";
-        getDriver().findElementWithoutWaiting(pane, By.xpath(String.format(versionXPath, 1, fromVersion))).click();
-        getDriver().findElementWithoutWaiting(pane, By.xpath(String.format(versionXPath, 2, toVersion))).click();
+        this.selectVersions(fromVersion, toVersion);
         getDriver().findElementWithoutWaiting(pane, By.xpath(".//input[@accesskey = 'c']")).click();
         return new ComparePage();
     }

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/viewers/history.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/viewers/history.js
@@ -87,7 +87,7 @@ require(['jquery', 'xwiki-events-bridge'], function($) {
     var displayCompareButton = $("input[type='submit'][name='displayCompare']");
     displayCompareButton.on("click", displayCompareFunc);
 
-    var deleteVersionButton = $("input[type='submit'][name='deleteVersion']");
+    var deleteVersionButton = $("input[type='submit'][name='deleteVersions']");
     deleteVersionButton.on("click", deleteVersionFunc);
 
     var viewMinorVersionsButton = $("input[type='submit'][name='viewMinorVersions']");

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/src/test/it/org/xwiki/test/ui/CompareVersionsTest.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/src/test/it/org/xwiki/test/ui/CompareVersionsTest.java
@@ -66,11 +66,11 @@ public class CompareVersionsTest extends AbstractTest
      */
     private ViewPage testPage;
 
+    private final static String pageName = "PageWithManyVersions";
+
     @Before
     public void setUp() throws Exception
     {
-        String pageName = "PageWithManyVersions";
-
         // Check if the test page exists.
         testPage = getUtil().gotoPage(getTestClassName(), pageName);
         if (testPage.exists()) {
@@ -174,8 +174,10 @@ public class CompareVersionsTest extends AbstractTest
 
     private void testDeleteVersions()
     {
+        getUtil().loginAsAdmin();
+        testPage = getUtil().gotoPage(getTestClassName(), pageName);
         HistoryPane historyTab = testPage.openHistoryDocExtraPane().showMinorEdits();
-        HistoryPane historyPane = historyTab.deleteRangeVersions("1.3", "6.3");
+        HistoryPane historyPane = historyTab.deleteRangeVersions("1.3", "6.4");
         String queryString = "viewer=changes&rev1=1.1&rev2=1.2";
         getUtil().gotoPage(getTestClassName(), testPage.getMetaDataValue("page"), "view", queryString);
         ChangesPane changesPane = new ChangesPane();
@@ -185,16 +187,16 @@ public class CompareVersionsTest extends AbstractTest
         assertTrue(changesPane.hasNextChange());
         assertFalse(changesPane.hasPreviousFromVersion());
         assertTrue(changesPane.hasNextFromVersion());
-        assertFalse(changesPane.hasPreviousToVersion());
+        assertTrue(changesPane.hasPreviousToVersion());
         assertTrue(changesPane.hasNextToVersion());
         changesPane.clickNextChange();
 
         assertEquals("1.2", changesPane.getFromVersion());
-        assertEquals("6.4", changesPane.getToVersion());
+        assertEquals("6.5", changesPane.getToVersion());
         assertTrue(changesPane.hasPreviousChange());
         assertFalse(changesPane.hasNextChange());
         assertTrue(changesPane.hasPreviousFromVersion());
-        assertFalse(changesPane.hasNextFromVersion());
+        assertTrue(changesPane.hasNextFromVersion());
         assertTrue(changesPane.hasPreviousToVersion());
         assertFalse(changesPane.hasNextToVersion());
     }
@@ -204,6 +206,7 @@ public class CompareVersionsTest extends AbstractTest
      */
     private void testAllChanges()
     {
+        testPage = getUtil().gotoPage(getTestClassName(), pageName);
         HistoryPane historyTab = testPage.openHistoryDocExtraPane().showMinorEdits();
         String currentVersion = historyTab.getCurrentVersion();
 
@@ -294,6 +297,7 @@ public class CompareVersionsTest extends AbstractTest
      */
     private void testNoChanges()
     {
+        testPage = getUtil().gotoPage(getTestClassName(), pageName);
         HistoryPane historyTab = testPage.openHistoryDocExtraPane();
         String currentVersion = historyTab.getCurrentVersion();
         assertTrue(historyTab.compare(currentVersion, currentVersion).getChangesPane().hasNoChanges());
@@ -304,6 +308,7 @@ public class CompareVersionsTest extends AbstractTest
      */
     private void testUnifiedDiffShowsInlineChanges()
     {
+        testPage = getUtil().gotoPage(getTestClassName(), pageName);
         ChangesPane changesPane =
             testPage.openHistoryDocExtraPane().showMinorEdits().compare("2.2", "2.3").getChangesPane();
         EntityDiff jsxDiff = changesPane.getEntityDiff("XWiki.JavaScriptExtension[0]");

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/src/test/it/org/xwiki/test/ui/CompareVersionsTest.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/src/test/it/org/xwiki/test/ui/CompareVersionsTest.java
@@ -162,11 +162,47 @@ public class CompareVersionsTest extends AbstractTest
         getDriver().navigate().refresh();
     }
 
+    @Test
+    public void testCompareVersionScenario()
+    {
+        testAllChanges();
+        testVersionNavigation();
+        testUnifiedDiffShowsInlineChanges();
+        testNoChanges();
+        testDeleteVersions();
+    }
+
+    private void testDeleteVersions()
+    {
+        HistoryPane historyTab = testPage.openHistoryDocExtraPane().showMinorEdits();
+        HistoryPane historyPane = historyTab.deleteRangeVersions("1.3", "6.3");
+        String queryString = "viewer=changes&rev1=1.1&rev2=1.2";
+        getUtil().gotoPage(getTestClassName(), testPage.getMetaDataValue("page"), "view", queryString);
+        ChangesPane changesPane = new ChangesPane();
+        assertEquals("1.1", changesPane.getFromVersion());
+        assertEquals("1.2", changesPane.getToVersion());
+        assertFalse(changesPane.hasPreviousChange());
+        assertTrue(changesPane.hasNextChange());
+        assertFalse(changesPane.hasPreviousFromVersion());
+        assertTrue(changesPane.hasNextFromVersion());
+        assertFalse(changesPane.hasPreviousToVersion());
+        assertTrue(changesPane.hasNextToVersion());
+        changesPane.clickNextChange();
+
+        assertEquals("1.2", changesPane.getFromVersion());
+        assertEquals("6.4", changesPane.getToVersion());
+        assertTrue(changesPane.hasPreviousChange());
+        assertFalse(changesPane.hasNextChange());
+        assertTrue(changesPane.hasPreviousFromVersion());
+        assertFalse(changesPane.hasNextFromVersion());
+        assertTrue(changesPane.hasPreviousToVersion());
+        assertFalse(changesPane.hasNextToVersion());
+    }
+
     /**
      * Tests that all changes are displayed.
      */
-    @Test
-    public void testAllChanges()
+    private void testAllChanges()
     {
         HistoryPane historyTab = testPage.openHistoryDocExtraPane().showMinorEdits();
         String currentVersion = historyTab.getCurrentVersion();
@@ -251,15 +287,12 @@ public class CompareVersionsTest extends AbstractTest
         assertDiff(ageDiff.getDiff("Pretty Name"), "+age");
         assertDiff(ageDiff.getDiff("Size"), "+30");
         assertDiff(ageDiff.getDiff("Number Type"), "+integer");
-
-        testVersionNavigation();
     }
 
     /**
      * Tests that a message is displayed when there are no changes.
      */
-    @Test
-    public void testNoChanges()
+    private void testNoChanges()
     {
         HistoryPane historyTab = testPage.openHistoryDocExtraPane();
         String currentVersion = historyTab.getCurrentVersion();
@@ -269,8 +302,7 @@ public class CompareVersionsTest extends AbstractTest
     /**
      * Tests that the unified diff (for multi-line text) shows the inline changes.
      */
-    @Test
-    public void testUnifiedDiffShowsInlineChanges()
+    private void testUnifiedDiffShowsInlineChanges()
     {
         ChangesPane changesPane =
             testPage.openHistoryDocExtraPane().showMinorEdits().compare("2.2", "2.3").getChangesPane();


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XWIKI-15883

## Fix

  * Add a missing "s" to identify properly the input

## Test

Add new integration-test to identify properly the behaviour of delete range version