### PR TITLE
XWIKI-15885: When visiting a user profile page with a different user, the list of joined wikis is wrong

### DIFF
--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-mainwiki/src/main/resources/WikiManager/UserWikiSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-mainwiki/src/main/resources/WikiManager/UserWikiSheet.xml
@@ -57,7 +57,7 @@
       #set ($joinedWikis = [])
       #set ($wikis = $services.wiki.getAll())
       #foreach ($wiki in $wikis)
-        #if($services.wiki.user.isMember($currentUser, $wiki.id))
+        #if($services.wiki.user.isMember($documentUser, $wiki.id))
           #set($temp = $joinedWikis.add($wiki))
         #end
       #end


### PR DESCRIPTION
  * Use the documentUser instead of the currentUser