### PR TITLE
XWIKI-15843: Missing use of translation key in tags.js

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -2069,6 +2069,9 @@ core.tags.remove.tooltip=Delete this tag from the page
 core.tags.remove.error.notFound=This tag is not set
 core.tags.remove.error.notAllowed=You are not allowed to remove tags from this page
 core.tags.remove.error.failed=Failed to remove tag "{0}" due to an internal server error
+core.tags.adding=Adding tag...
+core.tags.deleting=Deleting tag...
+core.tags.fetchform=Fetching form...
 xe.tag.paramerror=Do not use "space" and "spaces" parameter in the same time
 
 ### Page footer

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/viewers/tags.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/viewers/tags.js
@@ -52,7 +52,7 @@ viewers.Tags = Class.create({
             onCreate : function () {
               // ignore "cascade" clicks
               item.disabled = true;
-              item.notification = new XWiki.widgets.Notification("Deleting tag...", "inprogress");
+              item.notification = new XWiki.widgets.Notification("$services.localization.render('core.tags.deleting')", "inprogress");
             },
             onSuccess : function () {
               // delete the corresponding element
@@ -87,7 +87,7 @@ viewers.Tags = Class.create({
               onCreate : function () {
                 // ignore "cascade" clicks
                 item.disabled = true;
-                item.notification = new XWiki.widgets.Notification("Fetching form...", "inprogress");
+                item.notification = new XWiki.widgets.Notification("$services.localization.render('core.tags.fetchform')", "inprogress");
               },
               onSuccess : function (response) {
                 var iParent = item.up();
@@ -132,7 +132,7 @@ viewers.Tags = Class.create({
             onCreate : function () {
               // ignore "cascade" clicks
               form.disable();
-              form.notification = new XWiki.widgets.Notification("Adding tag...", "inprogress");
+              form.notification = new XWiki.widgets.Notification("$services.localization.render('core.tags.adding')", "inprogress");
             },
             onSuccess : function (response) {
               var wrapper = new Element('span');


### PR DESCRIPTION
  * Add missing translation keys and use them in tags.js