### PR TITLE
XWIKI-15920: Some macros are rendered twice

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroRenderer.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroRenderer.java
@@ -338,7 +338,7 @@ public class DefaultWikiMacroRenderer extends AbstractBlockAsyncRenderer
 
             Block syncMetaDataBlock;
 
-            if (async) {
+            if (!async) {
                 block = macroXDOM;
                 xdom = macroXDOM;
 


### PR DESCRIPTION
  * Change a condition by adding a missing "!" in
DefaultWikiMacroRenderer