### PR TITLE
XWIKI-15899: Global users cannot recover their password from a subwiki due to macro errors

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/ResetPassword.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/ResetPassword.xml
@@ -106,7 +106,7 @@ u = user account sent in the form
       #set ($discard = $verifObj.set('verification', $verifStr))
       #set ($discard = $userDoc.saveAsAuthor($services.localization.render('xe.admin.passwordReset.versionComment'), true))
       ## Compose the verification URL
-      #set ($passwordResetURL = $xwiki.getDocument('XWiki.ResetPasswordComplete').getExternalURL('view', "u=${userName}&amp;v=${verifStr}"))
+      #set ($passwordResetURL = $xwiki.getDocument("${userDoc.wiki}:XWiki.ResetPasswordComplete").getExternalURL('view', "u=${userName}&amp;v=${verifStr}"))
       ## Send the email
       #set ($from = $services.mailsender.configuration.fromAddress)
       #if ("$!from" == '')

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/ResetPassword.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/ResetPassword.xml
@@ -106,7 +106,8 @@ u = user account sent in the form
       #set ($discard = $verifObj.set('verification', $verifStr))
       #set ($discard = $userDoc.saveAsAuthor($services.localization.render('xe.admin.passwordReset.versionComment'), true))
       ## Compose the verification URL
-      #set ($passwordResetURL = $xwiki.getDocument("${userDoc.wiki}:XWiki.ResetPasswordComplete").getExternalURL('view', "u=${userName}&amp;v=${verifStr}"))
+      #set ($userDocRef = $escapetool.url($services.model.serialize($userDoc.documentReference, 'default')))
+      #set ($passwordResetURL = $xwiki.getDocument("XWiki.ResetPasswordComplete").getExternalURL('view', "u=${userDocRef}&amp;v=${verifStr}"))
       ## Send the email
       #set ($from = $services.mailsender.configuration.fromAddress)
       #if ("$!from" == '')

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PasswordClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PasswordClass.java
@@ -211,11 +211,13 @@ public class PasswordClass extends StringClass
     public String getEquivalentPassword(String storedPassword, String plainPassword)
     {
         String result = plainPassword;
-        if (storedPassword.startsWith(HASH_IDENTIFIER + SEPARATOR)) {
-            result =
-                getPasswordHash(result, getAlgorithmFromPassword(storedPassword), getSaltFromPassword(storedPassword));
-        } else if (storedPassword.startsWith(CRYPT_IDENTIFIER + SEPARATOR)) {
-            result = getPasswordCrypt(result, getAlgorithmFromPassword(storedPassword));
+        if (storedPassword != null && plainPassword != null) {
+            if (storedPassword.startsWith(HASH_IDENTIFIER + SEPARATOR)) {
+                result =
+                        getPasswordHash(result, getAlgorithmFromPassword(storedPassword), getSaltFromPassword(storedPassword));
+            } else if (storedPassword.startsWith(CRYPT_IDENTIFIER + SEPARATOR)) {
+                result = getPasswordCrypt(result, getAlgorithmFromPassword(storedPassword));
+            }
         }
         return result;
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PasswordClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PasswordClass.java
@@ -213,8 +213,8 @@ public class PasswordClass extends StringClass
         String result = plainPassword;
         if (storedPassword != null && plainPassword != null) {
             if (storedPassword.startsWith(HASH_IDENTIFIER + SEPARATOR)) {
-                result =
-                        getPasswordHash(result, getAlgorithmFromPassword(storedPassword), getSaltFromPassword(storedPassword));
+                result = getPasswordHash(result, getAlgorithmFromPassword(storedPassword),
+                        getSaltFromPassword(storedPassword));
             } else if (storedPassword.startsWith(CRYPT_IDENTIFIER + SEPARATOR)) {
                 result = getPasswordCrypt(result, getAlgorithmFromPassword(storedPassword));
             }


### PR DESCRIPTION
### Issue

https://jira.xwiki.org/browse/XWIKI-15899

### Change

* Generate the password recovery URL by serializing the user document.
* Avoid NPE.