### PR TITLE
XWIKI-15713: History tab indicate that the page does not exist when the history is empty

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/historyinline.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/historyinline.vm
@@ -19,7 +19,7 @@
 #set ($discard = $collectionstool.reverse($versions))
 #set ($totalVersions = $versions.size())
 #if ($totalVersions == 0)
-  #warning ($services.localization.render('thispagedoesnotexist'))
+  #warning ($services.localization.render(core.history.empty''))
 #else
   #set ($paginationParameters = {'url' : "?${viewer}&amp;showminor=${minorVersions}", 'totalItems' : $totalVersions, 'defaultItemsPerPage' : 20, 'position': 'top'})
   #pagination ($paginationParameters)

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/historyinline.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/historyinline.vm
@@ -19,7 +19,7 @@
 #set ($discard = $collectionstool.reverse($versions))
 #set ($totalVersions = $versions.size())
 #if ($totalVersions == 0)
-  #warning ($services.localization.render(core.history.empty''))
+  #warning ($services.localization.render('core.viewers.history.empty'))
 #else
   #set ($paginationParameters = {'url' : "?${viewer}&amp;showminor=${minorVersions}", 'totalItems' : $totalVersions, 'defaultItemsPerPage' : 20, 'position': 'top'})
   #pagination ($paginationParameters)

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -5281,7 +5281,7 @@ xe.admin.users.filter.lastname=Last name filter
 #######################################
 ## until 10.11
 #######################################
-core.history.empty="The history of this page is empty."
+core.viewers.history.empty="The history of this page is empty."
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -5279,7 +5279,7 @@ xe.admin.users.lastname=Last name
 xe.admin.users.filter.lastname=Last name filter
 
 #######################################
-## until 10.11
+## until 10.11RC1
 #######################################
 core.viewers.history.empty="The history of this page is empty."
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -1109,6 +1109,7 @@ core.viewers.history.confirmDeleteRange=This action is not reversible. Are you s
 core.viewers.history.showMinorEdits=Show minor edits
 core.viewers.history.hideMinorEdits=Hide minor edits
 core.viewers.history.extension.label={0}Version{1} coming from extension {2}{3} {4}{5}
+core.viewers.history.empty="The history of this page is empty."
 
 core.viewers.information.title=Information about <a href="{1}">{0}</a>
 core.viewers.information.parent=Parent
@@ -5277,11 +5278,6 @@ xe.admin.users.filter.firstname=First name filter
 #@deprecated xe.admin.users.last_name
 xe.admin.users.lastname=Last name
 xe.admin.users.filter.lastname=Last name filter
-
-#######################################
-## until 10.11RC1
-#######################################
-core.viewers.history.empty="The history of this page is empty."
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -5278,6 +5278,11 @@ xe.admin.users.filter.firstname=First name filter
 xe.admin.users.lastname=Last name
 xe.admin.users.filter.lastname=Last name filter
 
+#######################################
+## until 10.11
+#######################################
+core.history.empty="The history of this page is empty."
+
 ## Used to indicate where deprecated keys end
 #@deprecatedend
 


### PR DESCRIPTION
### Issue

https://jira.xwiki.org/browse/XWIKI-15713

### Change

* Change the warning message of an empty history of a page.

### Note

I'm making a PR because I haven't tested the change and maybe the new key should have another name.