### PR TITLE
XWIKI-15944: Add ability to pass test resources to Docker-based tests

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/AbstractContainerExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/AbstractContainerExecutor.java
@@ -60,7 +60,7 @@ public abstract class AbstractContainerExecutor
      * @param targetDirectory the target where to mount the directory in the container.
      * @since 10.11RC1
      */
-    protected static void mountFromHostToContainer(GenericContainer container, String sourceDirectory,
+    protected void mountFromHostToContainer(GenericContainer container, String sourceDirectory,
         String targetDirectory)
     {
         // File mounting is awfully slow on Mac OSX. For example starting Tomcat with XWiki mounted takes

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/AbstractContainerExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/AbstractContainerExecutor.java
@@ -23,6 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.utility.MountableFile;
 
 /**
  * Common code for container execution.
@@ -50,5 +51,26 @@ public abstract class AbstractContainerExecutor
 
         // Display logs after the container has been started so that we can see problems happening in the containers
         DockerTestUtils.followOutput(container, getClass());
+    }
+
+    /**
+     * Utility method to mount a directory from the host to the container with some optimization for different OS.
+     * @param container the container on which to mount the directory.
+     * @param sourceDirectory the path of the directory on the host to mount in the container.
+     * @param targetDirectory the target where to mount the directory in the container.
+     * @since 10.11RC1
+     */
+    protected static void mountFromHostToContainer(GenericContainer container, String sourceDirectory,
+        String targetDirectory)
+    {
+        // File mounting is awfully slow on Mac OSX. For example starting Tomcat with XWiki mounted takes
+        // 45s+, while doing a COPY first and then starting Tomcat takes 8s (+5s for the copy).
+        String osName = System.getProperty("os.name").toLowerCase();
+        if (osName.startsWith("mac os x")) {
+            MountableFile mountableDirectory = MountableFile.forHostPath(sourceDirectory);
+            container.withCopyFileToContainer(mountableDirectory, targetDirectory);
+        } else {
+            container.withFileSystemBind(sourceDirectory, targetDirectory);
+        }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/TestConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/TestConfiguration.java
@@ -73,8 +73,6 @@ public class TestConfiguration
 
     private static final String PROFILES_PROPERTY = "xwiki.test.ui.profiles";
 
-    private static final String TEST_RESOURCES_PATH = "/tmp/test-resources";
-
     private UITest uiTestAnnotation;
 
     private Browser browser;
@@ -460,14 +458,5 @@ public class TestConfiguration
             outputDirectory = mavenBuildDir;
         }
         return outputDirectory;
-    }
-
-    /**
-     * @return the path of the directory containing the test resources on the container.
-     * @since 10.11RC1
-     */
-    public String getTestResourcesPath()
-    {
-        return TEST_RESOURCES_PATH;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/TestConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/TestConfiguration.java
@@ -73,6 +73,8 @@ public class TestConfiguration
 
     private static final String PROFILES_PROPERTY = "xwiki.test.ui.profiles";
 
+    private static final String TEST_RESOURCES_PATH = "/tmp/test-resources";
+
     private UITest uiTestAnnotation;
 
     private Browser browser;
@@ -458,5 +460,14 @@ public class TestConfiguration
             outputDirectory = mavenBuildDir;
         }
         return outputDirectory;
+    }
+
+    /**
+     * @return the path of the directory containing the test resources on the container.
+     * @since 10.11RC1
+     */
+    public String getTestResourcesPath()
+    {
+        return TEST_RESOURCES_PATH;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/XWikiDockerExtension.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/XWikiDockerExtension.java
@@ -33,9 +33,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.Testcontainers;
 import org.testcontainers.containers.BrowserWebDriverContainer;
-import org.testcontainers.containers.Network;
 import org.testcontainers.containers.VncRecordingContainer;
-import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.xwiki.test.docker.junit5.browser.BrowserContainerExecutor;
 import org.xwiki.test.docker.junit5.database.DatabaseContainerExecutor;
 import org.xwiki.test.docker.junit5.servletEngine.ServletContainerExecutor;
 import org.xwiki.test.docker.junit5.servletEngine.ServletEngine;
@@ -83,8 +82,6 @@ public class XWikiDockerExtension extends AbstractExtension implements BeforeAll
     private static final Logger LOGGER = LoggerFactory.getLogger(XWikiDockerExtension.class);
 
     private static final String SUPERADMIN = "superadmin";
-
-    private static final String TEST_RESOURCES_HOST_PATH = "target/test-classes";
 
     @Override
     public void beforeAll(ExtensionContext extensionContext) throws Exception
@@ -242,27 +239,8 @@ public class XWikiDockerExtension extends AbstractExtension implements BeforeAll
     private BrowserWebDriverContainer startBrowser(TestConfiguration testConfiguration,
         ExtensionContext extensionContext)
     {
-        LOGGER.info("(*) Starting browser [{}]...", testConfiguration.getBrowser());
-
-        // Create a single BrowserWebDriverContainer instance and reuse it for all the tests in the test class.
-        BrowserWebDriverContainer webDriverContainer = new BrowserWebDriverContainer<>()
-            .withDesiredCapabilities(testConfiguration.getBrowser().getCapabilities())
-            .withNetwork(Network.SHARED)
-            .withNetworkAliases("vnchost")
-            .withRecordingMode(BrowserWebDriverContainer.VncRecordingMode.SKIP, null)
-            .withFileSystemBind(TEST_RESOURCES_HOST_PATH, testConfiguration.getTestResourcesPath());
-
-        if (testConfiguration.isVerbose()) {
-            LOGGER.info(String.format("Docker image used: [%s]",
-                BrowserWebDriverContainer.getImageForCapabilities(testConfiguration.getBrowser().getCapabilities())));
-            webDriverContainer.withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger(this.getClass())));
-        }
-
-        webDriverContainer.start();
-
-        if (testConfiguration.vnc()) {
-            LOGGER.info("VNC server address = " + webDriverContainer.getVncAddress());
-        }
+        BrowserContainerExecutor browserContainerExecutor = new BrowserContainerExecutor();
+        BrowserWebDriverContainer webDriverContainer = browserContainerExecutor.start(testConfiguration);
 
         // Store it so that we can retrieve it later on.
         // Note that we don't need to stop it as this is taken care of by TestContainers

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/XWikiDockerExtension.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/XWikiDockerExtension.java
@@ -84,6 +84,8 @@ public class XWikiDockerExtension extends AbstractExtension implements BeforeAll
 
     private static final String SUPERADMIN = "superadmin";
 
+    private static final String TEST_RESOURCES_HOST_PATH = "target/test-classes";
+
     @Override
     public void beforeAll(ExtensionContext extensionContext) throws Exception
     {
@@ -247,7 +249,8 @@ public class XWikiDockerExtension extends AbstractExtension implements BeforeAll
             .withDesiredCapabilities(testConfiguration.getBrowser().getCapabilities())
             .withNetwork(Network.SHARED)
             .withNetworkAliases("vnchost")
-            .withRecordingMode(BrowserWebDriverContainer.VncRecordingMode.SKIP, null);
+            .withRecordingMode(BrowserWebDriverContainer.VncRecordingMode.SKIP, null)
+            .withFileSystemBind(TEST_RESOURCES_HOST_PATH, testConfiguration.getTestResourcesPath());
 
         if (testConfiguration.isVerbose()) {
             LOGGER.info(String.format("Docker image used: [%s]",

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/browser/Browser.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/browser/Browser.java
@@ -46,6 +46,11 @@ public enum Browser
      */
     CHROME(DesiredCapabilities.chrome());
 
+    /**
+     * The path where to store the test-resources on the browser container.
+     */
+    private static final String TEST_RESOURCES_PATH = "/tmp/test-resources";
+
     private DesiredCapabilities capabilities;
 
     Browser()
@@ -64,5 +69,14 @@ public enum Browser
     public DesiredCapabilities getCapabilities()
     {
         return this.capabilities;
+    }
+
+    /**
+     * @return the path of the directory containing the test resources on the browser container.
+     * @since 10.11RC1
+     */
+    public String getTestResourcesPath()
+    {
+        return TEST_RESOURCES_PATH;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/browser/BrowserContainerExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/browser/BrowserContainerExecutor.java
@@ -1,0 +1,78 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.test.docker.junit5.browser;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.BrowserWebDriverContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.xwiki.test.docker.junit5.AbstractContainerExecutor;
+import org.xwiki.test.docker.junit5.TestConfiguration;
+
+/**
+ * Create and execute the browser docker container for driving the tests.
+ *
+ * @version $Id$
+ * @since 10.11RC1
+ */
+public class BrowserContainerExecutor extends AbstractContainerExecutor
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(BrowserContainerExecutor.class);
+
+    /**
+     * This path represents the standard path where the test-resources are stored with Maven after test compilation.
+     */
+    private static final String TEST_RESOURCES_HOST_PATH = "target/test-classes";
+
+    /**
+     * Create and start the {@link BrowserWebDriverContainer} based on the test given test configuration.
+     *
+     * @param testConfiguration the configuration used to parameterize this container.
+     * @return the started browser driver container.
+     */
+    public BrowserWebDriverContainer start(TestConfiguration testConfiguration)
+    {
+        LOGGER.info("(*) Starting browser [{}]...", testConfiguration.getBrowser());
+        Browser browser = testConfiguration.getBrowser();
+
+        // Create a single BrowserWebDriverContainer instance and reuse it for all the tests in the test class.
+        BrowserWebDriverContainer webDriverContainer = new BrowserWebDriverContainer<>()
+            .withDesiredCapabilities(browser.getCapabilities())
+            .withNetwork(Network.SHARED)
+            .withNetworkAliases("vnchost")
+            .withRecordingMode(BrowserWebDriverContainer.VncRecordingMode.SKIP, null)
+            .withFileSystemBind(TEST_RESOURCES_HOST_PATH, browser.getTestResourcesPath());
+
+        if (testConfiguration.isVerbose()) {
+            LOGGER.info(String.format("Docker image used: [%s]",
+                BrowserWebDriverContainer.getImageForCapabilities(testConfiguration.getBrowser().getCapabilities())));
+            webDriverContainer.withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger(this.getClass())));
+        }
+
+        webDriverContainer.start();
+
+        if (testConfiguration.vnc()) {
+            LOGGER.info("VNC server address = " + webDriverContainer.getVncAddress());
+        }
+
+        return webDriverContainer;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/browser/BrowserContainerExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/browser/BrowserContainerExecutor.java
@@ -59,6 +59,9 @@ public class BrowserContainerExecutor extends AbstractContainerExecutor
             .withNetwork(Network.SHARED)
             .withNetworkAliases("vnchost")
             .withRecordingMode(BrowserWebDriverContainer.VncRecordingMode.SKIP, null)
+
+            // In case some test-resources are provided, they need to be available from the browser
+            // for example in order to upload some files on the wiki.
             .withFileSystemBind(TEST_RESOURCES_HOST_PATH, browser.getTestResourcesPath());
 
         if (testConfiguration.isVerbose()) {

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/servletEngine/ServletContainerExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/servletEngine/ServletContainerExecutor.java
@@ -27,7 +27,6 @@ import org.apache.commons.io.IOUtils;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.utility.MountableFile;
 import org.xwiki.test.docker.junit5.AbstractContainerExecutor;
 import org.xwiki.test.docker.junit5.ArtifactResolver;
 import org.xwiki.test.docker.junit5.MavenResolver;
@@ -91,7 +90,8 @@ public class ServletContainerExecutor extends AbstractContainerExecutor
                 String tomcatTag = String.format("tomcat:%s", this.testConfiguration.getServletEngineTag() != null
                     ? this.testConfiguration.getServletEngineTag() : LATEST);
                 this.servletContainer = new GenericContainer<>(tomcatTag);
-                mountFromHostToContainer(sourceWARDirectory, "/usr/local/tomcat/webapps/xwiki");
+                mountFromHostToContainer(this.servletContainer, sourceWARDirectory.toString(),
+                    "/usr/local/tomcat/webapps/xwiki");
 
                 this.servletContainer.withEnv("CATALINA_OPTS", "-Xmx1024m "
                     + "-Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true "
@@ -103,7 +103,8 @@ public class ServletContainerExecutor extends AbstractContainerExecutor
                 String jettyTag = String.format("jetty:%s", this.testConfiguration.getServletEngineTag() != null
                     ? this.testConfiguration.getServletEngineTag() : LATEST);
                 this.servletContainer = new GenericContainer<>(jettyTag);
-                mountFromHostToContainer(sourceWARDirectory, "/var/lib/jetty/webapps/xwiki");
+                mountFromHostToContainer(this.servletContainer, sourceWARDirectory.toString(),
+                    "/var/lib/jetty/webapps/xwiki");
 
                 break;
             case WILDFLY:
@@ -111,7 +112,7 @@ public class ServletContainerExecutor extends AbstractContainerExecutor
                     this.testConfiguration.getServletEngineTag() != null
                         ? this.testConfiguration.getServletEngineTag() : LATEST);
                 this.servletContainer = new GenericContainer<>(wildflyTag);
-                mountFromHostToContainer(sourceWARDirectory,
+                mountFromHostToContainer(this.servletContainer, sourceWARDirectory.toString(),
                     "/opt/jboss/wildfly/standalone/deployments/xwiki");
 
                 break;
@@ -173,19 +174,6 @@ public class ServletContainerExecutor extends AbstractContainerExecutor
                 break;
             default:
                 // Nothing else to do, TestContainers automatically stops the container
-        }
-    }
-
-    private void mountFromHostToContainer(File sourceDirectory, String targetDirectory)
-    {
-        // File mounting is awfully slow on Mac OSX. For example starting Tomcat with XWiki mounted takes
-        // 45s+, while doing a COPY first and then starting Tomcat takes 8s (+5s for the copy).
-        String osName = System.getProperty("os.name").toLowerCase();
-        if (osName.startsWith("mac os x")) {
-            MountableFile mountableDirectory = MountableFile.forHostPath(sourceDirectory.toString());
-            this.servletContainer.withCopyFileToContainer(mountableDirectory, targetDirectory);
-        } else {
-            this.servletContainer.withFileSystemBind(sourceDirectory.toString(), targetDirectory);
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/servletEngine/ServletContainerExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/servletEngine/ServletContainerExecutor.java
@@ -154,14 +154,6 @@ public class ServletContainerExecutor extends AbstractContainerExecutor
                 Wait.forHttp("/xwiki/bin/get/Main/WebHome")
                     .forStatusCode(200).withStartupTimeout(Duration.of(480, SECONDS)));
 
-        // Mount the test resources directory from the host into the container so that it's possible for tests to
-        // use test resource data (e.g. a word doc to import in the XWiki for office tests).
-        File testResourcesDirectory = new File(this.testConfiguration.getOutputDirectory(), "test-classes");
-        if (testResourcesDirectory.exists()) {
-            mountFromHostToContainer(testResourcesDirectory,
-                this.testConfiguration.getServletEngine().getTestResourcesPath());
-        }
-
         if (this.testConfiguration.isOffline()) {
             String repoLocation = this.repositoryResolver.getSession().getLocalRepository().getBasedir().toString();
             this.servletContainer.withFileSystemBind(repoLocation, "/root/.m2/repository");

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/servletEngine/ServletEngine.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/servletEngine/ServletEngine.java
@@ -62,8 +62,6 @@ public enum ServletEngine
 
     private static final String PERMANENT_DIRECTORY = "/var/local/xwiki";
 
-    private static final String TEST_RESOURCES_PATH = String.format("%s/testResources", PERMANENT_DIRECTORY);
-
     private static final String LOCALHOST = "localhost";
 
     private static final String HOST_INTERNAL = "host.testcontainers.internal";
@@ -165,15 +163,5 @@ public enum ServletEngine
     public String getPermanentDirectory()
     {
         return PERMANENT_DIRECTORY;
-    }
-
-    /**
-     * @return the location inside the Docker container for resources used by tests. They make it possible for tests to
-     *         use test resource data (e.g. a word doc to import in the XWiki for office tests).
-     * @since 10.11RC1
-     */
-    public String getTestResourcesPath()
-    {
-        return TEST_RESOURCES_PATH;
     }
 }


### PR DESCRIPTION
  * Fix places of the test resources: they should be mounted in browser
container, not in servlet container