### PR TITLE
XWIKI-15666: Validation check broken for 2 consecutive line breaks on translation pages

### DIFF
--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards/pom.xml
@@ -97,6 +97,9 @@
           <!-- Display report on screen when all tests are completed -->  
           <useFile>false</useFile>
           <reportFormat>plain</reportFormat>
+          <systemPropertyVariables>
+            <whitelistedWCAGClasses>Panels.PanelClass</whitelistedWCAGClasses>
+          </systemPropertyVariables>
         </configuration>
       </plugin>
     </plugins>

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards/src/test/it/org/xwiki/test/webstandards/CustomDutchWebGuidelinesValidationTest.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards/src/test/it/org/xwiki/test/webstandards/CustomDutchWebGuidelinesValidationTest.java
@@ -27,6 +27,11 @@ import org.xwiki.test.webstandards.framework.Target;
 
 public class CustomDutchWebGuidelinesValidationTest extends DefaultValidationTest
 {
+    /**
+     * This field is needed to skip technical pages. It is read by reflexivity.
+     */
+    private static boolean skipTechnicalPages = true;
+
     public CustomDutchWebGuidelinesValidationTest(Target target, HttpClient client, Validator validator,
         String credentials) throws Exception
     {

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards/src/test/it/org/xwiki/test/webstandards/CustomDutchWebGuidelinesValidationTest.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards/src/test/it/org/xwiki/test/webstandards/CustomDutchWebGuidelinesValidationTest.java
@@ -19,6 +19,9 @@
  */
 package org.xwiki.test.webstandards;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.apache.commons.httpclient.HttpClient;
 import org.xwiki.test.webstandards.framework.DefaultValidationTest;
 import org.xwiki.validator.Validator;
@@ -31,6 +34,11 @@ public class CustomDutchWebGuidelinesValidationTest extends DefaultValidationTes
      * This field is needed to skip technical pages. It is read by reflexivity.
      */
     private static boolean skipTechnicalPages = true;
+
+    /**
+     * This field is needed to whitelist some classes from the technical pages. It is read by reflexivity.
+     */
+    private static List<String> whitelistedClasses = Arrays.asList("Panels.PanelClass");
 
     public CustomDutchWebGuidelinesValidationTest(Target target, HttpClient client, Validator validator,
         String credentials) throws Exception

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards/src/test/it/org/xwiki/test/webstandards/CustomDutchWebGuidelinesValidationTest.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards/src/test/it/org/xwiki/test/webstandards/CustomDutchWebGuidelinesValidationTest.java
@@ -33,12 +33,12 @@ public class CustomDutchWebGuidelinesValidationTest extends DefaultValidationTes
     /**
      * This field is needed to skip technical pages. It is read by reflexivity.
      */
-    private static boolean skipTechnicalPages = true;
+    private static final boolean skipTechnicalPages = true;
 
     /**
      * This field is needed to whitelist some classes from the technical pages. It is read by reflexivity.
      */
-    private static List<String> whitelistedClasses = Arrays.asList("Panels.PanelClass");
+    private static final String whitelistedClasses = System.getProperty("whitelistedWCAGClasses", "");
 
     public CustomDutchWebGuidelinesValidationTest(Target target, HttpClient client, Validator validator,
         String credentials) throws Exception

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards/src/test/it/org/xwiki/test/webstandards/framework/AbstractValidationTest.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards/src/test/it/org/xwiki/test/webstandards/framework/AbstractValidationTest.java
@@ -237,16 +237,17 @@ public class AbstractValidationTest extends TestCase
     private static boolean isTechnicalPage(String directoryPath, XarEntry entry, DocumentBuilder documentBuilder)
         throws Exception
     {
-        InputStream inputStream = new FileInputStream(new File(directoryPath, entry.getEntryName()));
-        Document parsedDocument = documentBuilder.parse(inputStream);
+        try (InputStream inputStream = new FileInputStream(new File(directoryPath, entry.getEntryName()))) {
+            Document parsedDocument = documentBuilder.parse(inputStream);
 
-        NodeList elements = parsedDocument.getElementsByTagName("hidden");
+            NodeList elements = parsedDocument.getElementsByTagName("hidden");
 
-        boolean isHiddenPage = false;
-        if (elements.getLength() == 1) {
-            isHiddenPage = "true".equals(elements.item(0).getTextContent());
+            boolean isHiddenPage = false;
+            if (elements.getLength() == 1) {
+                    isHiddenPage = "true".equals(elements.item(0).getTextContent());
+                }
+            return isHiddenPage;
         }
-        return isHiddenPage;
     }
 
     protected static List<DocumentReference> readXarContents(String fileName, String patternFilter) throws Exception

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards/src/test/it/org/xwiki/test/webstandards/framework/AbstractValidationTest.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards/src/test/it/org/xwiki/test/webstandards/framework/AbstractValidationTest.java
@@ -244,7 +244,7 @@ public class AbstractValidationTest extends TestCase
             whitelistedClasses = "";
         }
 
-        List<String> whitelistedClassesList = Arrays.asList(whitelistedClasses.split(":"));
+        List<String> whitelistedClassesList = Arrays.asList(whitelistedClasses.split("\\s"));
 
         if (skipTechnicalPages) {
             logger.info(String.format("[%s] will skip technical pages, except those containing the following classes:"

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards/src/test/it/org/xwiki/test/webstandards/framework/AbstractValidationTest.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards/src/test/it/org/xwiki/test/webstandards/framework/AbstractValidationTest.java
@@ -43,6 +43,7 @@ import org.xwiki.model.reference.WikiReference;
 import org.xwiki.validator.Validator;
 import org.xwiki.xar.XarEntry;
 import org.xwiki.xar.XarPackage;
+import org.xwiki.xar.internal.type.DefaultXarEntryType;
 
 import junit.framework.Test;
 import junit.framework.TestCase;
@@ -217,6 +218,11 @@ public class AbstractValidationTest extends TestCase
         }
     }
 
+    private static boolean isNotTechnicalPage(XarEntry entry)
+    {
+        return DefaultXarEntryType.HINT.equals(entry.getEntryType());
+    }
+
     protected static List<DocumentReference> readXarContents(String fileName, String patternFilter) throws Exception
     {
         Collection<XarEntry> entries = XarPackage.getEntries(new File(fileName));
@@ -228,7 +234,8 @@ public class AbstractValidationTest extends TestCase
         Pattern pattern = patternFilter == null ? null : Pattern.compile(patternFilter);
 
         for (XarEntry entry : entries) {
-            if (pattern == null || pattern.matcher(SERIALIZER.serialize(entry)).matches()) {
+            if (isNotTechnicalPage(entry)
+                && (pattern == null || pattern.matcher(SERIALIZER.serialize(entry)).matches())) {
                 result.add(new DocumentReference(entry, wikiReference));
             }
         }

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards/src/test/it/org/xwiki/test/webstandards/framework/AbstractValidationTest.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards/src/test/it/org/xwiki/test/webstandards/framework/AbstractValidationTest.java
@@ -244,8 +244,8 @@ public class AbstractValidationTest extends TestCase
 
             boolean isHiddenPage = false;
             if (elements.getLength() == 1) {
-                    isHiddenPage = "true".equals(elements.item(0).getTextContent());
-                }
+               isHiddenPage = "true".equals(elements.item(0).getTextContent());
+            }
             return isHiddenPage;
         }
     }


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XWIKI-15666

## Solution

As discussed in https://markmail.org/message/okihfnpkavhnbkib the proposed solution for now is to skip technical pages from WCAG validator.
This has been done by checking a boolean `skipTechnicalPages` in the validator classes: if set to true, then the pages are parsed to get the value of the `hidden` attribute.
