### PR TITLE
XWIKI-15961: A page appears more then once in the "My Recent Modifications" when it has more then one translation

### DIFF
--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/MyRecentModifications.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/MyRecentModifications.xml
@@ -186,8 +186,8 @@
 #end
 #if ($recentDocs.size() &gt; 0 || $showEmptyPanels)
   #panelheader($services.localization.render('xe.panels.modifications.my'))
-  #foreach ($doc in $recentDocs)
-    #set ($recentDoc = $xwiki.getDocument($doc[0]).getTranslatedDocument($doc[1]))
+  #foreach ($recentDocResult in $recentDocs)
+    #set ($recentDoc = $xwiki.getDocument($recentDocResult[0]).getTranslatedDocument($recentDocResult[1]))
     #if ($recentDoc)
       #set ($docLocale = $recentDoc.locale)
       #if ("$docLocale" == '')
@@ -199,7 +199,7 @@
         #set ($docUrl = $recentDoc.getURL())
       #end
       ## We use HTML here because we don't have a tool to escape wiki syntax in document title.
-      * {{html}}&lt;a href="${docUrl}"&gt;$escapetool.xml($recentDoc.plainTitle)#if ($docNamesCounter[$doc[0]] &gt; 1) &lt;em&gt;($docLocale)&lt;/em&gt;#end&lt;/a&gt;{{/html}}
+      * {{html}}&lt;a href="${docUrl}"&gt;$escapetool.xml($recentDoc.plainTitle)#if ($docNamesCounter[$recentDocResult[0]] &gt; 1) &lt;em&gt;($docLocale)&lt;/em&gt;#end&lt;/a&gt;{{/html}}
     #end
   #end
   #panelfooter()

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/MyRecentModifications.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/MyRecentModifications.xml
@@ -173,7 +173,7 @@
     <property>
       <content>{{velocity}}
 #set ($void = $services.async.useEntity("wiki:$xcontext.database"))
-#set ($query = $services.query.xwql('select doc.fullName, doc.language from XWikiDocument doc where doc.author = :author order by doc.date desc'))
+#set ($query = $services.query.xwql('select doc.fullName, doc.language from Document doc where doc.author = :author order by doc.date desc'))
 #set ($recentDocs = $query.addFilter('hidden').addFilter('unique').bindValue('author', $xcontext.user).setLimit(5).execute())
 ## We count the occurence of a document to specify the document language when there are duplicates
 #set ($docNamesCounter = {})

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/MyRecentModifications.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/MyRecentModifications.xml
@@ -187,22 +187,19 @@
 #if ($recentDocs.size() &gt; 0 || $showEmptyPanels)
   #panelheader($services.localization.render('xe.panels.modifications.my'))
   #foreach ($doc in $recentDocs)
-    #if ($docNamesCounter[$doc[0]] &gt; 1)
-      #set ($recentDoc = $xwiki.getDocument($doc[0]).getTranslatedDocument($doc[1]))
-      #if ($recentDoc)
-        #set ($docLanguage = $recentDoc.language)
-        #if ("$docLanguage" == '')
-          #set ($docLanguage = $recentDoc.defaultLanguage)
-        #end
-        ## We use HTML here because we don't have a tool to escape wiki syntax in document title.
-        * {{html}}&lt;a href="$recentDoc.getURL('view', "language=${docLanguage}")"&gt;$escapetool.xml($recentDoc.plainTitle) &lt;em&gt;($docLanguage)&lt;/em&gt;&lt;/a&gt;{{/html}}
+    #set ($recentDoc = $xwiki.getDocument($doc[0]).getTranslatedDocument($doc[1]))
+    #if ($recentDoc)
+      #set ($docLocale = $recentDoc.locale)
+      #if ("$docLocale" == '')
+        #set ($docLocale = $recentDoc.defaultLocale)
       #end
-    #else
-      #set ($recentDoc = $xwiki.getDocument($doc[0]).getTranslatedDocument())
-      #if ($recentDoc)
-        ## We use HTML here because we don't have a tool to escape wiki syntax in document title.
-        * {{html}}&lt;a href="$recentDoc.getURL()"&gt;$escapetool.xml($recentDoc.plainTitle)&lt;/a&gt;{{/html}}
+      #if ("$docLocale" != '' &amp;&amp; $docLocale != $xcontext.locale)
+        #set ($docUrl = $recentDoc.getURL('view', "language=${docLocale}"))
+      #else
+        #set ($docUrl = $recentDoc.getURL())
       #end
+      ## We use HTML here because we don't have a tool to escape wiki syntax in document title.
+      * {{html}}&lt;a href="${docUrl}"&gt;$escapetool.xml($recentDoc.plainTitle)#if ($docNamesCounter[$doc[0]] &gt; 1) &lt;em&gt;($docLocale)&lt;/em&gt;#end&lt;/a&gt;{{/html}}
     #end
   #end
   #panelfooter()

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/MyRecentModifications.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/MyRecentModifications.xml
@@ -173,15 +173,36 @@
     <property>
       <content>{{velocity}}
 #set ($void = $services.async.useEntity("wiki:$xcontext.database"))
-#set ($query = $services.query.xwql('where doc.author = :author order by doc.date desc'))
+#set ($query = $services.query.hql('select doc.fullName, doc.language from XWikiDocument doc where doc.author = :author order by doc.date desc'))
 #set ($recentDocs = $query.addFilter('hidden').addFilter('unique').bindValue('author', $xcontext.user).setLimit(5).execute())
+## We count the occurence of a document to specify the document language when there are duplicates
+#set ($docNamesCounter = {})
+#foreach ($doc in $recentDocs)
+  #if ($docNamesCounter.containsKey($doc[0]))
+    #set ($docNamesCounter[$doc[0]] = $docNamesCounter[$doc[0]] + 1)
+  #else
+    #set ($docNamesCounter[$doc[0]] = 1)
+  #end
+#end
 #if ($recentDocs.size() &gt; 0 || $showEmptyPanels)
   #panelheader($services.localization.render('xe.panels.modifications.my'))
-  #foreach ($docName in $recentDocs)
-    #set ($recentDoc = $xwiki.getDocument($docName).getTranslatedDocument())
-    #if ($recentDoc)
-      ## We use HTML here because we don't have a tool to escape wiki syntax in document title.
-      * {{html}}&lt;a href="$recentDoc.getURL()"&gt;$escapetool.xml($recentDoc.plainTitle)&lt;/a&gt;{{/html}}
+  #foreach ($doc in $recentDocs)
+    #if ($docNamesCounter[$doc[0]] &gt; 1)
+      #set ($recentDoc = $xwiki.getDocument($doc[0]).getTranslatedDocument($doc[1]))
+      #if ($recentDoc)
+        #set ($docLanguage = $recentDoc.language)
+        #if ("$docLanguage" == '')
+          #set ($docLanguage = $recentDoc.defaultLanguage)
+        #end
+        ## We use HTML here because we don't have a tool to escape wiki syntax in document title.
+        * {{html}}&lt;a href="$recentDoc.getURL('view', "language=${docLanguage}")"&gt;$escapetool.xml($recentDoc.plainTitle) &lt;em&gt;($docLanguage)&lt;/em&gt;&lt;/a&gt;{{/html}}
+      #end
+    #else
+      #set ($recentDoc = $xwiki.getDocument($doc[0]).getTranslatedDocument())
+      #if ($recentDoc)
+        ## We use HTML here because we don't have a tool to escape wiki syntax in document title.
+        * {{html}}&lt;a href="$recentDoc.getURL()"&gt;$escapetool.xml($recentDoc.plainTitle)&lt;/a&gt;{{/html}}
+      #end
     #end
   #end
   #panelfooter()

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/MyRecentModifications.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/MyRecentModifications.xml
@@ -173,7 +173,7 @@
     <property>
       <content>{{velocity}}
 #set ($void = $services.async.useEntity("wiki:$xcontext.database"))
-#set ($query = $services.query.hql('select doc.fullName, doc.language from XWikiDocument doc where doc.author = :author order by doc.date desc'))
+#set ($query = $services.query.xwql('select doc.fullName, doc.language from XWikiDocument doc where doc.author = :author order by doc.date desc'))
 #set ($recentDocs = $query.addFilter('hidden').addFilter('unique').bindValue('author', $xcontext.user).setLimit(5).execute())
 ## We count the occurence of a document to specify the document language when there are duplicates
 #set ($docNamesCounter = {})


### PR DESCRIPTION
### Issue

https://jira.xwiki.org/browse/XWIKI-15961

### Change

* Specify the document language when duplicates are shown.

### Result

![image](https://user-images.githubusercontent.com/2213999/49941064-ad191900-fee1-11e8-9082-91df4bfde5b2.png)

### Note

Maybe a better solution would be to always show the document title using the user language (as it was already the case) and keep the language hint when duplicates are shown.