### PR TITLE
XWIKI-15979: Global Menu is displayed (with error) in subwiki for a local user

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/rightpanels.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/rightpanels.vm
@@ -4,7 +4,8 @@
 ## Global Variable
 #set($xwikiPanelWidth = $rightPanelsWidth)
 #foreach($panelUix in $panelUixs)
-  #if($xwiki.hasAccessLevel('view', $panelUix.getId()))
+  #set($panelDocName = $panelUix.getDocumentReference())
+  #if($panelDocName && $services.security.authorization.hasAccess('view', $panelDocName))
     $services.rendering.render($panelUix.execute(), "html/5.0")
   #end
 #end


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XWIKI-15979

## Solution

When checking the rights of the menu in the subwiki we are currently checking them against `Menu.Menu1.WebHome`: the reference to the wiki is lost.
I proposed to fix it by getting the proper reference to the page (like we already do in https://github.com/xwiki/xwiki-platform/blob/master/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-api/src/main/java/org/xwiki/panels/internal/AbstractPanelsUIExtensionManager.java#L124-L129) and check the rights against it.

## Test

Tested locally against the scenario of the issue. I get the menu displayed with Admin and hidden with the local user of the subwiki. With a guest user I get it displayed too: I don't know if it's expected.