### PR TITLE
XWIKI-15876: Display Skin Pages With Their Real Name

### DIFF
--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-ui/src/main/resources/SkinsCode/XWikiSkinsSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-ui/src/main/resources/SkinsCode/XWikiSkinsSheet.xml
@@ -31,7 +31,7 @@
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
   <version>1.1</version>
-  <title>$services.localization.render('xe.admin.skin')</title>
+  <title>#set ($title = $doc.getObject('XWiki.XWikiSkins').getValue('name'))#if ("$!title" == '')$services.localization.render('xe.admin.skin')#else$title#end</title>
   <comment/>
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>


### PR DESCRIPTION
### Issue

https://jira.xwiki.org/browse/XWIKI-15876

### Change

* Use the XWiki.XWikiSkins#Name to display the title of a Skin and fallback to the previous title.