### PR TITLE
XWIKI-15991: Wrong locale used in multilingual wiki

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/test/AbstractBridgedXWikiComponentTestCase.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/test/AbstractBridgedXWikiComponentTestCase.java
@@ -82,6 +82,7 @@ public abstract class AbstractBridgedXWikiComponentTestCase extends AbstractXWik
         // Make sure response.encodeURL() calls don't fail
         Mock xwikiResponse = mock(XWikiResponse.class);
         xwikiResponse.stubs().method("setLocale");
+        xwikiResponse.stubs().method("addCookie");
         xwikiResponse.stubs().method("encodeURL").will(
             new CustomStub("Implements XWikiResponse.encodeURL")
             {


### PR DESCRIPTION
### Issue

https://jira.xwiki.org/browse/XWIKI-15991

### Changes

* Take into account the xwiki.language.forceSupported xwiki parameter.
* Move the logic of XWiki#getLanguagePreference to XWiki#getLocalePreference.

### Note

To actually see the benefits of the improvement, the `xwiki.language.forceSupported` parameter should be set to `1`.