### PR TITLE
[Misc] Fix empty html title

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/htmlheader.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/htmlheader.vm
@@ -32,9 +32,9 @@
     ## ---------------------------------------------------------------------------------------------------------------
     ## Compute the title.
     ## ---------------------------------------------------------------------------------------------------------------
-    #if(!$title)
+    #if("$!title" == '')
       #set($title = $!xwiki.getSpacePreference('title'))
-      #if($title != '')
+      #if("$!title" != '')
         ## Evaluate the title since it can have velocity code.
         #set($title = "#evaluate($title)")
         ## Don`t forget to escape it.


### PR DESCRIPTION
### Failing test

https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/stable-10.11.x/lastCompletedBuild/testReport/org.xwiki.test.webstandards.framework/DefaultValidationTest/Platform_Builds___main___flavor_test_webstandards___Build_for_Flavor_Test___Webstandards___Validating_HTML5_validity_for__xwiki_XWiki_XWikiSkinsTemplate_executed_with_credentials_Admin_admin/

### Change

* Prevent empty titles from being displayed in the html header.