### PR TITLE
XWIKI-15199: Uncaught exception when previewing deleted section

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/EditAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/EditAction.java
@@ -217,7 +217,7 @@ public class EditAction extends XWikiAction
         // Update the edited title.
         if (editForm.getTitle() != null) {
             document.setTitle(editForm.getTitle());
-        } else if (sectionNumber > 0) {
+        } else if (sectionNumber > 0 && document.getSections().size() > 0) {
             // The edited content is either the content of the specified section or the content provided on the
             // request. We assume the content provided on the request is meant to overwrite the specified section.
             // In both cases the document content is currently having one section, so we can take its title.


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XWIKI-15199

## Solution 

 * Add a supplementary condition when previewing a deleted section.

## Test

tested locally.