### PR TITLE
XWIKI-16022: Limit the generic page picker search to a space

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/suggest/suggestPages.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/suggest/suggestPages.js
@@ -31,10 +31,11 @@ define('xwiki-suggestPages', ['jquery', 'xwiki-selectize'], function($) {
   var webHome = "$!services.model.getEntityReference('DOCUMENT', 'default').name" || 'WebHome';
 
   var getSelectizeOptions = function(select) {
+    var space = select.data('suggest-space');
     return {
       create: true,
       load: function(text, callback) {
-        loadPages(text).done(function(data) {
+        loadPages(text, space).done(function(data) {
           var pages = [];
           data.searchResults.forEach(function (element) {
             var hierarchy = element.hierarchy.items;
@@ -62,9 +63,9 @@ define('xwiki-suggestPages', ['jquery', 'xwiki-selectize'], function($) {
     }
   };
 
-  var loadPages = function(text) {
+  var loadPages = function(text, space) {
     var scopes = ['name', 'title'];
-    return $.getJSON(XWiki.Document.getRestSearchURL(), $.param({
+    return $.getJSON(XWiki.Document.getRestSearchURL("", space), $.param({
       'q': text,
       'scope': scopes,
       'number': 10,


### PR DESCRIPTION
### Issue

https://jira.xwiki.org/browse/XWIKI-16022

### Change

* Add a way to limit the page picker search under a certain space.

### Usage

```
{{velocity}}
{{html}}
  #set ($param = {'data-suggest-space': 'XWiki'})
  #pagePicker($param)
{{/html}}
{{/velocity}}
```

![dm4lxw](https://user-images.githubusercontent.com/2213999/50892179-35fe7400-13fe-11e9-96ba-26a1c4645543.jpg)