### PR TITLE
XWIKI-15182: Wrong action in XWikiContext for extensions contributing a new entity action URL handler

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiAction.java
@@ -430,16 +430,7 @@ public abstract class XWikiAction extends Action
                 EntityResourceReference entityResourceReference =
                     (EntityResourceReference) Utils.getComponent(ResourceReferenceManager.class).getResourceReference();
 
-                // We save the current action set since:
-                // - by default the action is set to "view" for Extensions not installed as root and contributing some
-                // new Entity Action (see https://jira.xwiki.org/browse/XWIKI-15182).
-                // - we want to set back the action in case no ResourceReferenceHandler was found to handle the URL
-                // TODO: Remove once https://jira.xwiki.org/browse/XWIKI-15182 is fixed
-                String originalAction = context.getAction();
                 try {
-                    // Force the action in the context because of https://jira.xwiki.org/browse/XWIKI-15182.
-                    // TODO: Remove once https://jira.xwiki.org/browse/XWIKI-15182 is fixed
-                    context.setAction(entityResourceReference.getAction().getActionName());
                     entityResourceReferenceHandler.handle(entityResourceReference,
                         DefaultResourceReferenceHandlerChain.EMPTY);
                     // Don't let the old actions kick in!
@@ -447,9 +438,6 @@ public abstract class XWikiAction extends Action
                 } catch (NotFoundResourceHandlerException e) {
                     // No Entity Resource Action has been found. Don't do anything and let it go through
                     // so that the old Action system kicks in...
-                    // Put back the action, because of https://jira.xwiki.org/browse/XWIKI-15182
-                    // TODO: Remove once https://jira.xwiki.org/browse/XWIKI-15182 is fixed
-                    context.setAction(originalAction);
                 } catch (Throwable e) {
                     // Some real failure, log it since it's a problem but still allow the old Action system a chance
                     // to do something...


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XWIKI-15182

## Solution
  * Remove remaining TODOS from a closed issue

@vmassol could you review this one? it's unclear when reading your comments on the issue if this should be indeed removed after the issue 15182 is closed or if we should wait another refactoring? 