### PR TITLE
XWIKI-16044: className vs classname inconsistency in "objectremove" and "objectadd" actions

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editobject.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editobject.vm
@@ -139,7 +139,7 @@
 #macro(displayAddObject $class)
   <div id="add_xobject_${escapetool.xml($class.name)}" class="add_xobject">
     <div id="add_xobject_${escapetool.xml($class.name)}_title" class="add_xobject-title">
-      <a href="$doc.getURL('edit', "xpage=editobject&amp;xaction=addObject&amp;className=$escapetool.url(${class.name})&amp;xredirect=$escapetool.url(${doc.getURL('edit', 'editor=object')})")" class="xobject-add-control" title="$services.localization.render('core.editors.object.newObjectForClass.tooltip', ["#cleanClassname(${class.name})"])">$services.localization.render('core.editors.object.newObjectForClass', ["#cleanClassname(${class.name})"])</a>
+      <a href="$doc.getURL('edit', "xpage=editobject&amp;xaction=addObject&amp;classname=$escapetool.url(${class.name})&amp;xredirect=$escapetool.url(${doc.getURL('edit', 'editor=object')})")" class="xobject-add-control" title="$services.localization.render('core.editors.object.newObjectForClass.tooltip', ["#cleanClassname(${class.name})"])">$services.localization.render('core.editors.object.newObjectForClass', ["#cleanClassname(${class.name})"])</a>
     </div>
   </div>
 #end

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/ObjectAddForm.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/ObjectAddForm.java
@@ -47,7 +47,12 @@ public class ObjectAddForm extends XWikiForm
     @Override
     public void readRequest()
     {
-        setClassName(getRequest().getParameter("classname"));
+        // We need to support both 'classname' and 'className' since an inconsistency has been introduced.
+        String className = getRequest().getParameter("classname");
+        if (className == null) {
+            className = getRequest().getParameter("className");
+        }
+        setClassName(className);
     }
 
     public Map<String, String[]> getObject(String prefix)


### PR DESCRIPTION
### Issue

https://jira.xwiki.org/browse/XWIKI-16044

### Changes

* Use 'classname' instead of 'className' as this is the one use
  everywhere else.
* Add support for both 'className' and 'classname' (for backward
  compatibility).