### PR TITLE
XWIKI-16044: className vs classname inconsistency in "objectremove" and "objectadd" actions

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editobject.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editobject.vm
@@ -139,7 +139,7 @@
 #macro(displayAddObject $class)
   <div id="add_xobject_${escapetool.xml($class.name)}" class="add_xobject">
     <div id="add_xobject_${escapetool.xml($class.name)}_title" class="add_xobject-title">
-      <a href="$doc.getURL('edit', "xpage=editobject&amp;xaction=addObject&amp;className=$escapetool.url(${class.name})&amp;xredirect=$escapetool.url(${doc.getURL('edit', 'editor=object')})")" class="xobject-add-control" title="$services.localization.render('core.editors.object.newObjectForClass.tooltip', ["#cleanClassname(${class.name})"])">$services.localization.render('core.editors.object.newObjectForClass', ["#cleanClassname(${class.name})"])</a>
+      <a href="$doc.getURL('edit', "xpage=editobject&amp;xaction=addObject&amp;classname=$escapetool.url(${class.name})&amp;xredirect=$escapetool.url(${doc.getURL('edit', 'editor=object')})")" class="xobject-add-control" title="$services.localization.render('core.editors.object.newObjectForClass.tooltip', ["#cleanClassname(${class.name})"])">$services.localization.render('core.editors.object.newObjectForClass', ["#cleanClassname(${class.name})"])</a>
     </div>
   </div>
 #end
@@ -208,14 +208,14 @@
 ##
 ## Ajax object add:
 #if ("$!{request.xaction}" == 'addObject')
-  #set ($class = $xwiki.getClass(${request.className}))
+  #set ($class = $xwiki.getClass(${request.classname}))
   #set ($props = $class.getProperties())
   #if ($props.isEmpty())
     $response.setStatus(404)
-    #error($services.localization.render('core.editors.object.add.invalidClassName', [$request.className]))
+    #error($services.localization.render('core.editors.object.add.invalidClassName', [$request.classname]))
   #else
-    #set ($isNewClass = $doc.getObjects(${request.className}).isEmpty())
-    #set ($newobj = $doc.newObject(${request.className}))
+    #set ($isNewClass = $doc.getObjects(${request.classname}).isEmpty())
+    #set ($newobj = $doc.newObject(${request.classname}))
     #set ($discard = $doc.save())
     #if ("$!{request.xredirect}" != '')
       $response.sendRedirect($request.xredirect)

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editobject.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editobject.vm
@@ -208,14 +208,19 @@
 ##
 ## Ajax object add:
 #if ("$!{request.xaction}" == 'addObject')
-  #set ($class = $xwiki.getClass(${request.classname}))
+  ## We keep 'className' for backward compatibility and use 'classname' to be consistent with other actions.
+  #set ($classname = ${request.classname})
+  #if ("$!classname" == '')
+    #set ($classname = ${request.className})
+  #end
+  #set ($class = $xwiki.getClass($classname))
   #set ($props = $class.getProperties())
   #if ($props.isEmpty())
     $response.setStatus(404)
-    #error($services.localization.render('core.editors.object.add.invalidClassName', [$request.classname]))
+    #error($services.localization.render('core.editors.object.add.invalidClassName', [$classname]))
   #else
-    #set ($isNewClass = $doc.getObjects(${request.classname}).isEmpty())
-    #set ($newobj = $doc.newObject(${request.classname}))
+    #set ($isNewClass = $doc.getObjects($classname).isEmpty())
+    #set ($newobj = $doc.newObject($classname))
     #set ($discard = $doc.save())
     #if ("$!{request.xredirect}" != '')
       $response.sendRedirect($request.xredirect)

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/editors/dataeditors.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/editors/dataeditors.js
@@ -74,7 +74,7 @@ editors.XDataEditors = Class.create({
           url = this.editedDocument.getURL('edit', Object.toQueryString({
             xpage: 'editobject',
             xaction: 'addObject',
-            className: classNameVal
+            classname: classNameVal
           }));
         }
         if (!item.disabled && validClassName) {

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-escaping/src/test/it/org/xwiki/test/escaping/ObjectAndClassEditorTest.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-escaping/src/test/it/org/xwiki/test/escaping/ObjectAndClassEditorTest.java
@@ -60,7 +60,7 @@ public class ObjectAndClassEditorTest extends AbstractManualTest
         // add a new object of that class to the class document
         AbstractEscapingTest.getUrlContent(createUrl("view", test, test, params(kv("xpage", "editobject"),
                                                                                 kv("xaction", "addObject"),
-                                                                                kv("className", test + "." + test))));
+                                                                                kv("classname", test + "." + test))));
         // set the property of that object
         AbstractEscapingTest.getUrlContent(createUrl("save", test, test, params(kv("classname", "-"),
                                                                                 kv(escapeUrl(test + "." + test + "_0_test"), test),


### PR DESCRIPTION
### Issue

https://jira.xwiki.org/browse/XWIKI-16044

### Changes

* Use 'classname' instead of 'className' as this is the one use everywhere else.