### PR TITLE
XWIKI-15641: Display information to user when a job is waiting another to finish/timeout

### DIFF
--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/resources/ApplicationResources.properties
@@ -66,3 +66,5 @@ job.question.OverwriteQuestion.lastModified=Last modified: {0}
 job.question.OverwriteQuestion.applyToAll=Apply this action to all the following pages.
 job.question.OverwriteQuestion.replace=Replace
 job.question.OverwriteQuestion.skip=Skip
+
+job.waiting=This job is waiting to start, please be patient: another job might be running on the same pages.

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/resources/ApplicationResources.properties
@@ -67,4 +67,4 @@ job.question.OverwriteQuestion.applyToAll=Apply this action to all the following
 job.question.OverwriteQuestion.replace=Replace
 job.question.OverwriteQuestion.skip=Skip
 
-job.waiting=This job is waiting to start, please be patient: another job might be running on the same pages.
+job.state.NONE.hint=This job is waiting to start, please be patient: another job might be running on the same pages.

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/job_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/job_macros.vm
@@ -3,25 +3,31 @@
 $services.template.execute('logging_macros.vm')
 
 #macro (displayJobProgressBar $jobStatus)
-  <div class="ui-progress">
-    <div class="ui-progress-background">
-      #set ($percent = $jobStatus.progress.offset)
-      ## There is no progress information if the job was scheduled but hasn't started yet.
-      #if (!$percent)
-        #set ($percent = 0)
-      #end
-      #set ($percent = $mathtool.toInteger($mathtool.mul($percent, 100)))
-      <div class="ui-progress-bar green" style="width:${percent}%"></div>
+  #if ($jobStatus.state == 'NONE')
+    <div class="box info">
+      $services.localization.render("job.waiting");
     </div>
-    #if ($jobStatus && !$jobStatus.log.isEmpty())
-      ## We need the tail of the log queue.
-      #set ($logList = [])
-      #set ($discard = $logList.addAll($jobStatus.log))
-      <p class="ui-progress-message">
-        #printLogMessage($logList.get($mathtool.sub($logList.size(), 1)))
-      </p>
-    #end
-  </div>
+  #else
+    <div class="ui-progress">
+      <div class="ui-progress-background">
+        #set ($percent = $jobStatus.progress.offset)
+        ## There is no progress information if the job was scheduled but hasn't started yet.
+        #if (!$percent)
+          #set ($percent = 0)
+        #end
+        #set ($percent = $mathtool.toInteger($mathtool.mul($percent, 100)))
+        <div class="ui-progress-bar green" style="width:${percent}%"></div>
+      </div>
+      #if ($jobStatus && !$jobStatus.log.isEmpty())
+        ## We need the tail of the log queue.
+        #set ($logList = [])
+        #set ($discard = $logList.addAll($jobStatus.log))
+        <p class="ui-progress-message">
+          #printLogMessage($logList.get($mathtool.sub($logList.size(), 1)))
+        </p>
+      #end
+    </div>
+  #end
 #end
 
 #macro (displayJobStatusLog $status $collapsed)

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/job_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/job_macros.vm
@@ -5,7 +5,7 @@ $services.template.execute('logging_macros.vm')
 #macro (displayJobProgressBar $jobStatus)
   #if ($jobStatus.state == 'NONE')
     <div class="box info">
-      $services.localization.render("job.waiting");
+      $services.localization.render("job.state.NONE.hint");
     </div>
   #else
     <div class="ui-progress">


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XWIKI-15641

## Solution

  * Add a simple info box when a job is waiting to start

![screenshot_2019-01-31 home - xwiki](https://user-images.githubusercontent.com/1478232/52047096-963d8d00-2548-11e9-9c06-1b91c788707d.png)