### PR TITLE
XWIKI-15641: Display information to user when a job is waiting another to finish/timeout

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/job/job.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/job/job.js
@@ -33,6 +33,15 @@ require.config({
 require(['jquery', 'xwiki-meta', 'JobRunner'], function($, xm, JobRunner) {
   'use strict';
   var updateProgress = function(jobUI, job) {
+    if (job.state === 'NONE') {
+      jobUI.find('.ui-progress-background').css('display', 'none');
+      jobUI.find('.ui-progress-message').css('display', 'none');
+    } else {
+      jobUI.find('#state-none-hint').remove();
+      jobUI.find('.ui-progress-background').css('display', 'block');
+      jobUI.find('.ui-progress-message').css('display', 'block');
+    }
+
     var percent = Math.floor((job.progress.offset || 0) * 100);
     jobUI.find('.ui-progress-bar').css('width', percent + '%');
     var jobLog = job.log.items || [];

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/job/job.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/job/job.js
@@ -33,13 +33,11 @@ require.config({
 require(['jquery', 'xwiki-meta', 'JobRunner'], function($, xm, JobRunner) {
   'use strict';
   var updateProgress = function(jobUI, job) {
-    if (job.state === 'NONE') {
-      jobUI.find('.ui-progress-background').css('display', 'none');
-      jobUI.find('.ui-progress-message').css('display', 'none');
-    } else {
+    jobUI.find('.ui-progress-background').toggle(job.state !== 'NONE');
+    jobUI.find('.ui-progress-message').toggle(job.state === 'NONE');
+
+    if (job.state !== 'NONE') {
       jobUI.find('#state-none-hint').remove();
-      jobUI.find('.ui-progress-background').css('display', 'block');
-      jobUI.find('.ui-progress-message').css('display', 'block');
     }
 
     var percent = Math.floor((job.progress.offset || 0) * 100);

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/job_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/job_macros.vm
@@ -3,31 +3,28 @@
 $services.template.execute('logging_macros.vm')
 
 #macro (displayJobProgressBar $jobStatus)
-  #if ($jobStatus.state == 'NONE')
-    <div class="box info">
-      $services.localization.render("job.state.NONE.hint");
+  <div class="ui-progress">
+    <div class="box info" id="state-none-hint">
+      $services.localization.render("job.state.NONE.hint")
     </div>
-  #else
-    <div class="ui-progress">
-      <div class="ui-progress-background">
-        #set ($percent = $jobStatus.progress.offset)
-        ## There is no progress information if the job was scheduled but hasn't started yet.
-        #if (!$percent)
-          #set ($percent = 0)
-        #end
-        #set ($percent = $mathtool.toInteger($mathtool.mul($percent, 100)))
-        <div class="ui-progress-bar green" style="width:${percent}%"></div>
-      </div>
-      #if ($jobStatus && !$jobStatus.log.isEmpty())
-        ## We need the tail of the log queue.
-        #set ($logList = [])
-        #set ($discard = $logList.addAll($jobStatus.log))
-        <p class="ui-progress-message">
-          #printLogMessage($logList.get($mathtool.sub($logList.size(), 1)))
-        </p>
+    <div class="ui-progress-background">
+      #set ($percent = $jobStatus.progress.offset)
+      ## There is no progress information if the job was scheduled but hasn't started yet.
+      #if (!$percent)
+        #set ($percent = 0)
       #end
+      #set ($percent = $mathtool.toInteger($mathtool.mul($percent, 100)))
+      <div class="ui-progress-bar green" style="width:${percent}%"></div>
     </div>
-  #end
+    #if ($jobStatus && !$jobStatus.log.isEmpty())
+      ## We need the tail of the log queue.
+      #set ($logList = [])
+      #set ($discard = $logList.addAll($jobStatus.log))
+      <p class="ui-progress-message">
+        #printLogMessage($logList.get($mathtool.sub($logList.size(), 1)))
+      </p>
+    #end
+  </div>
 #end
 
 #macro (displayJobStatusLog $status $collapsed)


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XWIKI-15641

This PR is complementary to: https://github.com/xwiki/xwiki-platform/pull/1051
It aims at fixing a bug I introduced which force the user to reload the page when the blocking job is finished. 

## Solution

  * Process the info message in JS to remove it when the blocking job is
finished.