### PR TITLE
XWIKI-6732: Introduce DocumentRenamingEvent and DocumentRenamedEvent events

### DIFF
--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-script/src/test/java/org/xwiki/extension/script/ExtensionManagerScriptServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-script/src/test/java/org/xwiki/extension/script/ExtensionManagerScriptServiceTest.java
@@ -37,6 +37,7 @@ import org.xwiki.job.Job;
 import org.xwiki.logging.LogLevel;
 import org.xwiki.logging.event.LogEvent;
 import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.observation.EventListener;
 import org.xwiki.script.service.ScriptService;
 import org.xwiki.security.authorization.AccessDeniedException;
 import org.xwiki.security.authorization.Right;
@@ -99,6 +100,10 @@ public class ExtensionManagerScriptServiceTest
         // lookup
 
         this.scriptService = this.mocker.getInstance(ScriptService.class, "extension");
+        this.mocker.unregisterComponent(EventListener.class, "refactoring.automaticRedirectCreator");
+        this.mocker.unregisterComponent(EventListener.class, "refactoring.backLinksUpdater");
+        this.mocker.unregisterComponent(EventListener.class, "refactoring.relativeLinksUpdater");
+        this.mocker.unregisterComponent(EventListener.class, "refactoring.legacyParentFieldUpdater");
     }
 
     // tools

--- a/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-sources/xwiki-platform-localization-source-wiki/src/test/java/org/xwiki/localization/wiki/internal/DocumentTranslationBundleFactoryTest.java
+++ b/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-sources/xwiki-platform-localization-source-wiki/src/test/java/org/xwiki/localization/wiki/internal/DocumentTranslationBundleFactoryTest.java
@@ -36,6 +36,7 @@ import org.xwiki.localization.TranslationBundleFactoryDoesNotExistsException;
 import org.xwiki.localization.internal.DefaultTranslationBundleContext;
 import org.xwiki.localization.wiki.internal.TranslationDocumentModel.Scope;
 import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.observation.EventListener;
 import org.xwiki.query.Query;
 import org.xwiki.query.QueryManager;
 import org.xwiki.rendering.syntax.Syntax;
@@ -79,6 +80,11 @@ public class DocumentTranslationBundleFactoryTest
     @Before
     public void before() throws Exception
     {
+        this.oldcore.getMocker().unregisterComponent(EventListener.class, "refactoring.automaticRedirectCreator");
+        this.oldcore.getMocker().unregisterComponent(EventListener.class, "refactoring.backLinksUpdater");
+        this.oldcore.getMocker().unregisterComponent(EventListener.class, "refactoring.relativeLinksUpdater");
+        this.oldcore.getMocker().unregisterComponent(EventListener.class, "refactoring.legacyParentFieldUpdater");
+
         this.oldcore.getXWikiContext().setMainXWiki("xwiki");
         this.oldcore.getXWikiContext().setWikiId("xwiki");
 

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-bridge/src/test/java/org/xwiki/security/authorization/AbstractWikiTestCase.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-bridge/src/test/java/org/xwiki/security/authorization/AbstractWikiTestCase.java
@@ -24,9 +24,12 @@ import org.junit.Before;
 import org.xwiki.context.Execution;
 import org.xwiki.context.ExecutionContext;
 import org.xwiki.observation.EventListener;
+import org.xwiki.refactoring.internal.ModelBridge;
 import org.xwiki.security.authorization.testwikibuilding.LegacyTestWiki;
 import org.xwiki.test.annotation.AllComponents;
 import org.xwiki.test.jmock.AbstractComponentTestCase;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
 
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.web.Utils;
@@ -66,6 +69,10 @@ public abstract class AbstractWikiTestCase extends AbstractComponentTestCase
         getComponentManager().unregisterComponent(EventListener.class, "XObjectEventGeneratorListener");
         getComponentManager().unregisterComponent(EventListener.class, "AttachmentEventGeneratorListener");
         getComponentManager().unregisterComponent(EventListener.class, "XClassPropertyEventGeneratorListener");
+        getComponentManager().unregisterComponent(EventListener.class, "refactoring.automaticRedirectCreator");
+        getComponentManager().unregisterComponent(EventListener.class, "refactoring.backLinksUpdater");
+        getComponentManager().unregisterComponent(EventListener.class, "refactoring.relativeLinksUpdater");
+        getComponentManager().unregisterComponent(EventListener.class, "refactoring.legacyParentFieldUpdater");
     }
 
     protected void setContext(XWikiContext ctx)


### PR DESCRIPTION
  * Unregister new listener components in some module tests to avoid
missing dependencies.