### PR TITLE
 XWIKI-6732: Introduce DocumentRenamingEvent and DocumentRenamedEvent events

### DIFF
--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/test/java/org/xwiki/extension/xar/internal/handler/WikiCopiedEventListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/test/java/org/xwiki/extension/xar/internal/handler/WikiCopiedEventListenerTest.java
@@ -35,6 +35,7 @@ import org.xwiki.extension.repository.internal.local.DefaultLocalExtensionReposi
 import org.xwiki.extension.test.EmptyExtension;
 import org.xwiki.extension.test.MockitoRepositoryUtilsRule;
 import org.xwiki.extension.version.internal.DefaultVersionConstraint;
+import org.xwiki.observation.EventListener;
 import org.xwiki.observation.ObservationManager;
 import org.xwiki.security.authorization.AuthorizationManager;
 import org.xwiki.security.authorization.ContextualAuthorizationManager;
@@ -86,6 +87,15 @@ public class WikiCopiedEventListenerTest
 
         this.localExtensionDependency1 = this.localExtensionRepository.storeExtension(extensionDependency);
         this.localExtension1 = this.localExtensionRepository.storeExtension(extension);
+
+        this.repositoryUtil.getComponentManager().unregisterComponent(EventListener.class,
+            "refactoring.automaticRedirectCreator");
+        this.repositoryUtil.getComponentManager().unregisterComponent(EventListener.class,
+            "refactoring.backLinksUpdater");
+        this.repositoryUtil.getComponentManager().unregisterComponent(EventListener.class,
+            "refactoring.relativeLinksUpdater");
+        this.repositoryUtil.getComponentManager().unregisterComponent(EventListener.class,
+            "refactoring.legacyParentFieldUpdater");
     }
 
     @AfterComponent

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/test/java/org/xwiki/extension/xar/internal/handler/XarExtensionHandlerTest.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/test/java/org/xwiki/extension/xar/internal/handler/XarExtensionHandlerTest.java
@@ -51,6 +51,7 @@ import org.xwiki.logging.LogLevel;
 import org.xwiki.logging.event.LogEvent;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.LocalDocumentReference;
+import org.xwiki.observation.EventListener;
 import org.xwiki.observation.ObservationManager;
 import org.xwiki.rendering.syntax.Syntax;
 import org.xwiki.security.authorization.AccessDeniedException;
@@ -114,6 +115,11 @@ public class XarExtensionHandlerTest
     @Before
     public void setUp() throws Exception
     {
+        this.componentManager.unregisterComponent(EventListener.class, "refactoring.automaticRedirectCreator");
+        this.componentManager.unregisterComponent(EventListener.class, "refactoring.backLinksUpdater");
+        this.componentManager.unregisterComponent(EventListener.class, "refactoring.relativeLinksUpdater");
+        this.componentManager.unregisterComponent(EventListener.class, "refactoring.legacyParentFieldUpdater");
+
         // mock
 
         this.contextUser = new DocumentReference(getXWikiContext().getWikiId(), "XWiki", "ExtensionUser");

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/test/java/org/xwiki/extension/xar/internal/job/RepairXarJobTest.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/test/java/org/xwiki/extension/xar/internal/job/RepairXarJobTest.java
@@ -28,6 +28,7 @@ import org.xwiki.extension.test.AbstractExtensionHandlerTest;
 import org.xwiki.extension.xar.internal.handler.XarExtensionHandler;
 import org.xwiki.job.Job;
 import org.xwiki.logging.LogLevel;
+import org.xwiki.observation.EventListener;
 import org.xwiki.security.authorization.ContextualAuthorizationManager;
 import org.xwiki.test.annotation.AfterComponent;
 import org.xwiki.wiki.descriptor.WikiDescriptorManager;
@@ -50,6 +51,11 @@ public class RepairXarJobTest extends AbstractExtensionHandlerTest
     public void setUp() throws Exception
     {
         super.setUp();
+
+        this.mocker.unregisterComponent(EventListener.class, "refactoring.automaticRedirectCreator");
+        this.mocker.unregisterComponent(EventListener.class, "refactoring.backLinksUpdater");
+        this.mocker.unregisterComponent(EventListener.class, "refactoring.relativeLinksUpdater");
+        this.mocker.unregisterComponent(EventListener.class, "refactoring.legacyParentFieldUpdater");
 
         this.mocker.registerMockComponent(ContextualAuthorizationManager.class);
 

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/test/java/org/xwiki/rendering/wikimacro/internal/WikiMacrosTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/test/java/org/xwiki/rendering/wikimacro/internal/WikiMacrosTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.xwiki.component.manager.ComponentLookupException;
 import org.xwiki.component.manager.ComponentManager;
 import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.observation.EventListener;
 import org.xwiki.rendering.macro.Macro;
 import org.xwiki.rendering.syntax.Syntax;
 import org.xwiki.security.authorization.Right;
@@ -58,6 +59,11 @@ public class WikiMacrosTest
     @Before
     public void before() throws Exception
     {
+        this.oldcore.getMocker().unregisterComponent(EventListener.class, "refactoring.automaticRedirectCreator");
+        this.oldcore.getMocker().unregisterComponent(EventListener.class, "refactoring.backLinksUpdater");
+        this.oldcore.getMocker().unregisterComponent(EventListener.class, "refactoring.relativeLinksUpdater");
+        this.oldcore.getMocker().unregisterComponent(EventListener.class, "refactoring.legacyParentFieldUpdater");
+
         this.macroDocument = new XWikiDocument(new DocumentReference("wiki", "Space", "Page"));
         this.macroDocument.setSyntax(Syntax.XWIKI_2_0);
         this.macroObject = new BaseObject();


### PR DESCRIPTION
  * Unregister new listener components in some module tests to avoid
missing dependencies.