### PR TITLE
XWIKI-6732: Introduce DocumentRenamingEvent and DocumentRenamedEvent events

### DIFF
--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/test/java/org/xwiki/extension/xar/internal/handler/WikiCopiedEventListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/test/java/org/xwiki/extension/xar/internal/handler/WikiCopiedEventListenerTest.java
@@ -36,6 +36,8 @@ import org.xwiki.extension.test.EmptyExtension;
 import org.xwiki.extension.test.MockitoRepositoryUtilsRule;
 import org.xwiki.extension.version.internal.DefaultVersionConstraint;
 import org.xwiki.observation.ObservationManager;
+import org.xwiki.refactoring.internal.LinkRefactoring;
+import org.xwiki.refactoring.internal.ModelBridge;
 import org.xwiki.security.authorization.AuthorizationManager;
 import org.xwiki.security.authorization.ContextualAuthorizationManager;
 import org.xwiki.test.annotation.AfterComponent;
@@ -70,6 +72,10 @@ public class WikiCopiedEventListenerTest
     @Before
     public void setUp() throws Exception
     {
+        // avoid dependency issue with refactoring listeners
+        this.repositoryUtil.getComponentManager().registerMockComponent(ModelBridge.class);
+        this.repositoryUtil.getComponentManager().registerMockComponent(LinkRefactoring.class);
+
         this.localExtensionRepository =
             this.repositoryUtil.getComponentManager().getInstance(LocalExtensionRepository.class);
         this.installedExtensionRepository =

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/test/java/org/xwiki/extension/xar/internal/job/RepairXarJobTest.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/test/java/org/xwiki/extension/xar/internal/job/RepairXarJobTest.java
@@ -28,6 +28,8 @@ import org.xwiki.extension.test.AbstractExtensionHandlerTest;
 import org.xwiki.extension.xar.internal.handler.XarExtensionHandler;
 import org.xwiki.job.Job;
 import org.xwiki.logging.LogLevel;
+import org.xwiki.refactoring.internal.LinkRefactoring;
+import org.xwiki.refactoring.internal.ModelBridge;
 import org.xwiki.security.authorization.ContextualAuthorizationManager;
 import org.xwiki.test.annotation.AfterComponent;
 import org.xwiki.wiki.descriptor.WikiDescriptorManager;
@@ -52,6 +54,10 @@ public class RepairXarJobTest extends AbstractExtensionHandlerTest
         super.setUp();
 
         this.mocker.registerMockComponent(ContextualAuthorizationManager.class);
+
+        // avoid dependency issue with refactoring listeners
+        this.mocker.registerMockComponent(ModelBridge.class);
+        this.mocker.registerMockComponent(LinkRefactoring.class);
 
         this.xarExtensionRepository =
             this.mocker.getInstance(InstalledExtensionRepository.class, XarExtensionHandler.TYPE);

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-script/src/test/java/org/xwiki/extension/script/ExtensionManagerScriptServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-script/src/test/java/org/xwiki/extension/script/ExtensionManagerScriptServiceTest.java
@@ -100,10 +100,6 @@ public class ExtensionManagerScriptServiceTest
         // lookup
 
         this.scriptService = this.mocker.getInstance(ScriptService.class, "extension");
-        this.mocker.unregisterComponent(EventListener.class, "refactoring.automaticRedirectCreator");
-        this.mocker.unregisterComponent(EventListener.class, "refactoring.backLinksUpdater");
-        this.mocker.unregisterComponent(EventListener.class, "refactoring.relativeLinksUpdater");
-        this.mocker.unregisterComponent(EventListener.class, "refactoring.legacyParentFieldUpdater");
     }
 
     // tools

--- a/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-sources/xwiki-platform-localization-source-wiki/src/test/java/org/xwiki/localization/wiki/internal/DocumentTranslationBundleFactoryTest.java
+++ b/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-sources/xwiki-platform-localization-source-wiki/src/test/java/org/xwiki/localization/wiki/internal/DocumentTranslationBundleFactoryTest.java
@@ -80,11 +80,6 @@ public class DocumentTranslationBundleFactoryTest
     @Before
     public void before() throws Exception
     {
-        this.oldcore.getMocker().unregisterComponent(EventListener.class, "refactoring.automaticRedirectCreator");
-        this.oldcore.getMocker().unregisterComponent(EventListener.class, "refactoring.backLinksUpdater");
-        this.oldcore.getMocker().unregisterComponent(EventListener.class, "refactoring.relativeLinksUpdater");
-        this.oldcore.getMocker().unregisterComponent(EventListener.class, "refactoring.legacyParentFieldUpdater");
-
         this.oldcore.getXWikiContext().setMainXWiki("xwiki");
         this.oldcore.getXWikiContext().setWikiId("xwiki");
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/test/MockitoOldcore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/test/MockitoOldcore.java
@@ -56,6 +56,8 @@ import org.xwiki.model.reference.LocalDocumentReference;
 import org.xwiki.model.reference.WikiReference;
 import org.xwiki.observation.ObservationManager;
 import org.xwiki.query.QueryManager;
+import org.xwiki.refactoring.internal.LinkRefactoring;
+import org.xwiki.refactoring.internal.ModelBridge;
 import org.xwiki.rendering.syntax.Syntax;
 import org.xwiki.script.ScriptContextManager;
 import org.xwiki.script.internal.ScriptExecutionContextInitializer;
@@ -368,6 +370,15 @@ public class MockitoOldcore
             componentManagerDescriptor.setRoleHint("context");
             componentManagerDescriptor.setRoleType(ComponentManager.class);
             this.componentManager.registerComponent(componentManagerDescriptor, this.componentManager);
+        }
+
+        // Register mock components for refactoring listener components
+        if (!this.componentManager.hasComponent(ModelBridge.class)) {
+            this.componentManager.registerMockComponent(ModelBridge.class);
+        }
+
+        if (!this.componentManager.hasComponent(LinkRefactoring.class)) {
+            this.componentManager.registerMockComponent(LinkRefactoring.class);
         }
 
         // XWiki


### PR DESCRIPTION
  * Register mock component in MockitoOldCore to avoid missing
dependency related to refactoring listener
  * Also register those mock components in some tests that are not using
the MockitoOldCore