### PR TITLE
XWIKI-6732: Introduce DocumentRenamingEvent and DocumentRenamedEvent events

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/test/AbstractBridgedXWikiComponentTestCase.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/test/AbstractBridgedXWikiComponentTestCase.java
@@ -34,6 +34,8 @@ import org.xwiki.component.util.DefaultParameterizedType;
 import org.xwiki.context.Execution;
 import org.xwiki.environment.Environment;
 import org.xwiki.environment.internal.ServletEnvironment;
+import org.xwiki.refactoring.internal.LinkRefactoring;
+import org.xwiki.refactoring.internal.ModelBridge;
 import org.xwiki.rendering.configuration.ExtendedRenderingConfiguration;
 import org.xwiki.rendering.syntax.Syntax;
 import org.xwiki.wiki.descriptor.WikiDescriptor;
@@ -167,6 +169,10 @@ public abstract class AbstractBridgedXWikiComponentTestCase extends AbstractXWik
         // consequence we need to provide a mock ExtendedRenderingConfiguration component as otherwise injecting
         // WikiModel would fail (since XWikiWikiModel depends on ExtendedRenderingConfiguration).
         registerMockComponent(ExtendedRenderingConfiguration.class);
+
+        // Avoid error when loading components for refactoring-api
+        registerMockComponent(ModelBridge.class);
+        registerMockComponent(LinkRefactoring.class);
     }
 
     @Override


### PR DESCRIPTION
  * Register also mock components in
AbstractBridgeXWikiComponentTestCase for legacy tests