### PR TITLE
XWIKI-6073: Browsers usually cache JS/CSS resources even if they have changed

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/XWikiWebDriver.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/XWikiWebDriver.java
@@ -529,6 +529,28 @@ public class XWikiWebDriver extends RemoteWebDriver
     }
 
     /**
+     * Waits until the given element contain a certain value for an attribute.
+     * @param locator the element to wait on.
+     * @param attributeName the name of attribute to check.
+     * @param expectedValue the value that should be contained in the attribute.
+     */
+    public void waitUntilElementContainsAttributeValue(final By locator, final String attributeName,
+        final String expectedValue)
+    {
+        waitUntilCondition(driver -> {
+            try {
+                WebElement element = driver.findElement(locator);
+                return element.getAttribute(attributeName).contains(expectedValue);
+            } catch (NotFoundException e) {
+                return false;
+            } catch (StaleElementReferenceException e) {
+                // The element was removed from DOM in the meantime
+                return false;
+            }
+        });
+    }
+
+    /**
      * Waits until the given element has a certain value as its inner text.
      *
      * @param locator the element to wait on

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/XWikiWebDriver.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/XWikiWebDriver.java
@@ -533,6 +533,7 @@ public class XWikiWebDriver extends RemoteWebDriver
      * @param locator the element to wait on.
      * @param attributeName the name of attribute to check.
      * @param expectedValue the value that should be contained in the attribute.
+     * @since 11.1RC1
      */
     public void waitUntilElementContainsAttributeValue(final By locator, final String attributeName,
         final String expectedValue)

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/EditRightsPane.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/EditRightsPane.java
@@ -20,10 +20,8 @@
 package org.xwiki.test.ui.po;
 
 import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
-import org.openqa.selenium.support.ui.ExpectedCondition;
 
 /**
  * Class that holds the types of Rights and the types of States of a check-box

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/EditRightsPane.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/EditRightsPane.java
@@ -20,8 +20,10 @@
 package org.xwiki.test.ui.po;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.ExpectedCondition;
 
 /**
  * Class that holds the types of Rights and the types of States of a check-box
@@ -71,7 +73,9 @@ public class EditRightsPane extends BaseElement
         static State getButtonState(WebElement button)
         {
             for (State s : values()) {
-                if ((button.getAttribute("src").endsWith(s.imageURL))) {
+                // starting with 11.1RC1 the resource URLs can now contain a query parameter to avoid cache issue
+                // so we cannot rely to a full URL anymore
+                if ((button.getAttribute("src").contains(s.imageURL))) {
                     return s;
                 }
             }
@@ -127,8 +131,12 @@ public class EditRightsPane extends BaseElement
             // Note: Selenium 2.0a4 returns a relative URL when calling getAttribute("src") but since we moved to
             // Selenium 2.0a7 it returns a *full* URL even though the DOM has a relative URL as in:
             // <img src="/xwiki/resources/js/xwiki/usersandgroups/img/allow.png">
-            getDriver().waitUntilElementEndsWithAttributeValue(buttonLocator, "src",
-                currentState.getNextState().imageURL);
+            getDriver().waitUntilCondition(webDriver -> {
+                // starting with 11.1RC1 the resource URLs can now contain a query parameter to avoid cache issue
+                // so we cannot rely to a full URL anymore
+                return webDriver.findElement(buttonLocator).getAttribute("src")
+                    .contains(currentState.getNextState().imageURL);
+            });
         } finally {
             getDriver().executeJavascript("window.confirm = window.__oldConfirm;");
         }
@@ -154,7 +162,11 @@ public class EditRightsPane extends BaseElement
             // Note: Selenium 2.0a4 returns a relative URL when calling getAttribute("src") but since we moved to
             // Selenium 2.0a7 it returns a *full* URL even though the DOM has a relative URL as in:
             // <img src="/xwiki/resources/js/xwiki/usersandgroups/img/allow.png">
-            getDriver().waitUntilElementEndsWithAttributeValue(buttonLocator, "src", currentState.imageURL);
+            getDriver().waitUntilCondition(webDriver -> {
+                // starting with 11.1RC1 the resource URLs can now contain a query parameter to avoid cache issue
+                // so we cannot rely to a full URL anymore
+                return webDriver.findElement(buttonLocator).getAttribute("src").contains(currentState.imageURL);
+            });
         } finally {
             getDriver().executeJavascript("window.confirm = window.__oldConfirm;");
         }

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/EditRightsPane.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/EditRightsPane.java
@@ -73,8 +73,8 @@ public class EditRightsPane extends BaseElement
         static State getButtonState(WebElement button)
         {
             for (State s : values()) {
-                // starting with 11.1RC1 the resource URLs can now contain a query parameter to avoid cache issue
-                // so we cannot rely to a full URL anymore
+                //  The URL may contain query string parameters (e.g. starting with 11.1RC1 the resource URLs can now
+                //  contain a query parameter to avoid cache issue) and we don't care about that to identify the state.
                 if ((button.getAttribute("src").contains(s.imageURL))) {
                     return s;
                 }
@@ -131,12 +131,8 @@ public class EditRightsPane extends BaseElement
             // Note: Selenium 2.0a4 returns a relative URL when calling getAttribute("src") but since we moved to
             // Selenium 2.0a7 it returns a *full* URL even though the DOM has a relative URL as in:
             // <img src="/xwiki/resources/js/xwiki/usersandgroups/img/allow.png">
-            getDriver().waitUntilCondition(webDriver -> {
-                // starting with 11.1RC1 the resource URLs can now contain a query parameter to avoid cache issue
-                // so we cannot rely to a full URL anymore
-                return webDriver.findElement(buttonLocator).getAttribute("src")
-                    .contains(currentState.getNextState().imageURL);
-            });
+            getDriver().waitUntilElementContainsAttributeValue(buttonLocator, "src",
+                currentState.getNextState().imageURL);
         } finally {
             getDriver().executeJavascript("window.confirm = window.__oldConfirm;");
         }
@@ -162,11 +158,7 @@ public class EditRightsPane extends BaseElement
             // Note: Selenium 2.0a4 returns a relative URL when calling getAttribute("src") but since we moved to
             // Selenium 2.0a7 it returns a *full* URL even though the DOM has a relative URL as in:
             // <img src="/xwiki/resources/js/xwiki/usersandgroups/img/allow.png">
-            getDriver().waitUntilCondition(webDriver -> {
-                // starting with 11.1RC1 the resource URLs can now contain a query parameter to avoid cache issue
-                // so we cannot rely to a full URL anymore
-                return webDriver.findElement(buttonLocator).getAttribute("src").contains(currentState.imageURL);
-            });
+            getDriver().waitUntilElementContainsAttributeValue(buttonLocator, "src", currentState.imageURL);
         } finally {
             getDriver().executeJavascript("window.confirm = window.__oldConfirm;");
         }


### PR DESCRIPTION
  * Fix EditRightsPane to not rely anymore on a full resource URL