### PR TITLE
XWIKI-8346: Broken cross-wiki links on page rename

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
@@ -2064,8 +2064,8 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
 
             // the select clause is compulsory to reach the fullName i.e. the page pointed
             Query query = session
-                .createQuery("select backlink.fullName from XWikiLink as backlink where backlink.id.link = :backlink"
-                    + " or backlink.id.link = :backlinkwithwiki");
+                .createQuery("select backlink.fullName from XWikiLink as backlink where "
+                    + "backlink.id.link in (:backlink, :backlinkwithwiki)");
             query.setString("backlink", this.localEntityReferenceSerializer.serialize(documentReference));
             query.setString("backlinkwithwiki", this.defaultEntityReferenceSerializer.serialize(documentReference));
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
@@ -2064,8 +2064,10 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
 
             // the select clause is compulsory to reach the fullName i.e. the page pointed
             Query query = session
-                .createQuery("select backlink.fullName from XWikiLink as backlink where backlink.id.link = :backlink");
+                .createQuery("select backlink.fullName from XWikiLink as backlink where backlink.id.link = :backlink"
+                    + " or backlink.id.link = :backlinkwithwiki");
             query.setString("backlink", this.localEntityReferenceSerializer.serialize(documentReference));
+            query.setString("backlinkwithwiki", this.defaultEntityReferenceSerializer.serialize(documentReference));
 
             @SuppressWarnings("unchecked")
             List<String> backlinkNames = query.list();

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
@@ -2063,6 +2063,11 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
             Session session = getSession(context);
 
             // the select clause is compulsory to reach the fullName i.e. the page pointed
+            // here we check both the backlink serialized with AND without the wiki part
+            // the reason is in case of a farm of wiki, if the link points to a page from another wiki
+            // its reference is saved with the wiki part, so using only the local serialization won't be enough in that
+            // case. This should be changed once the refactoring to support backlinks properly has been done.
+            // See: XWIKI-16192
             Query query = session
                 .createQuery("select backlink.fullName from XWikiLink as backlink where "
                     + "backlink.id.link in (:backlink, :backlinkwithwiki)");

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
@@ -2064,25 +2064,14 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
 
             // the select clause is compulsory to reach the fullName i.e. the page pointed
             Query query = session
-                .createQuery("select backlink.fullName from XWikiLink as backlink where "
-                    + "backlink.id.link = :backlink");
-
-            WikiReference wikiReference = documentReference.getWikiReference();
-            boolean sameWikiContext = (wikiReference == null || wikiReference.equals(context.getWikiReference()));
-
-            String serializedBacklink;
+                .createQuery("select backlink.fullName from XWikiLink as backlink where backlink.id.link = :backlink");
 
             // if we are in the same wiki context, we should only get the local reference
             // but if we are not, then we have to check the full reference, containing the wiki part since
             // it's how the link are recorded.
             // This should be changed once the refactoring to support backlinks properly has been done.
             // See: XWIKI-16192
-            if (sameWikiContext) {
-                serializedBacklink = this.localEntityReferenceSerializer.serialize(documentReference);
-            } else {
-                serializedBacklink = this.defaultEntityReferenceSerializer.serialize(documentReference);
-            }
-            query.setString("backlink", serializedBacklink);
+            query.setString("backlink", this.compactWikiEntityReferenceSerializer.serialize(documentReference));
 
             @SuppressWarnings("unchecked")
             List<String> backlinkNames = query.list();

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/AbstractXWikiHibernateStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/AbstractXWikiHibernateStoreTest.java
@@ -29,6 +29,7 @@ import org.junit.Before;
 import org.xwiki.context.Execution;
 import org.xwiki.context.ExecutionContext;
 import org.xwiki.model.reference.DocumentReferenceResolver;
+import org.xwiki.model.reference.EntityReferenceSerializer;
 import org.xwiki.test.mockito.MockitoComponentMockingRule;
 
 import com.xpn.xwiki.XWiki;
@@ -66,6 +67,10 @@ public abstract class AbstractXWikiHibernateStoreTest<T>
 
     protected DocumentReferenceResolver<String> currentMixedDocumentReferenceResolver;
 
+    protected EntityReferenceSerializer<String> defaultEntityReferenceSerializer;
+
+    protected EntityReferenceSerializer<String> localEntityReferenceSerializer;
+
     @Before
     public void setUp() throws Exception
     {
@@ -84,6 +89,10 @@ public abstract class AbstractXWikiHibernateStoreTest<T>
 
         currentMixedDocumentReferenceResolver = getMocker().registerMockComponent(DocumentReferenceResolver.TYPE_STRING
             , "currentmixed");
+
+        defaultEntityReferenceSerializer = getMocker().registerMockComponent(EntityReferenceSerializer.TYPE_STRING);
+        localEntityReferenceSerializer = getMocker().registerMockComponent(EntityReferenceSerializer.TYPE_STRING,
+            "local");
 
         XWiki wiki = mock(XWiki.class);
         when(this.xcontext.getWiki()).thenReturn(wiki);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/AbstractXWikiHibernateStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/AbstractXWikiHibernateStoreTest.java
@@ -67,9 +67,7 @@ public abstract class AbstractXWikiHibernateStoreTest<T>
 
     protected DocumentReferenceResolver<String> currentMixedDocumentReferenceResolver;
 
-    protected EntityReferenceSerializer<String> defaultEntityReferenceSerializer;
-
-    protected EntityReferenceSerializer<String> localEntityReferenceSerializer;
+    protected EntityReferenceSerializer<String> compactWikiEntityReferenceSerializer;
 
     @Before
     public void setUp() throws Exception
@@ -90,9 +88,8 @@ public abstract class AbstractXWikiHibernateStoreTest<T>
         currentMixedDocumentReferenceResolver = getMocker().registerMockComponent(DocumentReferenceResolver.TYPE_STRING
             , "currentmixed");
 
-        defaultEntityReferenceSerializer = getMocker().registerMockComponent(EntityReferenceSerializer.TYPE_STRING);
-        localEntityReferenceSerializer = getMocker().registerMockComponent(EntityReferenceSerializer.TYPE_STRING,
-            "local");
+        compactWikiEntityReferenceSerializer = getMocker().registerMockComponent(EntityReferenceSerializer.TYPE_STRING,
+            "compactwiki");
 
         XWiki wiki = mock(XWiki.class);
         when(this.xcontext.getWiki()).thenReturn(wiki);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/AbstractXWikiHibernateStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/AbstractXWikiHibernateStoreTest.java
@@ -28,6 +28,7 @@ import org.hibernate.classic.Session;
 import org.junit.Before;
 import org.xwiki.context.Execution;
 import org.xwiki.context.ExecutionContext;
+import org.xwiki.model.reference.DocumentReferenceResolver;
 import org.xwiki.test.mockito.MockitoComponentMockingRule;
 
 import com.xpn.xwiki.XWiki;
@@ -63,6 +64,8 @@ public abstract class AbstractXWikiHibernateStoreTest<T>
 
     protected HibernateStore hibernateStore;
 
+    protected DocumentReferenceResolver<String> currentMixedDocumentReferenceResolver;
+
     @Before
     public void setUp() throws Exception
     {
@@ -78,6 +81,9 @@ public abstract class AbstractXWikiHibernateStoreTest<T>
         when(xcontextProvider.get()).thenReturn(this.xcontext);
         xcontextProvider = getMocker().registerMockComponent(XWikiContext.TYPE_PROVIDER, "readonly");
         when(xcontextProvider.get()).thenReturn(this.xcontext);
+
+        currentMixedDocumentReferenceResolver = getMocker().registerMockComponent(DocumentReferenceResolver.TYPE_STRING
+            , "currentmixed");
 
         XWiki wiki = mock(XWiki.class);
         when(this.xcontext.getWiki()).thenReturn(wiki);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/XWikiHibernateStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/XWikiHibernateStoreTest.java
@@ -337,9 +337,7 @@ public class XWikiHibernateStoreTest extends AbstractXWikiHibernateStoreTest<XWi
         // We are currently in the context of "xwiki"
         WikiReference currentWikiReference = new WikiReference("xwiki");
         when(this.xcontext.getWikiReference()).thenReturn(currentWikiReference);
-
-        // we are in the same wiki context, so the localEntityReferenceSerializer should be used
-        when(this.localEntityReferenceSerializer.serialize(documentReference)).thenReturn("B.WebHome");
+        when(this.compactWikiEntityReferenceSerializer.serialize(documentReference)).thenReturn("B.WebHome");
         List<String> resultList = new ArrayList<>();
         resultList.add("A.WebHome");
 
@@ -354,7 +352,6 @@ public class XWikiHibernateStoreTest extends AbstractXWikiHibernateStoreTest<XWi
         assertEquals(1, obtainedReferences.size());
         assertEquals(expectedBacklink, obtainedReferences.get(0));
         verify(query).setString("backlink", "B.WebHome");
-        verify(this.defaultEntityReferenceSerializer, never()).serialize(any());
         verify(this.hibernateStore).beginTransaction();
         verify(this.hibernateStore).endTransaction(false);
     }
@@ -367,9 +364,7 @@ public class XWikiHibernateStoreTest extends AbstractXWikiHibernateStoreTest<XWi
         // We are currently in the context of "xwiki"
         WikiReference currentWikiReference = new WikiReference("xwiki");
         when(this.xcontext.getWikiReference()).thenReturn(currentWikiReference);
-
-        // we are in a different wiki context, so the defaultEntityReferenceSerializer should be used
-        when(this.defaultEntityReferenceSerializer.serialize(documentReference)).thenReturn("subwiki:B.WebHome");
+        when(this.compactWikiEntityReferenceSerializer.serialize(documentReference)).thenReturn("subwiki:B.WebHome");
         List<String> resultList = new ArrayList<>();
         resultList.add("Foo.WebHome");
 
@@ -384,7 +379,6 @@ public class XWikiHibernateStoreTest extends AbstractXWikiHibernateStoreTest<XWi
         assertEquals(1, obtainedReferences.size());
         assertEquals(expectedBacklink, obtainedReferences.get(0));
         verify(query).setString("backlink", "subwiki:B.WebHome");
-        verify(this.localEntityReferenceSerializer, never()).serialize(any());
         verify(this.hibernateStore).beginTransaction();
         verify(this.hibernateStore).endTransaction(false);
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/XWikiHibernateStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/XWikiHibernateStoreTest.java
@@ -20,12 +20,12 @@
 package com.xpn.xwiki.store;
 
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
-import org.hibernate.FlushMode;
 import org.hibernate.Query;
 import org.hibernate.SQLQuery;
 import org.hibernate.Session;
@@ -39,6 +39,7 @@ import org.mockito.ArgumentCaptor;
 import org.xwiki.bridge.event.ActionExecutingEvent;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReferenceSerializer;
+import org.xwiki.model.reference.WikiReference;
 import org.xwiki.observation.EventListener;
 import org.xwiki.observation.ObservationManager;
 import org.xwiki.query.QueryManager;
@@ -49,16 +50,13 @@ import com.xpn.xwiki.objects.BaseObject;
 import com.xpn.xwiki.objects.BaseProperty;
 import com.xpn.xwiki.objects.LargeStringProperty;
 import com.xpn.xwiki.objects.StringProperty;
-import com.xpn.xwiki.store.migration.DataMigrationManager;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -329,5 +327,57 @@ public class XWikiHibernateStoreTest extends AbstractXWikiHibernateStoreTest<XWi
         verify(query).setWiki(documentReference.getWikiReference().getName());
         verify(query).bindValue("space", "Path.To");
         verify(query).bindValue("name", documentReference.getName());
+    }
+
+    @Test
+    public void loadBacklinksFromSameWiki() throws Exception
+    {
+        DocumentReference documentReference = new DocumentReference("xwiki", Arrays.asList("B"), "WebHome");
+        // We are currently in the context of "xwiki"
+        WikiReference currentWikiReference = new WikiReference("xwiki");
+        when(this.xcontext.getWikiReference()).thenReturn(currentWikiReference);
+        String[] result0 = new String[]{ "A.WebHome", "B.WebHome" };
+        List<Object[]> resultList = new ArrayList<>();
+        resultList.add(result0);
+
+        Query query = mock(Query.class);
+        when(this.session.createQuery(any())).thenReturn(query);
+        when(query.list()).thenReturn(resultList);
+        DocumentReference expectedBacklink = new DocumentReference("xwiki", Arrays.asList("A"), "WebHome");
+        when(this.currentMixedDocumentReferenceResolver.resolve("A.WebHome")).thenReturn(expectedBacklink);
+
+        List<DocumentReference> obtainedReferences = this.store.loadBacklinks(documentReference, true, this.xcontext);
+        assertEquals(1, obtainedReferences.size());
+        assertEquals(expectedBacklink, obtainedReferences.get(0));
+    }
+
+    @Test
+    public void loadBacklinksFromSubwiki() throws Exception
+    {
+        DocumentReference documentReference = new DocumentReference("subwiki", Arrays.asList("B"), "WebHome");
+        // We are currently in the context of "xwiki"
+        WikiReference currentWikiReference = new WikiReference("xwiki");
+        when(this.xcontext.getWikiReference()).thenReturn(currentWikiReference);
+
+        // This link is not right: it's about xwiki:A.WebHome -> xwiki:B.WebHome, it doesn't concern subxwiki:B.WebHome
+        String[] result0 = new String[]{ "A.WebHome", "B.WebHome" };
+
+        // This one is right
+        String[] result1 = new String[] { "Foo.WebHome", "subwiki:B.WebHome "};
+        List<Object[]> resultList = new ArrayList<>();
+        resultList.add(result0);
+        resultList.add(result1);
+
+        Query query = mock(Query.class);
+        when(this.session.createQuery(any())).thenReturn(query);
+        when(query.list()).thenReturn(resultList);
+        DocumentReference expectedBacklink = new DocumentReference("xwiki", Arrays.asList("Foo"), "WebHome");
+        when(this.currentMixedDocumentReferenceResolver.resolve("Foo.WebHome")).thenReturn(expectedBacklink);
+        DocumentReference wrongBackLink = new DocumentReference("xwiki", Arrays.asList("A"), "WebHome");
+        when(this.currentMixedDocumentReferenceResolver.resolve("A.WebHome")).thenReturn(wrongBackLink);
+
+        List<DocumentReference> obtainedReferences = this.store.loadBacklinks(documentReference, true, this.xcontext);
+        assertEquals(1, obtainedReferences.size());
+        assertEquals(expectedBacklink, obtainedReferences.get(0));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultLinkRefactoring.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultLinkRefactoring.java
@@ -107,8 +107,10 @@ public class DefaultLinkRefactoring implements LinkRefactoring
         DocumentReference newLinkTarget)
     {
         boolean popLevelProgress = false;
+        XWikiContext xcontext = this.xcontextProvider.get();
+        String previousWikiId = xcontext.getWikiId();
         try {
-            XWikiContext xcontext = this.xcontextProvider.get();
+            xcontext.setWikiId(documentReference.getWikiReference().getName());
             XWikiDocument document = xcontext.getWiki().getDocument(documentReference, xcontext);
             List<Locale> locales = document.getTranslationLocales(xcontext);
 
@@ -133,6 +135,7 @@ public class DefaultLinkRefactoring implements LinkRefactoring
             if (popLevelProgress) {
                 this.progressManager.popLevelProgress(this);
             }
+            xcontext.setWikiId(previousWikiId);
         }
     }
 


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XWIKI-8346

## Solution

  * Check two schemes when executing load backlinks request: with and
without the wiki id.

## Limitation

This fix itself is not enough for fixing completely XWIKI-8346: the `updateLinksOnFarm` needs to be set to true in the move/rename request too. Which is by default not the case. 