### PR TITLE
XWIKI-11062: Make "Search Suggest" responsive on mobile

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/action-menus.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/action-menus.less
@@ -84,7 +84,10 @@
     border: 0;
     min-width: 0;
     transition: width 0.3s, padding 0.3s;
-    width: 200px; // we need to set a width in pixels otherwise the transition is not applied nicely
+    width: 115px; // we need to set a width in pixels otherwise the transition is not applied nicely
+    @media (min-width: @screen-sm-min) {
+      width: 200px;
+    }
   }
 
   // When the global search is close

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/QuickSearchUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/QuickSearchUIX.xml
@@ -118,12 +118,20 @@
     </property>
     <property>
       <code>require(['jquery', 'bootstrap'], function($) {
+
+  // Returns true if the window inner width is lower than 768.
+  function isSmallScreen() {
+    var windowWidth = window.innerWidth;
+    return windowWidth &lt; 768;
+  }
   $(document).ready(function() {
 
     // Some variables used in the next 2 functions
     var globalSearch = $('#globalsearch');
     var globalSearchInput = globalSearch.find('input');
     var globalSearchButton = globalSearch.find('button');
+    var notificationButton = $('#tmNotifications');
+    var avatar = $('li.navbar-avatar');
 
     // Open the global search when the user click on the global search button
     globalSearchButton.click(function(event) {
@@ -131,6 +139,11 @@
         return true;
       }
       globalSearch.removeClass('globalsearch-close');
+      // Hide the notification and avatar buttons on small screens
+      if (isSmallScreen()) {
+        notificationButton.addClass('hidden');
+        avatar.addClass('hidden');
+      }
       globalSearchInput.focus();
       return false;
     });
@@ -145,6 +158,14 @@
         // actually performing the search).
         if (document.activeElement !== globalSearchButton[0] &amp;&amp; document.activeElement !== globalSearchInput[0]) {
           globalSearch.addClass('globalsearch-close');
+          // Make the notification and the avatar buttons visible again, on small screens, with a timeout so as to
+          // display the buttons only once the search input is visible.
+          if (isSmallScreen()) {
+            setTimeout( function() {
+              notificationButton.removeClass('hidden');
+              avatar.removeClass('hidden');
+            }, 350);
+          }
         }
       }, 1);
     });

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/search/searchSuggest.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/search/searchSuggest.js
@@ -152,6 +152,10 @@ var XWiki = (function (XWiki) {
         }
       });
       var allResults = allResultsNode.getElement();
+      var suggestWidth = 500;
+      if (window.innerWidth < 768) {
+        suggestWidth =  250;
+      }
       this.suggest = new XWiki.widgets.Suggest( this.searchInput, {
         parentContainer: $('searchSuggest'),
         className: 'searchSuggest horizontalLayout',
@@ -164,7 +168,7 @@ var XWiki = (function (XWiki) {
         displayValueText: "$escapetool.javascript($services.localization.render('platform.search.suggestResultLocatedIn'))",
         resultInfoHTML: true,
         timeout: 0,
-        width: 500,
+        width: suggestWidth,
         unifiedLoader: true,
         loaderNode: allResults.down("li"),
         shownoresults: false,

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/suggest/suggest.css
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/suggest/suggest.css
@@ -121,10 +121,13 @@ div.resultContainer div.sourceName {
 
 .horizontalLayout div.resultContainer div.sourceName {
   float:left;
-  width:150px;
+  width:80px;
   padding-right:23px;
   text-align:right;
   background-position:right 3px center;
+  @media (min-width: @screen-sm-min) {
+    width: 150px;
+  }
 }
 
 .horizontalLayout div.resultContainer div.xitemcontainer {


### PR DESCRIPTION
## Issue

* [XWIKI-11062](https://jira.xwiki.org/browse/XWIKI-11062)

## Solution

- Make the quick search input field responsive
- Make the quick search suggestions responsive
- For windows narrower than small tablets (768px): show the notification and avatar buttons only when the quick search widget is inactive

## Comments

- This highlights the possible need of an XWiki JavaScript API that checks the window current width range (small, medium, large, ...), considering that screens may not be measured uniformally, in case such an API does not exist already.
- There is still the need to add smoother show / hide transitions to the notification and avatar buttons, this will be the object of another issue if this pull request gets accepted.