### PR TITLE
XWIKI-16138: Email addresses are shown in clear in REST results

### DIFF
--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-api/src/main/java/org/xwiki/mail/MailGeneralConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-api/src/main/java/org/xwiki/mail/MailGeneralConfiguration.java
@@ -1,0 +1,38 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.mail;
+
+import org.xwiki.component.annotation.Role;
+
+/**
+ * Represents all XWiki general configuration options for Mail.
+ *
+ * @version $Id$
+ * @since 11.1
+ * @since 10.11.4
+ */
+@Role
+public interface MailGeneralConfiguration
+{
+    /**
+     * @return true if user emails should only be shown obfuscated
+     */
+    boolean isObfuscateEmails();
+}

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/configuration/GeneralMailConfigClassDocumentConfigurationSource.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/configuration/GeneralMailConfigClassDocumentConfigurationSource.java
@@ -1,0 +1,126 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.mail.internal.configuration;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.configuration.ConfigurationSource;
+import org.xwiki.configuration.internal.AbstractDocumentConfigurationSource;
+import org.xwiki.mail.MailGeneralConfiguration;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.LocalDocumentReference;
+import org.xwiki.model.reference.RegexEntityReference;
+import org.xwiki.observation.event.Event;
+
+import com.xpn.xwiki.internal.event.XObjectAddedEvent;
+import com.xpn.xwiki.internal.event.XObjectDeletedEvent;
+import com.xpn.xwiki.internal.event.XObjectUpdatedEvent;
+import com.xpn.xwiki.objects.BaseObjectReference;
+
+/**
+ * Provides configuration from the Mail.GeneralMailConfigClass document in the current wiki.
+ * If the Mail.GeneralMailConfigClass xobject exists in the Mail.MailConfig document
+ * then use configuration values from it and if it doesn't then look up similar values
+ * in the main preferences.
+ *
+ * @version $Id$
+ * @since 11.1
+ * @since 10.11.4
+ */
+@Component(roles = {MailGeneralConfiguration.class})
+@Singleton
+public class GeneralMailConfigClassDocumentConfigurationSource extends AbstractDocumentConfigurationSource
+    implements MailGeneralConfiguration
+{
+    private static final String MAIL_SPACE = "Mail";
+
+    private static final String PROPERTY_OBFUSCATE_NAME = "obfuscate";
+
+    /**
+     * The local reference of the Mail.GeneralMailConfigClass xclass.
+     */
+    private static final LocalDocumentReference CLASS_REFERENCE = new LocalDocumentReference(MAIL_SPACE,
+        "GeneralMailConfigClass");
+
+    /**
+     * The local reference of the Mail.MailConfig document.
+     */
+    private static final LocalDocumentReference DOC_REFERENCE = new LocalDocumentReference(MAIL_SPACE, "MailConfig");
+
+    @Inject
+    @Named("wiki")
+    private ConfigurationSource wikiConfig;
+
+    @Override
+    protected String getCacheId()
+    {
+        return "configuration.document.mail.general";
+    }
+
+    @Override
+    protected DocumentReference getDocumentReference()
+    {
+        return new DocumentReference(DOC_REFERENCE, getCurrentWikiReference());
+    }
+
+    @Override
+    protected LocalDocumentReference getClassReference()
+    {
+        return CLASS_REFERENCE;
+    }
+
+    @Override
+    protected <T> T getPropertyValue(String key, Class<T> valueClass)
+    {
+        T value = super.getPropertyValue(key, valueClass);
+        if (value == null && PROPERTY_OBFUSCATE_NAME.equals(key)) {
+            value = wikiConfig.getProperty("obfuscateEmailAddresses", valueClass);
+        }
+        return value;
+    }
+
+    @Override
+    public boolean isObfuscateEmails()
+    {
+        return getProperty(PROPERTY_OBFUSCATE_NAME, 0) != 0;
+    }
+
+    protected List<Event> getCacheCleanupEvents()
+    {
+        List<Event> events = new ArrayList<>();
+        events.addAll(super.getCacheCleanupEvents());
+
+        // cannot access this:
+        // events.addAll(wikiConfig.getCacheCleanupEvents());
+        // so instead:
+        RegexEntityReference classMatcher = BaseObjectReference.any("XWiki.XWikiPreferences");
+        events.addAll(Arrays.<Event>asList(new XObjectAddedEvent(classMatcher), new XObjectDeletedEvent(classMatcher),
+            new XObjectUpdatedEvent(classMatcher)));
+
+        return events;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/script/AbstractMailScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/script/AbstractMailScriptService.java
@@ -30,6 +30,7 @@ import javax.mail.internet.MimeMessage;
 import org.xwiki.component.manager.ComponentLookupException;
 import org.xwiki.component.manager.ComponentManager;
 import org.xwiki.context.Execution;
+import org.xwiki.mail.MailGeneralConfiguration;
 import org.xwiki.mail.MailListener;
 import org.xwiki.mail.MailSender;
 import org.xwiki.mail.MailSenderConfiguration;
@@ -60,6 +61,9 @@ public abstract class AbstractMailScriptService implements ScriptService
 
     @Inject
     protected MailSenderConfiguration senderConfiguration;
+
+    @Inject
+    protected MailGeneralConfiguration generalConfiguration;
 
     /**
      * Send the mail asynchronously.

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/script/MailSenderScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/script/MailSenderScriptService.java
@@ -34,6 +34,7 @@ import javax.mail.internet.MimeMessage;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.manager.ComponentLookupException;
 import org.xwiki.component.util.DefaultParameterizedType;
+import org.xwiki.mail.MailGeneralConfiguration;
 import org.xwiki.mail.MailListener;
 import org.xwiki.mail.MailSenderConfiguration;
 import org.xwiki.mail.MimeMessageFactory;
@@ -275,12 +276,41 @@ public class MailSenderScriptService extends AbstractMailScriptService
     }
 
     /**
+     * Obfuscate the email for display purposes, if configured to do so.
+     * @param emailAddress the email address to be obfuscated
+     * @return the obfuscated address
+     * @since 11.1
+     * @since 10.11.4
+     */
+    public String obfuscateForDisplay(final String emailAddress)
+    {
+        String obfuscatedEmailAddress;
+        if (emailAddress != null && this.generalConfiguration.isObfuscateEmails()) {
+            obfuscatedEmailAddress = emailAddress.replaceAll("^(.).*@", "$1...@");
+        } else {
+            obfuscatedEmailAddress = emailAddress;
+        }
+        return obfuscatedEmailAddress;
+    }
+
+    /**
      * @return the configuration for sending mails (SMTP host, port, etc)
      */
     public MailSenderConfiguration getConfiguration()
     {
         return this.senderConfiguration;
     }
+
+    /**
+     * @return the general configuration about mails; i.e. everything that did not fit elswhere
+     * @since 11.1
+     * @since 10.11.4
+     */
+    public MailGeneralConfiguration getGeneralConfiguration()
+    {
+        return this.generalConfiguration;
+    }
+
 
     @Override
     protected String getErrorKey()

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/resources/META-INF/components.txt
@@ -16,6 +16,7 @@ org.xwiki.mail.internal.thread.context.XWikiRequestCopier
 org.xwiki.mail.internal.script.AlwaysAllowScriptServicePermissionChecker
 org.xwiki.mail.internal.script.ProgrammingRightsScriptServicePermissionChecker
 org.xwiki.mail.internal.configuration.DefaultMailSenderConfiguration
+org.xwiki.mail.internal.configuration.GeneralMailConfigClassDocumentConfigurationSource
 org.xwiki.mail.internal.configuration.SendMailConfigClassDocumentConfigurationSource
 org.xwiki.mail.internal.FileSystemMailContentStore
 org.xwiki.mail.internal.DefaultSessionFactory

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/test/java/org/xwiki/mail/internal/configuration/GeneralMailConfigClassDocumentConfigurationSourceTest.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/test/java/org/xwiki/mail/internal/configuration/GeneralMailConfigClassDocumentConfigurationSourceTest.java
@@ -1,0 +1,176 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.mail.internal.configuration;
+
+import javax.inject.Named;
+import javax.inject.Provider;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.xwiki.cache.Cache;
+import org.xwiki.cache.CacheManager;
+import org.xwiki.cache.config.CacheConfiguration;
+import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.configuration.ConfigurationSource;
+import org.xwiki.mail.MailGeneralConfiguration;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.LocalDocumentReference;
+import org.xwiki.properties.ConverterManager;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectComponentManager;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+import org.xwiki.wiki.descriptor.WikiDescriptorManager;
+
+import com.xpn.xwiki.XWiki;
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.objects.BaseObject;
+import com.xpn.xwiki.objects.BaseProperty;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link org.xwiki.mail.internal.configuration.DefaultMailSenderConfiguration}.
+ *
+ * @version $Id$
+ * @since 6.1M2
+ */
+@ComponentTest
+public class GeneralMailConfigClassDocumentConfigurationSourceTest
+{
+    @InjectMockComponents(role = MailGeneralConfiguration.class)
+    private GeneralMailConfigClassDocumentConfigurationSource configuration;
+
+    @InjectComponentManager
+    private ComponentManager componentManager;
+
+    @MockComponent
+    private Provider<XWikiContext> xcontextProvider;
+
+    @MockComponent
+    private WikiDescriptorManager wikiManager;
+
+    @MockComponent
+    protected CacheManager cacheManager;
+
+    @MockComponent
+    protected ConverterManager converter;
+
+    @MockComponent
+    @Named("wiki")
+    private ConfigurationSource xwikiConfigSource;
+
+    private LocalDocumentReference configClass;
+
+    private XWikiDocument configPage;
+
+    private BaseProperty<?> property;
+
+    @BeforeEach
+    private void mockPageObjectsSetup() throws Exception
+    {
+        configClass = new LocalDocumentReference("Mail", "GeneralMailConfigClass");
+
+        property = mock(BaseProperty.class);
+
+        configPage = mock(XWikiDocument.class);
+
+        DocumentReference documentReference = new DocumentReference("wiki", "Mail", "MailConfig");
+        XWiki xwiki = mock(XWiki.class);
+        when(xwiki.getDocument(eq(documentReference), any(XWikiContext.class))).thenReturn(configPage);
+
+        XWikiContext xcontext = mock(XWikiContext.class);
+        when(xcontext.getWiki()).thenReturn(xwiki);
+
+        when(wikiManager.getCurrentWikiId()).thenReturn("wiki");
+
+        // mock the converter to return the original value always
+        when(converter.convert(any(), any())).then(new Answer<Object>()
+        {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable
+            {
+                return invocation.getArgument(1);
+            }
+        });
+
+        @SuppressWarnings("unchecked")
+        Cache<Object> cache = mock(Cache.class);
+        when(cacheManager.createNewCache(any(CacheConfiguration.class))).thenReturn(cache);
+
+        when(xcontextProvider.get()).thenReturn(xcontext);
+
+        configuration.initialize();
+    }
+
+    private void createGeneralConfig()
+    {
+        BaseObject object = mock(BaseObject.class);
+        when(object.getField("obfuscate")).thenReturn(property);
+        when(configPage.getXObject(configClass)).thenReturn(object);
+    }
+
+    @Test
+    public void getDefaultObfuscatePropertyIfNotConfigured()
+    {
+        // test
+        assertEquals(0, this.configuration.getProperty("obfuscate", 0));
+        assertEquals(1, this.configuration.getProperty("obfuscate", 1));
+        assertFalse(this.configuration.isObfuscateEmails());
+    }
+
+    @Test
+    public void getObfuscatePropertyIfSet()
+    {
+        createGeneralConfig();
+        // set a mock value
+        when(property.getValue()).thenReturn(1);
+
+        // test
+        assertEquals(1, this.configuration.getProperty("obfuscate", 0));
+        assertTrue(this.configuration.isObfuscateEmails());
+    }
+
+    @Test
+    public void getObfuscatePropertyFromXWikiPreferencesOnlyIfGeneralConfigIsMissing()
+    {
+        // set property in XWikiPreferences
+        when(xwikiConfigSource.getProperty("obfuscateEmailAddresses", Integer.class)).thenReturn(1);
+
+        // test
+        assertEquals(1, this.configuration.getProperty("obfuscate", 0));
+        assertTrue(this.configuration.isObfuscateEmails());
+
+        createGeneralConfig();
+        when(property.getValue()).thenReturn(0);
+        assertEquals(0, this.configuration.getProperty("obfuscate", 1));
+        assertFalse(this.configuration.isObfuscateEmails());
+    }
+
+}

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/displayer_email.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/displayer_email.vm
@@ -4,15 +4,8 @@
   <input type="text" id="$!id" name="$!id" value="$!escapetool.xml($value)" class="email"
     #if ($disabled)disabled="disabled"#end />
 #elseif ($type == 'view' || $type == 'rendered')
-  #set ($mailConfigDoc = $xwiki.getDocument('Mail.MailConfig'))
-  #set ($generalMailConfigObject = $mailConfigDoc.getObject('Mail.GeneralMailConfigClass'))
-  #set ($obfuscate = $generalMailConfigObject.getValue('obfuscate'))
-  #if ("$!obfuscate" == '')
-    ## We handle backward compatibility by also looking in the XWikiPreferences xobject
-    #set ($obfuscate = $xwiki.getXWikiPreferenceAsInt('obfuscateEmailAddresses', 0))
-  #end
-  #if ($obfuscate == 1)
-$!escapetool.xml($value.replaceAll('^(.).*@', '$1...@'))##
+  #if ($services.mailsender.generalConfiguration.obfuscateEmails)
+$!escapetool.xml($services.mailsender.obfuscateForDisplay($value))##
   #elseif ($value != '')
 <a href="mailto:$!{escapetool.xml($value)}">$!{escapetool.xml($value)}</a>##
   #end


### PR DESCRIPTION
First version: 

- email addresses are only shown at all in REST results
   for users who have edit rights on the document (likely
   their own profile)
 - this only happens if email obfuscation is enabled
 - to check for this config settings a new MailGeneralConfiguration
   interface has been created, which for now exposes only this
   setting (the corresponding XClass has only this one)
   and also implements the fallback lookup on the
   XWiki.XWikiPreferences
 - that logic is then reused in the custom email displayer