### PR TITLE
 XWIKI-6665: Saving edits after lock expiration doesn't warn the user that the page may be stale

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/htmlheader.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/htmlheader.vm
@@ -19,6 +19,7 @@
   #xwikiDataAttribute('space', $doc.space)##deprecated, use 'reference' instead
   #xwikiDataAttribute('page', $doc.documentReference.name)##deprecated, use 'reference' instead
   #xwikiDataAttribute('version', $tdoc.version)
+  #xwikiDataAttribute('isnew', $tdoc.isNew())
   #xwikiDataAttribute('rest-url', $services.rest.url($tdoc.documentReferenceWithLocale))
   #xwikiDataAttribute('form-token', "$!{services.csrf.token}")
   #xwikiDataAttribute('user-reference', $!services.model.serialize($xcontext.userReference, 'default'))

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -1946,16 +1946,33 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
         return this.isContentDirty;
     }
 
+    /**
+     * Increment the current document version.
+     * This method will use {@link #getNextVersion(Version, boolean)} to compute the new version.
+     */
     public void incrementVersion()
     {
-        if (this.version == null) {
-            this.version = new Version("1.1");
+        this.version = getNextVersion(this.version, isMinorEdit());
+    }
+
+    /**
+     * This method computes the next version and returns it, but won't change the current version.
+     * In order to change the current version, see {@link #incrementVersion()}.
+     *
+     * @param version the based version from which to compute the next one.
+     * @param minorEdit true means it's a minor edition.
+     * @return the new version computed based on the current one.
+     * @since 11.2RC1
+     */
+    public static Version getNextVersion(Version version, boolean minorEdit)
+    {
+        if (version == null) {
+            return new Version("1.1");
+        }
+        if (minorEdit) {
+            return version.next();
         } else {
-            if (isMinorEdit()) {
-                this.version = this.version.next();
-            } else {
-                this.version = this.version.getBranchPoint().next().newBranch(1);
-            }
+            return version.getBranchPoint().next().newBranch(1);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -6323,6 +6323,16 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
     {
         XWikiDocument fromDoc = context.getWiki().getDocument(this, fromRev, context);
         XWikiDocument toDoc = context.getWiki().getDocument(this, toRev, context);
+        if (fromDoc == null) {
+            throw new XWikiException(XWikiException.MODULE_XWIKI_DIFF, XWikiException.ERROR_XWIKI_DIFF_CONTENT_ERROR,
+                String.format("The revision [%s] cannot be found in [%s] for making diff.", fromRev,
+                    this.getDocumentReference()));
+        }
+        if (toRev == null) {
+            throw new XWikiException(XWikiException.MODULE_XWIKI_DIFF, XWikiException.ERROR_XWIKI_DIFF_CONTENT_ERROR,
+                String.format("The revision [%s] cannot be found in [%s] for making diff.", toRev,
+                    this.getDocumentReference()));
+        }
         return getContentDiff(fromDoc, toDoc, context);
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SaveAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SaveAction.java
@@ -61,12 +61,12 @@ public class SaveAction extends PreviewAction
     /** The identifier of the save action. */
     public static final String ACTION_NAME = "save";
 
+    protected static final String ASYNC_PARAM = "async";
+
     /**
      * The key to retrieve the saved object version from the context.
      */
-    public static final String SAVED_OBJECT_VERSION_KEY = "SaveAction.savedObjectVersion";
-
-    protected static final String ASYNC_PARAM = "async";
+    private static final String SAVED_OBJECT_VERSION_KEY = "SaveAction.savedObjectVersion";
 
     private DocumentRevisionProvider documentRevisionProvider;
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SaveAndContinueAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SaveAndContinueAction.java
@@ -46,6 +46,11 @@ public class SaveAndContinueAction extends XWikiAction
     /** Key for storing the wrapped action in the context. */
     private static final String WRAPPED_ACTION_CONTEXT_KEY = "SaveAndContinueAction.wrappedAction";
 
+    /**
+     * The key to retrieve the saved object version from the context.
+     */
+    private static final String SAVED_OBJECT_VERSION_KEY = "SaveAction.savedObjectVersion";
+
     /** Logger. */
     private static final Logger LOGGER = LoggerFactory.getLogger(SaveAndContinueAction.class);
 
@@ -206,7 +211,7 @@ public class SaveAndContinueAction extends XWikiAction
 
         // If this is an ajax request, no need to redirect.
         if (isAjaxRequest) {
-            Version newVersion = (Version) context.get(SaveAction.SAVED_OBJECT_VERSION_KEY);
+            Version newVersion = (Version) context.get(SAVED_OBJECT_VERSION_KEY);
 
             // in case of property update, SaveAction has not been called, so we don't get the new version.
             if (newVersion != null) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SaveAndContinueAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SaveAndContinueAction.java
@@ -27,6 +27,7 @@ import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.suigeneris.jrcs.rcs.Version;
 import org.xwiki.csrf.CSRFToken;
 
 import com.xpn.xwiki.XWikiContext;
@@ -208,8 +209,14 @@ public class SaveAndContinueAction extends XWikiAction
         if (isAjaxRequest) {
             EditForm form = (EditForm) context.getForm();
             JSONObject jsonAnswer = new JSONObject();
-            jsonAnswer.element("newVersion",
-                XWikiDocument.getNextVersion(context.getDoc().getRCSVersion(), form.isMinorEdit()).toString());
+            Version newVersion;
+
+            if (context.getDoc().isNew()) {
+                newVersion = context.getDoc().getRCSVersion();
+            } else {
+                newVersion = XWikiDocument.getNextVersion(context.getDoc().getRCSVersion(), form.isMinorEdit());
+            }
+            jsonAnswer.element("newVersion", newVersion.toString());
             answerJSON(context, HttpStatus.SC_OK, jsonAnswer);
             return false;
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SaveAndContinueAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SaveAndContinueAction.java
@@ -210,16 +210,7 @@ public class SaveAndContinueAction extends XWikiAction
             JSONObject jsonAnswer = new JSONObject();
             jsonAnswer.element("newVersion",
                 XWikiDocument.getNextVersion(context.getDoc().getRCSVersion(), form.isMinorEdit()).toString());
-
-            String jsonAnswerAsString = jsonAnswer.toString();
-            try {
-                context.getResponse().setContentType("application/json");
-                context.getResponse().setContentLength(jsonAnswerAsString.length());
-                context.getResponse().getWriter().print(jsonAnswerAsString);
-                context.getResponse().setStatus(HttpStatus.SC_OK);
-            } catch (IOException e) {
-                throw new XWikiException("Error while sending JSON answer.", e);
-            }
+            answerJSON(context, HttpStatus.SC_OK, jsonAnswer);
             return false;
         }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiAction.java
@@ -85,6 +85,8 @@ import com.xpn.xwiki.monitor.api.MonitorPlugin;
 import com.xpn.xwiki.objects.BaseObject;
 import com.xpn.xwiki.plugin.fileupload.FileUploadPlugin;
 
+import net.sf.json.JSONObject;
+
 /**
  * <p>
  * Root class for most XWiki actions. It provides a common framework that allows actions to execute just the specific
@@ -943,5 +945,26 @@ public abstract class XWikiAction extends Action
         }
 
         return false;
+    }
+
+    /**
+     * Answer to a request with a JSON content.
+     * @param context the current context of the request.
+     * @param status the status code to send back.
+     * @param json the JSON to serialize in the content of the answer.
+     * @throws XWikiException in case of error during the serialization of the JSON.
+     */
+    protected void answerJSON(XWikiContext context, int status, JSONObject json) throws XWikiException
+    {
+        try {
+            String jsonAnswerAsString = json.toString();
+            context.getResponse().setContentType("application/json");
+            context.getResponse().setContentLength(jsonAnswerAsString.length());
+            context.getResponse().setStatus(status);
+            context.getResponse().setCharacterEncoding(context.getWiki().getEncoding());
+            context.getResponse().getWriter().print(jsonAnswerAsString);
+        } catch (IOException e) {
+            throw new XWikiException("Error while sending JSON answer.", e);
+        }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiAction.java
@@ -87,8 +87,6 @@ import com.xpn.xwiki.monitor.api.MonitorPlugin;
 import com.xpn.xwiki.objects.BaseObject;
 import com.xpn.xwiki.plugin.fileupload.FileUploadPlugin;
 
-import net.sf.json.JSONObject;
-
 /**
  * <p>
  * Root class for most XWiki actions. It provides a common framework that allows actions to execute just the specific

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiAction.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Vector;
 
 import javax.script.ScriptContext;
@@ -77,6 +78,7 @@ import org.xwiki.script.ScriptContextManager;
 import org.xwiki.template.TemplateManager;
 import org.xwiki.velocity.VelocityManager;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.xpn.xwiki.XWiki;
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
@@ -951,13 +953,15 @@ public abstract class XWikiAction extends Action
      * Answer to a request with a JSON content.
      * @param context the current context of the request.
      * @param status the status code to send back.
-     * @param json the JSON to serialize in the content of the answer.
+     * @param answer the content of the JSON answer.
      * @throws XWikiException in case of error during the serialization of the JSON.
      */
-    protected void answerJSON(XWikiContext context, int status, JSONObject json) throws XWikiException
+    protected void answerJSON(XWikiContext context, int status, Map<String, String> answer) throws XWikiException
     {
+        ObjectMapper mapper = new ObjectMapper();
+
         try {
-            String jsonAnswerAsString = json.toString();
+            String jsonAnswerAsString = mapper.writeValueAsString(answer);
             context.getResponse().setContentType("application/json");
             context.getResponse().setContentLength(jsonAnswerAsString.length());
             context.getResponse().setStatus(status);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -1251,6 +1251,10 @@ core.editors.saveandcontinue.notification.inprogress=Saving...
 core.editors.saveandcontinue.notification.done=Saved
 core.editors.saveandcontinue.notification.error=Failed to save the page. Reason: {0}
 core.editors.savewithprogress.notification=Saving... __PROGRESS__%
+core.editors.save.conflictversion.rollbackmessage=The document has been modified since you last saved it. Please copy your changes and reload the page to get the latest version and reapply your changes.
+core.editors.save.conflictversion.previousVersion=Your version of the document:
+core.editors.save.conflictversion.latestVersion=Latest version of the document:
+core.editors.save.conflictversion.diffLink=Click here to check out the changes made on the latest version since you started editing it.
 
 core.space.recyclebin.confirm=This action will move ALL pages in space {0} to the Recycle Bin. Are you sure you wish to continue?
 core.space.delete.confirm=This action will remove ALL pages in space {0} from your wiki. Are you sure you wish to continue?

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/actionbuttons/actionButtons.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/actionbuttons/actionButtons.js
@@ -23,359 +23,467 @@
 
 var XWiki = (function(XWiki) {
 // Start XWiki augmentation.
-var actionButtons = XWiki.actionButtons = XWiki.actionButtons || {};
+  var actionButtons = XWiki.actionButtons = XWiki.actionButtons || {};
 
-actionButtons.EditActions = Class.create({
-  initialize : function() {
-    this.addListeners();
-    this.addShortcuts();
-    this.addValidators();
-  },
-  addListeners : function() {
-    $$('input[name=action_cancel]').each(function(item) {
-      item.observe('click', this.onCancel.bindAsEventListener(this));
-    }.bind(this));
-    $$('input[name=action_preview]').each(function(item) {
-      item.observe('click', this.onSubmit.bindAsEventListener(this, 'preview'));
-    }.bind(this));
-    $$('input[name=action_save]').each(function(item) {
-      item.observe('click', this.onSubmit.bindAsEventListener(this, 'save'));
-    }.bind(this));
-    $$('input[name=action_saveandcontinue]').each(function(item) {
-      item.observe('click', this.onSubmit.bindAsEventListener(this, 'save', true));
-    }.bind(this));
-  },
-  addShortcuts : function() {
-    var shortcuts = {
-      'action_cancel' : "$services.localization.render('core.shortcuts.edit.cancel')",
-      'action_preview' : "$services.localization.render('core.shortcuts.edit.preview')",
-      // The following 2 are both "Back to edit" in the preview mode, depending on the used editor
-      'action_edit' : "$services.localization.render('core.shortcuts.edit.backtoedit')",
-      'action_inline' : "$services.localization.render('core.shortcuts.edit.backtoedit')",
-      'action_save' : "$services.localization.render('core.shortcuts.edit.saveandview')",
-      'action_propupdate' : "$services.localization.render('core.shortcuts.edit.saveandview')",
-      'action_saveandcontinue' : "$services.localization.render('core.shortcuts.edit.saveandcontinue')"
-    }
-    for (var key in shortcuts) {
-      var targetButtons = $$("input[name=" + key + "]");
-      if (targetButtons.size() > 0) {
-        shortcut.add(shortcuts[key], function() {
-          this.click();
-        }.bind(targetButtons.first()));
+  var currentVersion;
+  require(['xwiki-meta'], function (xm) {
+    currentVersion = xm.version;
+  });
+
+  actionButtons.EditActions = Class.create({
+    initialize : function() {
+      this.addListeners();
+      this.addShortcuts();
+      this.addValidators();
+    },
+    addListeners : function() {
+      $$('input[name=action_cancel]').each(function(item) {
+        item.observe('click', this.onCancel.bindAsEventListener(this));
+      }.bind(this));
+      $$('input[name=action_preview]').each(function(item) {
+        item.observe('click', this.onSubmit.bindAsEventListener(this, 'preview'));
+      }.bind(this));
+      $$('input[name=action_save]').each(function(item) {
+        item.observe('click', this.onSubmit.bindAsEventListener(this, 'save'));
+      }.bind(this));
+      $$('input[name=action_saveandcontinue]').each(function(item) {
+        item.observe('click', this.onSubmit.bindAsEventListener(this, 'save', true));
+      }.bind(this));
+    },
+    addShortcuts : function() {
+      var shortcuts = {
+        'action_cancel' : "$services.localization.render('core.shortcuts.edit.cancel')",
+        'action_preview' : "$services.localization.render('core.shortcuts.edit.preview')",
+        // The following 2 are both "Back to edit" in the preview mode, depending on the used editor
+        'action_edit' : "$services.localization.render('core.shortcuts.edit.backtoedit')",
+        'action_inline' : "$services.localization.render('core.shortcuts.edit.backtoedit')",
+        'action_save' : "$services.localization.render('core.shortcuts.edit.saveandview')",
+        'action_propupdate' : "$services.localization.render('core.shortcuts.edit.saveandview')",
+        'action_saveandcontinue' : "$services.localization.render('core.shortcuts.edit.saveandcontinue')"
       }
-    }
-  },
-  validators : new Array(),
-  addValidators : function() {
-    // Add live presence validation for inputs with classname 'required'.
-    var inputs = $('body').select("input.required");
-    for (var i = 0; i < inputs.length; i++) {
-      var input = inputs[i];
-      var validator = new LiveValidation(input, { validMessage: "" });
-      validator.add(Validate.Presence, {
-        failureMessage: "$services.localization.render('core.validation.required.message')"
-      });
-      validator.validate();
-      this.validators.push(validator);
-    }
-  },
-  validateForm : function(form) {
-    for (var i = 0; i < this.validators.length; i++) {
-      if (!this.validators[i].validate()) {
-        return false;
+      for (var key in shortcuts) {
+        var targetButtons = $$("input[name=" + key + "]");
+        if (targetButtons.size() > 0) {
+          shortcut.add(shortcuts[key], function() {
+            this.click();
+          }.bind(targetButtons.first()));
+        }
       }
-    }
-    var commentField = form.comment;
-    if (commentField && ($xwiki.isEditCommentSuggested() || $xwiki.isEditCommentMandatory())) {
-      while (commentField.value == '') {
-        var response = prompt("$services.localization.render('core.comment.prompt')", '');
-        if (response === null) {
+    },
+    validators : new Array(),
+    addValidators : function() {
+      // Add live presence validation for inputs with classname 'required'.
+      var inputs = $('body').select("input.required");
+      for (var i = 0; i < inputs.length; i++) {
+        var input = inputs[i];
+        var validator = new LiveValidation(input, { validMessage: "" });
+        validator.add(Validate.Presence, {
+          failureMessage: "$services.localization.render('core.validation.required.message')"
+        });
+        validator.validate();
+        this.validators.push(validator);
+      }
+    },
+    validateForm : function(form) {
+      for (var i = 0; i < this.validators.length; i++) {
+        if (!this.validators[i].validate()) {
           return false;
         }
-        commentField.value = response;
-        if (!$xwiki.isEditCommentMandatory()) break;
       }
-    }
-    return true;
-  },
-  onCancel : function(event) {
-    event.stop();
-
-    // Notify others we are going to cancel
-    this.notify(event, "cancel");
-
-    // Optimisation: Do not send the entire form's data when all we want is to cancel editing.
-
-    // Determine the form's action and clean it by removing any anchors.
-    var location = event.element().form.action;
-    if (typeof location != "string") {
-       location = event.element().form.attributes.getNamedItem("action");
-       if (location) {
-         location = location.nodeValue;
-       } else {
-         location = window.self.location.href;
-       }
-    }
-    var parts = location.split('#', 2);
-    var fragmentId = (parts.length == 2) ? parts[1] : '';
-    location = parts[0];
-    if (location.indexOf('?') == -1) {
-      location += '?';
-    }
-
-    // Make sure that we call the CancelAction using XWiki's ActionFilter, no matter what XWiki action was set in the form's action.
-    var cancelActionParameter = '&action_cancel=true';
-
-    // Include the xredirect element, if it exists.
-    var xredirectElement = event.element().form.select('input[name="xredirect"]')[0];
-    var xredirectParameter = xredirectElement ? '&xredirect=' + escape(xredirectElement.value) : '';
-
-    // Optimisation: Prevent a redundant request to remove the edit lock when the page unload event is triggered. Both the cancel action
-    // and the page unload event would unlock the document, so no point in doing both.
-    XWiki.EditLock && XWiki.EditLock.setLocked(false);
-
-    // Call the cancel URL directly instead of submitting the form. (optimisation)
-    window.location = location + cancelActionParameter + xredirectParameter + fragmentId;
-  },
-  onSubmit: function(event, action, continueEditing) {
-    var beforeAction = 'before' + action.substr(0, 1).toUpperCase() + action.substr(1);
-    if (this.notify(event, beforeAction, {'continue': continueEditing})) {
-      if (this.validateForm(event.element().form)) {
-        this.notify(event, action, {'continue' : continueEditing});
-      } else {
-        event.stop();
+      var commentField = form.comment;
+      if (commentField && ($xwiki.isEditCommentSuggested() || $xwiki.isEditCommentMandatory())) {
+        while (commentField.value == '') {
+          var response = prompt("$services.localization.render('core.comment.prompt')", '');
+          if (response === null) {
+            return false;
+          }
+          commentField.value = response;
+          if (!$xwiki.isEditCommentMandatory()) break;
+        }
       }
+      return true;
+    },
+    onCancel : function(event) {
+      event.stop();
+
+      // Notify others we are going to cancel
+      this.notify(event, "cancel");
+
+      // Optimisation: Do not send the entire form's data when all we want is to cancel editing.
+
+      // Determine the form's action and clean it by removing any anchors.
+      var location = event.element().form.action;
+      if (typeof location != "string") {
+        location = event.element().form.attributes.getNamedItem("action");
+        if (location) {
+          location = location.nodeValue;
+        } else {
+          location = window.self.location.href;
+        }
+      }
+      var parts = location.split('#', 2);
+      var fragmentId = (parts.length == 2) ? parts[1] : '';
+      location = parts[0];
+      if (location.indexOf('?') == -1) {
+        location += '?';
+      }
+
+      // Make sure that we call the CancelAction using XWiki's ActionFilter, no matter what XWiki action was set in the form's action.
+      var cancelActionParameter = '&action_cancel=true';
+
+      // Include the xredirect element, if it exists.
+      var xredirectElement = event.element().form.select('input[name="xredirect"]')[0];
+      var xredirectParameter = xredirectElement ? '&xredirect=' + escape(xredirectElement.value) : '';
+
+      // Optimisation: Prevent a redundant request to remove the edit lock when the page unload event is triggered. Both the cancel action
+      // and the page unload event would unlock the document, so no point in doing both.
+      XWiki.EditLock && XWiki.EditLock.setLocked(false);
+
+      // Call the cancel URL directly instead of submitting the form. (optimisation)
+      window.location = location + cancelActionParameter + xredirectParameter + fragmentId;
+    },
+    onSubmit: function(event, action, continueEditing) {
+      var beforeAction = 'before' + action.substr(0, 1).toUpperCase() + action.substr(1);
+      if (this.notify(event, beforeAction, {'continue': continueEditing})) {
+        if (this.validateForm(event.element().form)) {
+          this.notify(event, action, {'continue' : continueEditing});
+        } else {
+          event.stop();
+        }
+      }
+    },
+    notify : function(originalEvent, action, params) {
+      var event = document.fire('xwiki:actions:' + action, Object.extend({
+        originalEvent: originalEvent,
+        form: originalEvent.element().form
+      }, params || {}));
+      // We check both the current event and the original event in order to preserve backwards compatibility with older
+      // code that may stop only the original event. We recommend stopping only the current event becase most of the
+      // listeners shouldn't be aware of the original event.
+      var stopped = event.stopped || originalEvent.stopped;
+      // Stop the original event if the current event has been stopped. Also, in Internet Explorer the original event
+      // can't be stopped from the current event's handlers, so in case some old code has tried to stop the original event
+      // we must call stop() again here.
+      if (stopped) {
+        originalEvent.stop();
+      }
+      return !stopped;
     }
-  },
-  notify : function(originalEvent, action, params) {
-    var event = document.fire('xwiki:actions:' + action, Object.extend({
-      originalEvent: originalEvent,
-      form: originalEvent.element().form
-    }, params || {}));
-    // We check both the current event and the original event in order to preserve backwards compatibility with older
-    // code that may stop only the original event. We recommend stopping only the current event becase most of the
-    // listeners shouldn't be aware of the original event.
-    var stopped = event.stopped || originalEvent.stopped;
-    // Stop the original event if the current event has been stopped. Also, in Internet Explorer the original event
-    // can't be stopped from the current event's handlers, so in case some old code has tried to stop the original event
-    // we must call stop() again here.
-    if (stopped) {
-      originalEvent.stop();
-    }
-    return !stopped;
-  }
-});
+  });
 
 // ======================================
 // Save and continue button: Ajax improvements
-actionButtons.AjaxSaveAndContinue = Class.create({
-  initialize : function() {
-    this.createMessages();
-    this.addListeners();
-  },
-  createMessages : function() {
-    this.savingBox = new XWiki.widgets.Notification("$escapetool.javascript($services.localization.render('core.editors.saveandcontinue.notification.inprogress'))", "inprogress", {inactive: true});
-    this.savedBox = new XWiki.widgets.Notification("$escapetool.javascript($services.localization.render('core.editors.saveandcontinue.notification.done'))", "done", {inactive: true});
-    this.failedBox = new XWiki.widgets.Notification('$escapetool.javascript($services.localization.render("core.editors.saveandcontinue.notification.error", ["<span id=""ajaxRequestFailureReason""/>"]))', "error", {inactive: true});
-    this.progressMessageTemplate = "$escapetool.javascript($services.localization.render('core.editors.savewithprogress.notification'))";
-    this.progressBox = new XWiki.widgets.Notification(this.progressMessageTemplate.replace('__PROGRESS__', '0'), "inprogress", {inactive: true});
-  },
-  addListeners : function() {
-    document.observe("xwiki:actions:save", this.onSave.bindAsEventListener(this));
-  },
-  onSave : function(event) {
-    // Don't continue if the event has been stopped already
-    if (event.stopped) {
-      return;
-    }
-
-    var isContinue = event.memo["continue"];
-
-    this.form = $(event.memo.form);
-    this.savedBox.hide();
-    this.failedBox.hide();
-
-    var isCreateFromTemplate = (this.form.template && this.form.template.value);
-
-    // Save & View with no template specified needs no special handling.
-    // Same for Save & Continue with no template specified in preview mode.
-    if (!isCreateFromTemplate && (!isContinue  || $('body').hasClassName('previewbody'))) {
-      return;
-    }
-
-    // This could be a custom form, in which case we need to keep it simple to avoid breaking applications.
-    var isCustomForm = (this.form.action.indexOf("/preview/") == -1);
-
-    // Handle explicitly requested synchronous operations (mainly for backwards compatibility).
-    var isAsync = (this.form.async && this.form.async.value === 'true');
-
-    // Avoid template asynchronous handling of templates for synchronous or custom forms.
-    if (!isAsync || isCustomForm) {
-      if (!isContinue) {
-        // Save & View in sync mode needs no more work.
+  actionButtons.AjaxSaveAndContinue = Class.create({
+    initialize : function() {
+      this.createMessages();
+      this.addListeners();
+    },
+    createMessages : function() {
+      this.savingBox = new XWiki.widgets.Notification("$escapetool.javascript($services.localization.render('core.editors.saveandcontinue.notification.inprogress'))", "inprogress", {inactive: true});
+      this.savedBox = new XWiki.widgets.Notification("$escapetool.javascript($services.localization.render('core.editors.saveandcontinue.notification.done'))", "done", {inactive: true});
+      this.failedBox = new XWiki.widgets.Notification('$escapetool.javascript($services.localization.render("core.editors.saveandcontinue.notification.error", ["<span id=""ajaxRequestFailureReason""/>"]))', "error", {inactive: true});
+      this.progressMessageTemplate = "$escapetool.javascript($services.localization.render('core.editors.savewithprogress.notification'))";
+      this.progressBox = new XWiki.widgets.Notification(this.progressMessageTemplate.replace('__PROGRESS__', '0'), "inprogress", {inactive: true});
+    },
+    addListeners : function() {
+      document.observe("xwiki:actions:save", this.onSave.bindAsEventListener(this));
+    },
+    onSave : function(event) {
+      // Don't continue if the event has been stopped already
+      if (event.stopped) {
         return;
       }
 
-      // A synchronous create from template operation should behave as a regular save operation,
-      // waiting for the Save(AndContinue)Action to finish its work.
-      isCreateFromTemplate = false;
-    }
+      var isContinue = event.memo["continue"];
 
-    // Below we handle the following cases:
-    // - S&C no template / S&C from template sync (handled the same way),
-    // - S&C from template async in edit/preview mode,
-    // - S&V from template async.
+      this.form = $(event.memo.form);
+      this.savedBox.hide();
+      this.failedBox.hide();
 
-    // Stop the submit event.
-    event.stop();
+      var isCreateFromTemplate = (this.form.template && this.form.template.value);
 
-    // Show the right notification message.
-    if (isCreateFromTemplate) {
-      this.progressBox.show();
-    } else if (isContinue) {
-      this.savingBox.show();
-    }
-
-    // Compute the data and submit the form in an AJAX request instead.
-    var submitValue = 'action_save';
-    if (isContinue) {
-      submitValue = 'action_saveandcontinue';
-    }
-    var formData = new Hash(this.form.serialize({hash: true, submit: submitValue}));
-    if (isContinue) {
-      formData.set('minorEdit', '1');
-    }
-    if (!Prototype.Browser.Opera) {
-      // Opera can't handle properly 204 responses.
-      formData.set('ajax', 'true');
-    }
-    new Ajax.Request(this.form.action, {
-      method : 'post',
-      parameters : formData.toQueryString(),
-      onSuccess : this.onSuccess.bindAsEventListener(this, isContinue, isCreateFromTemplate),
-      on1223 : this.on1223.bindAsEventListener(this),
-      on0 : this.on0.bindAsEventListener(this),
-      onFailure : this.onFailure.bind(this)
-    });
-  },
-  // IE converts 204 status code into 1223...
-  on1223 : function(response) {
-    response.request.options.onSuccess(response);
-  },
-  // 0 is returned for network failures, except on IE where a strange large number (12031) is returned.
-  on0 : function(response) {
-    response.request.options.onFailure(response);
-  },
-  onSuccess : function(response, isContinue, isCreateFromTemplate) {
-    // If there was a 'template' field in the form, disable it to avoid 'This document already exists' errors.
-    if (this.form && this.form.template) {
-      this.form.template.disabled = true;
-      this.form.template.value = "";
-    }
-
-    if (isCreateFromTemplate) {
-      if (!isContinue) {
-        // Disable the form while waiting for the save&view operation to finish.
-        this.form.disable();
+      if ($('previousVersion')) {
+        $('previousVersion').setValue(currentVersion);
+      } else {
+        this.form.insert(new Element("input", {
+          type: "hidden",
+          name: "previousVersion",
+          id: "previousVersion",
+          value: currentVersion
+        }));
       }
-      // Start the progress display.
-      this.getStatus(response.responseJSON.links[0].href, isContinue);
-    } else if (isContinue) {
-      this.savingBox.replace(this.savedBox);
-    }
 
-    // Announce that the document has been saved
-    // TODO: We should send the new version as a memo field
-    document.fire("xwiki:document:saved");
-  },
-  onFailure : function(response) {
-    this.savingBox.replace(this.failedBox);
-    this.progressBox.replace(this.failedBox);
-    if (response.statusText == '' /* No response */ || response.status == 12031 /* In IE */) {
-      $('ajaxRequestFailureReason').update('Server not responding');
-    } else if (response.getHeader('Content-Type').match(/^\s*text\/plain/)) {
-      // Regard the body of plain text responses as custom status messages.
-      $('ajaxRequestFailureReason').update(response.responseText);
-    } else {
-      $('ajaxRequestFailureReason').update(response.statusText);
-    }
-    // Announce that a document save attempt has failed
-    document.fire("xwiki:document:saveFailed", {'response' : response});
-  },
-  startStatusReport : function(statusUrl) {
-    updateStatus(0);
-  },
-  getStatus : function(statusUrl, isContinue, redirectUrl) {
-    new Ajax.Request(statusUrl, {
-      method : 'get',
-      parameters : { 'media' : 'json' },
-      onSuccess : function(response) {
-        var progressOffset = response.responseJSON.progress.offset;
-        this.updateStatus(progressOffset);
-        if (progressOffset < 1) {
-          // Start polling for status updates, every second.
-          setTimeout(this.getStatus.bind(this, statusUrl, isContinue), 1000);
-        } else {
-          // Job complete.
-          this.progressBox.replace(this.savedBox);
-          this.maybeRedirect(isContinue);
+      // This could be a custom form, in which case we need to keep it simple to avoid breaking applications.
+      var isCustomForm = (this.form.action.indexOf("/preview/") == -1);
+
+      // Handle explicitly requested synchronous operations (mainly for backwards compatibility).
+      var isAsync = (this.form.async && this.form.async.value === 'true');
+
+      // Avoid template asynchronous handling of templates for synchronous or custom forms.
+      if (!isAsync || isCustomForm) {
+        // A synchronous create from template operation should behave as a regular save operation,
+        // waiting for the Save(AndContinue)Action to finish its work.
+        isCreateFromTemplate = false;
+      }
+
+      // Below we handle the following cases:
+      // - S&C no template / S&C from template sync (handled the same way),
+      // - S&C from template async in edit/preview mode,
+      // - S&V from template async.
+      // - S&V no template sync
+
+      // Stop the submit event.
+      event.stop();
+
+      // Show the right notification message.
+      if (isCreateFromTemplate) {
+        this.progressBox.show();
+      } else if (isContinue) {
+        this.savingBox.show();
+      }
+
+      // Compute the data and submit the form in an AJAX request instead.
+      var submitValue = 'action_save';
+      if (isContinue) {
+        submitValue = 'action_saveandcontinue';
+      }
+      var formData = new Hash(this.form.serialize({hash: true, submit: submitValue}));
+      if (isContinue) {
+        formData.set('minorEdit', '1');
+      }
+      if (!Prototype.Browser.Opera) {
+        // Opera can't handle properly 204 responses.
+        formData.set('ajax', 'true');
+      }
+      new Ajax.Request(this.form.action, {
+        method : 'post',
+        parameters : formData.toQueryString(),
+        onSuccess : this.onSuccess.bindAsEventListener(this, isContinue, isCreateFromTemplate),
+        on1223 : this.on1223.bindAsEventListener(this),
+        on0 : this.on0.bindAsEventListener(this),
+        on409 : this.on409.bindAsEventListener(this),
+        onFailure : this.onFailure.bind(this)
+      });
+    },
+    // IE converts 204 status code into 1223...
+    on1223 : function(response) {
+      response.request.options.onSuccess(response);
+    },
+    // 0 is returned for network failures, except on IE where a strange large number (12031) is returned.
+    on0 : function(response) {
+      response.request.options.onFailure(response);
+    },
+    onSuccess : function(response, isContinue, isCreateFromTemplate) {
+      // If there was a 'template' field in the form, disable it to avoid 'This document already exists' errors.
+      if (this.form && this.form.template) {
+        this.form.template.disabled = true;
+        this.form.template.value = "";
+      }
+
+      // Save & View with no template specified needs no special handling.
+      // Same for Save & Continue with no template specified in preview mode.
+      if (!isCreateFromTemplate && (!isContinue  || $('body').hasClassName('previewbody'))) {
+        window.location.href=XWiki.currentDocument.getURL('view');
+      }
+
+      if (isCreateFromTemplate) {
+        if (!isContinue) {
+          // Disable the form while waiting for the save&view operation to finish.
+          this.form.disable();
         }
-      }.bindAsEventListener(this),
-      on1223 : this.on1223.bindAsEventListener(this),
-      on0 : this.on0.bindAsEventListener(this),
-      onFailure : this.onFailure.bindAsEventListener(this)
-    });
-  }, 
-  updateStatus : function(progressOffset) {
-    var stringProgress = "" + (progressOffset * 100);
-    var dotIndex = stringProgress.indexOf('.');
-    if (dotIndex > -1) {
-      var stringProgress = stringProgress.substring(0, dotIndex + 2);
-    }
-    var newProgressBox = new XWiki.widgets.Notification(this.progressMessageTemplate.replace('__PROGRESS__', stringProgress), "inprogress");
-    this.progressBox.replace(newProgressBox);
-    this.progressBox = newProgressBox;
-  },
-  maybeRedirect : function(isContinue) {
-    var url = "";
-    if (!isContinue) {
-      // Redirect to view mode or to whatever URL was requested.
-      url = XWiki.currentDocument.getURL();
-      var xredirectElement = this.form.select('input[name="xredirect"]')[0];
-      if (xredirectElement && xredirectElement.value) {
-        url = xredirectElement.value;
+        // Start the progress display.
+        this.getStatus(response.responseJSON.links[0].href, isContinue);
+      } else if (isContinue) {
+        this.savingBox.replace(this.savedBox);
       }
-    } else if ($('body').hasClassName('previewbody')) {
-      // In preview mode, the &continue part of the save&continue should lead back to the edit action.
 
-      // Redirect to edit mode or to the previous edit mode, if not overridden.
-      url = XWiki.currentDocument.getURL('edit');
-      if (this.form.xcontinue && this.form.xcontinue.value) {
-        url = this.form.xcontinue.value;
+      currentVersion = response.responseJSON.newVersion;
+
+      // Announce that the document has been saved
+      // TODO: We should send the new version as a memo field
+      document.fire("xwiki:document:saved");
+    },
+    // 409 happens when the document is in conflict: i.e. someone's else edited it at the same time
+    on409 : function(response) {
+      this.progressBox.hide();
+      this.savingBox.hide();
+      this.savedBox.hide();
+      this.failedBox.hide();
+
+      var displayConflictModal = function (oldVersion, latestVersion) {
+        XWiki.widgets.EditModalPopup = Class.create(XWiki.widgets.ModalPopup, {
+          /** Default parameters can be added to the custom class. */
+          defaultInteractionParameters : {},
+          /** Constructor. Registers the key listener that pops up the dialog. */
+          initialize : function($super, interactionParameters) {
+            this.interactionParameters = Object.extend(Object.clone(this.defaultInteractionParameters), interactionParameters || {});
+            // call constructor from ModalPopup with params content, shortcuts, options
+            $super(
+              this.createContent(this.interactionParameters, this),
+              {
+                "show"  : { method : this.showDialog,  keys : [] },
+                //"close" : { method : this.closeDialog, keys : ['Esc'] }
+              },
+              {
+                displayCloseButton : false,
+                verticalPosition : "center",
+                backgroundColor : "#FFF",
+                removeOnClose : true
+              }
+            );
+            this.showDialog();
+          },
+          /** Get the content of the modal dialog using ajax */
+          createContent : function (data, modal) {
+            var content =  new Element('div', {'class': 'modal-popup'});
+            var buttonsDiv =  new Element('div', {'class': 'realtime-buttons'});
+
+            content.insert("$services.localization.render('core.editors.save.conflictversion.rollbackmessage')");
+
+            if (oldVersion && latestVersion) {
+              content.insert(new Element('br'));
+              content.insert(new Element('br'));
+              content.insert("$services.localization.render('core.editors.save.conflictversion.previousVersion') " + oldVersion);
+              content.insert(new Element('br'));
+              content.insert("$services.localization.render('core.editors.save.conflictversion.latestVersion') " + latestVersion);
+              content.insert(new Element('br'));
+              content.insert(new Element('br'));
+
+              var docVariant = XWiki.docvariant;
+              var diffURL = XWiki.currentDocument.getURL('view', "viewer=changes&rev1=__rev1__&rev2=__rev2__&" + docVariant)
+                .replace('__rev1__', oldVersion)
+                .replace('__rev2__', latestVersion);
+              var link = new Element('a', {'href': diffURL, 'target': '_new'});
+              link.insert("$services.localization.render('core.editors.save.conflictversion.diffLink')");
+              content.insert(link);
+            }
+
+            content.insert(buttonsDiv);
+
+            var br = new Element('br');
+            var buttonCreate = new Element('button', {'class': 'btn btn-primary'});
+            buttonCreate.insert("OK");
+            buttonsDiv.insert(br);
+            buttonsDiv.insert(buttonCreate);
+            buttonCreate.on("click", function () {
+              modal.closeDialog();
+            });
+            return content;
+          }
+        });
+        return new XWiki.widgets.EditModalPopup();
+      };
+
+      if (response.responseJSON) {
+        displayConflictModal(response.responseJSON.previousVersion, response.responseJSON.latestVersion);
+      } else {
+        displayConflictModal();
       }
-    } else {
-      // No redirect needed.
-      return;
-    }
+      this.form.disable();
+      // CkEditor tries to block the user from leaving the page with unsaved content.
+      // Our save mechanism doesn't update the flag about unsaved content, so we have
+      // to do it manually
+      if (CKEDITOR) {
+        try {
 
-    // Do the redirect.
-    if (url) {
-      window.location = url;
+          // FIXME: This still allows to switch CKEditor from source mode to WYSIWYG and back
+          // and doing that would disable the readOnly and activate back the warning about leaving page
+          CKEDITOR.instances.content.resetDirty();
+          CKEDITOR.instances.content.setReadOnly();
+        } catch (e) {}
+      }
+
+      // Announce that a document save attempt has failed
+      document.fire("xwiki:document:saveFailed", {'response' : response});
+    },
+    onFailure : function(response) {
+      this.savingBox.replace(this.failedBox);
+      this.progressBox.replace(this.failedBox);
+      if (response.statusText == '' /* No response */ || response.status == 12031 /* In IE */) {
+        $('ajaxRequestFailureReason').update('Server not responding');
+      } else if (response.getHeader('Content-Type').match(/^\s*text\/plain/)) {
+        // Regard the body of plain text responses as custom status messages.
+        $('ajaxRequestFailureReason').update(response.responseText);
+      } else {
+        $('ajaxRequestFailureReason').update(response.statusText);
+      }
+      // Announce that a document save attempt has failed
+      document.fire("xwiki:document:saveFailed", {'response' : response});
+    },
+    startStatusReport : function(statusUrl) {
+      updateStatus(0);
+    },
+    getStatus : function(statusUrl, isContinue, redirectUrl) {
+      new Ajax.Request(statusUrl, {
+        method : 'get',
+        parameters : { 'media' : 'json' },
+        onSuccess : function(response) {
+          var progressOffset = response.responseJSON.progress.offset;
+          this.updateStatus(progressOffset);
+          if (progressOffset < 1) {
+            // Start polling for status updates, every second.
+            setTimeout(this.getStatus.bind(this, statusUrl, isContinue), 1000);
+          } else {
+            // Job complete.
+            this.progressBox.replace(this.savedBox);
+            this.maybeRedirect(isContinue);
+          }
+        }.bindAsEventListener(this),
+        on1223 : this.on1223.bindAsEventListener(this),
+        on0 : this.on0.bindAsEventListener(this),
+        onFailure : this.onFailure.bindAsEventListener(this)
+      });
+    },
+    updateStatus : function(progressOffset) {
+      var stringProgress = "" + (progressOffset * 100);
+      var dotIndex = stringProgress.indexOf('.');
+      if (dotIndex > -1) {
+        var stringProgress = stringProgress.substring(0, dotIndex + 2);
+      }
+      var newProgressBox = new XWiki.widgets.Notification(this.progressMessageTemplate.replace('__PROGRESS__', stringProgress), "inprogress");
+      this.progressBox.replace(newProgressBox);
+      this.progressBox = newProgressBox;
+    },
+    maybeRedirect : function(isContinue) {
+      var url = "";
+      if (!isContinue) {
+        // Redirect to view mode or to whatever URL was requested.
+        url = XWiki.currentDocument.getURL();
+        var xredirectElement = this.form.select('input[name="xredirect"]')[0];
+        if (xredirectElement && xredirectElement.value) {
+          url = xredirectElement.value;
+        }
+      } else if ($('body').hasClassName('previewbody')) {
+        // In preview mode, the &continue part of the save&continue should lead back to the edit action.
+
+        // Redirect to edit mode or to the previous edit mode, if not overridden.
+        url = XWiki.currentDocument.getURL('edit');
+        if (this.form.xcontinue && this.form.xcontinue.value) {
+          url = this.form.xcontinue.value;
+        }
+      } else {
+        // No redirect needed.
+        return;
+      }
+
+      // Do the redirect.
+      if (url) {
+        window.location = url;
+      }
     }
+  });
+
+  function init() {
+    new actionButtons.EditActions();
+    new actionButtons.AjaxSaveAndContinue();
+    return true;
   }
-});
-
-function init() {
-  new actionButtons.EditActions();
-  new actionButtons.AjaxSaveAndContinue();
-  return true;
-}
 
 // When the document is loaded, install action buttons.
-(XWiki.domIsLoaded && init()) || document.observe('xwiki:dom:loaded', init);
+  (XWiki.domIsLoaded && init()) || document.observe('xwiki:dom:loaded', init);
 
 // End XWiki augmentation.
-return XWiki;
+  return XWiki;
 }(XWiki || {}));
 
 // Make sure the action buttons are visible at the bottom of the window.

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/actionbuttons/actionButtons.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/actionbuttons/actionButtons.js
@@ -245,12 +245,15 @@ var XWiki = (function(XWiki) {
 
       // This could be a custom form, in which case we need to keep it simple to avoid breaking applications.
       var isCustomForm = (this.form.action.indexOf("/preview/") == -1);
+      if (isCustomForm) {
+        return;
+      }
 
       // Handle explicitly requested synchronous operations (mainly for backwards compatibility).
       var isAsync = (this.form.async && this.form.async.value === 'true');
 
       // Avoid template asynchronous handling of templates for synchronous or custom forms.
-      if (!isAsync || isCustomForm) {
+      if (!isAsync) {
         // A synchronous create from template operation should behave as a regular save operation,
         // waiting for the Save(AndContinue)Action to finish its work.
         isCreateFromTemplate = false;

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/editors/dataeditors.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/editors/dataeditors.js
@@ -133,6 +133,9 @@ editors.XDataEditors = Class.create({
               },
               onComplete : function() {
                 item.disabled = false;
+                require(['xwiki-meta'], function (xm) {
+                  xm.bumpVersion(false);
+                });
                 document.fire('xwiki:dom:refresh');
               },
               // IE converts 204 status code into 1223...
@@ -208,6 +211,9 @@ editors.XDataEditors = Class.create({
                   }.bind(this),
                   onComplete : function() {
                     item.disabled = false;
+                    require(['xwiki-meta'], function (xm) {
+                      xm.bumpVersion(true);
+                    });
                     document.fire('xwiki:dom:refresh');
                   }
                 },

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/meta.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/meta.js
@@ -47,20 +47,25 @@ define(['jquery'], function($) {
       // Since 10.4RC1
       'userReference':     XWiki.Model.resolve(html.data('xwiki-user-reference'), XWiki.EntityType.DOCUMENT),
       // Since 11.2RC1
+      'isNew': html.data('xwiki-isnew'),
       'bumpVersion': function (isMinor) {
         var version = html.data('xwiki-version');
-        if (isMinor) {
-          version += 0.1;
-        } else {
-          version += 1;
+        if (typeof version === "number") {
+          version = version.toString();
         }
-
+        var parts = version.split('\.');
+        if (isMinor) {
+          parts[1] = parseInt(parts[1]) + 1;
+        } else {
+          parts[0] = parseInt(parts[0]) + 1;
+        }
+        version = parts[0] + "." + parts[1];
         html.data("xwiki-version", version);
-        document.fire('xwiki:document:changeVersion', {'version': version});
+        document.fire('xwiki:document:changeVersion', {'version': version, 'documentReference': documentReference});
       },
       'setVersion': function (version) {
         html.data("xwiki-version", version);
-        document.fire('xwiki:document:changeVersion', {'version': version});
+        document.fire('xwiki:document:changeVersion', {'version': version, 'documentReference': documentReference});
       }
     };
   }

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/meta.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/meta.js
@@ -58,6 +58,7 @@ define(['jquery'], function($) {
           parts[1] = parseInt(parts[1]) + 1;
         } else {
           parts[0] = parseInt(parts[0]) + 1;
+          parts[1] = 1;
         }
         version = parts[0] + "." + parts[1];
         html.data("xwiki-version", version);

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/meta.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/meta.js
@@ -50,17 +50,24 @@ define(['jquery'], function($) {
       'isNew': html.data('xwiki-isnew'),
       'bumpVersion': function (isMinor) {
         var version = html.data('xwiki-version');
-        if (typeof version === "number") {
-          version = version.toString();
-        }
-        var parts = version.split('\.');
-        if (isMinor) {
-          parts[1] = parseInt(parts[1]) + 1;
+        var isNew = html.data('xwiki-isnew');
+
+        if (isNew.toString() === "true") {
+          version = "1.1";
+          html.data('xwiki-isnew', "false");
         } else {
-          parts[0] = parseInt(parts[0]) + 1;
-          parts[1] = 1;
+          if (typeof version === "number") {
+            version = version.toString();
+          }
+          var parts = version.split('\.');
+          if (isMinor) {
+            parts[1] = parseInt(parts[1]) + 1;
+          } else {
+            parts[0] = parseInt(parts[0]) + 1;
+            parts[1] = 1;
+          }
+          version = parts[0] + "." + parts[1];
         }
-        version = parts[0] + "." + parts[1];
         html.data("xwiki-version", version);
         document.fire('xwiki:document:changeVersion', {'version': version, 'documentReference': documentReference});
       },

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/meta.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/meta.js
@@ -30,21 +30,38 @@ define(['jquery'], function($) {
     var documentReference = XWiki.Model.resolve(html.data('xwiki-reference'), XWiki.EntityType.DOCUMENT);
     var wikiReference     = documentReference.extractReference(XWiki.EntityType.WIKI);
     var spaceReference    = documentReference.extractReference(XWiki.EntityType.SPACE);
+
     return {
       'documentReference': documentReference,
-       // deprecated, use 'documentReference' instead
+      // deprecated, use 'documentReference' instead
       'document':          XWiki.Model.serialize(documentReference.relativeTo(wikiReference)),
-       // deprecated, use 'documentReference' instead
+      // deprecated, use 'documentReference' instead
       'wiki':              wikiReference.getName(),
-       // deprecated, use 'documentReference' instead
+      // deprecated, use 'documentReference' instead
       'space':             XWiki.Model.serialize(spaceReference.relativeTo(wikiReference)),
-       // deprecated, use 'documentReference' instead
+      // deprecated, use 'documentReference' instead
       'page':              documentReference.getName(),
       'version':           html.data('xwiki-version'),
       'restURL':           html.data('xwiki-rest-url'),
       'form_token':        html.data('xwiki-form-token'),
       // Since 10.4RC1
-      'userReference':     XWiki.Model.resolve(html.data('xwiki-user-reference'), XWiki.EntityType.DOCUMENT)
+      'userReference':     XWiki.Model.resolve(html.data('xwiki-user-reference'), XWiki.EntityType.DOCUMENT),
+      // Since 11.2RC1
+      'bumpVersion': function (isMinor) {
+        var version = html.data('xwiki-version');
+        if (isMinor) {
+          version += 0.1;
+        } else {
+          version += 1;
+        }
+
+        html.data("xwiki-version", version);
+        document.fire('xwiki:document:changeVersion', {'version': version});
+      },
+      'setVersion': function (version) {
+        html.data("xwiki-version", version);
+        document.fire('xwiki:document:changeVersion', {'version': version});
+      }
     };
   }
   // Case 2: meta information are stored in deprecated <meta> tags


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XWIKI-6665

## Design of the solution

The proposed solution is to record in a field of the editor the last version of the working document and to send it to the server when saving.
The server will compare this version number against the latest version of the document: if the latest version is different than the one sent on the request it means someone certainly save the document in the meantime. We also compare the edition dates: in some edge cases we could have the same revision numbers that are not the same revisions (e.g. a deleted and recreated document).
We then compute a content and an object diff to remove the false positive: the doc could have been saved in the meantime because of an attachment added.
Finally in case of conflict we send a 409 status with a JSON containing both the previous and the latest version number.
In case of success we send a JSON the latest version number, so that we can update it.

## Changes

  * XWikiDocument.java: add some utility method to be able to compute the next version, without updating it. Handle of errors in getContentDiff.
  * XWikiAction.java: add an utility method to send a JSON answer.
  * SaveAction.java: add the new method to compute the conflict and change the answer in case of success.
  * SaveAndContinueAction.java: manage the errors in case of conflict.
  * xwiki-meta.js: Allow to bump and set a new version. Fire an event when it's the case. New attribution: isNew to know if a page is already created or not.
  * dataeditor.js: Bump the version when an object is added or removed, since it saves the document. 
  * actionButton.js: 
    * Get the current document version and listen on the new event to update it when it's needed.
    * Create a new form input with this version, the date of the edition and the edit status to provide it when saving.
    * Handle the 409 status answer by displaying a popup with the conflict message and by disabling the form/editor.
    * Save and view now also send an AJAX request to save, instead of submitting the form like it did.
    * Handle the various modes "Save and view / Save and continue / preview". 

## Screenshot

![warning_conflict](https://user-images.githubusercontent.com/1478232/54133573-9ddd3500-4416-11e9-8de5-ee10fdaf7d72.png)

## Tests

Some selenium tests have been executed to ensure the changes: namely EditWikiTest, InlineEditTest, ObjectEditTest, CompareVersionsTest, LanguageTest.