### PR TITLE
XWIKI-16220: AWM applications located in extensions are not protected against move/rename anymore

### DIFF
--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/LiveTableViewSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/LiveTableViewSheet.xml
@@ -191,6 +191,13 @@
     $services.icon.renderHTML('warning')
     $services.localization.render('appWithinMinutes.renameApp.regenerateAppCodeWarning')
   &lt;/div&gt;
+  #if (!$services.extension.xar.isDeleteAllowed($doc.documentReference))
+  &lt;div class="box warningmessage"&gt;
+    $services.icon.renderHTML('warning')
+    $services.localization.render('job.question.ExtensionBreakingQuestion.refactoring/rename.title')
+    $services.localization.render('job.question.ExtensionBreakingQuestion.refactoring/rename.explanation')
+  &lt;/div&gt;
+  #end
   &lt;div class="hidden"&gt;
     &lt;input type="hidden" name="form_token" value="$!escapetool.xml($services.csrf.token)" /&gt;
     &lt;input type="hidden" name="oldAppReference" value="$escapetool.xml(

--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/LiveTableViewSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/LiveTableViewSheet.xml
@@ -41,7 +41,7 @@
 {{velocity output="false"}}
 #macro (displayApp)
   #set ($discard = $xwiki.ssx.use('AppWithinMinutes.LiveTableViewSheet'))
-  #set ($discard = $xwiki.jsx.use('AppWithinMinutes.LiveTableViewSheet'))
+  #set ($discard = $xwiki.jsx.use('AppWithinMinutes.LiveTableViewSheet', {'currentApp': $doc.getDocumentReference()}))
   #if (!$isReadOnly)
     #displayAppActions
   #end
@@ -411,6 +411,14 @@ return XWiki;
  * Rename Application
  */
 require(['jquery', 'bootstrap'], function($) {
+  #set ($currentDocReference = $xwiki.getDocument($request.currentApp).getDocumentReference())
+  // if we cannot find any extension related to this page app, it's not part of an extension.
+  var isNotAnExtension = $services.extension.xar.getInstalledExtensions($currentDocReference).isEmpty();
+
+  // double negation! if it's an extension, we stop there: we don't want to add custom AWM rename capabilities
+  if (!isNotAnExtension) {
+        return;
+  }
   // Hijack the rename page action.
   var renameAppModal = $('#renameAppModal');
   $('#tmActionRename').click(function(event) {

--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/LiveTableViewSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/LiveTableViewSheet.xml
@@ -191,13 +191,6 @@
     $services.icon.renderHTML('warning')
     $services.localization.render('appWithinMinutes.renameApp.regenerateAppCodeWarning')
   &lt;/div&gt;
-  #if (!$services.extension.xar.isDeleteAllowed($doc.documentReference))
-  &lt;div class="box warningmessage"&gt;
-    $services.icon.renderHTML('warning')
-    $services.localization.render('job.question.ExtensionBreakingQuestion.refactoring/rename.title')
-    $services.localization.render('job.question.ExtensionBreakingQuestion.refactoring/rename.explanation')
-  &lt;/div&gt;
-  #end
   &lt;div class="hidden"&gt;
     &lt;input type="hidden" name="form_token" value="$!escapetool.xml($services.csrf.token)" /&gt;
     &lt;input type="hidden" name="oldAppReference" value="$escapetool.xml(


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XWIKI-16220

## Proposal
  * Check if the AWM page is part of an extension: if it's the case, do not hijack the rename button. 

