### PR TITLE
XWIKI-15916: Use .xform style standard in Panels

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editinline.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editinline.vm
@@ -17,7 +17,7 @@ $xwiki.ssfx.use('uicomponents/widgets/fullScreen.css', true)##
 ## Start FORM at start of content area IF editing is allowed.
 ## ----------------------------------------------------------------------------
 #if ($allowDocEdit)
- <form id="inline" method="post" action="$doc.getURL("preview")" class="withLock xform">
+ <form id="inline" method="post" action="$doc.getURL("preview")" class="withLock">
 #end
 #if ($services.parentchild.isParentChildMechanismEnabled())
   <div class="edit-meta-tools">

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editinline.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editinline.vm
@@ -17,7 +17,7 @@ $xwiki.ssfx.use('uicomponents/widgets/fullScreen.css', true)##
 ## Start FORM at start of content area IF editing is allowed.
 ## ----------------------------------------------------------------------------
 #if ($allowDocEdit)
- <form id="inline" method="post" action="$doc.getURL("preview")" class="withLock">
+ <form id="inline" method="post" action="$doc.getURL("preview")" class="withLock xform">
 #end
 #if ($services.parentchild.isParentChildMechanismEnabled())
   <div class="edit-meta-tools">

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/PanelSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/PanelSheet.xml
@@ -38,11 +38,7 @@
   <hidden>true</hidden>
   <content>{{velocity output="false"}}
 #macro(displayPanelProperty $obj $propName)
-  ; #if ($xcontext.action == 'inline')
-    {{html}}&lt;label for="${class.getName()}_${obj.number}_${propName}"&gt;$services.localization.render("${class.getName()}_${propName}")&lt;/label&gt;{{/html}}
-  #else
-    $services.localization.render("${class.getName()}_${propName}")
-  #end
+  ; &lt;label#if ($xcontext.action == 'edit') for="${class.getName()}_${obj.number}_${propName}"#end&gt;$services.localization.render("${class.getName()}_${propName}")&lt;/label&gt;
   : $doc.display($propName, $obj)
 #end
 
@@ -53,10 +49,9 @@
 #set ($obj = $doc.getObject('Panels.PanelClass'))
 #if ($obj)
   #set($class = $obj.xWikiClass)
-  ## Enclose in .xform class div when editing
-  #if ($xcontext.action == 'edit')
-    {{html clean=false}}&lt;div class='xform'&gt;{{/html}}
-  #end
+  {{html wiki="true"}}
+  (% class="xform" %)
+  (((
     #displayPanelProperty($obj 'name')
     #displayPanelProperty($obj 'type')
     #displayPanelProperty($obj 'category')
@@ -65,9 +60,8 @@
     #displayPanelProperty($obj 'async_enabled')
     #displayPanelProperty($obj 'async_cached')
     #displayPanelProperty($obj 'async_context')
-  #if ($xcontext.action == 'edit')
-    {{html clean=false}}&lt;/div&gt;{{/html}}
-  #end
+  )))
+  {{/html}}
 #end
 {{/velocity}}</content>
 </xwikidoc>

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/PanelSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/PanelSheet.xml
@@ -53,14 +53,21 @@
 #set ($obj = $doc.getObject('Panels.PanelClass'))
 #if ($obj)
   #set($class = $obj.xWikiClass)
-  #displayPanelProperty($obj 'name')
-  #displayPanelProperty($obj 'type')
-  #displayPanelProperty($obj 'category')
-  #displayPanelProperty($obj 'description')
-  #displayPanelProperty($obj 'content')
-  #displayPanelProperty($obj 'async_enabled')
-  #displayPanelProperty($obj 'async_cached')
-  #displayPanelProperty($obj 'async_context')
+  ## Enclose in .xform class div when editing
+  #if ($xcontext.action == 'edit')
+    {{html clean=false}}&lt;div class='xform'&gt;{{/html}}
+  #end
+    #displayPanelProperty($obj 'name')
+    #displayPanelProperty($obj 'type')
+    #displayPanelProperty($obj 'category')
+    #displayPanelProperty($obj 'description')
+    #displayPanelProperty($obj 'content')
+    #displayPanelProperty($obj 'async_enabled')
+    #displayPanelProperty($obj 'async_cached')
+    #displayPanelProperty($obj 'async_context')
+  #if ($xcontext.action == 'edit')
+    {{html clean=false}}&lt;/div&gt;{{/html}}
+  #end
 #end
 {{/velocity}}</content>
 </xwikidoc>


### PR DESCRIPTION
This standardizes the Panels inline editing to follow the xform styling convention.

**Panel Editing Page Before Class Addition**:
![image](https://user-images.githubusercontent.com/36920441/54472526-47437280-47eb-11e9-80d9-b9bdad86bf8c.png)

**Panel Editing Page After Class Addition**:
![image](https://user-images.githubusercontent.com/36920441/54472530-51657100-47eb-11e9-817e-ae8db5a239d9.png)
