### PR TITLE
Fix XWIKI-16236 by enabling & increasing tomcat8 cache; use correct syntax for JarScanner, JarScanFilter.

### DIFF
--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-tomcat/xwiki-platform-distribution-debian-tomcat8-common/src/deb/resources/etc/xwiki/xwiki-tomcat8.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-tomcat/xwiki-platform-distribution-debian-tomcat8-common/src/deb/resources/etc/xwiki/xwiki-tomcat8.xml
@@ -25,9 +25,11 @@
 <!-- Context configuration file for the XWiki Web App -->
 
 <Context path="/xwiki" docBase="/usr/lib/xwiki" privileged="true" crossContext="true">
-  <!-- Make symlinks work in Tomcat -->
-  <Resources allowLinking="true" />
+  <!-- Make symlinks work in Tomcat, and fix problem described in XWIKI-16236
+       causing catalina.out warnings on "evicting expired cache entries", which
+       is solved by increasing the cache size. -->
+  <Resources allowLinking="true" cachingAllowed="true" cacheMaxSize="30720" cacheObjectMaxSize="1536" />
 
   <!-- Disable JAR scanning since Xwiki does not need that -->
-  <JarScanner scanClassPath="false"/>
+  <JarScanner scanClassPath="false"> <JarScanFilter defaultTldScan="false"/> </JarScanner>
 </Context>


### PR DESCRIPTION
As discussed in XWIKI-16236 , I am creating this PR to resolve the issues raised. See also XWIKI-15756 and XWIKI-16235 . See https://jira.xwiki.org/browse/XWIKI-16236 for details.