### PR TITLE
XWIKI-15630: Improve the items order in the Administration's "Look&Feel"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminSheet.xml
@@ -61,8 +61,8 @@
     'displayBeforeCategory': 'content',
     'children': [
        {'id' : 'Themes', 'perSpace' : true, 'order' : 100},
-       {'id' : 'Presentation', 'perSpace' : true, 'order' : 200},
-       {'id' : 'Panels.PanelWizard', 'perSpace' : true, 'order' : 400}
+       {'id' : 'Panels.PanelWizard', 'perSpace' : true, 'order' : 300},
+       {'id' : 'Presentation', 'perSpace' : true, 'order' : 600}
     ]
   },
   {

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminSheet.xml
@@ -61,8 +61,9 @@
     'displayBeforeCategory': 'content',
     'children': [
        {'id' : 'Themes', 'perSpace' : true, 'order' : 100},
-       {'id' : 'Panels.PanelWizard', 'perSpace' : true, 'order' : 200},
-       {'id' : 'Presentation', 'perSpace' : true, 'order' : 300}
+       {'id' : 'Presentation', 'perSpace' : true, 'order' : 200},
+       {'id' : 'menu.name', 'perSpace' : true, 'order' : 300},
+       {'id' : 'Panels.PanelWizard', 'perSpace' : true, 'order' : 400}
     ]
   },
   {

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminSheet.xml
@@ -62,7 +62,6 @@
     'children': [
        {'id' : 'Themes', 'perSpace' : true, 'order' : 100},
        {'id' : 'Presentation', 'perSpace' : true, 'order' : 200},
-       {'id' : 'menu.name', 'perSpace' : true, 'order' : 300},
        {'id' : 'Panels.PanelWizard', 'perSpace' : true, 'order' : 400}
     ]
   },

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminSheet.xml
@@ -61,7 +61,10 @@
     'displayBeforeCategory': 'content',
     'children': [
        {'id' : 'Themes', 'perSpace' : true, 'order' : 100},
+       ## displayInSection: menu.name | sectionOrder: 200 | page: Menu.MenuConfigurationSection
        {'id' : 'Panels.PanelWizard', 'perSpace' : true, 'order' : 300},
+       ## displayInSection: panels.applications | sectionOrder: 400 | page: PanelsCode.ApplicationsPanelConfigurable
+       ## displayInSection: panels.navigation | sectionOrder: 500 | page: PanelsCode.NavigationConfigurationSection
        {'id' : 'Presentation', 'perSpace' : true, 'order' : 600}
     ]
   },

--- a/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuConfigurationSection.xml
+++ b/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuConfigurationSection.xml
@@ -266,7 +266,7 @@
             <propertiesToShow/>
         </property>
         <property>
-            <sectionOrder>300</sectionOrder>
+            <sectionOrder>200</sectionOrder>
         </property>
     </object>
 </xwikidoc>

--- a/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuConfigurationSection.xml
+++ b/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuConfigurationSection.xml
@@ -266,7 +266,7 @@
             <propertiesToShow/>
         </property>
         <property>
-            <sectionOrder>500</sectionOrder>
+            <sectionOrder>300</sectionOrder>
         </property>
     </object>
 </xwikidoc>

--- a/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuTranslations.xml
+++ b/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuTranslations.xml
@@ -61,7 +61,7 @@ menu.livetable.emptyvalue=-
 menu.livetable.content1=Menu Structure
 
 # Administration keys
-admin.menu.name=Menu
+admin.menu.name=Menus
 
 # UIX keys
 menu.uix.extensionPoint.label=Menu Display Location


### PR DESCRIPTION
https://jira.xwiki.org/browse/XWIKI-15630

This improves the order of items in the "Look & Feel" category of Administration.
The P1 proposal for the order is implemented. This orders the items by their usage type.
If something is not right, please let me know. :)