### PR TITLE
XWIKI-16257: adjust cache size & disable unneeded tomcat8 features for debian xwiki-tomcat8-* packages

### DIFF
--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-tomcat/xwiki-platform-distribution-debian-tomcat8-common/src/deb/resources/etc/xwiki/xwiki-tomcat8.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-tomcat/xwiki-platform-distribution-debian-tomcat8-common/src/deb/resources/etc/xwiki/xwiki-tomcat8.xml
@@ -22,14 +22,36 @@
  *
 -->
 
-<!-- Context configuration file for the XWiki Web App -->
+<!--
+  Context configuration file for the XWiki Web App
 
-<Context path="/xwiki" docBase="/usr/lib/xwiki" privileged="true" crossContext="true">
-  <!-- Make symlinks work in Tomcat, and fix problem described in XWIKI-16236
-       causing catalina.out warnings on "evicting expired cache entries", which
-       is solved by increasing the cache size. -->
-  <Resources allowLinking="true" cachingAllowed="true" cacheMaxSize="30720" cacheObjectMaxSize="1536" />
+  This file is used only for Tomcat8 deployment of XWiki via debian packages.
+  It is equivalent to, and needs to be kept up to date with traditional
+  deployment file:
+  xwiki-platform/xwiki-platform-core/xwiki-platform-web/src/main/webapp/META-INF/context.xml
+
+  Prevent JAR scanning and disable WebSocket and JSP support. 
+  This is done to optimize Tomcat startup time, per
+  https://wiki.apache.org/tomcat/HowTo/FasterStartUp &
+  https://tcollignon.github.io/2016/02/09/Accelerate-tomcat-78-start-up.html
+  (see: "Disable scanning the web application", 
+        "Disable scanning web-fragment jar",
+        "Disable both WebSocket and JSP support (only tomcat 8)", 
+        "Excludes jars for scanning")
+-->
+<Context path="/xwiki" docBase="/usr/lib/xwiki"
+         containerSciFilter="org.apache.tomcat.websocket.server.WsSci|org.apache.jasper.servlet.JasperInitializer">
+
+  <!-- Make symlinks work in Tomcat, and fix problem described in
+       XWIKI-16236 & XWIKI-15756 causing catalina.out warnings on "evicting
+       expired cache entries", which is solved by increasing the cache
+       size. 
+  -->
+  <Resources allowLinking="true" cachingAllowed="true"
+             cacheMaxSize="12800" cacheObjectMaxSize="640" />
 
   <!-- Disable JAR scanning since Xwiki does not need that -->
-  <JarScanner scanClassPath="false"> <JarScanFilter defaultTldScan="false"/> </JarScanner>
+  <JarScanner scanClassPath="false">
+    <JarScanFilter defaultTldScan="false"/>
+  </JarScanner>
 </Context>


### PR DESCRIPTION
The changes to this file are detailed in https://jira.xwiki.org/browse/XWIKI-16257

Summary: Update to XWIKI-16236 to adjust cache size & disable unneeded
tomcat8 features. Update documentation, etc to be consistent with
https://github.com/xwiki/xwiki-platform/blob/master/xwiki-platform-core/xwiki-platform-web/src/main/webapp/META-INF/context.xml
per Vincent Massol's comments on PR associated with XWIKI-16236:
https://github.com/xwiki/xwiki-platform/pull/1083