### PR TITLE
XWIKI-15450: Browser cache for attachments is never invalidated (needs browser clear cache)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiServletURLFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiServletURLFactory.java
@@ -613,17 +613,14 @@ public class XWikiServletURLFactory extends XWikiDefaultURLFactory
             }
         }
 
-        if (context != null) {
-            try {
-                XWikiAttachment attachment = findAttachmentForDoc(context.getDoc(), filename, context);
-                if (attachment != null) {
-                    return createAttachmentRevisionURL(filename, spaces, name, attachment.getVersion(),
-                        querystring, xwikidb, context);
-                }
-            } catch (XWikiException e) {
-                if (LOGGER.isErrorEnabled()) {
-                    LOGGER.error("Exception while trying to get latest attachment version !", e);
-                }
+        XWikiAttachment attachment = context.getDoc().getAttachment(filename);
+        if (attachment != null) {
+            return createAttachmentRevisionURL(filename, spaces, name, attachment.getVersion(),
+                querystring, xwikidb, context);
+        } else {
+            if (LOGGER.isErrorEnabled()) {
+                LOGGER.error(String.format("Exception while trying to get attachment [%s] from [%s.%s]!",
+                    filename, spaces, name));
             }
         }
 
@@ -803,18 +800,6 @@ public class XWikiServletURLFactory extends XWikiDefaultURLFactory
     {
         XWikiAttachment attachment = null;
         XWikiDocument rdoc = context.getWiki().getDocument(doc, docRevision, context);
-        if (filename != null) {
-            attachment = rdoc.getAttachment(filename);
-        }
-
-        return attachment;
-    }
-
-    private XWikiAttachment findAttachmentForDoc(XWikiDocument doc, String filename, XWikiContext context)
-        throws XWikiException
-    {
-        XWikiAttachment attachment = null;
-        XWikiDocument rdoc = context.getWiki().getDocument(doc, context);
         if (filename != null) {
             attachment = rdoc.getAttachment(filename);
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiServletURLFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiServletURLFactory.java
@@ -619,10 +619,8 @@ public class XWikiServletURLFactory extends XWikiDefaultURLFactory
                 return createAttachmentRevisionURL(filename, spaces, name, attachment.getVersion(),
                     querystring, xwikidb, context);
             } else {
-                if (LOGGER.isErrorEnabled()) {
-                    LOGGER.error(String.format("Exception while trying to get attachment [%s] from [%s.%s]!",
-                        filename, spaces, name));
-                }
+                LOGGER.error("Exception while trying to get attachment [{}] from space [{}] and page [{}]!", filename,
+                    spaces, name);
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiServletURLFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiServletURLFactory.java
@@ -42,6 +42,7 @@ import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
 import org.xwiki.model.reference.EntityReferenceResolver;
 import org.xwiki.model.reference.EntityReferenceSerializer;
+import org.xwiki.model.reference.WikiReference;
 import org.xwiki.resource.internal.entity.EntityResourceActionLister;
 
 import com.xpn.xwiki.XWiki;
@@ -624,7 +625,7 @@ public class XWikiServletURLFactory extends XWikiDefaultURLFactory
                     spaces, name);
             }
         } else {
-            String originalWikiId = context.getWikiId();
+            WikiReference originalWikiReference = context.getWikiReference();
             context.setWikiId(xwikidb);
 
             DocumentReference documentReference = new DocumentReference(xwikidb, spaces, name);
@@ -639,7 +640,7 @@ public class XWikiServletURLFactory extends XWikiDefaultURLFactory
                 LOGGER.error("Exception while trying to get out of context attachment [{}] from space [{}] and page "
                         + "[{}]!", filename, spaces, name, e);
             } finally {
-                context.setWikiId(originalWikiId);
+                context.setWikiReference(originalWikiReference);
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiServletURLFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiServletURLFactory.java
@@ -613,14 +613,16 @@ public class XWikiServletURLFactory extends XWikiDefaultURLFactory
             }
         }
 
-        XWikiAttachment attachment = context.getDoc().getAttachment(filename);
-        if (attachment != null) {
-            return createAttachmentRevisionURL(filename, spaces, name, attachment.getVersion(),
-                querystring, xwikidb, context);
-        } else {
-            if (LOGGER.isErrorEnabled()) {
-                LOGGER.error(String.format("Exception while trying to get attachment [%s] from [%s.%s]!",
-                    filename, spaces, name));
+        if (isContextDoc(xwikidb, spaces, name, context)) {
+            XWikiAttachment attachment = context.getDoc().getAttachment(filename);
+            if (attachment != null) {
+                return createAttachmentRevisionURL(filename, spaces, name, attachment.getVersion(),
+                    querystring, xwikidb, context);
+            } else {
+                if (LOGGER.isErrorEnabled()) {
+                    LOGGER.error(String.format("Exception while trying to get attachment [%s] from [%s.%s]!",
+                        filename, spaces, name));
+                }
             }
         }
 


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XWIKI-15450

## Proposal

Fallback on `createAttachmentRevisionURL` when creating an attachment URL for download. This is an easy solution which use the already existing mechanism to add the revision number at the end of the URL. It should both prevents the cache mechanism in case of a new version has been updated, and use the cache mechanism when downloading several times the same attachment.

## Tests

I only ran oldcore unit tests for it, but perform manual validation by running an instance and downloading/uploading attachments.

## Discussion

@Enygma2002 suggested that we could also use the browser cache mechanism with the right header, but I find it more complicated, especially since apparently the example shown by @mflorea on it use a ResourceHandler that we currently only have for webjars. AFAIU it would imply to create the appropriate resource handler for attachment to use it here. 