### PR TITLE
XWIKI-14166: Inline edit not saving documents with default language blank and existing translation in the configured default language

### DIFF
--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/PanelSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/PanelSheet.xml
@@ -39,14 +39,14 @@
   <content>{{velocity output="false"}}
 #macro(displayPanelProperty $obj $propName)
   ; &lt;label#if ($xcontext.action == 'edit' || $xcontext.action == 'inline') for="${class.getName()}_${obj.number}_${propName}"#end&gt;$services.localization.render("${class.getName()}_${propName}")&lt;/label&gt;
-  : $tdoc.display($propName, $obj)
+  : $doc.display($propName, $obj)
 #end
 
-#set ($paneldoc = $tdoc)
+#set ($paneldoc = $doc)
 {{/velocity}}
 
 {{velocity}}
-#set ($obj = $tdoc.getObject('Panels.PanelClass'))
+#set ($obj = $doc.getObject('Panels.PanelClass'))
 #if ($obj)
   #set($class = $obj.xWikiClass)
   {{html wiki="true"}}

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/PanelSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/PanelSheet.xml
@@ -39,14 +39,14 @@
   <content>{{velocity output="false"}}
 #macro(displayPanelProperty $obj $propName)
   ; &lt;label#if ($xcontext.action == 'edit' || $xcontext.action == 'inline') for="${class.getName()}_${obj.number}_${propName}"#end&gt;$services.localization.render("${class.getName()}_${propName}")&lt;/label&gt;
-  : $doc.display($propName, $obj)
+  : $tdoc.display($propName, $obj)
 #end
 
-#set ($paneldoc = $doc)
+#set ($paneldoc = $tdoc)
 {{/velocity}}
 
 {{velocity}}
-#set ($obj = $doc.getObject('Panels.PanelClass'))
+#set ($obj = $tdoc.getObject('Panels.PanelClass'))
 #if ($obj)
   #set($class = $obj.xWikiClass)
   {{html wiki="true"}}

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/src/test/it/org/xwiki/test/ui/LanguageTest.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/src/test/it/org/xwiki/test/ui/LanguageTest.java
@@ -36,6 +36,9 @@ import org.xwiki.administration.test.po.LocalizationAdministrationSectionPage;
 import org.xwiki.model.reference.LocalDocumentReference;
 import org.xwiki.rest.model.jaxb.Page;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
+import org.xwiki.test.ui.po.CopyOrRenameOrDeleteStatusPage;
+import org.xwiki.test.ui.po.CopyPage;
+import org.xwiki.test.ui.po.InlinePage;
 import org.xwiki.test.ui.po.ViewPage;
 import org.xwiki.test.ui.po.editor.WikiEditPage;
 
@@ -257,6 +260,31 @@ public class LanguageTest extends AbstractTest
 
         assertEquals(Arrays.asList(), editPage.getNotExistingLocales());
         assertEquals(Arrays.asList(Locale.ENGLISH, Locale.FRENCH), editPage.getExistingLocales());
+    }
+
+    @Test
+    public void testTranslateNavigationPanel() throws Exception
+    {
+        ViewPage viewPage = getUtil().gotoPage("Panels", "Navigation");
+        CopyPage copyPage = viewPage.copy();
+        copyPage.setTargetSpaceName(getTestClassName());
+        copyPage.setTargetPageName(getTestMethodName());
+        CopyOrRenameOrDeleteStatusPage copyStatus = copyPage.clickCopyButton().waitUntilFinished();
+
+        assertEquals("Done.", copyStatus.getInfoMessage());
+        setLanguageSettings(true, "en", Arrays.asList("en", "fr"));
+        viewPage = getUtil().gotoPage(getTestClassName(), getTestMethodName());
+        InlinePage inlinePage = viewPage.editInline();
+        inlinePage.setValue("content", "test");
+        inlinePage.clickSaveAndView();
+        getUtil().gotoPage(getTestClassName(), getTestMethodName(), "inline", "language=en");
+        inlinePage = new InlinePage();
+        inlinePage.waitUntilPageJSIsLoaded();
+        assertEquals("test", inlinePage.getValue("content"));
+        inlinePage.setValue("content", "another value");
+        inlinePage.clickSaveAndView();
+        getUtil().gotoPage(getTestClassName(), getTestMethodName(), "inline", "language=en");
+        assertEquals("another value", inlinePage.getValue("content"));
     }
 
     /**


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XWIKI-14166

## Changes
  * Add a new test to show the problem
  * Edit PanelSheet to use tdoc instead of doc: the object are shared
but only the  translation is invalidated in the cache when the
translation is edited, so we need to retrieve their values from the
translation to avoid display inconsistencies.

## Discussion

The root problem of XWIKI-14166 is that objects are shared among documents and their translations, and our cache mechanism does not handle the changes on the objects properly. 
IMO we should invalidate the document and all their translations if the original document or one of its translations has a change on one of its objects. Else we could have inconsistencies such as the one described in XWIKI-14166.

So right now my fix only handle changes made on panels, but any other object can have the same issue if its sheet used doc instead of tdoc. One thing I could do at least might be to also change ObjectSheet to show that we use tdoc in it. 

Now as I said maybe the right fix to do is to handle it in the cache itself. WDYT? 