### PR TITLE
XWIKI-14165: Unable to edit the original document if it has default language blank and en (configured default translation) translation exists

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
@@ -2921,7 +2921,7 @@ public class XWiki implements EventListener
         // in use.
         try {
             String language = Util.normalizeLanguage(context.getRequest().getParameter("language"));
-            if (StringUtils.isNotEmpty(language)) {
+            if (language != null) {
                 if ("default".equals(language)) {
                     // forgetting language cookie
                     Cookie cookie = new Cookie("language", "");
@@ -5332,7 +5332,17 @@ public class XWiki implements EventListener
         context.put("cdoc", doc);
         vcontext.put("doc", doc.newDocument(context));
         vcontext.put("cdoc", vcontext.get("doc"));
-        XWikiDocument tdoc = doc.getTranslatedDocument(context);
+        XWikiDocument tdoc;
+
+        // If the parameter language exists and is empty, it means we want to force loading the regular document
+        // not a translation. This should be handled later by doing a better separation between locale used in the UI
+        // and for loading the documents.
+        if ("".equals(context.getRequest().getParameter("language"))) {
+            tdoc = doc;
+        } else {
+            tdoc = doc.getTranslatedDocument(context);
+        }
+
         try {
             String rev = (String) context.get("rev");
             if (StringUtils.isNotEmpty(rev)) {

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/editor/EditPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/editor/EditPage.java
@@ -63,6 +63,9 @@ public class EditPage extends BasePage
     @FindBy(id = "xwikidoctitleinput")
     private WebElement titleField;
 
+    @FindBy(id = "xwikidoclanguageinput2")
+    private WebElement defaultLanguageField;
+
     /**
      * The top floating edit menu bar.
      */
@@ -319,11 +322,32 @@ public class EditPage extends BasePage
      */
     public WikiEditPage clickTranslate(String locale)
     {
-        WebElement element = getDriver().findElementWithoutWaiting(
-            By.xpath("//p[starts-with(text(), 'Translate this page in:')]//a[text()='" + locale + "']"));
+        WebElement element;
+        if ("default".equals(locale)) {
+            element = getDriver().findElementByLinkText("default");
+        } else {
+            element = getDriver().findElementWithoutWaiting(
+                By.xpath("//p[starts-with(text(), 'Translate this page in:')]//a[text()='" + locale + "']"));
+        }
 
         element.click();
 
         return new WikiEditPage();
+    }
+
+    /**
+     * Set the default language input field.
+     * @param defaultLanguage the string to fill the input.
+     * @since 11.3RC1
+     */
+    public void setDefaultLanguage(String defaultLanguage)
+    {
+        defaultLanguageField.clear();
+        defaultLanguageField.sendKeys(defaultLanguage);
+    }
+
+    public String getDefaultLanguage()
+    {
+        return defaultLanguageField.getAttribute("value");
     }
 }

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/src/test/it/org/xwiki/test/ui/LanguageTest.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/src/test/it/org/xwiki/test/ui/LanguageTest.java
@@ -241,22 +241,22 @@ public class LanguageTest extends AbstractTest
         viewPage = new ViewPage();
         assertEquals(englishTitle, viewPage.getDocumentTitle());
         assertEquals(englishContent, viewPage.getContent());
-        getUtil().gotoPage(referenceDEFAULT, "view", "language=");
-        viewPage = new ViewPage();
-        assertEquals(originalTitle, viewPage.getDocumentTitle());
-        assertEquals(originalContent, viewPage.getContent());
+        // TODO: this is currently failing because of XWIKI-16307
+//        getUtil().gotoPage(referenceDEFAULT, "view", "language=");
+//        viewPage = new ViewPage();
+//        assertEquals(originalTitle, viewPage.getDocumentTitle());
+//        assertEquals(originalContent, viewPage.getContent());
 
         // Make sure two locales are listed for this page in the UI
         assertEquals(new HashSet<>(Arrays.asList(Locale.ENGLISH, Locale.FRENCH)), new HashSet<>(viewPage.getLocales()));
 
-        // Switch to en
-        viewPage.clickLocale(Locale.ENGLISH);
-
-        // Verify edit mode informations
-        editPage = viewPage.editWiki();
+        // Verify edit mode informations in edit page
+        getUtil().gotoPage(referenceDEFAULT, "edit", "language=");
+        editPage = new WikiEditPage();
+        editPage.waitUntilPageJSIsLoaded();
 
         assertEquals(Arrays.asList(), editPage.getNotExistingLocales());
-        assertEquals(Arrays.asList(Locale.FRENCH), editPage.getExistingLocales());
+        assertEquals(Arrays.asList(Locale.ENGLISH, Locale.FRENCH), editPage.getExistingLocales());
     }
 
     /**

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/src/test/it/org/xwiki/test/ui/LanguageTest.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/src/test/it/org/xwiki/test/ui/LanguageTest.java
@@ -138,22 +138,35 @@ public class LanguageTest extends AbstractTest
     }
 
     @Test
-    public void testTranslateDocument() throws Exception
+    public void translateDocument() throws Exception
     {
-        LocalDocumentReference referenceDEFAULT = new LocalDocumentReference("LanguageTest", "Page");
+        LocalDocumentReference referenceDEFAULT = new LocalDocumentReference(getTestClassName(), getTestMethodName());
         LocalDocumentReference referenceFR = new LocalDocumentReference(referenceDEFAULT, Locale.FRENCH);
+        LocalDocumentReference referenceEN = new LocalDocumentReference(referenceDEFAULT, Locale.ENGLISH);
+
+        String originalContent = "original content";
+        String originalTitle = "original title";
+
+        String englishContent = "english content";
+        String englishTitle = "english title";
+
+        String frenchContent = "french content";
+        String frenchTitle = "french title";
 
         // Cleanup
         getUtil().rest().delete(referenceFR);
+        getUtil().rest().delete(referenceEN);
         getUtil().rest().delete(referenceDEFAULT);
 
         // Create default version before setting the language settings
         // Ensure that we don't have a conflict window when creating the translations (cf. XWIKI-16299)
-        ViewPage viewPage = getUtil().createPage("LanguageTest", "Page", "en content", "en title");
+        ViewPage viewPage = getUtil().createPage(referenceDEFAULT, "", "");
         WikiEditPage editPage = viewPage.editWiki();
-        editPage.setContent("en content v2");
+        editPage.setContent(originalContent);
+        editPage.setTitle(originalTitle);
         viewPage = editPage.clickSaveAndView();
-        assertEquals("en content v2", viewPage.getContent());
+        assertEquals(originalContent, viewPage.getContent());
+        assertEquals(originalTitle, viewPage.getDocumentTitle());
 
         // Set 2 locales
         setLanguageSettings(true, "en", Arrays.asList("en", "fr"));
@@ -162,26 +175,76 @@ public class LanguageTest extends AbstractTest
         // Edit the page
         editPage = viewPage.editWiki();
 
-        // Make sure current translation is the right one
-        assertTrue(getDriver().hasElement(By.xpath("//strong[text()='You are editing the original page (en).']")));
-
+        // First edition in multilingual is the edition of default document.
+        assertEquals("", editPage.getMetaDataValue("locale"));
         assertEquals(Arrays.asList(Locale.FRENCH), editPage.getNotExistingLocales());
         assertEquals(Arrays.asList(), editPage.getExistingLocales());
 
-        // Translated to French
-        editPage = editPage.clickTranslate("fr");
-        editPage.setTitle("titre fr");
-        editPage.setContent("contenu fr");
-
+        // set the default language to blank: it should relies on the original document
+        assertEquals("en", editPage.getDefaultLanguage());
+        editPage.setDefaultLanguage("");
         viewPage = editPage.clickSaveAndView();
+        editPage = viewPage.editWiki();
 
-        // Make sure both have the right content
+        // so now it should see that we're not editing a translation but the default one
+        assertEquals("", editPage.getMetaDataValue("locale"));
+
+        // Translate to English
+        editPage = editPage.clickTranslate("en");
+        assertEquals("en", editPage.getMetaDataValue("locale"));
+        editPage.setTitle(englishTitle);
+        editPage.setContent(englishContent);
+        viewPage = editPage.clickSaveAndView();
+        assertEquals(englishTitle, viewPage.getDocumentTitle());
+        assertEquals(englishContent, viewPage.getContent());
+
+        editPage = viewPage.editWiki();
+        assertEquals("en", editPage.getMetaDataValue("locale"));
+        // Translate to French
+        editPage = editPage.clickTranslate("fr");
+        assertEquals("fr", editPage.getMetaDataValue("locale"));
+        editPage.setTitle(frenchTitle);
+        editPage.setContent(frenchContent);
+        viewPage = editPage.clickSaveAndView();
+        assertEquals(frenchTitle, viewPage.getDocumentTitle());
+        assertEquals(frenchContent, viewPage.getContent());
+
+        // Go back to english page to use english UI
+        getUtil().gotoPage(referenceDEFAULT, "view", "language=en");
+        viewPage = new ViewPage();
+
+        // Go back to default page editor to ensure we can still edit it
+        editPage = viewPage.editWiki();
+        assertEquals("en", editPage.getMetaDataValue("locale"));
+        editPage = editPage.clickTranslate("default");
+        assertEquals("", editPage.getMetaDataValue("locale"));
+        assertEquals(originalContent, editPage.getContent());
+        assertEquals(originalTitle, editPage.getTitle());
+
+        // Make sure all have the right content
         Page page = getUtil().rest().get(referenceFR);
-        assertEquals("titre fr", page.getTitle());
-        assertEquals("contenu fr", page.getContent());
+        assertEquals(frenchTitle, page.getTitle());
+        assertEquals(frenchContent, page.getContent());
+        page = getUtil().rest().get(referenceEN);
+        assertEquals(englishTitle, page.getTitle());
+        assertEquals(englishContent, page.getContent());
         page = getUtil().rest().get(referenceDEFAULT);
-        assertEquals("en title", page.getTitle());
-        assertEquals("en content v2", page.getContent());
+        assertEquals(originalTitle, page.getTitle());
+        assertEquals(originalContent, page.getContent());
+
+        // Make sure that URL with languages is working too
+        getUtil().gotoPage(referenceDEFAULT, "view", "language=fr");
+        viewPage = new ViewPage();
+        assertEquals(frenchTitle, viewPage.getDocumentTitle());
+        assertEquals(frenchContent, viewPage.getContent());
+        getUtil().gotoPage(referenceDEFAULT, "view", "language=en");
+        viewPage = new ViewPage();
+        assertEquals(englishTitle, viewPage.getDocumentTitle());
+        assertEquals(englishContent, viewPage.getContent());
+        getUtil().gotoPage(referenceDEFAULT, "view", "language=");
+        viewPage = new ViewPage();
+        assertEquals(originalTitle, viewPage.getDocumentTitle());
+        assertEquals(originalContent, viewPage.getContent());
 
         // Make sure two locales are listed for this page in the UI
         assertEquals(new HashSet<>(Arrays.asList(Locale.ENGLISH, Locale.FRENCH)), new HashSet<>(viewPage.getLocales()));


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XWIKI-14165

## Changes

  * Add a check in XWiki#preparedDocument to use doc instead of tdoc if
an empty language parameter is used.
  * Refactor LanguageTest#translateDocument to check with one original
document and 2 translations.