### PR TITLE
XWIKI-16295: All page is selected when selecting an Icon for a AWM

### DIFF
--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-ui/src/main/resources/IconThemesCode/IconPicker.xml
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-ui/src/main/resources/IconThemesCode/IconPicker.xml
@@ -384,7 +384,7 @@ require(['jquery', 'xwiki-icon-picker'], function($) {
     xwikiCurrentIconsPicker = $(document.createElement('div'));
     xwikiCurrentIconsPicker.addClass('xwikiIconPickerContainer');
     // Insert the picker in the DOM
-    $(body).after(xwikiCurrentIconsPicker);
+    $(body).append(xwikiCurrentIconsPicker);
     // Set the position
     setPickerPosition();
     // Add the icon list section


### PR DESCRIPTION
https://jira.xwiki.org/projects/XWIKI/issues/XWIKI-16295

Hi,
This issue does exist in edge. I have confirmed it.

After analyzing, what I noticed was that the `.xwikiIconPickerContainer div` was outside the `body` tag and directly inside the `html` tag. I do not know if this was intended but it was causing Microsoft Edge to behave inaccurately.
So, what I essentially did was put the `.xwikiIconPickerContainer div` inside the `body` tag rather than outside which fixed the issue.

**HTML Before:**
![before1](https://user-images.githubusercontent.com/36920441/55488119-da343780-5648-11e9-9bb8-3e3c537c5ecf.PNG)

**HTML After:**
![after](https://user-images.githubusercontent.com/36920441/55488134-e1f3dc00-5648-11e9-8ef9-8c35a18f64af.PNG)
