### PR TITLE
XWIKI-13011: "link":"editor" is not working in Livetable

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/main/resources/XWiki/LiveTableResults.xml
+++ b/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/main/resources/XWiki/LiveTableResults.xml
@@ -38,25 +38,23 @@
   <hidden>true</hidden>
   <content>{{include reference="XWiki.LiveTableResultsMacros" /}}
 
-{{velocity wiki="false"}}
-## the $extra variable is passed to the call to #gridresultwithfilter below and is used to perform some default
-## filtering on the LiveTable data even when the user has not performed any column filtering yet.
-## When users start using column filtering, the generated DB query will combine both the default filtering and what the
-## user has entered in the column filters.
+{{velocity}}
+## Used in editProperty for getting the field when "link": "editor" property is used.
 #if($request.value)
   #set($itemdoc = $xwiki.getDocument($request.page))
   #set($discard = $itemdoc.use($request.classname))
   #set($discard = $itemdoc.set($request.fieldname, $request.value))
-  #set($ok = $itemdoc.save("Field ${request.fieldname} updated"))
-  #if($ok)
-    SAVED
-  #end
+  #set($discard = $itemdoc.save("Field ${request.fieldname} updated"))
 #elseif($request.fieldname)
   #set($itemdoc = $xwiki.getDocument($request.page))
   #set($discard = $itemdoc.use($request.classname))
   #set($obj = $itemdoc.getObject($request.classname))
   $!itemdoc.display($request.fieldname, "edit", $obj)
 #else
+## the $extra variable is passed to the call to #gridresultwithfilter below and is used to perform some default
+## filtering on the LiveTable data even when the user has not performed any column filtering yet.
+## When users start using column filtering, the generated DB query will combine both the default filtering and what the
+## user has entered in the column filters.
   #set ($extra = '')
   #set ($params = [])
   #if ("$!request.space" != '')

--- a/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/main/resources/XWiki/LiveTableResults.xml
+++ b/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/main/resources/XWiki/LiveTableResults.xml
@@ -43,24 +43,39 @@
 ## filtering on the LiveTable data even when the user has not performed any column filtering yet.
 ## When users start using column filtering, the generated DB query will combine both the default filtering and what the
 ## user has entered in the column filters.
-#set ($extra = '')
-#set ($params = [])
-#if ("$!request.space" != '')
-  #set ($extra = "${extra} AND doc.space = ?")
-  #set ($discard = $params.add($request.space))
+#if($request.value)
+  #set($itemdoc = $xwiki.getDocument($request.page))
+  #set($discard = $itemdoc.use($request.classname))
+  #set($discard = $itemdoc.set($request.fieldname, $request.value))
+  #set($ok = $itemdoc.save("Field ${request.fieldname} updated"))
+  #if($ok)
+    SAVED
+  #end
+#elseif($request.fieldname)
+  #set($itemdoc = $xwiki.getDocument($request.page))
+  #set($discard = $itemdoc.use($request.classname))
+  #set($obj = $itemdoc.getObject($request.classname))
+  $!itemdoc.display($request.fieldname, "edit", $obj)
+#else
+  #set ($extra = '')
+  #set ($params = [])
+  #if ("$!request.space" != '')
+    #set ($extra = "${extra} AND doc.space = ?")
+    #set ($discard = $params.add($request.space))
+  #end
+  #addLivetableLocationFilter($extra, $params, $!request.location)
+  #if ("$!request.parent" != '')
+    #set ($extra = "${extra} and doc.parent = ?")
+    #set ($discard = $params.add($request.parent))
+  #end
+  #if ("$!request.orphaned" == '1')
+    #set ($homepage = $services.wiki.getById($services.wiki.currentWikiId).mainPageReference)
+    #set ($homepageFullName = $services.model.serialize($homepage, 'local'))
+    ## On Oracle the empty parent is actually null.
+    #set ($extra = "${extra} and (doc.parent = '' or doc.parent is null) and doc.fullName &lt;&gt; ?")
+    #set ($discard = $params.add($homepageFullName))
+  #end
+  #gridresultwithfilter("$!request.classname" $request.collist.split(',') '' "${extra}" $params)
 #end
-#addLivetableLocationFilter($extra, $params, $!request.location)
-#if ("$!request.parent" != '')
-  #set ($extra = "${extra} and doc.parent = ?")
-  #set ($discard = $params.add($request.parent))
-#end
-#if ("$!request.orphaned" == '1')
-  #set ($homepage = $services.wiki.getById($services.wiki.currentWikiId).mainPageReference)
-  #set ($homepageFullName = $services.model.serialize($homepage, 'local'))
-  ## On Oracle the empty parent is actually null.
-  #set ($extra = "${extra} and (doc.parent = '' or doc.parent is null) and doc.fullName &lt;&gt; ?")
-  #set ($discard = $params.add($homepageFullName))
-#end
-#gridresultwithfilter("$!request.classname" $request.collist.split(',') '' "${extra}" $params)
 {{/velocity}}</content>
 </xwikidoc>

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -2952,6 +2952,8 @@ platform.livetable.paginationResultsSingle=Result <span class="currentResultsNo"
 platform.livetable.paginationResultsMany=Results <span class="currentResultsNo">{0} - {1}</span> of <span class="totalResultsNo">{2}</span>
 platform.livetable.paginationResults=Results
 platform.livetable.paginationResultsOf=out of
+platform.livetable.propEditor.failed=Property saving failed
+platform.livetable.propEditor.modalTitle=You can modify the field and save:
 
 ####################
 # Daterange picker

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/table/livetable.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/table/livetable.js
@@ -1242,8 +1242,8 @@ return XWiki;
 
 
 // Used for "link": "editor" property.
-// TODO: move the entire definition of the class in jquery when #livetablecallback
-// from macros.vm will also be moved.
+// TODO: move the entire definition of the function in jquery when #livetablecallback
+// from macros.vm, where it is called, will also be moved.
 var editProperty = function(fullname, classname, fieldname, cb) {
   require(['jquery'], function($) {
     let doc = new XWiki.Document('LiveTableResults', 'XWiki');

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/table/livetable.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/table/livetable.js
@@ -1264,12 +1264,11 @@ var editProperty = function(fullname, classname, fieldname, cb) {
             + fieldname + '&value=' + value);
           $.ajax({
             url : surl,
-            complete : function(e) {
-              if(e.responseText.search('SAVED') != -1) {
-                cb(value);
-              } else {
-                alert("$services.localization.render('platform.livetable.propEditor.failed')");
-              }
+            success : function() {
+              cb(value);
+            },
+            error : function() {
+              alert("$services.localization.render('platform.livetable.propEditor.failed')");
             }
           });
         });

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/macros.vm
@@ -2760,3 +2760,31 @@ Recursive title display detected!##
     </optgroup>
   #end
 #end
+
+#**
+ * Used in livetable for "link": "editor" property. Displays a Bootstrap modal that will contain the requested field
+ * in edit mode.
+ *#
+#macro(editorModal)
+  <div class='modal fade' tabindex='-1' role='dialog' aria-hidden='true' id='propEditor'>
+    <div class='modal-dialog modal-sm modal-dialog-centered'>
+      <div class='modal-content'>
+        <div class='modal-header'>
+          <h3 class="modal-title">$services.localization.render('platform.livetable.propEditor.modalTitle')</h3>
+          <button type='button' class='close' data-dismiss='modal' aria-label='Close'>
+            <span aria-hidden='true'>&times;</span>
+          </button>
+        </div>
+        <div class='modal-body'>
+          <form id='propEditorForm' method='get'></form>
+        </div>
+        <div class='modal-footer'>
+          <input type='button' class='btn btn-primary' data-dismiss='modal' id='propEditorSave'
+            value="$escapetool.xml($services.localization.render('save'))"/>
+          <input type='button' class='btn btn-secondary' data-dismiss='modal'
+            value="$escapetool.xml($services.localization.render('cancel'))"/>
+        </div>
+      </div>
+    </div>
+  </div>
+#end

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/macros.vm
@@ -2770,10 +2770,10 @@ Recursive title display detected!##
     <div class='modal-dialog modal-sm modal-dialog-centered'>
       <div class='modal-content'>
         <div class='modal-header'>
-          <h3 class="modal-title">$services.localization.render('platform.livetable.propEditor.modalTitle')</h3>
           <button type='button' class='close' data-dismiss='modal' aria-label='Close'>
             <span aria-hidden='true'>&times;</span>
           </button>
+          <h4 class='modal-title'>$services.localization.render('platform.livetable.propEditor.modalTitle')</h4>
         </div>
         <div class='modal-body'>
           <form id='propEditorForm' method='get'></form>


### PR DESCRIPTION
**Issue**
https://jira.xwiki.org/browse/XWIKI-13011

**Proposal**
Display requested field in a modal and update the new value using the existing LiveTableResults.

This is how it looks like:
![propEditor](https://user-images.githubusercontent.com/22794181/55729604-1a1b6600-5a1f-11e9-9a5c-20b051ee43c5.png)

