### PR TITLE
XWIKI-16314: Force users to respect the DB limit when creating a page

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/ui/EditIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/ui/EditIT.java
@@ -415,7 +415,7 @@ public class EditIT
     {
         String name1 = "Company Presentation Events";
         String name2 = "Presentation from 10 december 2015 at the Fourth edition of the International Conference for "
-            + "the Environmental Responsibility (ICER 2015).";
+            + "the Environmental Responsibility (ICER 2015)";
         String name3 = "Intervention from the President of the Interdisciplinary Commission for Responsible Development"
             + " of Alternative Fuels (ICRDA)";
 

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/ui/EditIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/ui/EditIT.java
@@ -29,9 +29,11 @@ import org.openqa.selenium.Keys;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.xwiki.flamingo.skin.test.po.EditConflictModal;
 import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.SpaceReference;
 import org.xwiki.test.docker.junit5.TestReference;
 import org.xwiki.test.docker.junit5.UITest;
 import org.xwiki.test.ui.TestUtils;
+import org.xwiki.test.ui.po.CreatePagePage;
 import org.xwiki.test.ui.po.ViewPage;
 import org.xwiki.test.ui.po.editor.WikiEditPage;
 
@@ -402,5 +404,31 @@ public class EditIT
         // close second tab and switch back to first for other tests.
         setup.getDriver().close();
         setup.getDriver().switchTo().window(firstTab);
+    }
+
+    /**
+     * Ensure that document can be created with very long titles with more than 255 characters.
+     */
+    @Test
+    @Order(9)
+    public void createDocumentLongTitle(TestUtils setup, TestReference reference)
+    {
+        String name1 = "Company Presentation Events";
+        String name2 = "Presentation from 10 december 2015 at the Fourth edition of the International Conference for "
+            + "the Environmental Responsibility (ICER 2015).";
+        String name3 = "Intervention from the President of the Interdisciplinary Commission for Responsible Development"
+            + " of Alternative Fuels (ICRDA)";
+
+        SpaceReference spaceReference = new SpaceReference(reference.getWikiReference().getName(),
+            Arrays.asList(name1, name2));
+        DocumentReference documentReference = new DocumentReference(name3, spaceReference);
+        setup.gotoPage(documentReference, "create");
+        CreatePagePage createPagePage = new CreatePagePage();
+        String currentUrl = setup.getDriver().getCurrentUrl();
+        createPagePage.clickCreate();
+
+        // Ensure that we get an error message for path too long and that we remain on the same URL.
+        createPagePage.waitForErrorMessage();
+        assertEquals(currentUrl, setup.getDriver().getCurrentUrl());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
@@ -1813,6 +1813,20 @@ public class XWiki implements EventListener
             // Switch to document wiki
             context.setWikiId(document.getDocumentReference().getWikiReference().getName());
 
+            // Set the store so we can use it for checking the max length.
+            if (document.getStore() == null) {
+                document.setStore(this.getStore());
+            }
+            String fullName = getLocalStringEntityReferenceSerializer().serialize(document.getDocumentReference());
+            // If it's a new doc we check its name length to avoid a nasty SQL error.
+            if (document.isNew() && fullName.length() > document.getNameMaxLength()) {
+                java.lang.Object[] args = { fullName, document.getNameMaxLength(), fullName.length() };
+                throw new XWikiException(XWikiException.MODULE_XWIKI_STORE,
+                    XWikiException.ERROR_XWIKI_APP_DOCUMENT_PATH_TOO_LONG,
+                    "Cannot create document {0} because its full path is too long: only {1} characters are allowed and "
+                        + "current length is {2}.", null, args);
+            }
+
             // Setting comment & minor edit before saving
             document.setComment(StringUtils.defaultString(comment));
             document.setMinorEdit(isMinorEdit);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
@@ -1819,8 +1819,8 @@ public class XWiki implements EventListener
             }
             String fullName = getLocalStringEntityReferenceSerializer().serialize(document.getDocumentReference());
             // If it's a new doc we check its name length to avoid a nasty SQL error.
-            if (document.isNew() && fullName.length() > document.getFullNameMaxLength()) {
-                java.lang.Object[] args = { fullName, document.getFullNameMaxLength(), fullName.length() };
+            if (document.isNew() && fullName.length() > document.getLocalReferenceMaxLength()) {
+                java.lang.Object[] args = { fullName, document.getLocalReferenceMaxLength(), fullName.length() };
                 throw new XWikiException(XWikiException.MODULE_XWIKI_STORE,
                     XWikiException.ERROR_XWIKI_APP_DOCUMENT_PATH_TOO_LONG,
                     "Cannot create document {0} because its full path is too long: only {1} characters are allowed and "

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
@@ -1819,8 +1819,8 @@ public class XWiki implements EventListener
             }
             String fullName = getLocalStringEntityReferenceSerializer().serialize(document.getDocumentReference());
             // If it's a new doc we check its name length to avoid a nasty SQL error.
-            if (document.isNew() && fullName.length() > document.getNameMaxLength()) {
-                java.lang.Object[] args = { fullName, document.getNameMaxLength(), fullName.length() };
+            if (document.isNew() && fullName.length() > document.getFullNameMaxLength()) {
+                java.lang.Object[] args = { fullName, document.getFullNameMaxLength(), fullName.length() };
                 throw new XWikiException(XWikiException.MODULE_XWIKI_STORE,
                     XWikiException.ERROR_XWIKI_APP_DOCUMENT_PATH_TOO_LONG,
                     "Cannot create document {0} because its full path is too long: only {1} characters are allowed and "

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWikiException.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWikiException.java
@@ -266,6 +266,8 @@ public class XWikiException extends Exception
 
     public static final int ERROR_XWIKI_APP_TEMPLATE_NOT_AVAILABLE = 11016;
 
+    public static final int ERROR_XWIKI_APP_DOCUMENT_PATH_TOO_LONG = 11017;
+
     public static final int ERROR_XWIKI_EXPORT_XSL_FILE_NOT_FOUND = 12001;
 
     public static final int ERROR_XWIKI_EXPORT_PDF_FOP_FAILED = 12002;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Document.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Document.java
@@ -3158,4 +3158,14 @@ public class Document extends Api
     {
         return 1 == this.getDoc().getTranslation();
     }
+
+    /**
+     * @return the maximum authorized length for a document full name (see {@link #getFullName()}).
+     * @since 11.3RC1
+     */
+    @Unstable
+    public int getNameMaxLength()
+    {
+        return this.doc.getNameMaxLength();
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Document.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Document.java
@@ -3166,6 +3166,6 @@ public class Document extends Api
     @Unstable
     public int getNameMaxLength()
     {
-        return this.doc.getNameMaxLength();
+        return this.doc.getFullNameMaxLength();
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Document.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Document.java
@@ -3161,7 +3161,7 @@ public class Document extends Api
 
     /**
      * @return the maximum authorized length for a document full name (see {@link #getFullName()}).
-     * @since 11.3RC1
+     * @since 11.4RC1
      */
     @Unstable
     public int getLocalReferenceMaxLength()

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Document.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Document.java
@@ -3164,8 +3164,8 @@ public class Document extends Api
      * @since 11.3RC1
      */
     @Unstable
-    public int getNameMaxLength()
+    public int getLocalReferenceMaxLength()
     {
-        return this.doc.getFullNameMaxLength();
+        return this.doc.getLocalReferenceMaxLength();
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -9297,7 +9297,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
      * @since 11.3RC1
      */
     @Unstable
-    public int getNameMaxLength()
+    public int getFullNameMaxLength()
     {
         return getStore().getLimitSize(this.getXWikiContext(), this.getClass(), "fullName");
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -9297,7 +9297,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
      * @since 11.3RC1
      */
     @Unstable
-    public int getFullNameMaxLength()
+    public int getLocalReferenceMaxLength()
     {
         return getStore().getLimitSize(this.getXWikiContext(), this.getClass(), "fullName");
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -9294,7 +9294,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
      * document) based on the current store limitation.
      *
      * @return the maximum authorized length for a document full name.
-     * @since 11.3RC1
+     * @since 11.4RC1
      */
     @Unstable
     public int getLocalReferenceMaxLength()

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -9299,6 +9299,6 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
     @Unstable
     public int getNameMaxLength()
     {
-        return getStore().getLimitSize(this.getClass(), "fullName");
+        return getStore().getLimitSize(this.getXWikiContext(), this.getClass(), "fullName");
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -9288,4 +9288,17 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
 
         return null;
     }
+
+    /**
+     * Compute and return the maximum authorized length for the full name (i.e. the serialized reference of the
+     * document) based on the current store limitation.
+     *
+     * @return the maximum authorized length for a document full name.
+     * @since 11.3RC1
+     */
+    @Unstable
+    public int getNameMaxLength()
+    {
+        return getStore().getLimitSize(this.getClass(), "fullName");
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiCacheStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiCacheStore.java
@@ -772,4 +772,10 @@ public class XWikiCacheStore extends AbstractXWikiStore
     {
         return getStore().getQueryManager();
     }
+
+    @Override
+    public int getLimitSize(Class<?> entityType, String propertyName)
+    {
+        return this.store.getLimitSize(entityType, propertyName);
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiCacheStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiCacheStore.java
@@ -104,7 +104,7 @@ public class XWikiCacheStore extends AbstractXWikiStore
     private Cache<Boolean> pageExistCache;
 
     /**
-     * Used to cache the values asked by {@link #getLimitSize(Class, String)}.
+     * Used to cache the values asked by {@link #getLimitSize(XWikiContext, Class, String)}.
      */
     private Cache<Integer> limitSizePropertyCache;
 
@@ -757,7 +757,7 @@ public class XWikiCacheStore extends AbstractXWikiStore
 
     /**
      * @return the cache that handle the limit size properties.
-     * @since 11.3RC1
+     * @since 11.4RC1
      */
     @Unstable
     public Cache<Integer> getLimitSizePropertyCache()

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
@@ -57,6 +57,7 @@ import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.Settings;
 import org.hibernate.connection.ConnectionProvider;
 import org.hibernate.impl.SessionFactoryImpl;
+import org.hibernate.mapping.Column;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
 import org.slf4j.Logger;
@@ -3253,5 +3254,15 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
         }
 
         return this.attachmentContentStore;
+    }
+
+    @Override
+    public int getLimitSize(Class<?> entityType, String propertyName)
+    {
+        PersistentClass persistentClass = getConfiguration().getClassMapping(entityType.getName());
+        Property property = persistentClass.getProperty(propertyName);
+        int length = ((Column) property.getColumnIterator().next()).getLength();
+
+        return length;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
@@ -3265,7 +3265,11 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
         int result = -1;
 
         // retrieve the schema from the context
-        String schema = getSchemaFromWikiName(context);
+        String schema = null;
+        // apparently no schema should be used for oracle DB
+        if (getDatabaseProductName() != DatabaseProduct.ORACLE) {
+            schema = getSchemaFromWikiName(context);
+        }
 
         // retrieve the table and column name from entityType and propertyName
         PersistentClass persistentClass = getConfiguration().getClassMapping(entityType.getName());
@@ -3273,8 +3277,8 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
         String tableName = persistentClass.getTable().getName();
         String columnName = column.getName();
 
-        // HSQLDB needs to use uppercase table name to retrieve the value.
-        if (getDatabaseProductName() == DatabaseProduct.HSQLDB) {
+        // HSQLDB and Oracle needs to use uppercase table name to retrieve the value.
+        if (getDatabaseProductName() == DatabaseProduct.HSQLDB || getDatabaseProductName() == DatabaseProduct.ORACLE) {
             tableName = tableName.toUpperCase();
         }
 
@@ -3287,8 +3291,8 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
             connection = connectionProvider.getConnection();
             DatabaseMetaData databaseMetaData = connection.getMetaData();
             ResultSet resultSet = databaseMetaData.getColumns(null, schema, tableName, columnName);
-            // first will return false if the resultSet is empty.
-            if (resultSet.first()) {
+            // next will return false if the resultSet is empty.
+            if (resultSet.next()) {
                 result = resultSet.getInt("COLUMN_SIZE");
             }
         } catch (SQLException e) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiStoreInterface.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiStoreInterface.java
@@ -525,9 +525,10 @@ public interface XWikiStoreInterface
      * Get the limit size of a property.
      * @param entityType the entityType where the property is located.
      * @param property the property on which we want the limit size.
+     * @param context the context of the wiki to retrieve the property
      * @return an integer representing the limit size.
      * @since 11.3RC1
      */
     @Unstable
-    int getLimitSize(Class<?> entityType, String property);
+    int getLimitSize(XWikiContext context, Class<?> entityType, String property);
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiStoreInterface.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiStoreInterface.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.xwiki.component.annotation.Role;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.query.QueryManager;
+import org.xwiki.stability.Unstable;
 
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
@@ -519,4 +520,14 @@ public interface XWikiStoreInterface
      *         is more abstract from store implementation and support multiple query languages.
      */
     QueryManager getQueryManager();
+
+    /**
+     * Get the limit size of a property.
+     * @param entityType the entityType where the property is located.
+     * @param property the property on which we want the limit size.
+     * @return an integer representing the limit size.
+     * @since 11.3RC1
+     */
+    @Unstable
+    int getLimitSize(Class<?> entityType, String property);
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiStoreInterface.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiStoreInterface.java
@@ -527,7 +527,7 @@ public interface XWikiStoreInterface
      * @param property the property on which we want the limit size.
      * @param context the context of the wiki to retrieve the property
      * @return an integer representing the limit size.
-     * @since 11.3RC1
+     * @since 11.4RC1
      */
     @Unstable
     int getLimitSize(XWikiContext context, Class<?> entityType, String property);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/CreateAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/CreateAction.java
@@ -138,7 +138,8 @@ public class CreateAction extends XWikiAction
 
         // Check if the document to create already exists.
         XWikiDocument newDocument = context.getWiki().getDocument(newDocumentReference, context);
-        if (handler.isDocumentAlreadyExisting(newDocument)) {
+        if (handler.isDocumentAlreadyExisting(newDocument)
+            || handler.isDocumentPathTooLong(newDocumentReference)) {
             return CREATE_TEMPLATE;
         }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/CreateActionRequestHandler.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/CreateActionRequestHandler.java
@@ -689,13 +689,13 @@ public class CreateActionRequestHandler
     /**
      * @param reference the new document reference to check
      * @return true if the serialized document path is too long according to the limitation provided by
-     *              {@link XWikiDocument#getNameMaxLength()}.
+     *              {@link XWikiDocument#getFullNameMaxLength()}.
      * @since 11.3RC1
      */
     @Unstable
     public boolean isDocumentPathTooLong(DocumentReference reference)
     {
-        int maxLength = document.getNameMaxLength();
+        int maxLength = document.getFullNameMaxLength();
         String serializedDocumentName = getLocalEntityReferenceSerializer().serialize(reference);
         boolean isTooLong = serializedDocumentName.length() > maxLength;
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/CreateActionRequestHandler.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/CreateActionRequestHandler.java
@@ -689,13 +689,13 @@ public class CreateActionRequestHandler
     /**
      * @param reference the new document reference to check
      * @return true if the serialized document path is too long according to the limitation provided by
-     *              {@link XWikiDocument#getFullNameMaxLength()}.
+     *              {@link XWikiDocument#getLocalReferenceMaxLength()}.
      * @since 11.3RC1
      */
     @Unstable
     public boolean isDocumentPathTooLong(DocumentReference reference)
     {
-        int maxLength = document.getFullNameMaxLength();
+        int maxLength = document.getLocalReferenceMaxLength();
         String serializedDocumentName = getLocalEntityReferenceSerializer().serialize(reference);
         boolean isTooLong = serializedDocumentName.length() > maxLength;
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/CreateActionRequestHandler.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/CreateActionRequestHandler.java
@@ -690,7 +690,7 @@ public class CreateActionRequestHandler
      * @param reference the new document reference to check
      * @return true if the serialized document path is too long according to the limitation provided by
      *              {@link XWikiDocument#getLocalReferenceMaxLength()}.
-     * @since 11.3RC1
+     * @since 11.4RC1
      */
     @Unstable
     public boolean isDocumentPathTooLong(DocumentReference reference)

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -762,6 +762,7 @@ core.create.popup.loading=Loading...
 core.create.ajax.error=An error occurred, please refresh the page and try again
 core.create.page.error.docalreadyexists=The page <a href="{1}">{0}</a> already exists. You can fill in a new page name (or <a href="{2}">edit {0}</a>).
 core.create.space.error.docalreadyexists=The space {0} already exists. Please fill in a new space name.
+core.create.page.error.docpathtoolong=The full path of the page you want to create is too long: {0} Paths are limited to {1} characters and the current length is {2} characters. Please change the name of your page or move it to another space.
 
 ### Rename
 core.rename.title=Rename <a href="{1}">{0}</a>

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/XWikiMockitoTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/XWikiMockitoTest.java
@@ -187,10 +187,12 @@ public class XWikiMockitoTest
         when(target.isNew()).thenReturn(true);
         when(target.getDocumentReference()).thenReturn(targetReference);
         when(target.getDocumentReferenceWithLocale()).thenReturn(targetReferenceWithLocale);
+        when(target.getNameMaxLength()).thenReturn(255);
 
         DocumentReference sourceReference = new DocumentReference("foo", "Space", "Source");
         XWikiDocument source = mock(XWikiDocument.class);
         when(source.copyDocument(targetReference, context)).thenReturn(target);
+        when(source.getNameMaxLength()).thenReturn(255);
 
         when(xwiki.getStore().loadXWikiDoc(any(XWikiDocument.class), same(context))).thenReturn(source, target);
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/XWikiMockitoTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/XWikiMockitoTest.java
@@ -187,12 +187,12 @@ public class XWikiMockitoTest
         when(target.isNew()).thenReturn(true);
         when(target.getDocumentReference()).thenReturn(targetReference);
         when(target.getDocumentReferenceWithLocale()).thenReturn(targetReferenceWithLocale);
-        when(target.getNameMaxLength()).thenReturn(255);
+        when(target.getFullNameMaxLength()).thenReturn(255);
 
         DocumentReference sourceReference = new DocumentReference("foo", "Space", "Source");
         XWikiDocument source = mock(XWikiDocument.class);
         when(source.copyDocument(targetReference, context)).thenReturn(target);
-        when(source.getNameMaxLength()).thenReturn(255);
+        when(source.getFullNameMaxLength()).thenReturn(255);
 
         when(xwiki.getStore().loadXWikiDoc(any(XWikiDocument.class), same(context))).thenReturn(source, target);
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/XWikiMockitoTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/XWikiMockitoTest.java
@@ -187,12 +187,12 @@ public class XWikiMockitoTest
         when(target.isNew()).thenReturn(true);
         when(target.getDocumentReference()).thenReturn(targetReference);
         when(target.getDocumentReferenceWithLocale()).thenReturn(targetReferenceWithLocale);
-        when(target.getFullNameMaxLength()).thenReturn(255);
+        when(target.getLocalReferenceMaxLength()).thenReturn(255);
 
         DocumentReference sourceReference = new DocumentReference("foo", "Space", "Source");
         XWikiDocument source = mock(XWikiDocument.class);
         when(source.copyDocument(targetReference, context)).thenReturn(target);
-        when(source.getFullNameMaxLength()).thenReturn(255);
+        when(source.getLocalReferenceMaxLength()).thenReturn(255);
 
         when(xwiki.getStore().loadXWikiDoc(any(XWikiDocument.class), same(context))).thenReturn(source, target);
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/XWikiTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/XWikiTest.java
@@ -186,6 +186,7 @@ public class XWikiTest extends AbstractBridgedXWikiComponentTestCase
             });
         this.mockXWikiStore.stubs().method("getTranslationList").will(returnValue(Collections.EMPTY_LIST));
         this.mockXWikiStore.stubs().method("exists").will(returnValue(true));
+        this.mockXWikiStore.stubs().method("getLimitSize").will(returnValue(255));
 
         this.mockXWikiVersioningStore =
             mock(XWikiHibernateVersioningStore.class, new Class[] {XWiki.class, XWikiContext.class}, new Object[] {
@@ -578,6 +579,7 @@ public class XWikiTest extends AbstractBridgedXWikiComponentTestCase
     {
         Mock mockStore = registerMockComponent(XWikiStoreInterface.class);
         this.xwiki.setStore((XWikiStoreInterface) mockStore.proxy());
+        mockStore.stubs().method("getLimitSize").will(returnValue(255));
 
         XWikiDocument prefsDoc = new XWikiDocument(new DocumentReference("xwiki", "XWiki", "XWikiPreferences"));
         final Map<DocumentReference, XWikiDocument> documents = new HashMap<DocumentReference, XWikiDocument>();

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/api/XWikiTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/api/XWikiTest.java
@@ -109,6 +109,7 @@ public class XWikiTest extends AbstractBridgedXWikiComponentTestCase
                 }
             });
         this.mockXWikiStore.stubs().method("getTranslationList").will(returnValue(Collections.EMPTY_LIST));
+        this.mockXWikiStore.stubs().method("getLimitSize").will(returnValue(255));
 
         this.mockXWikiVersioningStore =
             mock(XWikiHibernateVersioningStore.class, new java.lang.Class[] {com.xpn.xwiki.XWiki.class,

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/plugin/packaging/ImportTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/plugin/packaging/ImportTest.java
@@ -161,6 +161,7 @@ public class ImportTest extends AbstractPackageTest
                 }
             });
         this.mockXWikiStore.stubs().method("injectCustomMapping").will(returnValue(false));
+        this.mockXWikiStore.stubs().method("getLimitSize").will(returnValue(255));
 
         this.mockRecycleBinStore =
             mock(XWikiHibernateRecycleBinStore.class, new Class[] {XWikiContext.class}, new Object[] {getContext()});

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
@@ -125,7 +125,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Run the action
@@ -148,7 +148,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Pass the tocreate=nonterminal request parameter
@@ -177,7 +177,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Run the action
@@ -197,7 +197,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Run the action
@@ -221,7 +221,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Run the action
@@ -246,7 +246,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Pass the tocreate=terminal request parameter
@@ -273,7 +273,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Pass the tocreate=terminal request parameter
@@ -303,6 +303,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Just landed on the create page or submitted with no values (no name) specified.
@@ -328,6 +329,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y
@@ -355,6 +357,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X.Y&name=Z
@@ -382,6 +385,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y&tocreate=terminal
@@ -410,6 +414,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X.Y&name=Z&tocreate=termina
@@ -438,6 +443,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
         // Mock it as existing in the DB as well with non-empty content
         oldcore.getDocuments().put(new DocumentReference(documentReference, Locale.ROOT), document);
@@ -469,6 +475,70 @@ public class CreateActionTest
     }
 
     @Test
+    public void notExistingDocumentFromUIButNameTooLong() throws Exception
+    {
+        // current document = xwiki:Main.WebHome
+        DocumentReference documentReference = new DocumentReference("xwiki", Arrays.asList("Main"), "WebHome");
+        XWikiDocument document = mock(XWikiDocument.class);
+        when(document.getDocumentReference()).thenReturn(documentReference);
+        when(document.isNew()).thenReturn(false);
+        when(document.getNameMaxLength()).thenReturn(10);
+        context.setDoc(document);
+
+        when(mockRequest.getParameter("spaceReference")).thenReturn("Main");
+        when(mockRequest.getParameter("name")).thenReturn("Foo123456789");
+
+        // Run the action
+        String result = action.render(context);
+
+        // The tests are below this line!
+
+        // Verify that the create template is rendered, so the UI is displayed for the user to see the error.
+        assertEquals("create", result);
+
+        // Check that the exception is properly set in the context for the UI to display.
+        XWikiException exception = (XWikiException) this.oldcore.getScriptContext().getAttribute("createException");
+        assertNotNull(exception);
+        assertEquals(XWikiException.ERROR_XWIKI_APP_DOCUMENT_PATH_TOO_LONG, exception.getCode());
+
+        // We should not get this far so no redirect should be done, just the template will be rendered.
+        verify(mockURLFactory, never()).createURL(any(), any(), any(), any(), any(),
+            any(), any(XWikiContext.class));
+    }
+
+    @Test
+    public void notExistingDocumentFromUIButSpaceTooLong() throws Exception
+    {
+        // current document = xwiki:Main.WebHome
+        DocumentReference documentReference = new DocumentReference("xwiki", Arrays.asList("Main"), "WebHome");
+        XWikiDocument document = mock(XWikiDocument.class);
+        when(document.getDocumentReference()).thenReturn(documentReference);
+        when(document.isNew()).thenReturn(false);
+        when(document.getNameMaxLength()).thenReturn(10);
+        context.setDoc(document);
+
+        when(mockRequest.getParameter("spaceReference")).thenReturn("1.3.5.7.9.11");
+        when(mockRequest.getParameter("name")).thenReturn("Foo");
+
+        // Run the action
+        String result = action.render(context);
+
+        // The tests are below this line!
+
+        // Verify that the create template is rendered, so the UI is displayed for the user to see the error.
+        assertEquals("create", result);
+
+        // Check that the exception is properly set in the context for the UI to display.
+        XWikiException exception = (XWikiException) this.oldcore.getScriptContext().getAttribute("createException");
+        assertNotNull(exception);
+        assertEquals(XWikiException.ERROR_XWIKI_APP_DOCUMENT_PATH_TOO_LONG, exception.getCode());
+
+        // We should not get this far so no redirect should be done, just the template will be rendered.
+        verify(mockURLFactory, never()).createURL(any(), any(), any(), any(), any(),
+            any(), any(XWikiContext.class));
+    }
+
+    @Test
     public void existingDocumentFromUITopLevelDocument() throws Exception
     {
         // current document = xwiki:Main.WebHome
@@ -476,6 +546,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI name=Y
@@ -506,6 +577,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI space=X&page=Y
@@ -533,6 +605,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI space=X.Y&page=Z
@@ -561,6 +634,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI space=X&tocreate=space
@@ -588,6 +662,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI space=X&page=Y&tocreate=space
@@ -617,6 +692,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI space=X.Y&tocreate=space
@@ -649,6 +725,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y
@@ -758,6 +835,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider
@@ -791,6 +869,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider
@@ -826,6 +905,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X.Y.Z&name=W&templateProvider=XWiki.MyTemplateProvider
@@ -863,6 +943,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider
@@ -903,7 +984,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Specifying a template provider in the URL: templateprovider=XWiki.MyTemplateProvider
@@ -941,7 +1022,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Specifying a template provider in the URL: templateprovider=XWiki.MyTemplateProvider
@@ -979,7 +1060,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Specifying a template provider in the URL: templateprovider=XWiki.MyTemplateProvider
@@ -1013,7 +1094,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Specifying a template provider in the URL: templateprovider=XWiki.MyTemplateProvider
@@ -1047,7 +1128,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Specifying a template provider in the URL: templateprovider=XWiki.MyTemplateProvider
@@ -1081,7 +1162,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Specifying a template provider in the URL: templateprovider=XWiki.MyTemplateProvider
@@ -1116,6 +1197,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
+        when(document.getNameMaxLength()).thenReturn(255);
 
         context.setDoc(document);
 
@@ -1151,6 +1233,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider
@@ -1186,6 +1269,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider
@@ -1222,6 +1306,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider
@@ -1258,6 +1343,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider
@@ -1295,7 +1381,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Specifying a template provider in the URL: templateprovider=XWiki.MyTemplateProvider
@@ -1331,7 +1417,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Specifying a template provider in the URL: templateprovider=XWiki.MyTemplateProvider
@@ -1367,6 +1453,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider
@@ -1404,6 +1491,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
+        when(document.getNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
@@ -125,7 +125,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Run the action
@@ -148,7 +148,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Pass the tocreate=nonterminal request parameter
@@ -177,7 +177,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Run the action
@@ -197,7 +197,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Run the action
@@ -221,7 +221,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Run the action
@@ -246,7 +246,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Pass the tocreate=terminal request parameter
@@ -273,7 +273,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Pass the tocreate=terminal request parameter
@@ -303,7 +303,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Just landed on the create page or submitted with no values (no name) specified.
@@ -329,7 +329,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y
@@ -357,7 +357,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X.Y&name=Z
@@ -385,7 +385,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y&tocreate=terminal
@@ -414,7 +414,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X.Y&name=Z&tocreate=termina
@@ -443,7 +443,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
         // Mock it as existing in the DB as well with non-empty content
         oldcore.getDocuments().put(new DocumentReference(documentReference, Locale.ROOT), document);
@@ -482,7 +482,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getNameMaxLength()).thenReturn(10);
+        when(document.getFullNameMaxLength()).thenReturn(10);
         context.setDoc(document);
 
         when(mockRequest.getParameter("spaceReference")).thenReturn("Main");
@@ -514,7 +514,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getNameMaxLength()).thenReturn(10);
+        when(document.getFullNameMaxLength()).thenReturn(10);
         context.setDoc(document);
 
         when(mockRequest.getParameter("spaceReference")).thenReturn("1.3.5.7.9.11");
@@ -546,7 +546,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI name=Y
@@ -577,7 +577,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI space=X&page=Y
@@ -605,7 +605,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI space=X.Y&page=Z
@@ -634,7 +634,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI space=X&tocreate=space
@@ -662,7 +662,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI space=X&page=Y&tocreate=space
@@ -692,7 +692,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI space=X.Y&tocreate=space
@@ -725,7 +725,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y
@@ -835,7 +835,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider
@@ -869,7 +869,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider
@@ -905,7 +905,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X.Y.Z&name=W&templateProvider=XWiki.MyTemplateProvider
@@ -943,7 +943,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider
@@ -984,7 +984,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Specifying a template provider in the URL: templateprovider=XWiki.MyTemplateProvider
@@ -1022,7 +1022,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Specifying a template provider in the URL: templateprovider=XWiki.MyTemplateProvider
@@ -1060,7 +1060,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Specifying a template provider in the URL: templateprovider=XWiki.MyTemplateProvider
@@ -1094,7 +1094,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Specifying a template provider in the URL: templateprovider=XWiki.MyTemplateProvider
@@ -1128,7 +1128,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Specifying a template provider in the URL: templateprovider=XWiki.MyTemplateProvider
@@ -1162,7 +1162,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Specifying a template provider in the URL: templateprovider=XWiki.MyTemplateProvider
@@ -1197,7 +1197,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
 
         context.setDoc(document);
 
@@ -1233,7 +1233,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider
@@ -1269,7 +1269,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider
@@ -1306,7 +1306,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider
@@ -1343,7 +1343,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider
@@ -1381,7 +1381,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Specifying a template provider in the URL: templateprovider=XWiki.MyTemplateProvider
@@ -1417,7 +1417,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Specifying a template provider in the URL: templateprovider=XWiki.MyTemplateProvider
@@ -1453,7 +1453,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider
@@ -1491,7 +1491,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getNameMaxLength()).thenReturn(255);
+        when(document.getFullNameMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
@@ -125,7 +125,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Run the action
@@ -148,7 +148,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Pass the tocreate=nonterminal request parameter
@@ -177,7 +177,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Run the action
@@ -197,7 +197,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Run the action
@@ -221,7 +221,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Run the action
@@ -246,7 +246,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Pass the tocreate=terminal request parameter
@@ -273,7 +273,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Pass the tocreate=terminal request parameter
@@ -303,7 +303,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Just landed on the create page or submitted with no values (no name) specified.
@@ -329,7 +329,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y
@@ -357,7 +357,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X.Y&name=Z
@@ -385,7 +385,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y&tocreate=terminal
@@ -414,7 +414,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X.Y&name=Z&tocreate=termina
@@ -443,7 +443,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
         // Mock it as existing in the DB as well with non-empty content
         oldcore.getDocuments().put(new DocumentReference(documentReference, Locale.ROOT), document);
@@ -482,7 +482,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getFullNameMaxLength()).thenReturn(10);
+        when(document.getLocalReferenceMaxLength()).thenReturn(10);
         context.setDoc(document);
 
         when(mockRequest.getParameter("spaceReference")).thenReturn("Main");
@@ -514,7 +514,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getFullNameMaxLength()).thenReturn(10);
+        when(document.getLocalReferenceMaxLength()).thenReturn(10);
         context.setDoc(document);
 
         when(mockRequest.getParameter("spaceReference")).thenReturn("1.3.5.7.9.11");
@@ -546,7 +546,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI name=Y
@@ -577,7 +577,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI space=X&page=Y
@@ -605,7 +605,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI space=X.Y&page=Z
@@ -634,7 +634,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI space=X&tocreate=space
@@ -662,7 +662,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI space=X&page=Y&tocreate=space
@@ -692,7 +692,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI space=X.Y&tocreate=space
@@ -725,7 +725,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y
@@ -835,7 +835,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider
@@ -869,7 +869,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider
@@ -905,7 +905,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X.Y.Z&name=W&templateProvider=XWiki.MyTemplateProvider
@@ -943,7 +943,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider
@@ -984,7 +984,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Specifying a template provider in the URL: templateprovider=XWiki.MyTemplateProvider
@@ -1022,7 +1022,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Specifying a template provider in the URL: templateprovider=XWiki.MyTemplateProvider
@@ -1060,7 +1060,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Specifying a template provider in the URL: templateprovider=XWiki.MyTemplateProvider
@@ -1094,7 +1094,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Specifying a template provider in the URL: templateprovider=XWiki.MyTemplateProvider
@@ -1128,7 +1128,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Specifying a template provider in the URL: templateprovider=XWiki.MyTemplateProvider
@@ -1162,7 +1162,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Specifying a template provider in the URL: templateprovider=XWiki.MyTemplateProvider
@@ -1197,7 +1197,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
 
         context.setDoc(document);
 
@@ -1233,7 +1233,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider
@@ -1269,7 +1269,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider
@@ -1306,7 +1306,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider
@@ -1343,7 +1343,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider
@@ -1381,7 +1381,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Specifying a template provider in the URL: templateprovider=XWiki.MyTemplateProvider
@@ -1417,7 +1417,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(true);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Specifying a template provider in the URL: templateprovider=XWiki.MyTemplateProvider
@@ -1453,7 +1453,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider
@@ -1491,7 +1491,7 @@ public class CreateActionTest
         XWikiDocument document = mock(XWikiDocument.class);
         when(document.getDocumentReference()).thenReturn(documentReference);
         when(document.isNew()).thenReturn(false);
-        when(document.getFullNameMaxLength()).thenReturn(255);
+        when(document.getLocalReferenceMaxLength()).thenReturn(255);
         context.setDoc(document);
 
         // Submit from the UI spaceReference=X&name=Y&templateProvider=XWiki.MyTemplateProvider

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/createinline.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/createinline.vm
@@ -67,6 +67,17 @@
       )
   </div>
 #end
+## check if the exception is about the document having a path too long
+#if("$!exception" != '' && $exception.code == 11017)
+  <div class='box errormessage'>
+      $services.localization.render('core.create.page.error.docpathtoolong',
+        ["<p><small>${tooLongPath}</small></p>",
+          $doc.getNameMaxLength(),
+          $tooLongPath.length()
+        ]
+      )
+  </div>
+#end
 
 ## ---------------------------------------------------------------------------------------------------------
 ## Determine if we need to do extra checks for a deprecated, pre-NestedSpaces request to create a space.

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/createinline.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/createinline.vm
@@ -72,7 +72,7 @@
   <div class='box errormessage'>
       $services.localization.render('core.create.page.error.docpathtoolong',
         ["<p><small>${tooLongPath}</small></p>",
-          $doc.getNameMaxLength(),
+          $doc.getLocalReferenceMaxLength(),
           $tooLongPath.length()
         ]
       )


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XWIKI-16314

## Solution

  * Add new store methods to check the limit size of a property
  * Add new cache store methods to cache the property limits. 
  * Add new checks in CreateAction and in save to check the length of a
page path
  * Edit createinline.vm to handle new exception in case of path too
long
  * Add new unit test to check new behaviours
  * Add new integration test to ensure UI changes

## Tests

Tested with the 4 database supported in docker test:
  * mysql
  * postgresql
  * HSQLDB
  * Oracle DB

## Limitations

HSQLDB showed that we might have exceptions to retrieve the limit based on the DB type, so I don't really know if this code would work on Oracle DB or other DB that are not supported in Docker tests.

## Screenshots

### UI in case of path too long

![Capture d’écran_2019-04-10_12-09-51](https://user-images.githubusercontent.com/1478232/55877929-95a22200-5b9b-11e9-8ffb-7d9b881f2ecc.png)

### Test with a REST request

![Capture d’écran_2019-04-10_13-40-34](https://user-images.githubusercontent.com/1478232/55877936-9fc42080-5b9b-11e9-931f-5ac3282e6d09.png)
