### PR TITLE
XWIKI-16389: Dedicated macro for inline editing of wikimacro content

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-macros/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-macros/pom.xml
@@ -19,21 +19,22 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
+  <modules>
+    <module>xwiki-platform-rendering-wikimacro-macro-wikimacrocontent</module>
+  </modules>
   <parent>
+    <artifactId>xwiki-platform-rendering-wikimacro</artifactId>
     <groupId>org.xwiki.platform</groupId>
-    <artifactId>xwiki-platform-rendering</artifactId>
     <version>11.4-SNAPSHOT</version>
   </parent>
-  <artifactId>xwiki-platform-rendering-wikimacro</artifactId>
+
   <packaging>pom</packaging>
-  <name>XWiki Platform - Rendering - Wiki Macro Bridge</name>
-  <description>XWiki Platform - Rendering - Wiki Macro Bridge</description>
-  <modules>
-    <module>xwiki-platform-rendering-wikimacro-api</module>
-    <module>xwiki-platform-rendering-wikimacro-store</module>
-    <module>xwiki-platform-rendering-wikimacro-macros</module>
-  </modules>
+  <name>XWiki Platform - Rendering - Wiki Macro Bridge - Macros</name>
+  <description>XWiki Platform - Rendering - Wiki Macro Bridge - Macros</description>
+  <artifactId>xwiki-platform-rendering-wikimacro-macros</artifactId>
+
 </project>

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-macros/xwiki-platform-rendering-wikimacro-macro-wikimacrocontent/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-macros/xwiki-platform-rendering-wikimacro-macro-wikimacrocontent/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>xwiki-platform-rendering-wikimacro-macros</artifactId>
+    <groupId>org.xwiki.platform</groupId>
+    <version>11.4-SNAPSHOT</version>
+  </parent>
+  <name>XWiki Platform - Rendering - Wiki Macro Bridge - Macro - WikiMacroContent</name>
+  <description>XWiki Platform - Rendering - Wiki Macro Bridge - Macro - WikiMacroContent</description>
+  <artifactId>xwiki-platform-rendering-wikimacro-macro-wikimacrocontent</artifactId>
+  <properties>
+    <xwiki.jacoco.instructionRatio>1.00</xwiki.jacoco.instructionRatio>
+    <xwiki.pitest.mutationThreshold>1</xwiki.pitest.mutationThreshold>
+    <!-- Name to display by the Extension Manager -->
+    <xwiki.extension.name>Wikimacro Content Macro</xwiki.extension.name>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-oldcore</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-tool-test-component</artifactId>
+      <version>${commons.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-macros/xwiki-platform-rendering-wikimacro-macro-wikimacrocontent/src/main/java/org/xwiki/rendering/wikimacro/macro/wikimacrocontent/WikiMacroContentMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-macros/xwiki-platform-rendering-wikimacro-macro-wikimacrocontent/src/main/java/org/xwiki/rendering/wikimacro/macro/wikimacrocontent/WikiMacroContentMacro.java
@@ -49,15 +49,15 @@ import com.xpn.xwiki.XWikiContext;
  * @version $Id$
  */
 @Component
-@Named(WikiMacroContentMacro.WIKIMACRO_CONTENT_MACRO)
+@Named("wikimacrocontent")
 @Singleton
 @Unstable
 public class WikiMacroContentMacro extends AbstractNoParameterMacro
 {
     /**
-     * The name of the macro.
+     * The description of the macro.
      */
-    public static final String WIKIMACRO_CONTENT_MACRO = "wikimacrocontent";
+    private static final String DESCRIPTION = "Display editable content of a wikimacro.";
 
     private static final String WIKIMACRO_CONTENT = "content";
 
@@ -77,7 +77,8 @@ public class WikiMacroContentMacro extends AbstractNoParameterMacro
      */
     public WikiMacroContentMacro()
     {
-        super(WIKIMACRO_CONTENT_MACRO);
+        super("WikiMacro Content", DESCRIPTION);
+        setDefaultCategory(DEFAULT_CATEGORY_DEVELOPMENT);
     }
 
     @Override
@@ -128,9 +129,11 @@ public class WikiMacroContentMacro extends AbstractNoParameterMacro
         Map<String, Object> macroInfo = (Map) getContext().get("macro");
         String macroContent = extractMacroContent(macroInfo);
         if (macroContent != null) {
+            MetaData nonGeneratedContentMetaData = this.getNonGeneratedContentMetaData(macroInfo);
+            nonGeneratedContentMetaData.addMetaData("wikimacrocontent", "true");
             XDOM parse = this.contentParser.parse(macroContent, context, true, context.isInline());
             result = Collections.singletonList(new MetaDataBlock(parse.getChildren(),
-                this.getNonGeneratedContentMetaData(macroInfo)));
+                nonGeneratedContentMetaData));
         }
 
         return result;

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-macros/xwiki-platform-rendering-wikimacro-macro-wikimacrocontent/src/main/java/org/xwiki/rendering/wikimacro/macro/wikimacrocontent/WikiMacroContentMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-macros/xwiki-platform-rendering-wikimacro-macro-wikimacrocontent/src/main/java/org/xwiki/rendering/wikimacro/macro/wikimacrocontent/WikiMacroContentMacro.java
@@ -1,0 +1,138 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rendering.wikimacro.macro.wikimacrocontent;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.context.Execution;
+import org.xwiki.rendering.block.Block;
+import org.xwiki.rendering.block.MetaDataBlock;
+import org.xwiki.rendering.block.XDOM;
+import org.xwiki.rendering.listener.MetaData;
+import org.xwiki.rendering.macro.AbstractMacro;
+import org.xwiki.rendering.macro.AbstractNoParameterMacro;
+import org.xwiki.rendering.macro.MacroContentParser;
+import org.xwiki.rendering.macro.MacroExecutionException;
+import org.xwiki.rendering.macro.descriptor.MacroDescriptor;
+import org.xwiki.rendering.transformation.MacroTransformationContext;
+import org.xwiki.stability.Unstable;
+
+import com.xpn.xwiki.XWikiContext;
+
+/**
+ * A macro that should only be used inside a WikiMacro to show the content of the wikimacro and make it inline editable.
+ * @since 11.4RC1
+ * @version $Id$
+ */
+@Component
+@Named(WikiMacroContentMacro.WIKIMACRO_CONTENT_MACRO)
+@Singleton
+@Unstable
+public class WikiMacroContentMacro extends AbstractNoParameterMacro
+{
+    /**
+     * The name of the macro.
+     */
+    public static final String WIKIMACRO_CONTENT_MACRO = "wikimacrocontent";
+
+    private static final String WIKIMACRO_CONTENT = "content";
+
+    private static final String WIKIMACRO_DESCRIPTOR = "descriptor";
+
+    /**
+     * The {@link Execution} component used for accessing XWikiContext.
+     */
+    @Inject
+    private Execution execution;
+
+    @Inject
+    private MacroContentParser contentParser;
+
+    /**
+     * Default constructor.
+     */
+    public WikiMacroContentMacro()
+    {
+        super(WIKIMACRO_CONTENT_MACRO);
+    }
+
+    @Override
+    public boolean supportsInlineMode()
+    {
+        return true;
+    }
+
+    /**
+     * Utility method for accessing XWikiContext.
+     *
+     * @return the XWikiContext.
+     */
+    private XWikiContext getContext()
+    {
+        return (XWikiContext) this.execution.getContext().getProperty("xwikicontext");
+    }
+
+    private String extractMacroContent(Map<String, Object> macroInfo)
+    {
+        String content = null;
+        if (macroInfo != null && macroInfo.containsKey(WIKIMACRO_CONTENT)) {
+            content = (String) macroInfo.get(WIKIMACRO_CONTENT);
+        }
+
+        return content;
+    }
+
+    private MetaData getNonGeneratedContentMetaData(Map<String, Object> macroInfo)
+    {
+        MetaData result;
+
+        if (macroInfo != null && macroInfo.containsKey(WIKIMACRO_DESCRIPTOR)) {
+            MacroDescriptor macroDescriptor = (MacroDescriptor) macroInfo.get(WIKIMACRO_DESCRIPTOR);
+            result = AbstractMacro.getNonGeneratedContentMetaData(macroDescriptor.getContentDescriptor());
+        } else {
+            result = AbstractMacro.getNonGeneratedContentMetaData(null);
+        }
+
+        return result;
+    }
+
+    @Override
+    public List<Block> execute(Object parameters, String content, MacroTransformationContext context)
+        throws MacroExecutionException
+    {
+        List<Block> result = Collections.emptyList();
+        Map<String, Object> macroInfo = (Map) getContext().get("macro");
+        String macroContent = extractMacroContent(macroInfo);
+        if (macroContent != null) {
+            XDOM parse = this.contentParser.parse(macroContent, context, true, context.isInline());
+            result = Collections.singletonList(new MetaDataBlock(parse.getChildren(),
+                this.getNonGeneratedContentMetaData(macroInfo)));
+        }
+
+        return result;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-macros/xwiki-platform-rendering-wikimacro-macro-wikimacrocontent/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-macros/xwiki-platform-rendering-wikimacro-macro-wikimacrocontent/src/main/resources/META-INF/components.txt
@@ -1,0 +1,1 @@
+org.xwiki.rendering.wikimacro.macro.wikimacrocontent.WikiMacroContentMacro

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-macros/xwiki-platform-rendering-wikimacro-macro-wikimacrocontent/src/test/java/org/xwiki/rendering/wikimacro/macro/wikimacrocontent/WikiMacroContentMacroTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-macros/xwiki-platform-rendering-wikimacro-macro-wikimacrocontent/src/test/java/org/xwiki/rendering/wikimacro/macro/wikimacrocontent/WikiMacroContentMacroTest.java
@@ -113,6 +113,7 @@ public class WikiMacroContentMacroTest
 
         MetaData metaData = new MetaData();
         metaData.addMetaData("non-generated-content", "java.util.List<org.xwiki.rendering.block.Block>");
+        metaData.addMetaData("wikimacrocontent", "true");
         List<Block> expectedBlocks = Collections.singletonList(new MetaDataBlock(
             Collections.singletonList(new WordBlock("foobar")), metaData));
 
@@ -138,6 +139,7 @@ public class WikiMacroContentMacroTest
 
         MetaData metaData = new MetaData();
         metaData.addMetaData("non-generated-content", "java.lang.String");
+        metaData.addMetaData("wikimacrocontent", "true");
         List<Block> expectedBlocks = Collections.singletonList(new MetaDataBlock(
             Collections.singletonList(new WordBlock("foobar")), metaData));
 

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-macros/xwiki-platform-rendering-wikimacro-macro-wikimacrocontent/src/test/java/org/xwiki/rendering/wikimacro/macro/wikimacrocontent/WikiMacroContentMacroTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-macros/xwiki-platform-rendering-wikimacro-macro-wikimacrocontent/src/test/java/org/xwiki/rendering/wikimacro/macro/wikimacrocontent/WikiMacroContentMacroTest.java
@@ -1,0 +1,146 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rendering.wikimacro.macro.wikimacrocontent;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.xwiki.context.Execution;
+import org.xwiki.context.ExecutionContext;
+import org.xwiki.rendering.block.Block;
+import org.xwiki.rendering.block.MetaDataBlock;
+import org.xwiki.rendering.block.WordBlock;
+import org.xwiki.rendering.block.XDOM;
+import org.xwiki.rendering.listener.MetaData;
+import org.xwiki.rendering.macro.MacroContentParser;
+import org.xwiki.rendering.macro.MacroExecutionException;
+import org.xwiki.rendering.macro.MacroId;
+import org.xwiki.rendering.macro.descriptor.ContentDescriptor;
+import org.xwiki.rendering.macro.descriptor.DefaultContentDescriptor;
+import org.xwiki.rendering.macro.descriptor.DefaultMacroDescriptor;
+import org.xwiki.rendering.macro.descriptor.MacroDescriptor;
+import org.xwiki.rendering.transformation.MacroTransformationContext;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+import org.xwiki.test.mockito.MockitoComponentManager;
+
+import com.xpn.xwiki.XWikiContext;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test of {@link WikiMacroContentMacro}.
+ */
+@ComponentTest
+public class WikiMacroContentMacroTest
+{
+    @InjectMockComponents
+    private WikiMacroContentMacro wikiMacroContentMacro;
+
+    @MockComponent
+    private Execution execution;
+
+    @MockComponent
+    private MacroContentParser contentParser;
+
+    @Mock
+    private MacroTransformationContext transformationContext;
+
+    XWikiContext xcontext;
+
+    @BeforeEach
+    public void setup(MockitoComponentManager componentManager) throws Exception
+    {
+        this.xcontext = new XWikiContext();
+        ExecutionContext executionContext = componentManager.registerMockComponent(ExecutionContext.class);
+        when(execution.getContext()).thenReturn(executionContext);
+        when(executionContext.getProperty("xwikicontext")).thenReturn(this.xcontext);
+    }
+
+    /**
+     * Ensure that by default it returns an empty list of blocks.
+     */
+    @Test
+    public void executeWithoutMacro() throws MacroExecutionException
+    {
+        assertEquals(Collections.emptyList(), wikiMacroContentMacro.execute(null,null,null));
+    }
+
+    /**
+     * Ensure that the content of the macro in the context is parsed and a proper metadata is put around.
+     */
+    @Test
+    public void executeWithSimpleMacro() throws MacroExecutionException
+    {
+        ContentDescriptor contentDescriptor = new DefaultContentDescriptor("", false, Block.LIST_BLOCK_TYPE);
+        MacroDescriptor macroDescriptor = new DefaultMacroDescriptor(new MacroId("mywikimacro"), "mywikimacro", "",
+            contentDescriptor);
+        String content = "foobar";
+
+        Map<String, Object> macroInfo = new HashMap<>();
+        macroInfo.put("content", content);
+        macroInfo.put("descriptor", macroDescriptor);
+        this.xcontext.put("macro", macroInfo);
+        when(this.transformationContext.isInline()).thenReturn(false);
+        when(this.contentParser.parse(eq(content), eq(this.transformationContext), eq(true), eq(false))).thenReturn(
+            new XDOM(Collections.singletonList(new WordBlock("foobar")))
+        );
+
+        MetaData metaData = new MetaData();
+        metaData.addMetaData("non-generated-content", "java.util.List<org.xwiki.rendering.block.Block>");
+        List<Block> expectedBlocks = Collections.singletonList(new MetaDataBlock(
+            Collections.singletonList(new WordBlock("foobar")), metaData));
+
+        assertEquals(expectedBlocks, this.wikiMacroContentMacro.execute(null, null, this.transformationContext));
+    }
+
+    /**
+     * Ensure that the content of the macro in the context is parsed and a proper metadata is put around, even if the
+     * macro descriptor is null.
+     */
+    @Test
+    public void executeWithMacroDescriptorNull() throws MacroExecutionException
+    {
+        String content = "foobar";
+
+        Map<String, Object> macroInfo = new HashMap<>();
+        macroInfo.put("content", content);
+        this.xcontext.put("macro", macroInfo);
+        when(this.transformationContext.isInline()).thenReturn(false);
+        when(this.contentParser.parse(eq(content), eq(this.transformationContext), eq(true), eq(false))).thenReturn(
+            new XDOM(Collections.singletonList(new WordBlock("foobar")))
+        );
+
+        MetaData metaData = new MetaData();
+        metaData.addMetaData("non-generated-content", "java.lang.String");
+        List<Block> expectedBlocks = Collections.singletonList(new MetaDataBlock(
+            Collections.singletonList(new WordBlock("foobar")), metaData));
+
+        assertEquals(expectedBlocks, this.wikiMacroContentMacro.execute(null, null, this.transformationContext));
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/pom.xml
@@ -46,6 +46,11 @@
     </dependency>
     <dependency>
       <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-rendering-wikimacro-macro-wikimacrocontent</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
       <artifactId>xwiki-platform-oldcore</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/internal/converter/DefaultHTMLConverter.java
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/internal/converter/DefaultHTMLConverter.java
@@ -223,6 +223,7 @@ public class DefaultHTMLConverter implements HTMLConverter
         TransformationContext txContext = new TransformationContext();
         txContext.setXDOM(xdom);
         txContext.setSyntax(syntax);
+        txContext.setTargetSyntax(Syntax.ANNOTATED_XHTML_1_0);
 
         // It's very important to set a Transformation id as otherwise if any Velocity Macro is executed it'll be
         // executed in isolation (and if you have, say, 2 velocity macros, the second one will not 'see' what's defined

--- a/xwiki-platform-distribution/xwiki-platform-distribution-war-dependencies/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-war-dependencies/pom.xml
@@ -400,6 +400,12 @@
       <version>${project.version}</version>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-rendering-wikimacro-macro-wikimacrocontent</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
     <!-- Active Installs -->
     <dependency>
       <groupId>org.xwiki.platform</groupId>


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XWIKI-16389

## Solution  

  * Create a dedicated macro for wikimacro content that insert the content of a wikimacro and put a dedicated metadata around it for inline editing
  * Process in DefaultWikiMacroRenderer the rendered wikimacro to remove the macro markers that could prevent from inline editing.

## Test

Unit tests has been added to the new module and some manual tests have been performed.
I mostly use this macro for testing manually my changes:
```
{{velocity}}
{{box}}
{{wikimacrocontent/}}
{{/box}}

This content is $xcontext.macro.content.length() characters length.
{{/velocity}}
```

I needed the fix provided for https://jira.xwiki.org/browse/XRENDERING-562 (see https://github.com/xwiki/xwiki-rendering/pull/174) to avoid some issues with the two consecutive metadatablocks created by box macro and wikimacrocontent.
I'm able to inline edit the content of this macro with this change and the fix from xwiki-rendering. 

However I encountered an issue when adding inside the macro box an error macro when inline editing it: it seems that any content added *after* the error box is removed when saving from the inline editor. I suspect another issue from xwiki-rendering. 