### PR TITLE
XCOMMONS-1503: workaround to use dom4j 2.1.1

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/pdf/impl/PdfExportImpl.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/pdf/impl/PdfExportImpl.java
@@ -327,6 +327,7 @@ public class PdfExportImpl implements PdfExport
             Reader re = new StringReader(html);
             InputSource source = new InputSource(re);
             SAXReader reader = new SAXReader(XHTMLDocumentFactory.getInstance());
+            reader.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", true);
             reader.setEntityResolver(new DefaultEntityResolver());
             XHTMLDocument document = (XHTMLDocument) reader.read(source);
 


### PR DESCRIPTION
When dom4j's SAXReader.read(InputSource) is called (as PdfExportImpl.java does), in the end SAXHelper.createXMLReader(boolean) is called, which in dom4j 2.1.1 sets the "http://apache.org/xml/features/nonvalidating/load-external-dtd" feature to false.

This PR sets the feature to true as a workaround. Perhaps this is going to be fixed upstream, in which case this PR could be reverted.