### PR TITLE
XWIKI-16412: Allow to type a custom value in a StaticListClass

### DIFF
--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/ClassEditSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/ClassEditSheet.xml
@@ -329,12 +329,18 @@ xcontext.put('propertyCustomDisplayer', new PropertyCustomDisplayer(xcontext))
 #**
  * Displays the input used to edit the specified property of the given object. The given object can be either an
  * instance of an XWiki class or a class field. In the first case the property represents an object field and in the
- * second case the property represents a field meta property.
+ * second case the property represents a field meta property. We currently don't use custom display for metaproperty,
+ * so in that case we fallback on displayEdit.
  *#
 #macro (displayPropertyEditInput $property $prefix $object)
   #set ($wrappedProperty = $property.propertyClass)
   #if ($wrappedProperty.isCustomDisplayed($xcontext.context))
-    $xcontext.get('propertyCustomDisplayer').display($property, $prefix, $object)
+    #set ($customDisplayer = $!xcontext.get('propertyCustomDisplayer').display($property, $prefix, $object))
+    #if ((! $customDisplayer) &amp;&amp; ("$!customDisplayer" == ""))
+      $doc.displayEdit($property, $prefix, $object)
+    #else
+      $customDisplayer
+    #end
   #else
     $doc.displayEdit($property, $prefix, $object)
   #end

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BaseClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BaseClass.java
@@ -881,7 +881,7 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
         boolean relationalStorage, String values, String displayType, String separators, String defaultValue)
     {
         return addStaticListField(fieldName, fieldPrettyName, size, multiSelect, relationalStorage, values,
-            displayType, separators, defaultValue, false);
+            displayType, separators, defaultValue, false, false);
     }
 
     /**
@@ -889,7 +889,7 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
      */
     public boolean addStaticListField(String fieldName, String fieldPrettyName, int size, boolean multiSelect,
         boolean relationalStorage, String values, String displayType, String separators, String defaultValue,
-        boolean allowCustomValues)
+        boolean allowCustomValues, boolean largeStorage)
     {
         if (get(fieldName) == null) {
             StaticListClass list_class = new StaticListClass();
@@ -913,6 +913,7 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
                 list_class.setAllowCustomValues(true);
                 list_class.setPicker(true);
             }
+            list_class.setLargeStorage(largeStorage);
             list_class.setObject(this);
             put(fieldName, list_class);
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BaseClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BaseClass.java
@@ -881,7 +881,7 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
         boolean relationalStorage, String values, String displayType, String separators, String defaultValue)
     {
         return addStaticListField(fieldName, fieldPrettyName, size, multiSelect, relationalStorage, values,
-            displayType, separators, defaultValue, false, false);
+            displayType, separators, defaultValue, ListClass.FREE_TEXT_FORBIDDEN, false);
     }
 
     /**
@@ -889,7 +889,7 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
      */
     public boolean addStaticListField(String fieldName, String fieldPrettyName, int size, boolean multiSelect,
         boolean relationalStorage, String values, String displayType, String separators, String defaultValue,
-        boolean allowCustomValues, boolean largeStorage)
+        String freeText, boolean largeStorage)
     {
         if (get(fieldName) == null) {
             StaticListClass list_class = new StaticListClass();
@@ -909,8 +909,8 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
             if (defaultValue != null) {
                 list_class.setDefaultValue(defaultValue);
             }
-            if (allowCustomValues) {
-                list_class.setAllowCustomValues(true);
+            list_class.setFreeText(freeText);
+            if (!freeText.equals(ListClass.FREE_TEXT_FORBIDDEN)) {
                 list_class.setPicker(true);
             }
             list_class.setLargeStorage(largeStorage);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BaseClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BaseClass.java
@@ -910,7 +910,7 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
                 list_class.setDefaultValue(defaultValue);
             }
             list_class.setFreeText(freeText);
-            if (!freeText.equals(ListClass.FREE_TEXT_FORBIDDEN)) {
+            if (!ListClass.FREE_TEXT_FORBIDDEN.equals(freeText)) {
                 list_class.setPicker(true);
             }
             list_class.setLargeStorage(largeStorage);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BaseClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BaseClass.java
@@ -880,6 +880,17 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
     public boolean addStaticListField(String fieldName, String fieldPrettyName, int size, boolean multiSelect,
         boolean relationalStorage, String values, String displayType, String separators, String defaultValue)
     {
+        return addStaticListField(fieldName, fieldPrettyName, size, multiSelect, relationalStorage, values,
+            displayType, separators, defaultValue, false);
+    }
+
+    /**
+     * @since 11.5RC1
+     */
+    public boolean addStaticListField(String fieldName, String fieldPrettyName, int size, boolean multiSelect,
+        boolean relationalStorage, String values, String displayType, String separators, String defaultValue,
+        boolean allowCustomValues)
+    {
         if (get(fieldName) == null) {
             StaticListClass list_class = new StaticListClass();
             list_class.setName(fieldName);
@@ -897,6 +908,10 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
             }
             if (defaultValue != null) {
                 list_class.setDefaultValue(defaultValue);
+            }
+            if (allowCustomValues) {
+                list_class.setAllowCustomValues(true);
+                list_class.setPicker(true);
             }
             list_class.setObject(this);
             put(fieldName, list_class);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
@@ -45,6 +45,7 @@ import com.xpn.xwiki.internal.xml.XMLAttributeValueFilter;
 import com.xpn.xwiki.objects.BaseCollection;
 import com.xpn.xwiki.objects.BaseProperty;
 import com.xpn.xwiki.objects.DBStringListProperty;
+import com.xpn.xwiki.objects.LargeStringProperty;
 import com.xpn.xwiki.objects.ListProperty;
 import com.xpn.xwiki.objects.StringListProperty;
 import com.xpn.xwiki.objects.StringProperty;
@@ -245,6 +246,22 @@ public abstract class ListClass extends PropertyClass
     public void setPicker(boolean picker)
     {
         setIntValue("picker", picker ? 1 : 0);
+    }
+
+    /**
+     * @since 11.5RC1
+     */
+    public boolean isAllowingCustomValues()
+    {
+        return (getIntValue("allowCustomValues") == 1);
+    }
+
+    /**
+     * @since 11.5RC1
+     */
+    public void setAllowCustomValues(boolean acceptCustomValues)
+    {
+        setIntValue("allowCustomValues", acceptCustomValues ? 1 : 0);
     }
 
     /**
@@ -471,6 +488,9 @@ public abstract class ListClass extends PropertyClass
             lprop = new DBStringListProperty();
         } else if (isMultiSelect()) {
             lprop = new StringListProperty();
+        // If we allow custom values, they might use a lot of space in DB, so better to put them in a LargeString.
+        } else if (isAllowingCustomValues()) {
+            lprop = new LargeStringProperty();
         } else {
             lprop = new StringProperty();
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
@@ -265,6 +265,22 @@ public abstract class ListClass extends PropertyClass
     }
 
     /**
+     * @since 11.5RC1
+     */
+    public boolean isLargeStorage()
+    {
+        return (getIntValue("largeStorage") == 1);
+    }
+
+    /**
+     * @since 11.5RC1
+     */
+    public void setLargeStorage(boolean largeStorage)
+    {
+        setIntValue("largeStorage", largeStorage ? 1 : 0);
+    }
+
+    /**
      * @return a string (usually just 1 character long) used to join this list's items when displaying it in the UI in
      *         view mode.
      * @see #displayView(StringBuffer, String, String, BaseCollection, XWikiContext)
@@ -489,7 +505,7 @@ public abstract class ListClass extends PropertyClass
         } else if (isMultiSelect()) {
             lprop = new StringListProperty();
         // If we allow custom values, they might use a lot of space in DB, so better to put them in a LargeString.
-        } else if (isAllowingCustomValues()) {
+        } else if (isLargeStorage()) {
             lprop = new LargeStringProperty();
         } else {
             lprop = new StringProperty();

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
@@ -251,22 +251,6 @@ public abstract class ListClass extends PropertyClass
     /**
      * @since 11.5RC1
      */
-    public boolean isAllowingCustomValues()
-    {
-        return (getIntValue("allowCustomValues") == 1);
-    }
-
-    /**
-     * @since 11.5RC1
-     */
-    public void setAllowCustomValues(boolean acceptCustomValues)
-    {
-        setIntValue("allowCustomValues", acceptCustomValues ? 1 : 0);
-    }
-
-    /**
-     * @since 11.5RC1
-     */
     public boolean isLargeStorage()
     {
         return (getIntValue("largeStorage") == 1);
@@ -504,7 +488,6 @@ public abstract class ListClass extends PropertyClass
             lprop = new DBStringListProperty();
         } else if (isMultiSelect()) {
             lprop = new StringListProperty();
-        // If we allow custom values, they might use a lot of space in DB, so better to put them in a LargeString.
         } else if (isLargeStorage()) {
             lprop = new LargeStringProperty();
         } else {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/meta/ListMetaClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/meta/ListMetaClass.java
@@ -67,15 +67,9 @@ public class ListMetaClass extends PropertyMetaClass
         displayTypeClass.setValues("input|select|radio|checkbox");
         safeput(displayTypeClass.getName(), displayTypeClass);
 
-        BooleanClass multiSelectClass = newCheckBox(false);
-        multiSelectClass.setName("multiSelect");
-        multiSelectClass.setPrettyName("Multiple Select");
-        safeput(multiSelectClass.getName(), multiSelectClass);
-
-        BooleanClass pickerClass = newCheckBox(true);
-        pickerClass.setName("picker");
-        pickerClass.setPrettyName("Use Suggest");
-        safeput(pickerClass.getName(), pickerClass);
+        addBooleanProperty("multiSelect", "Multiple Select", false);
+        addBooleanProperty("picker", "Use Suggest", true);
+        addBooleanProperty("allowCustomValues", "Allow Custom Values", false);
 
         NumberClass sizeClass = new NumberClass(this);
         sizeClass.setName("size");
@@ -131,5 +125,13 @@ public class ListMetaClass extends PropertyMetaClass
         checkBox.setDisplayFormType("checkbox");
         checkBox.setDefaultValue(checked ? 1 : 0);
         return checkBox;
+    }
+
+    private void addBooleanProperty(String name, String prettyName, boolean defaultValue)
+    {
+        BooleanClass booleanClass = newCheckBox(defaultValue);
+        booleanClass.setName(name);
+        booleanClass.setPrettyName(prettyName);
+        safeput(booleanClass.getName(), booleanClass);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/meta/ListMetaClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/meta/ListMetaClass.java
@@ -70,6 +70,7 @@ public class ListMetaClass extends PropertyMetaClass
         addBooleanProperty("multiSelect", "Multiple Select", false);
         addBooleanProperty("picker", "Use Suggest", true);
         addBooleanProperty("allowCustomValues", "Allow Custom Values", false);
+        addBooleanProperty("largeStorage", "Allow large strings", false);
 
         NumberClass sizeClass = new NumberClass(this);
         sizeClass.setName("size");

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/meta/ListMetaClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/meta/ListMetaClass.java
@@ -69,7 +69,6 @@ public class ListMetaClass extends PropertyMetaClass
 
         addBooleanProperty("multiSelect", "Multiple Select", false);
         addBooleanProperty("picker", "Use Suggest", true);
-        addBooleanProperty("allowCustomValues", "Allow Custom Values", false);
         addBooleanProperty("largeStorage", "Allow large strings", false);
 
         NumberClass sizeClass = new NumberClass(this);

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-model/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-model/pom.xml
@@ -35,8 +35,8 @@
       The jacoco instruction ratio precision is higher here because the jaxb2 plugin generates classes
       that are not excluded in the analysis.
     -->
-    <xwiki.jacoco.instructionRatio>0.0290</xwiki.jacoco.instructionRatio>
-    <xwiki.pitest.mutationThreshold>1</xwiki.pitest.mutationThreshold>
+    <xwiki.jacoco.instructionRatio>0.03</xwiki.jacoco.instructionRatio>
+    <xwiki.pitest.mutationThreshold>2</xwiki.pitest.mutationThreshold>
   </properties>
   <dependencies>
     <!-- Test dependencies. -->
@@ -45,6 +45,10 @@
       <artifactId>xwiki-commons-tool-test-component</artifactId>
       <version>${commons.version}</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
   </dependencies>
   <build>

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-model/src/main/java/org/xwiki/rest/model/jaxb/PropertyValue.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-model/src/main/java/org/xwiki/rest/model/jaxb/PropertyValue.java
@@ -27,6 +27,9 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
 /**
  * Holds the value of a class property and its associated meta data (e.g. label, icon, count).
  * <p>
@@ -102,26 +105,31 @@ public class PropertyValue
     }
 
     @Override
-    public boolean equals(java.lang.Object o)
+    public boolean equals(java.lang.Object object)
     {
-        if (o instanceof PropertyValue) {
-            PropertyValue other = (PropertyValue) o;
-
-            boolean equals;
-            if (this.getMetaData() != null) {
-                equals = this.getMetaData().equals(other.getMetaData());
-            } else {
-                equals = other.getMetaData() == null;
-            }
-
-            if (this.getValue() != null) {
-                equals &= this.getValue().equals(other.getValue());
-            } else {
-                equals &= other.getValue() == null;
-            }
-            return equals;
+        if (object == null) {
+            return false;
         }
-        return false;
+        if (object == this) {
+            return true;
+        }
+        if (object.getClass() != getClass()) {
+            return false;
+        }
+        PropertyValue other = (PropertyValue) object;
+        return new EqualsBuilder()
+            .append(getMetaData(), other.getMetaData())
+            .append(getValue(), other.getValue())
+            .isEquals();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return new HashCodeBuilder(3, 17)
+            .append(getMetaData())
+            .append(getValue())
+            .toHashCode();
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-model/src/main/java/org/xwiki/rest/model/jaxb/PropertyValue.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-model/src/main/java/org/xwiki/rest/model/jaxb/PropertyValue.java
@@ -100,4 +100,44 @@ public class PropertyValue
     {
         this.metaData = value;
     }
+
+    @Override
+    public boolean equals(java.lang.Object o)
+    {
+        if (o instanceof PropertyValue) {
+            PropertyValue other = (PropertyValue) o;
+
+            boolean equals;
+            if (this.getMetaData() != null) {
+                equals = this.getMetaData().equals(other.getMetaData());
+            } else {
+                equals = other.getMetaData() == null;
+            }
+
+            if (this.getValue() != null) {
+                equals &= this.getValue().equals(other.getValue());
+            } else {
+                equals &= other.getValue() == null;
+            }
+            return equals;
+        }
+        return false;
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder builder = new StringBuilder("PropertyValue[");
+        if (metaData != null) {
+            builder.append("metadata=");
+            builder.append(metaData.toString());
+            builder.append(",");
+        }
+        if (value != null) {
+            builder.append("value=");
+            builder.append(value.toString());
+        }
+        builder.append("]");
+        return builder.toString();
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-model/src/test/java/org/xwiki/rest/model/jaxb/PropertyValueTest.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-model/src/test/java/org/xwiki/rest/model/jaxb/PropertyValueTest.java
@@ -1,0 +1,64 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rest.model.jaxb;
+
+import java.util.HashMap;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * Test for {@link PropertyValue}.
+ */
+public class PropertyValueTest
+{
+    @Test
+    public void equals()
+    {
+        assertEquals(new PropertyValue(), new PropertyValue());
+
+        PropertyValue p1, p2;
+        p1 = new PropertyValue();
+        p2 = new PropertyValue();
+
+        p1.setValue("a string value");
+        assertNotEquals(p1, p2);
+        p2.setValue("a string value");
+        assertEquals(p1, p2);
+
+        java.util.Map<String, java.lang.Object> metadata1, metadata2;
+        metadata1 = new HashMap<>();
+        p1.setMetaData(metadata1);
+        metadata2 = new HashMap<>();
+        p2.setMetaData(metadata2);
+
+        assertEquals(p1, p2);
+        metadata1.put("somekey", true);
+        assertNotEquals(p1, p2);
+        metadata2.put("anotherkey", false);
+        assertNotEquals(p1, p2);
+
+        metadata1.put("anotherkey", false);
+        metadata2.put("somekey", true);
+        assertEquals(p1, p2);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/StaticListClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/StaticListClassPropertyValuesProvider.java
@@ -54,7 +54,7 @@ public class StaticListClassPropertyValuesProvider extends AbstractListClassProp
         final PropertyValues result = new PropertyValues();
         List<String> allValues = StaticListClass.getListFromString(propertyDefinition.getValues());
 
-        allValues.stream().filter(s -> s.contains(filter)).limit(limit)
+        allValues.stream().filter(s -> s.toLowerCase().contains(filter.toLowerCase())).limit(limit)
             .forEach(item -> result.withPropertyValues(new PropertyValue(item)));
         return result;
     }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/StaticListClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/StaticListClassPropertyValuesProvider.java
@@ -1,0 +1,61 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rest.internal.resources.classes;
+
+import java.util.List;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.rest.model.jaxb.PropertyValue;
+import org.xwiki.rest.model.jaxb.PropertyValues;
+
+import com.xpn.xwiki.objects.classes.StaticListClass;
+
+/**
+ * Provides values for Static List properties.
+ *
+ * @version $Id$
+ * @since 11.5RC1
+ */
+@Component
+@Named("StaticList")
+@Singleton
+public class StaticListClassPropertyValuesProvider extends AbstractListClassPropertyValuesProvider<StaticListClass>
+{
+    @Override
+    protected Class<StaticListClass> getPropertyType()
+    {
+        return StaticListClass.class;
+    }
+
+    @Override
+    protected PropertyValues getAllowedValues(StaticListClass propertyDefinition, int limit, String filter)
+        throws Exception
+    {
+        final PropertyValues result = new PropertyValues();
+        List<String> allValues = StaticListClass.getListFromString(propertyDefinition.getValues());
+
+        allValues.stream().filter(s -> s.contains(filter)).limit(limit)
+            .forEach(item -> result.withPropertyValues(new PropertyValue(item)));
+        return result;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/resources/META-INF/components.txt
@@ -57,6 +57,7 @@ org.xwiki.rest.internal.resources.classes.DBListClassPropertyValuesProvider
 org.xwiki.rest.internal.resources.classes.DefaultClassPropertyValuesProvider
 org.xwiki.rest.internal.resources.classes.GroupsClassPropertyValuesProvider
 org.xwiki.rest.internal.resources.classes.PageClassPropertyValuesProvider
+org.xwiki.rest.internal.resources.classes.StaticListClassPropertyValuesProvider
 org.xwiki.rest.internal.resources.classes.UsersClassPropertyValuesProvider
 org.xwiki.rest.internal.resources.search.HQLSearchSource
 org.xwiki.rest.internal.resources.search.XWQLSearchSource

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/StaticListClassPropertyValuesProviderTest.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/StaticListClassPropertyValuesProviderTest.java
@@ -1,0 +1,80 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rest.internal.resources.classes;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.rest.model.jaxb.PropertyValue;
+import org.xwiki.rest.model.jaxb.PropertyValues;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+
+import com.xpn.xwiki.objects.classes.StaticListClass;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Test for {@link StaticListClassPropertyValuesProvider}.
+ *
+ * @since 11.5RC1
+ * @version $Id$
+ */
+@ComponentTest
+public class StaticListClassPropertyValuesProviderTest
+{
+    @InjectMockComponents
+    private StaticListClassPropertyValuesProvider staticListClassPropertyValuesProvider;
+
+    @Test
+    public void getAllowedValues() throws Exception
+    {
+        StaticListClass staticListClass = new StaticListClass();
+        staticListClass.setValues("Foo|Bar|Toto|Tata|Foobar");
+        PropertyValues allowedValues = staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 1, "f");
+        assertEquals(Collections.singletonList(new PropertyValue("Foo")), allowedValues.getPropertyValues());
+
+        allowedValues = staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 2, "f");
+        assertEquals(Arrays.asList(new PropertyValue("Foo"), new PropertyValue("Foobar")),
+            allowedValues.getPropertyValues());
+
+        allowedValues = staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 1, "");
+        assertEquals(Collections.singletonList(new PropertyValue("Foo")),
+            allowedValues.getPropertyValues());
+
+        allowedValues = staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 5, "");
+        assertEquals(Arrays.asList(new PropertyValue("Foo"), new PropertyValue("Bar"), new PropertyValue("Toto"),
+            new PropertyValue("Tata"), new PropertyValue("Foobar")),
+            allowedValues.getPropertyValues());
+
+        allowedValues = staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 2, "foobar");
+        assertEquals(Collections.singletonList(new PropertyValue("Foobar")),
+            allowedValues.getPropertyValues());
+
+        allowedValues = staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 1, "baz");
+        assertEquals(Collections.emptyList(),
+            allowedValues.getPropertyValues());
+
+        allowedValues = staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 3, "o");
+        assertEquals(Arrays.asList(new PropertyValue("Foo"), new PropertyValue("Toto"), new PropertyValue("Foobar")),
+            allowedValues.getPropertyValues());
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/displayer_staticlist.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/displayer_staticlist.vm
@@ -1,0 +1,18 @@
+#if ($type == 'edit')
+    #if ($field.getProperty('displayType').value == 'input' && $field.getProperty('picker').value == 1
+    && $field.getProperty('allowCustomValues').value == 1)
+        #xpropertySuggestInputDisplayer($field $prefix $name $value)
+    #else
+        $doc.displayEdit($field, $prefix, $object)
+    #end
+#elseif ($type == 'view')
+    $doc.displayView($field, $prefix, $object)##
+#elseif ($type == 'rendered')
+    $doc.displayRendered($field, $prefix, $object)##
+#elseif ($type == 'hidden')
+    $doc.displayHidden($field, $prefix, $object)
+#else
+## In order for the custom displayer to be taken into account, the result of its evaluation with an unknown display
+## mode must not be empty. Let's output something.
+Unknown display mode.
+#end

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/displayer_staticlist.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/displayer_staticlist.vm
@@ -1,6 +1,5 @@
 #if ($type == 'edit')
-    #if ($field.getProperty('displayType').value == 'input' && $field.getProperty('picker').value == 1
-    && $field.getProperty('allowCustomValues').value == 1)
+    #if ($field.getProperty('displayType').value == 'input' && $field.getProperty('picker').value == 1)
         #xpropertySuggestInputDisplayer($field $prefix $name $value)
     #else
         $doc.displayEdit($field, $prefix, $object)


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XWIKI-16412
It also fixes
https://jira.xwiki.org/browse/XWIKI-16411

## Solution

  * Create the dedicated PropertyValuesProvider in rest-server to reuse
the mechanism already existing for picking a value
  * Create the dedicated displayer_staticlist.vm for it.