### PR TITLE
XWIKI-13365: Scripts are allowed in Comment previews

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/viewers/comments.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/viewers/comments.js
@@ -284,7 +284,7 @@ viewers.Comments = Class.create({
          var notification = new XWiki.widgets.Notification("$services.localization.render('core.viewers.comments.preview.inProgress')", "inprogress");
          new Ajax.Request(previewURL, {
             method : 'post',
-            parameters : {'xpage' : 'plain', 'sheet' : '', 'content' : form.commentElt.value, 'form_token': form.form_token.value},
+            parameters : {'xpage' : 'plain', 'sheet' : '', 'content' : form.commentElt.value, 'form_token': form.form_token.value, 'raw': '3'},
             onSuccess : function (response) {
               this.doPreview(response.responseText, form);
               notification.hide();

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/plain.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/plain.vm
@@ -3,6 +3,9 @@
 #elseif ("$!request.getParameter('raw')" == '2')
 $response.setContentType('text/plain')##
 $cdoc.getTranslatedContent()
+#elseif ("$!request.getParameter('raw')" == '3')
+$response.setContentType('text/plain')##
+$cdoc.getRenderedContentRestricted($cdoc.getContent(), $cdoc.getSyntax().toIdString())
 #else
 #template('xwikivars.vm')
 #template('displaycontent.vm')


### PR DESCRIPTION
## Issue

https://jira.xwiki.org/browse/XWIKI-13365

## Solution

The template `plain.vm` is currently use to display previewed comment, since we are using a plain parameter. And right now `plain.vm` can use two values for the raw parameters documented in https://www.xwiki.org/xwiki/bin/view/Documentation/DevGuide/Architecture/URL%20Architecture/Standard%20URL%20Format/:
> raw=1: Returns the page source as is without any formatting but XML-escaped
> raw=2: Returns the page source as is without any formatting (without any escaping)

In order to be able to render a content page in a restricted mode, I propose to add a new value, `raw=3` which would execute the content in restricted mode, and to call the preview of comments with this parameter.

I tested locally the solution and it seems to work well.