### PR TITLE
XWIKI-16607 : The package xwiki-tomcat9-common fails to install on Debian Bullseye

### DIFF
--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-tomcat/xwiki-platform-distribution-debian-tomcat9-common/src/deb/control/postinst
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-tomcat/xwiki-platform-distribution-debian-tomcat9-common/src/deb/control/postinst
@@ -8,7 +8,7 @@ set -e
 #########################
 
 ## Make sure tomcat is able to write in the data folder
-chown -R tomcat9.tomcat9 /var/lib/xwiki/data
+chown -R tomcat.tomcat /var/lib/xwiki/data
 
 #########################
 # Configuration
@@ -22,7 +22,7 @@ chown -R tomcat9.tomcat9 /var/lib/xwiki/data
 
 invoke-rc.d --quiet tomcat9 restart || {
     RESULT=$?
-    # Ignore if tomcat8 init script does not exist (yet)
+    # Ignore if tomcat9 init script does not exist (yet)
     if [ $RESULT != 100 ]; then
     exit $RESULT
     fi


### PR DESCRIPTION
* Update the user used when giving permissions in /var/lib/xwiki/data