### PR TITLE
XWIKI-16644: Symbolic link from etc/xwiki/xwiki-locales.txt to /usr/l…

### DIFF
--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-common/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-common/pom.xml
@@ -309,6 +309,12 @@
               <linkName>/usr/lib/xwiki/WEB-INF/xwiki.properties</linkName>
               <linkTarget>/etc/xwiki/xwiki.properties</linkTarget>
             </data>
+            <data>
+              <type>link</type>
+              <symlink>true</symlink>
+              <linkName>/usr/lib/xwiki/WEB-INF/xwiki-locales.txt</linkName>
+              <linkTarget>/etc/xwiki/xwiki-locales.txt</linkTarget>
+            </data>
           </dataSet>
         </configuration>
       </plugin>


### PR DESCRIPTION
…ib/xwiki/WEB-INF is missing

add file to symlink config section