### PR TITLE
XWIKI-12098: The icons used to display Annotations use Silk instead o…

### DIFF
--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Macros.xml
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Macros.xml
@@ -248,12 +248,15 @@
  * @param $docRef the reference of the annotated document
  *#
 #macro(displayAnnotationToolboxFromReference $ann $mode $docRef)
-  &lt;span class="annotationTools"&gt;
+  &lt;span class="annotationTools btn-group"&gt;
     #if($mode != 'create' &amp;&amp; $services.annotations.canEditAnnotation($ann.id, $docRef))
       #set($isUserComment = $services.model.resolveDocument("$!ann.get('author')", 'user') == $xcontext.userReference)
       #set($editURL = "${services.rest.url($docRef)}/annotation/${escapetool.url($ann.id)}?method=PUT&amp;media=json")
       #if ("$!{ann.state}" == 'UPDATED')
-        &lt;span class="tool accept"&gt;&lt;a class="validate" href="${editURL}" title="$services.localization.render('annotations.action.validate.tooltip')"&gt;$services.localization.render('annotations.action.validate.text')&lt;/a&gt;&lt;/span&gt;
+        &lt;a class='btn btn-default btn-xs validate' href="${editURL}"
+          title="$services.localization.render('annotations.action.validate.tooltip')"&gt;
+          $services.icon.renderHTML('check')
+        &lt;/a&gt;
       #end
       #if ($mode != 'edit')
         ## Comment reply button only for default annotations.
@@ -263,16 +266,25 @@
             #set($xredirect = "$xwiki.getURL($docRef, 'view', $!{request.queryString})")
           #end
           ## add "comment reply" button
-          &lt;span class="tool annotationReply"&gt;&lt;a class="reply" href="${xredirect}#xwikicomment_${ann.id}" title="$services.localization.render('core.viewers.comments.reply')"&gt;$services.localization.render('core.viewers.comments.reply')&lt;/a&gt;&lt;/span&gt;
+          &lt;a class='btn btn-default btn-xs' href="${xredirect}#xwikicomment_${ann.id}"
+            title="$services.localization.render('core.viewers.comments.reply')"&gt;
+            $services.icon.renderHTML('comment')
+          &lt;/a&gt;
         #end
         #if($hasAdmin || $isUserComment)
           ## use an edit url just for the fanciness of it, it won't really be used in this case. An edit form will be loaded
-          &lt;span class="tool annotationEdit"&gt;&lt;a class="edit" href="${editURL}" title="$services.localization.render('annotations.action.edit.tooltip')"&gt;$services.localization.render('annotations.action.edit.text')&lt;/a&gt;&lt;/span&gt;
+          &lt;a class='edit btn btn-default btn-xs' href="${editURL}"
+            title="$services.localization.render('annotations.action.edit.tooltip')"&gt;
+            $services.icon.renderHTML('pencil')
+          &lt;/a&gt;
         #end
       #end
       #if($hasAdmin || $isUserComment)
         #set($deleteURL = "${services.rest.url($docRef)}/annotation/${escapetool.url($ann.id)}?method=DELETE&amp;media=json")
-        &lt;span class="tool delete"&gt;&lt;a class="delete" href="${deleteURL}" title="$services.localization.render('annotations.action.delete.tooltip')"&gt;$services.localization.render('annotations.action.delete.text')&lt;/a&gt;&lt;/span&gt;
+        &lt;a class='delete btn btn-default btn-xs' href="${deleteURL}"
+          title="$services.localization.render('annotations.action.delete.tooltip')"&gt;
+          $services.icon.renderHTML('cross')
+        &lt;/a&gt;
       #end
     #end
   &lt;/span&gt;

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Style.xml
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Style.xml
@@ -402,29 +402,6 @@
   float: right;
   margin-top: -1.2em;
 }
-.annotationTools a {
-  background: transparent none no-repeat left top;
-  display: block;
-  float: left;
-  height: 16px;
-  margin:0 0 0 4px;
-  overflow: hidden;
-  text-indent: -9999px;
-  width: 16px;
-}
-.annotationTools .reply {
-  background-image: #imgURL('comments_add');
-  padding-left: 0px;
-}
-.annotationTools .edit {
-  background-image: #imgURL('pencil');
-}
-.annotationTools .delete {
-  background-image: #imgURL('cross');
-}
-.annotationTools .validate {
-  background-image: #imgURL('tick');
-}
 
 .annotationComment {
   padding: 4px 0;


### PR DESCRIPTION
…f the Icon Theme Application

* changed the icons from toolbar to look like the ones from comments
* indented the code to fit in 120 characters

The toolbar looks now like the comments one,both in the annotations tab and the popover:
![annotate](https://user-images.githubusercontent.com/22794181/62705609-62ab5600-b9f6-11e9-99a6-ec417064adcd.png)
