### PR TITLE
XWIKI-16147: Livetable suggest input field has no title

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/suggest/xwiki.selectize.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/suggest/xwiki.selectize.js
@@ -206,7 +206,7 @@ define('xwiki-selectize', ['jquery', 'selectize', 'xwiki-events-bridge'], functi
       this.selectize['$control'].width($(this).data('initialWidth'));
     }
     // Set the title of the input field.
-    this.selectize.$control_input.attr('title', $(this).attr('title'));
+    this.selectize['$control_input'].attr('title', $(this).attr('title'));
   };
 
   var setDropDownAlignment = function(selectize) {


### PR DESCRIPTION
* the way $control_input was accessed caused problems in velocity parsing, leading to test errors