### PR TITLE
XWIKI-16663: Computed field values should be available in REST representations

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/ModelFactory.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/ModelFactory.java
@@ -958,8 +958,8 @@ public class ModelFactory
     }
 
     /**
-     * Serializes the value of the given XObject property. Returns an empty string for ComputedFieldClass properties.
-     * 
+     * Serializes the value of the given XObject property. ComputedField properties are not evaluated.
+     *
      * @param property an XObject property
      * @return the String representation of the property value
      */
@@ -993,9 +993,12 @@ public class ModelFactory
         if (propertyClass instanceof ComputedFieldClass) {
             // TODO: the XWikiDocument needs to be explicitely set in the context, otherwise method
             // PropertyClass.renderInContext fires a null pointer exception: bug?
+            XWikiDocument document = context.getDoc();
             context.setDoc(property.getObject().getOwnerDocument());
             ComputedFieldClass computedFieldClass = (ComputedFieldClass) propertyClass;
             String value = computedFieldClass.displayView(propertyClass.getName(), property.getObject(), context);
+            // Reset the context document to its original value.
+            context.setDoc(document);
             return value;
         } else {
             return serializePropertyValue(property);

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/ModelFactory.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/ModelFactory.java
@@ -958,7 +958,7 @@ public class ModelFactory
     }
 
     /**
-     * Serializes the value of the given XObject property. ComputedField properties are not evaluated.
+     * Serializes the value of the given XObject property. {@link ComputedFieldClass} properties are not evaluated.
      *
      * @param property an XObject property
      * @return the String representation of the property value
@@ -980,8 +980,8 @@ public class ModelFactory
     }
 
     /**
-     * Serializes the value of the given XObject property. In case the property is a ComputedFieldClass, the serialized
-     * value is the computed property value.
+     * Serializes the value of the given XObject property. In case the property is an instance of
+     * {@link ComputedFieldClass}, the serialized value is the computed property value.
      * @param property an XObject property
      * @param propertyClass the PropertyClass of that XObject proprety
      * @param context the XWikiContext


### PR DESCRIPTION
This pull request introduces method `serializePropertyValue(PropertyInterface property,PropertyClass propertyClass,  XWikiContext context)` in ModelFactory so that ComputedFieldClass  properties get their value evaluated when represented.