### PR TITLE
XWIKI-16663: Computed field values should be available in REST representations

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ComputedFieldClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ComputedFieldClass.java
@@ -93,6 +93,7 @@ public class ComputedFieldClass extends PropertyClass
 
     /**
      * Computes and returns the raw value of this property for a given object.
+     *
      * @param name property name
      * @param prefix prefix to be added
      * @param object object for which the property value has to get computed
@@ -105,16 +106,16 @@ public class ComputedFieldClass extends PropertyClass
     {
         String script = getScript();
 
-            ScriptContext scontext = Utils.getComponent(ScriptContextManager.class).getCurrentScriptContext();
-            scontext.setAttribute("name", name, ScriptContext.ENGINE_SCOPE);
-            scontext.setAttribute("prefix", prefix, ScriptContext.ENGINE_SCOPE);
-            scontext.setAttribute("object", new com.xpn.xwiki.api.Object((BaseObject) object, context),
-                    ScriptContext.ENGINE_SCOPE);
+        ScriptContext scontext = Utils.getComponent(ScriptContextManager.class).getCurrentScriptContext();
+        scontext.setAttribute("name", name, ScriptContext.ENGINE_SCOPE);
+        scontext.setAttribute("prefix", prefix, ScriptContext.ENGINE_SCOPE);
+        scontext.setAttribute("object", new com.xpn.xwiki.api.Object((BaseObject) object, context),
+                ScriptContext.ENGINE_SCOPE);
 
-            XWikiDocument classDocument = object.getXClass(context).getOwnerDocument();
+        XWikiDocument classDocument = object.getXClass(context).getOwnerDocument();
 
-            return renderContentInContext(script, classDocument.getSyntax().toIdString(),
-                    classDocument.getAuthorReference(), classDocument.getDocumentReference(), context);
+        return renderContentInContext(script, classDocument.getSyntax().toIdString(),
+                classDocument.getAuthorReference(), classDocument.getDocumentReference(), context);
     }
 
     @Override
@@ -133,7 +134,7 @@ public class ComputedFieldClass extends PropertyClass
 
     @Override
     public void displayView(StringBuffer buffer, String name, String prefix, BaseCollection object,
-        XWikiContext context)
+            XWikiContext context)
     {
         try {
             buffer.append(getComputedValue(name, prefix, object, context));
@@ -145,14 +146,14 @@ public class ComputedFieldClass extends PropertyClass
 
     @Override
     public void displayEdit(StringBuffer buffer, String name, String prefix, BaseCollection object,
-        XWikiContext context)
+            XWikiContext context)
     {
         displayView(buffer, name, prefix, object, context);
     }
 
     @Override
     public void displayHidden(StringBuffer buffer, String name, String prefix, BaseCollection object,
-        XWikiContext context)
+            XWikiContext context)
     {
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ComputedFieldClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ComputedFieldClass.java
@@ -90,6 +90,47 @@ public class ComputedFieldClass extends PropertyClass
         return sValue;
     }
 
+    /**
+     * Computes and returns the raw value of this property for a given object.
+     * @param name property name
+     * @param prefix prefix to be added
+     * @param object object for which the property value has to get computed
+     * @param context current context
+     * @return the computed property value
+     */
+    public String getComputedValue(String name, String prefix, BaseCollection object, XWikiContext context) {
+        String script = getScript();
+
+        try {
+            ScriptContext scontext = Utils.getComponent(ScriptContextManager.class).getCurrentScriptContext();
+            scontext.setAttribute("name", name, ScriptContext.ENGINE_SCOPE);
+            scontext.setAttribute("prefix", prefix, ScriptContext.ENGINE_SCOPE);
+            scontext.setAttribute("object", new com.xpn.xwiki.api.Object((BaseObject) object, context),
+                    ScriptContext.ENGINE_SCOPE);
+
+            XWikiDocument classDocument = object.getXClass(context).getOwnerDocument();
+
+            return renderContentInContext(script, classDocument.getSyntax().toIdString(),
+                    classDocument.getAuthorReference(), classDocument.getDocumentReference(), context);
+
+        } catch (Exception e) {
+            return e.getMessage();
+        }
+    }
+
+    /**
+     * Appends the raw computed property value of this object to the passed buffer.
+     * @param buffer buffer to which the property value has to get appended
+     * @param name property name
+     * @param prefix prefix to be added
+     * @param object object for which the property value has to get computed
+     * @param context current context
+     */
+    public void getComputedValue(StringBuffer buffer, String name, String prefix, BaseCollection object,
+            XWikiContext context) {
+        buffer.append(getComputedValue(name, prefix, object, context));
+    }
+
     @Override
     public BaseProperty fromString(String value)
     {
@@ -108,25 +149,7 @@ public class ComputedFieldClass extends PropertyClass
     public void displayView(StringBuffer buffer, String name, String prefix, BaseCollection object,
         XWikiContext context)
     {
-        String script = getScript();
-
-        try {
-            ScriptContext scontext = Utils.getComponent(ScriptContextManager.class).getCurrentScriptContext();
-            scontext.setAttribute("name", name, ScriptContext.ENGINE_SCOPE);
-            scontext.setAttribute("prefix", prefix, ScriptContext.ENGINE_SCOPE);
-            scontext.setAttribute("object", new com.xpn.xwiki.api.Object((BaseObject) object, context),
-                ScriptContext.ENGINE_SCOPE);
-
-            XWikiDocument classDocument = object.getXClass(context).getOwnerDocument();
-
-            String result = renderContentInContext(script, classDocument.getSyntax().toIdString(),
-                classDocument.getAuthorReference(), classDocument.getDocumentReference(), context);
-
-            buffer.append(result);
-        } catch (Exception e) {
-            // TODO: append a rendering style complete error instead
-            buffer.append(e.getMessage());
-        }
+        buffer.append(getComputedValue(name, prefix, object, context));
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ComputedFieldClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ComputedFieldClass.java
@@ -24,6 +24,7 @@ import javax.script.ScriptContext;
 import org.xwiki.script.ScriptContextManager;
 
 import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.objects.BaseCollection;
 import com.xpn.xwiki.objects.BaseObject;
@@ -99,11 +100,11 @@ public class ComputedFieldClass extends PropertyClass
      * @return the computed property value
      * @since 11.8
      */
-    public String getComputedValue(String name, String prefix, BaseCollection object, XWikiContext context)
+    public String getComputedValue(String name, String prefix, BaseCollection object, XWikiContext context) throws
+            Exception
     {
         String script = getScript();
 
-        try {
             ScriptContext scontext = Utils.getComponent(ScriptContextManager.class).getCurrentScriptContext();
             scontext.setAttribute("name", name, ScriptContext.ENGINE_SCOPE);
             scontext.setAttribute("prefix", prefix, ScriptContext.ENGINE_SCOPE);
@@ -114,11 +115,6 @@ public class ComputedFieldClass extends PropertyClass
 
             return renderContentInContext(script, classDocument.getSyntax().toIdString(),
                     classDocument.getAuthorReference(), classDocument.getDocumentReference(), context);
-
-        } catch (Exception e) {
-            // TODO: append a rendering style complete error instead
-            return e.getMessage();
-        }
     }
 
     @Override
@@ -139,7 +135,12 @@ public class ComputedFieldClass extends PropertyClass
     public void displayView(StringBuffer buffer, String name, String prefix, BaseCollection object,
         XWikiContext context)
     {
-        buffer.append(getComputedValue(name, prefix, object, context));
+        try {
+            buffer.append(getComputedValue(name, prefix, object, context));
+        } catch (Exception e) {
+            // TODO: append a rendering style complete error instead
+            buffer.append(e.getMessage());
+        }
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ComputedFieldClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ComputedFieldClass.java
@@ -97,6 +97,7 @@ public class ComputedFieldClass extends PropertyClass
      * @param object object for which the property value has to get computed
      * @param context current context
      * @return the computed property value
+     * @since 11.8
      */
     public String getComputedValue(String name, String prefix, BaseCollection object, XWikiContext context) {
         String script = getScript();
@@ -114,21 +115,9 @@ public class ComputedFieldClass extends PropertyClass
                     classDocument.getAuthorReference(), classDocument.getDocumentReference(), context);
 
         } catch (Exception e) {
+            // TODO: append a rendering style complete error instead
             return e.getMessage();
         }
-    }
-
-    /**
-     * Appends the raw computed property value of this object to the passed buffer.
-     * @param buffer buffer to which the property value has to get appended
-     * @param name property name
-     * @param prefix prefix to be added
-     * @param object object for which the property value has to get computed
-     * @param context current context
-     */
-    public void getComputedValue(StringBuffer buffer, String name, String prefix, BaseCollection object,
-            XWikiContext context) {
-        buffer.append(getComputedValue(name, prefix, object, context));
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ComputedFieldClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ComputedFieldClass.java
@@ -99,7 +99,8 @@ public class ComputedFieldClass extends PropertyClass
      * @return the computed property value
      * @since 11.8
      */
-    public String getComputedValue(String name, String prefix, BaseCollection object, XWikiContext context) {
+    public String getComputedValue(String name, String prefix, BaseCollection object, XWikiContext context)
+    {
         String script = getScript();
 
         try {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ComputedFieldClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ComputedFieldClass.java
@@ -99,7 +99,7 @@ public class ComputedFieldClass extends PropertyClass
      * @param object object for which the property value has to get computed
      * @param context current context
      * @return the computed property value
-     * @since 11.8
+     * @since 11.8RC1
      */
     public String getComputedValue(String name, String prefix, BaseCollection object, XWikiContext context) throws
             Exception
@@ -134,7 +134,7 @@ public class ComputedFieldClass extends PropertyClass
 
     @Override
     public void displayView(StringBuffer buffer, String name, String prefix, BaseCollection object,
-            XWikiContext context)
+        XWikiContext context)
     {
         try {
             buffer.append(getComputedValue(name, prefix, object, context));
@@ -146,14 +146,14 @@ public class ComputedFieldClass extends PropertyClass
 
     @Override
     public void displayEdit(StringBuffer buffer, String name, String prefix, BaseCollection object,
-            XWikiContext context)
+        XWikiContext context)
     {
         displayView(buffer, name, prefix, object, context);
     }
 
     @Override
     public void displayHidden(StringBuffer buffer, String name, String prefix, BaseCollection object,
-            XWikiContext context)
+        XWikiContext context)
     {
     }
 }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/ModelFactory.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/ModelFactory.java
@@ -992,7 +992,7 @@ public class ModelFactory
     {
         if (propertyClass instanceof ComputedFieldClass) {
             // TODO: the XWikiDocument needs to be explicitely set in the context, otherwise method
-            // PropertyClass.renderInContext fires a null pointer exception: bug?
+            //  PropertyClass.renderInContext fires a null pointer exception: bug?
             XWikiDocument document = context.getDoc();
             context.setDoc(property.getObject().getOwnerDocument());
             ComputedFieldClass computedFieldClass = (ComputedFieldClass) propertyClass;

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/ModelFactory.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/ModelFactory.java
@@ -128,7 +128,7 @@ import com.xpn.xwiki.objects.classes.ListClass;
 
 /**
  * Various common tools for resources.
- *
+ * 
  * @version $Id$
  * @since 7.3M1
  */

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/ModelFactory.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/ModelFactory.java
@@ -128,7 +128,7 @@ import com.xpn.xwiki.objects.classes.ListClass;
 
 /**
  * Various common tools for resources.
- * 
+ *
  * @version $Id$
  * @since 7.3M1
  */
@@ -987,7 +987,7 @@ public class ModelFactory
      * @param context the XWikiContext
      * @return the String representation of the property value
      */
-    private static String serializePropertyValue(PropertyInterface property,
+    private String serializePropertyValue(PropertyInterface property,
         com.xpn.xwiki.objects.classes.PropertyClass propertyClass, XWikiContext context)
     {
         if (propertyClass instanceof ComputedFieldClass) {
@@ -998,6 +998,10 @@ public class ModelFactory
                 context.setDoc(property.getObject().getOwnerDocument());
                 ComputedFieldClass computedFieldClass = (ComputedFieldClass) propertyClass;
                 return computedFieldClass.getComputedValue(propertyClass.getName(), "", property.getObject(), context);
+            } catch (Exception e) {
+                logger.error("Error while computing property value [{}] of [{}]", propertyClass.getName(),
+                        property.getObject(), e);
+                return serializePropertyValue(property);
             } finally {
                 // Reset the context document to its original value, even if an exception is raised.
                 context.setDoc(document);

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/ModelFactory.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/ModelFactory.java
@@ -994,12 +994,14 @@ public class ModelFactory
             // TODO: the XWikiDocument needs to be explicitely set in the context, otherwise method
             //  PropertyClass.renderInContext fires a null pointer exception: bug?
             XWikiDocument document = context.getDoc();
-            context.setDoc(property.getObject().getOwnerDocument());
-            ComputedFieldClass computedFieldClass = (ComputedFieldClass) propertyClass;
-            String value = computedFieldClass.getComputedValue(propertyClass.getName(), "", property.getObject(), context);
-            // Reset the context document to its original value.
-            context.setDoc(document);
-            return value;
+            try {
+                context.setDoc(property.getObject().getOwnerDocument());
+                ComputedFieldClass computedFieldClass = (ComputedFieldClass) propertyClass;
+                return computedFieldClass.getComputedValue(propertyClass.getName(), "", property.getObject(), context);
+            } finally {
+                // Reset the context document to its original value, even if an exception is raised.
+                context.setDoc(document);
+            }
         } else {
             return serializePropertyValue(property);
         }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/ModelFactory.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/ModelFactory.java
@@ -123,6 +123,7 @@ import com.xpn.xwiki.objects.BaseObject;
 import com.xpn.xwiki.objects.BaseProperty;
 import com.xpn.xwiki.objects.PropertyInterface;
 import com.xpn.xwiki.objects.classes.BaseClass;
+import com.xpn.xwiki.objects.classes.ComputedFieldClass;
 import com.xpn.xwiki.objects.classes.ListClass;
 
 /**
@@ -353,7 +354,8 @@ public class ModelFactory
             property.setType(propertyClass.getClassType());
             if (hasAccess(property)) {
                 try {
-                    property.setValue(serializePropertyValue(xwikiObject.get(propertyClass.getName())));
+                    property.setValue(serializePropertyValue(xwikiObject.get(propertyClass.getName()), propertyClass,
+                        xwikiContext));
                 } catch (XWikiException e) {
                     // Should never happen
                     logger.error("Unexpected exception when accessing property [{}]", propertyClass.getName(), e);
@@ -956,8 +958,8 @@ public class ModelFactory
     }
 
     /**
-     * Serializes the value of the given XObject property.
-     * 
+     * Serializes the value of the given XObject property. {@link ComputedFieldClass} properties are not evaluated.
+     *
      * @param property an XObject property
      * @return the String representation of the property value
      */
@@ -976,6 +978,33 @@ public class ModelFactory
             return "";
         }
     }
+
+    /**
+     * Serializes the value of the given XObject property. In case the property is an instance of
+     * {@link ComputedFieldClass}, the serialized value is the computed property value.
+     * @param property an XObject property
+     * @param propertyClass the PropertyClass of that XObject proprety
+     * @param context the XWikiContext
+     * @return the String representation of the property value
+     */
+    private static String serializePropertyValue(PropertyInterface property,
+        com.xpn.xwiki.objects.classes.PropertyClass propertyClass, XWikiContext context)
+    {
+        if (propertyClass instanceof ComputedFieldClass) {
+            // TODO: the XWikiDocument needs to be explicitely set in the context, otherwise method
+            // PropertyClass.renderInContext fires a null pointer exception: bug?
+            XWikiDocument document = context.getDoc();
+            context.setDoc(property.getObject().getOwnerDocument());
+            ComputedFieldClass computedFieldClass = (ComputedFieldClass) propertyClass;
+            String value = computedFieldClass.getComputedValue(propertyClass.getName(), "", property.getObject(), context);
+            // Reset the context document to its original value.
+            context.setDoc(document);
+            return value;
+        } else {
+            return serializePropertyValue(property);
+        }
+    }
+
 
     public JobRequest toRestJobRequest(Request request) throws XWikiRestException
     {


### PR DESCRIPTION
- Add method ComputedFieldClass:getComputedValue() performing an evaluation of the ComputedFieldClass script.
- Introduce method ModelFactor:serializePropertyValue(PropertyInterface, PropertyClass, XWikiContext context) so that the ComputedFieldClass properties get their value evaluated when represented in REST.

(or should we create a distinct issue focusing on the introduction of ComputedFieldClass:getComputedValue?)