### PR TITLE
XWIKI-16091: "My groups" tab in user profile displays group fullname,…

### DIFF
--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserMembershipSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserMembershipSheet.xml
@@ -93,9 +93,13 @@
   #end
   #set($rows = [])
   #foreach ($group in $subGroups)
+    #set ($title = $xwiki.getDocument($group).title)
+    #if ($title == '')
+      #set ($title = $group.name)
+    #end
     #set($void = $rows.add({
         'doc_viewable' : true,
-        'group' : $group.name,
+        'group' : $title,
         'group_url' : $xwiki.getURL($group)
       }))
   #end


### PR DESCRIPTION
… not title

* displays group page title when this is defined