### PR TITLE
XWIKI-16719: Add ability to retrieve a SolrDocument by its identifier

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/AbstractSolrInstance.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/AbstractSolrInstance.java
@@ -28,6 +28,7 @@ import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.StreamingResponseCallback;
 import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.params.SolrParams;
 import org.slf4j.Logger;
@@ -67,6 +68,12 @@ public abstract class AbstractSolrInstance implements SolrInstance
         this.logger.debug("Add Solr documents [{}] to index", solrDocuments);
 
         this.server.add(solrDocuments);
+    }
+
+    @Override
+    public SolrDocument get(String id) throws IOException, SolrServerException
+    {
+        return server.getById(id);
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/api/SolrInstance.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/api/SolrInstance.java
@@ -72,6 +72,7 @@ public interface SolrInstance extends Initializable
      * @return SolrDocument matching the given id, if found, null otherwise.
      * @throws IOException if problems occur.
      * @throws SolrServerException if problems occur.
+     * @since 11.8RC1
      */
     SolrDocument get(String id) throws IOException, SolrServerException;
 

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/api/SolrInstance.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/api/SolrInstance.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.StreamingResponseCallback;
 import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.common.params.SolrParams;
 import org.xwiki.component.annotation.Role;
@@ -64,6 +65,15 @@ public interface SolrInstance extends Initializable
      * @throws IOException if problems occur.
      */
     void add(List<SolrInputDocument> solrDocuments) throws SolrServerException, IOException;
+
+    /**
+     * Retrieves a {@link SolrDocument} by its id.
+     * @param id a SolrDocument id.
+     * @return SolrDocument matching the given id, if found, null otherwise.
+     * @throws IOException if problems occur.
+     * @throws SolrServerException if problems occur.
+     */
+    SolrDocument get(String id) throws IOException, SolrServerException;
 
     /**
      * Delete a single entry from the Solr index.


### PR DESCRIPTION
- Add method "SolrDocument get(String id)" in SolrInstance
- Add implementation of the method in AbstractSolrInstance