### PR TITLE
XWIKI-16725: Add action to create Template Provider from the Class UI

### DIFF
--- a/xwiki-platform-core/xwiki-platform-xclass/xwiki-platform-xclass-ui/src/main/resources/XWiki/ClassSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-xclass/xwiki-platform-xclass-ui/src/main/resources/XWiki/ClassSheet.xml
@@ -112,6 +112,11 @@
     #set ($classTemplateReference = $services.model.createDocumentReference("${className}Template",
       $doc.documentReference.parent))
   #end
+  ## Determine the template provider using naming convention.
+  #set ($classTemplateProviderReference = $services.model.createDocumentReference("${className}TemplateProvider",
+    $doc.documentReference.parent))
+  #set ($classTemplateProviderDoc = $xwiki.getDocument($classTemplateProviderReference))
+  #set ($hasClassTemplateProvider = !$classTemplateProviderDoc.isNew())
   #set($classTemplateDoc = $xwiki.getDocument($classTemplateReference))
   #set($hasClassSheets = !$classSheetReferences.isEmpty() || $xwiki.exists($defaultClassSheetReference))
   #set($hasClassTemplate = !$classTemplateDoc.isNew())
@@ -317,6 +322,46 @@
     #set ($templatePath = "#hierarchy($classTemplateDoc.documentReference, {'plain': true, 'local': true, 'limit': 4})")
     [[$services.localization.render('platform.xclass.defaultClassSheet.template.view',
       [$templatePath.trim()]) »&gt;&gt;${classTemplateDoc.fullName}]]
+  #end
+  ## Create a template provider only if a template for the current class exists.
+  #if ($classTemplateDoc.getObject(${doc.fullName}))
+    (% id="HClassTemplateProvider" %)
+    = {{translation key="platform.xclass.defaultClassSheet.templateProvider.heading"/}} =
+
+      {{info}}$services.localization.render('platform.xclass.defaultClassSheet.templateProvider.description',
+        ['//']){{/info}}
+
+    #if (!$hasClassTemplateProvider)
+      #set ($templateProviderClassName = 'XWiki.TemplateProviderClass')
+      ## Do the page creation and object addition in one step, providing some default values.
+      #set ($restrictionSpace = $doc.documentReference.spaceReferences.get(0).name)
+      #set ($createUrlQueryString = $escapetool.url({
+        'classname': $templateProviderClassName,
+        'xredirect': $xwiki.relativeRequestURL,
+        'form_token': $services.csrf.token,
+        "${templateProviderClassName}_name": $className,
+        "${templateProviderClassName}_description":
+          $services.localization.render('platform.xclass.templateProvider.defaultDescription', [$className]),
+        "${templateProviderClassName}_template": $classTemplateDoc,
+        "${templateProviderClassName}_visibilityRestrictions": $restrictionSpace}))
+      #set ($createUrl = $classTemplateProviderDoc.getURL('objectadd', $createUrlQueryString))
+      {{html}}
+        &lt;form action="$classTemplateProviderDoc.getURL('save', 'editor=wiki')" method="post"&gt;
+          &lt;div&gt;
+            &lt;input type="hidden" name="form_token" value="$!{services.csrf.getToken()}" /&gt;
+            &lt;input type="hidden" name="parent" value="${doc.fullName}"/&gt;
+            &lt;input type="hidden" name="xredirect" value="$createUrl"/&gt;
+            &lt;input type="hidden" name="title" value="$className Template Provider"/&gt;
+            &lt;span class="buttonwrapper"&gt;&lt;input type="submit" class="button" value="$escapetool.xml(
+              $services.localization.render('platform.xclass.defaultClassSheet.templateProvider.create'))"/&gt;&lt;/span&gt;
+          &lt;/div&gt;
+        &lt;/form&gt;
+      {{/html}}
+    #else
+      #set ($templateProviderPath = "#hierarchy($classTemplateProviderDoc.documentReference, {'plain': true, 'local': true, 'limit': 4})")
+      [[$services.localization.render('platform.xclass.defaultClassSheet.templateProvider.view',
+        [$templateProviderPath.trim()]) »&gt;&gt;${classTemplateProviderDoc.fullName}]]
+    #end
   #end
 
 #end## !$isSheet

--- a/xwiki-platform-core/xwiki-platform-xclass/xwiki-platform-xclass-ui/src/main/resources/XWiki/XClassTranslations.xml
+++ b/xwiki-platform-core/xwiki-platform-xclass/xwiki-platform-xclass-ui/src/main/resources/XWiki/XClassTranslations.xml
@@ -71,6 +71,11 @@ platform.xclass.defaultClassSheet.template.missingObject=The template does not c
 platform.xclass.defaultClassSheet.template.addObject=Add a {0} object to the template
 platform.xclass.defaultClassSheet.template.view=View the template page ({0})
 
+platform.xclass.defaultClassSheet.templateProvider.heading=Class Template Provider
+platform.xclass.defaultClassSheet.templateProvider.description=The {0}template provider{0} allows to create wiki pages using an existing template. A template will be displayed in the {0}Create{0} menu.
+platform.xclass.defaultClassSheet.templateProvider.create=Create the template provider
+platform.xclass.defaultClassSheet.templateProvider.view=View the template provider page ({0})
+platform.xclass.templateProvider.defaultDescription=Add a new {0} entry.
 #
 # Classes
 #


### PR DESCRIPTION
* provide a way to create a template provider from a class
* the template must be created first, in order to be used in the template provider
* by default, the template provider is available only in the root space of the class (for XWiki.Code.MyClass -> XWiki)