### PR TITLE
XWIKI-16727: Use .xform style standard for Class Sheet

### DIFF
--- a/xwiki-platform-core/xwiki-platform-xclass/xwiki-platform-xclass-ui/src/main/resources/XWiki/ObjectSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-xclass/xwiki-platform-xclass-ui/src/main/resources/XWiki/ObjectSheet.xml
@@ -44,9 +44,9 @@
 (% class="xform" %)(((
   #foreach($prop in $class.properties)
     ; {{html clean="false"}}
-      <label for="${class.name}_${class.number}_${prop.name}">$doc.displayPrettyName($prop.name)</label>
+      &lt;label for="${class.name}_${class.number}_${prop.name}"&gt;$doc.displayPrettyName($prop.name)&lt;/label&gt;
       #if($prop.hint)
-        <span class="xHint">$prop.hint</span>
+        &lt;span class="xHint"&gt;$prop.hint&lt;/span&gt;
       #end
     {{/html}}
     : $doc.display($prop.name)


### PR DESCRIPTION
Escape XML content.