### PR TITLE
XWIKI-16794: Reply doesn't work properly

### DIFF
--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Macros.xml
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Macros.xml
@@ -266,7 +266,7 @@
             #set($xredirect = "$xwiki.getURL($docRef, 'view', $!{request.queryString})")
           #end
           ## add "comment reply" button
-          &lt;a class='btn btn-default btn-xs' href="${xredirect}#xwikicomment_${ann.id}"
+          &lt;a class='btn btn-default btn-xs reply' href="${xredirect}#xwikicomment_${ann.id}"
             title="$services.localization.render('core.viewers.comments.reply')"&gt;
             $services.icon.renderHTML('comment')
           &lt;/a&gt;

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Style.xml
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Style.xml
@@ -403,6 +403,10 @@
   margin-top: -1.2em;
 }
 
+.annotationTools .reply {
+  padding: 1px 3px;
+}
+
 .annotationComment {
   padding: 4px 0;
 }


### PR DESCRIPTION
* reply class is required from js for the functionality to work
* overridden padding added by 'reply' class