### PR TITLE
Fixes DocExtra in OfficeImporter (XWIKI-16498)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/office.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/office.vm
@@ -29,5 +29,6 @@
 #template("javascript.vm")
 </head>
 #set($attachmentReference = $services.model.createAttachmentReference($doc.documentReference, $request.attachment))
+#set($displayDocExtra = false)
 <body>$services.officeviewer.view($attachmentReference)</body>
 </html>


### PR DESCRIPTION
XWIKI-16498: Remove docextra from OfficeImporter action-result pages
Link : https://jira.xwiki.org/browse/XWIKI-16498
(Let me know my mistakes) - Haxsen