### PR TITLE
XWIKI-16498: Remove docextra from OfficeImporter action-result pages

### DIFF
--- a/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-ui/src/main/resources/XWiki/OfficeImporter.xml
+++ b/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-ui/src/main/resources/XWiki/OfficeImporter.xml
@@ -37,6 +37,7 @@
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
   <content>{{velocity}}
+#set($displayDocExtra = false)
 #if ($isguest)
   {{error}}$services.localization.render('xe.officeimporter.notallowed'){{/error}}
 #elseif ("$!services.officemanager.serverState" != 'Connected')

--- a/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-ui/src/main/resources/XWiki/OfficeImporterResults.xml
+++ b/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-ui/src/main/resources/XWiki/OfficeImporterResults.xml
@@ -37,6 +37,7 @@
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
   <content>{{velocity}}
+#set($displayDocExtra = false)
 #if ($isguest)
   #error($services.localization.render('xe.officeimporter.notallowed'))
 #else


### PR DESCRIPTION
XWIKI-16498: Remove docextra from OfficeImporter action-result pages
Link : https://jira.xwiki.org/browse/XWIKI-16498

Before: 
![Picture 2020-02-24 02_21_55](https://user-images.githubusercontent.com/33906649/75122020-7f218e00-56bb-11ea-9f40-7ef1e641be42.png)

After: 
![image](https://user-images.githubusercontent.com/33906649/75122007-6618dd00-56bb-11ea-92de-04a0f9d4ffa4.png)

(Let me know my mistakes, thanks!) - Haxsen