### PR TITLE
Made WYSIWYG word consistent on different pages

### DIFF
--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserSheet.xml
@@ -574,6 +574,10 @@ div.userInfo, div.userPreferences, div.watchlistManagement, div.userDashboard {
   background-color: $theme.backgroundSecondaryColor;
 }
 
+div#XWiki.XWikiUsers_0_editor {
+  text-transform: uppercase;
+}        
+
 .userInfo {
   -ms-word-break: break-all; /* IE8, IE9 */
 }


### PR DESCRIPTION
XWIKI-11269: WYSIWYG word is not consistent on different pages
Link: https://jira.xwiki.org/browse/XWIKI-11269

Before:
![image](https://user-images.githubusercontent.com/40496139/75265480-f9b2f080-5816-11ea-97bf-5b6708a5b38c.png)

After:
![image](https://user-images.githubusercontent.com/40496139/75265433-e56ef380-5816-11ea-9be3-8651934c0ceb.png)

