### PR TITLE
XWIKI-11269: WYSIWYG word is not consistent on different pages

### DIFF
--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-test/xwiki-platform-user-profile-test-docker/src/test/it/org/xwiki/user/test/ui/UserProfileIT.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-test/xwiki-platform-user-profile-test-docker/src/test/it/org/xwiki/user/test/ui/UserProfileIT.java
@@ -71,7 +71,7 @@ public class UserProfileIT
 
     private static final String USER_BLOGFEED = "http://xwiki.org/feed";
 
-    private static final String WYSIWYG_EDITOR = "Wysiwyg";
+    private static final String WYSIWYG_EDITOR = "WYSIWYG";
 
     private static final String TEXT_EDITOR = "Text";
 


### PR DESCRIPTION
XWIKI-11269: WYSIWYG word is not consistent on different pages
Link: https://jira.xwiki.org/browse/XWIKI-11269

Before:
![image](https://user-images.githubusercontent.com/40496139/75265480-f9b2f080-5816-11ea-97bf-5b6708a5b38c.png)

After:
![image](https://user-images.githubusercontent.com/40496139/75269234-988f1b00-581e-11ea-8f25-9b1c79417a09.png)


