### PR TITLE
XWIKI-16345: Use .xform style standard for the edit panels

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/editpanels.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/editpanels.vm
@@ -36,7 +36,7 @@
 #end
 #if ($!editorPanels != '')
   #set ($editorPanels = $editorPanels.split(','))
-  <div id="editPanels" class="panels editor">
+  <div id="editPanels" class="panels editor xform">
 
   ## Convert the list of panels to panel (UIExtension) IDs
   #set ($panelIDList = [])


### PR DESCRIPTION
Fixes XWIKI-16345.
Link (should I add links?) : https://jira.xwiki.org/browse/XWIKI-16345

Before:
![Picture 2020-02-25 23_09_37](https://user-images.githubusercontent.com/33906649/75286117-bae26200-5839-11ea-8b3b-e3c652e59c3c.png)

After:
![Picture 2020-02-25 23_09_55](https://user-images.githubusercontent.com/33906649/75286125-bf0e7f80-5839-11ea-9385-52f454fd2101.png)
