### PR TITLE
XWIKI-15490: Children macro not working for a document with a double quote in its name

### DIFF
--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-macro/src/main/resources/XWiki/ChildrenMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-macro/src/main/resources/XWiki/ChildrenMacro.xml
@@ -158,7 +158,7 @@
     </class>
     <property>
       <code>{{velocity}}
-{{documentTree root="document:$doc.documentReference" /}}
+{{documentTree root="document:$doc.documentReference.toString().replaceAll('([~""])', '~$1')" /}}
 {{/velocity}}</code>
     </property>
     <property>


### PR DESCRIPTION
Escape double quotes before calling documentTree.