### PR TITLE
XWIKI-11271: Use round borders on the user profile sections to be consistent with the user profile menu

### DIFF
--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserSheet.xml
@@ -459,6 +459,15 @@ return XWiki;
     <property>
       <code>#template("colorThemeInit.vm")
 #set($tabswidth = "130px")
+
+// Variables
+// --------------------------------------------------
+
+//== Components
+//
+
+@border-radius-base:        4px;
+
 /* ----- User menu ----- */
 #user-menu-col{
   float: left;
@@ -572,6 +581,10 @@ div.userDashboard, #dashboardPane .dashboard {
 div.highlighted-profile-section,
 div.userInfo, div.userPreferences, div.watchlistManagement, div.userDashboard {
   background-color: $theme.backgroundSecondaryColor;
+}
+
+div.userPreferences {
+  border-radius:  @border-radius-base
 }
 
 .userInfo {


### PR DESCRIPTION
XWIKI-11271: Use round borders on the user profile sections to be consistent with the user profile menu
Link: https://jira.xwiki.org/browse/XWIKI-11271

Used less variable @border-radius-base for rounder borders.

Before:
![image](https://user-images.githubusercontent.com/40496139/75300478-f98a1380-585d-11ea-88b1-0592f32d0a8e.png)

After:
![image](https://user-images.githubusercontent.com/40496139/75300591-67363f80-585e-11ea-8791-a709d42df838.png)

