### PR TITLE
XWIKI-16345: Use .xform style standard for the edit panels

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/edit.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/edit.vm
@@ -139,7 +139,7 @@
   #end
   #template("header.vm")
   #if($editor == 'wiki' || $editor == 'wysiwyg')
-    <form id="edit" method="post" action="$doc.getURL('preview')" class="withLock xform">
+    <form id="edit" method="post" action="$doc.getURL('preview')" class="withLock form xform">
     <div class="hidden">
     ## CSRF prevention
     <input type="hidden" name="form_token" value="$!{services.csrf.getToken()}" />

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/edit.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/edit.vm
@@ -139,7 +139,7 @@
   #end
   #template("header.vm")
   #if($editor == 'wiki' || $editor == 'wysiwyg')
-    <form id="edit" method="post" action="$doc.getURL('preview')" class="withLock form xform">
+    <form id="edit" method="post" action="$doc.getURL('preview')" class="withLock xform">
     <div class="hidden">
     ## CSRF prevention
     <input type="hidden" name="form_token" value="$!{services.csrf.getToken()}" />

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/edit.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/edit.vm
@@ -139,7 +139,7 @@
   #end
   #template("header.vm")
   #if($editor == 'wiki' || $editor == 'wysiwyg')
-    <form id="edit" method="post" action="$doc.getURL('preview')" class="withLock form">
+    <form id="edit" method="post" action="$doc.getURL('preview')" class="withLock xform">
     <div class="hidden">
     ## CSRF prevention
     <input type="hidden" name="form_token" value="$!{services.csrf.getToken()}" />


### PR DESCRIPTION
Fixes XWIKI-16345.
Link: https://jira.xwiki.org/browse/XWIKI-16345

Before:
![Picture 2020-02-25 23_09_37](https://user-images.githubusercontent.com/33906649/75482774-4a694b80-59c7-11ea-8233-561d8149d853.png)


After:
![Picture 2020-02-25 23_09_55](https://user-images.githubusercontent.com/33906649/75482788-4f2dff80-59c7-11ea-821d-fc3d0e9c2f70.png)
