### PR TITLE
XWIKI-16344: Use .xform style standard in the wiki and wysiwyg edit modes

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/edit.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/edit.vm
@@ -179,26 +179,28 @@
   #end
   #template("hierarchy.vm")
   <div class="row">
-    #if ($displayContentMenu)
-      <div class="col-xs-12 col-md-5 pull-right">
-        #template("menus_content.vm")
-      </div>
-    #end
-    #if (($editor == 'wiki' || $editor == 'wysiwyg') && !$request.section)
-      <div id="editMeta" class="col-xs-12#if ($displayContentMenu) col-md-7#end">
-        #template('editmeta.vm')
-      </div>
-    #else
-      <div id="document-title" class="col-xs-12#if ($displayContentMenu) col-md-7#end"><h1>
-      #if($editor == 'rights')
-        $services.localization.render('core.editors.rights.title', [$escapetool.xml($doc.plainTitle), $doc.getURL()])
-      #elseif($editor == 'object')
-        $services.localization.render('core.editors.object.title', [$escapetool.xml($doc.plainTitle), $doc.getURL()])
-      #elseif($editor == 'class')
-        $services.localization.render('core.editors.class.title', [$escapetool.xml($doc.fullName), $doc.getURL()])
+    <dl>
+      #if ($displayContentMenu)
+        <div class="col-xs-12 col-md-5 pull-right">
+          #template("menus_content.vm")
+        </div>
       #end
-      </h1></div>
-    #end
+      #if (($editor == 'wiki' || $editor == 'wysiwyg') && !$request.section)
+        <div id="editMeta" class="col-xs-12#if ($displayContentMenu) col-md-7#end">
+          #template('editmeta.vm')
+        </div>
+      #else
+        <div id="document-title" class="col-xs-12#if ($displayContentMenu) col-md-7#end"><h1>
+        #if($editor == 'rights')
+          $services.localization.render('core.editors.rights.title', [$escapetool.xml($doc.plainTitle), $doc.getURL()])
+        #elseif($editor == 'object')
+          $services.localization.render('core.editors.object.title', [$escapetool.xml($doc.plainTitle), $doc.getURL()])
+        #elseif($editor == 'class')
+          $services.localization.render('core.editors.class.title', [$escapetool.xml($doc.fullName), $doc.getURL()])
+        #end
+        </h1></div>
+      #end
+    </dl>
   </div> ## row
   #template("edit${editor}.vm")
   ## This javascript must be placed here since it uses velocity variables set in the template above.

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/edit.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/edit.vm
@@ -58,7 +58,8 @@
     #else
       #set($boxTitle = 'error')
     #end
-    #xwikimessageboxstart($services.localization.render('notice') $services.localization.render("extension.xar.edit${protectionLevel.name().toLowerCase()}.list"))
+    #xwikimessageboxstart($services.localization.render('notice') 
+      $services.localization.render("extension.xar.edit${protectionLevel.name().toLowerCase()}.list"))
     <ul>
       #foreach($extension in $extensions)
         <li>$extension.name ($extension.id.version)</li>
@@ -88,7 +89,8 @@
     #set($newquerystring = "$!{request.getQueryString().replaceAll('&', '&amp;').replaceAll('&amp;amp;', '&amp;')}"
                          + '&amp;force=1')
     #set($forceEditURL = $tdoc.getURL($xcontext.getAction(), ${newquerystring}))
-    #xwikimessageboxstart($services.localization.render('notice') "$services.localization.render('doclockedby') $xwiki.getUserName($tdoc.getLockingUser())")
+    #xwikimessageboxstart($services.localization.render('notice') 
+      "$services.localization.render('doclockedby') $xwiki.getUserName($tdoc.getLockingUser())")
     <a href="$forceEditURL">$services.localization.render('forcelock')</a>
     #xwikimessageboxend()
     ##
@@ -174,7 +176,9 @@
   #if(($editor == 'wiki' || $editor == 'wysiwyg' || $editor == 'inline') && $services.parentchild.isParentChildMechanismEnabled())
     ## Note: the inline editor never reaches this part since it is handled separately. We add the edit parent button in editinline.vm explicitly.
     <div class='edit-meta-tools'>
-      <a id='editParentTrigger' class='tool edit-parent' href='#mainEditArea' title="$services.localization.render('core.editors.content.parentField.edit.title')">[$services.localization.render('core.editors.content.parentField.edit')]</a>
+      <a id='editParentTrigger' class='tool edit-parent' href='#mainEditArea' 
+        title="$services.localization.render('core.editors.content.parentField.edit.title')">
+        [$services.localization.render('core.editors.content.parentField.edit')]</a>
     </div>
   #end
   #template("hierarchy.vm")

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/edit.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/edit.vm
@@ -142,7 +142,7 @@
   #end
   #template("header.vm")
   #if($editor == 'wiki' || $editor == 'wysiwyg')
-    <form id="edit" method="post" action="$doc.getURL('preview')" class="withLock form">
+    <form id="edit" method="post" action="$doc.getURL('preview')" class="withLock xform">
     <div class="hidden">
     ## CSRF prevention
     <input type="hidden" name="form_token" value="$!{services.csrf.getToken()}" />

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/edit.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/edit.vm
@@ -183,26 +183,26 @@
   #end
   #template("hierarchy.vm")
   <div class="row">
-      #if ($displayContentMenu)
-        <div class="col-xs-12 col-md-5 pull-right">
-          #template("menus_content.vm")
-        </div>
+    #if ($displayContentMenu)
+      <div class="col-xs-12 col-md-5 pull-right">
+        #template("menus_content.vm")
+      </div>
+    #end
+    #if (($editor == 'wiki' || $editor == 'wysiwyg') && !$request.section)
+      <div id="editMeta" class="col-xs-12#if ($displayContentMenu) col-md-7#end">
+        #template('editmeta.vm')
+      </div>
+    #else
+      <div id="document-title" class="col-xs-12#if ($displayContentMenu) col-md-7#end"><h1>
+      #if($editor == 'rights')
+        $services.localization.render('core.editors.rights.title', [$escapetool.xml($doc.plainTitle), $doc.getURL()])
+      #elseif($editor == 'object')
+        $services.localization.render('core.editors.object.title', [$escapetool.xml($doc.plainTitle), $doc.getURL()])
+      #elseif($editor == 'class')
+        $services.localization.render('core.editors.class.title', [$escapetool.xml($doc.fullName), $doc.getURL()])
       #end
-      #if (($editor == 'wiki' || $editor == 'wysiwyg') && !$request.section)
-        <div id="editMeta" class="col-xs-12#if ($displayContentMenu) col-md-7#end">
-          #template('editmeta.vm')
-        </div>
-      #else
-        <div id="document-title" class="col-xs-12#if ($displayContentMenu) col-md-7#end"><h1>
-        #if($editor == 'rights')
-          $services.localization.render('core.editors.rights.title', [$escapetool.xml($doc.plainTitle), $doc.getURL()])
-        #elseif($editor == 'object')
-          $services.localization.render('core.editors.object.title', [$escapetool.xml($doc.plainTitle), $doc.getURL()])
-        #elseif($editor == 'class')
-          $services.localization.render('core.editors.class.title', [$escapetool.xml($doc.fullName), $doc.getURL()])
-        #end
-        </h1></div>
-      #end
+      </h1></div>
+    #end
   </div> ## row
   #template("edit${editor}.vm")
   ## This javascript must be placed here since it uses velocity variables set in the template above.

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/edit.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/edit.vm
@@ -42,7 +42,8 @@
 ## Is the document protected?
 ## If yes, warn about it and show a forcing link:
 ##
-#set($protectionLevel = $services.extension.xar.getEditSecurityLevel($xcontext.userReference, $tdoc.documentReferenceWithLocale))
+#set($protectionLevel = $services.extension.xar.getEditSecurityLevel($xcontext.userReference,
+   $tdoc.documentReferenceWithLocale))
 #if ($protectionLevel.name() == 'DENY' || ($protectionLevel.name() != 'NONE' && !$editForced))
   #template("startpage.vm")
   <div class="main">

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/edit.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/edit.vm
@@ -179,7 +179,6 @@
   #end
   #template("hierarchy.vm")
   <div class="row">
-    <dl>
       #if ($displayContentMenu)
         <div class="col-xs-12 col-md-5 pull-right">
           #template("menus_content.vm")
@@ -200,7 +199,6 @@
         #end
         </h1></div>
       #end
-    </dl>
   </div> ## row
   #template("edit${editor}.vm")
   ## This javascript must be placed here since it uses velocity variables set in the template above.

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editmeta.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editmeta.vm
@@ -34,13 +34,23 @@
 </div>
 #if ($editor != 'inline')
 <div id="titleinput" class="form-group">
-  <label for="xwikidoctitleinput">$services.localization.render('core.editors.content.titleField.label')</label>
-  <input type="text" id="xwikidoctitleinput" name="title" value="$escapetool.xml("$!docTitle")" class="#if($xwiki.getXWikiPreference('xwiki.title.mandatory') == 1)required#end"/>
+    <dl>
+        <dt>
+          <label for="xwikidoctitleinput">$services.localization.render('core.editors.content.titleField.label')</label>
+        </dt>
+        <dd>
+          <input type="text" id="xwikidoctitleinput" name="title" value="$escapetool.xml("$!docTitle")" class="#if($xwiki.getXWikiPreference('xwiki.title.mandatory') == 1)required#end"/>
+        </dd>
+    </dl>
 </div>
 #end
 
 #if($editor == 'wiki')
 <div id="contentMeta">
-  <label for="content">$services.localization.render('core.editors.content.contentField.label')</label>
+    <dl>
+        <dt>
+          <label for="content">$services.localization.render('core.editors.content.contentField.label')</label>
+        </dt>
+    </dl>
 </div>
 #end

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editmeta.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editmeta.vm
@@ -30,7 +30,7 @@
 ##
 <div id="parentinput" class="form-group">
   <label for="xwikidocparentinput">$services.localization.render('core.editors.content.parentField.label') 
-  <a id='hideEditParentTrigger' href='#'>$services.localization.render('core.editors.content.parentField.edit.hide')</a></label>
+    <a id='hideEditParentTrigger' href='#'>$services.localization.render('core.editors.content.parentField.edit.hide')</a></label>
   <input type="text" id="xwikidocparentinput" name="parent" value="$!{escapetool.xml("$!docParent")}" size="30" class="suggestDocuments "/>
 </div>
 #if ($editor != 'inline')
@@ -41,7 +41,7 @@
     </dt>
     <dd>
       <input type="text" id="xwikidoctitleinput" name="title" value="$escapetool.xml("$!docTitle")" 
-      class="#if($xwiki.getXWikiPreference('xwiki.title.mandatory') == 1)required#end"/>
+        class="#if($xwiki.getXWikiPreference('xwiki.title.mandatory') == 1)required#end"/>
     </dd>
   </dl>
 </div>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editmeta.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editmeta.vm
@@ -30,7 +30,8 @@
 ##
 <div id="parentinput" class="form-group">
   <label for="xwikidocparentinput">$services.localization.render('core.editors.content.parentField.label') 
-    <a id='hideEditParentTrigger' href='#'>$services.localization.render('core.editors.content.parentField.edit.hide')</a></label>
+    <a id='hideEditParentTrigger' 
+     href='#'>$services.localization.render('core.editors.content.parentField.edit.hide')</a></label>
   <input type="text" id="xwikidocparentinput" name="parent" value="$!{escapetool.xml("$!docParent")}" size="30" class="suggestDocuments "/>
 </div>
 #if ($editor != 'inline')

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editmeta.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editmeta.vm
@@ -31,7 +31,9 @@
 <div id="parentinput" class="form-group">
   <label for="xwikidocparentinput">$services.localization.render('core.editors.content.parentField.label') 
     <a id='hideEditParentTrigger' 
-     href='#'>$services.localization.render('core.editors.content.parentField.edit.hide')</a></label>
+      href='#'>$services.localization.render('core.editors.content.parentField.edit.hide')
+    </a>
+  </label>
   <input type="text" id="xwikidocparentinput" name="parent" value="$!{escapetool.xml("$!docParent")}" size="30" class="suggestDocuments "/>
 </div>
 #if ($editor != 'inline')

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editmeta.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editmeta.vm
@@ -34,19 +34,19 @@
 </div>
 #if ($editor != 'inline')
 <div id="titleinput" class="form-group">
-    <dt>
-      <label for="xwikidoctitleinput">$services.localization.render('core.editors.content.titleField.label')</label>
-    </dt>
-    <dd>
-      <input type="text" id="xwikidoctitleinput" name="title" value="$escapetool.xml("$!docTitle")" class="#if($xwiki.getXWikiPreference('xwiki.title.mandatory') == 1)required#end"/>
-    </dd>
+  <dt>
+    <label for="xwikidoctitleinput">$services.localization.render('core.editors.content.titleField.label')</label>
+  </dt>
+  <dd>
+    <input type="text" id="xwikidoctitleinput" name="title" value="$escapetool.xml("$!docTitle")" class="#if($xwiki.getXWikiPreference('xwiki.title.mandatory') == 1)required#end"/>
+  </dd>
 </div>
 #end
 
 #if($editor == 'wiki')
 <div id="contentMeta">
-    <dt>
-      <label for="content">$services.localization.render('core.editors.content.contentField.label')</label>
-    </dt>
+  <dt>
+    <label for="content">$services.localization.render('core.editors.content.contentField.label')</label>
+  </dt>
 </div>
 #end

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editmeta.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editmeta.vm
@@ -34,23 +34,19 @@
 </div>
 #if ($editor != 'inline')
 <div id="titleinput" class="form-group">
-    <dl>
-        <dt>
-          <label for="xwikidoctitleinput">$services.localization.render('core.editors.content.titleField.label')</label>
-        </dt>
-        <dd>
-          <input type="text" id="xwikidoctitleinput" name="title" value="$escapetool.xml("$!docTitle")" class="#if($xwiki.getXWikiPreference('xwiki.title.mandatory') == 1)required#end"/>
-        </dd>
-    </dl>
+    <dt>
+      <label for="xwikidoctitleinput">$services.localization.render('core.editors.content.titleField.label')</label>
+    </dt>
+    <dd>
+      <input type="text" id="xwikidoctitleinput" name="title" value="$escapetool.xml("$!docTitle")" class="#if($xwiki.getXWikiPreference('xwiki.title.mandatory') == 1)required#end"/>
+    </dd>
 </div>
 #end
 
 #if($editor == 'wiki')
 <div id="contentMeta">
-    <dl>
-        <dt>
-          <label for="content">$services.localization.render('core.editors.content.contentField.label')</label>
-        </dt>
-    </dl>
+    <dt>
+      <label for="content">$services.localization.render('core.editors.content.contentField.label')</label>
+    </dt>
 </div>
 #end

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editmeta.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editmeta.vm
@@ -35,20 +35,25 @@
 </div>
 #if ($editor != 'inline')
 <div id="titleinput" class="form-group">
-  <dt>
-    <label for="xwikidoctitleinput">$services.localization.render('core.editors.content.titleField.label')</label>
-  </dt>
-  <dd>
-    <input type="text" id="xwikidoctitleinput" name="title" value="$escapetool.xml("$!docTitle")" 
-    class="#if($xwiki.getXWikiPreference('xwiki.title.mandatory') == 1)required#end"/>
-  </dd>
+  <dl>
+    <dt>
+      <label for="xwikidoctitleinput">$services.localization.render('core.editors.content.titleField.label')</label>
+    </dt>
+    <dd>
+      <input type="text" id="xwikidoctitleinput" name="title" value="$escapetool.xml("$!docTitle")" 
+      class="#if($xwiki.getXWikiPreference('xwiki.title.mandatory') == 1)required#end"/>
+    </dd>
+  </dl>
 </div>
 #end
 
 #if($editor == 'wiki')
 <div id="contentMeta">
-  <dt>
-    <label for="content">$services.localization.render('core.editors.content.contentField.label')</label>
-  </dt>
+  <dl>
+    <dt>
+      <label for="content">$services.localization.render('core.editors.content.contentField.label')</label>
+    </dt>
+    <dd></dd>
+  </dl>
 </div>
 #end

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editmeta.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editmeta.vm
@@ -29,7 +29,8 @@
 ## Title and parent
 ##
 <div id="parentinput" class="form-group">
-  <label for="xwikidocparentinput">$services.localization.render('core.editors.content.parentField.label') <a id='hideEditParentTrigger' href='#'>$services.localization.render('core.editors.content.parentField.edit.hide')</a></label>
+  <label for="xwikidocparentinput">$services.localization.render('core.editors.content.parentField.label') 
+  <a id='hideEditParentTrigger' href='#'>$services.localization.render('core.editors.content.parentField.edit.hide')</a></label>
   <input type="text" id="xwikidocparentinput" name="parent" value="$!{escapetool.xml("$!docParent")}" size="30" class="suggestDocuments "/>
 </div>
 #if ($editor != 'inline')
@@ -38,7 +39,8 @@
     <label for="xwikidoctitleinput">$services.localization.render('core.editors.content.titleField.label')</label>
   </dt>
   <dd>
-    <input type="text" id="xwikidoctitleinput" name="title" value="$escapetool.xml("$!docTitle")" class="#if($xwiki.getXWikiPreference('xwiki.title.mandatory') == 1)required#end"/>
+    <input type="text" id="xwikidoctitleinput" name="title" value="$escapetool.xml("$!docTitle")" 
+    class="#if($xwiki.getXWikiPreference('xwiki.title.mandatory') == 1)required#end"/>
   </dd>
 </div>
 #end


### PR DESCRIPTION
Issue link: https://jira.xwiki.org/browse/XWIKI-16344

Before:
![Picture 2020-02-28 00_30_48](https://user-images.githubusercontent.com/33906649/75485189-15abc300-59cc-11ea-9d65-784886487067.png)

After:
![Picture 2020-02-28 00_29_50](https://user-images.githubusercontent.com/33906649/75485210-1ba1a400-59cc-11ea-9e59-afb62ad4aea9.png)

Please let me know any mistakes.
Thanks to 9inpachi for helping me on this issue!
