### PR TITLE
XWIKI-7716: Use .xform style standard in the User Profile

### DIFF
--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
@@ -149,7 +149,8 @@ $services.localization.render('platform.core.profile.category.profile.disabled')
       #if ($xcontext.user == $doc.fullName)
         &lt;h2&gt;$services.localization.render('platform.core.profile.section.activity')&lt;/h2&gt;
       #else
-        &lt;h2&gt;$services.localization.render('platform.core.profile.section.activityof', [$xwiki.getUserName($doc.fullName, false)])&lt;/h2&gt;
+        &lt;h2&gt;$services.localization.render('platform.core.profile.section.activityof',
+         [$xwiki.getUserName($doc.fullName, false)])&lt;/h2&gt;
         #if ($hasWatch)
         $xwiki.ssx.use('XWiki.XWikiUserProfileSheet')##
         &lt;div class='activity-follow'&gt;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
@@ -89,7 +89,7 @@ $services.localization.render('platform.core.profile.category.profile.disabled')
     #end
     &lt;div class='userInfo'&gt;
     #if($xcontext.action == 'view' &amp;&amp; $hasEdit)
-      &lt;div class='editProfileCategory'&gt;&lt;a href="$doc.getURL('edit', 'editor=inline&amp;amp;category=profile')"&gt;&lt;span class='hidden'&gt;$services.localization.render('platform.core.profile.category.profile.edit')&lt;/span&gt;&lt;/a&gt;&lt;/div&gt;
+      &lt;div class='editProfileCategory'&gt;&lt;a class="xHelp"  href="$doc.getURL('edit', 'editor=inline&amp;amp;category=profile')"&gt;&lt;span class='hidden'&gt;$services.localization.render('platform.core.profile.category.profile.edit')&lt;/span&gt;&lt;/a&gt;&lt;/div&gt;
     #end
     ## Please do not insert extra empty lines here (as it affects the validity of the rendered xhtml)
     #set ($sectionsObject = $sheetDocument.getObject($sectionsObjectClassName))
@@ -111,7 +111,7 @@ $services.localization.render('platform.core.profile.category.profile.disabled')
       #set ($sectionPropertiesString = $sectionObject.getProperty('properties').value)
       #set ($sectionProperties = $sectionPropertiesString.split('\s+'))
       #if ($sectionProperties &amp;&amp; $sectionProperties.size() &gt; 0)
-        &lt;h1&gt;$sectionName&lt;/h1&gt;
+        &lt;h2&gt;$sectionName&lt;/h2&gt;
         &lt;dl&gt;
         #foreach ($sectionProperty in $sectionProperties)
           #set ($vCardData = $sectionProperty.split(':'))
@@ -145,9 +145,9 @@ $services.localization.render('platform.core.profile.category.profile.disabled')
       #end
       &lt;div class='userRecentChanges'&gt;
       #if ($xcontext.user == $doc.fullName)
-        &lt;h1&gt;$services.localization.render('platform.core.profile.section.activity')&lt;/h1&gt;
+        &lt;h2&gt;$services.localization.render('platform.core.profile.section.activity')&lt;/h2&gt;
       #else
-        &lt;h1&gt;$services.localization.render('platform.core.profile.section.activityof', [$xwiki.getUserName($doc.fullName, false)])&lt;/h1&gt;
+        &lt;h2&gt;$services.localization.render('platform.core.profile.section.activityof', [$xwiki.getUserName($doc.fullName, false)])&lt;/h2&gt;
         #if ($hasWatch)
         $xwiki.ssx.use('XWiki.XWikiUserProfileSheet')##
         &lt;div class='activity-follow'&gt;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
@@ -529,6 +529,13 @@ $services.localization.render('platform.core.profile.category.profile.disabled')
   font-weight: 700;
   margin-bottom: 0.3em;
   text-transform: uppercase;
+}
+        
+/* ----- Profile ----- */
+
+.userInfo h2 {
+    font-size: 16px;
+    font-weight: bold;
 }</code>
     </property>
     <property>

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
@@ -92,8 +92,8 @@ $services.localization.render('platform.core.profile.category.profile.disabled')
       &lt;div class='editProfileCategory'&gt;
         &lt;a title="$escapetool.xml($services.localization.render('platform.core.profile.category.profile.edit'))" 
               href="$doc.getURL('edit', 'editor=inline&amp;amp;category=profile')"&gt;
-        &lt;span class='sr-only'&gt;$escapetool.xml($services.localization.render('platform.core.profile.category.profile.edit'))&lt;/span&gt;
-       &lt;/a&gt;
+          &lt;span class='sr-only'&gt;$escapetool.xml($services.localization.render('platform.core.profile.category.profile.edit'))&lt;/span&gt;
+        &lt;/a&gt;
       &lt;/div&gt;
     #end
     ## Please do not insert extra empty lines here (as it affects the validity of the rendered xhtml)

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
@@ -90,9 +90,9 @@ $services.localization.render('platform.core.profile.category.profile.disabled')
     &lt;div class='userInfo'&gt;
     #if($xcontext.action == 'view' &amp;&amp; $hasEdit)
       &lt;div class='editProfileCategory'&gt;
-       &lt;a title="$escapetool.xml($services.localization.render('platform.core.profile.category.profile.edit'))" 
-        href="$doc.getURL('edit', 'editor=inline&amp;amp;category=profile')"&gt;
-        &lt;span class='sr-only'&gt;$services.localization.render('platform.core.profile.category.profile.edit')&lt;/span&gt;
+        &lt;a title="$escapetool.xml($services.localization.render('platform.core.profile.category.profile.edit'))" 
+              href="$doc.getURL('edit', 'editor=inline&amp;amp;category=profile')"&gt;
+        &lt;span class='sr-only'&gt;$escapetool.xml($services.localization.render('platform.core.profile.category.profile.edit'))&lt;/span&gt;
        &lt;/a&gt;
       &lt;/div&gt;
     #end
@@ -153,8 +153,8 @@ $services.localization.render('platform.core.profile.category.profile.disabled')
         &lt;h2&gt;$services.localization.render('platform.core.profile.section.activity')&lt;/h2&gt;
       #else
         &lt;h2&gt;
-         $services.localization.render('platform.core.profile.section.activityof',
-         [$xwiki.getUserName($doc.fullName, false)])
+          $services.localization.render('platform.core.profile.section.activityof',
+            [$xwiki.getUserName($doc.fullName, false)])
         &lt;/h2&gt;
         #if ($hasWatch)
         $xwiki.ssx.use('XWiki.XWikiUserProfileSheet')##

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
@@ -121,7 +121,7 @@ $services.localization.render('platform.core.profile.category.profile.disabled')
             #set ($sectionProperty = $vCardData[1])
           #end
           #if ("$!sectionProperty" != '' &amp;&amp; $xwikiUsersClass.get($sectionProperty))
-          &lt;dt class='label'&gt;
+          &lt;dt&gt;
             &lt;label #if($inEditMode)for="${xwikiUsersClassName}_${obj.number}_${sectionProperty}"#{end}&gt;$doc.displayPrettyName("${sectionProperty}")&lt;/label&gt;
           &lt;/dt&gt;
           &lt;dd #if("$!vCardProperty" != '' &amp;&amp; !$inEditMode)class="$vCardProperty"#{end}&gt;$doc.display($sectionProperty)&lt;/dd&gt;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
@@ -142,7 +142,7 @@ $services.localization.render('platform.core.profile.category.profile.disabled')
       #set ($isMessageStreamActive = $services.messageStream.isActive())
       #if ($isMessageStreamActive &amp;&amp; !$isGuest)
       &lt;div class='userMessage profile-section'&gt;
-        &lt;h1&gt;$services.localization.render('platform.core.profile.section.sendMessage')&lt;/h1&gt;
+        &lt;h1&gt;$escapetool.xml($services.localization.render('platform.core.profile.section.sendMessage'))&lt;/h1&gt;
 
           {{messageSender /}}
 
@@ -150,11 +150,11 @@ $services.localization.render('platform.core.profile.category.profile.disabled')
       #end
       &lt;div class='userRecentChanges'&gt;
       #if ($xcontext.user == $doc.fullName)
-        &lt;h2&gt;$services.localization.render('platform.core.profile.section.activity')&lt;/h2&gt;
+        &lt;h2&gt;$escapetool.xml($services.localization.render('platform.core.profile.section.activity'))&lt;/h2&gt;
       #else
         &lt;h2&gt;
-          $services.localization.render('platform.core.profile.section.activityof',
-            [$xwiki.getUserName($doc.fullName, false)])
+          $escapetool.xml($services.localization.render('platform.core.profile.section.activityof',
+            [$xwiki.getUserName($doc.fullName, false)]))
         &lt;/h2&gt;
         #if ($hasWatch)
         $xwiki.ssx.use('XWiki.XWikiUserProfileSheet')##

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
@@ -89,7 +89,7 @@ $services.localization.render('platform.core.profile.category.profile.disabled')
     #end
     &lt;div class='userInfo'&gt;
     #if($xcontext.action == 'view' &amp;&amp; $hasEdit)
-      &lt;div class='editProfileCategory'&gt;&lt;a class="xHelp"  href="$doc.getURL('edit', 'editor=inline&amp;amp;category=profile')"&gt;&lt;span class='hidden'&gt;$services.localization.render('platform.core.profile.category.profile.edit')&lt;/span&gt;&lt;/a&gt;&lt;/div&gt;
+      &lt;div class='editProfileCategory'&gt;&lt;a title="$services.localization.render('platform.core.profile.category.profile.edit')" href="$doc.getURL('edit', 'editor=inline&amp;amp;category=profile')"&gt;&lt;span class='hidden'&gt;$services.localization.render('platform.core.profile.category.profile.edit')&lt;/span&gt;&lt;/a&gt;&lt;/div&gt;
     #end
     ## Please do not insert extra empty lines here (as it affects the validity of the rendered xhtml)
     #set ($sectionsObject = $sheetDocument.getObject($sectionsObjectClassName))

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
@@ -89,7 +89,9 @@ $services.localization.render('platform.core.profile.category.profile.disabled')
     #end
     &lt;div class='userInfo'&gt;
     #if($xcontext.action == 'view' &amp;&amp; $hasEdit)
-      &lt;div class='editProfileCategory'&gt;&lt;a title="$services.localization.render('platform.core.profile.category.profile.edit')" href="$doc.getURL('edit', 'editor=inline&amp;amp;category=profile')"&gt;&lt;span class='hidden'&gt;$services.localization.render('platform.core.profile.category.profile.edit')&lt;/span&gt;&lt;/a&gt;&lt;/div&gt;
+      &lt;div class='editProfileCategory'&gt;&lt;a title="$escapetool.xml($services.localization.render('platform.core.profile.category.profile.edit'))" 
+       href="$doc.getURL('edit', 'editor=inline&amp;amp;category=profile')"&gt;
+       &lt;span class='sr-only'&gt;$services.localization.render('platform.core.profile.category.profile.edit')&lt;/span&gt;&lt;/a&gt;&lt;/div&gt;
     #end
     ## Please do not insert extra empty lines here (as it affects the validity of the rendered xhtml)
     #set ($sectionsObject = $sheetDocument.getObject($sectionsObjectClassName))

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
@@ -529,13 +529,6 @@ $services.localization.render('platform.core.profile.category.profile.disabled')
   font-weight: 700;
   margin-bottom: 0.3em;
   text-transform: uppercase;
-}
-        
-/* ----- Profile ----- */
-
-.userInfo h2 {
-    font-size: 16px;
-    font-weight: bold;
 }</code>
     </property>
     <property>

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
@@ -89,9 +89,12 @@ $services.localization.render('platform.core.profile.category.profile.disabled')
     #end
     &lt;div class='userInfo'&gt;
     #if($xcontext.action == 'view' &amp;&amp; $hasEdit)
-      &lt;div class='editProfileCategory'&gt;&lt;a title="$escapetool.xml($services.localization.render('platform.core.profile.category.profile.edit'))" 
-       href="$doc.getURL('edit', 'editor=inline&amp;amp;category=profile')"&gt;
-       &lt;span class='sr-only'&gt;$services.localization.render('platform.core.profile.category.profile.edit')&lt;/span&gt;&lt;/a&gt;&lt;/div&gt;
+      &lt;div class='editProfileCategory'&gt;
+       &lt;a title="$escapetool.xml($services.localization.render('platform.core.profile.category.profile.edit'))" 
+        href="$doc.getURL('edit', 'editor=inline&amp;amp;category=profile')"&gt;
+        &lt;span class='sr-only'&gt;$services.localization.render('platform.core.profile.category.profile.edit')&lt;/span&gt;
+       &lt;/a&gt;
+      &lt;/div&gt;
     #end
     ## Please do not insert extra empty lines here (as it affects the validity of the rendered xhtml)
     #set ($sectionsObject = $sheetDocument.getObject($sectionsObjectClassName))
@@ -149,8 +152,10 @@ $services.localization.render('platform.core.profile.category.profile.disabled')
       #if ($xcontext.user == $doc.fullName)
         &lt;h2&gt;$services.localization.render('platform.core.profile.section.activity')&lt;/h2&gt;
       #else
-        &lt;h2&gt;$services.localization.render('platform.core.profile.section.activityof',
-         [$xwiki.getUserName($doc.fullName, false)])&lt;/h2&gt;
+        &lt;h2&gt;
+         $services.localization.render('platform.core.profile.section.activityof',
+         [$xwiki.getUserName($doc.fullName, false)])
+        &lt;/h2&gt;
         #if ($hasWatch)
         $xwiki.ssx.use('XWiki.XWikiUserProfileSheet')##
         &lt;div class='activity-follow'&gt;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserSheet.xml
@@ -587,8 +587,8 @@ div.userInfo, div.userPreferences, div.watchlistManagement, div.userDashboard {
 }
         
 .userInfo h2 {
-  font-size: large;
-  font-weight: bold;
+  font-size: larger;
+  font-weight: bolder;
 }
         
 div.userInfo input[type="text"], div.userInfo input[type="password"], div.userInfo textarea, div.userInfo select, div.userPreferences select {

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserSheet.xml
@@ -585,7 +585,12 @@ div.userInfo, div.userPreferences, div.watchlistManagement, div.userDashboard {
 .userInfo img {
   max-width: 100%;
 }
-
+        
+.userInfo h2 {
+  font-size: 16px;
+  font-weight: bold;
+}
+        
 div.userInfo input[type="text"], div.userInfo input[type="password"], div.userInfo textarea, div.userInfo select, div.userPreferences select {
   width: 100%;
 }

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserSheet.xml
@@ -587,7 +587,7 @@ div.userInfo, div.userPreferences, div.watchlistManagement, div.userDashboard {
 }
         
 .userInfo h2 {
-  font-size: 16px;
+  font-size: large;
   font-weight: bold;
 }
         


### PR DESCRIPTION
Issue XWIKI-7716 has been solved.
Issue-Link: https://jira.xwiki.org/browse/XWIKI-7716
Replacing h1 tags with h2 tags. As there should be only one h1 tag in the document.
Added a title to a link `<a>`  tag.
**Result:** 
![Issue-7716-solved](https://user-images.githubusercontent.com/40354433/75925637-d4fbf000-5e8a-11ea-901c-0d042444b04e.PNG)
**Inspect**
![Issue-7716-solved-inspect](https://user-images.githubusercontent.com/40354433/75925825-37ed8700-5e8b-11ea-8d87-8e59dfa80866.PNG)


