### PR TITLE
Issue XWIKI-16341 " 'Add summary' input not aligned with 'Save' buttons "

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/actionbuttons/actionButtons.css
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/actionbuttons/actionButtons.css
@@ -12,6 +12,5 @@
 
 #commentinput {
   width: inherit;
-  position:relative;
-  top:1px;
+  vertical-align: middle;
 }

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/actionbuttons/actionButtons.css
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/actionbuttons/actionButtons.css
@@ -12,4 +12,6 @@
 
 #commentinput {
   width: inherit;
+  position:relative;
+  top:1px;
 }


### PR DESCRIPTION
**Issue link:** https://jira.xwiki.org/browse/XWIKI-16341
**Issue Description:** The input is aligned with the button ONLY on the 'editor=wiki' mode. If you switch to WYSIWYG, object, class editors, the alignment is lost. There is a 1px difference.

**Before:**
![Before](https://user-images.githubusercontent.com/40354433/75989194-a591c580-5f14-11ea-9da5-2304fdc16667.PNG)

After:
![After](https://user-images.githubusercontent.com/40354433/75989221-b04c5a80-5f14-11ea-8de4-ddb5d8662753.PNG)

**Solution:** 
Input box "Add Summary" was a little bit above the line of actions-buttons. So 1px from the top is added to keep align it with other action buttons.