### PR TITLE
XWIKI-15708: Consistent #tmEditObject and #tmEditClass menu entries icons

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_content.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_content.vm
@@ -257,11 +257,11 @@
     ##
     ## OBJECTS EDITOR
     ##
-    #set ($discard = $staticExtensions.add( { 'content': "#submenuitem($doc.getURL('edit', 'editor=object') $services.localization.render('core.menu.edit.object') 'tmEditObject', '', 'drive', $extraAttributes)", 'order': 60000}))
+    #set ($discard = $staticExtensions.add( { 'content': "#submenuitem($doc.getURL('edit', 'editor=object') $services.localization.render('core.menu.edit.object') 'tmEditObject', '', 'bricks', $extraAttributes)", 'order': 60000}))
     ##
     ## CLASS EDITOR
     ##
-    #set ($discard = $staticExtensions.add( { 'content': "#submenuitem($doc.getURL('edit', 'editor=class') $services.localization.render('core.menu.edit.class') 'tmEditClass', '', 'drive', $extraAttributes)", 'order': 70000}))
+    #set ($discard = $staticExtensions.add( { 'content': "#submenuitem($doc.getURL('edit', 'editor=class') $services.localization.render('core.menu.edit.class') 'tmEditClass', '', 'box', $extraAttributes)", 'order': 70000}))
   #end
   ##
   ## Display all the extensions points, including the static ones


### PR DESCRIPTION
Issue link: https://jira.xwiki.org/browse/XWIKI-15708

Before:
![Picture 2020-03-06 00_58_26](https://user-images.githubusercontent.com/33906649/76020646-9b3bef80-5f45-11ea-9064-02f6155352c5.png)

After:
![Picture 2020-03-06 00_58_55](https://user-images.githubusercontent.com/33906649/76020674-aa22a200-5f45-11ea-8da7-602134555bd9.png)
