### PR TITLE
XWIKI-15477: Missing Annotations icon in the More Actions menu when Annotation tab is displayed

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/shortcuts.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/shortcuts.vm
@@ -48,7 +48,7 @@
       ## config document. This however should not happen.
       #set ($annotationCount = $services.annotations.getAnnotations($doc).size())
     #end
-    #set ($discard = $docextralinks.add(['annotations', $services.localization.render('docextra.annotations'), $annotationCount, 'pushpin']))
+    #set ($discard = $docextralinks.add(['annotations', $services.localization.render('docextra.annotations'), $annotationCount, 'note', '', 'tmAnnotation']))
   #end
   #if($viewer != 'attachments' && $showattachments && !$doc.isNew())
     #set ($discard = $docextralinks.add(['attachments', $services.localization.render('docextra.attachments'), $doc.getAttachmentList().size(), 'attach', '', 'tmAttachments']))


### PR DESCRIPTION
Issue link: https://jira.xwiki.org/browse/XWIKI-15477

Before:
![Picture 2020-03-06 01_04_59](https://user-images.githubusercontent.com/33906649/76021161-90358f00-5f46-11ea-8f59-a1956a055a83.png)

After:
![Picture 2020-03-06 01_05_43](https://user-images.githubusercontent.com/33906649/76021195-a17e9b80-5f46-11ea-8bac-202c8982b843.png)
