### PR TITLE
XWIKI-16342 "Unaligned buttons for class and object editors"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
@@ -323,7 +323,10 @@ div#xwikiobjects input[type="radio"], div#xwikiclassproperties input[type="radio
   text-decoration: underline;
   background-color: $theme.highlightColor;
 }
-
+#add_xobject .buttonwrapper, #add_xproperty .buttonwrapper{
+  position: relative;
+  top: -2px;
+}
 #switch-xclass {
   text-align: right;
   margin: 4px 0 -16px;

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
@@ -337,6 +337,7 @@ div#xwikiobjects input[type="radio"], div#xwikiclassproperties input[type="radio
 .suggest-classes.selectize-control {
   /* Display on the same line as the Add button */
   display: inline-block;
+  /* Align with the Add button */
   vertical-align: middle;
 }
 .suggest-classes > .selectize-dropdown > .selectize-dropdown-content,

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
@@ -324,22 +324,22 @@ div#xwikiobjects input[type="radio"], div#xwikiclassproperties input[type="radio
   background-color: $theme.highlightColor;
 }
 #add_xobject .buttonwrapper, #add_xproperty .buttonwrapper{
-  position: relative;
-  top: -2px;
+  vertical-align:top;
+}
+#add_xobject .buttonwrapper input , #add_xproperty .buttonwrapper input {
+    vertical-align: top;
+    margin: 0px;
 }
 #switch-xclass {
   text-align: right;
   margin: 4px 0 -16px;
 }
-
 #switch-xclass .suggest-classes {
   text-align: left;
 }
 .suggest-classes.selectize-control {
   /* Display on the same line as the Add button */
   display: inline-block;
-  /* Align with the Add button */
-  margin-top: 2px;
   vertical-align: middle;
 }
 .suggest-classes > .selectize-dropdown > .selectize-dropdown-content,

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
@@ -323,9 +323,6 @@ div#xwikiobjects input[type="radio"], div#xwikiclassproperties input[type="radio
   text-decoration: underline;
   background-color: $theme.highlightColor;
 }
-#add_xobject .buttonwrapper, #add_xproperty .buttonwrapper{
-  vertical-align:top;
-}
 #add_xobject .buttonwrapper input , #add_xproperty .buttonwrapper input {
     vertical-align: top;
     margin: 0px;

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
@@ -323,12 +323,10 @@ div#xwikiobjects input[type="radio"], div#xwikiclassproperties input[type="radio
   text-decoration: underline;
   background-color: $theme.highlightColor;
 }
-#add_xobject .buttonwrapper input {  
-  vertical-align: top;
-}
+#add_xobject .buttonwrapper input,
 #add_xproperty .buttonwrapper input {
   vertical-align: top;
-  margin: 0px;
+  margin: 0;
 }
 #switch-xclass {
   text-align: right;

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
@@ -323,9 +323,12 @@ div#xwikiobjects input[type="radio"], div#xwikiclassproperties input[type="radio
   text-decoration: underline;
   background-color: $theme.highlightColor;
 }
-#add_xobject .buttonwrapper input , #add_xproperty .buttonwrapper input {
-    vertical-align: top;
-    margin: 0px;
+#add_xobject .buttonwrapper input {  
+  vertical-align: top;
+}
+#add_xproperty .buttonwrapper input {
+  vertical-align: top;
+  margin: 0px;
 }
 #switch-xclass {
   text-align: right;


### PR DESCRIPTION
**Issue:**  XWIKI-16342 Unaligned buttons for class and object editors
**Issue link:**  https://jira.xwiki.org/browse/XWIKI-16342

**Before:** 

<img width="594" alt="selectClass" src="https://user-images.githubusercontent.com/40354433/76028148-ca595d80-5f53-11ea-88bf-47595c2bac16.png">

<img width="621" alt="addToClass" src="https://user-images.githubusercontent.com/40354433/76028184-dfce8780-5f53-11ea-9fd9-33e21fec35fc.png">

**After:**

![After-Object](https://user-images.githubusercontent.com/40354433/76028659-e0b3e900-5f54-11ea-8450-6a33aaffec1e.PNG)

![After-Class](https://user-images.githubusercontent.com/40354433/76028668-e6113380-5f54-11ea-849d-2dee6e74cb97.PNG)
