### PR TITLE
XWIKI-16344: Use .xform style standard in the wiki and wysiwyg edit modes

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editmeta.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editmeta.vm
@@ -34,13 +34,25 @@
 </div>
 #if ($editor != 'inline')
 <div id="titleinput" class="form-group">
-  <label for="xwikidoctitleinput">$services.localization.render('core.editors.content.titleField.label')</label>
-  <input type="text" id="xwikidoctitleinput" name="title" value="$escapetool.xml("$!docTitle")" class="#if($xwiki.getXWikiPreference('xwiki.title.mandatory') == 1)required#end"/>
+  <dl>
+    <dt>
+      <label for="xwikidoctitleinput">$services.localization.render('core.editors.content.titleField.label')</label>
+    </dt>
+    <dd>
+      <input type="text" id="xwikidoctitleinput" name="title" value="$escapetool.xml("$!docTitle")" 
+        class="#if($xwiki.getXWikiPreference('xwiki.title.mandatory') == 1)required#end"/>
+    </dd>
+  </dl>
 </div>
 #end
 
 #if($editor == 'wiki')
-<div id="contentMeta">
-  <label for="content">$services.localization.render('core.editors.content.contentField.label')</label>
+<div id="contentMeta" class="ContentMetaLabel">
+  <dl>
+    <dt>
+      <label for="content">$services.localization.render('core.editors.content.contentField.label')</label>
+    </dt>
+    <dd></dd>
+  </dl>
 </div>
 #end

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/forms.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/forms.less
@@ -97,6 +97,9 @@ select[size="0"], select[size="1"] {
   .xErrorField {
     border-color: @state-danger-border;
   }
+  .ContentMetaLabel dl {
+    margin-bottom: 1px;   // XWIKI-16344
+  }
 }
 
 .xformInline {


### PR DESCRIPTION
Issue link: https://jira.xwiki.org/browse/XWIKI-16344

Before:
![chrome_q08pUYynUb](https://user-images.githubusercontent.com/33906649/76114531-1f56ab80-6008-11ea-80dc-97ec1cf935c8.png)
`also`:
![Picture 2020-02-28 00_29_50](https://user-images.githubusercontent.com/33906649/75485210-1ba1a400-59cc-11ea-9e59-afb62ad4aea9.png)

After:
![chrome_8D5wyXMZXH](https://user-images.githubusercontent.com/33906649/76114529-1d8ce800-6008-11ea-9297-ccccc82e561d.png)
