### PR TITLE
XWIKI-15364: Add role="search" to the global / quicksearch form

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/QuickSearchUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/QuickSearchUIX.xml
@@ -240,9 +240,13 @@
       <content>{{velocity}}{{html clean="false"}} ## we need clean="false" because we want to display the raw content
   #if ($displayQuickSearch &amp;&amp; ($xwiki.exists('Main.Search') || $xwiki.exists('Main.WebSearch')))
     #set ($discard = $xwiki.jsx.use('XWiki.QuickSearchUIX'))
+        #if ($xwiki.exists('Main.Search'))
+          #set ($searchUrl = $xwiki.getURL('Main.Search'))
+        #else
+          #set ($searchUrl = $xwiki.getURL('Main.WebSearch'))
+        #end
     &lt;li&gt;
-      &lt;form class="navbar-form globalsearch globalsearch-close form-inline" id="globalsearch" 
-        action="#if($xwiki.exists('Main.Search'))$xwiki.getURL('Main.Search')#else$xwiki.getURL('Main.WebSearch')#end" role="search"&gt;
+      &lt;form class="navbar-form globalsearch globalsearch-close form-inline" id="globalsearch" action="$searchUrl" role="search"&gt;
         &lt;label class="hidden" for="headerglobalsearchinput"&gt;$services.localization.render('search')&lt;/label&gt;
         &lt;input type="text" name="text" placeholder="$services.localization.render('panels.search.inputText')" id="headerglobalsearchinput" /&gt;
         &lt;button type="submit" class="btn" title="$services.localization.render('search')"&gt;$services.icon.renderHTML('search')&lt;/button&gt;

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/QuickSearchUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/QuickSearchUIX.xml
@@ -240,11 +240,11 @@
       <content>{{velocity}}{{html clean="false"}} ## we need clean="false" because we want to display the raw content
   #if ($displayQuickSearch &amp;&amp; ($xwiki.exists('Main.Search') || $xwiki.exists('Main.WebSearch')))
     #set ($discard = $xwiki.jsx.use('XWiki.QuickSearchUIX'))
-        #if ($xwiki.exists('Main.Search'))
-          #set ($searchUrl = $xwiki.getURL('Main.Search'))
-        #else
-          #set ($searchUrl = $xwiki.getURL('Main.WebSearch'))
-        #end
+      #if ($xwiki.exists('Main.Search'))
+        #set ($searchUrl = $xwiki.getURL('Main.Search'))
+      #else
+        #set ($searchUrl = $xwiki.getURL('Main.WebSearch'))
+      #end
     &lt;li&gt;
       &lt;form class="navbar-form globalsearch globalsearch-close form-inline" id="globalsearch" action="$searchUrl" role="search"&gt;
         &lt;label class="hidden" for="headerglobalsearchinput"&gt;$services.localization.render('search')&lt;/label&gt;

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/QuickSearchUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/QuickSearchUIX.xml
@@ -241,7 +241,8 @@
   #if ($displayQuickSearch &amp;&amp; ($xwiki.exists('Main.Search') || $xwiki.exists('Main.WebSearch')))
     #set ($discard = $xwiki.jsx.use('XWiki.QuickSearchUIX'))
     &lt;li&gt;
-      &lt;form class="navbar-form globalsearch globalsearch-close form-inline" id="globalsearch" action="#if($xwiki.exists('Main.Search'))$xwiki.getURL('Main.Search')#else$xwiki.getURL('Main.WebSearch')#end"&gt;
+      &lt;form class="navbar-form globalsearch globalsearch-close form-inline" id="globalsearch" 
+        action="#if($xwiki.exists('Main.Search'))$xwiki.getURL('Main.Search')#else$xwiki.getURL('Main.WebSearch')#end" role="search"&gt;
         &lt;label class="hidden" for="headerglobalsearchinput"&gt;$services.localization.render('search')&lt;/label&gt;
         &lt;input type="text" name="text" placeholder="$services.localization.render('panels.search.inputText')" id="headerglobalsearchinput" /&gt;
         &lt;button type="submit" class="btn" title="$services.localization.render('search')"&gt;$services.icon.renderHTML('search')&lt;/button&gt;

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/QuickSearchUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/QuickSearchUIX.xml
@@ -240,13 +240,14 @@
       <content>{{velocity}}{{html clean="false"}} ## we need clean="false" because we want to display the raw content
   #if ($displayQuickSearch &amp;&amp; ($xwiki.exists('Main.Search') || $xwiki.exists('Main.WebSearch')))
     #set ($discard = $xwiki.jsx.use('XWiki.QuickSearchUIX'))
-      #if ($xwiki.exists('Main.Search'))
-        #set ($searchUrl = $xwiki.getURL('Main.Search'))
-      #else
-        #set ($searchUrl = $xwiki.getURL('Main.WebSearch'))
-      #end
+    #if ($xwiki.exists('Main.Search'))
+      #set ($searchURL = $xwiki.getURL('Main.Search'))
+    #else
+      #set ($searchURL = $xwiki.getURL('Main.WebSearch'))
+    #end
     &lt;li&gt;
-      &lt;form class="navbar-form globalsearch globalsearch-close form-inline" id="globalsearch" action="$searchUrl" role="search"&gt;
+      &lt;form class="navbar-form globalsearch globalsearch-close form-inline" id="globalsearch" action="$searchURL" 
+          role="search"&gt;
         &lt;label class="hidden" for="headerglobalsearchinput"&gt;$services.localization.render('search')&lt;/label&gt;
         &lt;input type="text" name="text" placeholder="$services.localization.render('panels.search.inputText')" id="headerglobalsearchinput" /&gt;
         &lt;button type="submit" class="btn" title="$services.localization.render('search')"&gt;$services.icon.renderHTML('search')&lt;/button&gt;


### PR DESCRIPTION
**Issue**: XWIKI-15364
**Issue link:** https://jira.xwiki.org/browse/XWIKI-15364
**Description:** This is done in the form of the Main Search page, but we should also do it for the global/quick search form, on the navbar-menu.

**Before:** 

![QuickSearch-Before](https://user-images.githubusercontent.com/40354433/76127233-fe4f8400-6022-11ea-8c31-9d4b37abf48c.PNG)

**After:**

![QuickSearch-After](https://user-images.githubusercontent.com/40354433/76127260-0b6c7300-6023-11ea-9a89-e68d169a4e8d.PNG)
