### PR TITLE
XWIKI-10954: "Panel Title" field is not aligned with "Create" button

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/forms.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/forms.less
@@ -7,6 +7,10 @@ textarea, select, input[type="text"], input[type="password"] {
   display: inline-block;
   max-width: 100%; /* Prevent resizing beyond the visible area in modern browsers */
   width: auto;
+}
+
+input.withTip,
+input.panelinput {
   vertical-align: middle; /* Align with other form elements */
 }
 

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/forms.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/forms.less
@@ -7,6 +7,7 @@ textarea, select, input[type="text"], input[type="password"] {
   display: inline-block;
   max-width: 100%; /* Prevent resizing beyond the visible area in modern browsers */
   width: auto;
+  vertical-align: middle; /* Align with other form elements */
 }
 
 select.input-sm, input[type="text"].input-sm, input[type="password"].input-sm {

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/forms.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/forms.less
@@ -9,11 +9,6 @@ textarea, select, input[type="text"], input[type="password"] {
   width: auto;
 }
 
-input.withTip,
-input.panelinput {
-  vertical-align: middle; /* Align with other form elements */
-}
-
 select.input-sm, input[type="text"].input-sm, input[type="password"].input-sm {
   .input-sm;
 }

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/CreatePanel.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/CreatePanel.xml
@@ -39,14 +39,16 @@
   <content>{{velocity output="false"}}
 #macro (displayCreatePanelForm)
 {{html}}
-  &lt;form method="post" action="$doc.getURL('view', 'xpage=plain')" onsubmit="cancelCancelEdit()"&gt;
+  &lt;form method="post" action="$doc.getURL('view', 'xpage=plain')" class="form-inline" onsubmit="cancelCancelEdit()"&gt;
     &lt;div&gt;
       &lt;input type="hidden" name="form_token" value="$!{services.csrf.getToken()}" /&gt;
       &lt;input type="hidden" name="create" value="1"/&gt;
       &lt;input type="hidden" name="parent" value="Panels.WebHome"/&gt;
       &lt;label for="panelTitle" class="hidden"&gt;$services.localization.render('xe.panels.create.title')&lt;/label&gt;
-      &lt;input type="text" id="panelTitle" name="panelTitle" value="$services.localization.render('xe.panels.create.title')" class="panelinput withTip" /&gt;
-      &lt;input type="submit" class="btn btn-success button" value="$services.localization.render('create')"/&gt;
+      &lt;input type="text" id="panelTitle" name="panelTitle" 
+          value="$escapetool.xml($services.localization.render('xe.panels.create.title'))" /&gt;
+      &lt;input type="submit" class="btn btn-success" 
+          value="$escapetool.xml($services.localization.render('create'))"/&gt;
     &lt;/div&gt;
   &lt;/form&gt;
 {{/html}}##

--- a/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-ui/src/main/resources/Scheduler/WebHome.xml
+++ b/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-ui/src/main/resources/Scheduler/WebHome.xml
@@ -186,15 +186,19 @@ $services.localization.render('xe.scheduler.welcome')
 {{info}}$services.localization.render('xe.scheduler.jobs.explaincreate'){{/info}}
 
 {{html}}
-&lt;form action="$doc.getURL('create')" id="newdoc"&gt;&lt;div&gt;
+&lt;form action="$doc.getURL('create')" id="newdoc" class="form-inline"&gt;&lt;div&gt;
   &lt;input type="hidden" name="form_token" value="$!{services.csrf.getToken()}" /&gt;
   &lt;input type="hidden" name="parent" value="Scheduler.WebHome" /&gt;
   &lt;input type="hidden" name="template" value="XWiki.SchedulerJobTemplate" /&gt;
   &lt;input type="hidden" name="sheet" value="1" /&gt;
   &lt;input type="hidden" name="space" value="Scheduler"/&gt;
   &lt;label class="hidden" for="page"&gt;$services.localization.render('xe.scheduler.jobs.create.nameTip')&lt;/label&gt;
-  &lt;input id="page" name="page" size="30" type="text" class="withTip" value="$services.localization.render('xe.scheduler.jobs.create.nameTip')" /&gt;
-  &lt;span class="buttonwrapper"&gt;&lt;input type="submit" class="btn btn-success button" value="$services.localization.render('xe.scheduler.jobs.create.submit')"/&gt;&lt;/span&gt;
+  &lt;input id="page" name="page" size="30" type="text"
+      value="$escapetool.xml($services.localization.render('xe.scheduler.jobs.create.nameTip'))" /&gt;
+  &lt;span class="buttonwrapper"&gt;
+    &lt;input type="submit" class="btn btn-success"
+        value="$escapetool.xml($services.localization.render('xe.scheduler.jobs.create.submit'))"/&gt;
+  &lt;/span&gt;
 &lt;/div&gt;&lt;/form&gt;
 {{/html}}
 


### PR DESCRIPTION
**Issue**: XWIKI-10954 
**Issue link**: https://jira.xwiki.org/browse/XWIKI-10954

**Description:** Text Field and button input elements are aligned. I tested my changes on multiple browsers (Edge, Firefox, Chrome). I have solved both `Create a Job` and `Create a Panel` with a single line of code. `vertical-align: middle`.

**Before:**  

![Before vertical_align](https://user-images.githubusercontent.com/40354433/76419903-fe54d880-63c2-11ea-9eb8-3f6902f7dafb.PNG)
![Job_before_align](https://user-images.githubusercontent.com/40354433/76419920-044ab980-63c3-11ea-8d16-36837c994997.PNG)

**After:**

![after-vertical_align](https://user-images.githubusercontent.com/40354433/76419944-14629900-63c3-11ea-9ce6-8764062354b8.PNG)

![job_after_align](https://user-images.githubusercontent.com/40354433/76419952-19274d00-63c3-11ea-9081-e3f2bf2858cf.PNG)

