### PR TITLE
XWIKI-10952: The "Available package" information is not aligned

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/xlist.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/xlist.less
@@ -53,14 +53,6 @@ ul.xlist li.create a {
   padding-left: 1.5em;
 }
 
-ul.xlist li.xitem div.xitemcontainer {
-  text-indent: 0;
-}
-
-ul.xlist li.xitem div.xitemcontainer ul.xlist {
-  text-indent: 0;
-}
-
 .xspacer {
   display: none;
 }

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/xlist.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/xlist.less
@@ -54,7 +54,7 @@ ul.xlist li.create a {
 }
 
 ul.xlist li.xitem div.xitemcontainer {
-  text-indent: 1.5em;
+  text-indent: 0;
 }
 
 ul.xlist li.xitem div.xitemcontainer ul.xlist {

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/importer/import.css
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/importer/import.css
@@ -37,7 +37,7 @@ div.loading {
   background: transparent url("$xwiki.getSkinFile('icons/silk/package.png')") no-repeat scroll 5px 0.5em;
   font-size: .85em;
   margin-bottom: .2em;
-  padding: .3em 0 .3em 1em;
+  padding: .3em 0 .3em 2.5em;
 }
 
 #packagelist .active {


### PR DESCRIPTION
**Issue**: XWIKI-10952
**Issue link:**  https://jira.xwiki.org/browse/XWIKI-10952
**Description:**  Aligned the title and the description rows having only the icon on the left side. Tested on multiple Browsers (IE, Edge, Firefox, and chrome). Responsive across all devices. Responsiveness can be seen in the screenshots.

**Before:** 

Desktop:
![Desktop_Before](https://user-images.githubusercontent.com/40354433/76449346-bbf4c100-63ed-11ea-87d2-a36a3f466ad5.PNG)
Tablet : 
![Tablet_Before](https://user-images.githubusercontent.com/40354433/76449348-bd25ee00-63ed-11ea-88ef-be273783dab4.PNG)
Mobile:
![mobile_before](https://user-images.githubusercontent.com/40354433/76449351-be571b00-63ed-11ea-87cd-3bb7c3344d5c.PNG)

**After:**

Desktop:
![Desktop_After](https://user-images.githubusercontent.com/40354433/76449401-d890f900-63ed-11ea-9a8c-7d8f82a395cf.PNG)
Tablet:
![Tablet_720px_After](https://user-images.githubusercontent.com/40354433/76449396-d75fcc00-63ed-11ea-935c-26e6301fe483.PNG)
Mobile: 
![mobile_350px_after](https://user-images.githubusercontent.com/40354433/76449398-d890f900-63ed-11ea-8129-46cf6c5da91b.PNG)


