### PR TITLE
XWIKI-16344: Use .xform style standard in the wiki and wysiwyg edit modes

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editmeta.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editmeta.vm
@@ -35,7 +35,9 @@
 #if ($editor != 'inline')
 <dl id="titleinput" class="form-group">
   <dt>
-    <label for="xwikidoctitleinput">$escapetool.xml($services.localization.render('core.editors.content.titleField.label'))</label>
+    <label for="xwikidoctitleinput">
+      $escapetool.xml($services.localization.render('core.editors.content.titleField.label'))
+    </label>
   </dt>
   <dd>
     <input type="text" id="xwikidoctitleinput" name="title" value="$escapetool.xml("$!docTitle")" 
@@ -47,7 +49,9 @@
 #if($editor == 'wiki')
 <dl id="contentMeta">
   <dt>
-    <label for="content">$escapetool.xml($services.localization.render('core.editors.content.contentField.label'))</label>
+    <label for="content">
+      $escapetool.xml($services.localization.render('core.editors.content.contentField.label'))
+    </label>
   </dt>
   ## Content area has an empty <dd> because the content text area is far below and couldn't be moved here,
   ## and the HTML needs to remain valid.

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editmeta.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editmeta.vm
@@ -33,14 +33,24 @@
   <input type="text" id="xwikidocparentinput" name="parent" value="$!{escapetool.xml("$!docParent")}" size="30" class="suggestDocuments "/>
 </div>
 #if ($editor != 'inline')
-<div id="titleinput" class="form-group">
-  <label for="xwikidoctitleinput">$services.localization.render('core.editors.content.titleField.label')</label>
-  <input type="text" id="xwikidoctitleinput" name="title" value="$escapetool.xml("$!docTitle")" class="#if($xwiki.getXWikiPreference('xwiki.title.mandatory') == 1)required#end"/>
-</div>
+<dl id="titleinput" class="form-group">
+  <dt>
+    <label for="xwikidoctitleinput" value="$escapetool.xml("$!docTitle")">$services.localization.render('core.editors.content.titleField.label')</label>
+  </dt>
+  <dd>
+    <input type="text" id="xwikidoctitleinput" name="title" value="$escapetool.xml("$!docTitle")" 
+      class="#if($xwiki.getXWikiPreference('xwiki.title.mandatory') == 1)required#end"/>
+  </dd>
+</dl>
 #end
 
 #if($editor == 'wiki')
-<div id="contentMeta">
-  <label for="content">$services.localization.render('core.editors.content.contentField.label')</label>
-</div>
+<dl id="contentMeta">
+  <dt>
+    <label for="content" value="$escapetool.xml("$!docTitle")">$services.localization.render('core.editors.content.contentField.label')</label>
+  </dt>
+## Content area has an empty <dd> because the content text area is far below and couldn't be moved here,
+## and the HTML needs to remain valid.
+  <dd></dd>
+</dl>
 #end

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editmeta.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editmeta.vm
@@ -35,7 +35,7 @@
 #if ($editor != 'inline')
 <dl id="titleinput" class="form-group">
   <dt>
-    <label for="xwikidoctitleinput" value="$escapetool.xml("$!docTitle")">$services.localization.render('core.editors.content.titleField.label')</label>
+    <label for="xwikidoctitleinput">$escapetool.xml($services.localization.render('core.editors.content.titleField.label'))</label>
   </dt>
   <dd>
     <input type="text" id="xwikidoctitleinput" name="title" value="$escapetool.xml("$!docTitle")" 
@@ -47,10 +47,10 @@
 #if($editor == 'wiki')
 <dl id="contentMeta">
   <dt>
-    <label for="content" value="$escapetool.xml("$!docTitle")">$services.localization.render('core.editors.content.contentField.label')</label>
+    <label for="content">$escapetool.xml($services.localization.render('core.editors.content.contentField.label'))</label>
   </dt>
-## Content area has an empty <dd> because the content text area is far below and couldn't be moved here,
-## and the HTML needs to remain valid.
+  ## Content area has an empty <dd> because the content text area is far below and couldn't be moved here,
+  ## and the HTML needs to remain valid.
   <dd></dd>
 </dl>
 #end

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/edit.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/edit.less
@@ -82,7 +82,7 @@
 // XWIKI-16344: Use .xform style standard in the wiki and wysiwyg edit modes
 // Fix for the content's margin-bottom which creates a big vertical gap.
 #contentMeta {
-  margin-bottom: 0px;
+  margin-bottom: 0;
 }
 
 textarea#content {

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/edit.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/edit.less
@@ -79,6 +79,12 @@
   width: 100%;
 }
 
+// XWIKI-16344: Use .xform style standard in the wiki and wysiwyg edit modes
+// Fix for the content's margin-bottom which creates a big vertical gap.
+#contentMeta {
+  margin-bottom: 0px;
+}
+
 textarea#content {
   width: 100%;
 }


### PR DESCRIPTION
Issue link: https://jira.xwiki.org/browse/XWIKI-16344
Tested.

Before:
![image](https://user-images.githubusercontent.com/33906649/76114531-1f56ab80-6008-11ea-80dc-97ec1cf935c8.png)

After:
![image](https://user-images.githubusercontent.com/33906649/76454418-71c40d80-63f6-11ea-8b3e-17edde3f76df.png)

Any problems, let me know. Thanks!