### PR TITLE
XWIKI-17077: Pre-filled text from Summary field should be cleared automatically when the page is saved after uploading a logo

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/actionbuttons/actionButtons.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/actionbuttons/actionButtons.js
@@ -340,6 +340,9 @@ var XWiki = (function(XWiki) {
         this.form.template.value = "";
       }
 
+      // Reset the comment after a successful save and continue action.
+      $("commentinput").value = '';
+
       // don't force save twice
       if ($('forceSave')) {
         $('forceSave').remove();


### PR DESCRIPTION
Clear the comment content after a successful save and continue action.