### PR TITLE
XWIKI-17127: Page Information "xhidden" checkbox is misaligned

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/panels.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/panels.less
@@ -56,3 +56,9 @@ a.panel-collapse-carret {
   float: left;
   padding: 15px
 }
+
+// Checkbox xhidden in the Edit Panel (Page Information) ==================
+#editPanels #xhidden {
+  position: relative;
+  margin-left: -20px;
+}


### PR DESCRIPTION
Issue link: https://jira.xwiki.org/browse/XWIKI-17127

Before:
![PageInfoXhidden_Before](https://user-images.githubusercontent.com/33906649/76856632-76187c80-6875-11ea-90f6-5a496d74aaea.png)

After:
![PageInfoXhidden_After](https://user-images.githubusercontent.com/33906649/76856640-79ac0380-6875-11ea-83f4-7801cf18bd4c.png)

Let me know any problems.
Thanks!