### PR TITLE
XWIKI-17128: "Queue size" in Solr Search Administration is not using xform standards

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/XWiki/SolrSearchAdmin.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/XWiki/SolrSearchAdmin.xml
@@ -105,10 +105,11 @@
   #set ($discard = $xwiki.jsx.use('XWiki.SolrSearchAdmin'))
   == $services.localization.render('solr.admin.status.title') ==
 
-  (% class="xform" %)
-  ; {{html clean="false"}}&lt;label&gt;$services.localization.render('solr.admin.status.queueSize.label')&lt;/label&gt;{{/html}}##
+  (% class="xform" %)(((
+  ; {{html clean="false"}}<label>$services.localization.render('solr.admin.status.queueSize.label')</label>{{/html}}##
     (% class="xHint" %)$services.localization.render('solr.admin.status.queueSize.hint')
   : (% class="solrQueueSize" %)$services.solr.queueSize
+  )))
 
   == $services.localization.render('solr.admin.indexing.title') ==
 

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/XWiki/SolrSearchAdmin.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/XWiki/SolrSearchAdmin.xml
@@ -106,7 +106,7 @@
   == $services.localization.render('solr.admin.status.title') ==
 
   (% class="xform" %)(((
-  ; {{html clean="false"}}<label>$services.localization.render('solr.admin.status.queueSize.label')</label>{{/html}}##
+  ; {{html clean="false"}}&lt;label&gt;$services.localization.render('solr.admin.status.queueSize.label')&lt;/label&gt;{{/html}}##
     (% class="xHint" %)$services.localization.render('solr.admin.status.queueSize.hint')
   : (% class="solrQueueSize" %)$services.solr.queueSize
   )))


### PR DESCRIPTION
Issue Link: https://jira.xwiki.org/browse/XWIKI-17128

Line `109` has 118 characters so it doesn't exceed the limit.

Before:
![QueueSizeBefore](https://user-images.githubusercontent.com/33906649/76863883-08268200-6882-11ea-9f5a-187b2158a0a7.png)

After:
![QueueSizeAfter](https://user-images.githubusercontent.com/33906649/76863911-107ebd00-6882-11ea-8a37-db25a23b42fd.png)

Let me know any mistakes, thanks!