### PR TITLE
XWIKI-17127: Page Information "xhidden" checkbox is misaligned

### DIFF
--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/DocumentInformation.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/DocumentInformation.xml
@@ -256,7 +256,7 @@
 : [[$services.localization.render('panels.documentInformation.configureSyntaxes')&gt;&gt;path:$xwiki.getURL('XWiki.XWikiPreferences', 'admin', 'editor=globaladmin&amp;section=Syntaxes')]]
 #end
 ##--------------------------------------------------------------------------
-; (% class="checkbox" %){{html}}
+; {{html}}
 &lt;label for="xhidden"&gt;&lt;input id="xhidden" type="checkbox" name="xhidden" #if($tdoc.isHidden()) checked="checked"#end value="1"/&gt;$services.localization.render('panels.documentInformation.hiddenDocument')&lt;/label&gt;
 &lt;input name="xhidden" type="hidden" value="0" /&gt;
 {{/html}}


### PR DESCRIPTION
Issue link: https://jira.xwiki.org/browse/XWIKI-17127
The checkbox was loading wrong styles after `form` class was replaced by `xform`.

Before:
![PageInfoXhidden_Before](https://user-images.githubusercontent.com/33906649/76856632-76187c80-6875-11ea-90f6-5a496d74aaea.png)

After:
![PageInfoXhidden_After2](https://user-images.githubusercontent.com/33906649/76987034-5449f300-6964-11ea-8606-f4294fa71119.png)

Thanks to Marius for telling me the right solution.