### PR TITLE
XWIKI-16303: Make utf8mb4 the default in XWiki Debian packages.

### DIFF
--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-mysql-common/src/deb/control/postinst
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-mysql-common/src/deb/control/postinst
@@ -11,7 +11,7 @@ set -e
 if [ -f /usr/share/dbconfig-common/dpkg/postinst.mysql ]; then
   . /usr/share/dbconfig-common/dpkg/postinst.mysql
 
-  extrasql=" CHARACTER SET utf8 COLLATE utf8_bin"
+  extrasql=" CHARACTER SET utf8mb4 COLLATE utf8mb4_bin"
 
   dbc_generate_include='template:/etc/xwiki/hibernate.cfg.xml'
   dbc_generate_include_perms='644'

--- a/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/hibernate.cfg.xml.vm
+++ b/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/hibernate.cfg.xml.vm
@@ -160,7 +160,7 @@
     <property name="hibernate.dbcp.poolPreparedStatements">true</property>
     <property name="hibernate.dbcp.maxOpenPreparedStatements">20</property>
 
-    <property name="hibernate.connection.charSet">UTF-8</property>
+    <property name="hibernate.connection.charSet">utf8mb4</property>
     <property name="hibernate.connection.useUnicode">true</property>
     <property name="hibernate.connection.characterEncoding">utf8</property>
 

--- a/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/hibernate.cfg.xml.vm
+++ b/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/hibernate.cfg.xml.vm
@@ -160,7 +160,7 @@
     <property name="hibernate.dbcp.poolPreparedStatements">true</property>
     <property name="hibernate.dbcp.maxOpenPreparedStatements">20</property>
 
-    <property name="hibernate.connection.charSet">utf8mb4</property>
+    <property name="hibernate.connection.charSet">UTF-8</property>
     <property name="hibernate.connection.useUnicode">true</property>
     <property name="hibernate.connection.characterEncoding">utf8</property>
 


### PR DESCRIPTION
I'm asking a review because these new settings are the ones that I have tested with success on a virtual machine, but I have not tried to build the debian package nor to upgrade an existing installation with the new packages. You could see it as a WIP with a request to point me where I should improve my proposition.

Thank you!

Guillaume