### PR TITLE
XWIKI-6721: The include macro should have an option to filter out the first heading in the included document or section

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
@@ -222,7 +222,8 @@ public class IncludeMacro extends AbstractMacro<IncludeMacroParameters>
                 result.removeBlock(heading);
             } else {
                 String includeType = parameters.getSection() != null ? "section" : "document";
-                throw new MacroExecutionException(String.format("The included " + includeType + " doesn't contain any heading"));
+                throw new MacroExecutionException(
+                    String.format("The included [%s] doesn't contain any heading",includeType));
            }
         }
         

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
@@ -215,13 +215,13 @@ public class IncludeMacro extends AbstractMacro<IncludeMacroParameters>
         }
         
         // Exclude the heading from the content
-        if (parameters.isExcludeHeading()) {
+        if (parameters.excludeHeading()) {
             HeaderBlock heading =
                     result.getFirstBlock(new ClassBlockMatcher(HeaderBlock.class), Block.Axes.DESCENDANT_OR_SELF);
             if (heading != null) {
                 result.removeBlock(heading);
             } else {
-                throw new MacroExecutionException("The included section doesn't contain main heading");
+                throw new MacroExecutionException("The included section doesn't contain any heading");
             }
         }
         

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
@@ -41,6 +41,7 @@ import org.xwiki.properties.BeanManager;
 import org.xwiki.properties.PropertyException;
 import org.xwiki.rendering.block.Block;
 import org.xwiki.rendering.block.MacroBlock;
+import org.xwiki.rendering.block.HeaderBlock;
 import org.xwiki.rendering.block.MacroMarkerBlock;
 import org.xwiki.rendering.block.MetaDataBlock;
 import org.xwiki.rendering.block.XDOM;

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
@@ -216,15 +216,15 @@ public class IncludeMacro extends AbstractMacro<IncludeMacroParameters>
         
         // Exclude the first heading from the content
         if (parameters.excludeFirstHeading()) {
-            HeaderBlock heading =
-                    result.getFirstBlock(new ClassBlockMatcher(HeaderBlock.class), Block.Axes.DESCENDANT_OR_SELF);
+            HeaderBlock heading = result.getFirstBlock(new ClassBlockMatcher(HeaderBlock.class),
+                    Block.Axes.DESCENDANT_OR_SELF);
             if (heading != null) {
-                result.removeBlock(heading);
+                removeBlockRecursively(result, heading);
             } else {
                 String includeType = parameters.getSection() != null ? "section" : "document";
                 throw new MacroExecutionException(
-                    String.format("The included [%s] doesn't contain any heading",includeType));
-           }
+                        String.format("The included [%s] doesn't contain any heading", includeType));
+            }
         }
         
         // Step 5: Wrap Blocks in a MetaDataBlock with the "source" meta data specified so that we know from where the
@@ -238,7 +238,26 @@ public class IncludeMacro extends AbstractMacro<IncludeMacroParameters>
 
         return Arrays.asList(metadata);
     }
-
+    
+    private boolean removeBlockRecursively(Block block, Block blockToRemove)
+    {
+        // Go through all children and remove the block if found
+        List<Block> allChildren = block.getChildren();
+        for (Block child : allChildren) {
+            if (child == blockToRemove) {
+                block.removeBlock(child);
+                return true;
+            } else {
+                // Check in children of the child
+                if (removeBlockRecursively(child, blockToRemove)) {
+                    // Return without moving on if child found
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+    
     /**
      * Protect form recursive inclusion.
      * 

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
@@ -221,7 +221,7 @@ public class IncludeMacro extends AbstractMacro<IncludeMacroParameters>
             if (heading != null) {
                 result.removeBlock(heading);
             } else {
-                throw new MacroExecutionException("The included section doesn't contain any heading");
+                throw new MacroExecutionException("The included document doesn't contain any heading");
             }
         }
         

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
@@ -215,13 +215,13 @@ public class IncludeMacro extends AbstractMacro<IncludeMacroParameters>
         }
         
         // Exclude the first heading from the content
-        if (parameters.excludeHeading()) {
+        if (parameters.excludeFirstHeading()) {
             HeaderBlock heading =
                     result.getFirstBlock(new ClassBlockMatcher(HeaderBlock.class), Block.Axes.DESCENDANT_OR_SELF);
             if (heading != null) {
                 result.removeBlock(heading);
             } else {
-                throw new MacroExecutionException("The included document doesn't contain any heading");
+                throw new MacroExecutionException("The included document or section doesn't contain first heading");
             }
         }
         

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
@@ -221,7 +221,7 @@ public class IncludeMacro extends AbstractMacro<IncludeMacroParameters>
             if (heading != null) {
                 result.removeBlock(heading);
             } else {
-                throw new MacroExecutionException("The included document or section doesn't contain first heading");
+                throw new MacroExecutionException("The included document or section doesn't contain any heading");
             }
         }
         

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
@@ -221,8 +221,9 @@ public class IncludeMacro extends AbstractMacro<IncludeMacroParameters>
             if (heading != null) {
                 result.removeBlock(heading);
             } else {
-                throw new MacroExecutionException("The included document or section doesn't contain any heading");
-            }
+                String includeType = parameters.getSection() != null ? "section" : "document";
+                throw new MacroExecutionException(String.format("The included " + includeType + " doesn't contain any heading"));
+           }
         }
         
         // Step 5: Wrap Blocks in a MetaDataBlock with the "source" meta data specified so that we know from where the

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
@@ -214,7 +214,7 @@ public class IncludeMacro extends AbstractMacro<IncludeMacroParameters>
             }
         }
         
-        // Exclude the heading from the content
+        // Exclude the first heading from the content
         if (parameters.excludeHeading()) {
             HeaderBlock heading =
                     result.getFirstBlock(new ClassBlockMatcher(HeaderBlock.class), Block.Axes.DESCENDANT_OR_SELF);

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
@@ -212,7 +212,18 @@ public class IncludeMacro extends AbstractMacro<IncludeMacroParameters>
                 references.pop();
             }
         }
-
+        
+        // Exclude the heading from the content
+        if (parameters.isExcludeHeading()) {
+            HeaderBlock heading =
+                    result.getFirstBlock(new ClassBlockMatcher(HeaderBlock.class), Block.Axes.DESCENDANT_OR_SELF);
+            if (heading != null) {
+                result.removeBlock(heading);
+            } else {
+                throw new MacroExecutionException("The included section doesn't contain main heading");
+            }
+        }
+        
         // Step 5: Wrap Blocks in a MetaDataBlock with the "source" meta data specified so that we know from where the
         // content comes and "base" meta data so that reference are properly resolved
         MetaDataBlock metadata = new MetaDataBlock(result.getChildren(), result.getMetaData());

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
@@ -204,13 +204,26 @@ public class IncludeMacro extends AbstractMacro<IncludeMacroParameters>
             }
         }
         
-        // Exclude the first heading from the content
         if (parameters.excludeFirstHeading()) {
-            HeaderBlock heading = result.getFirstBlock(new ClassBlockMatcher(HeaderBlock.class),
-                    Block.Axes.DESCENDANT_OR_SELF);
-            if (heading != null) {
-                removeBlockRecursively(result, heading);
-            } else {
+            List<HeaderBlock> headingList = result.getBlocks(new ClassBlockMatcher(HeaderBlock.class),
+                    Block.Axes.DESCENDANT);
+
+            if (!headingList.isEmpty()) {
+
+                // Get the First Heading Block from list of Heading Blocks
+                HeaderBlock heading = headingList.get(0);
+
+                // Get the parent block in document
+                Block parent = result.getChildren().get(0);
+
+                // Get the first child Block of the document
+                Block child = parent.getChildren().get(0);
+                if (child == heading) {
+                    parent.removeBlock(child);
+                }
+            }
+              
+            else {
                 String includeType = parameters.getSection() != null ? "section" : "document";
                 throw new MacroExecutionException(
                         String.format("The included [%s] doesn't contain any heading", includeType));
@@ -227,25 +240,6 @@ public class IncludeMacro extends AbstractMacro<IncludeMacroParameters>
         }
 
         return Arrays.asList(metadata);
-    }
-    
-    private boolean removeBlockRecursively(Block block, Block blockToRemove)
-    {
-        // Go through all children and remove the block if found
-        List<Block> allChildren = block.getChildren();
-        for (Block child : allChildren) {
-            if (child == blockToRemove) {
-                block.removeBlock(child);
-                return true;
-            } else {
-                // Check in children of the child
-                if (removeBlockRecursively(child, blockToRemove)) {
-                    // Return without moving on if child found
-                    return true;
-                }
-            }
-        }
-        return false;
     }
     
     /**

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
@@ -161,7 +161,7 @@ public class IncludeMacroParameters
      * exclude the heading from the section if true.
      * 
      * @param excludeHeading {@code true} whether the heading from the section is
-     *                       excluded, {@code false} otherwise
+     *        excluded, {@code false} otherwise
      */
     @PropertyName("Exclude Heading")
     @PropertyDescription("Exclude any top-level heading from the included section")
@@ -171,6 +171,7 @@ public class IncludeMacroParameters
     
     /**
      * @return {@code true} exclude the heading, {@code false} otherwise
+     *          include the heading
      */
     public boolean isExcludeHeading() {
         return excludeHeading;

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
@@ -166,18 +166,19 @@ public class IncludeMacroParameters
     @Unstable
     @PropertyName("Exclude Heading")
     @PropertyGroup("Section")
-    @PropertyDescription("Exclude the heading from the included section.")
-    public void setExcludeHeading(boolean excludeHeading) {
+    @PropertyDescription("Exclude the first heading from the included section.")
+    public void setExcludeHeading(boolean excludeHeading)
+    {
         this.excludeHeading = excludeHeading;
     }
     
     /**
-     * @return exclude the first heading from the included section. If the section 
-     *         doesn't contain the first heading nothing will be excluded.
+     * @return whether the user want to exclude the section headline.
      * @since 12.3RC1 
      */
     @Unstable
-    public boolean excludeHeading() {
+    public boolean excludeHeading()
+    {
         return this.excludeHeading;
     }
     

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
@@ -158,10 +158,10 @@ public class IncludeMacroParameters
     }
     
     /**
-     * exclude the heading from the section if true.
+     * Exclude the heading from the section if true.
      * 
      * @param excludeHeading {@code true} whether the heading from the section is
-     *        excluded, {@code false} otherwise
+     *        excluded, {@code false} otherwise 
      */
     @PropertyName("Exclude Heading")
     @PropertyDescription("Exclude any top-level heading from the included section")
@@ -170,8 +170,7 @@ public class IncludeMacroParameters
     }
     
     /**
-     * @return {@code true} exclude the heading, {@code false} otherwise
-     *          include the heading
+     * @return exclude the heading from the section
      */
     public boolean isExcludeHeading() {
         return this.excludeHeading;

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
@@ -71,7 +71,7 @@ public class IncludeMacroParameters
     /**
      * @see #excludeHeading()
      */
-    private boolean excludeHeading;
+    private boolean excludeFirstHeading;
     
     /**
      * @see #getSection()
@@ -160,25 +160,25 @@ public class IncludeMacroParameters
     
     /**
      * @param excludeHeading {@code true} to remove the first heading found inside
-     *         the document, {@code false} to keep it 
+     *         the document or a section, {@code false} to keep it 
      * @since 12.3RC1 
      */
     @Unstable
-    @PropertyName("Exclude Heading")
-    @PropertyDescription("Exclude the first heading from the included document/section.")
-    public void setExcludeHeading(boolean excludeHeading)
+    @PropertyName("Exclude First Heading")
+    @PropertyDescription("Exclude the first heading from the included document or section.")
+    public void setExcludeFirstHeading(boolean excludeFirstHeading)
     {
-        this.excludeHeading = excludeHeading;
+        this.excludeFirstHeading = excludeFirstHeading;
     }
     
     /**
-     * @return whether the user want to exclude the document/section headline.
+     * @return whether the user wants to exclude the first heading from the included document or section.
      * @since 12.3RC1 
      */
     @Unstable
-    public boolean excludeHeading()
+    public boolean excludeFirstHeading()
     {
-        return this.excludeHeading;
+        return this.excludeFirstHeading;
     }
     
     /**

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
@@ -160,20 +160,19 @@ public class IncludeMacroParameters
     
     /**
      * @param excludeHeading {@code true} to remove the first heading found inside
-     *         the specified section, {@code false} to keep it 
+     *         the document, {@code false} to keep it 
      * @since 12.3RC1 
      */
     @Unstable
     @PropertyName("Exclude Heading")
-    @PropertyGroup("Section")
-    @PropertyDescription("Exclude the first heading from the included section.")
+    @PropertyDescription("Exclude the first heading from the included document/section.")
     public void setExcludeHeading(boolean excludeHeading)
     {
         this.excludeHeading = excludeHeading;
     }
     
     /**
-     * @return whether the user want to exclude the section headline.
+     * @return whether the user want to exclude the document/section headline.
      * @since 12.3RC1 
      */
     @Unstable

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
@@ -69,7 +69,7 @@ public class IncludeMacroParameters
     private Context context = Context.CURRENT;
      
     /**
-     * @see #excludeHeading()
+     * @see #excludeFirstHeading()
      */
     private boolean excludeFirstHeading;
     
@@ -159,8 +159,8 @@ public class IncludeMacroParameters
     }
     
     /**
-     * @param excludeHeading {@code true} to remove the first heading found inside
-     *         the document or a section, {@code false} to keep it 
+     * @param excludeFirstHeading {@code true} to remove the first heading found inside
+     *        the document or the section, {@code false} to keep it 
      * @since 12.3RC1 
      */
     @Unstable
@@ -172,7 +172,7 @@ public class IncludeMacroParameters
     }
     
     /**
-     * @return whether the user wants to exclude the first heading from the included document or section.
+     * @return whether to exclude the first heading from the included document or section, or not.
      * @since 12.3RC1 
      */
     @Unstable

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
@@ -174,7 +174,7 @@ public class IncludeMacroParameters
      *          include the heading
      */
     public boolean isExcludeHeading() {
-        return excludeHeading;
+        return this.excludeHeading;
     }
     
     /**

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
@@ -26,7 +26,8 @@ import org.xwiki.properties.annotation.PropertyDescription;
 import org.xwiki.properties.annotation.PropertyDisplayType;
 import org.xwiki.properties.annotation.PropertyFeature;
 import org.xwiki.properties.annotation.PropertyGroup;
-
+import org.xwiki.properties.annotation.PropertyName;
+import org.xwiki.stability.Unstable;
 /**
  * Parameters for the {@link org.xwiki.rendering.internal.macro.include.IncludeMacro} Macro.
  * 
@@ -162,7 +163,9 @@ public class IncludeMacroParameters
      * 
      * @param excludeHeading {@code true} whether the heading from the section is
      *        excluded, {@code false} otherwise 
+     * @since 12.3RC1 
      */
+    @Unstable
     @PropertyName("Exclude Heading")
     @PropertyDescription("Exclude any top-level heading from the included section")
     public void setExcludeHeading(boolean excludeHeading) {
@@ -171,7 +174,9 @@ public class IncludeMacroParameters
     
     /**
      * @return exclude the heading from the section
+     * @since 12.3RC1 
      */
+    @Unstable
     public boolean isExcludeHeading() {
         return this.excludeHeading;
     }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
@@ -60,13 +60,18 @@ public class IncludeMacroParameters
      * @see #getType()
      */
     private EntityType type = EntityType.DOCUMENT;
-
+    
     /**
      * Defines whether the included page is executed in its separated execution context or whether it's executed in the
      * context of the current page.
      */
     private Context context = Context.CURRENT;
-
+     
+    /**
+     * @see #excludeHeading()
+     */
+    private boolean excludeHeading;
+    
     /**
      * @see #getSection()
      */
@@ -151,7 +156,26 @@ public class IncludeMacroParameters
     {
         return this.section;
     }
-
+    
+    /**
+     * exclude the heading from the section if true.
+     * 
+     * @param excludeHeading {@code true} whether the heading from the section is
+     *                       excluded, {@code false} otherwise
+     */
+    @PropertyName("Exclude Heading")
+    @PropertyDescription("Exclude any top-level heading from the included section")
+    public void setExcludeHeading(boolean excludeHeading) {
+        this.excludeHeading = excludeHeading;
+    }
+    
+    /**
+     * @return {@code true} exclude the heading, {@code false} otherwise
+     */
+    public boolean isExcludeHeading() {
+        return excludeHeading;
+    }
+    
     /**
      * @param page the reference of the page to include
      * @since 10.6RC1

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
@@ -161,23 +161,25 @@ public class IncludeMacroParameters
     /**
      * Exclude the heading from the section if true.
      * 
-     * @param excludeHeading {@code true} whether the heading from the section is
-     *        excluded, {@code false} otherwise 
+     * @param excludeHeading {@code true} to remove the first heading found inside
+     *         the specified section, {@code false} to keep it 
      * @since 12.3RC1 
      */
     @Unstable
     @PropertyName("Exclude Heading")
-    @PropertyDescription("Exclude any top-level heading from the included section")
+    @PropertyDescription("Exclude the first heading from the included section."
+        + " If the section doesn't have first block as heading, simply ignore it")
     public void setExcludeHeading(boolean excludeHeading) {
         this.excludeHeading = excludeHeading;
     }
     
     /**
-     * @return exclude the heading from the section
+     * @return exclude the first heading from the included section. If the section 
+     *         doesn't contain the first heading nothing will be excluded.
      * @since 12.3RC1 
      */
     @Unstable
-    public boolean isExcludeHeading() {
+    public boolean excludeHeading() {
         return this.excludeHeading;
     }
     

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
@@ -159,16 +159,14 @@ public class IncludeMacroParameters
     }
     
     /**
-     * Exclude the heading from the section if true.
-     * 
      * @param excludeHeading {@code true} to remove the first heading found inside
      *         the specified section, {@code false} to keep it 
      * @since 12.3RC1 
      */
     @Unstable
     @PropertyName("Exclude Heading")
-    @PropertyDescription("Exclude the first heading from the included section."
-        + " If the section doesn't have first block as heading, simply ignore it")
+    @PropertyGroup("Section")
+    @PropertyDescription("Exclude the heading from the included section.")
     public void setExcludeHeading(boolean excludeHeading) {
         this.excludeHeading = excludeHeading;
     }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/IncludeMacroParametersTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/IncludeMacroParametersTest.java
@@ -22,7 +22,6 @@ package org.xwiki.rendering.internal.macro;
 import org.junit.jupiter.api.Test;
 import org.xwiki.model.EntityType;
 import org.xwiki.rendering.macro.include.IncludeMacroParameters;
-import org.xwiki.stability.Unstable;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
@@ -42,7 +41,6 @@ public class IncludeMacroParametersTest
         assertSame(EntityType.PAGE, parameters.getType());
     }
     
-    @Unstable
     @Test
     public void setExcludeFirstHeading()
     {

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/IncludeMacroParametersTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/IncludeMacroParametersTest.java
@@ -41,4 +41,14 @@ public class IncludeMacroParametersTest
 
         assertSame(EntityType.PAGE, parameters.getType());
     }
+    
+    @Test
+    public void setExcludeFirstHeading()
+    {
+        IncludeMacroParameters parameters = new IncludeMacroParameters();
+
+        parameters.setExcludeFirstHeading(true);
+        
+        assertSame(true, parameters.excludeFirstHeading());
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/IncludeMacroParametersTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/IncludeMacroParametersTest.java
@@ -22,7 +22,7 @@ package org.xwiki.rendering.internal.macro;
 import org.junit.jupiter.api.Test;
 import org.xwiki.model.EntityType;
 import org.xwiki.rendering.macro.include.IncludeMacroParameters;
-
+import org.xwiki.stability.Unstable;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
@@ -42,6 +42,7 @@ public class IncludeMacroParametersTest
         assertSame(EntityType.PAGE, parameters.getType());
     }
     
+    @Unstable
     @Test
     public void setExcludeFirstHeading()
     {

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/IncludeMacroTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/IncludeMacroTest.java
@@ -538,14 +538,10 @@ public class IncludeMacroTest
     }
     
     @Test
-    void executeIncludeMacroWhenExcludeFirstHeadingTrue() throws Exception 
-    {
+    void executeIncludeMacroWhenExcludeFirstHeadingTrue() throws Exception {
         // @formatter:off
         String expected = "beginDocument\n"
             + "beginMetaData [[source]=[wiki:space.document][syntax]=[XWiki 2.0]]\n"
-            + "beginParagraph\n"
-            + "onWord [content]\n"
-            + "endParagraph\n"
             + "beginSection\n"
             + "endSection\n"
             + "endMetaData [[source]=[wiki:space.document][syntax]=[XWiki 2.0]]\n"
@@ -568,7 +564,7 @@ public class IncludeMacroTest
                 .thenReturn(new DocumentReference("wiki", "Space", "IncludingPage"));
         when(this.document.getDocumentReference()).thenReturn(resolvedReference);
         when(this.document.getSyntax()).thenReturn(Syntax.XWIKI_2_1);
-        when(this.document.getXDOM()).thenReturn(getXDOM("content\n= Hello =")); // To test
+        when(this.document.getXDOM()).thenReturn(getXDOM("=content=")); // To test
         when(this.document.getRealLanguage()).thenReturn("");
 
         List<Block> blocks = this.includeMacro.execute(parameters, null, macroContext);
@@ -577,26 +573,62 @@ public class IncludeMacroTest
     }
 
     @Test
-    void executeIncludeMacroWhenExcludeFirstHeadingFalse() throws Exception 
-    {
+    void executeIncludeMacroWhenExcludeFirstHeadingFalse() throws Exception {
+        // @formatter:off
+        String expected = "beginDocument\n"
+            + "beginMetaData [[source]=[wiki:space.document][syntax]=[XWiki 2.0]]\n"
+            + "beginSection\n"
+            + "beginHeader [1, Hcontent]\n"
+            + "onWord [content]\n"
+            + "endHeader [1, Hcontent]\n"
+            + "endSection\n"
+            + "endMetaData [[source]=[wiki:space.document][syntax]=[XWiki 2.0]]\n"
+            + "endDocument";
+        // @formatter:on
+
+        IncludeMacroParameters parameters = new IncludeMacroParameters();
+        parameters.setReference("document");
+        parameters.setExcludeFirstHeading(false);
+
+        // Getting the macro context
+        MacroTransformationContext macroContext = createMacroTransformationContext("whatever", false);
+        DocumentReference resolvedReference = new DocumentReference("wiki", "space", "document");
+        when(this.macroEntityReferenceResolver.resolve("document", EntityType.DOCUMENT,
+                macroContext.getCurrentMacroBlock())).thenReturn(resolvedReference);
+        when(this.contextualAuthorizationManager.hasAccess(Right.VIEW, resolvedReference)).thenReturn(true);
+        when(this.dab.getDocumentInstance((EntityReference) resolvedReference)).thenReturn(this.document);
+        when(this.dab.getTranslatedDocumentInstance(this.document)).thenReturn(this.document);
+        when(this.dab.getCurrentDocumentReference())
+                .thenReturn(new DocumentReference("wiki", "Space", "IncludingPage"));
+        when(this.document.getDocumentReference()).thenReturn(resolvedReference);
+        when(this.document.getSyntax()).thenReturn(Syntax.XWIKI_2_1);
+        when(this.document.getXDOM()).thenReturn(getXDOM("=content=")); // To test
+        when(this.document.getRealLanguage()).thenReturn("");
+
+        List<Block> blocks = this.includeMacro.execute(parameters, null, macroContext);
+
+        assertBlocks(expected, blocks, this.rendererFactory);
+    }
+
+    @Test
+    void executeIncludeMacroWhenHeadingIsNotFirstBlock() throws Exception {
         // @formatter:off
         String expected = "beginDocument\n"
                 + "beginMetaData [[source]=[wiki:space.document][syntax]=[XWiki 2.0]]\n"
-                + "beginParagraph\n"
-                + "onWord [content]\n"
-                + "endParagraph\n"
+                + "beginGroup\n"
                 + "beginSection\n"
                 + "beginHeader [1, Hcontent1]\n"
                 + "onWord [content1]\n"
                 + "endHeader [1, Hcontent1]\n"
                 + "endSection\n"
+                + "endGroup\n"
                 + "endMetaData [[source]=[wiki:space.document][syntax]=[XWiki 2.0]]\n"
                 + "endDocument";
         // @formatter:on
 
         IncludeMacroParameters parameters = new IncludeMacroParameters();
         parameters.setReference("wiki");
-        parameters.setExcludeFirstHeading(false);
+        parameters.setExcludeFirstHeading(true);
 
         // Getting the macro context
         MacroTransformationContext macroContext = createMacroTransformationContext("whatever", false);
@@ -607,7 +639,7 @@ public class IncludeMacroTest
         when(this.dab.getDocumentInstance((EntityReference) resolvedReference)).thenReturn(this.document);
         when(this.document.getDocumentReference()).thenReturn(resolvedReference);
         when(this.document.getSyntax()).thenReturn(Syntax.XWIKI_2_0);
-        when(this.document.getXDOM()).thenReturn(getXDOM("content\n= content1 =")); // To test
+        when(this.document.getXDOM()).thenReturn(getXDOM("(((= content1 =)))")); // To test
         when(this.document.getRealLanguage()).thenReturn("");
 
         List<Block> blocks = this.includeMacro.execute(parameters, null, macroContext);
@@ -616,10 +648,10 @@ public class IncludeMacroTest
     }
 
     @Test
-    void executeIncludeMacroWhenNoHeadingFoundInDocument() throws Exception 
-    {
-        
+    void executeIncludeMacroWhenNoHeadingFoundInDocument() throws Exception {
+        // @formatter:off
         String expected = "The included [document] doesn't contain any heading";
+        // @formatter:on
 
         IncludeMacroParameters parameters = new IncludeMacroParameters();
         parameters.setReference("document");
@@ -634,99 +666,12 @@ public class IncludeMacroTest
         when(this.dab.getDocumentInstance((EntityReference) resolvedReference)).thenReturn(this.document);
         when(this.document.getDocumentReference()).thenReturn(resolvedReference);
         when(this.document.getSyntax()).thenReturn(Syntax.XWIKI_2_0);
-        when(this.document.getXDOM()).thenReturn(getXDOM("\ncontent1")); // To test
+        when(this.document.getXDOM()).thenReturn(getXDOM("content1")); // To test
         when(this.document.getRealLanguage()).thenReturn("");
 
         Throwable exception = assertThrows(MacroExecutionException.class,
                 () -> this.includeMacro.execute(parameters, null, macroContext));
 
         assertEquals(expected, exception.getMessage());
-    }
-
-    @Test
-    void executeIncludeMacroForExcludingOnlyFirstHeading() throws Exception 
-    {
-        // @formatter:off
-        String expected = "beginDocument\n"
-            + "beginMetaData [[source]=[wiki:space.document][syntax]=[XWiki 2.0]]\n"
-            + "beginSection\n"
-            + "beginParagraph\n"
-            + "onWord [helloworld]\n"
-            + "endParagraph\n"
-            + "endSection\n"
-            + "beginSection\n"
-            + "beginHeader [1, Hcontent1]\n"
-            + "onWord [content1]\n"
-            + "endHeader [1, Hcontent1]\n"
-            + "endSection\n"
-            + "endMetaData [[source]=[wiki:space.document][syntax]=[XWiki 2.0]]\n"
-            + "endDocument";
-        // @formatter:on
-
-        IncludeMacroParameters parameters = new IncludeMacroParameters();
-        parameters.setReference("document");
-        parameters.setExcludeFirstHeading(true);
-
-        // Getting the macro context
-        MacroTransformationContext macroContext = createMacroTransformationContext("whatever", false);
-        DocumentReference resolvedReference = new DocumentReference("wiki", "space", "document");
-        when(this.macroEntityReferenceResolver.resolve("document", EntityType.DOCUMENT,
-                macroContext.getCurrentMacroBlock())).thenReturn(resolvedReference);
-        when(this.contextualAuthorizationManager.hasAccess(Right.VIEW, resolvedReference)).thenReturn(true);
-        when(this.dab.getDocumentInstance((EntityReference) resolvedReference)).thenReturn(this.document);
-        when(this.dab.getTranslatedDocumentInstance(this.document)).thenReturn(this.document);
-        when(this.dab.getCurrentDocumentReference())
-                .thenReturn(new DocumentReference("wiki", "Space", "IncludingPage"));
-        when(this.document.getDocumentReference()).thenReturn(resolvedReference);
-        when(this.document.getSyntax()).thenReturn(Syntax.XWIKI_2_0);
-        when(this.document.getXDOM()).thenReturn(getXDOM("= content =\nhelloworld\n = content1 =")); // To test
-        when(this.document.getRealLanguage()).thenReturn("");
-
-        List<Block> blocks = this.includeMacro.execute(parameters, null, macroContext);
-
-        assertBlocks(expected, blocks, this.rendererFactory);
-    }
-
-    @Test
-    void executeIncludeMacroWhenFirstHeadingIsChildOfAChild() throws Exception 
-    {
-        // @formatter:off
-        String expected = "beginDocument\n"
-            + "beginMetaData [[source]=[wiki:space.document][syntax]=[XWiki 2.0]]\n"
-            + "beginGroup\n"
-            + "beginGroup\n"
-            + "beginSection\n"
-            + "endSection\n"
-            + "endGroup\n"
-            + "beginParagraph\n"
-            + "onWord [helloWorld]\n"
-            + "endParagraph\n"
-            + "endGroup\n"
-            + "endMetaData [[source]=[wiki:space.document][syntax]=[XWiki 2.0]]\n"
-            + "endDocument";
-        // @formatter:on
-
-        IncludeMacroParameters parameters = new IncludeMacroParameters();
-        parameters.setReference("document");
-        parameters.setExcludeFirstHeading(true);
-
-        // Getting the macro context
-        MacroTransformationContext macroContext = createMacroTransformationContext("whatever", false);
-        DocumentReference resolvedReference = new DocumentReference("wiki", "space", "document");
-        when(this.macroEntityReferenceResolver.resolve("document", EntityType.DOCUMENT,
-                macroContext.getCurrentMacroBlock())).thenReturn(resolvedReference);
-        when(this.contextualAuthorizationManager.hasAccess(Right.VIEW, resolvedReference)).thenReturn(true);
-        when(this.dab.getDocumentInstance((EntityReference) resolvedReference)).thenReturn(this.document);
-        when(this.dab.getTranslatedDocumentInstance(this.document)).thenReturn(this.document);
-        when(this.dab.getCurrentDocumentReference())
-                .thenReturn(new DocumentReference("wiki", "Space", "IncludingPage"));
-        when(this.document.getDocumentReference()).thenReturn(resolvedReference);
-        when(this.document.getSyntax()).thenReturn(Syntax.XWIKI_2_0);
-        when(this.document.getXDOM()).thenReturn(getXDOM("((((((= content =)))\nhelloWorld)))")); // To test
-        when(this.document.getRealLanguage()).thenReturn("");
-
-        List<Block> blocks = this.includeMacro.execute(parameters, null, macroContext);
-
-        assertBlocks(expected, blocks, this.rendererFactory);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/IncludeMacroTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/IncludeMacroTest.java
@@ -63,7 +63,6 @@ import org.xwiki.security.authorization.ContextualAuthorizationManager;
 import org.xwiki.security.authorization.Right;
 import org.xwiki.test.jmock.AbstractComponentTestCase;
 import org.xwiki.velocity.VelocityManager;
-import org.xwiki.stability.Unstable;
 import static org.xwiki.rendering.test.BlockAssert.assertBlocks;
 import static org.xwiki.rendering.test.BlockAssert.assertBlocksStartsWith;
 

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/IncludeMacroTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/IncludeMacroTest.java
@@ -45,20 +45,14 @@ import org.xwiki.model.reference.AttachmentReferenceResolver;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
 import org.xwiki.model.reference.EntityReferenceResolver;
-import org.xwiki.rendering.block.AbstractBlock;
 import org.xwiki.rendering.block.Block;
-import org.xwiki.rendering.block.GroupBlock;
-import org.xwiki.rendering.block.HeaderBlock;
 import org.xwiki.rendering.block.MacroBlock;
 import org.xwiki.rendering.block.MacroMarkerBlock;
 import org.xwiki.rendering.block.MetaDataBlock;
-import org.xwiki.rendering.block.WordBlock;
 import org.xwiki.rendering.block.XDOM;
-import org.xwiki.rendering.block.match.ClassBlockMatcher;
 import org.xwiki.rendering.internal.macro.include.IncludeMacro;
 import org.xwiki.rendering.internal.transformation.macro.CurrentMacroEntityReferenceResolver;
 import org.xwiki.rendering.internal.transformation.macro.MacroTransformation;
-import org.xwiki.rendering.listener.HeaderLevel;
 import org.xwiki.rendering.listener.MetaData;
 import org.xwiki.rendering.macro.Macro;
 import org.xwiki.rendering.macro.MacroExecutionException;
@@ -100,8 +94,12 @@ import static org.xwiki.rendering.test.integration.junit5.BlockAssert.assertBloc
  * @since 1.5M2
  */
 @ComponentTest
-@AllComponents(excludes = { CurrentMacroEntityReferenceResolver.class, DefaultAuthorizationManager.class })
-public class IncludeMacroTest {
+@AllComponents(excludes = {
+    CurrentMacroEntityReferenceResolver.class,
+    DefaultAuthorizationManager.class
+})
+public class IncludeMacroTest
+{
     @InjectComponentManager
     private MockitoComponentManager componentManager;
 
@@ -111,8 +109,7 @@ public class IncludeMacroTest {
     @MockComponent
     private DocumentAccessBridge dab;
 
-    // Make sure to not load the standard AuthorizationManager which trigger too
-    // many things
+    // Make sure to not load the standard AuthorizationManager which trigger too many things
     @MockComponent
     private AuthorizationManager authorizationManager;
 
@@ -123,8 +120,7 @@ public class IncludeMacroTest {
     @Named("current")
     private AttachmentReferenceResolver<String> currentAttachmentReferenceResolver;
 
-    // Register a WikiModel mock so that we're in wiki mode (otherwise links will be
-    // considered as URLs for ex).
+    // Register a WikiModel mock so that we're in wiki mode (otherwise links will be considered as URLs for ex).
     @MockComponent
     private WikiModel wikiModel;
 
@@ -140,7 +136,8 @@ public class IncludeMacroTest {
     private EntityReferenceResolver<String> macroEntityReferenceResolver;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() throws Exception
+    {
         MemoryConfigurationSource memoryConfigurationSource = new MemoryConfigurationSource();
         this.componentManager.registerComponent(ConfigurationSource.class, memoryConfigurationSource);
         this.componentManager.registerComponent(ConfigurationSource.class, "xwikicfg", memoryConfigurationSource);
@@ -160,7 +157,8 @@ public class IncludeMacroTest {
     }
 
     @Test
-    void executeIncludeMacro() throws Exception {
+    void executeIncludeMacro() throws Exception
+    {
         // @formatter:off
         String expected = "beginDocument\n"
             + "beginMetaData [[source]=[wiki:Space.IncludedPage][syntax]=[XWiki 2.0]]\n"
@@ -177,7 +175,8 @@ public class IncludeMacroTest {
     }
 
     @Test
-    void executeIncludeMacroWithNewContextShowsVelocityMacrosAreIsolated() throws Exception {
+    void executeIncludeMacroWithNewContextShowsVelocityMacrosAreIsolated() throws Exception
+    {
         // @formatter:off
         String expected = "beginDocument\n"
             + "beginMetaData [[base]=[wiki:Space.IncludedPage][source]=[wiki:Space.IncludedPage][syntax]=[XWiki 2.0]]\n"
@@ -191,16 +190,16 @@ public class IncludeMacroTest {
             + "endDocument";
         // @formatter:on
 
-        // We verify that a Velocity macro set in the including page is not seen in the
-        // included page.
-        List<Block> blocks = runIncludeMacroWithPreVelocity(Context.NEW, "#macro(testmacro)#end",
-                "{{velocity}}#testmacro{{/velocity}}");
+        // We verify that a Velocity macro set in the including page is not seen in the included page.
+        List<Block> blocks =
+            runIncludeMacroWithPreVelocity(Context.NEW, "#macro(testmacro)#end", "{{velocity}}#testmacro{{/velocity}}");
 
         assertBlocks(expected, blocks, this.rendererFactory);
     }
 
     @Test
-    void executeIncludeMacroWithNewContextShowsPassingOnRestrictedFlag() throws Exception {
+    void executeIncludeMacroWithNewContextShowsPassingOnRestrictedFlag() throws Exception
+    {
         // @formatter:off
         String expected = "beginDocument\n"
             + "beginMetaData "
@@ -216,15 +215,15 @@ public class IncludeMacroTest {
             + "The execution of the [velocity] script macro is not allowed.";
         // @formatter:on
 
-        // We verify that a Velocity macro set in the including page is not seen in the
-        // included page.
+        // We verify that a Velocity macro set in the including page is not seen in the included page.
         List<Block> blocks = runIncludeMacro(Context.NEW, "{{velocity}}$foo{{/velocity}}", true);
 
         assertBlocksStartsWith(expected, blocks, this.rendererFactory);
     }
 
     @Test
-    void executeIncludeMacroWithCurrentContextShowsVelocityMacrosAreShared() throws Exception {
+    void executeIncludeMacroWithCurrentContextShowsVelocityMacrosAreShared() throws Exception
+    {
         // @formatter:off
         String expected = "beginDocument\n"
             + "beginMetaData [[source]=[wiki:Space.IncludedPage][syntax]=[XWiki 2.0]]\n"
@@ -233,30 +232,30 @@ public class IncludeMacroTest {
             + "endDocument";
         // @formatter:on
 
-        // We verify that a Velocity macro set in the including page is seen in the
-        // included page.
+        // We verify that a Velocity macro set in the including page is seen in the included page.
         List<Block> blocks = runIncludeMacroWithPreVelocity(Context.CURRENT, "#macro(testmacro)#end",
-                "{{velocity}}#testmacro{{/velocity}}");
+            "{{velocity}}#testmacro{{/velocity}}");
 
         assertBlocks(expected, blocks, this.rendererFactory);
     }
 
     @Test
-    void executeIncludeMacroWithNoDocumentSpecified() {
+    void executeIncludeMacroWithNoDocumentSpecified()
+    {
         IncludeMacroParameters parameters = new IncludeMacroParameters();
 
         Throwable exception = assertThrows(MacroExecutionException.class,
-                () -> this.includeMacro.execute(parameters, null, createMacroTransformationContext("whatever", false)));
+            () -> this.includeMacro.execute(parameters, null, createMacroTransformationContext("whatever", false)));
         assertEquals("You must specify a 'reference' parameter pointing to the entity to include.",
-                exception.getMessage());
+            exception.getMessage());
     }
 
     /**
-     * Verify that relative links returned by the Include macro as wrapped with a
-     * MetaDataBlock.
+     * Verify that relative links returned by the Include macro as wrapped with a MetaDataBlock.
      */
     @Test
-    void executeIncludeMacroWhenIncludingDocumentWithRelativeReferences() throws Exception {
+    void executeIncludeMacroWhenIncludingDocumentWithRelativeReferences() throws Exception
+    {
         // @formatter:off
         String expected = "beginDocument\n"
             + "beginMetaData [[base]=[includedWiki:includedSpace.includedPage]"
@@ -275,20 +274,20 @@ public class IncludeMacroTest {
             + "endDocument";
         // @formatter:on
 
-        DocumentReference includedDocumentReference = new DocumentReference("includedWiki", "includedSpace",
-                "includedPage");
+        DocumentReference includedDocumentReference =
+            new DocumentReference("includedWiki", "includedSpace", "includedPage");
         setUpDocumentMock("includedWiki:includedSpace.includedPage", includedDocumentReference,
-                "[[page]] [[attach:test.png]] image:test.png");
+            "[[page]] [[attach:test.png]] image:test.png");
         when(this.contextualAuthorizationManager.hasAccess(eq(Right.VIEW), any(EntityReference.class)))
-                .thenReturn(true);
+            .thenReturn(true);
         when(this.dab.getCurrentDocumentReference()).thenReturn(includedDocumentReference);
 
         IncludeMacroParameters parameters = new IncludeMacroParameters();
         parameters.setReference("includedWiki:includedSpace.includedPage");
         parameters.setContext(Context.NEW);
 
-        List<Block> blocks = this.includeMacro.execute(parameters, null,
-                createMacroTransformationContext("whatever", false));
+        List<Block> blocks =
+            this.includeMacro.execute(parameters, null, createMacroTransformationContext("whatever", false));
 
         assertBlocks(expected, blocks, this.rendererFactory);
         verify(this.dab).pushDocumentInContext(any(Map.class), any(DocumentModelBridge.class));
@@ -296,34 +295,36 @@ public class IncludeMacroTest {
     }
 
     @Test
-    void executeIncludeMacroWithRecursiveIncludeContextCurrent() throws Exception {
+    void executeIncludeMacroWithRecursiveIncludeContextCurrent() throws Exception
+    {
         MacroTransformationContext macroContext = createMacroTransformationContext("wiki:space.page", false);
-        // Add an Include Macro MarkerBlock as a parent of the include Macro block since
-        // this is what would have
+        // Add an Include Macro MarkerBlock as a parent of the include Macro block since this is what would have
         // happened if an Include macro is included in another Include macro.
-        MacroMarkerBlock includeMacroMarker = new MacroMarkerBlock("include",
-                Collections.singletonMap("reference", "space.page"),
+        MacroMarkerBlock includeMacroMarker =
+            new MacroMarkerBlock("include", Collections.singletonMap("reference", "space.page"),
                 Collections.singletonList(macroContext.getCurrentMacroBlock()), false);
 
         when(this.macroEntityReferenceResolver.resolve("wiki:space.page", EntityType.DOCUMENT,
-                macroContext.getCurrentMacroBlock())).thenReturn(new DocumentReference("wiki", "space", "page"));
+            macroContext.getCurrentMacroBlock())).thenReturn(new DocumentReference("wiki", "space", "page"));
         when(this.macroEntityReferenceResolver.resolve("space.page", EntityType.DOCUMENT, includeMacroMarker))
-                .thenReturn(new DocumentReference("wiki", "space", "page"));
+            .thenReturn(new DocumentReference("wiki", "space", "page"));
 
         IncludeMacroParameters parameters = new IncludeMacroParameters();
         parameters.setReference("wiki:space.page");
         parameters.setContext(Context.CURRENT);
 
         Throwable exception = assertThrows(MacroExecutionException.class,
-                () -> this.includeMacro.execute(parameters, null, macroContext));
+            () -> this.includeMacro.execute(parameters, null, macroContext));
         assertTrue(exception.getMessage().startsWith("Found recursive inclusion"));
     }
 
-    private static class ExpectedRecursiveInclusionException extends RuntimeException {
+    private static class ExpectedRecursiveInclusionException extends RuntimeException
+    {
     }
 
     @Test
-    void executeIncludeMacroWithRecursiveIncludeContextNew() throws Exception {
+    void executeIncludeMacroWithRecursiveIncludeContextNew() throws Exception
+    {
         DocumentDisplayer documentDisplayer = mock(DocumentDisplayer.class);
 
         this.includeMacro.setDocumentDisplayer(documentDisplayer);
@@ -337,27 +338,29 @@ public class IncludeMacroTest {
         DocumentReference includedDocumentReference = new DocumentReference("wiki", "space", "page");
         setUpDocumentMock("wiki:space.page", includedDocumentReference, "");
         when(this.contextualAuthorizationManager.hasAccess(eq(Right.VIEW), any(EntityReference.class)))
-                .thenReturn(true);
+            .thenReturn(true);
 
-        when(documentDisplayer.display(same(this.document), any(DocumentDisplayerParameters.class)))
-                .thenAnswer((Answer) invocation -> {
-                    try {
-                        this.includeMacro.execute(parameters, null, macroContext);
-                    } catch (Exception expected) {
-                        if (expected.getMessage().contains("Found recursive inclusion")) {
-                            throw new ExpectedRecursiveInclusionException();
-                        }
+        when(documentDisplayer.display(same(this.document), any(DocumentDisplayerParameters.class))).thenAnswer(
+            (Answer) invocation -> {
+                try {
+                    this.includeMacro.execute(parameters, null, macroContext);
+                } catch (Exception expected) {
+                    if (expected.getMessage().contains("Found recursive inclusion")) {
+                        throw new ExpectedRecursiveInclusionException();
                     }
-                    return true;
-                });
+                }
+                return true;
+            }
+        );
 
         Throwable exception = assertThrows(MacroExecutionException.class,
-                () -> this.includeMacro.execute(parameters, null, macroContext));
+            () -> this.includeMacro.execute(parameters, null, macroContext));
         assertTrue(exception.getCause() instanceof ExpectedRecursiveInclusionException);
     }
 
     @Test
-    void executeIncludeMacroInsideSourceMetaDataBlockAndWithRelativeDocumentReferencePassed() throws Exception {
+    void executeIncludeMacroInsideSourceMetaDataBlockAndWithRelativeDocumentReferencePassed() throws Exception
+    {
         // @formatter:off
         String expected = "beginDocument\n"
             + "beginMetaData [[source]=[wiki:space.relativePage][syntax]=[XWiki 2.0]]\n"
@@ -374,12 +377,12 @@ public class IncludeMacroTest {
         MacroTransformationContext macroContext = createMacroTransformationContext("whatever", false);
         // Add a Source MetaData Block as a parent of the include Macro block.
         new MetaDataBlock(Collections.<Block>singletonList(macroContext.getCurrentMacroBlock()),
-                new MetaData(Collections.singletonMap(MetaData.BASE, "wiki:space.page")));
+            new MetaData(Collections.singletonMap(MetaData.BASE, "wiki:space.page")));
 
         DocumentReference sourceReference = new DocumentReference("wiki", "space", "page");
         DocumentReference resolvedReference = new DocumentReference("wiki", "space", "relativePage");
         when(this.macroEntityReferenceResolver.resolve("relativePage", EntityType.DOCUMENT,
-                macroContext.getCurrentMacroBlock())).thenReturn(resolvedReference);
+            macroContext.getCurrentMacroBlock())).thenReturn(resolvedReference);
         when(this.contextualAuthorizationManager.hasAccess(Right.VIEW, resolvedReference)).thenReturn(true);
         when(this.dab.getDocumentInstance((EntityReference) resolvedReference)).thenReturn(this.document);
         when(this.dab.getTranslatedDocumentInstance(this.document)).thenReturn(this.document);
@@ -394,9 +397,9 @@ public class IncludeMacroTest {
         assertBlocks(expected, blocks, this.rendererFactory);
     }
 
-
     @Test
-    void executeIncludeMacroWhenSectionSpecified() throws Exception {
+    void executeIncludeMacroWhenSectionSpecified() throws Exception
+    {
         // @formatter:off
         String expected = "beginDocument\n"
             + "beginMetaData [[source]=[wiki:space.document][syntax]=[XWiki 2.0]]\n"
@@ -417,12 +420,12 @@ public class IncludeMacroTest {
         MacroTransformationContext macroContext = createMacroTransformationContext("whatever", false);
         DocumentReference resolvedReference = new DocumentReference("wiki", "space", "document");
         when(this.macroEntityReferenceResolver.resolve("document", EntityType.DOCUMENT,
-                macroContext.getCurrentMacroBlock())).thenReturn(resolvedReference);
+            macroContext.getCurrentMacroBlock())).thenReturn(resolvedReference);
         when(this.contextualAuthorizationManager.hasAccess(Right.VIEW, resolvedReference)).thenReturn(true);
         when(this.dab.getDocumentInstance((EntityReference) resolvedReference)).thenReturn(this.document);
         when(this.dab.getTranslatedDocumentInstance(this.document)).thenReturn(this.document);
-        when(this.dab.getCurrentDocumentReference())
-                .thenReturn(new DocumentReference("wiki", "Space", "IncludingPage"));
+        when(this.dab.getCurrentDocumentReference()).thenReturn(
+            new DocumentReference("wiki", "Space", "IncludingPage"));
         when(this.document.getDocumentReference()).thenReturn(resolvedReference);
         when(this.document.getSyntax()).thenReturn(Syntax.XWIKI_2_0);
         when(this.document.getXDOM()).thenReturn(getXDOM("content1\n\n= section =\ncontent2"));
@@ -434,7 +437,8 @@ public class IncludeMacroTest {
     }
 
     @Test
-    void executeIncludeMacroWhenInvalidSectionSpecified() throws Exception {
+    void executeIncludeMacroWhenInvalidSectionSpecified() throws Exception
+    {
         IncludeMacroParameters parameters = new IncludeMacroParameters();
         parameters.setReference("document");
         parameters.setSection("unknown");
@@ -442,33 +446,35 @@ public class IncludeMacroTest {
         MacroTransformationContext macroContext = createMacroTransformationContext("whatever", false);
         DocumentReference resolvedReference = new DocumentReference("wiki", "space", "document");
         when(this.macroEntityReferenceResolver.resolve("document", EntityType.DOCUMENT,
-                macroContext.getCurrentMacroBlock())).thenReturn(resolvedReference);
+            macroContext.getCurrentMacroBlock())).thenReturn(resolvedReference);
         when(this.contextualAuthorizationManager.hasAccess(Right.VIEW, resolvedReference)).thenReturn(true);
         when(this.dab.getDocumentInstance((EntityReference) resolvedReference)).thenReturn(this.document);
         when(this.dab.getTranslatedDocumentInstance(this.document)).thenReturn(this.document);
-        when(this.dab.getCurrentDocumentReference())
-                .thenReturn(new DocumentReference("wiki", "Space", "IncludingPage"));
+        when(this.dab.getCurrentDocumentReference()).thenReturn(
+            new DocumentReference("wiki", "Space", "IncludingPage"));
         when(this.document.getDocumentReference()).thenReturn(resolvedReference);
         when(this.document.getSyntax()).thenReturn(Syntax.XWIKI_2_0);
         when(this.document.getXDOM()).thenReturn(getXDOM("content"));
         when(this.document.getRealLanguage()).thenReturn("");
 
         Throwable exception = assertThrows(MacroExecutionException.class,
-                () -> this.includeMacro.execute(parameters, null, macroContext));
+            () -> this.includeMacro.execute(parameters, null, macroContext));
         assertEquals("Cannot find section [unknown] in document [wiki:space.document]", exception.getMessage());
     }
 
-    private MacroTransformationContext createMacroTransformationContext(String documentName, boolean isInline) {
+    private MacroTransformationContext createMacroTransformationContext(String documentName, boolean isInline)
+    {
         MacroTransformationContext context = new MacroTransformationContext();
-        MacroBlock includeMacro = new MacroBlock("include", Collections.singletonMap("reference", documentName),
-                isInline);
+        MacroBlock includeMacro =
+            new MacroBlock("include", Collections.singletonMap("reference", documentName), isInline);
         context.setCurrentMacroBlock(includeMacro);
         return context;
     }
 
-    private void setUpDocumentMock(String resolve, DocumentReference reference, String content) throws Exception {
+    private void setUpDocumentMock(String resolve, DocumentReference reference, String content) throws Exception
+    {
         when(this.macroEntityReferenceResolver.resolve(eq(resolve), eq(EntityType.DOCUMENT), any(MacroBlock.class)))
-                .thenReturn(reference);
+            .thenReturn(reference);
         when(this.dab.getDocumentInstance((EntityReference) reference)).thenReturn(this.document);
         when(this.dab.getTranslatedDocumentInstance(this.document)).thenReturn(this.document);
         when(this.document.getDocumentReference()).thenReturn(reference);
@@ -477,27 +483,31 @@ public class IncludeMacroTest {
         when(this.document.getRealLanguage()).thenReturn("");
     }
 
-    private XDOM getXDOM(String content) throws Exception {
+    private XDOM getXDOM(String content) throws Exception
+    {
         Parser parser = this.componentManager.getInstance(Parser.class, "xwiki/2.0");
         return parser.parse(new StringReader(content));
     }
 
     private List<Block> runIncludeMacroWithPreVelocity(Context context, String velocity, String includedContent)
-            throws Exception {
+        throws Exception
+    {
         VelocityManager velocityManager = this.componentManager.getInstance(VelocityManager.class);
         StringWriter writer = new StringWriter();
         velocityManager.getVelocityEngine().evaluate(velocityManager.getVelocityContext(), writer,
-                "wiki:Space.IncludingPage", velocity);
+            "wiki:Space.IncludingPage", velocity);
 
         return runIncludeMacro(context, includedContent);
     }
 
-    private List<Block> runIncludeMacro(final Context context, String includedContent) throws Exception {
+    private List<Block> runIncludeMacro(final Context context, String includedContent) throws Exception
+    {
         return runIncludeMacro(context, includedContent, false);
     }
 
     private List<Block> runIncludeMacro(final Context context, String includedContent, boolean restricted)
-            throws Exception {
+        throws Exception
+    {
         DocumentReference includedDocumentReference = new DocumentReference("wiki", "Space", "IncludedPage");
         String includedDocStringRef = "wiki:space.page";
         setUpDocumentMock(includedDocStringRef, includedDocumentReference, includedContent);
@@ -508,8 +518,7 @@ public class IncludeMacroTest {
         parameters.setReference(includedDocStringRef);
         parameters.setContext(context);
 
-        // Create a Macro transformation context with the Macro transformation object
-        // defined so that the include
+        // Create a Macro transformation context with the Macro transformation object defined so that the include
         // macro can transform included page which is using a new context.
         MacroTransformation macroTransformation = this.componentManager.getInstance(Transformation.class, "macro");
         MacroTransformationContext macroContext = createMacroTransformationContext(includedDocStringRef, false);
@@ -527,8 +536,10 @@ public class IncludeMacroTest {
 
         return blocks;
     }
+    
     @Test
-    void executeIncludeMacroWhenExcludeFirstHeadingTrue() throws Exception {
+    void executeIncludeMacroWhenExcludeFirstHeadingTrue() throws Exception 
+    {
         // Expected content containing no heading.
         // @formatter:off
         String expected = "beginDocument\n"


### PR DESCRIPTION
Issue link: https://jira.xwiki.org/browse/XWIKI-6721
After:

![Capture](https://user-images.githubusercontent.com/40354433/78713202-52f06280-7933-11ea-9193-34ea922f0be2.PNG)
