### PR TITLE
XWIKI-14824 Support indenting header level in the include macro

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
@@ -208,7 +208,8 @@ public class IncludeMacro extends AbstractMacro<IncludeMacroParameters>
         }
         
         // Indent the heading Level
-        if (parameters.getIndentHeadingLevel() > 0 && result.getChildren().size() > 0) {
+        if (parameters.getIndentHeadingLevel() > 0 && result.getChildren().size() > 0
+                && result.getParent() instanceof SectionBlock) {
 
             // Getting all the HeaderBlocks
             List<HeaderBlock> headingList = result.getBlocks(new ClassBlockMatcher(HeaderBlock.class),

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
@@ -52,7 +52,9 @@ import org.xwiki.rendering.macro.include.IncludeMacroParameters.Context;
 import org.xwiki.rendering.transformation.MacroTransformationContext;
 import org.xwiki.security.authorization.ContextualAuthorizationManager;
 import org.xwiki.security.authorization.Right;
-
+import org.xwiki.rendering.block.match.ClassBlockMatcher;
+import org.xwiki.rendering.listener.HeaderLevel;
+import org.xwiki.rendering.block.HeaderBlock;
 /**
  * @version $Id$
  * @since 1.5M2

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
@@ -202,7 +202,38 @@ public class IncludeMacro extends AbstractMacro<IncludeMacroParameters>
                 references.pop();
             }
         }
+        
+        if (parameters.getIndentHeadingLevel() > 0) {
 
+            HeaderBlock heading = result.getFirstBlock(new ClassBlockMatcher(HeaderBlock.class), Block.Axes.DESCENDANT);
+
+            if (heading != null) {
+
+                // Define header Levels
+                HeaderLevel[] headerLevels = { HeaderLevel.LEVEL1, HeaderLevel.LEVEL2, HeaderLevel.LEVEL3,
+                        HeaderLevel.LEVEL4, HeaderLevel.LEVEL5, HeaderLevel.LEVEL6 };
+                HeaderLevel headinglevel;
+
+                // Get specified header level
+                if (parameters.getIndentHeadingLevel() > 6) {
+                    headinglevel = headerLevels[5];
+                } else {
+                    headinglevel = headerLevels[parameters.getIndentHeadingLevel() - 1];
+                }
+
+                HeaderBlock newHeading = new HeaderBlock(heading.getChildren(), headinglevel);
+
+                // Get the parent block in document
+                Block parent = result.getChildren().get(0);
+
+                // Get the first child Block of the document
+                Block child = parent.getChildren().get(0);
+                if (child == heading) {
+                    parent.replaceChild(newHeading, child);
+                }
+            }
+        }
+        
         // Step 5: Wrap Blocks in a MetaDataBlock with the "source" meta data specified so that we know from where the
         // content comes and "base" meta data so that reference are properly resolved
         MetaDataBlock metadata = new MetaDataBlock(result.getChildren(), result.getMetaData());

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
@@ -205,33 +205,37 @@ public class IncludeMacro extends AbstractMacro<IncludeMacroParameters>
             }
         }
         
+        // Indent the heading Level
         if (parameters.getIndentHeadingLevel() > 0) {
 
             HeaderBlock heading = result.getFirstBlock(new ClassBlockMatcher(HeaderBlock.class), Block.Axes.DESCENDANT);
 
             if (heading != null) {
+                if (heading.getSection() != null) {
+                    
+                    // Define header Levels
+                    HeaderLevel[] headerLevels = { HeaderLevel.LEVEL1, HeaderLevel.LEVEL2, HeaderLevel.LEVEL3,
+                            HeaderLevel.LEVEL4, HeaderLevel.LEVEL5, HeaderLevel.LEVEL6 };
+                    HeaderLevel headinglevel;
 
-                // Define header Levels
-                HeaderLevel[] headerLevels = { HeaderLevel.LEVEL1, HeaderLevel.LEVEL2, HeaderLevel.LEVEL3,
-                        HeaderLevel.LEVEL4, HeaderLevel.LEVEL5, HeaderLevel.LEVEL6 };
-                HeaderLevel headinglevel;
+                    // Get specified header level
+                    if (parameters.getIndentHeadingLevel() > 5) {
+                        headinglevel = headerLevels[5];
+                    } else {
+                        headinglevel = headerLevels[parameters.getIndentHeadingLevel() - 1];
+                    }
 
-                // Get specified header level
-                if (parameters.getIndentHeadingLevel() > 6) {
-                    headinglevel = headerLevels[5];
-                } else {
-                    headinglevel = headerLevels[parameters.getIndentHeadingLevel() - 1];
-                }
+                    HeaderBlock newHeading = new HeaderBlock(heading.getChildren(), headinglevel);
+                    newHeading.setParameter("id", heading.getId());
+                    
+                    // Get the parent block in document
+                    Block parent = result.getChildren().get(0);
 
-                HeaderBlock newHeading = new HeaderBlock(heading.getChildren(), headinglevel);
-
-                // Get the parent block in document
-                Block parent = result.getChildren().get(0);
-
-                // Get the first child Block of the document
-                Block child = parent.getChildren().get(0);
-                if (child == heading) {
-                    parent.replaceChild(newHeading, child);
+                    // Get the first child Block of the document
+                    Block child = parent.getChildren().get(0);
+                    if (child == heading) {
+                        parent.replaceChild(newHeading, child);
+                    }
                 }
             }
         }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
@@ -160,19 +160,19 @@ public class IncludeMacroParameters
     }
     
     /**
-     * @param indentHeadingLevel the heading level for headings in the included
+     * @param indentHeadingLevel the heading level for level 1 headings in the included
      *        document or section.
      * @since 12.4RC1
      */
     @Unstable
     @PropertyName("Indent Heading Level")
-    @PropertyDescription("Adjust the heading level for headings in the included document or section.")
+    @PropertyDescription("Adjust the heading level for level 1 headings in the included document or section.")
     public void setIndentHeadingLevel(int indentHeadingLevel) {
         this.indentHeadingLevel = indentHeadingLevel;
     }
 
     /**
-     * @return the heading level to apply to the headings. If not specified or
+     * @return the heading level to apply to the level 1 headings. If not specified or
      *         zero, default heading level will be applied.
      * @since 12.4RC1
      */

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
@@ -162,19 +162,19 @@ public class IncludeMacroParameters
     /**
      * @param indentHeadingLevel the heading level for first heading in the included
      *        document or section.
-     * @since 12.3RC1
+     * @since 12.4RC1
      */
     @Unstable
     @PropertyName("Indent Heading Level")
-    @PropertyDescription("Adjust the heading level for first heading in the included document or section.")
+    @PropertyDescription("Adjust the heading level for headings in the included document or section.")
     public void setIndentHeadingLevel(int indentHeadingLevel) {
         this.indentHeadingLevel = indentHeadingLevel;
     }
 
     /**
-     * @return the heading level to apply to the first heading. If not specified or
+     * @return the heading level to apply to the headings. If not specified or
      *         zero, default heading level will be applied.
-     * @since 12.3RC1
+     * @since 12.4RC1
      */
     @Unstable
     public int getIndentHeadingLevel() {

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
@@ -160,7 +160,7 @@ public class IncludeMacroParameters
     }
     
     /**
-     * @param indentHeadingLevel the heading level for first heading in the included
+     * @param indentHeadingLevel the heading level for headings in the included
      *        document or section.
      * @since 12.4RC1
      */

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
@@ -26,6 +26,8 @@ import org.xwiki.properties.annotation.PropertyDescription;
 import org.xwiki.properties.annotation.PropertyDisplayType;
 import org.xwiki.properties.annotation.PropertyFeature;
 import org.xwiki.properties.annotation.PropertyGroup;
+import org.xwiki.properties.annotation.PropertyName;
+import org.xwiki.stability.Unstable;
 
 /**
  * Parameters for the {@link org.xwiki.rendering.internal.macro.include.IncludeMacro} Macro.
@@ -60,7 +62,7 @@ public class IncludeMacroParameters
      * @see #getType()
      */
     private EntityType type = EntityType.DOCUMENT;
-
+    
     /**
      * Defines whether the included page is executed in its separated execution context or whether it's executed in the
      * context of the current page.
@@ -71,6 +73,11 @@ public class IncludeMacroParameters
      * @see #getSection()
      */
     private String section;
+    
+    /**
+     * @see #getIndentHeadingLevel()
+     */
+    private int indentHeadingLevel;
 
     /**
      * @param reference the reference of the resource to include
@@ -151,7 +158,29 @@ public class IncludeMacroParameters
     {
         return this.section;
     }
+    
+    /**
+     * @param indentHeadingLevel the heading level for first heading in the included
+     *        document or section.
+     * @since 12.3RC1
+     */
+    @Unstable
+    @PropertyName("Indent Heading Level")
+    @PropertyDescription("Adjust the heading level for first heading in the included document or section.")
+    public void setIndentHeadingLevel(int indentHeadingLevel) {
+        this.indentHeadingLevel = indentHeadingLevel;
+    }
 
+    /**
+     * @return the heading level to apply to the first heading. If not specified or
+     *         zero, default heading level will be applied.
+     * @since 12.3RC1
+     */
+    @Unstable
+    public int getIndentHeadingLevel() {
+        return this.indentHeadingLevel;
+    }
+    
     /**
      * @param page the reference of the page to include
      * @since 10.6RC1

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/IncludeMacroParametersTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/IncludeMacroParametersTest.java
@@ -24,6 +24,7 @@ import org.xwiki.model.EntityType;
 import org.xwiki.rendering.macro.include.IncludeMacroParameters;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Validate {@link IncludeMacroParameters}.
@@ -40,5 +41,15 @@ public class IncludeMacroParametersTest
         parameters.setPage("page");
 
         assertSame(EntityType.PAGE, parameters.getType());
+    }
+    
+    @Test
+    public void setIndentHeadingLevel() 
+    {
+        IncludeMacroParameters parameters = new IncludeMacroParameters();
+
+        parameters.setIndentHeadingLevel(1);
+
+        assertEquals(1, parameters.getIndentHeadingLevel());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/IncludeMacroTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/IncludeMacroTest.java
@@ -536,4 +536,110 @@ public class IncludeMacroTest
 
         return blocks;
     }
+    
+    @Test
+    void executeIncludeMacroWhenIndentHeadingLevelIsSpecified() throws Exception {
+        // @formatter:off
+        String expected = "beginDocument\n"
+            + "beginMetaData [[source]=[wiki:space.document][syntax]=[XWiki 2.0]]\n"
+            + "beginSection\n"
+            + "beginHeader [4, null] [[id]=[HHeading]]\n"
+            + "onWord [Heading]\n"
+            + "endHeader [4, null] [[id]=[HHeading]]\n"
+            + "beginParagraph\n"
+            + "onWord [content]\n"
+            + "endParagraph\n"
+            + "endSection\n"
+            + "endMetaData [[source]=[wiki:space.document][syntax]=[XWiki 2.0]]\n"
+            + "endDocument";
+        // @formatter:on
+
+        IncludeMacroParameters parameters = new IncludeMacroParameters();
+        parameters.setReference("wiki");
+        parameters.setIndentHeadingLevel(3);
+
+        // Getting the macro context
+        MacroTransformationContext macroContext = createMacroTransformationContext("whatever", false);
+        DocumentReference resolvedReference = new DocumentReference("wiki", "space", "document");
+        when(this.macroEntityReferenceResolver.resolve("wiki", EntityType.DOCUMENT,
+                macroContext.getCurrentMacroBlock())).thenReturn(resolvedReference);
+        when(this.contextualAuthorizationManager.hasAccess(Right.VIEW, resolvedReference)).thenReturn(true);
+        when(this.dab.getDocumentInstance((EntityReference) resolvedReference)).thenReturn(this.document);
+        when(this.document.getDocumentReference()).thenReturn(resolvedReference);
+        when(this.document.getSyntax()).thenReturn(Syntax.XWIKI_2_0);
+        when(this.document.getXDOM()).thenReturn(getXDOM("= Heading =\ncontent")); // To test
+        when(this.document.getRealLanguage()).thenReturn("");
+
+        List<Block> blocks = this.includeMacro.execute(parameters, null, macroContext);
+        assertBlocks(expected, blocks, this.rendererFactory);
+    }
+
+    @Test
+    void executeIncludeMacroWhenIndentHeadingLevelIsNotSpecifiedOrZero() throws Exception {
+        // @formatter:off
+        String expected = "beginDocument\n"
+            + "beginMetaData [[source]=[wiki:space.document][syntax]=[XWiki 2.0]]\n"
+            + "beginSection\n"
+            + "beginHeader [1, Hcontent]\n"
+            + "onWord [content]\n"
+            + "endHeader [1, Hcontent]\n"
+            + "endSection\n"
+            + "endMetaData [[source]=[wiki:space.document][syntax]=[XWiki 2.0]]\n"
+            + "endDocument";
+        // @formatter:on
+
+        IncludeMacroParameters parameters = new IncludeMacroParameters();
+        parameters.setReference("wiki");
+        parameters.setIndentHeadingLevel(0);
+
+        // Getting the macro context
+        MacroTransformationContext macroContext = createMacroTransformationContext("whatever", false);
+        DocumentReference resolvedReference = new DocumentReference("wiki", "space", "document");
+        when(this.macroEntityReferenceResolver.resolve("wiki", EntityType.DOCUMENT,
+                macroContext.getCurrentMacroBlock())).thenReturn(resolvedReference);
+        when(this.contextualAuthorizationManager.hasAccess(Right.VIEW, resolvedReference)).thenReturn(true);
+        when(this.dab.getDocumentInstance((EntityReference) resolvedReference)).thenReturn(this.document);
+        when(this.document.getDocumentReference()).thenReturn(resolvedReference);
+        when(this.document.getSyntax()).thenReturn(Syntax.XWIKI_2_0);
+        when(this.document.getXDOM()).thenReturn(getXDOM("= content =")); // To test
+        when(this.document.getRealLanguage()).thenReturn("");
+
+        List<Block> blocks = this.includeMacro.execute(parameters, null, macroContext);
+        assertBlocks(expected, blocks, this.rendererFactory);
+    }
+    @Test
+    void executeIncludeMacroWhenIndentHeadingLevelIsSpecifiedButHeadingLevelIsTwo() throws Exception {
+        // @formatter:off
+        String expected = "beginDocument\n"
+            + "beginMetaData [[source]=[wiki:space.document][syntax]=[XWiki 2.0]]\n"
+            + "beginSection\n"
+            + "beginSection\n"
+            + "beginHeader [2, Hcontent]\n"
+            + "onWord [content]\n"
+            + "endHeader [2, Hcontent]\n"
+            + "endSection\n"
+            + "endSection\n"
+            + "endMetaData [[source]=[wiki:space.document][syntax]=[XWiki 2.0]]\n"
+            + "endDocument";
+        // @formatter:on
+
+        IncludeMacroParameters parameters = new IncludeMacroParameters();
+        parameters.setReference("wiki");
+        parameters.setIndentHeadingLevel(4);
+
+        // Getting the macro context
+        MacroTransformationContext macroContext = createMacroTransformationContext("whatever", false);
+        DocumentReference resolvedReference = new DocumentReference("wiki", "space", "document");
+        when(this.macroEntityReferenceResolver.resolve("wiki", EntityType.DOCUMENT,
+                macroContext.getCurrentMacroBlock())).thenReturn(resolvedReference);
+        when(this.contextualAuthorizationManager.hasAccess(Right.VIEW, resolvedReference)).thenReturn(true);
+        when(this.dab.getDocumentInstance((EntityReference) resolvedReference)).thenReturn(this.document);
+        when(this.document.getDocumentReference()).thenReturn(resolvedReference);
+        when(this.document.getSyntax()).thenReturn(Syntax.XWIKI_2_0);
+        when(this.document.getXDOM()).thenReturn(getXDOM("== content ==")); // To test
+        when(this.document.getRealLanguage()).thenReturn("");
+
+        List<Block> blocks = this.includeMacro.execute(parameters, null, macroContext);
+        assertBlocks(expected, blocks, this.rendererFactory);
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/IncludeMacroTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/IncludeMacroTest.java
@@ -607,6 +607,7 @@ public class IncludeMacroTest
         List<Block> blocks = this.includeMacro.execute(parameters, null, macroContext);
         assertBlocks(expected, blocks, this.rendererFactory);
     }
+    
     @Test
     void executeIncludeMacroWhenIndentHeadingLevelIsSpecifiedButHeadingLevelIsTwo() throws Exception {
         // @formatter:off


### PR DESCRIPTION
**Issue link:** https://jira.xwiki.org/browse/XWIKI-14824
**Issue Description:**
Indent the header level for the include macro. So that level 1 headings become  subheadings of that included section/document

**Output:**

![IndentHeading](https://user-images.githubusercontent.com/40354433/79892022-46800580-841b-11ea-93e5-c40b5c278c44.gif)
