### PR TITLE
XWIKI-16967: Failed to get the list of flavors on Distribution Wizard on Tomcat

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/Utils.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/Utils.java
@@ -360,17 +360,18 @@ public class Utils
             if (pathElement != null) {
                 try {
                     // see generateEncodedSpacesURISegment() to understand why we manually handle "spaceName"
+                    // Note that it would be cleaner to not rely on the variable name and to rely on the instanceof List
+                    // and on generateEncodedListURISegment and to give as argument
+                    // the list of spaces with the intermediate "spaces" segments. We don't go there for now to avoid
+                    // breaking something since this method is heavily used.
                     if (i < pathVariableNames.size() && "spaceName".equals(pathVariableNames.get(i))) {
                         if (!(pathElement instanceof List)) {
                             throw new RuntimeException("The 'spaceName' parameter must be a list!");
                         }
                         encodedPathElements[i] = generateEncodedSpacesURISegment((List) pathElements[i]);
-                    // see generateEncodedJobIdURISegment to understand why we manually handle "jobId"
-                    } else if (i < pathVariableNames.size() && "jobId".equals(pathVariableNames.get(i))) {
-                        if (!(pathElement instanceof List)) {
-                            throw new RuntimeException("The 'jobId' parameter must be a list!");
-                        }
-                        encodedPathElements[i] = generateEncodedJobIdURISegment((List) pathElements[i]);
+                    // see generateEncodedJobIdURISegment to understand why we manually handle the lists
+                    } else if (pathElement instanceof List) {
+                        encodedPathElements[i] = generateEncodedListURISegment((List) pathElements[i]);
                     } else if (pathElement instanceof EncodedElement) {
                         encodedPathElements[i] = pathElement.toString();
                     } else {
@@ -422,21 +423,20 @@ public class Utils
     }
 
     /**
-     * Generate an encoded segment for the 'jobId' segment of a resource URL.
+     * Generate an encoded segment for the List arguments.
+     * Apparently RestLet does not handle properly when several segments are expected for the same variable name
+     * in the path and given as an array in createURI. To avoid problems, we pass list as argument and handle them
+     * directly here.
+     * An example of such usage can be find in {@link org.xwiki.rest.internal.url.resources.JobStatusRestURLGenerator}.
      *
-     * We use the same trick as for 'spaceName' here but for jobId: we used to concatenate the jobId in
-     * {@link org.xwiki.rest.internal.url.resources.AbstractJobRestURLGenerator} but it's not a good idea since we want
-     * to encode that URL later and so it's then considered as a unique segment to be encoded.
-     * Performing the build of the URL here is safer since we encode it at the same time.
-     *
-     * @param jobId the list of elements to be used for the jobId
+     * @param listSegment the list of elements to be used for the listSegment
      * @return a proper segment
      * @throws URIException in case of problem when performing the encoding.
      */
-    private static String generateEncodedJobIdURISegment(List<Object> jobId) throws URIException
+    private static String generateEncodedListURISegment(List<Object> listSegment) throws URIException
     {
         StringBuilder jobIdSegment = new StringBuilder();
-        for (Object idElement : jobId) {
+        for (Object idElement : listSegment) {
             if (jobIdSegment.length() > 0) {
                 jobIdSegment.append('/');
             }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/url/resources/JobStatusRestURLGenerator.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/url/resources/JobStatusRestURLGenerator.java
@@ -46,7 +46,7 @@ public class JobStatusRestURLGenerator extends AbstractJobRestURLGenerator<List<
         // The idea is to use the UriBuilder of jax-rs to generate URLs that match the resources paths.
         // So it is consistent.
         try {
-            return Utils.createURI(getBaseURI(), JobStatusResource.class, getIdStringElement(id)).toURL();
+            return Utils.createURI(getBaseURI(), JobStatusResource.class, id).toURL();
         } catch (MalformedURLException e) {
             throw new XWikiRestException(String.format("Failed to generate a REST URL for the job id [%s].", id), e);
         }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/url/resources/JobStatusRestURLGeneratorTest.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/url/resources/JobStatusRestURLGeneratorTest.java
@@ -1,0 +1,76 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rest.internal.url.resources;
+
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.inject.Provider;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+
+import com.xpn.xwiki.XWiki;
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.web.XWikiURLFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test the behaviour of {@link JobStatusRestURLGenerator}.
+ *
+ * @version $Id$
+ * @since 11.10.5
+ * @since 12.3RC1
+ */
+@ComponentTest
+public class JobStatusRestURLGeneratorTest
+{
+    @InjectMockComponents
+    private JobStatusRestURLGenerator jobStatusRestURLGenerator;
+
+    @BeforeEach
+    public void setup(ComponentManager componentManager) throws Exception
+    {
+        Provider<XWikiContext> xwikiContextProvider = componentManager.getInstance(XWikiContext.TYPE_PROVIDER);
+        XWikiContext xwikiContext = xwikiContextProvider.get();
+        XWiki xwiki = mock(XWiki.class);
+        XWikiURLFactory urlFactory = mock(XWikiURLFactory.class);
+
+        when(xwikiContext.getWiki()).thenReturn(xwiki);
+        when(xwikiContext.getURLFactory()).thenReturn(urlFactory);
+        when(xwiki.getWebAppPath(xwikiContext)).thenReturn("/");
+        when(urlFactory.getServerURL(xwikiContext)).thenReturn(new URL("http://localhost"));
+    }
+
+    @Test
+    public void getURL() throws Exception
+    {
+        List<String> stringList = Arrays.asList("flavor", "search", "wiki:xwiki");
+        URL expectedUrl = new URL("http://localhost/rest/jobstatus/flavor/search/wiki:xwiki");
+        assertEquals(expectedUrl, this.jobStatusRestURLGenerator.getURL(stringList));
+    }
+}


### PR DESCRIPTION
JIRA: https://jira.xwiki.org/browse/XWIKI-16967

  * Don't use AbstractJobRestURLGenerator#getIdStringElement anymore but
    rely on the full list and handle it in Utils#createURI same as we do
for space names
  * Add a unit test for JobStatusRestURLGenerator