### PR TITLE
XWIKI-6721 The include macro should have an option to filter out the first heading in the included document or section.

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
@@ -40,9 +40,11 @@ import org.xwiki.model.reference.EntityReferenceSerializer;
 import org.xwiki.properties.BeanManager;
 import org.xwiki.properties.PropertyException;
 import org.xwiki.rendering.block.Block;
+import org.xwiki.rendering.block.HeaderBlock;
 import org.xwiki.rendering.block.MacroBlock;
 import org.xwiki.rendering.block.MacroMarkerBlock;
 import org.xwiki.rendering.block.MetaDataBlock;
+import org.xwiki.rendering.block.SectionBlock;
 import org.xwiki.rendering.block.XDOM;
 import org.xwiki.rendering.listener.MetaData;
 import org.xwiki.rendering.macro.AbstractMacro;
@@ -52,6 +54,7 @@ import org.xwiki.rendering.macro.include.IncludeMacroParameters.Context;
 import org.xwiki.rendering.transformation.MacroTransformationContext;
 import org.xwiki.security.authorization.ContextualAuthorizationManager;
 import org.xwiki.security.authorization.Right;
+
 
 /**
  * @version $Id$
@@ -202,7 +205,21 @@ public class IncludeMacro extends AbstractMacro<IncludeMacroParameters>
                 references.pop();
             }
         }
-
+        
+        // Exclude First Heading
+        if (parameters.isExcludeFirstHeading() && result.getChildren().size() > 0) {
+            Block firstBlock = result.getChildren().get(0);
+            if (firstBlock instanceof SectionBlock && firstBlock.getChildren().size() > 0) {
+                Block sectionFirstBlock = firstBlock.getChildren().get(0);
+                if (sectionFirstBlock instanceof HeaderBlock) {
+                    List<Block> contentWithoutheading = firstBlock.getChildren().subList(1,
+                            firstBlock.getChildren().size());
+                    // To remove section blocks we will replace the content with the contentWithoutheading.
+                    result.replaceChild(contentWithoutheading, firstBlock); // section block removed
+                }
+            }
+        }
+        
         // Step 5: Wrap Blocks in a MetaDataBlock with the "source" meta data specified so that we know from where the
         // content comes and "base" meta data so that reference are properly resolved
         MetaDataBlock metadata = new MetaDataBlock(result.getChildren(), result.getMetaData());

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/macro/include/IncludeMacroParameters.java
@@ -26,6 +26,8 @@ import org.xwiki.properties.annotation.PropertyDescription;
 import org.xwiki.properties.annotation.PropertyDisplayType;
 import org.xwiki.properties.annotation.PropertyFeature;
 import org.xwiki.properties.annotation.PropertyGroup;
+import org.xwiki.properties.annotation.PropertyName;
+import org.xwiki.stability.Unstable;
 
 /**
  * Parameters for the {@link org.xwiki.rendering.internal.macro.include.IncludeMacro} Macro.
@@ -71,7 +73,13 @@ public class IncludeMacroParameters
      * @see #getSection()
      */
     private String section;
-
+    
+    /**
+     * @see #isExcludeFirstHeading()
+     */
+    private boolean excludeFirstHeading;
+    
+    
     /**
      * @param reference the reference of the resource to include
      * @since 3.4M1
@@ -152,6 +160,29 @@ public class IncludeMacroParameters
         return this.section;
     }
 
+    /**
+     * @param excludeFirstHeading {@code true} to remove the first heading found inside
+     *        the document or the section, {@code false} to keep it 
+     * @since 12.4RC1 
+     */
+    @Unstable
+    @PropertyName("Exclude First Heading")
+    @PropertyDescription("Exclude the first heading from the included document or section.")
+    public void setExcludeFirstHeading(boolean excludeFirstHeading)
+    {
+        this.excludeFirstHeading = excludeFirstHeading;
+    }
+    
+    /**
+     * @return whether to exclude the first heading from the included document or section, or not.
+     * @since 12.4RC1 
+     */
+    @Unstable
+    public boolean isExcludeFirstHeading()
+    {
+        return this.excludeFirstHeading;
+    }
+    
     /**
      * @param page the reference of the page to include
      * @since 10.6RC1

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/IncludeMacroParametersTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/IncludeMacroParametersTest.java
@@ -24,6 +24,7 @@ import org.xwiki.model.EntityType;
 import org.xwiki.rendering.macro.include.IncludeMacroParameters;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Validate {@link IncludeMacroParameters}.
@@ -40,5 +41,15 @@ public class IncludeMacroParametersTest
         parameters.setPage("page");
 
         assertSame(EntityType.PAGE, parameters.getType());
+    }
+    
+    @Test
+    public void setExcludeFirstHeading() 
+    {
+        IncludeMacroParameters parameters = new IncludeMacroParameters();
+
+        parameters.setExcludeFirstHeading(true);
+
+        assertTrue(parameters.isExcludeFirstHeading());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/IncludeMacroTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/IncludeMacroTest.java
@@ -536,4 +536,112 @@ public class IncludeMacroTest
 
         return blocks;
     }
+    @Test
+    void executeIncludeMacroWhenExcludeFirstHeadingTrueAndHeadingIsFirstBlock() throws Exception {
+        // @formatter:off
+        String expected = "beginDocument\n"
+            + "beginMetaData [[source]=[wiki:space.document][syntax]=[XWiki 2.0]]\n"
+            + "beginParagraph\n"
+            + "onWord [content]\n"
+            + "endParagraph\n"
+            + "endMetaData [[source]=[wiki:space.document][syntax]=[XWiki 2.0]]\n"
+            + "endDocument";
+        // @formatter:on
+
+        IncludeMacroParameters parameters = new IncludeMacroParameters();
+        parameters.setReference("document");
+        parameters.setExcludeFirstHeading(true);
+        // Getting the macro context
+        MacroTransformationContext macroContext = createMacroTransformationContext("whatever", false);
+        DocumentReference resolvedReference = new DocumentReference("wiki", "space", "document");
+        when(this.macroEntityReferenceResolver.resolve("document", EntityType.DOCUMENT,
+                macroContext.getCurrentMacroBlock())).thenReturn(resolvedReference);
+        when(this.contextualAuthorizationManager.hasAccess(Right.VIEW, resolvedReference)).thenReturn(true);
+        when(this.dab.getDocumentInstance((EntityReference) resolvedReference)).thenReturn(this.document);
+        when(this.dab.getTranslatedDocumentInstance(this.document)).thenReturn(this.document);
+        when(this.dab.getCurrentDocumentReference())
+                .thenReturn(new DocumentReference("wiki", "Space", "IncludingPage"));
+        when(this.document.getDocumentReference()).thenReturn(resolvedReference);
+        when(this.document.getSyntax()).thenReturn(Syntax.XWIKI_2_0);
+        when(this.document.getXDOM()).thenReturn(getXDOM("= Heading =\ncontent")); // To test
+        when(this.document.getRealLanguage()).thenReturn("");
+
+        List<Block> blocks = this.includeMacro.execute(parameters, null, macroContext);
+
+        assertBlocks(expected, blocks, this.rendererFactory);
+    }
+
+    @Test
+    void executeIncludeMacroWhenExcludeFirstHeadingFalseAndHeadingIsFirstBlock() throws Exception {
+        // @formatter:off
+        String expected = "beginDocument\n"
+            + "beginMetaData [[source]=[wiki:space.document][syntax]=[XWiki 2.0]]\n"
+            + "beginSection\n"
+            + "beginHeader [1, Hcontent]\n"
+            + "onWord [content]\n"
+            + "endHeader [1, Hcontent]\n"
+            + "endSection\n"
+            + "endMetaData [[source]=[wiki:space.document][syntax]=[XWiki 2.0]]\n"
+            + "endDocument";
+        // @formatter:on
+
+        IncludeMacroParameters parameters = new IncludeMacroParameters();
+        parameters.setReference("document");
+        parameters.setExcludeFirstHeading(false);
+
+        // Getting the macro context
+        MacroTransformationContext macroContext = createMacroTransformationContext("whatever", false);
+        DocumentReference resolvedReference = new DocumentReference("wiki", "space", "document");
+        when(this.macroEntityReferenceResolver.resolve("document", EntityType.DOCUMENT,
+                macroContext.getCurrentMacroBlock())).thenReturn(resolvedReference);
+        when(this.contextualAuthorizationManager.hasAccess(Right.VIEW, resolvedReference)).thenReturn(true);
+        when(this.dab.getDocumentInstance((EntityReference) resolvedReference)).thenReturn(this.document);
+        when(this.dab.getTranslatedDocumentInstance(this.document)).thenReturn(this.document);
+        when(this.dab.getCurrentDocumentReference())
+                .thenReturn(new DocumentReference("wiki", "Space", "IncludingPage"));
+        when(this.document.getDocumentReference()).thenReturn(resolvedReference);
+        when(this.document.getSyntax()).thenReturn(Syntax.XWIKI_2_1);
+        when(this.document.getXDOM()).thenReturn(getXDOM("=content=")); // To test
+        when(this.document.getRealLanguage()).thenReturn("");
+
+        List<Block> blocks = this.includeMacro.execute(parameters, null, macroContext);
+
+        assertBlocks(expected, blocks, this.rendererFactory);
+    }
+
+    @Test
+    void executeIncludeMacroWhenExcludeFirstHeadingTrueAndHeadingIsNotFirstBlock() throws Exception {
+        // @formatter:off
+        String expected = "beginDocument\n"
+            + "beginMetaData [[source]=[wiki:space.document][syntax]=[XWiki 2.0]]\n"
+            + "beginGroup\n"
+            + "beginSection\n"
+            + "beginHeader [1, Hcontent]\n"
+            + "onWord [content]\n"
+            + "endHeader [1, Hcontent]\n"
+            + "endSection\n"
+            + "endGroup\n"
+            + "endMetaData [[source]=[wiki:space.document][syntax]=[XWiki 2.0]]\n"
+            + "endDocument";
+        // @formatter:on
+
+        IncludeMacroParameters parameters = new IncludeMacroParameters();
+        parameters.setReference("wiki");
+        parameters.setExcludeFirstHeading(true);
+
+        // Getting the macro context
+        MacroTransformationContext macroContext = createMacroTransformationContext("whatever", false);
+        DocumentReference resolvedReference = new DocumentReference("wiki", "space", "document");
+        when(this.macroEntityReferenceResolver.resolve("wiki", EntityType.DOCUMENT,
+                macroContext.getCurrentMacroBlock())).thenReturn(resolvedReference);
+        when(this.contextualAuthorizationManager.hasAccess(Right.VIEW, resolvedReference)).thenReturn(true);
+        when(this.dab.getDocumentInstance((EntityReference) resolvedReference)).thenReturn(this.document);
+        when(this.document.getDocumentReference()).thenReturn(resolvedReference);
+        when(this.document.getSyntax()).thenReturn(Syntax.XWIKI_2_0);
+        when(this.document.getXDOM()).thenReturn(getXDOM("(((= content =)))")); // To test
+        when(this.document.getRealLanguage()).thenReturn("");
+
+        List<Block> blocks = this.includeMacro.execute(parameters, null, macroContext);
+        assertBlocks(expected, blocks, this.rendererFactory);
+    }
 }


### PR DESCRIPTION
Issue link: https://jira.xwiki.org/browse/XWIKI-6721
Hi all! Here is my approach to fix this issue. 
![excludeFirstHeading](https://user-images.githubusercontent.com/40354433/79634428-abb9c980-8183-11ea-9580-10f0ad3443fa.gif)
