### PR TITLE
XWIKI-16973: Spaces in file names in Zip files cause VFS Tree macro break

### DIFF
--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/VfsResourceReference.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/VfsResourceReference.java
@@ -107,7 +107,7 @@ public class VfsResourceReference extends EntityResourceReference
      * @param fullURI the full opaque URI containing both the reference to the archive and the path to the entry inside
      * it, e.g. {@code attach:space.page@attachment/path/to/file}. Note that this constructor requires that the
      * full URL to be URL-encoded.
-     * @deprecated Since 12.4RC1 and 11.10.5, this constructor shouldn't be used anymore, in particular not for internal
+     * @deprecated Since 12.4RC1, this constructor shouldn't be used anymore, in particular not for internal
      * references such as {@code attach:space.page@attachment/path/to/file}, {@link #VfsResourceReference(String)}
      * should be used instead
      */
@@ -122,7 +122,6 @@ public class VfsResourceReference extends EntityResourceReference
      * @param fullReference the full opaque reference containing both the reference to the archive and the path to the
      * entry inside it, e.g. {@code attach:space.page@attachment/path/to/file}.
      * @since 12.4RC1
-     * @since 11.10.5
      */
     @Unstable
     public VfsResourceReference(String fullReference)
@@ -149,7 +148,7 @@ public class VfsResourceReference extends EntityResourceReference
 
     /**
      * @return the URI to the VFS (e.g. {@code attach:space.page@file.zip}, {@code http://server/path/to/zip})
-     * @deprecated Since 12.4RC1 and 11.10.5 this method shouldn't be used anymore, in favor of {@link #getReference}.
+     * @deprecated Since 12.4RC1 this method shouldn't be used anymore, in favor of {@link #getReference}.
      */
     @Deprecated
     public URI getURI()
@@ -163,7 +162,6 @@ public class VfsResourceReference extends EntityResourceReference
     /**
      * @return the actual reference to the VFS (e.g. {@code attach:space.page@file.zip}).
      * @since 12.4RC1
-     * @since 11.10.5
      */
     @Unstable
     public String getReference()
@@ -174,7 +172,6 @@ public class VfsResourceReference extends EntityResourceReference
     /**
      * @return the scheme of this reference (e.g. {@code attach}).
      * @since 12.4RC1
-     * @since 11.10.5
      */
     @Unstable
     public String getScheme()

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/VfsResourceReference.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/VfsResourceReference.java
@@ -107,8 +107,8 @@ public class VfsResourceReference extends EntityResourceReference
      * @param fullURI the full opaque URI containing both the reference to the archive and the path to the entry inside
      * it, e.g. {@code attach:space.page@attachment/path/to/file}. Note that this constructor requires that the
      * full URL to be URL-encoded.
-     * @deprecated Since 12.3, this constructor shouldn't be used anymore, in particular not for internal references
-     * such as {@code attach:space.page@attachment/path/to/file}, {@link #VfsResourceReference(String)}
+     * @deprecated Since 12.4RC1 and 11.10.5, this constructor shouldn't be used anymore, in particular not for internal
+     * references such as {@code attach:space.page@attachment/path/to/file}, {@link #VfsResourceReference(String)}
      * should be used instead
      */
     @Deprecated
@@ -121,7 +121,8 @@ public class VfsResourceReference extends EntityResourceReference
     /**
      * @param fullReference the full opaque reference containing both the reference to the archive and the path to the
      * entry inside it, e.g. {@code attach:space.page@attachment/path/to/file}.
-     * @since 12.3
+     * @since 12.4RC1
+     * @since 11.10.5
      */
     @Unstable
     public VfsResourceReference(String fullReference)
@@ -148,17 +149,21 @@ public class VfsResourceReference extends EntityResourceReference
 
     /**
      * @return the URI to the VFS (e.g. {@code attach:space.page@file.zip}, {@code http://server/path/to/zip})
-     * @deprecated Since 12.3 this method shouldn't be used anymore, in favor of {@link #getReference}.
+     * @deprecated Since 12.4RC1 and 11.10.5 this method shouldn't be used anymore, in favor of {@link #getReference}.
      */
     @Deprecated
     public URI getURI()
     {
+        if (this.uri == null) {
+            this.uri = URI.create(String.format("%s:%s", getScheme(), getReference()));
+        }
         return this.uri;
     }
 
     /**
      * @return the actual reference to the VFS (e.g. {@code attach:space.page@file.zip}).
-     * @since 12.3
+     * @since 12.4RC1
+     * @since 11.10.5
      */
     @Unstable
     public String getReference()
@@ -168,7 +173,8 @@ public class VfsResourceReference extends EntityResourceReference
 
     /**
      * @return the scheme of this reference (e.g. {@code attach}).
-     * @since 12.3
+     * @since 12.4RC1
+     * @since 11.10.5
      */
     @Unstable
     public String getScheme()

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/VfsResourceReference.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/VfsResourceReference.java
@@ -19,7 +19,9 @@
  */
 package org.xwiki.vfs;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -51,6 +53,8 @@ public class VfsResourceReference extends EntityResourceReference
     private static final String PARAMETER_CONTENTTYPE = "content-type";
 
     private static final String RESOURCE_PATH_SEPARATOR = "/";
+
+    private static final String DECODER_LOCALE = "UTF-8";
 
     private URI uri;
 
@@ -95,14 +99,35 @@ public class VfsResourceReference extends EntityResourceReference
 
     /**
      * @param fullURI the full opaque URI containing both the reference to the archive and the path to the entry inside
-     *        it, e.g. {@code attach:space.page@attachment/path/to/file}. Note that this constructor requires that any
-     *        "/" character inside the reference to the archive be URL-encoded
+     *        it, e.g. {@code attach:space.page@attachment/path/to/file}. Note that this constructor requires that the
+     *        full URL to be URL-encoded.
      */
     public VfsResourceReference(URI fullURI)
     {
         // Find the first "/" and consider that everything after is the path
-        this(URI.create(StringUtils.substringBefore(fullURI.toString(), RESOURCE_PATH_SEPARATOR)),
-            StringUtils.substringAfter(fullURI.toString(), RESOURCE_PATH_SEPARATOR));
+        this(retrieveRootURI(fullURI), retrievePathSegment(fullURI));
+    }
+
+    private static URI retrieveRootURI(URI fullURI)
+    {
+        try {
+            return URI.create(StringUtils.substringBefore(
+                URLDecoder.decode(fullURI.toString(), DECODER_LOCALE), RESOURCE_PATH_SEPARATOR));
+        } catch (UnsupportedEncodingException e) {
+            // should never happen
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static String retrievePathSegment(URI fullURI)
+    {
+        try {
+            return StringUtils.substringAfter(
+                URLDecoder.decode(fullURI.toString(), DECODER_LOCALE), RESOURCE_PATH_SEPARATOR);
+        } catch (UnsupportedEncodingException e) {
+            // should never happen
+            throw new RuntimeException(e);
+        }
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/AbstractVfsResourceReferenceSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/AbstractVfsResourceReferenceSerializer.java
@@ -69,10 +69,10 @@ public abstract class AbstractVfsResourceReferenceSerializer
     }
 
     /**
-     * Converts the passed URI into a URI containing an absolute reference to the VFS.
+     * Get an absolute reference to the VFS from the resource reference.
      *
-     * @param resourceReference the URI containing a relative reference to the VFS
-     * @return a URI with an absolute reference to the VFS
+     * @param resourceReference the reference to the VFS
+     * @return a String with an absolute reference to the VFS
      */
     protected abstract String getAbsoluteReference(VfsResourceReference resourceReference);
 }

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/AbstractVfsResourceReferenceSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/AbstractVfsResourceReferenceSerializer.java
@@ -19,7 +19,6 @@
  */
 package org.xwiki.vfs.internal;
 
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -57,7 +56,7 @@ public abstract class AbstractVfsResourceReferenceSerializer
         segments.add("vfs");
 
         // Add the VFS URI part
-        segments.add(makeAbsolute(resourceReference.getURI()).toString());
+        segments.add(getAbsoluteReference(resourceReference));
 
         // Add the VFS path
         segments.addAll(resourceReference.getPathSegments());
@@ -72,8 +71,8 @@ public abstract class AbstractVfsResourceReferenceSerializer
     /**
      * Converts the passed URI into a URI containing an absolute reference to the VFS.
      *
-     * @param uri the URI containing a relative reference to the VFS
+     * @param resourceReference the URI containing a relative reference to the VFS
      * @return a URI with an absolute reference to the VFS
      */
-    protected abstract URI makeAbsolute(URI uri);
+    protected abstract String getAbsoluteReference(VfsResourceReference resourceReference);
 }

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/CascadingVfsPermissionChecker.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/CascadingVfsPermissionChecker.java
@@ -52,7 +52,7 @@ public class CascadingVfsPermissionChecker implements VfsPermissionChecker
     public void checkPermission(VfsResourceReference resourceReference) throws VfsException
     {
         // Prevent using a VFS scheme that correspond to the hint of this component
-        String scheme = resourceReference.getURI().getScheme();
+        String scheme = resourceReference.getScheme();
         if (HINT.equals(scheme)) {
             throw new VfsException(String.format("[%s] is a reserved VFS URI scheme and cannot be used.", HINT));
         }

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/DefaultVfsPermissionChecker.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/DefaultVfsPermissionChecker.java
@@ -59,7 +59,7 @@ public class DefaultVfsPermissionChecker implements VfsPermissionChecker
         if (!this.authorizationManager.hasAccess(Right.PROGRAM, xcontext.getUserReference(), null)) {
             throw new VfsException(
                 String.format("Current logged-in user ([%s]) needs to have Programming Rights to use the [%s] VFS",
-                    xcontext.getUserReference(), resourceReference.getURI().getScheme()));
+                    xcontext.getUserReference(), resourceReference.getScheme()));
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/URIVfsResourceReferenceSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/URIVfsResourceReferenceSerializer.java
@@ -61,7 +61,7 @@ public class URIVfsResourceReferenceSerializer implements ResourceReferenceSeria
             ResourceReferenceSerializer<VfsResourceReference, URI> serializer =
                 this.componentManagerProvider.get().getInstance(new DefaultParameterizedType(null,
                         ResourceReferenceSerializer.class, VfsResourceReference.class, URI.class),
-                    String.format("truevfs/%s", reference.getURI().getScheme()));
+                    String.format("truevfs/%s", reference.getScheme()));
             resultURI = serializer.serialize(reference);
         } catch (ComponentLookupException e) {
             // No serializer exist, we just don't perform any conversion!

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/VfsResourceReferenceResolver.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/VfsResourceReferenceResolver.java
@@ -19,9 +19,6 @@
  */
 package org.xwiki.vfs.internal;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -29,6 +26,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.StringUtils;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.AttachmentReferenceResolver;
 import org.xwiki.resource.CreateResourceReferenceException;
@@ -65,20 +63,7 @@ public class VfsResourceReferenceResolver extends AbstractResourceReferenceResol
     {
         List<String> segments = extendedURL.getSegments();
 
-        // First segment is the url-encoded VFS reference, defined as URI
-        URI vfsUri;
-        try {
-            vfsUri = new URI(segments.get(0));
-        } catch (URISyntaxException e) {
-            throw new CreateResourceReferenceException(
-                String.format("Invalid VFS URI [%s] for URL [%s]", segments.get(0), extendedURL));
-        }
-
-        // Other segments are the path to the archive resource
-        List<String> vfsPathSegments = new ArrayList<>(segments);
-        vfsPathSegments.remove(0);
-
-        VfsResourceReference vfsReference = new VfsResourceReference(vfsUri, vfsPathSegments);
+        VfsResourceReference vfsReference = new VfsResourceReference(StringUtils.join(segments, "/"));
         copyParameters(extendedURL, vfsReference);
         return vfsReference;
     }

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/VfsResourceReferenceSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/VfsResourceReferenceSerializer.java
@@ -20,7 +20,6 @@
 package org.xwiki.vfs.internal;
 
 import java.lang.reflect.Type;
-import java.net.URI;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -65,10 +64,10 @@ public class VfsResourceReferenceSerializer extends AbstractVfsResourceReference
         //
         // Look for a scheme-specific serializer to convert from a relative URI into an absolute URI and if not found
         // then don't perform any transformation of the URI.
-        URI uri = resourceReference.getURI();
+        String scheme = resourceReference.getScheme();
         try {
             ResourceReferenceSerializer<VfsResourceReference, ExtendedURL> schemeSpecificSerializer =
-                this.componentManagerProvider.get().getInstance(TYPE, uri.getScheme());
+                this.componentManagerProvider.get().getInstance(TYPE, scheme);
             extendedURL = schemeSpecificSerializer.serialize(resourceReference);
         } catch (ComponentLookupException e) {
             extendedURL = super.serialize(resourceReference);
@@ -78,9 +77,9 @@ public class VfsResourceReferenceSerializer extends AbstractVfsResourceReference
     }
 
     @Override
-    protected URI makeAbsolute(URI uri)
+    protected String getAbsoluteReference(VfsResourceReference resourceReference)
     {
         // Don't make any transformation by default
-        return uri;
+        return String.format("%s:%s", resourceReference.getScheme(), resourceReference.getReference());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/attach/AttachURIVfsResourceReferenceSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/attach/AttachURIVfsResourceReferenceSerializer.java
@@ -25,6 +25,8 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.apache.commons.httpclient.URIException;
+import org.apache.commons.httpclient.util.URIUtil;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.AttachmentReference;
 import org.xwiki.model.reference.AttachmentReferenceResolver;
@@ -65,8 +67,13 @@ public class AttachURIVfsResourceReferenceSerializer implements ResourceReferenc
             this.attachmentResolver.resolve(reference.getURI().getSchemeSpecificPart());
         String scheme = reference.getURI().getScheme();
         String documentRefefenceString = this.documentSerializer.serialize(attachmentReference.getDocumentReference());
-
-        return URI.create(String.format("%s://%s/%s/%s", scheme, documentRefefenceString, attachmentReference.getName(),
-            reference.getPath()));
+        try {
+            String referencePath = URIUtil.encodePath(reference.getPath());
+            return URI.create(String.format("%s://%s/%s/%s", scheme, documentRefefenceString,
+                attachmentReference.getName(), referencePath));
+        } catch (URIException e) {
+            throw new SerializeResourceReferenceException(
+                String.format("Error when encoding attachment name [%s]", attachmentReference.getName()), e);
+        }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/attach/AttachURIVfsResourceReferenceSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/attach/AttachURIVfsResourceReferenceSerializer.java
@@ -64,16 +64,20 @@ public class AttachURIVfsResourceReferenceSerializer implements ResourceReferenc
         throws SerializeResourceReferenceException, UnsupportedResourceReferenceException
     {
         AttachmentReference attachmentReference =
-            this.attachmentResolver.resolve(reference.getURI().getSchemeSpecificPart());
-        String scheme = reference.getURI().getScheme();
+            this.attachmentResolver.resolve(reference.getReference());
+        String scheme = reference.getScheme();
         String documentRefefenceString = this.documentSerializer.serialize(attachmentReference.getDocumentReference());
         try {
+            // TODO: this encode the attachment name, but apparently the created URI is not valid for TPath
+            // so for example an URI such as attach://xwiki:Toto.Toto2.WebHome/test%20vfs.zip is generated as expected
+            // but this is not recognized properly in NIOTool it seems.
+            String attachmentName = URIUtil.encodePath(attachmentReference.getName());
             String referencePath = URIUtil.encodePath(reference.getPath());
             return URI.create(String.format("%s://%s/%s/%s", scheme, documentRefefenceString,
-                attachmentReference.getName(), referencePath));
+                attachmentName, referencePath));
         } catch (URIException e) {
             throw new SerializeResourceReferenceException(
-                String.format("Error when encoding attachment name [%s]", attachmentReference.getName()), e);
+                String.format("Error when encoding resource reference [%s]", reference.toString()), e);
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/attach/AttachURIVfsResourceReferenceSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/attach/AttachURIVfsResourceReferenceSerializer.java
@@ -68,9 +68,6 @@ public class AttachURIVfsResourceReferenceSerializer implements ResourceReferenc
         String scheme = reference.getScheme();
         String documentRefefenceString = this.documentSerializer.serialize(attachmentReference.getDocumentReference());
         try {
-            // TODO: this encode the attachment name, but apparently the created URI is not valid for TPath
-            // so for example an URI such as attach://xwiki:Toto.Toto2.WebHome/test%20vfs.zip is generated as expected
-            // but this is not recognized properly in NIOTool it seems.
             String attachmentName = URIUtil.encodePath(attachmentReference.getName());
             String referencePath = URIUtil.encodePath(reference.getPath());
             return URI.create(String.format("%s://%s/%s/%s", scheme, documentRefefenceString,

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/attach/AttachVfsPermissionChecker.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/attach/AttachVfsPermissionChecker.java
@@ -61,7 +61,7 @@ public class AttachVfsPermissionChecker implements VfsPermissionChecker
         // request.
 
         AttachmentReference attachmentReference =
-            this.defaultAttachmentReferenceresolver.resolve(resourceReference.getURI().getSchemeSpecificPart());
+            this.defaultAttachmentReferenceresolver.resolve(resourceReference.getReference());
 
         if (!this.authorizationManager.hasAccess(Right.VIEW, attachmentReference)) {
             throw new VfsException(String.format("No View permission for attachment [%s]", attachmentReference));

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/attach/AttachVfsResourceReferenceSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/attach/AttachVfsResourceReferenceSerializer.java
@@ -19,8 +19,6 @@
  */
 package org.xwiki.vfs.internal.attach;
 
-import java.net.URI;
-
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -53,10 +51,10 @@ public class AttachVfsResourceReferenceSerializer extends AbstractVfsResourceRef
     private EntityReferenceSerializer<String> entitySerializer;
 
     @Override
-    protected URI makeAbsolute(URI uri)
+    protected String getAbsoluteReference(VfsResourceReference resourceReference)
     {
-        AttachmentReference attachmentReference = this.attachmentResolver.resolve(uri.getSchemeSpecificPart());
-        String scheme = uri.getScheme();
-        return URI.create(String.format("%s:%s", scheme, this.entitySerializer.serialize(attachmentReference)));
+        AttachmentReference attachmentReference = this.attachmentResolver.resolve(resourceReference.getReference());
+        String scheme = resourceReference.getScheme();
+        return String.format("%s:%s", scheme, this.entitySerializer.serialize(attachmentReference));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/attach/XWikiModelNode.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/attach/XWikiModelNode.java
@@ -24,6 +24,7 @@ import java.net.URI;
 
 import javax.inject.Provider;
 
+import org.apache.commons.httpclient.util.URIUtil;
 import org.xwiki.component.manager.ComponentManager;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.DocumentReferenceResolver;
@@ -132,7 +133,8 @@ public class XWikiModelNode
             try {
                 XWikiDocument document = getXWikiContext().getWiki().getDocument(
                     getDocumentReference(), getXWikiContext());
-                this.attachment = document.getAttachment(this.name);
+                String decodedName = URIUtil.decode(this.name);
+                this.attachment = document.getAttachment(decodedName);
             } catch (Exception e) {
                 throw new IOException(String.format("Failed to get Attachment for [%s]", this.uri), e);
             }

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/script/PathConverter.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/script/PathConverter.java
@@ -21,7 +21,6 @@ package org.xwiki.vfs.internal.script;
 
 import java.lang.reflect.Type;
 import java.net.URI;
-import java.net.URLEncoder;
 import java.nio.file.Path;
 
 import javax.inject.Inject;
@@ -69,8 +68,7 @@ public class PathConverter extends AbstractConverter<Path>
         Path path;
 
         try {
-            VfsResourceReference reference =
-                new VfsResourceReference(new URI(URLEncoder.encode(value.toString(), "UTF-8")));
+            VfsResourceReference reference = new VfsResourceReference(value.toString());
 
             // Verify that the user has the permission for the specified VFS scheme. We need to do this at this level
             // since it's possible to do the check in the driver itself since TrueVFS controls whether the driver is

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/script/PathConverter.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/script/PathConverter.java
@@ -21,6 +21,7 @@ package org.xwiki.vfs.internal.script;
 
 import java.lang.reflect.Type;
 import java.net.URI;
+import java.net.URLEncoder;
 import java.nio.file.Path;
 
 import javax.inject.Inject;
@@ -68,7 +69,8 @@ public class PathConverter extends AbstractConverter<Path>
         Path path;
 
         try {
-            VfsResourceReference reference = new VfsResourceReference(new URI(value.toString()));
+            VfsResourceReference reference =
+                new VfsResourceReference(new URI(URLEncoder.encode(value.toString(), "UTF-8")));
 
             // Verify that the user has the permission for the specified VFS scheme. We need to do this at this level
             // since it's possible to do the check in the driver itself since TrueVFS controls whether the driver is

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/script/VfsResourceReferenceConverter.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/script/VfsResourceReferenceConverter.java
@@ -20,9 +20,6 @@
 package org.xwiki.vfs.internal.script;
 
 import java.lang.reflect.Type;
-import java.net.URI;
-import java.net.URLEncoder;
-
 import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
@@ -57,7 +54,7 @@ public class VfsResourceReferenceConverter extends AbstractConverter<VfsResource
         VfsResourceReference reference;
 
         try {
-            reference = new VfsResourceReference(URI.create(URLEncoder.encode(value.toString(), "UTF-8")));
+            reference = new VfsResourceReference(value.toString());
         } catch (Exception e) {
             throw new ConversionException(
                 String.format("Failed to convert [%s] to a VFS Resource Reference", value), e);

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/script/VfsResourceReferenceConverter.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/script/VfsResourceReferenceConverter.java
@@ -21,6 +21,7 @@ package org.xwiki.vfs.internal.script;
 
 import java.lang.reflect.Type;
 import java.net.URI;
+import java.net.URLEncoder;
 
 import javax.inject.Singleton;
 
@@ -56,7 +57,7 @@ public class VfsResourceReferenceConverter extends AbstractConverter<VfsResource
         VfsResourceReference reference;
 
         try {
-            reference = new VfsResourceReference(new URI(value.toString()));
+            reference = new VfsResourceReference(URI.create(URLEncoder.encode(value.toString(), "UTF-8")));
         } catch (Exception e) {
             throw new ConversionException(
                 String.format("Failed to convert [%s] to a VFS Resource Reference", value), e);

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/test/java/org/xwiki/vfs/internal/DefaultVfsManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/test/java/org/xwiki/vfs/internal/DefaultVfsManagerTest.java
@@ -76,7 +76,7 @@ public class DefaultVfsManagerTest
             this.mocker.getComponentUnderTest().getURL(reference);
             fail("Should have thrown an exception");
         } catch (VfsException expected) {
-            assertEquals("Failed to compute URL for [uri = [attach:xwiki:space.page@attachment], "
+            assertEquals("Failed to compute URL for [scheme = [attach], reference = [xwiki:space.page@attachment], "
                 + "path = [path1/path2/test.txt], parameters = []]", expected.getMessage());
         }
     }

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/test/java/org/xwiki/vfs/internal/VfsResourceReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/test/java/org/xwiki/vfs/internal/VfsResourceReferenceTest.java
@@ -39,7 +39,13 @@ public class VfsResourceReferenceTest
     {
         VfsResourceReference reference = new VfsResourceReference(
             URI.create("attach:Sandbox.WebHome@my.zip/path/to/file"));
-        assertEquals("attach:Sandbox.WebHome@my.zip", reference.getURI().toString());
+        assertEquals("Sandbox.WebHome@my.zip", reference.getReference());
+        assertEquals("attach", reference.getScheme());
+        assertEquals("path/to/file", reference.getPath());
+
+        reference = new VfsResourceReference("attach:Sandbox.WebHome@my.zip/path/to/file");
+        assertEquals("Sandbox.WebHome@my.zip", reference.getReference());
+        assertEquals("attach", reference.getScheme());
         assertEquals("path/to/file", reference.getPath());
     }
 
@@ -75,6 +81,7 @@ public class VfsResourceReferenceTest
         VfsResourceReference reference =
             new VfsResourceReference(URI.create("scheme:specific"), "a/b");
         reference.addParameter("key", "value");
-        assertEquals("uri = [scheme:specific], path = [a/b], parameters = [[key] = [[value]]]", reference.toString());
+        assertEquals("scheme = [scheme], reference = [specific], path = [a/b], parameters = [[key] = [[value]]]",
+            reference.toString());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/test/java/org/xwiki/vfs/internal/VfsResourceReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/test/java/org/xwiki/vfs/internal/VfsResourceReferenceTest.java
@@ -39,6 +39,7 @@ public class VfsResourceReferenceTest
     {
         VfsResourceReference reference = new VfsResourceReference(
             URI.create("attach:Sandbox.WebHome@my.zip/path/to/file"));
+        assertEquals("attach:Sandbox.WebHome@my.zip", reference.getURI().toString());
         assertEquals("Sandbox.WebHome@my.zip", reference.getReference());
         assertEquals("attach", reference.getScheme());
         assertEquals("path/to/file", reference.getPath());
@@ -47,6 +48,7 @@ public class VfsResourceReferenceTest
         assertEquals("Sandbox.WebHome@my.zip", reference.getReference());
         assertEquals("attach", reference.getScheme());
         assertEquals("path/to/file", reference.getPath());
+        assertEquals("attach:Sandbox.WebHome@my.zip", reference.getURI().toString());
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/test/java/org/xwiki/vfs/internal/attach/AttachURIVfsResourceReferenceSerializerTest.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/test/java/org/xwiki/vfs/internal/attach/AttachURIVfsResourceReferenceSerializerTest.java
@@ -37,27 +37,23 @@ import org.xwiki.url.URLNormalizer;
 import org.xwiki.vfs.VfsResourceReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
 
 /**
- * Unit tests for {@link AttachVfsResourceReferenceSerializer}.
+ * Unit tests for {@link AttachURIVfsResourceReferenceSerializer}.
  *
  * @version $Id$
- * @since 7.4M2
+ * @since 12.3
  */
 @ComponentTest
-public class AttachVfsResourceReferenceSerializerTest
+public class AttachURIVfsResourceReferenceSerializerTest
 {
     @InjectMockComponents
-    private AttachVfsResourceReferenceSerializer vfsResourceReferenceSerializer;
+    private AttachURIVfsResourceReferenceSerializer vfsResourceReferenceSerializer;
 
     @MockComponent
     @Named("current")
     private AttachmentReferenceResolver<String> attachmentReferenceResolver;
-
-    @MockComponent
-    @Named("contextpath")
-    private URLNormalizer<ExtendedURL> urlNormalizer;
 
     @MockComponent
     private EntityReferenceSerializer<String> entityReferenceSerializer;
@@ -66,19 +62,16 @@ public class AttachVfsResourceReferenceSerializerTest
     public void serialize() throws Exception
     {
         VfsResourceReference reference = new VfsResourceReference(
-            URI.create("attach:attachment"), "path1/path2/test.txt");
+            URI.create("attach:xwiki:Toto.WebHome@testvfs.zip"), "path1/path2/test.txt");
 
-        ExtendedURL extendedURL = new ExtendedURL(Arrays.asList(
-            "vfs", "attach:wiki:space.page@attachment", "path1", "path2", "test.txt"));
-        when(urlNormalizer.normalize(extendedURL)).thenReturn(extendedURL);
+        AttachmentReference attachmentReference = new AttachmentReference("testvfs.zip",
+            new DocumentReference("xwiki", Arrays.asList("Toto"), "WebHome"));
+        when(attachmentReferenceResolver.resolve("xwiki:Toto.WebHome@testvfs.zip")).thenReturn(attachmentReference);
 
-        AttachmentReference attachmentReference = new AttachmentReference("attachment",
-            new DocumentReference("wiki", Arrays.asList("space"), "page"));
-        when(attachmentReferenceResolver.resolve("attachment")).thenReturn(attachmentReference);
+        when(entityReferenceSerializer.serialize(attachmentReference.getDocumentReference()))
+            .thenReturn("xwiki:Toto.WebHome");
 
-        when(entityReferenceSerializer.serialize(attachmentReference)).thenReturn("wiki:space.page@attachment");
-
-        assertEquals("/vfs/attach%3Awiki%3Aspace.page%40attachment/path1/path2/test.txt",
+        assertEquals("attach://xwiki:Toto.WebHome/testvfs.zip/path1/path2/test.txt",
             vfsResourceReferenceSerializer.serialize(reference).toString());
     }
 
@@ -86,19 +79,16 @@ public class AttachVfsResourceReferenceSerializerTest
     public void serializeWithSpace() throws Exception
     {
         VfsResourceReference reference = new VfsResourceReference(
-            URI.create("attach:attachment"), "path1/path2/xwiki logo.png");
+            URI.create("attach:xwiki:Toto.WebHome@testvfs.zip"), "path1/path2/xwiki logo.png");
 
-        ExtendedURL extendedURL = new ExtendedURL(Arrays.asList(
-            "vfs", "attach:wiki:space.page@attachment", "path1", "path2", "xwiki logo.png"));
-        when(urlNormalizer.normalize(extendedURL)).thenReturn(extendedURL);
+        AttachmentReference attachmentReference = new AttachmentReference("testvfs.zip",
+            new DocumentReference("xwiki", Arrays.asList("Toto"), "WebHome"));
+        when(attachmentReferenceResolver.resolve("xwiki:Toto.WebHome@testvfs.zip")).thenReturn(attachmentReference);
 
-        AttachmentReference attachmentReference = new AttachmentReference("attachment",
-            new DocumentReference("wiki", Arrays.asList("space"), "page"));
-        when(attachmentReferenceResolver.resolve("attachment")).thenReturn(attachmentReference);
+        when(entityReferenceSerializer.serialize(attachmentReference.getDocumentReference()))
+            .thenReturn("xwiki:Toto.WebHome");
 
-        when(entityReferenceSerializer.serialize(attachmentReference)).thenReturn("wiki:space.page@attachment");
-
-        assertEquals("/vfs/attach%3Awiki%3Aspace.page%40attachment/path1/path2/xwiki+logo.png",
+        assertEquals("attach://xwiki:Toto.WebHome/testvfs.zip/path1/path2/xwiki%20logo.png",
             vfsResourceReferenceSerializer.serialize(reference).toString());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/test/java/org/xwiki/vfs/internal/attach/AttachURIVfsResourceReferenceSerializerTest.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/test/java/org/xwiki/vfs/internal/attach/AttachURIVfsResourceReferenceSerializerTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.when;
  * Unit tests for {@link AttachURIVfsResourceReferenceSerializer}.
  *
  * @version $Id$
- * @since 12.3
+ * @since 12.4RC1
  */
 @ComponentTest
 public class AttachURIVfsResourceReferenceSerializerTest

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/test/java/org/xwiki/vfs/internal/script/VfsResourceReferenceConverterTest.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/test/java/org/xwiki/vfs/internal/script/VfsResourceReferenceConverterTest.java
@@ -35,8 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  * Tests for {@link VfsResourceReferenceConverter}.
  *
  * @version $Id$
- * @since 12.3
- * @since 11.10.5
+ * @since 12.4RC1
  */
 @ComponentTest
 public class VfsResourceReferenceConverterTest

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/test/java/org/xwiki/vfs/internal/script/VfsResourceReferenceConverterTest.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/test/java/org/xwiki/vfs/internal/script/VfsResourceReferenceConverterTest.java
@@ -17,59 +17,53 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.xwiki.vfs.script;
+package org.xwiki.vfs.internal.script;
 
 import java.net.URI;
+import java.net.URLEncoder;
 
 import org.junit.jupiter.api.Test;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
-import org.xwiki.test.junit5.mockito.MockComponent;
-import org.xwiki.vfs.VfsException;
-import org.xwiki.vfs.VfsManager;
+import org.xwiki.url.ExtendedURL;
 import org.xwiki.vfs.VfsResourceReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.Mockito.*;
 
 /**
- * Unit tests for {@link VfsScriptService}.
+ * Tests for {@link VfsResourceReferenceConverter}.
  *
  * @version $Id$
- * @since 7.4M2
+ * @since 12.3
+ * @since 11.10.5
  */
 @ComponentTest
-public class VfsScriptServiceTest
+public class VfsResourceReferenceConverterTest
 {
     @InjectMockComponents
-    private VfsScriptService scriptService;
-
-    @MockComponent
-    private VfsManager manager;
+    private VfsResourceReferenceConverter vfsResourceReferenceConverter;
 
     @Test
-    public void url() throws Exception
+    public void convertWithNull()
     {
-        VfsResourceReference reference = new VfsResourceReference(
-            URI.create("attach:xwiki:space.page@attachment"), "path1/path2/test.txt");
-
-        when(manager.getURL(reference)).thenReturn("/generated/url");
-
-        assertEquals("/generated/url",
-            this.scriptService.url(
-                new VfsResourceReference(URI.create("attach:xwiki:space.page@attachment"), "path1/path2/test.txt")));
+        assertNull(this.vfsResourceReferenceConverter.convertToType(null, null));
     }
 
     @Test
-    public void urlError() throws Exception
+    public void convertWithString() throws Exception
     {
-        VfsResourceReference reference = new VfsResourceReference(
-            URI.create("attach:xwiki:space.page@attachment"), "path1/path2/test.txt");
+        String value = "attach:Toto.WebHome@testvfs.zip///test.doc";
+        VfsResourceReference expectedReference = new VfsResourceReference(URI.create(value));
+        assertEquals(expectedReference, this.vfsResourceReferenceConverter.convertToType(null, value));
+    }
 
-        when(manager.getURL(reference)).thenThrow(new VfsException("error"));
-
-        assertNull(this.scriptService.url(
-            new VfsResourceReference(URI.create("attach:xwiki:space.page@attachment"), "path1/path2/test.txt")));
+    @Test
+    public void convertWithSpecialString() throws Exception
+    {
+        String value = "attach:Toto.WebHome@testvfs.zip///logo xwiki.png";
+        VfsResourceReference expectedReference =
+            new VfsResourceReference(URI.create(URLEncoder.encode(value, "UTF-8")));
+        assertEquals(expectedReference, this.vfsResourceReferenceConverter.convertToType(null, value));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/test/java/org/xwiki/vfs/internal/script/VfsResourceReferenceConverterTest.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/test/java/org/xwiki/vfs/internal/script/VfsResourceReferenceConverterTest.java
@@ -63,7 +63,7 @@ public class VfsResourceReferenceConverterTest
     {
         String value = "attach:Toto.WebHome@testvfs.zip///logo xwiki.png";
         VfsResourceReference expectedReference =
-            new VfsResourceReference(URI.create(URLEncoder.encode(value, "UTF-8")));
+            new VfsResourceReference("attach:Toto.WebHome@testvfs.zip///logo xwiki.png");
         assertEquals(expectedReference, this.vfsResourceReferenceConverter.convertToType(null, value));
     }
 }


### PR DESCRIPTION
JIRA: 
  * https://jira.xwiki.org/browse/XWIKI-16793
  * https://jira.xwiki.org/browse/XWIKI-17244

This PR fixes two issues related to VFS macro:
  * the fact that we couldn't have a file with a space in a name in an archive (XWIKI-16973)
  * the fact that we couldn't rely on an archive with a space in its name (XWIKI-17244)

The provided fix consists mainly in not relying anymore on URI in VfsResourceReference, but on a new String reference attribute. For the problem of the space name in attachment name, it also needed some work to encode the name and decode it in VFS. 
