### PR TITLE
XWIKI-17636: Use a lighter library to perform disk-persistent blocking queue in mention

### DIFF
--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/pom.xml
@@ -32,7 +32,7 @@
   <packaging>jar</packaging>
   <description>Default implementation of the Mentions components.</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.82</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.76</xwiki.jacoco.instructionRatio>
     <!-- This component must be installed at the farm level because
     org.xwiki.eventstream.store.internal.RecordableEventListener.convertEvent uses
     org.xwiki.component.manager.ComponentManager. To be removed once XWIKI-17359 is fixed. -->
@@ -56,11 +56,11 @@
       <version>${project.version}</version>
     </dependency>
     <!-- third party-->
+    <!-- Use to persist on disk a map of data not yet processed -->
     <dependency>
-      <!-- Persistent queue implementations. Used to persist on disk the queue of documents to analyze for mentions.  -->
-      <groupId>ch.rasc</groupId>
-      <artifactId>xodus-queue</artifactId>
-      <version>1.0.1</version>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2-mvstore</artifactId>
+      <version>1.4.200</version>
     </dependency>
   </dependencies>
 </project>

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/async/MapBasedLinkedBlockingQueue.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/async/MapBasedLinkedBlockingQueue.java
@@ -1,0 +1,364 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.mentions.internal.async;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+/**
+ * A dedicated implementation of {@link BlockingQueue} internally based on a {@link LinkedBlockingQueue} and on
+ * a {@link ConcurrentMap}indexed by {@code Long}.
+ * The idea is to be able to obtain a {@link java.util.concurrent.BlockingQueue} from a {@code Map} persisted on disk.
+ * @param <T> The type of object manipulated by this queue.
+ *
+ * @version $Id$
+ * @since 12.7RC1
+ * @since 12.6.1
+ */
+public class MapBasedLinkedBlockingQueue<T> implements BlockingQueue<T>
+{
+    private final ConcurrentMap<Long, T> internalMap;
+    private final AtomicLong highestKey;
+    private final LinkedBlockingQueue<Pair<Long, T>> internalQueue;
+
+    /**
+     * Default constructor. It uses the provided map to populate the queue information, and then keep in sync the
+     * map and the queue.
+     *
+     * @param internalMap the map in charge of the disk persistency.
+     */
+    public MapBasedLinkedBlockingQueue(ConcurrentMap<Long, T> internalMap)
+    {
+        super();
+        this.internalMap = internalMap;
+        this.highestKey = new AtomicLong(computeHighestKey());
+        this.internalQueue = new LinkedBlockingQueue<>();
+
+        // if the map contains some element, we want to populate the actual queue with those info.
+        this.populateUnderlyingQueue();
+    }
+
+    /**
+     * Compute from the internal map what's the highest key number.
+     *
+     * @return A {@code Long} corresponding to the highest key value of the Map or 0 if none is found.
+     */
+    private Long computeHighestKey()
+    {
+        return this.internalMap.keySet()
+            .stream()
+            // Sort in descending order to get the highest element first
+            .sorted((a, b) ->
+            {
+                if (a.equals(b)) {
+                    return 0;
+                } else if (a < b) {
+                    return 1;
+                } else {
+                    return -1;
+                }
+            })
+            .limit(1).findFirst().orElse(0L);
+    }
+
+    private class DefaultComparator implements Comparator<Map.Entry<Long, T>>
+    {
+        @Override
+        public int compare(Map.Entry<Long, T> a, Map.Entry<Long, T> b)
+        {
+            Long keyA = a.getKey();
+            Long keyB = b.getKey();
+
+            if (keyA.equals(keyB)) {
+                return 0;
+            } else if (keyA < keyB) {
+                return -1;
+            } else {
+                return 1;
+            }
+        }
+    }
+
+    /**
+     * Populate the internal queue representation with the information coming from the Map.
+     * The idea is to be able to reuse entirely the original {@link LinkedBlockingQueue} method without really needing
+     * the map.
+     */
+    private void populateUnderlyingQueue()
+    {
+        this.internalMap.entrySet()
+            .stream()
+            .sorted(new DefaultComparator())
+            .forEach((entry) ->
+            {
+                try {
+                    this.internalQueue.put(Pair.of(entry));
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+    }
+
+    /**
+     * Put an element in the internal map and with the incremented highest key.
+     *
+     * @param t an element to add in the internal map.
+     * @return the actual key used to put the info in the map.
+     */
+    private Long internalPut(T t)
+    {
+        Long key = this.highestKey.incrementAndGet();
+        this.internalMap.put(key, t);
+        return key;
+    }
+
+    /**
+     * Remove an element from the internal map and decrement the highest key only if there's no more element
+     * associated to this key.
+     *
+     * @param pair the element to remove, should be of type Pair.
+     */
+    private void internalRemove(Object pair)
+    {
+        if (pair != null && pair instanceof Pair) {
+            Pair<Long, T> castedPair = (Pair) pair;
+            this.internalMap.remove(castedPair.getKey());
+        }
+    }
+
+    /**
+     * Clear the internal map and reset the highest key to 0.
+     */
+    private void clearInternalMap()
+    {
+        this.internalMap.clear();
+        this.highestKey.set(0);
+    }
+
+    @Override
+    public void put(T t) throws InterruptedException
+    {
+        Long key = this.internalPut(t);
+        this.internalQueue.put(Pair.of(key, t));
+    }
+
+    @Override
+    public boolean offer(T t, long l, TimeUnit timeUnit) throws InterruptedException
+    {
+        Long key = this.internalPut(t);
+        return this.internalQueue.offer(Pair.of(key, t), l, timeUnit);
+    }
+
+    @Override
+    public boolean offer(T t)
+    {
+        Long key = this.internalPut(t);
+        return this.internalQueue.offer(Pair.of(key, t));
+    }
+
+    @Override
+    public T take() throws InterruptedException
+    {
+        Pair<Long, T> result = this.internalQueue.take();
+        this.internalRemove(result);
+        return result.getValue();
+    }
+
+    @Override
+    public T poll(long l, TimeUnit timeUnit) throws InterruptedException
+    {
+        Pair<Long, T> result = this.internalQueue.poll(l, timeUnit);
+        this.internalRemove(result);
+        return result.getValue();
+    }
+
+    @Override
+    public int remainingCapacity()
+    {
+        return this.internalQueue.remainingCapacity();
+    }
+
+    @Override
+    public T poll()
+    {
+        Pair<Long, T> result = this.internalQueue.poll();
+        this.internalRemove(result);
+        return result.getValue();
+    }
+
+    @Override
+    public T element()
+    {
+        return this.internalQueue.element().getValue();
+    }
+
+    @Override
+    public T peek()
+    {
+        Pair<Long, T> result = this.internalQueue.peek();
+        return result.getValue();
+    }
+
+    @Override
+    public boolean remove(Object o)
+    {
+        boolean result = this.internalQueue.remove(o);
+        this.internalRemove(o);
+        return result;
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> collection)
+    {
+        for (Object o : collection) {
+            if (!this.contains(o)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public int size()
+    {
+        return this.internalQueue.size();
+    }
+
+    @Override
+    public boolean isEmpty()
+    {
+        return this.internalQueue.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o)
+    {
+        // We check on the map since most likely the given object is not a Pair but a T.
+        return this.internalMap.containsValue(o);
+    }
+
+    @Override
+    public Iterator<T> iterator()
+    {
+        return this.internalMap.entrySet().stream().sorted(new DefaultComparator()).map(Map.Entry::getValue).iterator();
+    }
+
+    @Override
+    public Object[] toArray()
+    {
+        return this.internalMap.values().toArray();
+    }
+
+    @Override
+    public <T1> T1[] toArray(T1[] t1s)
+    {
+        return this.internalMap.values().toArray(t1s);
+    }
+
+    @Override
+    public void clear()
+    {
+        this.internalQueue.clear();
+        this.clearInternalMap();
+    }
+
+    @Override
+    public int drainTo(Collection<? super T> collection)
+    {
+        int result = 0;
+        while (!this.internalQueue.isEmpty()) {
+            collection.add(this.poll());
+            result++;
+        }
+        return result;
+    }
+
+    @Override
+    public int drainTo(Collection<? super T> collection, int i)
+    {
+        int result = 0;
+        while (!this.internalQueue.isEmpty() && result < i) {
+            collection.add(this.poll());
+            result++;
+        }
+        return result;
+    }
+
+    @Override
+    public boolean add(T t)
+    {
+        Long key = this.internalPut(t);
+        return this.internalQueue.add(Pair.of(key, t));
+    }
+
+    @Override
+    public T remove()
+    {
+        Pair<Long, T> result = this.internalQueue.remove();
+        this.internalRemove(result);
+        return result.getValue();
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends T> collection)
+    {
+        boolean result = false;
+        for (T t : collection) {
+            Long key = this.internalPut(t);
+            result = result || this.internalQueue.add(Pair.of(key, t));
+        }
+
+        return result;
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> collection)
+    {
+        for (Object o : collection) {
+            this.internalRemove(o);
+        }
+
+        return this.internalQueue.removeAll(collection);
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> collection)
+    {
+        boolean result = false;
+        for (Map.Entry<Long, T> entry : this.internalMap.entrySet()) {
+            if (!collection.contains(entry.getValue())) {
+                this.internalRemove(Pair.of(entry));
+                this.internalQueue.remove(Pair.of(entry));
+                result = true;
+            }
+        }
+        return result;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/async/MentionsData.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/async/MentionsData.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.mentions.internal.async;
 
+import java.io.Serializable;
+
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.xwiki.text.XWikiToStringBuilder;
@@ -29,13 +31,15 @@ import org.xwiki.text.XWikiToStringBuilder;
  * @version $Id$
  * @since 12.6
  */
-public class MentionsData
+public class MentionsData implements Serializable
 {
     /**
      * Static object used to identify if elements has been persisted 
      * in the current JVM.
      */
     public static final MentionsData STOP = new MentionsData(true);
+
+    private static final long serialVersionUID = -6254703177038788112L;
 
     private String documentReference;
 

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/async/DefaultMentionsBlockingQueueProviderTest.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/async/DefaultMentionsBlockingQueueProviderTest.java
@@ -29,8 +29,6 @@ import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
 
-import ch.rasc.xodusqueue.XodusBlockingQueue;
-
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -54,7 +52,7 @@ class DefaultMentionsBlockingQueueProviderTest
     {
         when(this.environment.getPermanentDirectory()).thenReturn(tmpDir);
         BlockingQueue<MentionsData> actual = this.provider.initBlockingQueue();
-        assertTrue(actual instanceof XodusBlockingQueue);
+        assertTrue(actual instanceof MapBasedLinkedBlockingQueue);
     }
 
     @Test
@@ -64,6 +62,6 @@ class DefaultMentionsBlockingQueueProviderTest
         this.provider.initBlockingQueue();
         this.provider.closeQueue();
         BlockingQueue<MentionsData> actual = this.provider.initBlockingQueue();
-        assertTrue(actual instanceof XodusBlockingQueue);
+        assertTrue(actual instanceof MapBasedLinkedBlockingQueue);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/async/MapBasedLinkedBlockingQueueTest.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/async/MapBasedLinkedBlockingQueueTest.java
@@ -1,0 +1,155 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.mentions.internal.async;
+
+import java.util.Collections;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.hibernate.internal.util.collections.ConcurrentReferenceHashMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link MapBasedLinkedBlockingQueue}.
+ *
+ * @version $Id$
+ */
+public class MapBasedLinkedBlockingQueueTest
+{
+    private ConcurrentMap<Long, String> map;
+
+    @BeforeEach
+    void setup()
+    {
+        this.map = new ConcurrentReferenceHashMap();
+        map.put(13L, "Foo");
+        map.put(28L, "Bar");
+        map.put(0L, "Baz");
+        map.put(256L, "buz");
+    }
+
+    @Test
+    void constructor()
+    {
+        BlockingQueue<String> queue = new MapBasedLinkedBlockingQueue(this.map);
+        assertEquals(4, queue.size());
+        assertEquals("Baz", queue.poll());
+        assertEquals("Foo", queue.poll());
+        assertEquals("Bar", queue.poll());
+        assertEquals("buz", queue.poll());
+        assertTrue(queue.isEmpty());
+    }
+
+    @Test
+    void contructorAndOffer()
+    {
+        BlockingQueue<String> queue = new MapBasedLinkedBlockingQueue(this.map);
+        assertEquals(4, queue.size());
+        assertTrue(queue.offer("Ahaha"));
+        assertTrue(queue.offer("Foo"));
+        assertEquals(6, queue.size());
+        assertEquals(Integer.MAX_VALUE - 6, queue.remainingCapacity());
+
+        assertEquals("Baz", queue.poll());
+        assertEquals("Foo", queue.poll());
+        assertEquals("Bar", queue.poll());
+        assertEquals("buz", queue.poll());
+        assertEquals("Ahaha", queue.poll());
+        assertEquals("Foo", queue.poll());
+        assertTrue(queue.isEmpty());
+    }
+
+    @Test
+    void putAndPeek() throws Exception
+    {
+        BlockingQueue<String> queue = new MapBasedLinkedBlockingQueue(new ConcurrentReferenceHashMap());
+        assertTrue(queue.isEmpty());
+        queue.put("Something");
+        queue.put("Else");
+        assertEquals(2, queue.size());
+        assertFalse(queue.isEmpty());
+
+        assertEquals("Something", queue.peek());
+        assertTrue(queue.contains("Something"));
+        assertEquals(2, queue.size());
+        assertEquals("Something", queue.poll());
+        assertEquals(1, queue.size());
+    }
+
+    @Test
+    void take() throws Exception
+    {
+        BlockingQueue<String> queue = new MapBasedLinkedBlockingQueue(this.map);
+        assertEquals(4, queue.size());
+        assertEquals("Baz", queue.take());
+        assertEquals("Foo", queue.take());
+        assertEquals("Bar", queue.take());
+        assertEquals("buz", queue.take());
+        assertTrue(queue.isEmpty());
+    }
+
+    @Test
+    void clear()
+    {
+        BlockingQueue<String> queue = new MapBasedLinkedBlockingQueue(this.map);
+        assertEquals(4, queue.size());
+        assertFalse(queue.isEmpty());
+        queue.clear();
+        assertTrue(queue.isEmpty());
+    }
+
+    @Test
+    void addElementAndIterate()
+    {
+        BlockingQueue<String> queue = new MapBasedLinkedBlockingQueue(new ConcurrentReferenceHashMap());
+        assertTrue(queue.isEmpty());
+        queue.add("Something");
+        queue.add("Foo");
+        queue.add("Bar");
+        assertEquals(3, queue.size());
+        assertEquals("Something", queue.element());
+        assertEquals(3, queue.size());
+
+        int i = 0;
+        for (String s : queue) {
+            switch (i) {
+                case 0:
+                    assertEquals("Something", s);
+                    break;
+                case 1:
+                    assertEquals("Foo", s);
+                    break;
+                case 2:
+                    assertEquals("Bar", s);
+                    break;
+            }
+            i++;
+        }
+        assertEquals(3, i);
+        assertEquals(3, queue.size());
+    }
+}


### PR DESCRIPTION
  * Provide a dedicated Map-based implementation of LinkedBlockingQueue
  * Use H2 MVStore as the underlying lib to persist the map of data on
    disk

(marking as draft since it's still missing the unit tests)