### PR TITLE
XWIKI-17649: The DefaultMentionsEventExecutor produces 100% CPU load …

### DIFF
--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/DefaultMentionsEventExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/DefaultMentionsEventExecutor.java
@@ -192,7 +192,7 @@ public class DefaultMentionsEventExecutor implements MentionsEventExecutor, Init
         {
             MentionsData data = null;
             try {
-                data = DefaultMentionsEventExecutor.this.queue.poll();
+                data = DefaultMentionsEventExecutor.this.queue.take();
                 if (data != null) {
                     data.increaseAttempts();
                     if (data.isStop()) {

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/DefaultMentionsEventExecutorTest.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/DefaultMentionsEventExecutorTest.java
@@ -177,7 +177,7 @@ class DefaultMentionsEventExecutorTest
                                  .setAuthorReference("xwiki:XWiki.Author")
                                  .setWikiId("xwiki")
                                  .setVersion("1.0");
-        when(this.blockingQueue.poll()).thenReturn(value);
+        when(this.blockingQueue.take()).thenReturn(value);
         this.executor.startThreads();
         verify(this.threadPoolProvider, times(NB_THREADS)).initializeThread(any(Runnable.class));
 
@@ -196,7 +196,7 @@ class DefaultMentionsEventExecutorTest
                                  .setAuthorReference("xwiki:XWiki.Author")
                                  .setWikiId("xwiki")
                                  .setVersion("1.0");
-        when(this.blockingQueue.poll()).thenReturn(value);
+        when(this.blockingQueue.take()).thenReturn(value);
         this.executor.startThreads();
         verify(this.threadPoolProvider, times(NB_THREADS)).initializeThread(any(Runnable.class));
 


### PR DESCRIPTION
seems a simple switch to another method solves the issue.