### PR TITLE
XWIKI-17699 Page tree is not sorted by title when using Oracle DB

### DIFF
--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/main/resources/org/xwiki/index/tree/internal/nestedpages/query/queries.hbm.xml
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/main/resources/org/xwiki/index/tree/internal/nestedpages/query/queries.hbm.xml
@@ -72,7 +72,7 @@
             left outer join xwikidoc doc on (
                 doc.XWD_WEB = XWS_REFERENCE and
                 doc.XWD_NAME = 'WebHome' and
-                doc.XWD_LANGUAGE = '')
+                (doc.XWD_LANGUAGE = '' OR doc.XWD_LANGUAGE is NULL))
             left outer join xwikidoc tdoc on (
                 tdoc.XWD_WEB = XWS_REFERENCE and
                 tdoc.XWD_NAME = 'WebHome' and
@@ -134,7 +134,7 @@
         left outer join xwikidoc doc on (
             doc.XWD_WEB = XWS_REFERENCE and
             doc.XWD_NAME = 'WebHome' and
-            doc.XWD_LANGUAGE = '')
+            (doc.XWD_LANGUAGE = '' OR doc.XWD_LANGUAGE is NULL))
         left outer join xwikidoc tdoc on (
             tdoc.XWD_WEB = XWS_REFERENCE and
             tdoc.XWD_NAME = 'WebHome' and

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/main/resources/org/xwiki/index/tree/internal/nestedpages/query/queries.hbm.xml
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/main/resources/org/xwiki/index/tree/internal/nestedpages/query/queries.hbm.xml
@@ -55,7 +55,10 @@
   </resultset>
 
   <!-- Note that we use 0 and 1 instead of false and true because Oracle doesn't support the boolean constants. The
-    returned value is boolean though because we specify the type in the result set meta-data. -->
+    returned value is boolean though because we specify the type in the result set meta-data.
+    The double check on doc.XWD_LANGUAGE being the empty string or null to find out the original language page is needed
+    because Oracle stores empty strings as nulls unless a not-null constraint is present, which is not the case for the
+    language field. -->
   <!-- This query follows the SQL-2013 ANSI standard, but it uses a non-core feature F591 "Derived tables" which is
     implemented by most of the databases (HSQLDB, MySql, Oracle, PostgreSQL) -->
   <sql-query name="nestedPagesOrderedByTitle" resultset-ref="XWikiPageReference" read-only="true">
@@ -123,7 +126,8 @@
 
   <!-- We have to duplicate the title fall-back expression in the order by clause because PostgreSQL doesn't support the
     usage of column aliases in order by expressions (e.g. for lower(columnAlias) it throws "column 'columnAlias' does
-    not exist"). See https://www.postgresql.org/docs/9.4/static/sql-select.html#SQL-ORDERBY -->
+    not exist"). See https://www.postgresql.org/docs/9.4/static/sql-select.html#SQL-ORDERBY
+    For the double check on doc.XWD_LANGUAGE see comment in query "nestedPagesOrderedByTitle" above -->
   <!-- This query conforms to Core SQL-2003 ANSI standard. -->
   <sql-query name="nonTerminalPagesOrderedByTitle" resultset-ref="XWikiPageReference" read-only="true">
     <synchronize table="xwikidoc" />


### PR DESCRIPTION
Added a condition for `doc.XWD_LANGUAGE is null` beside of `doc.XWD_LANGUAGE = ''` to handle cases where the DB stores a null in the language field instead of an empty string.
Oracle does that; see also comment at https://github.com/xwiki/xwiki-platform/blob/master/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/xwiki.oracle.hbm.xml#L37

As I am not fully comfortable with the document tree part of the code it would be nice if someone else could double check the two changes, small as they are.