### PR TITLE
XWIKI-17718: Duplicate user when editing the mentions macro in WYSIWYG

### DIFF
--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/DefaultMentionXDOMService.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/DefaultMentionXDOMService.java
@@ -40,6 +40,7 @@ import org.xwiki.component.manager.ComponentLookupException;
 import org.xwiki.component.manager.ComponentManager;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.DocumentReferenceResolver;
+import org.xwiki.model.reference.WikiReference;
 import org.xwiki.rendering.block.Block;
 import org.xwiki.rendering.block.MacroBlock;
 import org.xwiki.rendering.block.XDOM;
@@ -85,12 +86,13 @@ public class DefaultMentionXDOMService implements MentionXDOMService
     }
 
     @Override
-    public Map<DocumentReference, List<String>> countByIdentifier(List<MacroBlock> mentions)
+    public Map<DocumentReference, List<String>> countByIdentifier(List<MacroBlock> mentions,
+        WikiReference wikiReference)
     {
         Map<DocumentReference, List<String>> ret = new HashMap<>();
         for (MacroBlock block : mentions) {
             String macroReference = block.getParameter(REFERENCE_PARAM_NAME);
-            DocumentReference reference = this.documentReferenceResolver.resolve(macroReference);
+            DocumentReference reference = this.documentReferenceResolver.resolve(macroReference, wikiReference);
             String anchor = block.getParameter(ANCHORID_PARAM_NAME);
             ret.merge(reference, new ArrayList<>(Collections.singletonList(anchor)), (l1, l2) -> {
                 l1.addAll(l2);

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/DefaultMentionXDOMService.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/DefaultMentionXDOMService.java
@@ -86,13 +86,15 @@ public class DefaultMentionXDOMService implements MentionXDOMService
     }
 
     @Override
-    public Map<DocumentReference, List<String>> countByIdentifier(List<MacroBlock> mentions,
+    public Map<DocumentReference, List<String>> groupAnchorsByUserReference(List<MacroBlock> mentions,
         WikiReference wikiReference)
     {
         Map<DocumentReference, List<String>> ret = new HashMap<>();
         for (MacroBlock block : mentions) {
-            String macroReference = block.getParameter(REFERENCE_PARAM_NAME);
-            DocumentReference reference = this.documentReferenceResolver.resolve(macroReference, wikiReference);
+            String serializedUserReference = block.getParameter(REFERENCE_PARAM_NAME);
+            // We are currently resolving to DocumentReference to allow us to support the mention of groups.
+            DocumentReference reference =
+                this.documentReferenceResolver.resolve(serializedUserReference, wikiReference);
             String anchor = block.getParameter(ANCHORID_PARAM_NAME);
             ret.merge(reference, new ArrayList<>(Collections.singletonList(anchor)), (l1, l2) -> {
                 l1.addAll(l2);

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/DefaultMentionsDataConsumer.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/DefaultMentionsDataConsumer.java
@@ -42,6 +42,7 @@ import org.xwiki.mentions.internal.async.MentionsData;
 import org.xwiki.mentions.notifications.MentionNotificationParameters;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.DocumentReferenceResolver;
+import org.xwiki.model.reference.WikiReference;
 import org.xwiki.rendering.block.MacroBlock;
 import org.xwiki.rendering.block.XDOM;
 import org.xwiki.rendering.syntax.Syntax;
@@ -196,7 +197,7 @@ public class DefaultMentionsDataConsumer implements MentionsDataConsumer
         List<MacroBlock> blocks = this.xdomService.listMentionMacros(xdom);
 
         Map<DocumentReference, List<String>> counts =
-            this.xdomService.countByIdentifier(blocks);
+            this.xdomService.countByIdentifier(blocks, documentReference.getWikiReference());
 
         for (Map.Entry<DocumentReference, List<String>> entry : counts.entrySet()) {
             boolean emptyAnchorProcessed = false;
@@ -217,8 +218,9 @@ public class DefaultMentionsDataConsumer implements MentionsDataConsumer
         List<MacroBlock> oldMentions = this.xdomService.listMentionMacros(oldXDOM);
         List<MacroBlock> newMentions = this.xdomService.listMentionMacros(newXDOM);
 
-        Map<DocumentReference, List<String>> oldCounts = this.xdomService.countByIdentifier(oldMentions);
-        Map<DocumentReference, List<String>> newCounts = this.xdomService.countByIdentifier(newMentions);
+        WikiReference wikiReference = documentReference.getWikiReference();
+        Map<DocumentReference, List<String>> oldCounts = this.xdomService.countByIdentifier(oldMentions, wikiReference);
+        Map<DocumentReference, List<String>> newCounts = this.xdomService.countByIdentifier(newMentions, wikiReference);
 
         for (Map.Entry<DocumentReference, List<String>> entry : newCounts.entrySet()) {
             DocumentReference key = entry.getKey();
@@ -256,8 +258,7 @@ public class DefaultMentionsDataConsumer implements MentionsDataConsumer
 
         // the matching element has not be found in the previous version of the document
         // notification are send unconditionally to all mentioned users.
-        this.xdomService
-            .countByIdentifier(newMentions)
+        this.xdomService.countByIdentifier(newMentions, documentReference.getWikiReference())
             .forEach((key, value) -> value.forEach(
                 anchorId -> sendNotif(
                     new MentionNotificationParameters(authorReference, documentReference, key, location, anchorId,

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/DefaultMentionsDataConsumer.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/DefaultMentionsDataConsumer.java
@@ -140,12 +140,13 @@ public class DefaultMentionsDataConsumer implements MentionsDataConsumer
 
                 if (doc.getPreviousVersion() == null) {
                     // CREATE
-                    handleOnCreate(doc.getXDOM(), documentReference, authorReference, DOCUMENT);
+                    handleContentOnCreate(doc.getXDOM(), documentReference, authorReference, DOCUMENT);
                     traverseXObjectsOnCreate(doc.getXObjects(), documentReference, authorReference, syntax);
                 } else {
                     // UPDATE
                     XWikiDocument oldDoc = this.documentRevisionProvider.getRevision(dr, doc.getPreviousVersion());
-                    handleOnUpdate(oldDoc.getXDOM(), doc.getXDOM(), documentReference, authorReference, DOCUMENT);
+                    handleUpdatedContent(oldDoc.getXDOM(), doc.getXDOM(), documentReference, authorReference,
+                        DOCUMENT);
                     traverseXObjectsOnUpdate(oldDoc.getXObjects(), doc.getXObjects(), documentReference,
                         authorReference, syntax);
                 }
@@ -158,25 +159,55 @@ public class DefaultMentionsDataConsumer implements MentionsDataConsumer
         }
     }
 
+    /**
+     * Traverses the objects of a created document and search for mentions to notify.
+     * @param xObjects the objects of the document
+     * @param documentReference the create document reference
+     * @param authorReference the reference of the author of the document
+     * @param syntax the syntax of the document
+     */
     private void traverseXObjectsOnCreate(Map<DocumentReference, List<BaseObject>> xObjects,
         DocumentReference documentReference, DocumentReference authorReference, Syntax syntax)
     {
         for (Map.Entry<DocumentReference, List<BaseObject>> entry : xObjects.entrySet()) {
             for (BaseObject baseObject : entry.getValue()) {
                 if (baseObject != null) {
-                    for (Object o : baseObject.getProperties()) {
-                        if (o instanceof LargeStringProperty) {
-                            String content = ((LargeStringProperty) o).getValue();
-                            this.xdomService
-                                .parse(content, syntax)
-                                .ifPresent(xdom -> handleOnCreate(xdom, documentReference, authorReference, AWM_FIELD));
-                        }
-                    }
+                    handleBaseObjectOnCreate(baseObject, documentReference, authorReference, syntax);
                 }
             }
         }
     }
 
+    /**
+     * Handles an object of a created document and search for mentions to notify its content.
+     * @param baseObject the object
+     * @param documentReference the reference of the document
+     * @param authorReference the reference of the author of the document
+     * @param syntax the syntax of the document
+     */
+    private void handleBaseObjectOnCreate(BaseObject baseObject, DocumentReference documentReference,
+        DocumentReference authorReference,
+        Syntax syntax)
+    {
+        for (Object o : baseObject.getProperties()) {
+            if (o instanceof LargeStringProperty) {
+                String content = ((LargeStringProperty) o).getValue();
+                this.xdomService
+                    .parse(content, syntax)
+                    .ifPresent(xdom -> handleContentOnCreate(xdom, documentReference, authorReference, AWM_FIELD));
+            }
+        }
+    }
+
+    /**
+     * Traverses the objects of an updated document and compares them to the objects of the document
+     * before the update to search for new mentions to notify.
+     * @param oldXObjects the objects of the document before the update
+     * @param xObjects the objects of the document after the update
+     * @param documentReference the reference of the updated document
+     * @param authorReference the reference of the author of the update
+     * @param syntax the syntax of the document
+     */
     private void traverseXObjectsOnUpdate(Map<DocumentReference, List<BaseObject>> oldXObjects,
         Map<DocumentReference, List<BaseObject>> xObjects, DocumentReference documentReference,
         DocumentReference authorReference, Syntax syntax)
@@ -185,25 +216,32 @@ public class DefaultMentionsDataConsumer implements MentionsDataConsumer
             List<BaseObject> oldEntry = oldXObjects.get(entry.getKey());
             for (BaseObject baseObject : entry.getValue()) {
                 if (baseObject != null) {
-                    handleBaseObject(oldEntry, baseObject, documentReference, authorReference, syntax);
+                    handleBaseObjectOnUpdate(oldEntry, baseObject, documentReference, authorReference, syntax);
                 }
             }
         }
     }
 
-    private void handleOnCreate(XDOM xdom, DocumentReference documentReference, DocumentReference authorReference,
-        MentionLocation location)
+    /**
+     * Handles the analysis of a created content to search for mentions to notify.
+     * @param xdom the xdom of the content
+     * @param documentReference the reference of the document containing the content
+     * @param authorReference the reference of the author of the created document
+     * @param location the location of the content
+     */
+    private void handleContentOnCreate(XDOM xdom, DocumentReference documentReference,
+        DocumentReference authorReference, MentionLocation location)
     {
         List<MacroBlock> blocks = this.xdomService.listMentionMacros(xdom);
 
         Map<DocumentReference, List<String>> counts =
-            this.xdomService.countByIdentifier(blocks, documentReference.getWikiReference());
+            this.xdomService.groupAnchorsByUserReference(blocks, documentReference.getWikiReference());
 
         for (Map.Entry<DocumentReference, List<String>> entry : counts.entrySet()) {
             boolean emptyAnchorProcessed = false;
             for (String anchorId : entry.getValue()) {
                 if (!StringUtils.isEmpty(anchorId) || !emptyAnchorProcessed) {
-                    sendNotif(
+                    sendNotification(
                         new MentionNotificationParameters(authorReference, documentReference, entry.getKey(), location,
                             anchorId, xdom));
                     emptyAnchorProcessed = emptyAnchorProcessed || StringUtils.isEmpty(anchorId);
@@ -212,15 +250,25 @@ public class DefaultMentionsDataConsumer implements MentionsDataConsumer
         }
     }
 
-    private void handleOnUpdate(XDOM oldXDOM, XDOM newXDOM, DocumentReference documentReference,
+    /**
+     * Handles the analysis of an updated content to search for new mentions to notify.
+     * @param oldXDOM the old xdom of the content before the update
+     * @param newXDOM the new xom of the content after the update
+     * @param documentReference the reference of the updated document containing the content
+     * @param authorReference the reference of the author of the update
+     * @param location the location of the content
+     */
+    private void handleUpdatedContent(XDOM oldXDOM, XDOM newXDOM, DocumentReference documentReference,
         DocumentReference authorReference, MentionLocation location)
     {
         List<MacroBlock> oldMentions = this.xdomService.listMentionMacros(oldXDOM);
         List<MacroBlock> newMentions = this.xdomService.listMentionMacros(newXDOM);
 
         WikiReference wikiReference = documentReference.getWikiReference();
-        Map<DocumentReference, List<String>> oldCounts = this.xdomService.countByIdentifier(oldMentions, wikiReference);
-        Map<DocumentReference, List<String>> newCounts = this.xdomService.countByIdentifier(newMentions, wikiReference);
+        Map<DocumentReference, List<String>> oldCounts =
+            this.xdomService.groupAnchorsByUserReference(oldMentions, wikiReference);
+        Map<DocumentReference, List<String>> newCounts =
+            this.xdomService.groupAnchorsByUserReference(newMentions, wikiReference);
 
         for (Map.Entry<DocumentReference, List<String>> entry : newCounts.entrySet()) {
             DocumentReference key = entry.getKey();
@@ -238,35 +286,51 @@ public class DefaultMentionsDataConsumer implements MentionsDataConsumer
 
             // Notify with an empty anchorId if there's new mentions without an anchor.
             if (newEmptyAnchorsNumber > oldEmptyAnchorsNumber) {
-                sendNotif(new MentionNotificationParameters(authorReference, documentReference, key, location, "",
-                    newXDOM));
+                sendNotification(
+                    new MentionNotificationParameters(authorReference, documentReference, key, location, "",
+                        newXDOM));
             }
 
             // Notify all new mentions with new anchors.
             for (String anchorId : anchorsToNotify) {
-                sendNotif(
+                sendNotification(
                     new MentionNotificationParameters(authorReference, documentReference, key, location, anchorId,
                         newXDOM));
             }
         }
     }
 
-    private void handleMissing(XDOM newXdom, DocumentReference documentReference, DocumentReference authorReference,
-        MentionLocation location)
+    /**
+     * Handles the analysis of the mentions of a created content to search for mentions to notify.
+     * @param newXdom the xdom of the created content
+     * @param documentReference the reference of the document holding the content
+     * @param authorReference the reference of the author of the change
+     * @param location the location of the content
+     */
+    private void handleCreatedContent(XDOM newXdom, DocumentReference documentReference,
+        DocumentReference authorReference, MentionLocation location)
     {
         List<MacroBlock> newMentions = this.xdomService.listMentionMacros(newXdom);
 
         // the matching element has not be found in the previous version of the document
         // notification are send unconditionally to all mentioned users.
-        this.xdomService.countByIdentifier(newMentions, documentReference.getWikiReference())
+        this.xdomService.groupAnchorsByUserReference(newMentions, documentReference.getWikiReference())
             .forEach((key, value) -> value.forEach(
-                anchorId -> sendNotif(
+                anchorId -> sendNotification(
                     new MentionNotificationParameters(authorReference, documentReference, key, location, anchorId,
                         newXdom))));
     }
 
-    private void handleBaseObject(List<BaseObject> oldEntry, BaseObject baseObject, DocumentReference documentReference,
-        DocumentReference authorReference, Syntax syntax)
+    /**
+     * Handles a base object during the update of a document to search for new mentions to notify.
+     * @param oldEntry the old base object (if it exists)
+     * @param baseObject the new base object
+     * @param documentReference the reference of the document holding the base object
+     * @param authorReference the reference of the author of the change
+     * @param syntax the syntax of the document
+     */
+    private void handleBaseObjectOnUpdate(List<BaseObject> oldEntry, BaseObject baseObject,
+        DocumentReference documentReference, DocumentReference authorReference, Syntax syntax)
     {
         Optional<BaseObject> oldBaseObject = ofNullable(oldEntry).flatMap(
             optOldEntries -> optOldEntries
@@ -286,12 +350,12 @@ public class DefaultMentionsDataConsumer implements MentionsDataConsumer
                         PropertyInterface field = lsp.getObject().getField(SELECTION_FIELD);
                         boolean isComment = field == null || StringUtils.isEmpty(field.toFormString());
                         MentionLocation location = isComment ? COMMENT : ANNOTATION;
-                        handleField(oldBaseObject, lsp, location, documentReference, authorReference, syntax);
+                        handleProperty(oldBaseObject, lsp, location, documentReference, authorReference, syntax);
                     });
             } else {
                 for (Object o : baseObject.getProperties()) {
                     if (o instanceof LargeStringProperty) {
-                        handleField(oldBaseObject, (LargeStringProperty) o, AWM_FIELD, documentReference,
+                        handleProperty(oldBaseObject, (LargeStringProperty) o, AWM_FIELD, documentReference,
                             authorReference, syntax);
                     }
                 }
@@ -299,23 +363,33 @@ public class DefaultMentionsDataConsumer implements MentionsDataConsumer
         }
     }
 
-    private void handleField(Optional<BaseObject> oldBaseObject, LargeStringProperty lsp, MentionLocation location,
+    /**
+     * Handle a property of an object to search for new mentions to notify.
+     * @param oldBaseObject the old base object (if it exists).
+     * @param largeStringProperty the large string property
+     * @param location the location of the property
+     * @param documentReference the reference of the document holding the property
+     * @param authorReference the reference of the author change
+     * @param syntax the syntax of the document
+     */
+    private void handleProperty(Optional<BaseObject> oldBaseObject, LargeStringProperty largeStringProperty,
+        MentionLocation location,
         DocumentReference documentReference, DocumentReference authorReference, Syntax syntax)
     {
-        Optional<XDOM> oldDom = oldBaseObject.flatMap(it -> ofNullable(it.getField(lsp.getName())))
+        Optional<XDOM> oldDom = oldBaseObject.flatMap(it -> ofNullable(it.getField(largeStringProperty.getName())))
                                     .filter(it -> it instanceof LargeStringProperty)
                                     .flatMap(
                                         it -> this.xdomService.parse(((LargeStringProperty) it).getValue(), syntax));
-        this.xdomService.parse(lsp.getValue(), syntax).ifPresent(xdom -> {
+        this.xdomService.parse(largeStringProperty.getValue(), syntax).ifPresent(xdom -> {
             // can be replaced by ifPresentOrElse for in java 9+ 
-            oldDom.ifPresent(od -> handleOnUpdate(od, xdom, documentReference, authorReference, location));
+            oldDom.ifPresent(od -> handleUpdatedContent(od, xdom, documentReference, authorReference, location));
             if (!oldDom.isPresent()) {
-                handleMissing(xdom, documentReference, authorReference, location);
+                handleCreatedContent(xdom, documentReference, authorReference, location);
             }
         });
     }
 
-    private void sendNotif(MentionNotificationParameters notificationParameters)
+    private void sendNotification(MentionNotificationParameters notificationParameters)
     {
         this.notificationService.sendNotification(notificationParameters);
     }

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/MentionXDOMService.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/MentionXDOMService.java
@@ -47,14 +47,17 @@ public interface MentionXDOMService
     List<MacroBlock> listMentionMacros(XDOM xdom);
 
     /**
-     * Count the number of mentions per reference.
+     * Groups the mention anchors by user references.
+     * An anchor is the unique identifier of a mention inside a document.
+     * If the anchor is not specified for a given user reference (the mentioned user), then the corresponding list
+     * contains an empty value (null or empty string).
      *
-     * @param mentions the list of mentions
-     * @param wikiReference the reference to the wiki in which the mentions occured
-     * @return the map of anchors of mentions per reference. If the anchor is not specified, then the list must contain
-     *          an empty value (null or empty string)
+     *
+     * @param mentions the list of mention macros in the content
+     * @param wikiReference the reference to the wiki in which the mentions occurred
+     * @return the map of the anchors grouped by user references
      */
-    Map<DocumentReference, List<String>> countByIdentifier(List<MacroBlock> mentions,
+    Map<DocumentReference, List<String>> groupAnchorsByUserReference(List<MacroBlock> mentions,
         WikiReference wikiReference);
 
     /**

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/MentionXDOMService.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/MentionXDOMService.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 
 import org.xwiki.component.annotation.Role;
 import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.WikiReference;
 import org.xwiki.rendering.block.MacroBlock;
 import org.xwiki.rendering.block.XDOM;
 import org.xwiki.rendering.syntax.Syntax;
@@ -48,11 +49,13 @@ public interface MentionXDOMService
     /**
      * Count the number of mentions per reference.
      *
-     * @param mentions the list of mentions.
+     * @param mentions the list of mentions
+     * @param wikiReference the reference to the wiki in which the mentions occured
      * @return the map of anchors of mentions per reference. If the anchor is not specified, then the list must contain
-     *          an empty value (null or empty string).
+     *          an empty value (null or empty string)
      */
-    Map<DocumentReference, List<String>> countByIdentifier(List<MacroBlock> mentions);
+    Map<DocumentReference, List<String>> countByIdentifier(List<MacroBlock> mentions,
+        WikiReference wikiReference);
 
     /**
      *

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/DefaultMentionXDOMServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/DefaultMentionXDOMServiceTest.java
@@ -124,26 +124,26 @@ class DefaultMentionXDOMServiceTest
     }
 
     @Test
-    void countByIdentifierEmpty()
+    void groupAnchorsByUserReferenceEmpty()
     {
-        Map<DocumentReference, List<String>> actual = this.xdomService.countByIdentifier(emptyList(), new WikiReference("xwiki"));
+        Map<DocumentReference, List<String>> actual = this.xdomService.groupAnchorsByUserReference(emptyList(), new WikiReference("xwiki"));
         assertTrue(actual.isEmpty());
     }
 
     @Test
-    void countByIdentifierOne()
+    void groupAnchorsByUserReferenceOne()
     {
         Map<DocumentReference, List<String>> actual =
-            this.xdomService.countByIdentifier(singletonList(initMentionMacro("A", "A1")), new WikiReference("xwiki"));
+            this.xdomService.groupAnchorsByUserReference(singletonList(initMentionMacro("A", "A1")), new WikiReference("xwiki"));
         Map<DocumentReference, List<String>> expected = new HashMap<>();
         expected.put(this.documentReferenceA, Collections.singletonList("A1"));
         assertEquals(expected, actual);
     }
 
     @Test
-    void countByIdentifierTwo()
+    void groupAnchorsByUserReferenceTwo()
     {
-        Map<DocumentReference, List<String>> actual = this.xdomService.countByIdentifier(asList(
+        Map<DocumentReference, List<String>> actual = this.xdomService.groupAnchorsByUserReference(asList(
             initMentionMacro("A", "A1"),
             initMentionMacro("A", "A2")
         ), new WikiReference("xwiki"));
@@ -153,9 +153,9 @@ class DefaultMentionXDOMServiceTest
     }
 
     @Test
-    void countByIdentifierThree()
+    void groupAnchorsByUserReferenceThree()
     {
-        Map<DocumentReference, List<String>> actual = this.xdomService.countByIdentifier(asList(
+        Map<DocumentReference, List<String>> actual = this.xdomService.groupAnchorsByUserReference(asList(
             initMentionMacro("A", "A1"),
             initMentionMacro("B", "B1"),
             initMentionMacro("A", "A2")
@@ -167,9 +167,9 @@ class DefaultMentionXDOMServiceTest
     }
 
     @Test
-    void countByIdentifierWithEmptyValues()
+    void groupAnchorsByUserReferenceWithEmptyValues()
     {
-        Map<DocumentReference, List<String>> actual = this.xdomService.countByIdentifier(asList(
+        Map<DocumentReference, List<String>> actual = this.xdomService.groupAnchorsByUserReference(asList(
             initMentionMacro("A", null),
             initMentionMacro("A", "A1"),
             initMentionMacro("A", ""),

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/DefaultMentionsDataConsumerTest.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/DefaultMentionsDataConsumerTest.java
@@ -123,7 +123,7 @@ class DefaultMentionsDataConsumerTest
         Map<DocumentReference, List<String>> value = new HashMap<>();
         value.put(user1, asList("anchor1", "anchor2"));
         value.put(authorReference, asList("", null));
-        when(this.xdomService.countByIdentifier(mentions)).thenReturn(value);
+        when(this.xdomService.countByIdentifier(mentions, documentReference.getWikiReference())).thenReturn(value);
         when(this.documentReferenceResolver.resolve("xwiki:XWiki.U2")).thenReturn(authorReference);
         when(this.documentReferenceResolver.resolve("xwiki:XWiki.Doc")).thenReturn(documentReference);
         XWikiDocument mock = mock(XWikiDocument.class);
@@ -187,7 +187,7 @@ class DefaultMentionsDataConsumerTest
         Map<DocumentReference, List<String>> value = new HashMap<>();
         value.put(user1, asList("anchor1", "anchor2"));
         value.put(authorReference, asList("", null));
-        when(this.xdomService.countByIdentifier(mentions)).thenReturn(value);
+        when(this.xdomService.countByIdentifier(mentions, documentReference.getWikiReference())).thenReturn(value);
         when(this.xdomService.parse("some content with mentions", XWIKI_2_1)).thenReturn(Optional.of(xdom));
         when(this.documentReferenceResolver.resolve("xwiki:XWiki.U2")).thenReturn(authorReference);
         when(this.documentReferenceResolver.resolve("xwiki:XWiki.Doc")).thenReturn(documentReference);
@@ -415,10 +415,9 @@ class DefaultMentionsDataConsumerTest
         when(this.documentReferenceResolver.resolve("xwiki:XWiki.Creator")).thenReturn(authorReference);
         when(this.documentRevisionProvider.getRevision(any(DocumentReference.class), any(String.class)))
             .thenReturn(null);
-        this.dataConsumer.consume(buildDefaultUpdateMentionData()
-        );
+        this.dataConsumer.consume(buildDefaultUpdateMentionData());
 
-        verify(this.xdomService, never()).countByIdentifier(any());
+        verify(this.xdomService, never()).countByIdentifier(any(), any());
         verify(this.xdomService, never()).listMentionMacros(any());
         verify(this.xdomService, never()).parse(any(), any());
         verify(this.notificationService, never()).sendNotification(any());
@@ -430,7 +429,8 @@ class DefaultMentionsDataConsumerTest
         DocumentReference documentReference1 = new DocumentReference("xwiki", "XWiki", "U1");
         Map<DocumentReference, List<String>> mentionsCount = new HashMap<>();
         mentionsCount.put(documentReference1, Collections.singletonList("anchor1"));
-        when(this.xdomService.countByIdentifier(newCommentNewMentions)).thenReturn(mentionsCount);
+        when(this.xdomService.countByIdentifier(newCommentNewMentions, documentReference.getWikiReference()))
+            .thenReturn(mentionsCount);
         when(this.documentReferenceResolver.resolve("xwiki:XWiki.Creator")).thenReturn(authorReference);
         when(this.documentReferenceResolver.resolve("xwiki:XWiki.Doc")).thenReturn(documentReference);
         return documentReference1;

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/DefaultMentionsDataConsumerTest.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/DefaultMentionsDataConsumerTest.java
@@ -123,7 +123,7 @@ class DefaultMentionsDataConsumerTest
         Map<DocumentReference, List<String>> value = new HashMap<>();
         value.put(user1, asList("anchor1", "anchor2"));
         value.put(authorReference, asList("", null));
-        when(this.xdomService.countByIdentifier(mentions, documentReference.getWikiReference())).thenReturn(value);
+        when(this.xdomService.groupAnchorsByUserReference(mentions, documentReference.getWikiReference())).thenReturn(value);
         when(this.documentReferenceResolver.resolve("xwiki:XWiki.U2")).thenReturn(authorReference);
         when(this.documentReferenceResolver.resolve("xwiki:XWiki.Doc")).thenReturn(documentReference);
         XWikiDocument mock = mock(XWikiDocument.class);
@@ -187,7 +187,7 @@ class DefaultMentionsDataConsumerTest
         Map<DocumentReference, List<String>> value = new HashMap<>();
         value.put(user1, asList("anchor1", "anchor2"));
         value.put(authorReference, asList("", null));
-        when(this.xdomService.countByIdentifier(mentions, documentReference.getWikiReference())).thenReturn(value);
+        when(this.xdomService.groupAnchorsByUserReference(mentions, documentReference.getWikiReference())).thenReturn(value);
         when(this.xdomService.parse("some content with mentions", XWIKI_2_1)).thenReturn(Optional.of(xdom));
         when(this.documentReferenceResolver.resolve("xwiki:XWiki.U2")).thenReturn(authorReference);
         when(this.documentReferenceResolver.resolve("xwiki:XWiki.Doc")).thenReturn(documentReference);
@@ -417,7 +417,7 @@ class DefaultMentionsDataConsumerTest
             .thenReturn(null);
         this.dataConsumer.consume(buildDefaultUpdateMentionData());
 
-        verify(this.xdomService, never()).countByIdentifier(any(), any());
+        verify(this.xdomService, never()).groupAnchorsByUserReference(any(), any());
         verify(this.xdomService, never()).listMentionMacros(any());
         verify(this.xdomService, never()).parse(any(), any());
         verify(this.notificationService, never()).sendNotification(any());
@@ -429,7 +429,7 @@ class DefaultMentionsDataConsumerTest
         DocumentReference documentReference1 = new DocumentReference("xwiki", "XWiki", "U1");
         Map<DocumentReference, List<String>> mentionsCount = new HashMap<>();
         mentionsCount.put(documentReference1, Collections.singletonList("anchor1"));
-        when(this.xdomService.countByIdentifier(newCommentNewMentions, documentReference.getWikiReference()))
+        when(this.xdomService.groupAnchorsByUserReference(newCommentNewMentions, documentReference.getWikiReference()))
             .thenReturn(mentionsCount);
         when(this.documentReferenceResolver.resolve("xwiki:XWiki.Creator")).thenReturn(authorReference);
         when(this.documentReferenceResolver.resolve("xwiki:XWiki.Doc")).thenReturn(documentReference);

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-ui/src/main/resources/XWiki/Mentions/MentionsMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-ui/src/main/resources/XWiki/Mentions/MentionsMacro.xml
@@ -207,22 +207,14 @@ require(['deferred!ckeditor', 'xwiki-suggestUsers', 'jquery', 'xwiki-meta'], fun
             '&lt;/li&gt;',
         outputTemplate: function (param) {
           var editor = ckeditor.instances[name];
-          var currentWikiReference = xm.documentReference.extractReference(XWiki.EntityType.WIKI);
-          
-          // Compute an absolute reference containing the wiki reference even if the user is local.
-          var documentReference = XWiki.Model.resolve(param.id, XWiki.EntityType.DOCUMENT);
-          if (!documentReference.extractReference(XWiki.EntityType.WIKI)) {
-            documentReference = documentReference.appendParent(currentWikiReference);
-          }
-          var serializedReference = XWiki.Model.serialize(documentReference);
           editor.once('afterInsertHtml', function () {
             editor.execCommand('xwiki-macro-insert', {
               name: 'mention',
               inline: true,
               parameters: {
-                reference: serializedReference,
+                reference: param.id,
                 style: 'FULL_NAME',
-                anchor: getAnchor(serializedReference)
+                anchor: getAnchor(param.id)
               }
             });
           });
@@ -250,8 +242,7 @@ require(['deferred!ckeditor', 'xwiki-suggestUsers', 'jquery', 'xwiki-meta'], fun
       return oldInline.call(this, element, updateConf(config, element.id));
     };
   });
-});
-</code>
+});</code>
     </property>
     <property>
       <name/>


### PR DESCRIPTION
https://jira.xwiki.org/browse/XWIKI-17718

Currently the mention is fully qualified identifier (eg, "xwiki:XWiki.U1") to reference the mentioned user, even when the user is local to the wiki.
The user picker is expecting to see local users identified by their short qualifier (eg, "XWiki.U1").
Consequently,  when the user picker is displayed twice, once for the short form and once for the fully qualified one.

The solution is to use the short for the mention's identifier.
As a consequence, the wiki in which the mention occurred is now needed for the resolution of the user.