### PR TITLE
XWIKI-17790: Use bootstrap-like columns for the container macro (columns layout)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/container/columns.css
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/container/columns.css
@@ -3,10 +3,10 @@
 #if (!$maxColumnsNumber || $maxColumnsNumber <= 0)
   #set ($maxColumnsNumber = 50)
 #end
-/* Don't fill 100% because IE doesn't fit things properly in. */
-#set($columnsTotalWidth = 99)
-/* 1.5% padding right to all the columns except last one. */
-#set($columnPadding = 0.75)
+## using velocity variables here because we don't have Less, normally we'd use bootstrap variables & less
+#set($gridGutterWidth = "30")
+## 15px padding right to all the columns except last one. 15px = @grid-gutter-width / 2
+#set($columnPadding = "${mathtool.div($gridGutterWidth, 2)}px")
 
 /* Render generic css first */
 
@@ -17,41 +17,41 @@
   text-align: justify;
 }
 
+/* Bootstrap row, copy of .make-row() mixin */
+.container-columns {
+  margin-left: -$columnPadding;
+  margin-right: -$columnPadding;
+}
+.container-columns:after, .container-columns:before {
+  display: table;
+  content: " ";
+}
+.container-columns:after {
+  clear: both;
+}
+
+/* Bootstrap column, copy of .make-xs-column(12) mixin, the default display, mobile first */
 .container-columns .column {
   float: left;
+  position: relative;
+  width: 100%;
+  min-height: 1px;
+  padding-left: $columnPadding;
+  padding-right: $columnPadding;
 }
 
-/* Make sure that the columns take space when they're empty: if height is auto, and they are floated, they will collapse
-   as if they didn't exist, which breaks the layout */
-.container-columns .column {
-  min-height: 10px;
-}
-
-.container-columns .first-column {
-  padding-left: 0;
-}
-.container-columns .last-column {
-  padding-right: 0;
-}
-
-
-/* Generate column-specific css classes */
-#foreach($columns in [1..$maxColumnsNumber])
-  /* Compute the percent of the screen width of a column. Round so that the java upper rounding doesn't screw IE, and because 2 decimals should be enough for everyone. */
-  #set($rawComputedColumnWidth = (($columnsTotalWidth - $columnPadding * 2 * ($columns - 1)) / $columns))
-  #set($computedColumnWidth = $mathtool.roundTo(2, $rawComputedColumnWidth))
-  .container-columns-$columns .column{
-    width: $computedColumnWidth%;
-    padding-right: $columnPadding%;
-    padding-left: $columnPadding%;
-  }
-#end
-
-/* Responsiveness, upon the same limit than Twitter Bootstrap (768px) */
-@media (max-width: 768px) {
-  .container-columns .column {
-    width: 100%;
-    padding-right: 0;
-    padding-left: 0;
-  }
+/*
+ * Responsiveness, upon the same limit than Twitter Bootstrap (768px)
+ * On desktop, set the width of the columns as Bootstrap does it (by dividing 100% by the number of columns)
+ */
+@media (min-width: 768px) {
+  /* Generate column-specific css classes */
+  #foreach($columns in [1..$maxColumnsNumber])
+    /* Compute the percent of the screen width of a column. Round so that the java upper rounding doesn't break the sum and because 4 decimals should be enough for everyone. */
+    #set($rawComputedColumnWidth = $mathtool.div(100, $columns))
+    #set($computedColumnWidth = $mathtool.roundTo(4, $rawComputedColumnWidth))
+    .container-columns-$columns .column{
+      width: $computedColumnWidth%;
+    }
+  #end
 }

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/container/columns.css
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/container/columns.css
@@ -3,9 +3,9 @@
 #if (!$maxColumnsNumber || $maxColumnsNumber <= 0)
   #set ($maxColumnsNumber = 50)
 #end
-## using velocity variables here because we don't have Less, normally we'd use bootstrap variables & less
+#* using velocity variables here because we don't have Less, normally we'd use bootstrap variables & less *#
 #set($gridGutterWidth = "30")
-## 15px padding right to all the columns except last one. 15px = @grid-gutter-width / 2
+#* 15px padding right to all the columns except last one. 15px = @grid-gutter-width / 2 *#
 #set($columnPadding = "${mathtool.div($gridGutterWidth, 2)}px")
 
 /* Render generic css first */
@@ -47,7 +47,7 @@
 @media (min-width: 768px) {
   /* Generate column-specific css classes */
   #foreach($columns in [1..$maxColumnsNumber])
-    /* Compute the percent of the screen width of a column. Round so that the java upper rounding doesn't break the sum and because 4 decimals should be enough for everyone. */
+    #* Compute the percent of the screen width of a column. Round so that the java upper rounding doesn't break the sum and because 4 decimals should be enough for everyone. *#
     #set($rawComputedColumnWidth = $mathtool.div(100, $columns))
     #set($computedColumnWidth = $mathtool.roundTo(4, $rawComputedColumnWidth))
     .container-columns-$columns .column{


### PR DESCRIPTION
Rewritten the whole CSS of the columns layout of the container macro using the bootstrap layout strategy (but not using bootstrap because there is no less in ssfx files).