### PR TITLE
XWIKI-17796: Use ComponentManager to set the XMLReader used by PDF export

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/pdf/impl/PdfExportImpl.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/pdf/impl/PdfExportImpl.java
@@ -48,8 +48,6 @@ import org.dom4j.io.XMLWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.InputSource;
-import org.xml.sax.SAXNotRecognizedException;
-import org.xml.sax.SAXNotSupportedException;
 import org.xml.sax.XMLReader;
 import org.xwiki.bridge.DocumentAccessBridge;
 import org.xwiki.environment.Environment;
@@ -329,26 +327,10 @@ public class PdfExportImpl implements PdfExport
             XHTMLDocumentFactory docFactory = XHTMLDocumentFactory.getInstance();
             SAXReader reader = new SAXReader(docFactory);
 
-            // Dom4J 2.1.1 disables external DTDs by default, which is required here, putting it back.
+            // Dom4J 2.1.1 disables external DTDs by default, so we set our own XMLReader.
             // See https://github.com/dom4j/dom4j/issues/51
-            try {
-                reader.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", true);
-            } catch (SAXNotSupportedException | SAXNotRecognizedException e) {
-                // We ingore these 2 exceptions to properly handle the case when a non-Xerces parser is provided by
-                // JAXP. Here are the possible flows:
-                //
-                // A) JAXP gives a Xerces instance:
-                // dom4j 2.1.1 sets "http://apache.org/xml/features/nonvalidating/load-external-dtd" to false,
-                // to disable DTD. No exception is thrown.
-                // XWiki sets "http://apache.org/xml/features/nonvalidating/load-external-dtd" to true, to enable DTD
-                // loading. No exception.
-                //
-                // B) JAXP gives a non-Xerces instance:
-                // dom4j 2.1.1 sets "http://apache.org/xml/features/nonvalidating/load-external-dtd" to false. The
-                // feature is not recognized: exception is thrown and ignored.
-                // XWiki sets "http://apache.org/xml/features/nonvalidating/load-external-dtd" to true. Exception is
-                // thrown (and was not being ignored). Boom.
-            }
+            XMLReader xmlReader = Utils.getComponent(XMLReaderFactory.class).createXMLReader();
+            reader.setXMLReader(xmlReader);
 
             reader.setEntityResolver(new DefaultEntityResolver());
             XHTMLDocument document = (XHTMLDocument) reader.read(source);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/pdf/impl/PdfExportImplTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/pdf/impl/PdfExportImplTest.java
@@ -24,6 +24,7 @@ import org.xwiki.bridge.DocumentAccessBridge;
 import org.xwiki.environment.Environment;
 import org.xwiki.model.reference.DocumentReferenceResolver;
 import org.xwiki.model.reference.EntityReferenceSerializer;
+import org.xwiki.test.annotation.ComponentList;
 import org.xwiki.velocity.VelocityManager;
 
 import com.xpn.xwiki.XWikiContext;
@@ -42,6 +43,9 @@ import static org.mockito.Mockito.when;
  *
  * @version $Id$
  */
+@ComponentList({
+    org.xwiki.xml.internal.DefaultXMLReaderFactory.class,
+})
 @OldcoreTest
 public class PdfExportImplTest
 {
@@ -109,13 +113,14 @@ public class PdfExportImplTest
 
         String expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
             + "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" "
-                + "\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">"
-                + "<html xmlns=\"http://www.w3.org/1999/xhtml\"><head><title>\n"
+            + "\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">"
+            + "<html xmlns=\"http://www.w3.org/1999/xhtml\"><head>\n"
+            + "<title>\n"
             + "  Main.ttt - ttt\n"
-            + "</title>"
-            + "<meta content=\"text/html; charset=UTF-8\" http-equiv=\"Content-Type\"/>"
-            + "<meta content=\"en\" name=\"language\"/>"
-            + "</head><body class=\"exportbody\" id=\"body\" pdfcover=\"0\" pdftoc=\"0\">"
+            + "</title>\n"
+            + "<meta content=\"text/html; charset=UTF-8\" http-equiv=\"Content-Type\"/>\n"
+            + "<meta content=\"en\" name=\"language\"/>\n\n"
+            + "</head><body class=\"exportbody\" id=\"body\" pdfcover=\"0\" pdftoc=\"0\">\n\n"
             + "<div id=\"xwikimaincontainer\">\n"
             + "<div id=\"xwikimaincontainerinner\">\n\n"
             + "<div id=\"xwikicontent\">\n"
@@ -125,7 +130,7 @@ public class PdfExportImplTest
                 + "background-attachment: scroll; \">Hello Clément</span></p>\n"
             + "          </div>\n"
             + "</div>\n"
-            + "</div>"
+            + "</div>\n\n"
             + "</body></html>";
 
         assertEquals(expected, pdfExport.applyCSS(html, css, xcontext));


### PR DESCRIPTION
Creates a `XMLReader` and sets it to dom4j's `SAXReader`. It sets the `http://xml.org/sax/features/namespaces` feature which is generally a good idea (and compatible with what _dom4j_ did to its default reader).

The new reader uses a _Xerces-j_ fixed configuration which causes whitespace to be different to the previous test output, so the text in the test is now compared after doing a `replaceAll` that removes whitespace between tags. This also prevents a bogus test fail depending on which XML parser is used.

This pull request depends on xwiki/xwiki-commons#103.