### PR TITLE
XWIKI-17811: Comment text not displayed after being submited with an invalid captcha

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/commentfield.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/commentfield.vm
@@ -42,6 +42,11 @@
   #set ($value = '')
 #end
 
+## Forces the value of the comment to the content from the request if it exists.
+#if ($request.content)
+  #set ($value = $request.content)
+#end
+
 ## We can't simply call $doc.display() on this object because we would get comment as the
 ## field name. Instead we want the field name to be XWiki.XWikiComments_comment for new comments
 ## and XWiki.XWikiComments_N_comment for edited comments.

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/commentsinline.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/commentsinline.vm
@@ -229,7 +229,11 @@ $xwiki.ssfx.use('uicomponents/viewers/comments.css', true)
         <input type="hidden" name="${xCommentClass}_replyto" value="$!replyTo"/>
         <div class="commentcontainer">
           <div class="commenteditor">
-              <!-- loaded by javascript (see comments.js) -->
+            <!-- loaded by javascript (see comments.js) -->
+            <!-- stores the submitted comment in case of error during the submission (eg, invalid captcha). -->
+            #if ($captchaAnswerWrong)
+              <input type="hidden" id="submittedcomment" value="$!comment" />
+            #end
           </div>
         </div>
         #if($xcontext.user == 'XWiki.XWikiGuest' && $offerGuestsCaptcha)

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/viewers/comments.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/viewers/comments.js
@@ -102,7 +102,9 @@ viewers.Comments = Class.create({
   displayHiddenForm: function () {
     if (!this.formDisplayed) {
       var placeHolder = $(this.commentPlaceHolderSelector);
-      placeHolder.removeClassName('hidden');
+      if (placeHolder) {
+        placeHolder.removeClassName('hidden');
+      }
       var button = $('openCommentForm');
       if (button) {
         button.remove();
@@ -362,8 +364,23 @@ viewers.Comments = Class.create({
 
               if (this.restartNeeded) {
                 this.container.update(response.responseText);
+
+                // If a content is found in submittedcomment that means the submission was not valid.
+                // For instance, the captcha was not accepted.
+                var submittedCommentContainer =  $("submittedcomment");
+                var submittedComment = '';
+                if(submittedCommentContainer) {
+                  submittedComment = submittedCommentContainer.value;
+                  // Removed since it is not useful anymore.
+                  submittedCommentContainer.remove();
+                  // Forces displayHiddenForm to display the comment form with the content of the comment
+                  // before submission.
+                  this.formDisplayed = false;
+                }
+
                 this.displayHiddenForm();
                 this.reloadEditor({
+                  content: submittedComment,
                   callback: function () {
                     this.getForm();
                     this.addSubmitListener(this.form);
@@ -567,6 +584,8 @@ viewers.Comments = Class.create({
       wfClass = wfClass + '-' + commentNbr;
     }
 
+    var content = options.content || {};
+
     this.destroyEditor("[name='" + name + "']", name);
 
     require(['jquery', 'xwiki-events-bridge'], function ($) {
@@ -576,6 +595,7 @@ viewers.Comments = Class.create({
           vm: 'commentfield.vm',
           number: commentNbr,
           name: name,
+          content: content
         }), function (data, status, jqXHR) {
           function loadRequiredSkinExtensions(requiredSkinExtensions)
           {


### PR DESCRIPTION
https://jira.xwiki.org/browse/XWIKI-17811

Stores the submitted comment in a hidden field in case of error during the comment form submission (eg, invalid captcha).
The content is then retrieved and the form redisplayed with its previous content when the form is not validated.