### PR TITLE
XWIKI-17827: MentionsIT#documentBody is flickering

### DIFF
--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-test/xwiki-platform-mentions-test-docker/src/test/it/org/xwiki/mentions/test/ui/MentionsIT.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-test/xwiki-platform-mentions-test-docker/src/test/it/org/xwiki/mentions/test/ui/MentionsIT.java
@@ -58,11 +58,16 @@ import static org.xwiki.platform.notifications.test.po.NotificationsTrayPage.wai
     }, resolveExtraJARs = true)
 public class MentionsIT
 {
-    public static final String U1_USERNAME = "U1";
+    private static final String U1_USERNAME = "U1";
 
-    public static final String USERS_PWD = "password";
+    private static final String USERS_PWD = "password";
 
-    public static final String U2_USERNAME = "U2";
+    private static final String U2_USERNAME = "U2";
+
+    /**
+     * Increased timeout for waiting to receive mention notifications.
+     */
+    private static final int NOTIFICATIONS_COUNT_TIMEOUT = 15;
 
     /**
      * A duplicate of {@link Runnable} which allows to throw checked {@link Exception}.
@@ -107,7 +112,7 @@ public class MentionsIT
 
         runAsUser(setup, U2_USERNAME, USERS_PWD, () -> {
             setup.gotoPage("Main", "WebHome");
-            waitOnNotificationCount("xwiki:XWiki.U2", "xwiki", 1);
+            waitOnNotificationCount("xwiki:XWiki.U2", "xwiki", 1, NOTIFICATIONS_COUNT_TIMEOUT);
             // check that a notif is well received
             NotificationsTrayPage tray = new NotificationsTrayPage();
             tray.showNotificationTray();
@@ -160,15 +165,15 @@ public class MentionsIT
             properties.put("date", "17/08/2020 14:55:18");
             properties
                 .put("comment",
-                    "AAAAA\n\n" +
-                        "{{mention reference=\"xwiki:XWiki.U2\" style=\"LOGIN\" anchor=\"test-mention-2\" /}} XYZ\n\n" +
-                        "BBBBB");
+                    "AAAAA\n\n"
+                        + "{{mention reference=\"xwiki:XWiki.U2\" style=\"LOGIN\" anchor=\"test-mention-2\" /}} XYZ\n\n"
+                        + "BBBBB");
             setup.addObject(reference, "XWiki.XWikiComments", properties);
         });
 
         runAsUser(setup, U2_USERNAME, USERS_PWD, () -> {
             setup.gotoPage("Main", "WebHome");
-            waitOnNotificationCount("xwiki:XWiki.U2", "xwiki", 1);
+            waitOnNotificationCount("xwiki:XWiki.U2", "xwiki", 1, NOTIFICATIONS_COUNT_TIMEOUT);
             // check that a notif is well received
             NotificationsTrayPage tray = new NotificationsTrayPage();
             tray.showNotificationTray();

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-pageobjects/src/main/java/org/xwiki/platform/notifications/test/po/NotificationsTrayPage.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-pageobjects/src/main/java/org/xwiki/platform/notifications/test/po/NotificationsTrayPage.java
@@ -79,12 +79,28 @@ public class NotificationsTrayPage extends ViewPage
      * This method uses an AJAX request to the REST notification endpoint to compute how many unread notification
      * the given user has on the given wiki, using user preferences.
      *
-     * @param userId the serialized user reference for which to get notifications.
+     * @param userId the serialized user reference for which to get notifications
      * @param wiki the wiki on which to get notifications
      * @param expectedUnread the number of expected unread notifications to wait for
      * @since 12.6
      */
     public static void waitOnNotificationCount(String userId, String wiki, int expectedUnread)
+    {
+        waitOnNotificationCount(userId, wiki, expectedUnread, getUtil().getDriver().getTimeout());
+    }
+
+    /**
+     * Wait until the given number of unread notification is received.
+     * This method uses an AJAX request to the REST notification endpoint to compute how many unread notification
+     * the given user has on the given wiki, using user preferences.
+     *
+     * @param userId the serialized user reference for which to get notifications
+     * @param wiki the wiki on which to get notifications
+     * @param expectedUnread the number of expected unread notifications to wait for
+     * @param timeout the time delay in seconds before stopping the notifications count
+     * @since 12.8RC1
+     */
+    public static void waitOnNotificationCount(String userId, String wiki, int expectedUnread, int timeout)
     {
         String notificationCountAjaxURL = String.format("/xwiki/rest/notifications/count?media=json&userId=%s"
             + "&useUserPreferences=true&currentWiki=%s&async=true", userId, wiki);
@@ -104,9 +120,8 @@ public class NotificationsTrayPage extends ViewPage
                         + "});");
                 responses.add(response);
                 return response != null && Integer.valueOf(response.toString()).equals(expectedUnread);
-            });
-        } catch (TimeoutException e)
-        {
+            }, timeout);
+        } catch (TimeoutException e) {
             String latestResponse = null;
             if (!responses.isEmpty()) {
                 Object response = responses.get(responses.size() - 1);
@@ -474,13 +489,11 @@ public class NotificationsTrayPage extends ViewPage
      * @param username name of the current user
      * @param password password of the current user
      * @return the rss feed
-     * @throws Exception if an error happens
-     *
      * @since 11.5RC1
      * @since 11.4
      * @since 11.3.1
      */
-    public NotificationsRSS getNotificationRSS(String username, String password) throws Exception
+    public NotificationsRSS getNotificationRSS(String username, String password)
     {
         String url = this.rssLink.getAttribute("href");
         return new NotificationsRSS(url, username, password);


### PR DESCRIPTION
https://jira.xwiki.org/browse/XWIKI-17827

The asynchronous tasks of the mentions and the notifications take longer than the default timeout of `waitOnNotificationCount`.
Consequently the test fails before the expected notification is received.

The notification is then received by `Mentions#comment` which fails too because it reads an unexpected mentions.

- Increases the timeout of the mention docker tests to 15 seconds.
- `NotificationsTrayPage#waitOnNotificationCount(String userId, String wiki, int expectedUnread, int timeout)` allowing to choose the timeout before stopping to wait for the notification count to reach the expected number.