### PR TITLE
XWIKI-17658: Unsaved content changes are not preserved anymore when using the browser's Back button to return to edit mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -330,6 +330,13 @@
         <version>${keypress.version}</version>
         <scope>runtime</scope>
       </dependency>
+      <!-- Needed for IE11 backward compatibility: this API is currently used in platform-web -->
+      <dependency>
+        <groupId>org.webjars.npm</groupId>
+        <artifactId>url-search-params-polyfill</artifactId>
+        <version>8.1.0</version>
+        <scope>runtime</scope>
+      </dependency>
 
       <!-- All Batik artifacts should be in sync -->
       <dependency>

--- a/xwiki-platform-core/xwiki-platform-edit/xwiki-platform-edit-ui/src/main/resources/XWiki/InplaceEditing.xml
+++ b/xwiki-platform-core/xwiki-platform-edit/xwiki-platform-edit-ui/src/main/resources/XWiki/InplaceEditing.xml
@@ -817,8 +817,7 @@ define('editInPlace', [
       // Check for merge conflicts only if the document is not new and we know the current version.
       if (!xwikiDocument.isNew &amp;&amp; xwikiDocument.version) {
         formData.previousVersion = xwikiDocument.version;
-        // It would have been easier to send the timestamp but that's what the Save action expects.
-        formData.editingVersionDate = new Date(xwikiDocument.modified).toISOString();
+        formData.editingVersionDate = new Date(xwikiDocument.modified).getTime();
       }
       return $.extend(formData, extra);
     }

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/edit.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/edit.vm
@@ -100,6 +100,7 @@
     <div class="hidden">
     ## CSRF prevention
     <input type="hidden" name="form_token" value="$!{services.csrf.getToken()}" />
+
     ## Pass the section number when the form is submitted in order to affect only the specified section.
     ## We need to test if the section number is present to prevent a NumberFormatException for the empty string.
     #if("$!{request.section}" != '')

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editactions.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editactions.vm
@@ -37,6 +37,12 @@
     ## This allows the preview form to redirect back to the correct editor when pressing "Back to edit":
     <span class="meta-versionSummary metamodifs">
       <input type="hidden" name="xeditaction" value="$!xcontext.action" />
+      ## Current version of the document for the conflict check
+      <input type="hidden" id="previousVersion" name="previousVersion" value="$doc.version" />
+      ## If the document is new or not when the user started the edition, for the conflict check too.
+      <input type="hidden" id="isNew" name="isNew" value="$doc.isNew()" />
+      ## We store the date of the beginning of the edition for the conflict check mechanism.
+      <input type="hidden" id="editingVersionDate" name="editingVersionDate" value="$datetool.date.getTime()" />
       #if ((!$commentFieldAdded) && $xwiki.hasEditComment())
         #set ($commentFieldAdded = 1)
         #if ($xwiki.isEditCommentFieldHidden())

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/EditIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/EditIT.java
@@ -800,7 +800,7 @@ public class EditIT
         wikiEditPage.setContent("First edit");
         wikiEditPage.clickSaveAndContinue();
 
-        // Simple way, just by going to the view page and going back to edit
+        // Simple way, just by going to the view page after a save and going back to edit
         setup.gotoPage(testReference);
         setup.getDriver().navigate().back();
         wikiEditPage = new WikiEditPage();
@@ -808,36 +808,24 @@ public class EditIT
         ViewPage viewPage = wikiEditPage.clickSaveAndView();
         assertEquals("Second edit", viewPage.getContent());
 
-        // Complex way: continue to another editor, make other changes, and then get back to the editor.
+        // Complex way: Save&Continue first, then forget an edit and move on.
+        // Come back to check the unsaved changes are still there and can be saved.
         wikiEditPage = viewPage.editWiki();
         wikiEditPage.setContent("third edit");
         wikiEditPage.clickSaveAndContinue();
+        // We set the content without saving.
+        wikiEditPage.setContent("fourth edit");
 
         viewPage = setup.gotoPage(testReference);
         viewPage.waitUntilPageJSIsLoaded();
 
-        WYSIWYGEditPage wysiwygEditPage = viewPage.editWYSIWYG();
-        wysiwygEditPage.setContent("fourth edit");
-        wysiwygEditPage.clickSaveAndContinue();
-
-        // WYSIWYG editor -> view page
-        setup.getDriver().navigate().back();
         // view page -> wiki editor
         setup.getDriver().navigate().back();
 
-        setup.getDriver().waitUntilCondition(driver -> {
-            try {
-                return driver.findElement(By.id("content")) != null
-                && driver.findElement(By.id("content")).getText().equals("fourth edit");
-            } catch (NoSuchElementException | StaleElementReferenceException e) {
-                return false;
-            }
-        });
-
         wikiEditPage = new WikiEditPage();
-        wikiEditPage.setContent("fifth edit");
+        assertEquals("fourth edit", wikiEditPage.getExactContent());
         viewPage = wikiEditPage.clickSaveAndView();
-        assertEquals("fifth edit", viewPage.getContent());
+        assertEquals("fourth edit", viewPage.getContent());
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-minimaldependencies/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-minimaldependencies/pom.xml
@@ -52,6 +52,12 @@
       <version>${project.version}</version>
       <scope>runtime</scope>
     </dependency>
+    <!-- Needed for IE11 backward compatibility: this API is currently used in platform-web -->
+    <dependency>
+      <groupId>org.webjars.npm</groupId>
+      <artifactId>url-search-params-polyfill</artifactId>
+      <scope>runtime</scope>
+    </dependency>
     <dependency>
       <groupId>org.xwiki.platform</groupId>
       <artifactId>xwiki-platform-localization-script</artifactId>

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SaveAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SaveAction.java
@@ -24,6 +24,7 @@ import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -34,7 +35,6 @@ import javax.script.ScriptContext;
 
 import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.lang3.StringUtils;
-import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.suigeneris.jrcs.diff.DifferentiationFailedException;
@@ -402,11 +402,11 @@ public class SaveAction extends PreviewAction
         Version previousVersion = new Version(request.getParameter("previousVersion"));
         Version latestVersion = originalDoc.getRCSVersion();
 
-        DateTime editingVersionDate = new DateTime(request.getParameter("editingVersionDate"));
-        DateTime latestVersionDate = new DateTime(originalDoc.getDate());
+        Date editingVersionDate = new Date(Long.parseLong(request.getParameter("editingVersionDate")));
+        Date latestVersionDate = originalDoc.getDate();
 
         // we ensure that nobody edited the document between the moment the user started to edit and now
-        if (!latestVersion.equals(previousVersion) || latestVersionDate.isAfter(editingVersionDate)) {
+        if (!latestVersion.equals(previousVersion) || latestVersionDate.after(editingVersionDate)) {
             try {
                 XWikiDocument previousDoc =
                     getDocumentRevisionProvider().getRevision(originalDoc, previousVersion.toString());

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/actionbuttons/actionButtons.js
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/js/xwiki/actionbuttons/actionButtons.js
@@ -26,25 +26,24 @@ var XWiki = (function(XWiki) {
   var actionButtons = XWiki.actionButtons = XWiki.actionButtons || {};
 
   // we need to handle the creation of document
-  var currentDocument, currentVersion, isNew, versionRefreshed;
-  var editingVersionDate = new Date();
+  var currentDocument;
+  var editingVersionDateField = $('editingVersionDate');
+  var previousVersionField = $('previousVersion');
+  var isNewField = $('isNew');
 
-  var getCurrentVersion = function (event) {
+  var refreshVersion = function (event) {
     if (currentDocument.equals(event.memo.documentReference)) {
-      // We are certainly coming from a back button navigation: the content of the editor might not reflect the real
-      // content, let's reload the editor.
-      if (!versionRefreshed && currentVersion != event.memo.version) {
-        window.location.reload();
+      if (previousVersionField) {
+        previousVersionField.setValue(event.memo.version);
       }
-      currentVersion = event.memo.version;
-      editingVersionDate = new Date();
-      isNew = "false";
-      versionRefreshed = true;
+      if (isNewField) {
+        isNewField.setValue(false);
+      }
     }
   };
 
-  // in object editor the version is updated when an object is added.
-  document.observe('xwiki:document:changeVersion', getCurrentVersion);
+  // Listen for versions change to update properly the version fields.
+  document.observe('xwiki:document:changeVersion', refreshVersion);
 
   actionButtons.EditActions = Class.create({
     initialize : function() {
@@ -243,36 +242,6 @@ var XWiki = (function(XWiki) {
         return;
       }
 
-      // We only send the version info if we are on a standard edit.
-      var isFromStandardEditor = window.location.href.indexOf("/edit/") != -1;
-
-      if (isFromStandardEditor) {
-        if ($('previousVersion')) {
-          $('previousVersion').setValue(currentVersion);
-          $('editingVersionDate').setValue(editingVersionDate.toISOString());
-          $('isNew').setValue(isNew);
-        } else {
-          this.form.insert(new Element("input", {
-            type: "hidden",
-            name: "previousVersion",
-            id: "previousVersion",
-            value: currentVersion
-          }));
-          this.form.insert(new Element("input", {
-            type: "hidden",
-            name: "editingVersionDate",
-            id: "editingVersionDate",
-            value: editingVersionDate.toISOString()
-          }));
-          this.form.insert(new Element("input", {
-            type: "hidden",
-            name: "isNew",
-            id: "isNew",
-            value: isNew.toString()
-          }));
-        }
-      }
-
       var isCreateFromTemplate = (this.form.template && this.form.template.value);
 
       // Handle explicitly requested synchronous operations (mainly for backwards compatibility).
@@ -385,6 +354,11 @@ var XWiki = (function(XWiki) {
         require(['xwiki-meta'], function (xm) {
           xm.setVersion(response.responseJSON.newVersion);
         });
+
+        // We only update this field since the other ones are updated by the callback of setVersion.
+        if (editingVersionDateField) {
+          editingVersionDateField.setValue(new Date().getTime())
+        }
       }
 
       // Announce that the document has been saved
@@ -425,7 +399,15 @@ var XWiki = (function(XWiki) {
     },
     // Reload the editors in case the user want to loose his change.
     reloadEditor : function () {
-      window.location.reload();
+      // We don't rely on window.location.reload() since it might keep cached data from the form.
+      // We don't rely on window.location.reload(true) either since it's unclear if it's properly supported by
+      // all browsers. Instead we rely on a query parameter with the current date.
+      // URLSearchParams is not supported by IE11 but we rely on a polyfill.
+      require(["$services.webjars.url('org.webjars.npm:url-search-params-polyfill', 'index.js')"], function() {
+        var params = new URLSearchParams(window.location.search);
+        params.set("timestamp", new Date().getTime());
+        window.location.search = "?" + params.toString();
+      });
     },
     // 401 happens when the user is not authorized to do that: can be a logout or a change in perm
     on401 : function (response) {
@@ -770,19 +752,7 @@ var XWiki = (function(XWiki) {
   function init() {
     require(['xwiki-meta'], function (xm) {
       currentDocument = xm.documentReference;
-      isNew = xm.isNew;
-      currentVersion = xm.version;
-
-      // in case of 404 the document is new
-      xm.refreshVersion(function () {
-        isNew = true;
-        versionRefreshed = true;
-      });
     });
-    if ($('content')) {
-      // ensure that the shown value is the true value in case of reload.
-      $('content').value = $('content').defaultValue;
-    }
 
     new actionButtons.EditActions();
     new actionButtons.AjaxSaveAndContinue();


### PR DESCRIPTION
JIRA: https://jira.xwiki.org/browse/XWIKI-17658 and https://jira.xwiki.org/browse/XWIKI-17871

## Description of the fix

The idea of this fix is to rely on the cached data of previousVersion field in case of using the back button to ensure
  1. that the content is sent with the right version info to avoid a conflict
  2. that the user will not send data with wrong previous information which could override existing data (situation before the check conflict mechanism)

In order to do that, I had to inject the needed fields for the check conflict mechanism in the edit template, since they need to be in the original DOM to be properly cached by the browser: fields injected with Javascript are not cached. 
I also had to change the way we reload the editor in actionButtons.js to ensure to force the reload without the cached information. Finally I also changed the format of the date we send to the server to use something more standard and easy to use.

Since I use a javascript API that is not supported by IE11 (`URLSearchParams`) I also introduced in this PR a polyfill through a Webjar dependency. 

## Tests

 - [x] `xwiki-platform-flamingo-skin-test-docker` (contains EditIT tests)
 - [x] `xwiki-platform-appwithinminutes-test` (AWM uses actionButtons.js)
 - [x] `xwiki-platform-administration-test` (Administration uses actionButtons.js)
 - [x] `xwiki-platform-distribution-flavor-test-ui` (various tests uses actionButtons.js)

Manual testing:
  - Steps  from https://test.xwiki.org/xwiki/bin/view/Nested%20Spaces/Warning%20conflict%20when%20editing%20a%20page
    - [x] With wiki editor
    - [x] With inline editing

  - [x] Steps from https://test.xwiki.org/xwiki/bin/view/CKEditor/Preview%20A%20Page


## List of changes

  * Remove in actionButtons.js all the mechanism to detect if the page
    was reached with back button
  * Remove in actionsButtons.js the injection of fields needed for
    conflict check mechanism
  * Put in edit.vm the fields needed for conflict check mechanism in
    order to be able to rely on cache for them in case of usage of back
button
  * Change the format of Date send to SaveAction to rely on milliseconds
    since Epoch instead of sending a formatted date
  * Change the reload editor function in actionButtons.js to ensure that
    the cache is discarded