### PR TITLE
XWIKI-15815: The visible to Group option doesn't send any message to any user from the selected group

### DIFF
--- a/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/pom.xml
@@ -31,7 +31,7 @@
   <name>XWiki Platform - Message Stream - API</name>
   <description>API to publish and display user status messages in different streams</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.70</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.71</xwiki.jacoco.instructionRatio>
     <!-- Old names of this module used for retro compatibility when resolving dependencies of old extensions -->
     <xwiki.extension.features>xwiki-platform-messagestream</xwiki.extension.features>
     <!-- TODO: Remove once the tests have been fixed to not output anything to the console! -->

--- a/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/main/java/org/xwiki/messagestream/GroupMessageDescriptor.java
+++ b/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/main/java/org/xwiki/messagestream/GroupMessageDescriptor.java
@@ -38,6 +38,11 @@ import org.xwiki.messagestream.internal.AbstractMessageDescriptor;
 public class GroupMessageDescriptor extends AbstractMessageDescriptor
 {
     /**
+     * Event type of the group messages.
+     */
+    public static final String EVENT_TYPE = "groupMessage";
+
+    /**
      * Construct a GroupMessageDescriptor.
      */
     public GroupMessageDescriptor()
@@ -48,7 +53,7 @@ public class GroupMessageDescriptor extends AbstractMessageDescriptor
     @Override
     public String getEventType()
     {
-        return "groupMessage";
+        return EVENT_TYPE;
     }
 
     @Override
@@ -60,8 +65,6 @@ public class GroupMessageDescriptor extends AbstractMessageDescriptor
     @Override
     public boolean isEnabled(String wikiId)
     {
-        // TODO: enable this descriptor and add a notification filter so users only get messages that are sent to a
-        // group they belong to.
-        return false;
+        return super.isEnabled(wikiId);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/main/java/org/xwiki/messagestream/internal/AbstractMessageStreamNotificationFilter.java
+++ b/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/main/java/org/xwiki/messagestream/internal/AbstractMessageStreamNotificationFilter.java
@@ -1,0 +1,72 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.messagestream.internal;
+
+import java.util.Collection;
+import java.util.Objects;
+
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.notifications.NotificationFormat;
+import org.xwiki.notifications.filters.NotificationFilter;
+import org.xwiki.notifications.filters.NotificationFilterPreference;
+import org.xwiki.notifications.filters.NotificationFilterType;
+import org.xwiki.notifications.filters.expression.ExpressionNode;
+import org.xwiki.notifications.preferences.NotificationPreference;
+import org.xwiki.notifications.preferences.NotificationPreferenceProperty;
+
+/**
+ * Base class for the message notification filters.
+ *
+ * @version $Id$
+ * @since 12.10RC1
+ */
+public abstract class AbstractMessageStreamNotificationFilter implements NotificationFilter
+{
+    @Override
+    public boolean matchesPreference(NotificationPreference preference)
+    {
+        return Objects.equals(getEventType(), getEventType(preference));
+    }
+
+    @Override
+    public ExpressionNode filterExpression(DocumentReference user,
+        Collection<NotificationFilterPreference> filterPreferences, NotificationFilterType type,
+        NotificationFormat format)
+    {
+        return null;
+    }
+
+    @Override
+    public ExpressionNode filterExpression(DocumentReference user,
+        Collection<NotificationFilterPreference> filterPreferences, NotificationPreference preference)
+    {
+        return null;
+    }
+
+    /**
+     * @return the event type handled by the filter
+     */
+    abstract String getEventType();
+
+    private String getEventType(NotificationPreference preference)
+    {
+        return (String) preference.getProperties().get(NotificationPreferenceProperty.EVENT_TYPE);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/main/java/org/xwiki/messagestream/internal/DirectMessageStreamNotificationFilter.java
+++ b/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/main/java/org/xwiki/messagestream/internal/DirectMessageStreamNotificationFilter.java
@@ -31,15 +31,7 @@ import org.xwiki.messagestream.DirectMessageDescriptor;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReferenceSerializer;
 import org.xwiki.notifications.NotificationFormat;
-import org.xwiki.notifications.filters.NotificationFilter;
 import org.xwiki.notifications.filters.NotificationFilterPreference;
-import org.xwiki.notifications.filters.NotificationFilterType;
-import org.xwiki.notifications.filters.expression.EventProperty;
-import org.xwiki.notifications.filters.expression.ExpressionNode;
-import org.xwiki.notifications.preferences.NotificationPreference;
-import org.xwiki.notifications.preferences.NotificationPreferenceProperty;
-
-import static org.xwiki.notifications.filters.expression.generics.ExpressionBuilder.value;
 
 /**
  * Filter that make sure a direct message (to someone) from the message stream is visible by the current user.
@@ -51,22 +43,22 @@ import static org.xwiki.notifications.filters.expression.generics.ExpressionBuil
 @Component
 @Singleton
 @Named("DirectMessageStreamNotificationFilter")
-public class DirectMessageStreamNotificationFilter implements NotificationFilter
+public class DirectMessageStreamNotificationFilter extends AbstractMessageStreamNotificationFilter
 {
     @Inject
     private EntityReferenceSerializer<String> serializer;
 
     @Override
     public FilterPolicy filterEvent(Event event, DocumentReference user,
-            Collection<NotificationFilterPreference> filterPreferences, NotificationFormat format)
+        Collection<NotificationFilterPreference> filterPreferences, NotificationFormat format)
     {
         // Don't handle events that are not direct messages!
-        if (!DirectMessageDescriptor.EVENT_TYPE.equals(event.getType())) {
+        if (!getEventType().equals(event.getType())) {
             return FilterPolicy.NO_EFFECT;
         }
 
         if (user != null) {
-            String userId = serializer.serialize(user);
+            String userId = this.serializer.serialize(user);
             // Here we don't use FilterPolicy.KEEP in case the message is addressed to the given user, because the
             // sender might be blacklisted by an other filter (the sender might be an harasser).
             // So we just make sure the message is filtered if the current user is not the recipient, but nothing more.
@@ -74,35 +66,6 @@ public class DirectMessageStreamNotificationFilter implements NotificationFilter
         } else {
             return FilterPolicy.FILTER;
         }
-    }
-
-    @Override
-    public boolean matchesPreference(NotificationPreference preference)
-    {
-        return DirectMessageDescriptor.EVENT_TYPE.equals(getEventType(preference));
-    }
-
-    @Override
-    public ExpressionNode filterExpression(DocumentReference user,
-            Collection<NotificationFilterPreference> filterPreferences, NotificationPreference preference)
-    {
-        if (user == null) {
-            return null;
-        }
-        return value(EventProperty.STREAM).eq(value(user));
-    }
-
-    private String getEventType(NotificationPreference preference)
-    {
-        return (String) preference.getProperties().get(NotificationPreferenceProperty.EVENT_TYPE);
-    }
-
-    @Override
-    public ExpressionNode filterExpression(DocumentReference user,
-            Collection<NotificationFilterPreference> filterPreferences, NotificationFilterType type,
-            NotificationFormat format)
-    {
-        return null;
     }
 
     @Override
@@ -119,5 +82,11 @@ public class DirectMessageStreamNotificationFilter implements NotificationFilter
         // In particular, the priority must be higher than org.xwiki.notifications.filters.internal.user.EventUserFilter
         // otherwise users will receive direct messages addressed to others if they follow the sender.
         return Integer.MAX_VALUE;
+    }
+
+    @Override
+    String getEventType()
+    {
+        return DirectMessageDescriptor.EVENT_TYPE;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/main/java/org/xwiki/messagestream/internal/GroupMessageStreamNotificationFilter.java
+++ b/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/main/java/org/xwiki/messagestream/internal/GroupMessageStreamNotificationFilter.java
@@ -1,0 +1,105 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.messagestream.internal;
+
+import java.util.Collection;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import com.xpn.xwiki.api.User;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.eventstream.Event;
+import org.xwiki.messagestream.GroupMessageDescriptor;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.notifications.NotificationFormat;
+import org.xwiki.notifications.filters.NotificationFilterPreference;
+
+import com.xpn.xwiki.XWikiContext;
+
+/**
+ * Filter that make sure a group message (to a group) from the message stream is visible only to members of this group.
+ *
+ * @version $Id$
+ * @since 12.10RC1
+ */
+@Component
+@Singleton
+@Named("GroupMessageStreamNotificationFilter")
+public class GroupMessageStreamNotificationFilter extends AbstractMessageStreamNotificationFilter
+{
+    @Inject
+    private Provider<XWikiContext> xcontextProvider;
+
+    @Override
+    public FilterPolicy filterEvent(Event event, DocumentReference userDocumentReference,
+        Collection<NotificationFilterPreference> filterPreferences, NotificationFormat format)
+    {
+        FilterPolicy ret;
+        // Don't handle events that are not group messages.
+        if (!getEventType().equals(event.getType())) {
+            ret = FilterPolicy.NO_EFFECT;
+        } else if (userDocumentReference != null) {
+            XWikiContext xWikiContext = this.xcontextProvider.get();
+            // If the user is not in the messaged group, the event is filtered.
+            // If the user is in the group, we let it pass and let downstream filter analyze the event.
+            User user = xWikiContext.getWiki().getUser(userDocumentReference, xWikiContext);
+            if (user == null) {
+                ret = FilterPolicy.NO_EFFECT;
+            } else {
+                boolean userInGroup = user.isUserInGroup(event.getStream());
+                if (!userInGroup) {
+                    ret = FilterPolicy.FILTER;
+                } else {
+                    ret = FilterPolicy.NO_EFFECT;
+                }
+            }
+        } else {
+            ret = FilterPolicy.FILTER;
+        }
+
+        return ret;
+    }
+
+    @Override
+    public String getName()
+    {
+        return "Group Message Stream Notification Filter";
+    }
+
+    @Override
+    String getEventType()
+    {
+        return GroupMessageDescriptor.EVENT_TYPE;
+    }
+
+    @Override
+    public int getPriority()
+    {
+        // Makes the priority higher than org.xwiki.notifications.filters.internal.user.EventUserFilter.getPriority, to
+        // force the group memberships to be checked before other filters.
+        // EventUserFilter in particular because it keeps events if they are send by followers of the sender, even
+        // if the follower is not part of the targeted group in our context (and consequently, skipping this filter).
+        return 2001;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/main/java/org/xwiki/messagestream/internal/PersonalMessageStreamNotificationFilter.java
+++ b/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/main/java/org/xwiki/messagestream/internal/PersonalMessageStreamNotificationFilter.java
@@ -31,13 +31,8 @@ import org.xwiki.messagestream.PersonalMessageDescriptor;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReferenceSerializer;
 import org.xwiki.notifications.NotificationFormat;
-import org.xwiki.notifications.filters.NotificationFilter;
 import org.xwiki.notifications.filters.NotificationFilterPreference;
-import org.xwiki.notifications.filters.NotificationFilterType;
-import org.xwiki.notifications.filters.expression.ExpressionNode;
 import org.xwiki.notifications.filters.internal.user.EventUserFilterPreferencesGetter;
-import org.xwiki.notifications.preferences.NotificationPreference;
-import org.xwiki.notifications.preferences.NotificationPreferenceProperty;
 
 /**
  * Filter that make sure a message from the message stream is visible by the current user.
@@ -49,7 +44,7 @@ import org.xwiki.notifications.preferences.NotificationPreferenceProperty;
 @Component
 @Singleton
 @Named("PersonalMessageStreamNotificationFilter")
-public class PersonalMessageStreamNotificationFilter implements NotificationFilter
+public class PersonalMessageStreamNotificationFilter extends AbstractMessageStreamNotificationFilter
 {
     @Inject
     private EntityReferenceSerializer<String> serializer;
@@ -62,44 +57,24 @@ public class PersonalMessageStreamNotificationFilter implements NotificationFilt
             Collection<NotificationFilterPreference> filterPreferences, NotificationFormat format)
     {
         // Don't handle events that are not personal messages!
-        if (!PersonalMessageDescriptor.EVENT_TYPE.equals(event.getType())) {
+        if (!getEventType().equals(event.getType())) {
             return FilterPolicy.NO_EFFECT;
         }
 
-        String sender = serializer.serialize(event.getUser());
-        return preferencesGetter.isUsedFollowed(sender, filterPreferences, format) ? FilterPolicy.KEEP
+        String sender = this.serializer.serialize(event.getUser());
+        return this.preferencesGetter.isUsedFollowed(sender, filterPreferences, format) ? FilterPolicy.KEEP
                 : FilterPolicy.FILTER;
-    }
-
-    @Override
-    public boolean matchesPreference(NotificationPreference preference)
-    {
-        return PersonalMessageDescriptor.EVENT_TYPE.equals(getEventType(preference));
-    }
-
-    @Override
-    public ExpressionNode filterExpression(DocumentReference user,
-            Collection<NotificationFilterPreference> filterPreferences, NotificationPreference preference)
-    {
-        return null;
-    }
-
-    private String getEventType(NotificationPreference preference)
-    {
-        return (String) preference.getProperties().get(NotificationPreferenceProperty.EVENT_TYPE);
-    }
-
-    @Override
-    public ExpressionNode filterExpression(DocumentReference user,
-            Collection<NotificationFilterPreference> filterPreferences, NotificationFilterType type,
-            NotificationFormat format)
-    {
-        return null;
     }
 
     @Override
     public String getName()
     {
         return "Personal Message Stream Notification Filter";
+    }
+
+    @Override
+    String getEventType()
+    {
+        return PersonalMessageDescriptor.EVENT_TYPE;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/main/resources/META-INF/components.txt
@@ -2,6 +2,7 @@ org.xwiki.messagestream.internal.DefaultMessageStream
 org.xwiki.messagestream.internal.DefaultMessageStreamConfiguration
 org.xwiki.messagestream.internal.DirectMessageStreamNotificationFilter
 org.xwiki.messagestream.internal.PersonalMessageStreamNotificationFilter
+org.xwiki.messagestream.internal.GroupMessageStreamNotificationFilter
 org.xwiki.messagestream.script.MessageStreamScriptService
 org.xwiki.messagestream.DirectMessageDescriptor
 org.xwiki.messagestream.GroupMessageDescriptor

--- a/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/test/java/org/xwiki/messagestream/internal/DirectMessageStreamNotificationFilterTest.java
+++ b/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/test/java/org/xwiki/messagestream/internal/DirectMessageStreamNotificationFilterTest.java
@@ -22,47 +22,43 @@ package org.xwiki.messagestream.internal;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xwiki.eventstream.Event;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReferenceSerializer;
-import org.xwiki.notifications.filters.NotificationFilter;
 import org.xwiki.notifications.preferences.NotificationPreference;
 import org.xwiki.notifications.preferences.NotificationPreferenceProperty;
-import org.xwiki.test.mockito.MockitoComponentMockingRule;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.xwiki.notifications.filters.NotificationFilter.FilterPolicy.FILTER;
+import static org.xwiki.notifications.filters.NotificationFilter.FilterPolicy.NO_EFFECT;
 
 /**
+ * Test of {@link DirectMessageStreamNotificationFilter}.
  * @version $Id$
- * @since
  */
-public class DirectMessageStreamNotificationFilterTest
+@ComponentTest
+class DirectMessageStreamNotificationFilterTest
 {
-    @Rule
-    public MockitoComponentMockingRule<DirectMessageStreamNotificationFilter> mocker =
-            new MockitoComponentMockingRule<>(DirectMessageStreamNotificationFilter.class);
+    @InjectMockComponents
+    private DirectMessageStreamNotificationFilter groupMessageFilter;
 
+    @MockComponent
     private EntityReferenceSerializer<String> serializer;
 
-    @Before
-    public void setUp() throws Exception
-    {
-        serializer = mocker.getInstance(EntityReferenceSerializer.TYPE_STRING);
-    }
-
     @Test
-    public void filterEvent() throws Exception
+    void filterEvent()
     {
         DocumentReference user = new DocumentReference("xwiki", "XWiki", "User");
-        when(serializer.serialize(user)).thenReturn("xwiki:XWiki.User");
+        when(this.serializer.serialize(user)).thenReturn("xwiki:XWiki.User");
 
         Event event1 = mock(Event.class);
         when(event1.getType()).thenReturn("directMessage");
@@ -74,48 +70,38 @@ public class DirectMessageStreamNotificationFilterTest
         when(event3.getType()).thenReturn("someType");
         when(event3.getStream()).thenReturn("xwiki:XWiki.OtherUser");
 
-        assertEquals(NotificationFilter.FilterPolicy.NO_EFFECT,
-                mocker.getComponentUnderTest().filterEvent(event1, user, null, null));
-        assertEquals(NotificationFilter.FilterPolicy.FILTER,
-                mocker.getComponentUnderTest().filterEvent(event2, user, null, null));
-        assertEquals(NotificationFilter.FilterPolicy.NO_EFFECT,
-                mocker.getComponentUnderTest().filterEvent(event3, user, null, null));
+        assertEquals(NO_EFFECT, this.groupMessageFilter.filterEvent(event1, user, null, null));
+        assertEquals(FILTER, this.groupMessageFilter.filterEvent(event2, user, null, null));
+        assertEquals(NO_EFFECT, this.groupMessageFilter.filterEvent(event3, user, null, null));
     }
 
     @Test
-    public void matchesPreference() throws Exception
+    void matchesPreference()
     {
         NotificationPreference notificationPreference = mock(NotificationPreference.class);
         Map<NotificationPreferenceProperty, Object> properties = new HashMap<>();
         properties.put(NotificationPreferenceProperty.EVENT_TYPE, "directMessage");
         when(notificationPreference.getProperties()).thenReturn(properties);
 
-        assertTrue(mocker.getComponentUnderTest().matchesPreference(notificationPreference));
+        assertTrue(this.groupMessageFilter.matchesPreference(notificationPreference));
 
         NotificationPreference notificationPreference2 = mock(NotificationPreference.class);
         Map<NotificationPreferenceProperty, Object> properties2 = new HashMap<>();
         properties2.put(NotificationPreferenceProperty.EVENT_TYPE, "otherEventType");
         when(notificationPreference2.getProperties()).thenReturn(properties2);
 
-        assertFalse(mocker.getComponentUnderTest().matchesPreference(notificationPreference2));
+        assertFalse(this.groupMessageFilter.matchesPreference(notificationPreference2));
     }
 
     @Test
-    public void getName() throws Exception
+    void getName()
     {
-        assertEquals("Direct Message Stream Notification Filter", mocker.getComponentUnderTest().getName());
+        assertEquals("Direct Message Stream Notification Filter", this.groupMessageFilter.getName());
     }
 
     @Test
-    public void filterExpression() throws Exception
+    void filterExpressionNull()
     {
-        // Test 1
-        DocumentReference user = new DocumentReference("xwiki", "XWiki", "User");
-        assertEquals("STREAM = \"xwiki:XWiki.User\"",
-                mocker.getComponentUnderTest().filterExpression(user, null, null).toString());
-
-        // Test 2
-        assertNull(mocker.getComponentUnderTest().filterExpression(null, null, null));
+        assertNull(this.groupMessageFilter.filterExpression(null, null, null));
     }
-
 }

--- a/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/test/java/org/xwiki/messagestream/internal/GroupMessageStreamNotificationFilterTest.java
+++ b/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/test/java/org/xwiki/messagestream/internal/GroupMessageStreamNotificationFilterTest.java
@@ -1,0 +1,174 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.messagestream.internal;
+
+import javax.inject.Provider;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.eventstream.internal.DefaultEvent;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.DocumentReferenceResolver;
+import org.xwiki.notifications.filters.NotificationFilter.FilterPolicy;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+import org.xwiki.test.mockito.MockitoComponentManager;
+
+import com.xpn.xwiki.XWiki;
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.api.User;
+import com.xpn.xwiki.web.Utils;
+
+import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.xwiki.notifications.NotificationFormat.ALERT;
+import static org.xwiki.notifications.filters.NotificationFilter.FilterPolicy.FILTER;
+import static org.xwiki.notifications.filters.NotificationFilter.FilterPolicy.NO_EFFECT;
+
+/**
+ * Test of {@link GroupMessageStreamNotificationFilter}.
+ *
+ * @version $Id$
+ * @since 12.10RC1
+ */
+@ComponentTest
+class GroupMessageStreamNotificationFilterTest
+{
+    private static final DocumentReference USER = new DocumentReference("xwiki", "XWiki", "User");
+
+    private static final String GROUP_NAME = "GroupName";
+
+    @InjectMockComponents
+    private GroupMessageStreamNotificationFilter groupMessageFilter;
+
+    @MockComponent
+    private Provider<XWikiContext> xcontextProvider;
+
+    private XWikiContext xWikiContext;
+
+    @BeforeEach
+    void setUp()
+    {
+        this.xWikiContext = mock(XWikiContext.class);
+        when(this.xcontextProvider.get()).thenReturn(this.xWikiContext);
+    }
+
+    @Test
+    void filterEventWrongType()
+    {
+        DefaultEvent event = new DefaultEvent();
+        event.setType("WRONG TYPE");
+        FilterPolicy filterPolicy = this.groupMessageFilter.filterEvent(event, USER, emptyList(), ALERT);
+        assertEquals(NO_EFFECT, filterPolicy);
+    }
+
+    @Test
+    void filterEventUserNull()
+    {
+        DefaultEvent event = new DefaultEvent();
+        event.setType(this.groupMessageFilter.getEventType());
+        FilterPolicy filterPolicy = this.groupMessageFilter.filterEvent(event, null, emptyList(), ALERT);
+        assertEquals(FILTER, filterPolicy);
+    }
+
+    @Test
+    void filterEventUserGetUserNull(MockitoComponentManager rootComponentManager) throws Exception
+    {
+        Utils.setComponentManager(rootComponentManager);
+        ComponentManager componentManager =
+            rootComponentManager.registerMockComponent(ComponentManager.class, "context");
+        when(componentManager.getInstance(DocumentReferenceResolver.class, "currentmixed"))
+            .thenReturn(mock(DocumentReferenceResolver.class));
+
+        XWiki xWiki = mock(XWiki.class);
+        when(this.xWikiContext.getWiki()).thenReturn(xWiki);
+
+        when(xWiki.getUser(USER, this.xWikiContext)).thenReturn(null);
+
+        DefaultEvent event = new DefaultEvent();
+        event.setType(this.groupMessageFilter.getEventType());
+        event.setStream(GROUP_NAME);
+        FilterPolicy filterPolicy = this.groupMessageFilter.filterEvent(event, USER, emptyList(), ALERT);
+        assertEquals(NO_EFFECT, filterPolicy);
+    }
+
+    @Test
+    void filterEventUserNotInGroup(MockitoComponentManager rootComponentManager) throws Exception
+    {
+        Utils.setComponentManager(rootComponentManager);
+        ComponentManager componentManager =
+            rootComponentManager.registerMockComponent(ComponentManager.class, "context");
+        when(componentManager.getInstance(DocumentReferenceResolver.class, "currentmixed"))
+            .thenReturn(mock(DocumentReferenceResolver.class));
+
+        XWiki xWiki = mock(XWiki.class);
+        when(this.xWikiContext.getWiki()).thenReturn(xWiki);
+
+        User user = mock(User.class);
+        when(xWiki.getUser(USER, this.xWikiContext)).thenReturn(user);
+        when(user.isUserInGroup(GROUP_NAME)).thenReturn(false);
+
+        DefaultEvent event = new DefaultEvent();
+        event.setType(this.groupMessageFilter.getEventType());
+        event.setStream(GROUP_NAME);
+        FilterPolicy filterPolicy = this.groupMessageFilter.filterEvent(event, USER, emptyList(), ALERT);
+        assertEquals(FILTER, filterPolicy);
+    }
+
+    @Test
+    void filterEventUser(MockitoComponentManager rootComponentManager) throws Exception
+    {
+        Utils.setComponentManager(rootComponentManager);
+        ComponentManager componentManager =
+            rootComponentManager.registerMockComponent(ComponentManager.class, "context");
+        when(componentManager.getInstance(DocumentReferenceResolver.class, "currentmixed"))
+            .thenReturn(mock(DocumentReferenceResolver.class));
+
+        XWiki xWiki = mock(XWiki.class);
+        when(this.xWikiContext.getWiki()).thenReturn(xWiki);
+
+        User user = mock(User.class);
+        when(xWiki.getUser(USER, this.xWikiContext)).thenReturn(user);
+        when(user.isUserInGroup(GROUP_NAME)).thenReturn(true);
+
+        DefaultEvent event = new DefaultEvent();
+        event.setType(this.groupMessageFilter.getEventType());
+        event.setStream(GROUP_NAME);
+        FilterPolicy filterPolicy = this.groupMessageFilter.filterEvent(event, USER, emptyList(), ALERT);
+        assertEquals(NO_EFFECT, filterPolicy);
+    }
+
+    @Test
+    void filterExpressionNull()
+    {
+        assertNull(this.groupMessageFilter.filterExpression(null, null, null));
+    }
+
+    @Test
+    void getName()
+    {
+        assertEquals("Group Message Stream Notification Filter", this.groupMessageFilter.getName());
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/test/java/org/xwiki/messagestream/script/MessageStreamScriptServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/test/java/org/xwiki/messagestream/script/MessageStreamScriptServiceTest.java
@@ -19,165 +19,147 @@
  */
 package org.xwiki.messagestream.script;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.xwiki.bridge.DocumentAccessBridge;
 import org.xwiki.context.Execution;
 import org.xwiki.context.ExecutionContext;
 import org.xwiki.messagestream.MessageStream;
 import org.xwiki.messagestream.MessageStreamConfiguration;
 import org.xwiki.model.reference.DocumentReference;
-import org.xwiki.test.mockito.MockitoComponentMockingRule;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link MessageStreamScriptService}.
- * 
+ *
  * @version $Id$
  */
-public class MessageStreamScriptServiceTest
+@ComponentTest
+class MessageStreamScriptServiceTest
 {
     private final DocumentReference targetUser = new DocumentReference("wiki", "XWiki", "JaneBuck");
 
     private final DocumentReference targetGroup = new DocumentReference("wiki", "XWiki", "MyFriends");
 
-    @Rule
-    public MockitoComponentMockingRule<MessageStreamScriptService> mocker =
-        new MockitoComponentMockingRule<>(MessageStreamScriptService.class);
-
+    @InjectMockComponents
     private MessageStreamScriptService streamService;
 
-    private DocumentAccessBridge documentAccessBridge;
+    @MockComponent
+    private Execution execution;
 
+    @MockComponent
+    private MessageStream stream;
+
+    @MockComponent
     private MessageStreamConfiguration messageStreamConfiguration;
 
-    private ExecutionContext executionContext;
+    @MockComponent
+    private DocumentAccessBridge documentAccessBridge;
 
-    @Before
-    public void configure() throws Exception
+    @BeforeEach
+    void setUp()
     {
-        this.streamService = this.mocker.getComponentUnderTest();
-
-        Execution execution = this.mocker.getInstance(Execution.class);
-        this.executionContext = new ExecutionContext();
-        when(execution.getContext()).thenReturn(this.executionContext);
-
-        documentAccessBridge = mocker.getInstance(DocumentAccessBridge.class);
-        messageStreamConfiguration = mocker.getInstance(MessageStreamConfiguration.class);
+        when(this.execution.getContext()).thenReturn(new ExecutionContext());
     }
 
     @Test
-    public void postPublicMessage() throws Exception
+    void postPublicMessage()
     {
         assertTrue(this.streamService.postPublicMessage("Hello World!"));
-
-        MessageStream stream = this.mocker.getInstance(MessageStream.class);
-        verify(stream).postPublicMessage("Hello World!");
+        verify(this.stream).postPublicMessage("Hello World!");
     }
 
     @Test
-    public void postPublicMessageWithFailure() throws Exception
+    void postPublicMessageWithFailure()
     {
-        MessageStream stream = this.mocker.getInstance(MessageStream.class);
-        doThrow(new RuntimeException("error")).when(stream).postPublicMessage("Hello World!");
-
+        doThrow(new RuntimeException("error")).when(this.stream).postPublicMessage("Hello World!");
         assertFalse(this.streamService.postPublicMessage("Hello World!"));
     }
 
     @Test
-    public void postPersonalMessage() throws Exception
+    void postPersonalMessage()
     {
         assertTrue(this.streamService.postPersonalMessage("Hello World!"));
-
-        MessageStream stream = this.mocker.getInstance(MessageStream.class);
-        verify(stream).postPersonalMessage("Hello World!");
+        verify(this.stream).postPersonalMessage("Hello World!");
     }
 
     @Test
-    public void postPersonalMessageWithFailure() throws Exception
+    void postPersonalMessageWithFailure()
     {
-        MessageStream stream = this.mocker.getInstance(MessageStream.class);
-        doThrow(new RuntimeException("error")).when(stream).postPersonalMessage("Hello World!");
-
+        doThrow(new RuntimeException("error")).when(this.stream).postPersonalMessage("Hello World!");
         assertFalse(this.streamService.postPersonalMessage("Hello World!"));
         assertEquals("error", this.streamService.getLastError().getMessage());
     }
 
     @Test
-    public void postDirectMessage() throws Exception
+    void postDirectMessage()
     {
         assertTrue(this.streamService.postDirectMessageToUser("Hello World!", this.targetUser));
-
-        MessageStream stream = this.mocker.getInstance(MessageStream.class);
-        verify(stream).postDirectMessageToUser("Hello World!", this.targetUser);
+        verify(this.stream).postDirectMessageToUser("Hello World!", this.targetUser);
     }
 
     @Test
-    public void postDirectMessageWithFailure() throws Exception
+    void postDirectMessageWithFailure()
     {
-        MessageStream stream = this.mocker.getInstance(MessageStream.class);
-        doThrow(new RuntimeException("error")).when(stream).postDirectMessageToUser("Hello World!", this.targetUser);
+        doThrow(new RuntimeException("error")).when(this.stream)
+            .postDirectMessageToUser("Hello World!", this.targetUser);
 
         assertFalse(this.streamService.postDirectMessageToUser("Hello World!", this.targetUser));
         assertEquals("error", this.streamService.getLastError().getMessage());
     }
 
     @Test
-    public void postGroupMessage() throws Exception
+    void postGroupMessage()
     {
         assertTrue(this.streamService.postMessageToGroup("Hello World!", this.targetGroup));
-
-        MessageStream stream = this.mocker.getInstance(MessageStream.class);
-        verify(stream).postMessageToGroup("Hello World!", this.targetGroup);
+        verify(this.stream).postMessageToGroup("Hello World!", this.targetGroup);
     }
 
     @Test
-    public void postGroupMessageWithFailure() throws Exception
+    void postGroupMessageWithFailure()
     {
-        MessageStream stream = this.mocker.getInstance(MessageStream.class);
-        doThrow(new RuntimeException("error")).when(stream).postMessageToGroup("Hello World!", this.targetGroup);
+        doThrow(new RuntimeException("error")).when(this.stream).postMessageToGroup("Hello World!", this.targetGroup);
 
         assertFalse(this.streamService.postMessageToGroup("Hello World!", this.targetGroup));
         assertEquals("error", this.streamService.getLastError().getMessage());
     }
 
     @Test
-    public void deleteMessage() throws Exception
+    void deleteMessage()
     {
         assertTrue(this.streamService.deleteMessage("abc123"));
-
-        MessageStream stream = this.mocker.getInstance(MessageStream.class);
-        verify(stream).deleteMessage("abc123");
+        verify(this.stream).deleteMessage("abc123");
     }
 
     @Test
-    public void deleteMessageWithFailure() throws Exception
+    void deleteMessageWithFailure()
     {
-        MessageStream stream = this.mocker.getInstance(MessageStream.class);
-        doThrow(new IllegalArgumentException("error")).when(stream).deleteMessage("abc123");
+        doThrow(new IllegalArgumentException("error")).when(this.stream).deleteMessage("abc123");
 
         assertFalse(this.streamService.deleteMessage("abc123"));
         assertEquals("error", this.streamService.getLastError().getMessage());
     }
 
     @Test
-    public void isActive() throws Exception
+    void isActive()
     {
-        when(documentAccessBridge.getCurrentDocumentReference()).thenReturn(
-                new DocumentReference("wikiA", "Space", "Page"),
-                new DocumentReference("wikiB", "Space", "Page"));
-        when(messageStreamConfiguration.isActive("wikiA")).thenReturn(true);
-        when(messageStreamConfiguration.isActive("wikiB")).thenReturn(false);
+        when(this.documentAccessBridge.getCurrentDocumentReference()).thenReturn(
+            new DocumentReference("wikiA", "Space", "Page"),
+            new DocumentReference("wikiB", "Space", "Page"));
+        when(this.messageStreamConfiguration.isActive("wikiA")).thenReturn(true);
+        when(this.messageStreamConfiguration.isActive("wikiB")).thenReturn(false);
 
         // Test
-        assertTrue(mocker.getComponentUnderTest().isActive());
-        assertFalse(mocker.getComponentUnderTest().isActive());
+        assertTrue(this.streamService.isActive());
+        assertFalse(this.streamService.isActive());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-ui/src/main/resources/Main/MessageSenderMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-ui/src/main/resources/Main/MessageSenderMacro.xml
@@ -943,7 +943,7 @@ Valid values are: 'everyone', 'followers', 'group' or 'user'. </description>
     <property>
       <description>Comma separated list of visibility options that the macro should allow the user to choose from.
 
-This list should be a sublist of the defualt ones: 'everyone', 'followers', 'group', 'user'.</description>
+This list should be a sublist of the default ones: 'everyone', 'followers', 'group', 'user'.</description>
     </property>
     <property>
       <mandatory/>

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/notification/groupMessage.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/notification/groupMessage.vm
@@ -1,0 +1,22 @@
+## ---------------------------------------------------------------------------
+## See the NOTICE file distributed with this work for additional
+## information regarding copyright ownership.
+##
+## This is free software; you can redistribute it and/or modify it
+## under the terms of the GNU Lesser General Public License as
+## published by the Free Software Foundation; either version 2.1 of
+## the License, or (at your option) any later version.
+##
+## This software is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+## Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public
+## License along with this software; if not, write to the Free
+## Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+## 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+## ---------------------------------------------------------------------------
+## TODO: find a way to move it to the "message stream" module
+#template('notification/macros.vm')
+#displayGroupMessageNotification($event, 'messagestream.notification.groupMessage.description', 'group')

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/notification/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/notification/macros.vm
@@ -193,15 +193,45 @@ $xwiki.getPlainUserName($user)##
 #**
  * Display a notification for a message sent through the Message Stream.
  * TODO: find a way to move it to the "message stream" module
+ *
+ * @param compositeEvent displays the message of the event
+ * @param translationKey the translation key of the title of the message
+ * @param icon the icon of the message
  * @since 10.5RC1
  * @since 9.11.6
  *#
 #macro(displayMessageNotification $compositeEvent $translationKey $icon)
   #define($content)
     #set ($messageEvent = $event.events[0])
-    <p>$services.localization.render($translationKey, ["#displayNotificationEventUser($messageEvent.user, false)"])</p>
+  <p>$services.localization.render($translationKey, ["#displayNotificationEventUser($messageEvent.user, false)"])</p>
+  <blockquote>
+    $messageEvent.body
+  </blockquote>
+  <div><small class="text-muted">$escapetool.xml($services.date.displayTimeAgo($compositeEvent.dates.get(0)))</small></div>
+  #end
+  #displayNotificationEventSkeleton($icon, 'comment', $content, '')
+#end
+##
+#*
+ * Display a notification from a message to a group sent through the Message Stream.
+ * TODO: find a way to move it to the "message stream" module
+ *
+ * @param compositeEvent displays the message of the event
+ * @param translationKey the translation key of the title of the message, takes two parameters, the first one for the
+ *                       user the second one for the group
+ * @param icon the icon of the message
+ * @since 12.10RC1
+ *#
+#macro(displayGroupMessageNotification $compositeEvent $translationKey $icon)
+  #define($content)
+    #set ($messageEvent = $event.events[0])
+    #set ($translationParameters = [
+      "#displayNotificationEventUser($messageEvent.user, false)",
+      "#displayNotificationEventUser($messageEvent.stream, false)"
+    ])
+    <p>$services.localization.render($translationKey, $translationParameters)</p>
     <blockquote>
-     $messageEvent.body
+    $messageEvent.body
     </blockquote>
     <div><small class="text-muted">$escapetool.xml($services.date.displayTimeAgo($compositeEvent.dates.get(0)))</small></div>
   #end


### PR DESCRIPTION
https://jira.xwiki.org/browse/XWIKI-15815

- Enables the group message descriptor
- Defines the group messages filter
- Introduces a group message notification template, and update of the common message macros to support more than one translation parameter.
- Introduces a common AbstractMessageStreamNotificationFilter for all the messages
- Migration of the remaining JUnit 4 tests to JUnit 5
