### PR TITLE
XWIKI-17820: Make the refactoring configuration more fine grained

### DIFF
--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/AbstractRefactoringConfigurationSource.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/AbstractRefactoringConfigurationSource.java
@@ -19,35 +19,31 @@
  */
 package org.xwiki.refactoring.internal;
 
-import javax.inject.Named;
-import javax.inject.Singleton;
+import java.util.Arrays;
+import java.util.List;
 
-import org.xwiki.component.annotation.Component;
-import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.configuration.internal.AbstractDocumentConfigurationSource;
+import org.xwiki.model.reference.LocalDocumentReference;
 
 /**
- * Provides configuration from the {@code Refactoring.Code.RefactoringConfigurationClass} document in the current wiki.
- * If the {@code Refactoring.Code.RefactoringConfigurationClass} xobject exists in the
- * {@code Refactoring.Code.RefactoringConfiguration} document then always use configuration values from it and if it
- * doesn't then use the passed default value.
+ * Provides configuration from the {@code Refactoring.Code.RefactoringConfiguration} document.
  *
  * @version $Id$
- * @since 12.8RC1
+ * @since 12.9RC1
  */
-@Component
-@Singleton
-@Named("refactoring")
-public class RefactoringConfigurationSource extends AbstractRefactoringConfigurationSource
+public abstract class AbstractRefactoringConfigurationSource extends AbstractDocumentConfigurationSource
 {
-    @Override
-    protected DocumentReference getDocumentReference()
-    {
-        return new DocumentReference(DOCUMENT_REFERENCE, this.getCurrentWikiReference());
-    }
+    protected static final List<String> SPACE_NAMES = Arrays.asList("Refactoring", "Code");
+
+    protected static final LocalDocumentReference DOCUMENT_REFERENCE =
+        new LocalDocumentReference(SPACE_NAMES, "RefactoringConfiguration");
+
+    private static final LocalDocumentReference CLASS_REFERENCE =
+        new LocalDocumentReference(SPACE_NAMES, "RefactoringConfigurationClass");
 
     @Override
-    protected String getCacheId()
+    protected LocalDocumentReference getClassReference()
     {
-        return "configuration.document.refactoring";
+        return CLASS_REFERENCE;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultRefactoringConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultRefactoringConfiguration.java
@@ -19,7 +19,6 @@
  */
 package org.xwiki.refactoring.internal;
 
-
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -27,9 +26,16 @@ import javax.inject.Singleton;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.configuration.ConfigurationSource;
 import org.xwiki.refactoring.RefactoringConfiguration;
+import org.xwiki.wiki.descriptor.WikiDescriptorManager;
 
 /**
  * Default implementation of {@link RefactoringConfiguration}.
+ * Search for the value of the configuration keys in the following order:
+ * <ul>
+ *   <li>In {@code Refactoring.Code.RefactoringConfiguration} in the current wiki</li>
+ *   <li>In {@code Refactoring.Code.RefactoringConfiguration} in the main wiki</li>
+ *   <li>In {@code xwiki.properties} (prefixed with {@code refactoring.}</li>
+ * </ul>
  *
  * @version $Id$
  * @since 12.8RC1
@@ -38,13 +44,65 @@ import org.xwiki.refactoring.RefactoringConfiguration;
 @Singleton
 public class DefaultRefactoringConfiguration implements RefactoringConfiguration
 {
+    private static final String IS_RECYCLE_BIN_SKIPPING_ACTIVATED_PROPERTY = "isRecycleBinSkippingActivated";
+
+    private static final String PREFIX = "refactoring.";
+
     @Inject
     @Named("refactoring")
-    private ConfigurationSource configurationSource;
+    private ConfigurationSource currentWikiConfigurationSource;
+
+    @Inject
+    @Named("refactoringmainwiki")
+    private ConfigurationSource mainWikiConfigurationSource;
+
+    @Inject
+    @Named("xwikiproperties")
+    private ConfigurationSource xwikiPropertiesSource;
+
+    @Inject
+    private WikiDescriptorManager wikiDescriptorManager;
 
     @Override
     public boolean isRecycleBinSkippingActivated()
     {
-        return this.configurationSource.getProperty("isRecycleBinSkippingActivated", false);
+        return defaultPropertyAccess(IS_RECYCLE_BIN_SKIPPING_ACTIVATED_PROPERTY, false);
+    }
+
+    /**
+     * Look for the property hierarchically.
+     *
+     * The value of the property is looked for in the following places, from the first to the last.
+     * <ul>
+     *     <li>In the {@code Refactoring.Code.RefactoringConfigurationClass} instance of the
+     *     {@code Refactoring.Code.RefactoringConfiguration} object in the current wiki.</li>
+     *     <li>In the {@code Refactoring.Code.RefactoringConfigurationClass} instance of the
+     *     {@code Refactoring.Code.RefactoringConfiguration} object in the main wiki wiki.</li>
+     *     <li>In the wiki properties (the property is prefixed with {@code refactoring.}</li>
+     * </ul>
+     * The search stops when a value is found.
+     * If no value is found, the default value is used.
+     *
+     * @param property the property name
+     * @param defaultValue the default value, used if no property declaration is found in the hierarchy
+     * @param <T> the type of the property
+     * @return the value of the property
+     */
+    private <T> T defaultPropertyAccess(String property, T defaultValue)
+    {
+        T ret = (T) this.currentWikiConfigurationSource.getProperty(property, defaultValue.getClass());
+        if (ret == null && !isMainWiki()) {
+            ret = (T) this.mainWikiConfigurationSource.getProperty(property, defaultValue.getClass());
+        }
+
+        if (ret == null) {
+            ret = this.xwikiPropertiesSource.getProperty(PREFIX + property, defaultValue);
+        }
+        return ret;
+    }
+
+    private boolean isMainWiki()
+    {
+        return this.wikiDescriptorManager.isMainWiki(this.wikiDescriptorManager.getCurrentWikiId());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/MainWikiRefactoringConfigurationSource.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/MainWikiRefactoringConfigurationSource.java
@@ -24,30 +24,31 @@ import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.WikiReference;
 
 /**
- * Provides configuration from the {@code Refactoring.Code.RefactoringConfigurationClass} document in the current wiki.
+ * Provides configuration from the {@code Refactoring.Code.RefactoringConfigurationClass} document in the main wiki.
  * If the {@code Refactoring.Code.RefactoringConfigurationClass} xobject exists in the
- * {@code Refactoring.Code.RefactoringConfiguration} document then always use configuration values from it and if it
- * doesn't then use the passed default value.
+ * {@code Refactoring.Code.RefactoringConfiguration} document of the main wiki then always use configuration values from
+ * it and if it doesn't then use the passed default value.
  *
  * @version $Id$
- * @since 12.8RC1
+ * @since 12.9RC1
  */
 @Component
 @Singleton
-@Named("refactoring")
-public class RefactoringConfigurationSource extends AbstractRefactoringConfigurationSource
+@Named("refactoringmainwiki")
+public class MainWikiRefactoringConfigurationSource extends AbstractRefactoringConfigurationSource
 {
     @Override
     protected DocumentReference getDocumentReference()
     {
-        return new DocumentReference(DOCUMENT_REFERENCE, this.getCurrentWikiReference());
+        return new DocumentReference(DOCUMENT_REFERENCE, new WikiReference(this.wikiManager.getMainWikiId()));
     }
 
     @Override
     protected String getCacheId()
     {
-        return "configuration.document.refactoring";
+        return "configuration.document.refactoring.mainwiki";
     }
 }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/resources/META-INF/components.txt
@@ -5,5 +5,6 @@ org.xwiki.refactoring.internal.DefaultLinkRefactoring
 org.xwiki.refactoring.internal.DefaultModelBridge
 org.xwiki.refactoring.internal.ReferenceRenamer
 org.xwiki.refactoring.internal.DefaultRefactoringConfiguration
+org.xwiki.refactoring.internal.MainWikiRefactoringConfigurationSource
 org.xwiki.refactoring.internal.RefactoringConfigurationSource
 org.xwiki.refactoring.job.XClassDeletingListener

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultLinkRefactoringTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultLinkRefactoringTest.java
@@ -676,4 +676,29 @@ class DefaultLinkRefactoringTest
             assertEquals(ResourceType.DOCUMENT, linkBlock.getReference().getType());
         }
     }
+
+    @Test
+    void renameLinksBlockRendererNotFound() throws XWikiException
+    {
+        DocumentReference newReference = new DocumentReference("xwiki", "XWiki", "new");
+
+        XWiki xWiki = mock(XWiki.class);
+        when(this.xcontext.getWiki()).thenReturn(xWiki);
+        XWikiDocument document = mock(XWikiDocument.class);
+        when(xWiki.getDocument(newReference, this.xcontext)).thenReturn(document);
+
+        ComponentManager componentManager = mock(ComponentManager.class);
+        when(this.componentManagerProvider.get()).thenReturn(componentManager);
+        when(document.getSyntax()).thenReturn(Syntax.MARKDOWN_1_1);
+        when(componentManager.hasComponent(BlockRenderer.class, Syntax.MARKDOWN_1_1.toIdString()))
+            .thenReturn(false);
+
+        DocumentReference oldReference = new DocumentReference("xwiki", "XWiki", "old");
+        this.refactoring.updateRelativeLinks(oldReference, newReference);
+
+        assertEquals(1, this.logCapture.size());
+        assertEquals(Level.WARN, this.logCapture.getLogEvent(0).getLevel());
+        assertEquals("We can't rename the links from [null] because there is no renderer available for its "
+                         + "syntax [Markdown 1.1].", this.logCapture.getMessage(0));
+    }
 }

--- a/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.properties.vm
+++ b/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.properties.vm
@@ -1137,6 +1137,20 @@ edit.defaultEditor.org.xwiki.rendering.block.XDOM#wysiwyg=$xwikiPropertiesDefaul
 #-# The default value is:
 # refactoring.rename.useAtomicRename = true
 
+#-# [Since 12.9RC1]
+#-# Indicates whether skipping the recycle bin when deleting pages is allowed for Advanced users.
+#-# It is disabled by default.
+#-# This setting is only used if the wiki has a recycle bin activated (xwiki.recyclebin=1 in xwiki.cfg).
+#-# This setting can be overloaded:
+#-# * By the main wiki in the Refactoring.Code.RefactoringConfigurationClass class of the
+#-#   Refactoring.Code.RefactoringConfiguration document of the main wiki.
+#-# * By sub-wikis in the Refactoring.Code.RefactoringConfigurationClass class of the
+#-#   Refactoring.Code.RefactoringConfiguration document of the sub-wikis (itself overloading the main wiki's
+#-#   configuration).
+#-#
+#-# The default value is:
+# refactoring.isRecycleBinSkippingActivated = false
+
 #-------------------------------------------------------------------------------------
 # Skin Extensions
 #-------------------------------------------------------------------------------------


### PR DESCRIPTION
https://jira.xwiki.org/browse/XWIKI-17820

- Introduces the main wiki refactoring configuration source that always look at the main wiki documents
- The configuration is now resolved by looking for a value:
  - In the current wiki
  - Then in the main wiki
  - Then in xwiki.properties
If no value is found, returns the default value.