### PR TITLE
XWIKI-17915: Message stream messages are not displayed correctly in the rss feeds

### DIFF
--- a/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/pom.xml
@@ -31,7 +31,7 @@
   <name>XWiki Platform - Message Stream - API</name>
   <description>API to publish and display user status messages in different streams</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.69</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.70</xwiki.jacoco.instructionRatio>
     <!-- Old names of this module used for retro compatibility when resolving dependencies of old extensions -->
     <xwiki.extension.features>xwiki-platform-messagestream</xwiki.extension.features>
     <!-- TODO: Remove once the tests have been fixed to not output anything to the console! -->

--- a/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/main/java/org/xwiki/messagestream/internal/DefaultMessageStream.java
+++ b/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/main/java/org/xwiki/messagestream/internal/DefaultMessageStream.java
@@ -92,6 +92,7 @@ public class DefaultMessageStream implements MessageStream
         e.setRelatedEntity(userDoc);
         e.setImportance(Importance.MINOR);
         e.setStream(this.serializer.serialize(userDoc));
+        e.setTitle("messagestream.descriptors.rss.publicMessage.title");
         saveEvent(e);
     }
 
@@ -102,6 +103,7 @@ public class DefaultMessageStream implements MessageStream
         DocumentReference userDoc = this.bridge.getCurrentUserReference();
         e.setRelatedEntity(userDoc);
         e.setStream(this.serializer.serialize(userDoc));
+        e.setTitle("messagestream.descriptors.rss.personalMessage.title");
         saveEvent(e);
     }
 
@@ -115,6 +117,7 @@ public class DefaultMessageStream implements MessageStream
         e.setRelatedEntity(new ObjectReference("XWiki.XWikiUsers", user));
         e.setStream(this.serializer.serialize(user));
         e.setImportance(Importance.CRITICAL);
+        e.setTitle("messagestream.descriptors.rss.directMessage.title");
         saveEvent(e);
     }
 
@@ -128,6 +131,7 @@ public class DefaultMessageStream implements MessageStream
         e.setRelatedEntity(new ObjectReference("XWiki.XWikiGroups", group));
         e.setStream(this.serializer.serialize(group));
         e.setImportance(Importance.MAJOR);
+        e.setTitle("messagestream.descriptors.rss.groupMessage.title");
         saveEvent(e);
     }
 

--- a/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/main/resources/ApplicationResources.properties
@@ -27,3 +27,7 @@ messagestream.notification.directMessage.description={0} sent you a message
 messagestream.notification.groupMessage.description={0} sent a message to {1}
 messagestream.notification.personalMessage.description={0} sent a message to followers
 messagestream.notification.email.tocItem=Message from {0}
+messagestream.descriptors.rss.publicMessage.title=New public message received
+messagestream.descriptors.rss.directMessage.title=New direct message received
+messagestream.descriptors.rss.groupMessage.title=New group message received
+messagestream.descriptors.rss.personalMessage.title=New message received from someone you are following

--- a/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/main/resources/templates/notification/rss/directMessage.vm
+++ b/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/main/resources/templates/notification/rss/directMessage.vm
@@ -1,0 +1,21 @@
+## ---------------------------------------------------------------------------
+## See the NOTICE file distributed with this work for additional
+## information regarding copyright ownership.
+##
+## This is free software; you can redistribute it and/or modify it
+## under the terms of the GNU Lesser General Public License as
+## published by the Free Software Foundation; either version 2.1 of
+## the License, or (at your option) any later version.
+##
+## This software is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+## Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public
+## License along with this software; if not, write to the Free
+## Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+## 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+## ---------------------------------------------------------------------------
+#template('notification/rss/messages_macros.vm')
+#messageStreamRss($event, 'messagestream.notification.directMessage.description', 'false')

--- a/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/main/resources/templates/notification/rss/groupMessage.vm
+++ b/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/main/resources/templates/notification/rss/groupMessage.vm
@@ -1,0 +1,21 @@
+## ---------------------------------------------------------------------------
+## See the NOTICE file distributed with this work for additional
+## information regarding copyright ownership.
+##
+## This is free software; you can redistribute it and/or modify it
+## under the terms of the GNU Lesser General Public License as
+## published by the Free Software Foundation; either version 2.1 of
+## the License, or (at your option) any later version.
+##
+## This software is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+## Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public
+## License along with this software; if not, write to the Free
+## Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+## 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+## ---------------------------------------------------------------------------
+#template('notification/rss/messages_macros.vm')
+#messageStreamRss($event, 'messagestream.notification.groupMessage.description', 'true')

--- a/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/main/resources/templates/notification/rss/messages_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/main/resources/templates/notification/rss/messages_macros.vm
@@ -1,0 +1,47 @@
+## ---------------------------------------------------------------------------
+## See the NOTICE file distributed with this work for additional
+## information regarding copyright ownership.
+##
+## This is free software; you can redistribute it and/or modify it
+## under the terms of the GNU Lesser General Public License as
+## published by the Free Software Foundation; either version 2.1 of
+## the License, or (at your option) any later version.
+##
+## This software is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+## Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public
+## License along with this software; if not, write to the Free
+## Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+## 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+## ---------------------------------------------------------------------------
+#template('notification/macros.vm')
+##
+##
+#*
+ * Displays the RSS feed content of a message stream event.
+ * @param event the group message event
+ * @param translationKey translation key of the message description sentence
+ * @param isGroup if 'true', includes the group as the second argument of the translationKey translation
+ *#
+#macro (messageStreamRss $event $translationKey $isGroup)
+  #set ($messageEvent = $event.events[0])
+  #set ($user = $messageEvent.user)
+  #set ($group = $messageEvent.stream)
+  #set ($userDoc = $xwiki.getDocument($user))
+  #set ($userName = $xwiki.getUserName($user, false))
+  #set ($translationParameters = ["<a href='$userDoc.getURL()'>$userName</a>"])
+  #if ($isGroup == 'true')
+    #set ($groupDoc = $xwiki.getDocument($group))
+    #set ($groupName = $xwiki.getUserName($group, false))
+    #set ($discard = $translationParameters.add("<a href='$groupDoc.getURL()'>$groupName</a>"))
+  #end
+
+<strong>$!event.events.get(0).application</strong>
+<div>
+  $services.localization.render($translationKey, $translationParameters)
+</div>
+<blockquote>$messageEvent.body</blockquote>
+#end

--- a/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/main/resources/templates/notification/rss/personalMessage.vm
+++ b/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/main/resources/templates/notification/rss/personalMessage.vm
@@ -1,0 +1,21 @@
+## ---------------------------------------------------------------------------
+## See the NOTICE file distributed with this work for additional
+## information regarding copyright ownership.
+##
+## This is free software; you can redistribute it and/or modify it
+## under the terms of the GNU Lesser General Public License as
+## published by the Free Software Foundation; either version 2.1 of
+## the License, or (at your option) any later version.
+##
+## This software is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+## Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public
+## License along with this software; if not, write to the Free
+## Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+## 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+## ---------------------------------------------------------------------------
+#template('notification/rss/messages_macros.vm')
+#messageStreamRss($event, 'messagestream.notification.personalMessage.description', 'false')

--- a/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/main/resources/templates/notification/rss/publicMessage.vm
+++ b/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/main/resources/templates/notification/rss/publicMessage.vm
@@ -1,0 +1,21 @@
+## ---------------------------------------------------------------------------
+## See the NOTICE file distributed with this work for additional
+## information regarding copyright ownership.
+##
+## This is free software; you can redistribute it and/or modify it
+## under the terms of the GNU Lesser General Public License as
+## published by the Free Software Foundation; either version 2.1 of
+## the License, or (at your option) any later version.
+##
+## This software is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+## Lesser General Public License for more details.
+##
+## You should have received a copy of the GNU Lesser General Public
+## License along with this software; if not, write to the Free
+## Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+## 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+## ---------------------------------------------------------------------------
+#template('notification/rss/messages_macros.vm')
+#messageStreamRss($event, 'messagestream.notification.publicMessage.description', 'false')

--- a/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/test/java/org/xwiki/messagestream/internal/DefaultMessageStreamConfigurationTest.java
+++ b/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/test/java/org/xwiki/messagestream/internal/DefaultMessageStreamConfigurationTest.java
@@ -19,52 +19,47 @@
  */
 package org.xwiki.messagestream.internal;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.xwiki.bridge.DocumentAccessBridge;
 import org.xwiki.model.reference.DocumentReference;
-import org.xwiki.test.mockito.MockitoComponentMockingRule;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Default implementation of {@link org.xwiki.messagestream.MessageStreamConfiguration}.
+ * Test of the default implementation of {@link org.xwiki.messagestream.MessageStreamConfiguration}.
  *
  * @version $Id$
  * @since 10.5RC1
  * @since 9.11.6
  */
-public class DefaultMessageStreamConfigurationTest
+@ComponentTest
+class DefaultMessageStreamConfigurationTest
 {
-    @Rule
-    public MockitoComponentMockingRule<DefaultMessageStreamConfiguration> mocker =
-            new MockitoComponentMockingRule<>(DefaultMessageStreamConfiguration.class);
+    @InjectMockComponents
+    private DefaultMessageStreamConfiguration defaultMessageStream;
 
+    @MockComponent
     private DocumentAccessBridge documentAccessBridge;
 
-    @Before
-    public void setUp() throws Exception
-    {
-        documentAccessBridge = mocker.getInstance(DocumentAccessBridge.class);
-    }
-
     @Test
-    public void isActive() throws Exception
+    void isActive()
     {
         DocumentReference configClass1 = new DocumentReference("wiki1", "XWiki", "MessageStreamConfig");
-        Mockito.when(documentAccessBridge.getProperty(configClass1, configClass1, "active")).thenReturn(1);
+        Mockito.when(this.documentAccessBridge.getProperty(configClass1, configClass1, "active")).thenReturn(1);
 
         DocumentReference configClass2 = new DocumentReference("wiki2", "XWiki", "MessageStreamConfig");
-        Mockito.when(documentAccessBridge.getProperty(configClass2, configClass2, "active")).thenReturn(0);
+        Mockito.when(this.documentAccessBridge.getProperty(configClass2, configClass2, "active")).thenReturn(0);
 
         DocumentReference configClass3 = new DocumentReference("wiki3", "XWiki", "MessageStreamConfig");
-        Mockito.when(documentAccessBridge.getProperty(configClass3, configClass3, "active")).thenReturn(null);
+        Mockito.when(this.documentAccessBridge.getProperty(configClass3, configClass3, "active")).thenReturn(null);
 
-        assertTrue(mocker.getComponentUnderTest().isActive("wiki1"));
-        assertFalse(mocker.getComponentUnderTest().isActive("wiki2"));
-        assertFalse(mocker.getComponentUnderTest().isActive("wiki3"));
+        assertTrue(this.defaultMessageStream.isActive("wiki1"));
+        assertFalse(this.defaultMessageStream.isActive("wiki2"));
+        assertFalse(this.defaultMessageStream.isActive("wiki3"));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/test/java/org/xwiki/messagestream/internal/DefaultMessageStreamTest.java
+++ b/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-api/src/test/java/org/xwiki/messagestream/internal/DefaultMessageStreamTest.java
@@ -1,0 +1,240 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.messagestream.internal;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.bridge.DocumentAccessBridge;
+import org.xwiki.eventstream.EventFactory;
+import org.xwiki.eventstream.EventStore;
+import org.xwiki.eventstream.EventStream;
+import org.xwiki.eventstream.internal.DefaultEvent;
+import org.xwiki.model.ModelContext;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.EntityReferenceSerializer;
+import org.xwiki.model.reference.ObjectReference;
+import org.xwiki.query.QueryManager;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.xwiki.eventstream.Event.Importance.CRITICAL;
+import static org.xwiki.eventstream.Event.Importance.MAJOR;
+import static org.xwiki.eventstream.Event.Importance.MEDIUM;
+import static org.xwiki.eventstream.Event.Importance.MINOR;
+
+/**
+ * Test of {@link DefaultMessageStream}.
+ *
+ * @version $Id$
+ * @since 12.9RC1
+ */
+@ComponentTest
+class DefaultMessageStreamTest
+{
+    public static final DocumentReference DOCUMENT_REFERENCE = new DocumentReference("xwiki", "XWiki", "Doc");
+
+    public static final DocumentReference USER_DOCUMENT_REFERENCE = new DocumentReference("xwiki", "XWiki", "User");
+
+    public static final String USER_REFERENCE = "xwiki:XWiki.User";
+
+    public static final DocumentReference EVENT_DOCUMENT_REFERENCE = new DocumentReference("xwiki", "XWiki", "eid");
+
+    public static final String MESSAGE = "message";
+
+    private static final DocumentReference RECIPIENT_USER_DOCUMENT_REFERENCE = new DocumentReference("xwiki", "XWiki",
+        "RecipientUser");
+
+    private static final DocumentReference RECIPIENT_GROUP_DOCUMENT_REFERENCE =
+        new DocumentReference("xwiki", "XWiki",
+            "RecipientGroup");
+
+    @InjectMockComponents
+    private DefaultMessageStream defaultMessageStream;
+
+    @MockComponent
+    private QueryManager qm;
+
+    @MockComponent
+    private ModelContext context;
+
+    @MockComponent
+    private EntityReferenceSerializer<String> serializer;
+
+    @MockComponent
+    private EventStream stream;
+
+    @MockComponent
+    private EventStore eventStore;
+
+    @MockComponent
+    private EventFactory factory;
+
+    @MockComponent
+    private DocumentAccessBridge bridge;
+
+    @Test
+    void postPublicMessage() throws Exception
+    {
+        DefaultEvent t = new DefaultEvent();
+        t.setId("eid");
+        when(this.factory.createEvent()).thenReturn(t);
+        when(this.context.getCurrentEntityReference()).thenReturn(DOCUMENT_REFERENCE);
+        when(this.bridge.getCurrentUserReference()).thenReturn(USER_DOCUMENT_REFERENCE);
+        when(this.serializer.serialize(USER_DOCUMENT_REFERENCE)).thenReturn(USER_REFERENCE);
+        CompletableFuture completableFuture = mock(CompletableFuture.class);
+        when(this.eventStore.saveEvent(t)).thenReturn(completableFuture);
+        this.defaultMessageStream.postPublicMessage(MESSAGE);
+        DefaultEvent event = new DefaultEvent();
+        event.setType("publicMessage");
+        event.setApplication("MessageStream");
+        event.setDocument(EVENT_DOCUMENT_REFERENCE);
+        event.setImportance(MINOR);
+        event.setRelatedEntity(USER_DOCUMENT_REFERENCE);
+        event.setId("eid");
+        event.setStream(USER_REFERENCE);
+        event.setBody(MESSAGE);
+        event.setTitle("messagestream.descriptors.rss.publicMessage.title");
+        verify(this.eventStore).saveEvent(event);
+        verify(completableFuture).get();
+    }
+
+    @Test
+    void postDirectMessageToUser() throws Exception
+    {
+        DefaultEvent t = new DefaultEvent();
+        t.setId("eid");
+        when(this.factory.createEvent()).thenReturn(t);
+        when(this.context.getCurrentEntityReference()).thenReturn(DOCUMENT_REFERENCE);
+        when(this.bridge.getCurrentUserReference()).thenReturn(USER_DOCUMENT_REFERENCE);
+        when(this.serializer.serialize(USER_DOCUMENT_REFERENCE)).thenReturn(USER_REFERENCE);
+        CompletableFuture completableFuture = mock(CompletableFuture.class);
+        when(this.eventStore.saveEvent(t)).thenReturn(completableFuture);
+        when(this.bridge.exists(RECIPIENT_USER_DOCUMENT_REFERENCE)).thenReturn(true);
+        this.defaultMessageStream.postDirectMessageToUser(MESSAGE, RECIPIENT_USER_DOCUMENT_REFERENCE);
+        DefaultEvent event = new DefaultEvent();
+        event.setType("directMessage");
+        event.setApplication("MessageStream");
+        event.setDocument(EVENT_DOCUMENT_REFERENCE);
+        event.setImportance(CRITICAL);
+        event.setRelatedEntity(new ObjectReference("XWiki.XWikiUsers", RECIPIENT_USER_DOCUMENT_REFERENCE));
+        event.setId("eid");
+        event.setBody(MESSAGE);
+        event.setTitle("messagestream.descriptors.rss.directMessage.title");
+        verify(this.eventStore).saveEvent(event);
+        verify(completableFuture).get();
+    }
+
+    @Test
+    void postDirectMessageToUserRecipientDoesNotExist()
+    {
+        DefaultEvent t = new DefaultEvent();
+        t.setId("eid");
+        when(this.factory.createEvent()).thenReturn(t);
+        when(this.context.getCurrentEntityReference()).thenReturn(DOCUMENT_REFERENCE);
+        when(this.bridge.getCurrentUserReference()).thenReturn(USER_DOCUMENT_REFERENCE);
+        when(this.serializer.serialize(USER_DOCUMENT_REFERENCE)).thenReturn(USER_REFERENCE);
+        when(this.bridge.exists(RECIPIENT_USER_DOCUMENT_REFERENCE)).thenReturn(false);
+
+        CompletableFuture completableFuture = mock(CompletableFuture.class);
+        when(this.eventStore.saveEvent(t)).thenReturn(completableFuture);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+            () -> this.defaultMessageStream.postDirectMessageToUser(MESSAGE, RECIPIENT_USER_DOCUMENT_REFERENCE));
+        assertEquals("Target user does not exist", exception.getMessage());
+    }
+
+    @Test
+    void postMessageToGroup() throws Exception
+    {
+        DefaultEvent t = new DefaultEvent();
+        t.setId("eid");
+        when(this.factory.createEvent()).thenReturn(t);
+        when(this.context.getCurrentEntityReference()).thenReturn(DOCUMENT_REFERENCE);
+        when(this.bridge.getCurrentUserReference()).thenReturn(USER_DOCUMENT_REFERENCE);
+        when(this.serializer.serialize(USER_DOCUMENT_REFERENCE)).thenReturn(USER_REFERENCE);
+        CompletableFuture completableFuture = mock(CompletableFuture.class);
+        when(this.eventStore.saveEvent(t)).thenReturn(completableFuture);
+        when(this.bridge.exists(RECIPIENT_GROUP_DOCUMENT_REFERENCE)).thenReturn(true);
+        this.defaultMessageStream.postMessageToGroup(MESSAGE, RECIPIENT_GROUP_DOCUMENT_REFERENCE);
+        DefaultEvent event = new DefaultEvent();
+        event.setType("groupMessage");
+        event.setApplication("MessageStream");
+        event.setDocument(EVENT_DOCUMENT_REFERENCE);
+        event.setImportance(MAJOR);
+        event.setRelatedEntity(new ObjectReference("XWiki.XWikiGroups", RECIPIENT_GROUP_DOCUMENT_REFERENCE));
+        event.setId("eid");
+        event.setBody(MESSAGE);
+        event.setTitle("messagestream.descriptors.rss.groupMessage.title");
+        verify(this.eventStore).saveEvent(event);
+        verify(completableFuture).get();
+    }
+
+    @Test
+    void postMessageToGroupRecipientDoesNotExist()
+    {
+        DefaultEvent t = new DefaultEvent();
+        t.setId("eid");
+        when(this.factory.createEvent()).thenReturn(t);
+        when(this.context.getCurrentEntityReference()).thenReturn(DOCUMENT_REFERENCE);
+        when(this.bridge.getCurrentUserReference()).thenReturn(USER_DOCUMENT_REFERENCE);
+        when(this.serializer.serialize(USER_DOCUMENT_REFERENCE)).thenReturn(USER_REFERENCE);
+        when(this.bridge.exists(RECIPIENT_GROUP_DOCUMENT_REFERENCE)).thenReturn(false);
+
+        CompletableFuture completableFuture = mock(CompletableFuture.class);
+        when(this.eventStore.saveEvent(t)).thenReturn(completableFuture);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+            () -> this.defaultMessageStream.postMessageToGroup(MESSAGE, RECIPIENT_GROUP_DOCUMENT_REFERENCE));
+        assertEquals("Target group does not exist", exception.getMessage());
+    }
+
+    @Test
+    void postPersonalMessage() throws Exception
+    {
+        DefaultEvent t = new DefaultEvent();
+        t.setId("eid");
+        when(this.factory.createEvent()).thenReturn(t);
+        when(this.context.getCurrentEntityReference()).thenReturn(DOCUMENT_REFERENCE);
+        when(this.bridge.getCurrentUserReference()).thenReturn(USER_DOCUMENT_REFERENCE);
+        when(this.serializer.serialize(USER_DOCUMENT_REFERENCE)).thenReturn(USER_REFERENCE);
+        CompletableFuture completableFuture = mock(CompletableFuture.class);
+        when(this.eventStore.saveEvent(t)).thenReturn(completableFuture);
+        this.defaultMessageStream.postPersonalMessage(MESSAGE);
+        DefaultEvent event = new DefaultEvent();
+        event.setType("personalMessage");
+        event.setApplication("MessageStream");
+        event.setDocument(EVENT_DOCUMENT_REFERENCE);
+        event.setImportance(MEDIUM);
+        event.setRelatedEntity(USER_DOCUMENT_REFERENCE);
+        event.setId("eid");
+        event.setStream(USER_REFERENCE);
+        event.setBody(MESSAGE);
+        event.setTitle("messagestream.descriptors.rss.personalMessage.title");
+        verify(this.eventStore).saveEvent(event);
+        verify(completableFuture).get();
+    }
+}


### PR DESCRIPTION
https://jira.xwiki.org/browse/XWIKI-17915

- Defines dedicated templates to display the message in RSS feeds
- Defines dedicated titles for the event, used as the titles of the message in the RSS feeds
- Hides the changes when no version is provided