### PR TITLE
XWIKI-18038: Livetable "html" field parameter doesn't generate HTML code anymore

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/macros.vm
@@ -1750,7 +1750,13 @@ function (row, i, table) {
       }
       // The value can be passed as a string..
       if (descriptor.html + '' === 'true') {
-        container.innerHTML = row[fieldName] || '';
+        // The value of the column must be unescaped to allow it to be used as html.
+        // For the values coming from XObjects fields, the unescaped value is found in a field suffixed with '_value'.
+        if (!columnDescriptors[column + '_value']) {
+          container.innerHTML = row[fieldName + '_value'] || row[fieldName] || '';
+        } else {
+          container.innerHTML = row[fieldName] || '';
+        }
       } else if (row[fieldName] !== undefined && row[fieldName] !== null) {
         var text = row[fieldName] + '';
         if (fieldName === 'doc_name' && !row['doc_viewable']) {


### PR DESCRIPTION
Retrieve the unescaped "colname"_value field when available during the livetable client side generation.