### PR TITLE
XWIKI-18063 : Allow wiki macros to change their macro content during their execution

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroRenderer.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroRenderer.java
@@ -592,6 +592,10 @@ public class DefaultWikiMacroRenderer extends AbstractBlockAsyncRenderer
             restoreBindingsOrClean();
         }
 
+        // Update the macro content to take into consideration any change that could have happened to the content
+        // during the macro execution.
+        this.macroContent = macroBinding.getContent();
+
         // Replace macro placeholders (content and parameters)
         block = resolveMacroPlaceholders(block);
 

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/test/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/test/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroTest.java
@@ -739,4 +739,16 @@ class DefaultWikiMacroTest
 
         assertEquals(expect, printer.toString());
     }
+
+    @Test
+    void testContentUpdateDuringMacroExecution() throws Exception
+    {
+        registerWikiMacro("contentWikiMacro",
+            "{{groovy}}wikimacro.setContent('This is some test content');println \"{{wikimacrocontent/}}\";{{/groovy}}",
+            Syntax.XWIKI_2_1);
+
+        // Note: We're using XHTML as the output syntax just to make it easy for asserting.
+        assertXHTML("<p>This is some test content</p>",
+            "{{contentWikiMacro param1=\"value1\" param2=\"value2\"/}}");
+    }
 }


### PR DESCRIPTION
* Update the macro content with the content provided by the wikimacro
  binding after the execution of a macro
* Add unit test

This fixes XWIKI-18063. Even though the fix is easy in itself, could someone review it before it going into the main tree, just to make sure that we're not introducing an unexpected behavior or a security flaw ?