### PR TITLE
XWIKI-17037: Vote isn't saved when the Page or it parent Space has a double quote in its name

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-ui/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-ui/pom.xml
@@ -47,5 +47,54 @@
       <version>${project.version}</version>
       <scope>runtime</scope>
     </dependency>
+    <!-- Test Dependencies -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-test-page</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <!-- The Ratings macro uses Velocity macros from the macros.vm template which is packaged inside the
+        platform WAR. We need to evaluate the macros.vm template when running the integration tests. -->
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-web</artifactId>
+      <version>${project.version}</version>
+      <type>war</type>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <!-- Maven doesn't put the WAR dependencies on the class path so in order for the ClasspathResourceLoader to find
+        the macros.vm template when running the integration tests we need to unpack the WAR in a folder that is included
+        in the class path. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>unpack-platform-web</id>
+            <phase>test-compile</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.xwiki.platform</groupId>
+                  <artifactId>xwiki-platform-web</artifactId>
+                  <version>${project.version}</version>
+                  <type>war</type>
+                  <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
+                  <includes>templates/*</includes>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-ui/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-ui/pom.xml
@@ -55,46 +55,5 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <!-- The Ratings macro uses Velocity macros from the macros.vm template which is packaged inside the
-        platform WAR. We need to evaluate the macros.vm template when running the integration tests. -->
-      <groupId>org.xwiki.platform</groupId>
-      <artifactId>xwiki-platform-web</artifactId>
-      <version>${project.version}</version>
-      <type>war</type>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
-  <build>
-    <plugins>
-      <!-- Maven doesn't put the WAR dependencies on the class path so in order for the ClasspathResourceLoader to find
-        the macros.vm template when running the integration tests we need to unpack the WAR in a folder that is included
-        in the class path. -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>unpack-platform-web</id>
-            <phase>test-compile</phase>
-            <goals>
-              <goal>unpack</goal>
-            </goals>
-            <configuration>
-              <artifactItems>
-                <artifactItem>
-                  <groupId>org.xwiki.platform</groupId>
-                  <artifactId>xwiki-platform-web</artifactId>
-                  <version>${project.version}</version>
-                  <type>war</type>
-                  <outputDirectory>${project.build.testOutputDirectory}</outputDirectory>
-                  <includes>templates/*</includes>
-                </artifactItem>
-              </artifactItems>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-ui/src/main/resources/XWiki/Ratings/RatingsMacros.xml
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-ui/src/main/resources/XWiki/Ratings/RatingsMacros.xml
@@ -59,7 +59,7 @@
       #set ($message = $services.localization.render("rating.rate"))
       #set ($isLockedClass = "")
     #end
-    &lt;div class="rating-wrapper $isLockedClass" data-reference="${requestDocRef}"&gt;
+    &lt;div class="rating-wrapper $isLockedClass" data-reference="$escapetool.xml($requestDocRef)"&gt;
       &lt;div class="avg-rating"&gt;
         #ratingstars($id "" $message $avgvote $votes $isLocked)
       &lt;/div&gt;

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-ui/src/test/java/org/xwiki/ratings/RatingsTest.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-ui/src/test/java/org/xwiki/ratings/RatingsTest.java
@@ -1,0 +1,133 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.ratings;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Properties;
+
+import javax.inject.Named;
+
+import org.apache.velocity.runtime.RuntimeConstants;
+import org.apache.velocity.runtime.resource.loader.ClasspathResourceLoader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.script.ModelScriptService;
+import org.xwiki.ratings.script.RatingsScriptService;
+import org.xwiki.rendering.block.XDOM;
+import org.xwiki.rendering.macro.Macro;
+import org.xwiki.rendering.macro.descriptor.MacroDescriptor;
+import org.xwiki.rendering.syntax.Syntax;
+import org.xwiki.script.service.ScriptService;
+import org.xwiki.template.TemplateManager;
+import org.xwiki.test.junit5.mockito.MockComponent;
+import org.xwiki.test.page.PageTest;
+import org.xwiki.test.page.XHTML10ComponentList;
+import org.xwiki.test.page.XWikiSyntax21ComponentList;
+import org.xwiki.velocity.VelocityConfiguration;
+import org.xwiki.velocity.tools.EscapeTool;
+import org.xwiki.xml.html.filter.HTMLFilter;
+
+import com.xpn.xwiki.doc.XWikiDocument;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Page test of the ratings.
+ *
+ * @version $Id$
+ * @since 13.0RC1
+ */
+@XWikiSyntax21ComponentList
+@XHTML10ComponentList
+class RatingsTest extends PageTest
+{
+    @MockComponent
+    @Named("template")
+    private Macro templateMacro;
+
+    // Needs to be registered for the ratings macro to be loaded.
+    @MockComponent
+    @Named("controlcharacters")
+    private HTMLFilter htmlFilter;
+
+    @BeforeEach
+    void setUp() throws Exception
+    {
+        // The Ratings macro uses Velocity macros from the macros.vm template. We need to overwrite the Velocity
+        // configuration in order to use the ClasspathResourceLoader for loading the macros.vm template from the class
+        // path.
+        VelocityConfiguration velocityConfiguration = this.oldcore.getMocker().getInstance(VelocityConfiguration.class);
+        Properties velocityConfigProps = velocityConfiguration.getProperties();
+        velocityConfigProps.put(RuntimeConstants.RESOURCE_LOADERS, "class");
+        velocityConfigProps.put(RuntimeConstants.RESOURCE_LOADER + ".class." + RuntimeConstants.RESOURCE_LOADER_CLASS,
+            ClasspathResourceLoader.class.getName());
+        velocityConfigProps.put(RuntimeConstants.VM_LIBRARY, "/templates/macros.vm");
+        velocityConfiguration = this.oldcore.getMocker().registerMockComponent(VelocityConfiguration.class);
+        when(velocityConfiguration.getProperties()).thenReturn(velocityConfigProps);
+
+        // The Ratings macro page includes the rating_macros.vm template.
+        this.oldcore.getMocker().registerMockComponent(TemplateManager.class);
+
+        MacroDescriptor templateMacroDescriptor = mock(MacroDescriptor.class);
+        when(this.templateMacro.getDescriptor()).thenReturn(templateMacroDescriptor);
+        when(templateMacroDescriptor.getParametersBeanClass()).thenReturn((Class) "".getClass());
+
+        registerVelocityTool("escapetool", new EscapeTool());
+
+        // Initialize a document reference to be used as parameter when calling displayFullRating.
+        ModelScriptService modelScriptService = mock(ModelScriptService.class);
+        when(modelScriptService.createDocumentReference("a", "b", "c\"d"))
+            .thenReturn(new DocumentReference("a", "b", "c\"d"));
+        this.oldcore.getMocker().registerComponent(ScriptService.class, "model", modelScriptService);
+
+        // Initialize the ratings script service to allow displayFullRating to display the blocks to be tested.
+        RatingsScriptService ratingsScriptService = mock(RatingsScriptService.class);
+        when(ratingsScriptService.getAverageRating(any())).thenReturn(Optional.of(mock(AverageRating.class)));
+        this.oldcore.getMocker().registerComponent(ScriptService.class, "ratings", ratingsScriptService);
+    }
+
+    @Test
+    void displayFullRatingEscapesRequestDocRef() throws Exception
+    {
+        setOutputSyntax(Syntax.XHTML_1_0);
+
+        // Load the RatingsMacros that contains the tested displayFullRating.
+        loadPage(new DocumentReference("xwiki", Arrays.asList("XWiki", "Ratings"), "RatingsMacros"));
+
+        // Call the displayFullRating macro with a name with a double quote to test that it is properly escaped.
+        String script = "{{include reference=\"XWiki.Ratings.RatingsMacros\"/}}\n"
+            + "{{velocity}}#set($tdoc = $services.model.createDocumentReference('a', 'b', 'c\"d'))\n"
+            + "#displayFullRating($tdoc){{/velocity}}";
+
+        XWikiDocument document = new XWikiDocument(new DocumentReference("xwiki", "XWiki", "Test"));
+        document.setSyntax(Syntax.XWIKI_2_0);
+        document.setContent(script);
+        this.xwiki.saveDocument(document, "registering document", true, this.context);
+        String content = document.getRenderedContent(this.context);
+
+        // Verify that the displayFullRating parameter is actually escaped when used.
+        assertTrue(content.contains("data-reference=\"a:b.c&#34;d\""));
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-ui/src/test/java/org/xwiki/ratings/RatingsTest.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-ui/src/test/java/org/xwiki/ratings/RatingsTest.java
@@ -53,7 +53,8 @@ import static org.mockito.Mockito.when;
  * Page test of the ratings.
  *
  * @version $Id$
- * @since 13.0RC1
+ * @since 13.1RC1
+ * @since 12.10.4
  */
 @XWikiSyntax21ComponentList
 @XHTML10ComponentList


### PR DESCRIPTION
Escapes the page name when displaying the displayFullRating macro.

https://jira.xwiki.org/browse/XWIKI-17037