### PR TITLE
XWIKI-17038: The votes are lost after renaming the page

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/pom.xml
@@ -37,7 +37,7 @@
     <!-- Needs to be installed on root to be able to use Solr Store -->
     <xwiki.extension.namespaces>{root}</xwiki.extension.namespaces>
     <checkstyle.suppressions.location>${basedir}/src/checkstyle/checkstyle-suppressions.xml</checkstyle.suppressions.location>
-    <xwiki.jacoco.instructionRatio>0.61</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.65</xwiki.jacoco.instructionRatio>
     <!-- Old names of this module used for retro compatibility when resolving dependencies of old extensions -->
     <xwiki.extension.features>
       org.xwiki.contrib.ratings:application-ratings-api

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/events/UpdateAverageRatingFailedEvent.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/events/UpdateAverageRatingFailedEvent.java
@@ -25,9 +25,11 @@ import org.xwiki.ratings.RatingsManager;
 import org.xwiki.stability.Unstable;
 
 /**
- * Event sent whenever an update of {@link AverageRating} failed.
- * The event is sent with the following informations:
- *   - source: the identifier of the {@link RatingsManager}
+ * Event sent whenever an update of {@link AverageRating} failed. The event is sent with the following information:
+ * <ul>
+ *   <li>source: the identifier of the {@link RatingsManager}</li>
+ *   <li>data: a {@link java.util.List} of updated {@link AverageRating}</li>
+ * </ul>
  *
  * @version $Id$
  * @since 12.9RC1
@@ -35,6 +37,17 @@ import org.xwiki.stability.Unstable;
 @Unstable
 public class UpdateAverageRatingFailedEvent extends AbstractAverageRatingEvent implements EndEvent
 {
+    /**
+     * Default constructor.
+     *
+     * @since 13.1RC1
+     * @since 12.10.4
+     */
+    @Unstable
+    public UpdateAverageRatingFailedEvent()
+    {
+    }
+
     /**
      * Default constructor.
      *

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/events/UpdatedAverageRatingEvent.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/events/UpdatedAverageRatingEvent.java
@@ -25,10 +25,11 @@ import org.xwiki.ratings.RatingsManager;
 import org.xwiki.stability.Unstable;
 
 /**
- * Event sent whenever an {@link AverageRating} is updated.
- * The event is sent with the following informations:
- *   - source: the identifier of the {@link RatingsManager}
- *   - data: the {@link AverageRating} updated.
+ * Event sent whenever an {@link AverageRating} is updated. The event is sent with the following information:
+ * <ul>
+ *   <li>source: the identifier of the {@link RatingsManager}</li>
+ *   <li>data: a {@link java.util.List} of updated {@link AverageRating}</li>
+ * </ul>
  *
  * @version $Id$
  * @since 12.9RC1
@@ -36,6 +37,17 @@ import org.xwiki.stability.Unstable;
 @Unstable
 public class UpdatedAverageRatingEvent extends AbstractAverageRatingEvent implements EndEvent
 {
+    /**
+     * Default constructor.
+     *
+     * @since 13.1RC1
+     * @since 12.10.4
+     */
+    @Unstable
+    public UpdatedAverageRatingEvent()
+    {
+    }
+
     /**
      * Default constructor.
      *

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/events/UpdatingAverageRatingEvent.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/events/UpdatingAverageRatingEvent.java
@@ -25,10 +25,11 @@ import org.xwiki.ratings.RatingsManager;
 import org.xwiki.stability.Unstable;
 
 /**
- * Event sent whenever an {@link AverageRating} is updated.
- * The event is sent with the following informations:
- *   - source: the identifier of the {@link RatingsManager}
- *   - data: the {@link AverageRating} updated.
+ * Event sent whenever an {@link AverageRating} is updated. The event is sent with the following information:
+ * <ul>
+ *   <li>source: the identifier of the {@link RatingsManager}</li>
+ *   <li>data: a {@link java.util.List} of updated {@link AverageRating}</li>
+ * </ul>
  *
  * @version $Id$
  * @since 12.9RC1

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/averagerating/AbstractAverageRatingManager.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/averagerating/AbstractAverageRatingManager.java
@@ -19,7 +19,9 @@
  */
 package org.xwiki.ratings.internal.averagerating;
 
+import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 
 import javax.inject.Inject;
 
@@ -81,18 +83,19 @@ public abstract class AbstractAverageRatingManager implements AverageRatingManag
     private AverageRating updateAverageRating(AverageRating averageRating, float oldAverageVote, int oldTotalVote)
         throws RatingsException
     {
+        List<AverageRating> averageRatingList = Collections.singletonList(averageRating);
         this.getObservationManager().notify(new UpdatingAverageRatingEvent(averageRating, oldAverageVote, oldTotalVote),
-            this.getIdentifier(), averageRating);
+            this.getIdentifier(), averageRatingList);
         try {
             this.saveAverageRating(averageRating);
             this.getObservationManager().notify(
                 new UpdatedAverageRatingEvent(averageRating, oldAverageVote, oldTotalVote), this.getIdentifier(),
-                averageRating);
+                averageRatingList);
             return averageRating;
         } catch (RatingsException e) {
             this.getObservationManager().notify(
                 new UpdateAverageRatingFailedEvent(averageRating, oldAverageVote, oldTotalVote), this.getIdentifier(),
-                averageRating);
+                averageRatingList);
             throw e;
         }
     }

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/resources/ApplicationResources.properties
@@ -1,0 +1,22 @@
+# ---------------------------------------------------------------------------
+# See the NOTICE file distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+# ---------------------------------------------------------------------------
+ratings.averagerating.manager.move.comment=Move average ratings XObjects
+ratings.averagerating.manager.remove.comment=Remove average rating
+ratings.averagerating.manager.update.comment=Update average rating

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/averagerating/AbstractAverageRatingManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/averagerating/AbstractAverageRatingManagerTest.java
@@ -19,9 +19,10 @@
  */
 package org.xwiki.ratings.internal.averagerating;
 
+import java.util.Collections;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.EntityReference;
 import org.xwiki.observation.ObservationManager;
@@ -30,14 +31,8 @@ import org.xwiki.ratings.RatingsException;
 import org.xwiki.ratings.RatingsManager;
 import org.xwiki.ratings.events.UpdatedAverageRatingEvent;
 import org.xwiki.ratings.events.UpdatingAverageRatingEvent;
-import org.xwiki.test.annotation.BeforeComponent;
-import org.xwiki.test.junit5.mockito.ComponentTest;
-import org.xwiki.test.junit5.mockito.InjectMockComponents;
-import org.xwiki.test.junit5.mockito.MockComponent;
-import org.xwiki.test.mockito.MockitoComponentManager;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -130,8 +125,10 @@ public class AbstractAverageRatingManagerTest
         assertEquals(this.averageRating, this.averageRatingsManager.addVote(this.entityReference, newVote));
         assertTrue(this.averageRatingsManager.isSaved);
         verify(this.averageRating).addRating(newVote);
-        verify(this.observationManager).notify(expectedEvent1, managerId, this.averageRating);
-        verify(this.observationManager).notify(expectedEvent2, managerId, this.averageRating);
+        verify(this.observationManager)
+            .notify(expectedEvent1, managerId, Collections.singletonList(this.averageRating));
+        verify(this.observationManager)
+            .notify(expectedEvent2, managerId, Collections.singletonList(this.averageRating));
     }
 
     @Test
@@ -152,8 +149,10 @@ public class AbstractAverageRatingManagerTest
         assertEquals(this.averageRating, this.averageRatingsManager.removeVote(this.entityReference, removedVote));
         assertTrue(this.averageRatingsManager.isSaved);
         verify(this.averageRating).removeRating(removedVote);
-        verify(this.observationManager).notify(expectedEvent1, managerId, this.averageRating);
-        verify(this.observationManager).notify(expectedEvent2, managerId, this.averageRating);
+        verify(this.observationManager).notify(expectedEvent1, managerId,
+            Collections.singletonList(this.averageRating));
+        verify(this.observationManager).notify(expectedEvent2, managerId,
+            Collections.singletonList(this.averageRating));
     }
 
     @Test
@@ -175,8 +174,10 @@ public class AbstractAverageRatingManagerTest
         assertEquals(this.averageRating, this.averageRatingsManager.updateVote(this.entityReference, oldVote, newVote));
         assertTrue(this.averageRatingsManager.isSaved);
         verify(this.averageRating).updateRating(oldVote, newVote);
-        verify(this.observationManager).notify(expectedEvent1, managerId, this.averageRating);
-        verify(this.observationManager).notify(expectedEvent2, managerId, this.averageRating);
+        verify(this.observationManager).notify(expectedEvent1, managerId,
+            Collections.singletonList(this.averageRating));
+        verify(this.observationManager).notify(expectedEvent2, managerId,
+            Collections.singletonList(this.averageRating));
     }
 
     @Test
@@ -207,7 +208,9 @@ public class AbstractAverageRatingManagerTest
         expectedAverageRating.setUpdatedAt(averageRating.getUpdatedAt());
         assertEquals(expectedAverageRating, averageRating);
         assertTrue(this.averageRatingsManager.isSaved);
-        verify(this.observationManager).notify(expectedEvent1, managerId, expectedAverageRating);
-        verify(this.observationManager).notify(expectedEvent2, managerId, expectedAverageRating);
+        verify(this.observationManager).notify(expectedEvent1, managerId,
+            Collections.singletonList(expectedAverageRating));
+        verify(this.observationManager).notify(expectedEvent2, managerId,
+            Collections.singletonList(expectedAverageRating));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/averagerating/XObjectAverageRatingManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/averagerating/XObjectAverageRatingManagerTest.java
@@ -19,9 +19,9 @@
  */
 package org.xwiki.ratings.internal.averagerating;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 
 import javax.inject.Provider;
 
@@ -30,13 +30,20 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.xwiki.bridge.DocumentAccessBridge;
+import org.xwiki.localization.ContextualLocalizationManager;
 import org.xwiki.model.EntityType;
+import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
 import org.xwiki.model.reference.EntityReferenceSerializer;
+import org.xwiki.model.reference.SpaceReference;
 import org.xwiki.model.reference.WikiReference;
+import org.xwiki.observation.ObservationManager;
 import org.xwiki.properties.converter.Converter;
 import org.xwiki.ratings.AverageRating;
+import org.xwiki.ratings.RatingsException;
 import org.xwiki.ratings.RatingsManager;
+import org.xwiki.ratings.events.UpdatedAverageRatingEvent;
+import org.xwiki.ratings.events.UpdatingAverageRatingEvent;
 import org.xwiki.ratings.internal.averagerating.AverageRatingManager.AverageRatingQueryField;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
@@ -47,12 +54,15 @@ import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.objects.BaseObject;
 
+import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.xwiki.model.EntityType.DOCUMENT;
 
 /**
  * Tests for {@link XObjectAverageRatingManager}.
@@ -77,6 +87,12 @@ public class XObjectAverageRatingManagerTest
     @MockComponent
     private Provider<XWikiContext> contextProvider;
 
+    @MockComponent
+    private ObservationManager observationManager;
+
+    @MockComponent
+    private ContextualLocalizationManager contextualLocalizationManager;
+
     @Mock
     private RatingsManager ratingsManager;
 
@@ -99,7 +115,7 @@ public class XObjectAverageRatingManagerTest
         BaseObject averageRating2 = mock(BaseObject.class);
 
         when(xWikiDocument.getXObjects(AverageRatingClassDocumentInitializer.AVERAGE_RATINGS_CLASSREFERENCE))
-            .thenReturn(Arrays.asList(averageRating1, averageRating2));
+            .thenReturn(asList(averageRating1, averageRating2));
         when(averageRating1.getStringValue(AverageRatingQueryField.MANAGER_ID.getFieldName()))
             .thenReturn("something");
         when(averageRating2.getStringValue(AverageRatingQueryField.MANAGER_ID.getFieldName()))
@@ -136,7 +152,7 @@ public class XObjectAverageRatingManagerTest
             .setUpdatedAt(expectedUpdateDate);
         assertEquals(expectedAverageRating, this.averageRatingManager.getAverageRating(reference));
     }
-    
+
     @Test
     void getAverageRatingNotExisting() throws Exception
     {
@@ -150,7 +166,7 @@ public class XObjectAverageRatingManagerTest
         BaseObject averageRating2 = mock(BaseObject.class);
 
         when(xWikiDocument.getXObjects(AverageRatingClassDocumentInitializer.AVERAGE_RATINGS_CLASSREFERENCE))
-            .thenReturn(Arrays.asList(averageRating1, averageRating2));
+            .thenReturn(asList(averageRating1, averageRating2));
         // Wrong identifier
         when(averageRating1.getStringValue(AverageRatingQueryField.MANAGER_ID.getFieldName()))
             .thenReturn("something");
@@ -221,6 +237,9 @@ public class XObjectAverageRatingManagerTest
         XWiki xWiki = mock(XWiki.class);
         when(context.getWiki()).thenReturn(xWiki);
 
+        when(this.contextualLocalizationManager.getTranslationPlain("ratings.averagerating.manager.update.comment"))
+            .thenReturn("Update average rating");
+
         this.averageRatingManager.saveAverageRating(averageRating);
 
         verify(xObject).setStringValue(AverageRatingQueryField.MANAGER_ID.getFieldName(), expectedManagerID);
@@ -247,7 +266,7 @@ public class XObjectAverageRatingManagerTest
         when(this.ratingsManager.getIdentifier()).thenReturn(expectedManagerID);
 
         when(xWikiDocument.getXObjects(AverageRatingClassDocumentInitializer.AVERAGE_RATINGS_CLASSREFERENCE))
-            .thenReturn(Arrays.asList(matchingAverageRating, anotherAverageRating));
+            .thenReturn(asList(matchingAverageRating, anotherAverageRating));
         // Wrong identifier
         when(anotherAverageRating.getStringValue(AverageRatingQueryField.MANAGER_ID.getFieldName()))
             .thenReturn("something");
@@ -274,6 +293,9 @@ public class XObjectAverageRatingManagerTest
 
         XWiki xWiki = mock(XWiki.class);
         when(context.getWiki()).thenReturn(xWiki);
+
+        when(this.contextualLocalizationManager.getTranslationPlain("ratings.averagerating.manager.update.comment"))
+            .thenReturn("Update average rating");
 
         this.averageRatingManager.saveAverageRating(averageRating);
 
@@ -325,7 +347,7 @@ public class XObjectAverageRatingManagerTest
         when(this.ratingsManager.getIdentifier()).thenReturn(expectedManagerID);
 
         when(xWikiDocument.getXObjects(AverageRatingClassDocumentInitializer.AVERAGE_RATINGS_CLASSREFERENCE))
-            .thenReturn(Arrays.asList(matchingAverageRating, anotherAverageRating));
+            .thenReturn(asList(matchingAverageRating, anotherAverageRating));
         // Wrong identifier
         when(anotherAverageRating.getStringValue(AverageRatingQueryField.MANAGER_ID.getFieldName()))
             .thenReturn("something");
@@ -338,8 +360,151 @@ public class XObjectAverageRatingManagerTest
         when(this.contextProvider.get()).thenReturn(context);
         XWiki xWiki = mock(XWiki.class);
         when(context.getWiki()).thenReturn(xWiki);
+        when(this.contextualLocalizationManager.getTranslationPlain("ratings.averagerating.manager.remove.comment"))
+            .thenReturn("Remove average rating");
+
         assertEquals(1, this.averageRatingManager.removeAverageRatings(reference));
+
         verify(xWikiDocument).removeXObject(matchingAverageRating);
         verify(xWiki).saveDocument(xWikiDocument, "Remove average rating", true, context);
+    }
+
+    @Test
+    void moveAverageRatingsOldNull()
+    {
+        RatingsException ratingsException =
+            assertThrows(RatingsException.class, () -> this.averageRatingManager.moveAverageRatings(
+                new DocumentReference("xwiki", "XWiki", "Old"), null));
+
+        assertEquals("Impossible to move the average ratings from [xwiki:XWiki.Old] to [null].",
+            ratingsException.getMessage());
+    }
+
+    @Test
+    void moveAverageRatingsNewNull()
+    {
+        RatingsException ratingsException =
+            assertThrows(RatingsException.class, () -> this.averageRatingManager.moveAverageRatings(null,
+                new DocumentReference("xwiki",
+                    "XWiki", "New")));
+        assertEquals("Impossible to move the average ratings from [null] to [xwiki:XWiki.New].",
+            ratingsException.getMessage());
+    }
+
+    @Test
+    void moveAverageRatingsOldWrongType()
+    {
+        RatingsException ratingsException =
+            assertThrows(RatingsException.class,
+                () -> this.averageRatingManager.moveAverageRatings(new SpaceReference("xwiki", "Space"),
+                    new DocumentReference("xwiki",
+                        "XWiki", "New")));
+        assertEquals("Impossible to move the average ratings from [Space xwiki:Space] to [xwiki:XWiki.New].",
+            ratingsException.getMessage());
+    }
+
+    @Test
+    void moveAverageRatingsNewWrongType()
+    {
+        RatingsException ratingsException =
+            assertThrows(RatingsException.class,
+                () -> this.averageRatingManager.moveAverageRatings(new DocumentReference("xwiki",
+                        "XWiki", "Old"),
+                    new SpaceReference("xwiki", "Space")));
+        assertEquals("Impossible to move the average ratings from [xwiki:XWiki.Old] to [Space xwiki:Space].",
+            ratingsException.getMessage());
+    }
+
+    @Test
+    void moveAverageRatings() throws Exception
+    {
+        EntityReference oldReference = new EntityReference("xwiki:XWiki.Old", EntityType.DOCUMENT);
+        EntityReference newReference = new EntityReference("xwiki:XWiki.New", EntityType.DOCUMENT);
+        XWikiContext context = mock(XWikiContext.class);
+        XWikiDocument actualDoc = mock(XWikiDocument.class);
+        // Skipped because wrong manager
+        BaseObject ratings1 = mock(BaseObject.class);
+        // Skiped because wrong entity
+        BaseObject ratings2 = mock(BaseObject.class);
+        // Pass because references Old
+        BaseObject ratings3 = mock(BaseObject.class);
+        // Pass because references a child of Old
+        BaseObject ratings4 = mock(BaseObject.class);
+        String expectedManager = "expectedManager";
+        XWiki xWiki = mock(XWiki.class);
+        Date r3UpdateDate = new Date();
+        Date r4UpdateDate = new Date();
+        EntityReference oldObjectEntityReference = new EntityReference("XWiki.Object", EntityType.OBJECT, oldReference);
+        EntityReference newObjectEntityReference = new EntityReference("XWiki.Object", EntityType.OBJECT, newReference);
+
+        when(this.contextProvider.get()).thenReturn(context);
+        when(context.getWiki()).thenReturn(xWiki);
+        when(this.documentAccessBridge.getDocumentInstance(newReference)).thenReturn(actualDoc);
+        when(actualDoc
+            .getXObjects(AverageRatingClassDocumentInitializer.AVERAGE_RATINGS_CLASSREFERENCE))
+            .thenReturn(asList(ratings1, ratings2, ratings3, ratings4));
+
+        when(ratings1.getStringValue(AverageRatingQueryField.ENTITY_REFERENCE.getFieldName()))
+            .thenReturn("ratings1EntityReference");
+        when(ratings1.getStringValue(AverageRatingQueryField.MANAGER_ID.getFieldName())).thenReturn("wrongManager");
+
+        when(ratings2.getStringValue(AverageRatingQueryField.MANAGER_ID.getFieldName())).thenReturn(expectedManager);
+        when(ratings2.getStringValue(AverageRatingQueryField.ENTITY_REFERENCE.getFieldName()))
+            .thenReturn("xwiki:XWiki.Unknown");
+
+        when(ratings3.getStringValue(AverageRatingQueryField.MANAGER_ID.getFieldName())).thenReturn(expectedManager);
+        when(ratings3.getStringValue(AverageRatingQueryField.ENTITY_REFERENCE.getFieldName()))
+            .thenReturn("xwiki:XWiki.Old");
+        when(ratings3.getFloatValue(AverageRatingQueryField.AVERAGE_VOTE.getFieldName())).thenReturn(10f);
+        when(ratings3.getDateValue(AverageRatingQueryField.UPDATED_AT.getFieldName())).thenReturn(r3UpdateDate);
+        when(ratings3.getIntValue(AverageRatingQueryField.SCALE.getFieldName(), 5)).thenReturn(9);
+
+        when(ratings4.getStringValue(AverageRatingQueryField.MANAGER_ID.getFieldName())).thenReturn(expectedManager);
+        when(ratings4.getStringValue(AverageRatingQueryField.ENTITY_REFERENCE.getFieldName()))
+            .thenReturn("xwiki:XWiki.Old^XWiki.Object");
+        when(ratings4.getFloatValue(AverageRatingQueryField.AVERAGE_VOTE.getFieldName())).thenReturn(20f);
+        when(ratings4.getDateValue(AverageRatingQueryField.UPDATED_AT.getFieldName())).thenReturn(r4UpdateDate);
+        when(ratings4.getIntValue(AverageRatingQueryField.SCALE.getFieldName(), 5)).thenReturn(2);
+
+        when(this.ratingsManager.getIdentifier()).thenReturn(expectedManager);
+        when(this.entityReferenceConverter.convert(EntityReference.class, "xwiki:XWiki.Unknown"))
+            .thenReturn(new EntityReference("xwiki:XWiki.Unknown", EntityType.DOCUMENT));
+        when(this.entityReferenceConverter.convert(EntityReference.class, "xwiki:XWiki.Old"))
+            .thenReturn(oldReference);
+        when(this.entityReferenceConverter.convert(EntityReference.class, "xwiki:XWiki.Old^XWiki.Object"))
+            .thenReturn(oldObjectEntityReference);
+        when(this.entityReferenceConverter.convert(String.class, newReference)).thenReturn("xwiki:XWiki.New");
+        when(this.entityReferenceConverter.convert(String.class, newObjectEntityReference))
+            .thenReturn("xwiki:XWiki.Old^XWiki.Object");
+
+        when(this.stringEntityReferenceSerializer.serialize(newReference.extractReference(DOCUMENT))).thenReturn(
+            "xwiki:XWiki.New");
+        when(this.contextualLocalizationManager.getTranslationPlain("ratings.averagerating.manager.move.comment"))
+            .thenReturn("Move average ratings XObjects");
+
+        long count = this.averageRatingManager.moveAverageRatings(oldReference, newReference);
+
+        assertEquals(2, count);
+        verify(ratings3).setStringValue(AverageRatingQueryField.ENTITY_REFERENCE.getFieldName(),
+            "xwiki:XWiki.New");
+        verify(ratings4).setStringValue(AverageRatingQueryField.ENTITY_REFERENCE.getFieldName(),
+            "xwiki:XWiki.Old^XWiki.Object");
+        verify(xWiki).saveDocument(actualDoc, "Move average ratings XObjects", true, context);
+        List<DefaultAverageRating> ratingsList = asList(
+            new DefaultAverageRating("xwiki:XWiki.New_1593976669")
+                .setManagerId("expectedManager")
+                .setReference(newReference)
+                .setAverageVote(10f)
+                .setUpdatedAt(r3UpdateDate)
+                .setScaleUpperBound(9),
+            new DefaultAverageRating("xwiki:XWiki.New_-989039879")
+                .setManagerId("expectedManager")
+                .setReference(newObjectEntityReference)
+                .setAverageVote(20f)
+                .setUpdatedAt(r4UpdateDate)
+                .setScaleUpperBound(2)
+        );
+        verify(this.observationManager).notify(new UpdatingAverageRatingEvent(), expectedManager, ratingsList);
+        verify(this.observationManager).notify(new UpdatedAverageRatingEvent(), expectedManager, ratingsList);
     }
 }


### PR DESCRIPTION
- Implements XObjectAverageRatingManager#moveAverageRatings and update the AverageRatings XObject entityReference field to reflect the new reference of the moved entities (the move Page as well as sub-entities). As a consequence, empty constructor added to UpdateAverageRatingFailedEvent and UpdatedAverageRatingEvent, and the data accompanying the average ratings event is now a list of AverageRatings to reflect the fact that multiple ratings can be modified on a single "transaction".
- The document save messages are now internationalized