### PR TITLE
XWIKI-17484: The orphaned pages panel does not scale

### DIFF
--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-api/src/main/java/org/xwiki/panels/internal/script/OrphanedPagesItem.java
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-api/src/main/java/org/xwiki/panels/internal/script/OrphanedPagesItem.java
@@ -1,0 +1,122 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.panels.internal.script;
+
+import java.util.List;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.xwiki.text.XWikiToStringBuilder;
+
+/**
+ * Contains the information required to display the orphaned page tree, namely a list of orphaned page references, the
+ * next offset, and if their is more orphan pages to be queried.
+ *
+ * @version $Id$
+ * @since 13.1RC1
+ * @since 12.10.4
+ * @since 12.6.8
+ */
+public class OrphanedPagesItem
+{
+    private final List<String> orphanedPages;
+
+    private final int offset;
+
+    private final boolean hasMore;
+
+    /**
+     * Default constructor, initializing all the fields of this object.
+     *
+     * @param orphanedPages the list of orphaned pages
+     * @param offset the next offset
+     * @param hasMore {@code true} if their is more orphaned pages to retrieve, {@code false} otherwise
+     */
+    public OrphanedPagesItem(List<String> orphanedPages, int offset, boolean hasMore)
+    {
+        this.orphanedPages = orphanedPages;
+        this.offset = offset;
+        this.hasMore = hasMore;
+    }
+
+    /**
+     * @return a list of orphaned pages
+     */
+    public List<String> getOrphanedPages()
+    {
+        return this.orphanedPages;
+    }
+
+    /**
+     * @return the offset for the next query
+     */
+    public int getOffset()
+    {
+        return this.offset;
+    }
+
+    /**
+     * @return {@code true} if their is more orphaned pages to retrieve, {@code false} otherwise
+     */
+    public boolean getHasMore()
+    {
+        return this.hasMore;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        OrphanedPagesItem that = (OrphanedPagesItem) o;
+
+        return new EqualsBuilder()
+            .append(this.offset, that.offset)
+            .append(this.hasMore, that.hasMore)
+            .append(this.orphanedPages, that.orphanedPages)
+            .isEquals();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return new HashCodeBuilder(17, 37)
+            .append(this.orphanedPages)
+            .append(this.offset)
+            .append(this.hasMore)
+            .toHashCode();
+    }
+
+    @Override
+    public String toString()
+    {
+        return new XWikiToStringBuilder(this)
+            .append("orphanedPages", this.orphanedPages)
+            .append("offset", this.offset)
+            .append("hasMore", this.hasMore)
+            .toString();
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-api/src/main/java/org/xwiki/panels/internal/script/PanelsInternalScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-api/src/main/java/org/xwiki/panels/internal/script/PanelsInternalScriptService.java
@@ -1,0 +1,137 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.panels.internal.script;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.slf4j.Logger;
+import org.xwiki.bridge.DocumentAccessBridge;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.model.reference.DocumentReferenceResolver;
+import org.xwiki.query.Query;
+import org.xwiki.query.QueryException;
+import org.xwiki.query.QueryFilter;
+import org.xwiki.query.QueryManager;
+import org.xwiki.script.service.ScriptService;
+import org.xwiki.security.authorization.AuthorizationManager;
+import org.xwiki.security.authorization.Right;
+
+import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCauseMessage;
+
+/**
+ * This script service provides useful operation for the panel pages.
+ *
+ * @version $Id$
+ * @since 13.1RC1
+ * @since 12.10.4
+ * @since 12.6.8
+ */
+@Component
+@Named("panels")
+@Singleton
+public class PanelsInternalScriptService implements ScriptService
+{
+    @Inject
+    private QueryManager queryManager;
+
+    @Inject
+    @Named("hidden/document")
+    private QueryFilter hiddenDocumentQueryFilter;
+
+    @Inject
+    private AuthorizationManager authorizationManager;
+
+    @Inject
+    private DocumentReferenceResolver<String> documentReferenceResolver;
+
+    @Inject
+    private DocumentAccessBridge documentAccessBridge;
+
+    @Inject
+    private Logger logger;
+
+    /**
+     * Returns the paginated list of orphaned pages, as well as the offset for the next call to this method, and if
+     * their is more elements to retrive.
+     *
+     * @param limit the number of elements to return
+     * @param offset the offset to use of the pagination
+     * @param homepage the current wiki home page
+     * @return an object holding the pagination state as well as the paginated list of orphaned pages
+     */
+    public OrphanedPagesItem listOrphaned(int limit, int offset, String homepage)
+    {
+        List<String> ret = new ArrayList<>();
+        int newOffset = offset;
+        try {
+            boolean hasMore;
+            List<String> orphanedPages = queryOrphanedPages(limit, homepage, newOffset);
+            do {
+                for (String orphanedPage : orphanedPages) {
+                    // Update the offset to return an updated offset to the caller
+                    newOffset = newOffset + 1;
+                    if (this.authorizationManager
+                        .hasAccess(Right.VIEW, this.documentAccessBridge.getCurrentUserReference(),
+                            this.documentReferenceResolver.resolve(orphanedPage)))
+                    {
+                        ret.add(orphanedPage);
+                    }
+                    if (ret.size() >= limit) {
+                        break;
+                    }
+                }
+                if (ret.size() >= limit) {
+                    hasMore = true;
+                } else {
+                    orphanedPages = queryOrphanedPages(limit, homepage, newOffset);
+                    hasMore = !orphanedPages.isEmpty();
+                }
+            } while (hasMore && ret.size() < limit);
+
+            return new OrphanedPagesItem(ret, newOffset, hasMore);
+        } catch (QueryException e) {
+            this.logger.warn(
+                "Failed to retrieve the list of orphaned pages with limit [{}], offset [{}], and homepage [{}]. "
+                    + "Cause: [{}]",
+                limit, offset, homepage, getRootCauseMessage(e));
+            return new OrphanedPagesItem(Collections.emptyList(), newOffset, false);
+        }
+    }
+
+    private List<String> queryOrphanedPages(int limit, String homepage, int newOffset) throws QueryException
+    {
+        return this.queryManager.createQuery(
+            "where doc.parent is null "
+                + "or doc.parent='' "
+                + "and doc.fullName <> :homepage "
+                + "order by doc.contentUpdateDate desc", Query.XWQL)
+            .setLimit(limit)
+            .setOffset(newOffset)
+            .addFilter(this.hiddenDocumentQueryFilter)
+            .bindValue("homepage", homepage)
+            .execute();
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-api/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-api/src/main/resources/META-INF/components.txt
@@ -2,3 +2,4 @@ org.xwiki.panels.internal.LeftPanelsUIExtensionManager
 org.xwiki.panels.internal.PanelClassDocumentInitializer
 org.xwiki.panels.internal.PanelWikiUIExtensionComponentBuilder
 org.xwiki.panels.internal.RightPanelsUIExtensionManager
+org.xwiki.panels.internal.script.PanelsInternalScriptService

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-api/src/test/java/org/xwiki/panels/internal/script/PanelsInternalScriptServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-api/src/test/java/org/xwiki/panels/internal/script/PanelsInternalScriptServiceTest.java
@@ -1,0 +1,157 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.panels.internal.script;
+
+import java.util.Arrays;
+
+import javax.inject.Named;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.bridge.DocumentAccessBridge;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.DocumentReferenceResolver;
+import org.xwiki.query.Query;
+import org.xwiki.query.QueryFilter;
+import org.xwiki.query.QueryManager;
+import org.xwiki.security.authorization.AuthorizationManager;
+import org.xwiki.security.authorization.Right;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test of {@link PanelsInternalScriptService}.
+ *
+ * @version $Id$
+ * @since 13.1RC1
+ * @since 12.10.4
+ * @since 12.6.8
+ */
+@ComponentTest
+class PanelsInternalScriptServiceTest
+{
+    @InjectMockComponents
+    private PanelsInternalScriptService panelsInternalScriptService;
+
+    @MockComponent
+    private QueryManager queryManager;
+
+    @MockComponent
+    @Named("hidden/document")
+    private QueryFilter hiddenDocumentQueryFilter;
+
+    @MockComponent
+    private AuthorizationManager authorizationManager;
+
+    @MockComponent
+    private DocumentReferenceResolver<String> documentReferenceResolver;
+
+    @MockComponent
+    private DocumentAccessBridge documentAccessBridge;
+
+    @Test
+    void listOrphaned() throws Exception
+    {
+        Query query = mock(Query.class);
+        DocumentReference currentUser = new DocumentReference("xwiki", "XWiki", "U1");
+        DocumentReference ok1 = new DocumentReference("xwiki", "XWiki", "ok1");
+        DocumentReference ok2 = new DocumentReference("xwiki", "XWiki", "ok2");
+        DocumentReference ok3 = new DocumentReference("xwiki", "XWiki", "ok3");
+        DocumentReference ok4 = new DocumentReference("xwiki", "XWiki", "ok4");
+        DocumentReference nok1 = new DocumentReference("xwiki", "XWiki", "nok1");
+        DocumentReference nok2 = new DocumentReference("xwiki", "XWiki", "nok2");
+
+        when(this.queryManager.createQuery(any(String.class), eq(Query.XWQL))).thenReturn(query);
+        when(query.setLimit(4)).thenReturn(query);
+        when(query.setOffset(5)).thenReturn(query);
+        when(query.setOffset(9)).thenReturn(query);
+        when(query.addFilter(this.hiddenDocumentQueryFilter)).thenReturn(query);
+        when(query.bindValue("homepage", "homePageVal")).thenReturn(query);
+        when(query.execute()).thenReturn(
+            Arrays.asList("ok1", "nok1", "ok2", "ok3"),
+            Arrays.asList("nok2", "ok4", "ok5", "ok6")
+        );
+        when(this.documentAccessBridge.getCurrentUserReference()).thenReturn(currentUser);
+        when(this.documentReferenceResolver.resolve("ok1")).thenReturn(ok1);
+        when(this.documentReferenceResolver.resolve("ok2")).thenReturn(ok2);
+        when(this.documentReferenceResolver.resolve("ok3")).thenReturn(ok3);
+        when(this.documentReferenceResolver.resolve("ok4")).thenReturn(ok4);
+        when(this.documentReferenceResolver.resolve("nok1")).thenReturn(nok1);
+        when(this.documentReferenceResolver.resolve("nok2")).thenReturn(nok2);
+
+        when(this.authorizationManager.hasAccess(Right.VIEW, currentUser, ok1)).thenReturn(true);
+        when(this.authorizationManager.hasAccess(Right.VIEW, currentUser, ok2)).thenReturn(true);
+        when(this.authorizationManager.hasAccess(Right.VIEW, currentUser, ok3)).thenReturn(true);
+        when(this.authorizationManager.hasAccess(Right.VIEW, currentUser, ok4)).thenReturn(true);
+        when(this.authorizationManager.hasAccess(Right.VIEW, currentUser, nok1)).thenReturn(false);
+        when(this.authorizationManager.hasAccess(Right.VIEW, currentUser, nok2)).thenReturn(false);
+
+        OrphanedPagesItem actual = this.panelsInternalScriptService.listOrphaned(4, 5, "homePageVal");
+
+        assertEquals(new OrphanedPagesItem(Arrays.asList("ok1", "ok2", "ok3", "ok4"), 11, true), actual);
+    }
+
+    @Test
+    void listOrphanedReachEnd() throws Exception
+    {
+        Query query = mock(Query.class);
+        DocumentReference currentUser = new DocumentReference("xwiki", "XWiki", "U1");
+        DocumentReference ok1 = new DocumentReference("xwiki", "XWiki", "ok1");
+        DocumentReference ok2 = new DocumentReference("xwiki", "XWiki", "ok2");
+        DocumentReference nok1 = new DocumentReference("xwiki", "XWiki", "nok1");
+        DocumentReference nok2 = new DocumentReference("xwiki", "XWiki", "nok2");
+        DocumentReference nok3 = new DocumentReference("xwiki", "XWiki", "nok3");
+
+        when(this.queryManager.createQuery(any(String.class), eq(Query.XWQL))).thenReturn(query);
+        when(query.setLimit(3)).thenReturn(query);
+        when(query.setOffset(5)).thenReturn(query);
+        when(query.setOffset(8)).thenReturn(query);
+        when(query.setOffset(10)).thenReturn(query);
+        when(query.addFilter(this.hiddenDocumentQueryFilter)).thenReturn(query);
+        when(query.bindValue("homepage", "homePageVal")).thenReturn(query);
+        when(query.execute()).thenReturn(
+            Arrays.asList("ok1", "nok1", "nok2"),
+            Arrays.asList("ok2", "nok3"),
+            Arrays.asList()
+        );
+        when(this.documentAccessBridge.getCurrentUserReference()).thenReturn(currentUser);
+        when(this.documentReferenceResolver.resolve("ok1")).thenReturn(ok1);
+        when(this.documentReferenceResolver.resolve("ok2")).thenReturn(ok2);
+        when(this.documentReferenceResolver.resolve("nok1")).thenReturn(nok1);
+        when(this.documentReferenceResolver.resolve("nok2")).thenReturn(nok2);
+        when(this.documentReferenceResolver.resolve("nok3")).thenReturn(nok3);
+
+        when(this.authorizationManager.hasAccess(Right.VIEW, currentUser, ok1)).thenReturn(true);
+        when(this.authorizationManager.hasAccess(Right.VIEW, currentUser, ok2)).thenReturn(true);
+        when(this.authorizationManager.hasAccess(Right.VIEW, currentUser, nok1)).thenReturn(false);
+        when(this.authorizationManager.hasAccess(Right.VIEW, currentUser, nok2)).thenReturn(false);
+        when(this.authorizationManager.hasAccess(Right.VIEW, currentUser, nok3)).thenReturn(false);
+
+        OrphanedPagesItem actual = this.panelsInternalScriptService.listOrphaned(3, 5, "homePageVal");
+
+        assertEquals(new OrphanedPagesItem(Arrays.asList("ok1", "ok2"), 10, false), actual);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/OrphanedPages.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/OrphanedPages.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.1" encoding="UTF-8"?>
 
 <!--
  * See the NOTICE file distributed with this work for additional
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.1">
+<xwikidoc version="1.4" reference="Panels.OrphanedPages" locale="">
   <web>Panels</web>
   <name>OrphanedPages</name>
   <language/>
@@ -36,7 +36,41 @@
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.0</syntaxId>
   <hidden>true</hidden>
-  <content/>
+  <content>{{include reference="XWiki.DocumentTreeMacros" /}}
+
+{{velocity wiki='false'}}
+#if ($xcontext.action == 'get')
+  #if ($request.offset)
+    #set ($offset = $request.offset)
+  #else
+    #set ($offset = 0)
+  #end
+
+  #if ($request.limit)
+    #set ($limit = $request.limit)
+  #else
+    #set ($limit = 20)
+  #end
+
+  #set ($homepage = $services.wiki.getById($services.wiki.currentWikiId).mainPageReference)
+  #set ($homepageFullName = $services.model.serialize($homepage, 'local'))
+
+  #set ($orphanedItem = $services.panels.listOrphaned($limit, $offset, $homepageFullName))
+
+  #set($data = [])
+  #updateDocTreeConfigFromRequest()
+  #foreach ($item in $orphanedItem.orphanedPages)
+    #addDocumentNode($item $data)
+  #end
+  #if ($orphanedItem.getHasMore())
+    #addPaginationNode($homepageFullName $orphanedItem.offset '' $data)
+    ## Replaces the pagination node with a generic message since we do not count the total number of orphaned pages.
+    #set($data[$data.size() - 1].text = $services.localization.render('panels.orphanedPages.tree.more'))
+  #end
+  #postProcessDocumentTreeData($data)
+  #jsonResponse($data)
+#end
+{{/velocity}}</content>
   <object>
     <name>Panels.OrphanedPages</name>
     <number>0</number>
@@ -51,17 +85,59 @@
       <defaultWeb/>
       <nameField/>
       <validationScript/>
+      <async_cached>
+        <defaultValue>0</defaultValue>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType/>
+        <name>async_cached</name>
+        <number>7</number>
+        <prettyName>Cached</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </async_cached>
+      <async_context>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
+        <name>async_context</name>
+        <number>8</number>
+        <prettyName>Context elements</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator>, </separator>
+        <separators>|, </separators>
+        <size>5</size>
+        <unmodifiable>0</unmodifiable>
+        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.parameters=Request parameters|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </async_context>
+      <async_enabled>
+        <defaultValue>0</defaultValue>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType/>
+        <name>async_enabled</name>
+        <number>6</number>
+        <prettyName>Asynchronous rendering</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </async_enabled>
       <category>
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>category</name>
-        <number>5</number>
+        <number>1</number>
         <prettyName>Category</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
-        <separators> ,|</separators>
+        <separators>|, </separators>
         <size>1</size>
         <unmodifiable>0</unmodifiable>
         <values>Information|Navigation|Tools|Administration|Other</values>
@@ -71,8 +147,8 @@
         <disabled>0</disabled>
         <editor>Text</editor>
         <name>content</name>
-        <number>4</number>
-        <prettyName>Content</prettyName>
+        <number>5</number>
+        <prettyName>Executed Content</prettyName>
         <rows>25</rows>
         <size>120</size>
         <unmodifiable>0</unmodifiable>
@@ -82,7 +158,7 @@
         <disabled>0</disabled>
         <editor>Text</editor>
         <name>description</name>
-        <number>3</number>
+        <number>2</number>
         <prettyName>Description</prettyName>
         <rows>5</rows>
         <size>40</size>
@@ -92,7 +168,7 @@
       <name>
         <disabled>0</disabled>
         <name>name</name>
-        <number>1</number>
+        <number>3</number>
         <prettyName>Name</prettyName>
         <size>40</size>
         <unmodifiable>0</unmodifiable>
@@ -102,19 +178,30 @@
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>type</name>
-        <number>2</number>
+        <number>4</number>
         <prettyName>Panel type</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
-        <separators> ,|</separators>
+        <separators>|, </separators>
         <size>1</size>
         <unmodifiable>0</unmodifiable>
         <values>view|edit</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </type>
     </class>
+    <property>
+      <async_cached>0</async_cached>
+    </property>
+    <property>
+      <async_context/>
+    </property>
+    <property>
+      <async_enabled>0</async_enabled>
+    </property>
     <property>
       <category>Information</category>
     </property>
@@ -123,12 +210,9 @@
 #panelheader($services.localization.render('xe.panels.orphaned'))
 #set ($homepage = $services.wiki.getById($services.wiki.currentWikiId).mainPageReference)
 #set ($homepageFullName = $services.model.serialize($homepage, 'local'))
-#foreach ($item in $services.query.xwql('where doc.parent is null or doc.parent='''' and doc.fullName &lt;&gt; :homepage order by doc.name asc').bindValue('homepage', $homepageFullName).addFilter('hidden').execute())
-  #if ($xwiki.hasAccessLevel('view', $xcontext.user, "${xcontext.database}:${item}"))
-    #set ($bentrydoc = $xwiki.getDocument($item))
-    * [[${bentrydoc.fullName}]]
-  #end
-#end
+
+{{tree reference="path:$xwiki.getURL('Panels.OrphanedPages', 'get', 'sheet=&amp;amp;outputSyntax=plain')" limit='10' links='true' /}}
+
 #panelfooter()
 {{/velocity}}</content>
     </property>

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Translations.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Translations.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.3" reference="Panels.Translations" locale="">
+<xwikidoc version="1.4" reference="Panels.Translations" locale="">
   <web>Panels</web>
   <name>Translations</name>
   <language/>
@@ -45,6 +45,7 @@ panels._actions=Actions
 panels.emptyvalue=
 panels.children.title=Child Pages
 panels.siblings.title=Sibling Pages
+panels.orphanedPages.tree.more=more
 
 ## Used to indicate where deprecated keys start
 #@deprecatedstart
@@ -75,6 +76,8 @@ panels.documentInformation.failedSyntaxConversion=Failed to convert to the selec
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>scope</name>
         <number>1</number>


### PR DESCRIPTION
Xwql query replaced by the use of the tree macro.
Consequently, the results are now provided by an ajax query provided by the content of the page.
The content of the page itself calls a new internal script service that deals with the Xwql query and the pagination.

https://jira.xwiki.org/browse/XWIKI-17484