### PR TITLE
XWIKI-17606: The Tag page should use a document tree or LiveTable to list all documents having a given tag

### DIFF
--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -138,6 +138,31 @@
                 <new>method org.xwiki.security.authentication.AuthenticationConfiguration org.xwiki.security.authentication.script.AuthenticationScriptService::getAuthenticationConfiguration()</new>
                 <justification>AuthenticationConfiguration has only been moved to a new package, so it should not be breaking for people using this API in scripts.</justification>
               </item>
+              <item>
+                <code>java.class.removed</code>
+                <old>enum com.xpn.xwiki.plugin.tag.TagOperationResult</old>
+                <justification>Moved to legacy.</justification>
+              </item>
+              <item>
+                <code>java.class.removed</code>
+                <old>class com.xpn.xwiki.plugin.tag.TagParamUtils</old>
+                <justification>Moved to legacy.</justification>
+              </item>
+              <item>
+                <code>java.class.removed</code>
+                <old>class com.xpn.xwiki.plugin.tag.TagPlugin</old>
+                <justification>Moved to legacy.</justification>
+              </item>
+              <item>
+                <code>java.class.removed</code>
+                <old>class com.xpn.xwiki.plugin.tag.TagPluginApi</old>
+                <justification>Moved to legacy.</justification>
+              </item>
+              <item>
+                <code>java.class.removed</code>
+                <old>class com.xpn.xwiki.plugin.tag.TagQueryUtils</old>
+                <justification>Moved to legacy.</justification>
+              </item>
             </revapi.ignore>
           </analysisConfiguration>
         </configuration>

--- a/xwiki-platform-core/xwiki-platform-legacy/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-legacy/pom.xml
@@ -52,6 +52,7 @@
     <module>xwiki-platform-legacy-url</module>
     <module>xwiki-platform-legacy-web</module>
     <module>xwiki-platform-legacy-refactoring</module>
+    <module>xwiki-platform-legacy-tag</module>
   </modules>
   <build>
     <pluginManagement>

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-tag/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-tag/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.xwiki.platform</groupId>
+    <artifactId>xwiki-platform-legacy</artifactId>
+    <version>13.1-SNAPSHOT</version>
+  </parent>
+  <artifactId>xwiki-platform-legacy-tag</artifactId>
+  <name>XWiki Platform - Legacy - Tag - Parent POM</name>
+  <packaging>pom</packaging>
+  <description>XWiki Platform - Legacy - Tag - Parent POM</description>
+  <modules>
+    <module>xwiki-platform-legacy-tag-api</module>
+  </modules>
+</project>

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-tag/xwiki-platform-legacy-tag-api/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-tag/xwiki-platform-legacy-tag-api/pom.xml
@@ -25,31 +25,20 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.xwiki.platform</groupId>
-    <artifactId>xwiki-platform-tag</artifactId>
+    <artifactId>xwiki-platform-legacy-tag</artifactId>
     <version>13.1-SNAPSHOT</version>
   </parent>
-  <artifactId>xwiki-platform-tag-api</artifactId>
-  <name>XWiki Platform - Tag - API</name>
-  <description>XWiki Platform - Tag - API</description>
+  <artifactId>xwiki-platform-legacy-tag-api</artifactId>
+  <name>XWiki Platform - Legacy- Tag - API</name>
+  <description>XWiki Platform - Legacy- Tag - API</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.51</xwiki.jacoco.instructionRatio>
-    <checkstyle.suppressions.location>${basedir}/src/checkstyle/checkstyle-suppressions.xml</checkstyle.suppressions.location>
+    <xwiki.jacoco.instructionRatio>0.13</xwiki.jacoco.instructionRatio>
   </properties>
   <dependencies>
     <dependency>
       <groupId>org.xwiki.platform</groupId>
-      <artifactId>xwiki-platform-livedata-api</artifactId>
+      <artifactId>xwiki-platform-oldcore</artifactId>
       <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.xwiki.commons</groupId>
-      <artifactId>xwiki-commons-component-api</artifactId>
-      <version>${commons.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.xwiki.commons</groupId>
-      <artifactId>xwiki-commons-script</artifactId>
-      <version>${commons.version}</version>
     </dependency>
     <dependency>
       <groupId>org.xwiki.platform</groupId>
@@ -57,19 +46,26 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.xwiki.platform</groupId>
-      <artifactId>xwiki-platform-oldcore</artifactId>
-      <version>${project.version}</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
+    <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-tag-api</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Testing Dependencies -->
     <dependency>
       <groupId>org.xwiki.commons</groupId>
       <artifactId>xwiki-commons-tool-test-component</artifactId>
       <version>${commons.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-tag/xwiki-platform-legacy-tag-api/src/main/java/com/xpn/xwiki/plugin/tag/TagOperationResult.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-tag/xwiki-platform-legacy-tag-api/src/main/java/com/xpn/xwiki/plugin/tag/TagOperationResult.java
@@ -1,0 +1,43 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package com.xpn.xwiki.plugin.tag;
+
+/**
+ * The result of a {@link TagPlugin} operation.
+ * 
+ * @version $Id$
+ * @deprecated since 13.1RC1, see {@link org.xwiki.tag.TagOperationResult}
+ */
+@Deprecated
+public enum TagOperationResult
+{
+    /** The operation was successful, and data changes occurred. */
+    OK,
+
+    /** The operation did not change any data. */
+    NO_EFFECT,
+
+    /** The current user does not have permission to perform the operation. */
+    NOT_ALLOWED,
+
+    /** The operation failed with an exception. */
+    FAILED
+}

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-tag/xwiki-platform-legacy-tag-api/src/main/java/com/xpn/xwiki/plugin/tag/TagParamUtils.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-tag/xwiki-platform-legacy-tag-api/src/main/java/com/xpn/xwiki/plugin/tag/TagParamUtils.java
@@ -29,7 +29,9 @@ import com.xpn.xwiki.XWikiException;
  *
  * @version $Id$
  * @since 8.2M1
+ * @deprecated since 13.1RC1
  */
+@Deprecated
 public final class TagParamUtils
 {
     /**

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-tag/xwiki-platform-legacy-tag-api/src/main/java/com/xpn/xwiki/plugin/tag/TagPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-tag/xwiki-platform-legacy-tag-api/src/main/java/com/xpn/xwiki/plugin/tag/TagPlugin.java
@@ -47,7 +47,9 @@ import com.xpn.xwiki.plugin.XWikiPluginInterface;
  * TagPlugin is a plugin that allows to manipulate tags easily. It allows to get, rename and delete tags.
  * 
  * @version $Id$
+ * @deprecated since 13.1RC1, use {@link TagService} instead 
  */
+@Deprecated
 public class TagPlugin extends XWikiDefaultPlugin implements XWikiPluginInterface
 {
     /** Logging helper object. */

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-tag/xwiki-platform-legacy-tag-api/src/main/java/com/xpn/xwiki/plugin/tag/TagPluginApi.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-tag/xwiki-platform-legacy-tag-api/src/main/java/com/xpn/xwiki/plugin/tag/TagPluginApi.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xwiki.tag.TagScriptService;
 
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
@@ -36,7 +37,9 @@ import com.xpn.xwiki.plugin.PluginApi;
  * 
  * @see PluginApi
  * @version $Id$
+ * @deprecated since 13.1RC1, see {@link TagScriptService} instead
  */
+@Deprecated
 public class TagPluginApi extends PluginApi<TagPlugin>
 {
     /** Logging helper object. */

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-tag/xwiki-platform-legacy-tag-api/src/main/java/com/xpn/xwiki/plugin/tag/TagQueryUtils.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-tag/xwiki-platform-legacy-tag-api/src/main/java/com/xpn/xwiki/plugin/tag/TagQueryUtils.java
@@ -41,7 +41,9 @@ import com.xpn.xwiki.web.Utils;
  *
  * @version $Id$
  * @since 5.0M1
+ * @deprecated since 13.1RC1, use {@link TagQueryService} instead
  */
+@Deprecated
 public final class TagQueryUtils
 {
     /**

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-tag/xwiki-platform-legacy-tag-api/src/test/java/com/xpn/xwiki/plugin/tag/TagParamUtilsTest.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-tag/xwiki-platform-legacy-tag-api/src/test/java/com/xpn/xwiki/plugin/tag/TagParamUtilsTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 
 import com.xpn.xwiki.XWikiException;
 
+import static org.junit.Assert.*;
 
 /**
  * Unit tests for {@link TagParamUtils}.
@@ -38,37 +39,39 @@ public class TagParamUtilsTest
     @Test
     public void spacesParameterToList() throws Exception
     {
-        Assert.assertThat(TagParamUtils.spacesParameterToList("'Space1','Space2'"),
-                Matchers.contains("Space1", "Space2"));
-        Assert.assertThat(TagParamUtils.spacesParameterToList("'Space1', 'Space 2',  'Apo''strophe'"),
-                Matchers.contains("Space1", "Space 2", "Apo'strophe"));
-        Assert.assertThat(TagParamUtils.spacesParameterToList("'single space'"),
-                Matchers.contains("single space"));
-        Assert.assertThat(TagParamUtils.spacesParameterToList(""),
-                Matchers.empty());
+        assertThat(TagParamUtils.spacesParameterToList("'Space1','Space2'"),
+            Matchers.contains("Space1", "Space2"));
+        assertThat(TagParamUtils.spacesParameterToList("'Space1', 'Space 2',  'Apo''strophe'"),
+            Matchers.contains("Space1", "Space 2", "Apo'strophe"));
+        assertThat(TagParamUtils.spacesParameterToList("'single space'"),
+            Matchers.contains("single space"));
+        assertThat(TagParamUtils.spacesParameterToList(""),
+            Matchers.empty());
     }
 
     @Test
     public void spacesParameterToListExceptions() throws XWikiException
     {
-	try {
-	    TagParamUtils.spacesParameterToList(null);
-	    Assert.fail("npe expected");
-	} catch (IllegalArgumentException expected) {}
+        try {
+            TagParamUtils.spacesParameterToList(null);
+            fail("npe expected");
+        } catch (IllegalArgumentException expected) {
+        }
 
-	try {
-	    TagParamUtils.spacesParameterToList("'space1','space2");
-	    Assert.fail("XWikiException expected");
-	} catch (XWikiException expected) {}
-	try {
-	    TagParamUtils.spacesParameterToList("'space1','space2',");
-	    Assert.fail("XWikiException expected");
-	} catch (XWikiException expected) {}
-	try {
-	    TagParamUtils.spacesParameterToList("'space1', or 'space2'");
-	    Assert.fail("XWikiException expected");
-	} catch (XWikiException expected) {}
+        try {
+            TagParamUtils.spacesParameterToList("'space1','space2");
+            fail("XWikiException expected");
+        } catch (XWikiException expected) {
+        }
+        try {
+            TagParamUtils.spacesParameterToList("'space1','space2',");
+            fail("XWikiException expected");
+        } catch (XWikiException expected) {
+        }
+        try {
+            TagParamUtils.spacesParameterToList("'space1', or 'space2'");
+            fail("XWikiException expected");
+        } catch (XWikiException expected) {
+        }
     }
-
-
 }

--- a/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/main/resources/XWiki/LiveTableResultsMacros.xml
+++ b/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/main/resources/XWiki/LiveTableResultsMacros.xml
@@ -290,7 +290,7 @@
   ##
   ## TagCloud matching the current filters
   ##
-  #set($tagsMatchingFilters = $xwiki.tag.getTagCountForQuery($tagsMatchingFiltersFrom, $tagsMatchingFiltersWhere, $tagsMatchingParams))
+  #set($tagsMatchingFilters = $services.tag.getTagCountForQuery($tagsMatchingFiltersFrom, $tagsMatchingFiltersWhere, $tagsMatchingParams))
   ## FIXME: We use a map just because the client expects an object, but all we really need is a list..
   #set($matchingTags = {})
   #foreach($tag in $tagsMatchingFilters.keySet())
@@ -301,7 +301,7 @@
   ##
   ## TagCloud matching all the documents used by the live table
   ##
-  #set($allMatchingTags = $xwiki.tag.getTagCountForQuery($allMatchingTagsFrom, $allMatchingTagsWhere, $allMatchingParams))
+  #set($allMatchingTags = $services.tag.getTagCountForQuery($allMatchingTagsFrom, $allMatchingTagsWhere, $allMatchingParams))
   ## FIXME: We use a list of maps just because the client expects an array, but we should simply return $allMatchingTags..
   #set($tags = [])
   #foreach($tag in $allMatchingTags.keySet())

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/checkstyle/checkstyle-suppressions.xml
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/checkstyle/checkstyle-suppressions.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ See the NOTICE file distributed with this work for additional
+  ~ information regarding copyright ownership.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<!DOCTYPE suppressions PUBLIC
+    "-//Puppy Crawl//DTD Suppressions 1.0//EN"
+    "http://www.puppycrawl.com/dtds/suppressions_1_0.dtd">
+
+<suppressions>
+  <suppress checks="MultipleStringLiterals" files="TagQueryManager.java"/>
+</suppressions>

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/org/xwiki/tag/TagException.java
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/org/xwiki/tag/TagException.java
@@ -1,0 +1,43 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.tag;
+
+import org.xwiki.stability.Unstable;
+
+/**
+ * Exception thrown by the tag module.
+ *
+ * @version $Id$
+ * @since 13.1RC1
+ */
+@Unstable
+public class TagException extends Exception
+{
+    /**
+     * Default constructor.
+     *
+     * @param message the exception message
+     * @param cause the cause of the exception
+     */
+    public TagException(String message, Exception cause)
+    {
+        super(message, cause);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/org/xwiki/tag/TagOperationResult.java
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/org/xwiki/tag/TagOperationResult.java
@@ -1,0 +1,44 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.tag;
+
+import org.xwiki.stability.Unstable;
+
+/**
+ * The result of a {@link TagScriptService} operation.
+ *
+ * @version $Id$
+ * @since 13.1RC1
+ */
+@Unstable
+public enum TagOperationResult
+{
+    /** The operation was successful, and data changes occurred. */
+    OK,
+
+    /** The operation did not change any data. */
+    NO_EFFECT,
+
+    /** The current user does not have permission to perform the operation. */
+    NOT_ALLOWED,
+
+    /** The operation failed with an exception. */
+    FAILED
+}

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/org/xwiki/tag/TagScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/org/xwiki/tag/TagScriptService.java
@@ -1,0 +1,323 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.tag;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.slf4j.Logger;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.EntityReferenceSerializer;
+import org.xwiki.model.reference.SpaceReference;
+import org.xwiki.script.service.ScriptService;
+import org.xwiki.security.authorization.ContextualAuthorizationManager;
+import org.xwiki.security.authorization.Right;
+import org.xwiki.stability.Unstable;
+import org.xwiki.tag.internal.TagDocumentManager;
+import org.xwiki.tag.internal.TagQueryManager;
+
+import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCauseMessage;
+
+/**
+ * This script service allows to manipulate tags easily. It allows to query, get, rename and delete tags.
+ *
+ * @version $Id$
+ * @since 13.1RC1
+ */
+@Component
+@Named("tag")
+@Singleton
+@Unstable
+public class TagScriptService implements ScriptService
+{
+    private static final Pattern LIKE_ESCAPE = Pattern.compile("[_%\\\\]");
+
+    private static final String LIKE_REPLACEMENT = "\\\\$0";
+
+    private static final String LIKE_APPEND = ".%";
+
+    @Inject
+    private Logger logger;
+
+    @Inject
+    private TagQueryManager tagQueryManager;
+
+    @Inject
+    private TagDocumentManager tagDocumentManager;
+
+    @Inject
+    private EntityReferenceSerializer<String> entityReferenceSerializer;
+
+    @Inject
+    private ContextualAuthorizationManager contextualAuthorization;
+
+    /**
+     * Get cardinality map of tags for a specific wiki space.
+     *
+     * @param space the space to get tags in
+     * @return map of tags with their occurrences counts
+     * @throws TagException if search query fails (possible failures: DB access problems, etc)
+     */
+    public Map<String, Integer> getTagCount(SpaceReference space) throws TagException
+    {
+        if (space != null) {
+            // Make sure to escape the LIKE syntax
+            String spaceReference = this.entityReferenceSerializer.serialize(space);
+            String escapedSpaceReference = LIKE_ESCAPE.matcher(spaceReference).replaceAll(LIKE_REPLACEMENT);
+
+            return getTagCountForQuery("", "(doc.space = ?1 OR doc.space LIKE ?2)",
+                Arrays.asList(spaceReference, escapedSpaceReference + LIKE_APPEND));
+        }
+
+        return getTagCountForQuery(null, null, (Map<String, ?>) null);
+    }
+
+    /**
+     * Get cardinality map of tags for list wiki spaces.
+     *
+     * @param spaces the list of space to get tags in, as a comma separated, quoted string
+     * @return map of tags with their occurrences counts
+     * @throws TagException if search query fails (possible failures: DB access problems, etc)
+     */
+    public Map<String, Integer> getTagCountForSpaces(List<SpaceReference> spaces) throws TagException
+    {
+        List<Object> queryParameters = new ArrayList<>();
+        StringBuilder where = new StringBuilder();
+        boolean first = true;
+        int parameterIndex = 1;
+        if (spaces == null) {
+            return getTagCountForQuery("", "", Collections.emptyList());
+        }
+        for (SpaceReference space : spaces) {
+            if (first) {
+                where.append("(");
+                first = false;
+            } else {
+                where.append(" OR ");
+            }
+            where.append("doc.space = ?");
+            where.append(parameterIndex++);
+            where.append(' ');
+            String spaceReference = this.entityReferenceSerializer.serialize(space);
+            queryParameters.add(spaceReference);
+
+            where.append("OR doc.space LIKE ?");
+            where.append(parameterIndex++);
+            String escapedSpaceReference = LIKE_ESCAPE
+                .matcher(spaceReference)
+                .replaceAll(LIKE_REPLACEMENT);
+            queryParameters.add(escapedSpaceReference + LIKE_APPEND);
+        }
+        // If first is true the "for" loop never ran, and spaces is empty so only close brace if first is false.
+        if (!first) {
+            where.append(')');
+        }
+
+        return getTagCountForQuery("", where.toString(), queryParameters);
+    }
+
+    /**
+     * Get cardinality map of tags matching an hql query (parameterized version). Example of usage:
+     * <ul>
+     * <li><code>
+     * $services.tag.getTagCountForQuery("", "doc.creator = :creator", {'creator' : "$!{request.creator}"})
+     * </code> will return the cardinality map of tags for documents created by user-provided creator name</li>
+     * </ul>
+     *
+     * @param from the from fragment of the query
+     * @param where the parameterized where fragment from the query
+     * @param parameters map of named parameters for the query
+     * @return map of tags with their occurrences counts
+     * @throws TagException if search query fails (possible failures: DB access problems, incorrect query
+     *     fragments).
+     */
+    public Map<String, Integer> getTagCountForQuery(String from, String where, Map<String, ?> parameters)
+        throws TagException
+    {
+        return this.tagQueryManager.getTagCountForQuery(from, where, parameters);
+    }
+
+    /**
+     * Get cardinality map of tags matching an hql query (parameterized version). Example of usage:
+     * <ul>
+     * <li><code>
+     * $services.tag.getTagCountForQuery("", "doc.creator = ?1", ["$!{request.creator}"])
+     * </code> will return the cardinality map of tags for documents created by user-provided creator name</li>
+     * </ul>
+     *
+     * @param from the from fragment of the query
+     * @param where the parameterized where fragment from the query
+     * @param parameterValues list of parameter values for the query
+     * @return map of tags with their occurrences counts
+     * @throws TagException if search query fails (possible failures: DB access problems, incorrect query
+     *     fragments).
+     */
+    public Map<String, Integer> getTagCountForQuery(String from, String where, List<?> parameterValues)
+        throws TagException
+    {
+        return this.tagQueryManager.getTagCountForQuery(from, where, parameterValues);
+    }
+
+    /**
+     * Get all the documents containing the given tag.
+     *
+     * @param tag tag to match
+     * @return list of pages
+     * @throws TagException if search query fails (possible failures: DB access problems, etc)
+     */
+    public List<String> getDocumentsWithTag(String tag) throws TagException
+    {
+        return this.tagQueryManager.getDocumentsWithTag(tag);
+    }
+
+    /**
+     * Count the document containing the given tag.
+     *
+     * @param tag the tag to match
+     * @return the count of document containing the given tag
+     * @throws TagException in case of error during the count
+     */
+    public Long countDocumentsWithTag(String tag) throws TagException
+    {
+        return this.tagQueryManager.countDocumentsWithTag(tag, false);
+    }
+
+    /**
+     * Get tags from a document.
+     *
+     * @param documentReference the document reference
+     * @return list of tags
+     * @throws TagException if document read fails (possible failures: insufficient rights, DB access problems,
+     *     etc).
+     */
+    public List<String> getTagsFromDocument(DocumentReference documentReference) throws TagException
+    {
+        return this.tagDocumentManager.getTagsFromDocument(documentReference);
+    }
+
+    /**
+     * Add a tag to a document. The document is saved (minor edit) after this operation.
+     *
+     * @param tag the tag to add to the document
+     * @param documentReference the reference of the target document
+     * @return the {@link TagOperationResult result} of the operation. {@link TagOperationResult#NO_EFFECT} is returned
+     *     only if all the tags were already set on the document, {@link TagOperationResult#OK} is returned even if only
+     *     some of the tags are new.
+     */
+    public TagOperationResult addTagToDocument(String tag, DocumentReference documentReference)
+    {
+        return addTagsToDocument(Arrays.asList(tag), documentReference);
+    }
+
+    /**
+     * Add a list of tags to a document. The document is saved (minor edit) after this operation.
+     *
+     * @param tags the tags to add to the document
+     * @param documentReference the reference of the target document
+     * @return the {@link TagOperationResult result} of the operation. {@link TagOperationResult#NO_EFFECT} is returned
+     *     only if all the tags were already set on the document, {@link TagOperationResult#OK} is returned even if only
+     *     some of the tags are new.
+     */
+    public TagOperationResult addTagsToDocument(List<String> tags, DocumentReference documentReference)
+    {
+        try {
+            if (!this.contextualAuthorization.hasAccess(Right.EDIT, documentReference)) {
+                return TagOperationResult.NOT_ALLOWED;
+            }
+            return this.tagDocumentManager.addTagsToDocument(tags, documentReference);
+        } catch (Exception e) {
+            this.logger.warn("Failed to add tag [{}] to document [{}]. Cause: [{}].", tags, documentReference,
+                getRootCauseMessage(e));
+            return TagOperationResult.FAILED;
+        }
+    }
+
+    /**
+     * Remove a tag from a document. The document is saved (minor edit) after this operation.
+     *
+     * @param tag tag to remove
+     * @param documentReference the reference of the document
+     * @return the {@link TagOperationResult result} of the operation
+     */
+    public TagOperationResult removeTagFromDocument(String tag, DocumentReference documentReference)
+    {
+        try {
+            if (!this.contextualAuthorization.hasAccess(Right.EDIT, documentReference)) {
+                return TagOperationResult.NOT_ALLOWED;
+            }
+            return this.tagDocumentManager.removeTagFromDocument(tag, documentReference);
+        } catch (Exception e) {
+            this.logger.warn("Failed to remove tag [{}] to document [{}]. Cause: [{}].", tag, documentReference,
+                getRootCauseMessage(e));
+            return TagOperationResult.FAILED;
+        }
+    }
+
+    /**
+     * Rename a tag in all the documents that contains it. Requires admin rights. Document containing this tag are saved
+     * (minor edit) during this operation.
+     *
+     * @param tag tag to rename
+     * @param newTag new tag
+     * @return the {@link TagOperationResult result} of the operation
+     */
+    public TagOperationResult renameTag(String tag, String newTag)
+    {
+        try {
+            if (!this.contextualAuthorization.hasAccess(Right.ADMIN)) {
+                return TagOperationResult.NOT_ALLOWED;
+            }
+            return this.tagDocumentManager.renameTag(tag, newTag);
+        } catch (Exception e) {
+            this.logger.warn("Failed to rename tag [{}] to [{}]. Cause: [{}].", tag, newTag,
+                getRootCauseMessage(e));
+            return TagOperationResult.FAILED;
+        }
+    }
+
+    /**
+     * Delete a tag from all the documents that contains it. Requires admin rights. Document containing this tag are
+     * saved (minor edit) during this operation.
+     *
+     * @param tag tag to delete
+     * @return the {@link TagOperationResult result} of the operation
+     */
+    public TagOperationResult deleteTag(String tag)
+    {
+        try {
+            if (!this.contextualAuthorization.hasAccess(Right.ADMIN)) {
+                return TagOperationResult.NOT_ALLOWED;
+            }
+            return this.tagDocumentManager.deleteTag(tag);
+        } catch (Exception e) {
+            this.logger.warn("Failed to remove tag [{}]. Cause: [{}].", tag, getRootCauseMessage(e));
+            return TagOperationResult.FAILED;
+        }
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/org/xwiki/tag/internal/TagDocumentManager.java
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/org/xwiki/tag/internal/TagDocumentManager.java
@@ -1,0 +1,393 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.tag.internal;
+
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.localization.ContextualLocalizationManager;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.DocumentReferenceResolver;
+import org.xwiki.tag.TagException;
+import org.xwiki.tag.TagOperationResult;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.objects.BaseObject;
+import com.xpn.xwiki.objects.BaseProperty;
+import com.xpn.xwiki.objects.ListProperty;
+import com.xpn.xwiki.objects.PropertyInterface;
+import com.xpn.xwiki.objects.classes.BaseClass;
+import com.xpn.xwiki.objects.classes.PropertyClass;
+
+import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCauseMessage;
+import static org.xwiki.tag.TagOperationResult.NO_EFFECT;
+import static org.xwiki.tag.TagOperationResult.OK;
+
+/**
+ * Provides the operation to manipulate the Tag XObjects attached to documents.
+ *
+ * @version $Id$
+ * @since 13.1RC1
+ */
+@Component(roles = { TagDocumentManager.class })
+@Singleton
+public class TagDocumentManager
+{
+    /**
+     * The XClass of the Tag objects.
+     */
+    public static final String XWIKI_TAG_CLASS = "XWiki.TagClass";
+
+    /**
+     * The name of the field that holds the tag names in the TagClass XClass.
+     */
+    public static final String TAGS_FIELD_NAME = "tags";
+
+    private static final String DOC_COMMENT_TAG_ADDED = "plugin.tag.editcomment.added";
+
+    private static final String DOC_COMMENT_TAG_REMOVED = "plugin.tag.editcomment.removed";
+
+    private static final String DOC_COMMENT_TAG_RENAMED = "plugin.tag.editcomment.renamed";
+
+    @Inject
+    private Logger logger;
+
+    @Inject
+    private Provider<XWikiContext> xcontextProvider;
+
+    @Inject
+    private ContextualLocalizationManager contextualLocalizationManager;
+
+    @Inject
+    private DocumentReferenceResolver<String> documentReferenceResolver;
+
+    @Inject
+    private TagQueryManager tagQueryManager;
+
+    /**
+     * Returns the list of tags of a document.
+     *
+     * @param documentReference the document reference of the document
+     * @return the list of tags of the document
+     * @throws TagException in case of error when loading the document from its reference
+     */
+    public List<String> getTagsFromDocument(DocumentReference documentReference) throws TagException
+    {
+        XWikiDocument document = loadDocument(documentReference);
+        return getTagsFromDocument(document);
+    }
+
+    /**
+     * Update the list of tags of a document with a list of possibly new tags. Tags are only added if the document is
+     * not already tagged with them. The case is ignored when looking for existing tags.
+     *
+     * @param tags the list of tags to add
+     * @param documentReference the document reference of the document to update
+     * @return {@link TagOperationResult#OK} if at least one tag was added to the document, {@link
+     *     TagOperationResult#NO_EFFECT} otherwise
+     * @throws TagException in case of error when loading or saving the document
+     */
+    public TagOperationResult addTagsToDocument(List<String> tags, DocumentReference documentReference)
+        throws TagException
+    {
+        XWikiDocument document = loadDocument(documentReference);
+        List<String> documentTags = getTagsFromDocument(document);
+
+        boolean newTags = false;
+        for (String tag : tags) {
+            if (!StringUtils.isBlank(tag) && !containsIgnoreCase(documentTags, tag)) {
+                documentTags.add(tag);
+                newTags = true;
+            }
+        }
+
+        if (newTags) {
+            setDocumentTags(document, documentTags);
+            String joinedTags = StringUtils.join(documentTags, ", ");
+            String comment = this.contextualLocalizationManager.getTranslationPlain(DOC_COMMENT_TAG_ADDED, joinedTags);
+
+            // Since we're changing the document we need to set the new author.
+            document.setAuthorReference(this.xcontextProvider.get().getUserReference());
+
+            XWikiContext context = this.xcontextProvider.get();
+            try {
+                context.getWiki().saveDocument(document, comment, true, context);
+            } catch (XWikiException e) {
+                throw new TagException(
+                    MessageFormat.format("Failed to save the document after adding tags [{0}]", joinedTags), e);
+            }
+
+            return OK;
+        }
+
+        return NO_EFFECT;
+    }
+
+    /**
+     * Remove a tag from a document. Nothing is done if the tag is not found (the case is not relevant).
+     *
+     * @param tag the to remove
+     * @param documentReference the document reference of the document to update
+     * @return {@link TagOperationResult#OK} if the tag was actually removed, {@link TagOperationResult#NO_EFFECT} if
+     *     the tag was not found in the document
+     * @throws TagException in case of error when loading or saving the document
+     */
+    public TagOperationResult removeTagFromDocument(String tag, DocumentReference documentReference) throws TagException
+    {
+        return removeTagFromDocument(tag, loadDocument(documentReference));
+    }
+
+    /**
+     * @param tag the tag to delete
+     * @return {@link TagOperationResult#OK} if the tag was deleted from all the document
+     * @throws TagException in case of error when retrieving or saving the documents containing the delete tag
+     */
+    public TagOperationResult deleteTag(String tag) throws TagException
+    {
+        // Since we're deleting a tag, we want to delete it even if the document is hidden. A hidden document is still
+        // accessible to users, it's just not visible for simple users; it doesn't change permissions.
+        List<String> docsToProcess = this.tagQueryManager.getDocumentsWithTag(tag, true);
+        if (docsToProcess.isEmpty()) {
+            return NO_EFFECT;
+        }
+
+        boolean hadEffectOnOneDoc = false;
+        boolean someStepFailed = false;
+        for (String docName : docsToProcess) {
+            try {
+                TagOperationResult tagOperationResult =
+                    removeTagFromDocument(tag, this.documentReferenceResolver.resolve(docName));
+                hadEffectOnOneDoc = tagOperationResult == OK;
+            } catch (TagException e) {
+                // Continue even if one document failed.
+                this.logger.warn("Failed to remove tag [{}] on document [{}]. Cause: [{}].", tag, docName,
+                    getRootCauseMessage(e));
+                someStepFailed = true;
+            }
+        }
+        if (someStepFailed) {
+            return TagOperationResult.FAILED;
+        } else if (hadEffectOnOneDoc) {
+            return OK;
+        } else {
+            return NO_EFFECT;
+        }
+    }
+
+    /**
+     * Rename a tag. If a document already contains the new tag, the tag with the old name is simply removed. Otherwise,
+     * the old tag is renamed to the new one.
+     *
+     * @param tag the current name of the tag
+     * @param newTag the new name of the tag
+     * @return {@link TagOperationResult#OK} if the operation completed successfully, {@link
+     *     TagOperationResult#NO_EFFECT} if no page contains the tag to rename
+     * @throws TagException in case of error when loading or updating the pages containing the tag to rename
+     */
+    public TagOperationResult renameTag(String tag, String newTag) throws TagException
+    {
+        // Since we're renaming a tag, we want to rename it even if the document is hidden. A hidden document is still
+        // accessible to users, it's just not visible for simple users; it doesn't change permissions.
+        List<String> docNamesToProcess = this.tagQueryManager.getDocumentsWithTag(tag, true);
+        if (StringUtils.equals(tag, newTag) || docNamesToProcess.isEmpty() || StringUtils.isBlank(newTag)) {
+            return NO_EFFECT;
+        }
+
+        XWikiContext context = this.xcontextProvider.get();
+
+        for (String docName : docNamesToProcess) {
+            XWikiDocument doc = loadDocument(this.documentReferenceResolver.resolve(docName));
+            List<String> tags = getTagsFromDocument(doc);
+
+            if (tags.stream().anyMatch(it -> it.equalsIgnoreCase(newTag))) {
+                // The new tag might already be present in the document, in this case we just need to remove the old one
+                removeTagFromDocument(tag, doc);
+            } else {
+                for (int i = 0; i < tags.size(); i++) {
+                    if (tags.get(i).equalsIgnoreCase(tag)) {
+                        tags.set(i, newTag);
+                    }
+                }
+                setDocumentTags(doc, tags);
+
+                // Since we're changing the document we need to set the new author
+                doc.setAuthorReference(context.getUserReference());
+
+                String comment =
+                    this.contextualLocalizationManager.getTranslationPlain(DOC_COMMENT_TAG_RENAMED, tag, newTag);
+                try {
+                    context.getWiki().saveDocument(doc, comment, true, context);
+                } catch (XWikiException e) {
+                    throw new TagException(
+                        MessageFormat
+                            .format("Failed to save document [{0}] while renaming tag [{1}] to [{2}]", docName, tag,
+                                newTag), e);
+                }
+            }
+        }
+
+        return OK;
+    }
+
+    private TagOperationResult removeTagFromDocument(String tag, XWikiDocument document) throws TagException
+    {
+        List<String> tags = getTagsFromDocument(document);
+
+        List<String> newTags = tags.stream().filter(it2 -> !it2.equalsIgnoreCase(tag)).collect(Collectors.toList());
+        boolean needsUpdate = tags.size() > newTags.size();
+
+        if (needsUpdate) {
+            setDocumentTags(document, newTags);
+            String comment = this.contextualLocalizationManager.getTranslationPlain(DOC_COMMENT_TAG_REMOVED, tag);
+
+            // Since we're changing the document we need to set the new author
+            XWikiContext context = this.xcontextProvider.get();
+            document.setAuthorReference(context.getUserReference());
+
+            try {
+                context.getWiki().saveDocument(document, comment, true, context);
+            } catch (XWikiException e) {
+                throw new TagException(
+                    MessageFormat.format("Failed to save the document after removing tag [{0}]", tag), e);
+            }
+
+            return OK;
+        } else {
+            // Document doesn't contain this tag.
+            return NO_EFFECT;
+        }
+    }
+
+    private List<String> getTagsFromDocument(XWikiDocument document) throws TagException
+    {
+        return getTagListFromObject(getTagObject(document, false));
+    }
+
+    private List<String> getTagListFromObject(BaseObject tagObject) throws TagException
+    {
+        if (tagObject == null) {
+            return new ArrayList<>();
+        }
+        try {
+            List<String> tagList;
+            PropertyInterface propertyInterface = tagObject.get(TAGS_FIELD_NAME);
+            if (propertyInterface == null) {
+                tagList = new ArrayList<>();
+            } else {
+                // It is important that the returned list is not the same instance as the list of the tags field, 
+                // otherwise we are at risk to see it modified (persistently) by the caller (e.g., a velocity template).
+                tagList = new ArrayList<>((List<String>) ((ListProperty) propertyInterface).getValue());
+            }
+            return tagList;
+        } catch (XWikiException e) {
+            throw new TagException(String.format("Failed to get the tags list of [%s]", tagObject), e);
+        }
+    }
+
+    private BaseObject getTagObject(XWikiDocument document, boolean create)
+    {
+        return document.getXObject(getTagXClassReference(), create, this.xcontextProvider.get());
+    }
+
+    private XWikiDocument loadDocument(DocumentReference documentReference) throws TagException
+    {
+        try {
+            return this.xcontextProvider.get().getWiki().getDocument(documentReference, this.xcontextProvider.get());
+        } catch (XWikiException e) {
+            throw new TagException(
+                String.format("Failed to load a document from the document reference [%s]", documentReference),
+                e);
+        }
+    }
+
+    /**
+     * @param collection a collection of strings
+     * @param item a string
+     * @return {@code true} if there is an item in the given collection that equals ignoring case the given string
+     */
+    private boolean containsIgnoreCase(List<String> collection, String item)
+    {
+        for (String existingItem : collection) {
+            if (existingItem.equalsIgnoreCase(item)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Set tags of the given document.
+     *
+     * @param document document to put the tags to.
+     * @param tags list of tags.
+     */
+    private void setDocumentTags(XWikiDocument document, List<String> tags) throws TagException
+    {
+        BaseObject tagObject = getTagObject(document, true);
+
+        try {
+            BaseProperty baseProperty = (BaseProperty) tagObject.get(TAGS_FIELD_NAME);
+            if (baseProperty == null) {
+                baseProperty = createTagProperty(tagObject);
+            }
+
+            baseProperty.setValue(tags);
+        } catch (XWikiException e) {
+            throw new TagException(
+                String.format("Failed to access the field [%s] of object [%s]", TAGS_FIELD_NAME, tagObject),
+                e);
+        }
+    }
+
+    private BaseProperty createTagProperty(BaseObject tagObject) throws TagException
+    {
+        try {
+            BaseClass tagClass =
+                this.xcontextProvider.get().getWiki().getXClass(getTagXClassReference(), this.xcontextProvider.get());
+            PropertyClass tagPropertyDefinition = (PropertyClass) tagClass.getField(TAGS_FIELD_NAME);
+            BaseProperty tagProperty = tagPropertyDefinition.newProperty();
+
+            tagProperty.setName(TAGS_FIELD_NAME);
+            tagProperty.setObject(tagObject);
+
+            tagObject.put(TAGS_FIELD_NAME, tagProperty);
+            return tagProperty;
+        } catch (XWikiException e) {
+            throw new TagException(String.format("Failed to initialize field [%s] on [%s]", TAGS_FIELD_NAME, tagObject),
+                e);
+        }
+    }
+
+    private DocumentReference getTagXClassReference()
+    {
+        return new DocumentReference(this.xcontextProvider.get().getWikiId(), "XWiki", "TagClass");
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/org/xwiki/tag/internal/TagQueryManager.java
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/org/xwiki/tag/internal/TagQueryManager.java
@@ -1,0 +1,356 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.tag.internal;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.apache.commons.lang3.StringUtils;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.DocumentReferenceResolver;
+import org.xwiki.query.Query;
+import org.xwiki.query.QueryException;
+import org.xwiki.query.QueryFilter;
+import org.xwiki.query.QueryManager;
+import org.xwiki.query.internal.HiddenDocumentFilter;
+import org.xwiki.query.internal.UniqueDocumentFilter;
+import org.xwiki.tag.TagException;
+
+import static com.xpn.xwiki.XWikiConstant.TAG_CLASS;
+import static org.xwiki.query.Query.HQL;
+import static org.xwiki.tag.internal.TagDocumentManager.TAGS_FIELD_NAME;
+import static org.xwiki.tag.internal.TagDocumentManager.XWIKI_TAG_CLASS;
+
+/**
+ * This class provides the services to query and manipulate the page's tags.
+ *
+ * @version $Id$
+ * @since 13.1RC1
+ */
+@Component(roles = { TagQueryManager.class })
+@Singleton
+public class TagQueryManager
+{
+    private static final String QUERY_TAG_BIND = "tag";
+
+    @Inject
+    private QueryManager queryManager;
+
+    @Inject
+    private DocumentReferenceResolver<String> documentReferenceResolver;
+
+    @Inject
+    @Named(HiddenDocumentFilter.HINT)
+    private QueryFilter hiddenDocumentQueryFilter;
+
+    @Inject
+    @Named(UniqueDocumentFilter.HINT)
+    private QueryFilter uniqueDocumentQueryFilter;
+
+    /**
+     * Count the number of pages with the provided tag.
+     *
+     * @param tag the tag
+     * @return the number of pages with the provided tag
+     * @throws TagException in case of error during the query
+     */
+    public long countPages(String tag) throws TagException
+    {
+        try {
+            String statement = initQuery(tag, "select count(doc.fullName) ");
+            Query query = this.queryManager.createQuery(statement, HQL);
+            if (tag != null) {
+                query = query.bindValue(QUERY_TAG_BIND, tag);
+            }
+            List<Long> execute = query.execute();
+            return execute.get(0);
+        } catch (QueryException e) {
+            throw new TagException(String.format("Failed to count the number of documents with tag [%s]", tag), e);
+        }
+    }
+
+    /**
+     * Returns a paginated list of {@link DocumentReference} with the provided tag.
+     *
+     * @param tag the tag
+     * @param limit the pagination limit
+     * @param offset the pagination offset
+     * @return the paginated list of {@link DocumentReference} with the provided tag
+     * @throws TagException in case of error during the query
+     */
+    public List<DocumentReference> getPages(String tag, Integer limit, Integer offset) throws TagException
+    {
+        try {
+            String statement = initQuery(tag, "select doc.fullName ");
+            Query query = this.queryManager.createQuery(statement, HQL);
+            if (tag != null) {
+                query = query.bindValue(QUERY_TAG_BIND, tag);
+            }
+            return query
+                .addFilter(this.hiddenDocumentQueryFilter)
+                .setLimit(limit)
+                .setOffset(offset)
+                .<String>execute()
+                .stream()
+                .map(it -> this.documentReferenceResolver.resolve(it))
+                .collect(Collectors.toList());
+        } catch (QueryException e) {
+            throw new TagException(
+                String.format("Failed to get the documents with tag [%s], limit [%s], offset [%s]", tag, limit, offset),
+                e);
+        }
+    }
+
+    /**
+     * Get all tags within the wiki.
+     *
+     * @return list of tags (alphabetical order).
+     * @throws TagException if search query fails (possible failures: DB access problems, etc).
+     */
+    public List<String> getAllTags() throws TagException
+    {
+        String hql =
+            "select distinct elements(prop.list) "
+                + "from XWikiDocument as doc, "
+                + "BaseObject as obj, "
+                + "DBStringListProperty as prop "
+                + "where obj.name = doc.fullName "
+                + "and obj.className='" + XWIKI_TAG_CLASS + "' "
+                + "and obj.id = prop.id.id "
+                + "and prop.id.name='" + TAGS_FIELD_NAME + "'";
+
+        try {
+            Query query = this.queryManager.createQuery(hql, Query.HQL);
+            query.addFilter(this.hiddenDocumentQueryFilter);
+            List<String> results = query.execute();
+            results.sort(String.CASE_INSENSITIVE_ORDER);
+            return results;
+        } catch (QueryException e) {
+            throw new TagException(String.format("Failed to get all tags for query [%s]", hql), e);
+        }
+    }
+
+    /**
+     * Get cardinality map of tags matching a parameterized hql query.
+     *
+     * @param fromHql the <code>from</code> fragment of the hql query
+     * @param whereHql the <code>where</code> fragment of the hql query
+     * @param parameterValues list of parameter values for the query
+     * @return map of tags (alphabetical order) with their occurrences counts.
+     * @throws TagException if search query fails (possible failures: DB access problems, etc).
+     * @see #getTagCountForQuery(String, String, List
+     */
+    public Map<String, Integer> getTagCountForQuery(String fromHql, String whereHql, List<?> parameterValues)
+        throws TagException
+    {
+        return getTagCountForQuery(fromHql, whereHql, (Object) parameterValues);
+    }
+
+    /**
+     * Get cardinality map of tags matching a parameterized hql query.
+     *
+     * @param fromHql the <code>from</code> fragment of the hql query
+     * @param whereHql the <code>where</code> fragment of the hql query
+     * @param parameters map of named parameters for the query
+     * @return map of tags (alphabetical order) with their occurrences counts.
+     * @throws TagException if search query fails (possible failures: DB access problems, etc).
+     * @see #getTagCountForQuery(String, String, Map
+     */
+    public Map<String, Integer> getTagCountForQuery(String fromHql, String whereHql, Map<String, ?> parameters)
+        throws TagException
+    {
+        return getTagCountForQuery(fromHql, whereHql, (Object) parameters);
+    }
+
+    private Map<String, Integer> getTagCountForQuery(String fromHql, String whereHql, Object parameters)
+        throws TagException
+    {
+        List<String> results;
+
+        String from = "select elements(prop.list) "
+            + "from XWikiDocument as doc, "
+            + "BaseObject as tagobject, "
+            + "DBStringListProperty as prop";
+        String where = " where tagobject.name = doc.fullName "
+            + "and tagobject.className='" + XWIKI_TAG_CLASS + "' "
+            + "and tagobject.id = prop.id.id "
+            + "and prop.id.name='" + TAGS_FIELD_NAME + "' "
+            + "and doc.translation = 0";
+
+        // If at least one of the fragments is passed, the query should be matching XWiki documents
+        if (!StringUtils.isBlank(fromHql) || !StringUtils.isBlank(whereHql)) {
+            from += fromHql;
+        }
+        if (!StringUtils.isBlank(whereHql)) {
+            where += " and " + whereHql;
+        }
+
+        String hql = from + where;
+
+        try {
+            Query query = this.queryManager.createQuery(hql, Query.HQL);
+            if (parameters != null) {
+                if (parameters instanceof Map) {
+                    query.bindValues((Map) parameters);
+                } else {
+                    query.bindValues((List) parameters);
+                }
+            }
+            query.addFilter(this.hiddenDocumentQueryFilter);
+            results = query.execute();
+        } catch (QueryException e) {
+            throw new TagException(
+                String.format("Failed to get tag count for query [%s], with parameters [%s]", hql, parameters), e);
+        }
+
+        results.sort(String.CASE_INSENSITIVE_ORDER);
+
+        Map<String, String> processedTags = new HashMap<>();
+        Map<String, Integer> tagCount = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+        // We have to manually build a cardinality map since we have to ignore tags case.
+        for (String result : results) {
+            // This key allows to keep track of the case variants we've encountered.
+            String lowerTag = result.toLowerCase();
+
+            // We store the first case variant to reuse it in the final result set.
+            if (!processedTags.containsKey(lowerTag)) {
+                processedTags.put(lowerTag, result);
+            }
+
+            String tagCountKey = processedTags.get(lowerTag);
+            int tagCountForTag = 0;
+            if (tagCount.get(tagCountKey) != null) {
+                tagCountForTag = tagCount.get(tagCountKey);
+            }
+            tagCount.put(tagCountKey, tagCountForTag + 1);
+        }
+
+        return tagCount;
+    }
+
+    /**
+     * Get non-hidden documents with the passed tags.
+     *
+     * @param tag a list of tags to match.
+     * @return list of docNames.
+     * @throws TagException if search query fails (possible failures: DB access problems, etc).
+     */
+    public List<String> getDocumentsWithTag(String tag) throws TagException
+    {
+        return getDocumentsWithTag(tag, false);
+    }
+
+    /**
+     * Get documents with the passed tags with the result depending on whether the caller decides to include hidden
+     * documents or not.
+     *
+     * @param tag a list of tags to match.
+     * @param includeHiddenDocuments if {@code true} then include hidden documents
+     * @return list of docNames.
+     * @throws TagException if search query fails (possible failures: DB access problems, etc).
+     */
+    public List<String> getDocumentsWithTag(String tag, boolean includeHiddenDocuments)
+        throws TagException
+    {
+        String hql = ", BaseObject as obj, "
+            + "DBStringListProperty as prop join prop.list item "
+            + "where obj.className = :className "
+            + "and obj.name = doc.fullName "
+            + "and obj.id = prop.id.id "
+            + "and prop.id.name='" + TAGS_FIELD_NAME + "' "
+            + "and lower(item) = lower(:item) "
+            + "order by doc.fullName";
+
+        try {
+            Query query = this.queryManager.createQuery(hql, Query.HQL);
+            query.bindValue("className", TAG_CLASS);
+            query.bindValue("item", tag);
+            query.addFilter(this.uniqueDocumentQueryFilter);
+            if (!includeHiddenDocuments) {
+                query.addFilter(this.hiddenDocumentQueryFilter);
+            }
+
+            return query.execute();
+        } catch (QueryException e) {
+            throw new TagException(String.format("Failed to search for document with tag [%s]", tag), e);
+        }
+    }
+
+    /**
+     * Count the number of documents with the given tag.
+     *
+     * @param tag tag tag
+     * @param includeHiddenDocuments if {@code true} then include hidden documents
+     * @return the number of document with the given tag.
+     * @throws TagException in case of error during the query execution
+     */
+    public Long countDocumentsWithTag(String tag, boolean includeHiddenDocuments) throws TagException
+    {
+        String hql = "select count(doc.fullName) "
+            + "from XWikiDocument as doc, " 
+            + "BaseObject as obj, "
+            + "DBStringListProperty as prop join prop.list item "
+            + "where obj.name = doc.fullName " 
+            + "and obj.className = :className "
+            + "and obj.name = doc.fullName "
+            + "and obj.id = prop.id.id "
+            + "and prop.id.name='" + TAGS_FIELD_NAME + "' "
+            + "and lower(item) = lower(:item)";
+
+        try {
+            Query query = this.queryManager.createQuery(hql, Query.HQL);
+            query.bindValue("className", TAG_CLASS);
+            query.bindValue("item", tag);
+            query.addFilter(this.uniqueDocumentQueryFilter);
+            if (!includeHiddenDocuments) {
+                query.addFilter(this.hiddenDocumentQueryFilter);
+            }
+
+            return query.<Long>execute().get(0);
+        } catch (QueryException e) {
+            throw new TagException(String.format("Failed to search for document with tag [%s]", tag), e);
+        }
+    }
+
+    private String initQuery(String tag, String s)
+    {
+        String statement = s
+            + "from XWikiDocument as  doc, "
+            + "BaseObject as tagobject, "
+            + "DBStringListProperty as tagsproperty "
+            + "where tagobject.name=doc.fullName "
+            + "and tagobject.className='" + XWIKI_TAG_CLASS + "' "
+            + "and tagsproperty.id=tagobject.id.id "
+            + "and tagsproperty.id.name='" + TAGS_FIELD_NAME + "' "
+            + "and doc.translation=0 ";
+        if (tag != null) {
+            statement = statement + "and :tag IN elements(tagsproperty.list)";
+        }
+        return statement;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/org/xwiki/tag/internal/livedata/TaggedDocumentLiveDataConfigurationProvider.java
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/org/xwiki/tag/internal/livedata/TaggedDocumentLiveDataConfigurationProvider.java
@@ -17,25 +17,36 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
+package org.xwiki.tag.internal.livedata;
 
-package com.xpn.xwiki.plugin.tag;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.livedata.LiveDataConfiguration;
+import org.xwiki.livedata.LiveDataQuery;
 
 /**
- * The result of a {@link TagPlugin} operation.
- * 
+ * Live data configuration for the tag.
+ *
  * @version $Id$
+ * @since 13.1RC1
  */
-public enum TagOperationResult
+@Component
+@Named("taggedDocument")
+@Singleton
+public class TaggedDocumentLiveDataConfigurationProvider implements Provider<LiveDataConfiguration>
 {
-    /** The operation was successful, and data changes occurred. */
-    OK,
-
-    /** The operation did not change any data. */
-    NO_EFFECT,
-
-    /** The current user does not have permission to perform the operation. */
-    NOT_ALLOWED,
-
-    /** The operation failed with an exception. */
-    FAILED
+    @Override
+    public LiveDataConfiguration get()
+    {
+        LiveDataConfiguration liveDataConfiguration = new LiveDataConfiguration();
+        LiveDataQuery query = new LiveDataQuery();
+        LiveDataQuery.Source source = new LiveDataQuery.Source();
+        source.setId("tag");
+        query.setSource(source);
+        liveDataConfiguration.setQuery(query);
+        return liveDataConfiguration;
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/org/xwiki/tag/internal/livedata/TaggedDocumentLiveDataConfigurationResolver.java
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/org/xwiki/tag/internal/livedata/TaggedDocumentLiveDataConfigurationResolver.java
@@ -1,0 +1,84 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.tag.internal.livedata;
+
+import java.util.Arrays;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.livedata.LiveDataConfiguration;
+import org.xwiki.livedata.LiveDataConfigurationResolver;
+import org.xwiki.livedata.LiveDataException;
+import org.xwiki.livedata.LiveDataMeta;
+import org.xwiki.livedata.LiveDataPropertyDescriptor;
+
+import static org.xwiki.livedata.LiveDataPropertyDescriptor.DisplayerDescriptor;
+
+/**
+ * Provides the tag live data configuration.
+ *
+ * @version $Id$
+ * @since 13.1RC1
+ */
+@Component
+@Named(TaggedDocumentLiveDataConfigurationResolver.HINT)
+@Singleton
+public class TaggedDocumentLiveDataConfigurationResolver implements LiveDataConfigurationResolver<LiveDataConfiguration>
+{
+    /**
+     * This component's hint.
+     */
+    public static final String HINT = "taggedDocument";
+
+    @Inject
+    @Named(HINT)
+    private Provider<LiveDataConfiguration> defaultConfigProvider;
+
+    @Override
+    public LiveDataConfiguration resolve(LiveDataConfiguration input) throws LiveDataException
+    {
+        LiveDataConfiguration liveDataConfiguration = this.defaultConfigProvider.get();
+        liveDataConfiguration.setQuery(input.getQuery());
+
+        LiveDataPropertyDescriptor liveDataPropertyDescriptor = new LiveDataPropertyDescriptor();
+        liveDataPropertyDescriptor.setId("page");
+        DisplayerDescriptor linkDisplayer = new DisplayerDescriptor("link");
+        linkDisplayer.setParameter("propertyHref", "page_link");
+        liveDataPropertyDescriptor.setDisplayer(linkDisplayer);
+        liveDataPropertyDescriptor.setSortable(false);
+        liveDataPropertyDescriptor.setEditable(false);
+        liveDataPropertyDescriptor.setVisible(true);
+        liveDataPropertyDescriptor.setFilterable(false);
+        liveDataPropertyDescriptor.setName("Page");
+        liveDataPropertyDescriptor.setType("document");
+
+        LiveDataMeta meta = new LiveDataMeta();
+        liveDataConfiguration.setMeta(meta);
+        meta.setPropertyDescriptors(Arrays.asList(
+            liveDataPropertyDescriptor
+        ));
+
+        return liveDataConfiguration;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/org/xwiki/tag/internal/livedata/TaggedDocumentLiveDataEntryStore.java
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/org/xwiki/tag/internal/livedata/TaggedDocumentLiveDataEntryStore.java
@@ -1,0 +1,107 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.tag.internal.livedata;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+
+import org.slf4j.Logger;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.annotation.InstantiationStrategy;
+import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
+import org.xwiki.livedata.LiveData;
+import org.xwiki.livedata.LiveDataEntryStore;
+import org.xwiki.livedata.LiveDataException;
+import org.xwiki.livedata.LiveDataQuery;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.tag.TagException;
+import org.xwiki.tag.internal.TagQueryManager;
+
+import com.xpn.xwiki.XWiki;
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiDocument;
+
+import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCauseMessage;
+
+/**
+ * Provides the paginated list of tags for a given page.
+ *
+ * @version $Id$
+ * @since 13.1RC1
+ */
+@Component
+@Named("taggedDocument")
+@InstantiationStrategy(ComponentInstantiationStrategy.PER_LOOKUP)
+public class TaggedDocumentLiveDataEntryStore implements LiveDataEntryStore
+{
+    @Inject
+    private TagQueryManager tagQueryManager;
+
+    @Inject
+    private Provider<XWikiContext> xcontextProvider;
+
+    @Inject
+    private Logger logger;
+
+    @Override
+    public Optional<Map<String, Object>> get(Object entryId) throws LiveDataException
+    {
+        return Optional.empty();
+    }
+
+    @Override
+    public LiveData get(LiveDataQuery query) throws LiveDataException
+    {
+        LiveData liveData = new LiveData();
+        String tag = (String) query.getSource().getParameters().getOrDefault("tag", null);
+        try {
+            liveData.setCount(this.tagQueryManager.countPages(tag));
+            List<DocumentReference> pages =
+                this.tagQueryManager.getPages(tag, query.getLimit(), query.getOffset().intValue());
+
+            XWikiContext context = this.xcontextProvider.get();
+            XWiki wiki = context.getWiki();
+            liveData.getEntries().addAll(pages.stream().map(page -> {
+                Map<String, Object> entry = new HashMap<>();
+                try {
+                    XWikiDocument document = wiki.getDocument(page, context);
+                    entry.put("page", document.getRenderedTitle(context));
+                    entry.put("page_link", wiki.getURL(page, context));
+                } catch (XWikiException e) {
+                    this.logger.warn("Failed to initialize the live table entry for the page [{}]. Cause: [{}].", page,
+                        getRootCauseMessage(e));
+                }
+
+                return entry;
+            }).collect(Collectors.toList()));
+            return liveData;
+        } catch (TagException e) {
+            throw new LiveDataException(e);
+        }
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/org/xwiki/tag/internal/livedata/TaggedDocumentLiveDataPropertyDescriptorStore.java
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/org/xwiki/tag/internal/livedata/TaggedDocumentLiveDataPropertyDescriptorStore.java
@@ -1,0 +1,50 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.tag.internal.livedata;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import javax.inject.Named;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.annotation.InstantiationStrategy;
+import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
+import org.xwiki.livedata.LiveDataException;
+import org.xwiki.livedata.LiveDataPropertyDescriptor;
+import org.xwiki.livedata.LiveDataPropertyDescriptorStore;
+
+/**
+ * {@link LiveDataPropertyDescriptorStore} implementation that exposes the known tag live data columns.
+ *
+ * @version $Id$
+ * @since 13.0RC1
+ */
+@Component
+@Named("taggedDocument")
+@InstantiationStrategy(ComponentInstantiationStrategy.PER_LOOKUP)
+public class TaggedDocumentLiveDataPropertyDescriptorStore implements LiveDataPropertyDescriptorStore
+{
+    @Override
+    public Collection<LiveDataPropertyDescriptor> get() throws LiveDataException
+    {
+        return Collections.emptyList();
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/org/xwiki/tag/internal/livedata/TaggedDocumentLiveDataSource.java
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/org/xwiki/tag/internal/livedata/TaggedDocumentLiveDataSource.java
@@ -1,0 +1,68 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.tag.internal.livedata;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.annotation.InstantiationStrategy;
+import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
+import org.xwiki.livedata.LiveDataEntryStore;
+import org.xwiki.livedata.LiveDataPropertyDescriptorStore;
+import org.xwiki.livedata.LiveDataSource;
+
+/**
+ * Live data source for the tagged document table.
+ *
+ * @version $Id$
+ * @since 13.1RC1
+ */
+@Component
+@Named(TaggedDocumentLiveDataSource.HINT)
+@InstantiationStrategy(ComponentInstantiationStrategy.PER_LOOKUP)
+public class TaggedDocumentLiveDataSource implements LiveDataSource
+{
+    /**
+     * The tagged document live table hint.
+     */
+    public static final String HINT = "taggedDocument";
+
+    @Inject
+    @Named("taggedDocument")
+    private LiveDataEntryStore entryStore;
+
+    @Inject
+    @Named("taggedDocument")
+    private LiveDataPropertyDescriptorStore propertyStore;
+
+
+    @Override
+    public LiveDataEntryStore getEntries()
+    {
+        return this.entryStore;
+    }
+
+    @Override
+    public LiveDataPropertyDescriptorStore getProperties()
+    {
+        return this.propertyStore;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/resources/META-INF/components.txt
@@ -1,0 +1,8 @@
+org.xwiki.tag.TagScriptService
+org.xwiki.tag.internal.TagDocumentManager
+org.xwiki.tag.internal.TagQueryManager
+org.xwiki.tag.internal.livedata.TaggedDocumentLiveDataEntryStore
+org.xwiki.tag.internal.livedata.TaggedDocumentLiveDataPropertyDescriptorStore
+org.xwiki.tag.internal.livedata.TaggedDocumentLiveDataSource
+org.xwiki.tag.internal.livedata.TaggedDocumentLiveDataConfigurationResolver
+org.xwiki.tag.internal.livedata.TaggedDocumentLiveDataConfigurationProvider

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/test/java/org/xwiki/tag/TagScriptServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/test/java/org/xwiki/tag/TagScriptServiceTest.java
@@ -1,0 +1,295 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.tag;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.EntityReferenceSerializer;
+import org.xwiki.model.reference.SpaceReference;
+import org.xwiki.security.authorization.ContextualAuthorizationManager;
+import org.xwiki.security.authorization.Right;
+import org.xwiki.tag.internal.TagDocumentManager;
+import org.xwiki.tag.internal.TagQueryManager;
+import org.xwiki.test.LogLevel;
+import org.xwiki.test.junit5.LogCaptureExtension;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import ch.qos.logback.classic.Level;
+
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test of {@link TagScriptService}.
+ *
+ * @version $Id$
+ * @since 13.1RC1
+ */
+@ComponentTest
+class TagScriptServiceTest
+{
+    @InjectMockComponents
+    private TagScriptService tagScriptService;
+
+    @MockComponent
+    private TagQueryManager tagQueryManager;
+
+    @MockComponent
+    private TagDocumentManager tagDocumentManager;
+
+    @MockComponent
+    private EntityReferenceSerializer<String> entityReferenceSerializer;
+
+    @MockComponent
+    private ContextualAuthorizationManager contextualAuthorization;
+
+    @RegisterExtension
+    LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.WARN);
+
+    @Test
+    void getTagCount() throws Exception
+    {
+        Map<String, Integer> expected = new HashMap<>();
+        SpaceReference space = new SpaceReference("wikiTest", "testSpace");
+
+        when(this.entityReferenceSerializer.serialize(space)).thenReturn("xwikiTest:testSpace");
+        when(this.tagQueryManager.getTagCountForQuery("", "(doc.space = ?1 OR doc.space LIKE ?2)",
+            asList("xwikiTest:testSpace", "xwikiTest:testSpace.%"))).thenReturn(expected);
+
+        Map<String, Integer> actual = this.tagScriptService.getTagCount(space);
+
+        assertSame(expected, actual);
+    }
+
+    @Test
+    void getTagCountNull() throws Exception
+    {
+        Map<String, Integer> expected = new HashMap<>();
+        when(this.tagQueryManager.getTagCountForQuery(null, null, (Map<String, ?>) null)).thenReturn(expected);
+        Map<String, Integer> actual = this.tagScriptService.getTagCount(null);
+        assertSame(expected, actual);
+    }
+
+    @Test
+    void getTagCountForSpaces() throws Exception
+    {
+        Map<String, Integer> expected = new HashMap<>();
+        SpaceReference s1 = new SpaceReference("wikiTest", "S1");
+        SpaceReference s2 = new SpaceReference("wikiTest", "S2");
+
+        when(this.tagQueryManager
+            .getTagCountForQuery("", "(doc.space = ?1 OR doc.space LIKE ?2 OR doc.space = ?3 OR doc.space LIKE ?4)",
+                asList(
+                    "wikiTest:S1",
+                    "wikiTest:S1.%",
+                    "wikiTest:S2",
+                    "wikiTest:S2.%"
+                ))).thenReturn(expected);
+        when(this.entityReferenceSerializer.serialize(s1)).thenReturn("wikiTest:S1");
+        when(this.entityReferenceSerializer.serialize(s2)).thenReturn("wikiTest:S2");
+
+        Map<String, Integer> actual = this.tagScriptService.getTagCountForSpaces(asList(s1, s2));
+
+        assertSame(expected, actual);
+    }
+
+    @Test
+    void getTagCountForSpacesSingleElement() throws Exception
+    {
+        Map<String, Integer> expected = new HashMap<>();
+        SpaceReference s1 = new SpaceReference("wikiTest", "S1");
+
+        when(this.tagQueryManager
+            .getTagCountForQuery("", "(doc.space = ?1 OR doc.space LIKE ?2)",
+                asList(
+                    "wikiTest:S1",
+                    "wikiTest:S1.%"
+                ))).thenReturn(expected);
+        when(this.entityReferenceSerializer.serialize(s1)).thenReturn("wikiTest:S1");
+
+        Map<String, Integer> actual = this.tagScriptService.getTagCountForSpaces(asList(s1));
+
+        assertSame(expected, actual);
+    }
+
+    @Test
+    void getTagCountForSpacesNull() throws Exception
+    {
+        Map<String, Integer> expected = new HashMap<>();
+        when(this.tagQueryManager.getTagCountForQuery("", "", asList())).thenReturn(expected);
+        Map<String, Integer> actual = this.tagScriptService.getTagCountForSpaces(null);
+        assertSame(expected, actual);
+    }
+
+    @Test
+    void getTagCountForSpacesEmpty() throws Exception
+    {
+        Map<String, Integer> expected = new HashMap<>();
+        when(this.tagQueryManager.getTagCountForQuery("", "", asList())).thenReturn(expected);
+        Map<String, Integer> actual = this.tagScriptService.getTagCountForSpaces(asList());
+        assertSame(expected, actual);
+    }
+
+    @Test
+    void addTagsToDocumentNotAllowed()
+    {
+        DocumentReference documentReference = new DocumentReference("xwiki", "XWiki", "Doc");
+        when(this.contextualAuthorization.hasAccess(Right.EDIT, documentReference)).thenReturn(false);
+        TagOperationResult tagOperationResult =
+            this.tagScriptService.addTagsToDocument(asList("t1", "t2"), documentReference);
+        assertEquals(TagOperationResult.NOT_ALLOWED, tagOperationResult);
+    }
+
+    @Test
+    void addTagsToDocumentFails() throws TagException
+    {
+        DocumentReference documentReference = new DocumentReference("xwiki", "XWiki", "Doc");
+        List<String> tags = asList("t1", "t2");
+
+        when(this.contextualAuthorization.hasAccess(Right.EDIT, documentReference)).thenReturn(true);
+        when(this.tagDocumentManager.addTagsToDocument(tags, documentReference)).thenThrow(TagException.class);
+
+        TagOperationResult tagOperationResult =
+            this.tagScriptService.addTagsToDocument(tags, documentReference);
+        assertEquals(TagOperationResult.FAILED, tagOperationResult);
+        assertEquals(1, this.logCapture.size());
+        assertEquals(Level.WARN, this.logCapture.getLogEvent(0).getLevel());
+        assertEquals("Failed to add tag [[t1, t2]] to document [xwiki:XWiki.Doc]. Cause: [TagException: ].",
+            this.logCapture.getMessage(0));
+    }
+
+    @Test
+    void addTagsToDocument() throws TagException
+    {
+        DocumentReference documentReference = new DocumentReference("xwiki", "XWiki", "Doc");
+        List<String> tags = asList("t1", "t2");
+
+        when(this.contextualAuthorization.hasAccess(Right.EDIT, documentReference)).thenReturn(true);
+        when(this.tagDocumentManager.addTagsToDocument(tags, documentReference)).thenReturn(TagOperationResult.OK);
+
+        TagOperationResult tagOperationResult = this.tagScriptService.addTagsToDocument(tags, documentReference);
+        assertEquals(TagOperationResult.OK, tagOperationResult);
+    }
+
+    @Test
+    void removeTagFromDocumentNotAllowed()
+    {
+        DocumentReference documentReference = new DocumentReference("xwiki", "XWiki", "Doc");
+        when(this.contextualAuthorization.hasAccess(Right.EDIT, documentReference)).thenReturn(false);
+        TagOperationResult tagOperationResult = this.tagScriptService.removeTagFromDocument("t1", documentReference);
+        assertEquals(TagOperationResult.NOT_ALLOWED, tagOperationResult);
+    }
+
+    @Test
+    void removeTagFromDocumentFails() throws TagException
+    {
+        DocumentReference documentReference = new DocumentReference("xwiki", "XWiki", "Doc");
+        when(this.contextualAuthorization.hasAccess(Right.EDIT, documentReference)).thenReturn(true);
+        when(this.tagDocumentManager.removeTagFromDocument("t1", documentReference)).thenThrow(TagException.class);
+        TagOperationResult tagOperationResult = this.tagScriptService.removeTagFromDocument("t1", documentReference);
+        assertEquals(TagOperationResult.FAILED, tagOperationResult);
+        assertEquals(1, this.logCapture.size());
+        assertEquals(Level.WARN, this.logCapture.getLogEvent(0).getLevel());
+        assertEquals("Failed to remove tag [t1] to document [xwiki:XWiki.Doc]. Cause: [TagException: ].",
+            this.logCapture.getMessage(0));
+    }
+
+    @Test
+    void removeTagFromDocument() throws TagException
+    {
+        DocumentReference documentReference = new DocumentReference("xwiki", "XWiki", "Doc");
+        when(this.contextualAuthorization.hasAccess(Right.EDIT, documentReference)).thenReturn(true);
+        when(this.tagDocumentManager.removeTagFromDocument("t1", documentReference))
+            .thenReturn(TagOperationResult.NO_EFFECT);
+        TagOperationResult tagOperationResult = this.tagScriptService.removeTagFromDocument("t1", documentReference);
+        assertEquals(TagOperationResult.NO_EFFECT, tagOperationResult);
+    }
+
+    @Test
+    void renameTagNotAllowed()
+    {
+        when(this.contextualAuthorization.hasAccess(Right.ADMIN)).thenReturn(false);
+        TagOperationResult tagOperationResult = this.tagScriptService.renameTag("t1", "t2");
+        assertEquals(TagOperationResult.NOT_ALLOWED, tagOperationResult);
+    }
+
+    @Test
+    void renameTagFails() throws TagException
+    {
+        when(this.contextualAuthorization.hasAccess(Right.ADMIN)).thenReturn(true);
+        when(this.tagDocumentManager.renameTag("t1", "t2")).thenThrow(TagException.class);
+        TagOperationResult tagOperationResult = this.tagScriptService.renameTag("t1", "t2");
+        assertEquals(TagOperationResult.FAILED, tagOperationResult);
+        assertEquals(1, this.logCapture.size());
+        assertEquals(Level.WARN, this.logCapture.getLogEvent(0).getLevel());
+        assertEquals("Failed to rename tag [t1] to [t2]. Cause: [TagException: ].",
+            this.logCapture.getMessage(0));
+    }
+
+    @Test
+    void renameTag() throws TagException
+    {
+        when(this.contextualAuthorization.hasAccess(Right.ADMIN)).thenReturn(true);
+        when(this.tagDocumentManager.renameTag("t1", "t2")).thenReturn(TagOperationResult.OK);
+        TagOperationResult tagOperationResult = this.tagScriptService.renameTag("t1", "t2");
+        assertEquals(TagOperationResult.OK, tagOperationResult);
+    }
+
+    @Test
+    void deleteTagNotAllowed()
+    {
+        when(this.contextualAuthorization.hasAccess(Right.ADMIN)).thenReturn(false);
+        TagOperationResult tagOperationResult = this.tagScriptService.deleteTag("t1");
+        assertEquals(TagOperationResult.NOT_ALLOWED, tagOperationResult);
+    }
+
+    @Test
+    void deleteTagFails() throws TagException
+    {
+        when(this.contextualAuthorization.hasAccess(Right.ADMIN)).thenReturn(true);
+        when(this.tagDocumentManager.deleteTag("t1")).thenThrow(TagException.class);
+        TagOperationResult tagOperationResult = this.tagScriptService.deleteTag("t1");
+        assertEquals(TagOperationResult.FAILED, tagOperationResult);
+        assertEquals(1, this.logCapture.size());
+        assertEquals(Level.WARN, this.logCapture.getLogEvent(0).getLevel());
+        assertEquals("Failed to remove tag [t1]. Cause: [TagException: ].",
+            this.logCapture.getMessage(0));
+    }
+
+    @Test
+    void deleteTag() throws TagException
+    {
+        when(this.contextualAuthorization.hasAccess(Right.ADMIN)).thenReturn(true);
+        when(this.tagDocumentManager.deleteTag("t1")).thenReturn(TagOperationResult.OK);
+        TagOperationResult tagOperationResult = this.tagScriptService.deleteTag("t1");
+        assertEquals(TagOperationResult.OK, tagOperationResult);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/test/java/org/xwiki/tag/internal/TagDocumentManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/test/java/org/xwiki/tag/internal/TagDocumentManagerTest.java
@@ -1,0 +1,334 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.tag.internal;
+
+import java.util.List;
+
+import javax.inject.Provider;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.xwiki.localization.ContextualLocalizationManager;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.DocumentReferenceResolver;
+import org.xwiki.tag.TagOperationResult;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import com.xpn.xwiki.XWiki;
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.objects.BaseObject;
+import com.xpn.xwiki.objects.ListProperty;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.xwiki.tag.internal.TagDocumentManager.TAGS_FIELD_NAME;
+
+/**
+ * Test of {@link TagDocumentManager}.
+ *
+ * @version $Id$
+ * @since 13.1RC1
+ */
+@ComponentTest
+class TagDocumentManagerTest
+{
+    private static final DocumentReference AUTHOR_REFERENCE = new DocumentReference("xwiki", "XWiki", "User");
+
+    private static final DocumentReference DOCUMENT_REFERENCE = new DocumentReference("xwiki", "XWiki", "Document");
+
+    @InjectMockComponents
+    private TagDocumentManager tagDocumentManager;
+
+    @MockComponent
+    private Provider<XWikiContext> xcontextProvider;
+
+    @MockComponent
+    private ContextualLocalizationManager contextualLocalizationManager;
+
+    @MockComponent
+    private DocumentReferenceResolver<String> documentReferenceResolver;
+
+    @MockComponent
+    private TagQueryManager tagQueryManager;
+
+    @Mock
+    private XWikiContext xWikiContext;
+
+    @Mock
+    private XWiki xWiki;
+
+    @Mock
+    private XWikiDocument xWikiDocument;
+
+    @BeforeEach
+    void setUp()
+    {
+        when(this.xcontextProvider.get()).thenReturn(this.xWikiContext);
+        when(this.xWikiContext.getWikiId()).thenReturn("xwiki");
+        when(this.xWikiContext.getWiki()).thenReturn(this.xWiki);
+        when(this.xWikiContext.getUserReference()).thenReturn(AUTHOR_REFERENCE);
+    }
+
+    @Test
+    void getTagsFromDocument() throws Exception
+    {
+        BaseObject tagObject = mock(BaseObject.class);
+        ListProperty tagsProperty = mock(ListProperty.class);
+        List<String> tags = asList("t1", "t2");
+
+        when(this.xWiki.getDocument(DOCUMENT_REFERENCE, this.xWikiContext)).thenReturn(this.xWikiDocument);
+        when(this.xWikiDocument
+            .getXObject(new DocumentReference("xwiki", "XWiki", "TagClass"), false, this.xWikiContext))
+            .thenReturn(tagObject);
+        when(tagObject.get(TAGS_FIELD_NAME)).thenReturn(tagsProperty);
+        when(tagsProperty.getValue()).thenReturn(tags);
+
+        List<String> tagsFromDocument = this.tagDocumentManager.getTagsFromDocument(DOCUMENT_REFERENCE);
+
+        assertEquals(tags, tagsFromDocument);
+        // It is important that the returned list is not the same instance as the list of the tags field, otherwise we 
+        // are at risk to see it modified (persistently) by the caller (e.g., a velocity template).
+        assertNotSame(tags, tagsFromDocument);
+    }
+
+    @Test
+    void addTagsToDocument() throws Exception
+    {
+        BaseObject tagObject = mock(BaseObject.class);
+        ListProperty tagsProperty = mock(ListProperty.class);
+        List<String> tags = asList("T1", "t3");
+
+        when(this.xWiki.getDocument(DOCUMENT_REFERENCE, this.xWikiContext)).thenReturn(this.xWikiDocument);
+        when(this.xWikiDocument
+            .getXObject(eq(new DocumentReference("xwiki", "XWiki", "TagClass")), anyBoolean(), eq(this.xWikiContext)))
+            .thenReturn(tagObject);
+        when(tagObject.get(TAGS_FIELD_NAME)).thenReturn(tagsProperty);
+        when(tagsProperty.getValue()).thenReturn(tags);
+        when(this.contextualLocalizationManager.getTranslationPlain("plugin.tag.editcomment.added", "T1, t3, t2"))
+            .thenReturn("commit message");
+
+        TagOperationResult tagOperationResult =
+            this.tagDocumentManager.addTagsToDocument(asList("t1", "t2"), DOCUMENT_REFERENCE);
+
+        assertEquals(TagOperationResult.OK, tagOperationResult);
+        verify(tagsProperty).setValue(asList("T1", "t3", "t2"));
+        verify(this.xWikiDocument).setAuthorReference(AUTHOR_REFERENCE);
+        verify(this.xWiki).saveDocument(this.xWikiDocument, "commit message", true, this.xWikiContext);
+    }
+
+    @Test
+    void addTagsToDocumentNoEffect() throws Exception
+    {
+        BaseObject tagObject = mock(BaseObject.class);
+        ListProperty tagsProperty = mock(ListProperty.class);
+        List<String> tags = asList("T1", "t2");
+
+        when(this.xWiki.getDocument(DOCUMENT_REFERENCE, this.xWikiContext)).thenReturn(this.xWikiDocument);
+        when(this.xWikiDocument
+            .getXObject(eq(new DocumentReference("xwiki", "XWiki", "TagClass")), anyBoolean(), eq(this.xWikiContext)))
+            .thenReturn(tagObject);
+        when(tagObject.get(TAGS_FIELD_NAME)).thenReturn(tagsProperty);
+        when(tagsProperty.getValue()).thenReturn(tags);
+
+        TagOperationResult tagOperationResult =
+            this.tagDocumentManager.addTagsToDocument(asList("t1", "t2"), DOCUMENT_REFERENCE);
+
+        assertEquals(TagOperationResult.NO_EFFECT, tagOperationResult);
+        verify(tagsProperty, never()).setValue(any());
+        verify(this.xWikiDocument, never()).setAuthorReference(any());
+        verify(this.xWiki, never()).saveDocument(any(), anyString(), anyBoolean(), any());
+    }
+
+    @Test
+    void removeTagFromDocument() throws Exception
+    {
+        BaseObject tagObject = mock(BaseObject.class);
+        ListProperty tagsProperty = mock(ListProperty.class);
+        List<String> tags = asList("T1", "t2");
+
+        when(this.xWiki.getDocument(DOCUMENT_REFERENCE, this.xWikiContext)).thenReturn(this.xWikiDocument);
+        when(this.xWikiDocument
+            .getXObject(eq(new DocumentReference("xwiki", "XWiki", "TagClass")), anyBoolean(), eq(this.xWikiContext)))
+            .thenReturn(tagObject);
+        when(tagObject.get(TAGS_FIELD_NAME)).thenReturn(tagsProperty);
+        when(tagsProperty.getValue()).thenReturn(tags);
+        when(this.contextualLocalizationManager.getTranslationPlain("plugin.tag.editcomment.removed", "t1"))
+            .thenReturn("commit message");
+
+        TagOperationResult tagOperationResult = this.tagDocumentManager.removeTagFromDocument("t1", DOCUMENT_REFERENCE);
+        assertEquals(TagOperationResult.OK, tagOperationResult);
+        verify(tagsProperty).setValue(asList("t2"));
+        verify(this.xWikiDocument).setAuthorReference(AUTHOR_REFERENCE);
+        verify(this.xWiki).saveDocument(this.xWikiDocument, "commit message", true, this.xWikiContext);
+    }
+
+    @Test
+    void removeTagFromDocumentNoEffect() throws Exception
+    {
+        BaseObject tagObject = mock(BaseObject.class);
+        ListProperty tagsProperty = mock(ListProperty.class);
+        List<String> tags = asList("T1", "t2");
+
+        when(this.xWiki.getDocument(DOCUMENT_REFERENCE, this.xWikiContext)).thenReturn(this.xWikiDocument);
+        when(this.xWikiDocument
+            .getXObject(eq(new DocumentReference("xwiki", "XWiki", "TagClass")), anyBoolean(), eq(this.xWikiContext)))
+            .thenReturn(tagObject);
+        when(tagObject.get(TAGS_FIELD_NAME)).thenReturn(tagsProperty);
+        when(tagsProperty.getValue()).thenReturn(tags);
+
+        TagOperationResult tagOperationResult = this.tagDocumentManager.removeTagFromDocument("t3", DOCUMENT_REFERENCE);
+        assertEquals(TagOperationResult.NO_EFFECT, tagOperationResult);
+        verify(tagsProperty, never()).setValue(any());
+        verify(this.xWikiDocument, never()).setAuthorReference(any());
+        verify(this.xWiki, never()).saveDocument(any(), anyString(), anyBoolean(), any());
+    }
+
+    @Test
+    void deleteTag() throws Exception
+    {
+        DocumentReference dr1 = new DocumentReference("xwiki", "XWiki", "d1");
+        DocumentReference dr2 = new DocumentReference("xwiki", "XWiki", "d2");
+
+        XWikiDocument xWikiDocument1 = mock(XWikiDocument.class);
+        BaseObject tagObject1 = mock(BaseObject.class);
+        ListProperty tagsProperty1 = mock(ListProperty.class);
+        List<String> tags1 = asList("T1", "t2");
+
+        XWikiDocument xWikiDocument2 = mock(XWikiDocument.class);
+        BaseObject tagObject2 = mock(BaseObject.class);
+        ListProperty tagsProperty2 = mock(ListProperty.class);
+        List<String> tags2 = asList("T1", "t3");
+
+        when(this.tagQueryManager.getDocumentsWithTag("t1", true)).thenReturn(asList("d1", "d2"));
+        when(this.documentReferenceResolver.resolve("d1")).thenReturn(dr1);
+        when(this.documentReferenceResolver.resolve("d2")).thenReturn(dr2);
+
+        when(this.xWiki.getDocument(dr1, this.xWikiContext)).thenReturn(xWikiDocument1);
+        when(xWikiDocument1
+            .getXObject(eq(new DocumentReference("xwiki", "XWiki", "TagClass")), anyBoolean(), eq(this.xWikiContext)))
+            .thenReturn(tagObject1);
+        when(tagObject1.get(TAGS_FIELD_NAME)).thenReturn(tagsProperty1);
+        when(tagsProperty1.getValue()).thenReturn(tags1);
+
+        when(this.xWiki.getDocument(dr2, this.xWikiContext)).thenReturn(xWikiDocument2);
+        when(xWikiDocument2
+            .getXObject(eq(new DocumentReference("xwiki", "XWiki", "TagClass")), anyBoolean(), eq(this.xWikiContext)))
+            .thenReturn(tagObject2);
+        when(tagObject2.get(TAGS_FIELD_NAME)).thenReturn(tagsProperty2);
+        when(tagsProperty2.getValue()).thenReturn(tags2);
+
+        when(this.contextualLocalizationManager.getTranslationPlain("plugin.tag.editcomment.removed", "t1"))
+            .thenReturn("commit message 1", "commit message 2");
+
+        TagOperationResult tagOperationResult = this.tagDocumentManager.deleteTag("t1");
+        assertEquals(TagOperationResult.OK, tagOperationResult);
+
+        verify(tagsProperty1).setValue(asList("t2"));
+        verify(xWikiDocument1).setAuthorReference(AUTHOR_REFERENCE);
+        verify(this.xWiki).saveDocument(xWikiDocument1, "commit message 1", true, this.xWikiContext);
+
+        verify(tagsProperty2).setValue(asList("t3"));
+        verify(xWikiDocument2).setAuthorReference(AUTHOR_REFERENCE);
+        verify(this.xWiki).saveDocument(xWikiDocument2, "commit message 2", true, this.xWikiContext);
+    }
+
+    @Test
+    void deleteTagNoEffect() throws Exception
+    {
+        when(this.tagQueryManager.getDocumentsWithTag("t1", true)).thenReturn(emptyList());
+        TagOperationResult tagOperationResult = this.tagDocumentManager.deleteTag("t1");
+        assertEquals(TagOperationResult.NO_EFFECT, tagOperationResult);
+        verify(this.xWiki, never()).saveDocument(any(), anyString(), anyBoolean(), any());
+    }
+
+    @Test
+    void renameTag() throws Exception
+    {
+        DocumentReference dr1 = new DocumentReference("xwiki", "XWiki", "d1");
+        DocumentReference dr2 = new DocumentReference("xwiki", "XWiki", "d2");
+
+        XWikiDocument xWikiDocument1 = mock(XWikiDocument.class);
+        BaseObject tagObject1 = mock(BaseObject.class);
+        ListProperty tagsProperty1 = mock(ListProperty.class);
+        List<String> tags1 = asList("T1", "t2");
+
+        XWikiDocument xWikiDocument2 = mock(XWikiDocument.class);
+        BaseObject tagObject2 = mock(BaseObject.class);
+        ListProperty tagsProperty2 = mock(ListProperty.class);
+        List<String> tags2 = asList("T1", "t3");
+
+        when(this.tagQueryManager.getDocumentsWithTag("t1", true)).thenReturn(asList("d1", "d2"));
+        when(this.documentReferenceResolver.resolve("d1")).thenReturn(dr1);
+        when(this.documentReferenceResolver.resolve("d2")).thenReturn(dr2);
+
+        when(this.xWiki.getDocument(dr1, this.xWikiContext)).thenReturn(xWikiDocument1);
+        when(xWikiDocument1
+            .getXObject(eq(new DocumentReference("xwiki", "XWiki", "TagClass")), anyBoolean(), eq(this.xWikiContext)))
+            .thenReturn(tagObject1);
+        when(tagObject1.get(TAGS_FIELD_NAME)).thenReturn(tagsProperty1);
+        when(tagsProperty1.getValue()).thenReturn(tags1);
+
+        when(this.xWiki.getDocument(dr2, this.xWikiContext)).thenReturn(xWikiDocument2);
+        when(xWikiDocument2
+            .getXObject(eq(new DocumentReference("xwiki", "XWiki", "TagClass")), anyBoolean(), eq(this.xWikiContext)))
+            .thenReturn(tagObject2);
+        when(tagObject2.get(TAGS_FIELD_NAME)).thenReturn(tagsProperty2);
+        when(tagsProperty2.getValue()).thenReturn(tags2);
+
+        when(this.contextualLocalizationManager.getTranslationPlain("plugin.tag.editcomment.removed", "t1"))
+            .thenReturn("commit message 1");
+        when(this.contextualLocalizationManager.getTranslationPlain("plugin.tag.editcomment.renamed", "t1", "T2"))
+            .thenReturn("commit message 2");
+
+        TagOperationResult tagOperationResult = this.tagDocumentManager.renameTag("t1", "T2");
+        assertEquals(TagOperationResult.OK, tagOperationResult);
+
+        verify(tagsProperty1).setValue(asList("t2"));
+        verify(xWikiDocument1).setAuthorReference(AUTHOR_REFERENCE);
+        verify(this.xWiki).saveDocument(xWikiDocument1, "commit message 1", true, this.xWikiContext);
+
+        verify(tagsProperty2).setValue(asList("T2", "t3"));
+        verify(xWikiDocument2).setAuthorReference(AUTHOR_REFERENCE);
+        verify(this.xWiki).saveDocument(xWikiDocument2, "commit message 2", true, this.xWikiContext);
+    }
+
+    @Test
+    void renameTagNoEffect() throws Exception
+    {
+        when(this.tagQueryManager.getDocumentsWithTag("t1", true)).thenReturn(emptyList());
+        TagOperationResult tagOperationResult = this.tagDocumentManager.renameTag("t1", "t2");
+        assertEquals(TagOperationResult.NO_EFFECT, tagOperationResult);
+        verify(this.xWiki, never()).saveDocument(any(), anyString(), anyBoolean(), any());
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/test/java/org/xwiki/tag/internal/livedata/TaggedDocumentLiveDataEntryStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/test/java/org/xwiki/tag/internal/livedata/TaggedDocumentLiveDataEntryStoreTest.java
@@ -1,0 +1,118 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.tag.internal.livedata;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.inject.Provider;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.xwiki.livedata.LiveDataQuery.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.xwiki.livedata.LiveData;
+import org.xwiki.livedata.LiveDataQuery;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.tag.internal.TagQueryManager;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import com.xpn.xwiki.XWiki;
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.doc.XWikiDocument;
+
+/**
+ * Test of {@link TaggedDocumentLiveDataEntryStore}.
+ *
+ * @version $Id$
+ * @since 13.1RC1
+ */
+@ComponentTest
+class TaggedDocumentLiveDataEntryStoreTest
+{
+    @InjectMockComponents
+    private TaggedDocumentLiveDataEntryStore taggedDocumentLiveDataEntryStore;
+
+    @MockComponent
+    private TagQueryManager tagQueryManager;
+
+    @MockComponent
+    private Provider<XWikiContext> xcontextProvider;
+
+    @Mock
+    private XWikiContext xWikiContext;
+
+    @Mock
+    private XWiki xWiki;
+
+    @BeforeEach
+    void setUp()
+    {
+        when(this.xcontextProvider.get()).thenReturn(this.xWikiContext);
+        when(this.xWikiContext.getWiki()).thenReturn(this.xWiki);
+    }
+
+    @Test
+    void get() throws Exception
+    {
+        LiveData expected = new LiveData();
+        expected.setCount(4);
+        Map<String, Object> entry1 = new HashMap<>();
+        entry1.put("page", "Title1");
+        entry1.put("page_link", "http://xwiki.test/P1");
+        Map<String, Object> entry2 = new HashMap<>();
+        entry2.put("page", "Title2");
+        entry2.put("page_link", "http://xwiki.test/P2");
+        expected.getEntries().addAll(Arrays.asList(entry1, entry2));
+        DocumentReference page1 = new DocumentReference("xwiki", "XWiki", "D1");
+        DocumentReference page2 = new DocumentReference("xwiki", "XWiki", "D2");
+        XWikiDocument document1 = mock(XWikiDocument.class);
+        XWikiDocument document2 = mock(XWikiDocument.class);
+
+        when(this.tagQueryManager.countPages("t1")).thenReturn(4L);
+        when(this.tagQueryManager.getPages("t1", 2, 1)).thenReturn(Arrays.asList(
+            page1,
+            page2
+        ));
+        when(this.xWiki.getDocument(page1, this.xWikiContext)).thenReturn(document1);
+        when(this.xWiki.getDocument(page2, this.xWikiContext)).thenReturn(document2);
+        when(document1.getRenderedTitle(this.xWikiContext)).thenReturn("Title1");
+        when(document2.getRenderedTitle(this.xWikiContext)).thenReturn("Title2");
+        when(this.xWiki.getURL(page1, this.xWikiContext)).thenReturn("http://xwiki.test/P1");
+        when(this.xWiki.getURL(page2, this.xWikiContext)).thenReturn("http://xwiki.test/P2");
+
+        LiveDataQuery query = new LiveDataQuery();
+        Source source = new Source();
+        source.setParameter("tag", "t1");
+        query.setSource(source);
+        query.setLimit(2);
+        query.setOffset(1L);
+        LiveData liveData = this.taggedDocumentLiveDataEntryStore.get(query);
+
+        assertEquals(expected, liveData);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-ui/src/main/resources/Main/Tags.xml
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-ui/src/main/resources/Main/Tags.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.1" encoding="UTF-8"?>
 
 <!--
  * See the NOTICE file distributed with this work for additional
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.2" reference="Main.Tags" locale="">
+<xwikidoc version="1.4" reference="Main.Tags" locale="">
   <web>Main</web>
   <name>Tags</name>
   <language/>
@@ -77,22 +77,25 @@ $xwiki.ssx.use('Main.Tags')##
     {{info}}$services.localization.render('xe.tag.rename.success', ["//${request.get('renamedTag')}//"]){{/info}}
 
   #end
-  #set ($list = $xwiki.tag.getDocumentsWithTag($tag))
+
   {{container layoutStyle="columns"}}
+    #set ($pagesCount = $services.tag.countDocumentsWithTag($request.tag))
     (((
       (% class="xapp" %)
       === $services.localization.render('xe.tag.alldocs', ["//${tag}//"]) ===
 
-      #if ($list.size()&gt; 0)
-        {{html}}#displayDocumentList($list false $blacklistedSpaces){{/html}}
-      #else
-        (% class='noitems' %)$services.localization.render('xe.tag.notags')
+      #if ($pagesCount &gt; 0)
+      {{liveData id="taggedPagesLiveData" properties="page" showPageSizeDropdown="false" source="taggedDocument"
+       sourceParameters="tag=$request.tag"}}{{/liveData}}
       #end
     )))
     (((
       (% class="xapp" %)
       === $services.localization.render('xe.tag.activity', ["//${tag}//"]) ===
+
+      #if ($pagesCount &gt; 0)
       {{notifications useUserPreferences="false" displayOwnEvents="true" tags="$tag" displayRSSLink="true" /}}
+      #end
     )))
   {{/container}}
 #elseif ($do == 'prepareRename')
@@ -117,7 +120,7 @@ $xwiki.ssx.use('Main.Tags')##
   #set ($renameTo = "$!{request.get('renameTo')}")
   #set ($success = false)
   #if ($renameTo != '')
-    #set ($success = $xwiki.tag.renameTag($tag, $renameTo))
+    #set ($success = $services.tag.renameTag($tag, $renameTo))
   #end
   #if ($success == true || $success == 'OK')
    #set ($urlEscapedRenameTo = $escapetool.url($renameTo))
@@ -144,7 +147,7 @@ $xwiki.ssx.use('Main.Tags')##
   ##
   ## Delete tag
   ##
-  #set ($success = $xwiki.tag.deleteTag($tag))
+  #set ($success = $services.tag.deleteTag($tag))
   #if ($success == true || $success == 'OK')
     $response.sendRedirect($doc.getURL('view', "deletedTag=${urlEscapedTag}"))
   #else
@@ -179,11 +182,14 @@ $xwiki.ssx.use('Main.Tags')##
       <validationScript/>
       <cache>
         <cache>0</cache>
+        <defaultValue>long</defaultValue>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>cache</name>
-        <number>6</number>
+        <number>5</number>
         <prettyName>Caching policy</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
@@ -194,9 +200,11 @@ $xwiki.ssx.use('Main.Tags')##
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </cache>
       <code>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>code</name>
-        <number>3</number>
+        <number>2</number>
         <prettyName>Code</prettyName>
         <rows>20</rows>
         <size>50</size>
@@ -207,9 +215,11 @@ $xwiki.ssx.use('Main.Tags')##
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>contentType</name>
-        <number>1</number>
+        <number>6</number>
         <prettyName>Content Type</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
@@ -222,7 +232,7 @@ $xwiki.ssx.use('Main.Tags')##
       <name>
         <disabled>0</disabled>
         <name>name</name>
-        <number>2</number>
+        <number>1</number>
         <prettyName>Name</prettyName>
         <size>30</size>
         <unmodifiable>0</unmodifiable>
@@ -233,7 +243,7 @@ $xwiki.ssx.use('Main.Tags')##
         <displayFormType>select</displayFormType>
         <displayType>yesno</displayType>
         <name>parse</name>
-        <number>5</number>
+        <number>4</number>
         <prettyName>Parse content</prettyName>
         <unmodifiable>0</unmodifiable>
         <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
@@ -242,9 +252,11 @@ $xwiki.ssx.use('Main.Tags')##
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>use</name>
-        <number>4</number>
+        <number>3</number>
         <prettyName>Use this extension</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
@@ -309,6 +321,9 @@ h1.xapp .button:hover {
   text-decoration: none;
 }
 </code>
+    </property>
+    <property>
+      <contentType/>
     </property>
     <property>
       <name/>

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-ui/src/main/resources/XWiki/TagCloud.xml
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-ui/src/main/resources/XWiki/TagCloud.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.1" encoding="UTF-8"?>
 
 <!--
  * See the NOTICE file distributed with this work for additional
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.1">
+<xwikidoc version="1.4" reference="XWiki.TagCloud" locale="">
   <web>XWiki</web>
   <name>TagCloud</name>
   <language/>
@@ -103,8 +103,11 @@
       <validationScript/>
       <cache>
         <cache>0</cache>
+        <defaultValue>long</defaultValue>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>cache</name>
         <number>5</number>
@@ -118,7 +121,9 @@
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </cache>
       <code>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>code</name>
         <number>2</number>
         <prettyName>Code</prettyName>
@@ -131,6 +136,8 @@
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>contentType</name>
         <number>6</number>
@@ -166,6 +173,8 @@
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>use</name>
         <number>3</number>
@@ -224,6 +233,9 @@ ol.tagCloud .ultraPopular {
 }</code>
     </property>
     <property>
+      <contentType/>
+    </property>
+    <property>
       <name>Tag cloud CSS</name>
     </property>
     <property>
@@ -247,10 +259,51 @@ ol.tagCloud .ultraPopular {
       <defaultWeb/>
       <nameField/>
       <validationScript/>
+      <async_cached>
+        <defaultValue>0</defaultValue>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType/>
+        <name>async_cached</name>
+        <number>13</number>
+        <prettyName>Cached</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </async_cached>
+      <async_context>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
+        <name>async_context</name>
+        <number>14</number>
+        <prettyName>Context elements</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator>, </separator>
+        <separators>|, </separators>
+        <size>5</size>
+        <unmodifiable>0</unmodifiable>
+        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.parameters=Request parameters|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </async_context>
+      <async_enabled>
+        <defaultValue>0</defaultValue>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType/>
+        <name>async_enabled</name>
+        <number>12</number>
+        <prettyName>Asynchronous rendering</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </async_enabled>
       <code>
         <disabled>0</disabled>
+        <editor>Text</editor>
         <name>code</name>
-        <number>9</number>
+        <number>10</number>
         <prettyName>Macro code</prettyName>
         <rows>20</rows>
         <size>40</size>
@@ -258,23 +311,47 @@ ol.tagCloud .ultraPopular {
         <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
       </code>
       <contentDescription>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>contentDescription</name>
-        <number>8</number>
+        <number>9</number>
         <prettyName>Content description (Not applicable for "No content" type)</prettyName>
         <rows>5</rows>
         <size>40</size>
         <unmodifiable>0</unmodifiable>
         <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
       </contentDescription>
+      <contentJavaType>
+        <cache>0</cache>
+        <defaultValue>Unknown</defaultValue>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <freeText>allowed</freeText>
+        <largeStorage>1</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>contentJavaType</name>
+        <number>8</number>
+        <picker>1</picker>
+        <prettyName>Macro content type</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator>|</separator>
+        <separators>|</separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>Unknown|Wiki</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </contentJavaType>
       <contentType>
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>contentType</name>
         <number>7</number>
-        <prettyName>Macro content type</prettyName>
+        <prettyName>Macro content availability</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator>|</separator>
         <separators>|</separators>
@@ -293,7 +370,9 @@ ol.tagCloud .ultraPopular {
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </defaultCategory>
       <description>
+        <contenttype>PureText</contenttype>
         <disabled>0</disabled>
+        <editor>PureText</editor>
         <name>description</name>
         <number>3</number>
         <prettyName>Macro description</prettyName>
@@ -320,6 +399,16 @@ ol.tagCloud .ultraPopular {
         <unmodifiable>0</unmodifiable>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
+      <priority>
+        <disabled>0</disabled>
+        <name>priority</name>
+        <number>11</number>
+        <numberType>integer</numberType>
+        <prettyName>Priority</prettyName>
+        <size>10</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.NumberClass</classType>
+      </priority>
       <supportsInlineMode>
         <disabled>0</disabled>
         <displayFormType>select</displayFormType>
@@ -334,6 +423,8 @@ ol.tagCloud .ultraPopular {
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>visibility</name>
         <number>6</number>
@@ -347,6 +438,15 @@ ol.tagCloud .ultraPopular {
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </visibility>
     </class>
+    <property>
+      <async_cached>0</async_cached>
+    </property>
+    <property>
+      <async_context/>
+    </property>
+    <property>
+      <async_enabled>0</async_enabled>
+    </property>
     <property>
       <code>{{velocity}}
 ##
@@ -370,11 +470,13 @@ $xwiki.ssx.use('XWiki.TagCloud')##
 
 ##If multiple spaces with "spaces" parameter
 #if( $tagCloudSpaces )
-  #set ($tagCount = $xwiki.tag.getTagCountForSpaces($tagCloudSpaces))
-#else
+  #set ($tagCount = $services.tag.getTagCountForSpaces($stringtool.split($tagCloudSpaces, ',')))
+#elseif ($tagCloudSpace)
   ##If only one space
   ## Get tag count map. Key: tag, value: number of occurrences.
-  #set ($tagCount = $xwiki.tag.getTagCount("$!tagCloudSpace"))
+  #set ($tagCount = $services.tag.getTagCount("$!tagCloudSpace"))
+#else
+  #set ($tagCount = $services.tag.getTagCountForQuery("","",{}))
 #end
 ##
 ## Only build popularity map if at least one tag exists
@@ -448,6 +550,9 @@ $xwiki.ssx.use('XWiki.TagCloud')##
       <contentDescription/>
     </property>
     <property>
+      <contentJavaType/>
+    </property>
+    <property>
       <contentType>No content</contentType>
     </property>
     <property>
@@ -461,6 +566,9 @@ $xwiki.ssx.use('XWiki.TagCloud')##
     </property>
     <property>
       <name>Tag Cloud</name>
+    </property>
+    <property>
+      <priority/>
     </property>
     <property>
       <supportsInlineMode>0</supportsInlineMode>
@@ -521,6 +629,15 @@ $xwiki.ssx.use('XWiki.TagCloud')##
         <unmodifiable>0</unmodifiable>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
+      <type>
+        <disabled>0</disabled>
+        <name>type</name>
+        <number>5</number>
+        <prettyName>Parameter type</prettyName>
+        <size>60</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </type>
     </class>
     <property>
       <defaultValue/>
@@ -533,6 +650,9 @@ $xwiki.ssx.use('XWiki.TagCloud')##
     </property>
     <property>
       <name>space</name>
+    </property>
+    <property>
+      <type/>
     </property>
   </object>
   <object>
@@ -587,6 +707,15 @@ $xwiki.ssx.use('XWiki.TagCloud')##
         <unmodifiable>0</unmodifiable>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
+      <type>
+        <disabled>0</disabled>
+        <name>type</name>
+        <number>5</number>
+        <prettyName>Parameter type</prettyName>
+        <size>60</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </type>
     </class>
     <property>
       <defaultValue/>
@@ -600,6 +729,9 @@ $xwiki.ssx.use('XWiki.TagCloud')##
     </property>
     <property>
       <name>spaces</name>
+    </property>
+    <property>
+      <type/>
     </property>
   </object>
 </xwikidoc>

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/documentTags.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/documentTags.vm
@@ -29,8 +29,8 @@
 #end
 ##
 #macro(removeTag $tag)
-    #if($xwiki.tag)
-        #set($result = $xwiki.tag.removeTagFromDocument($tag, $doc.fullName))
+    #if($services.tag)
+        #set($result = $services.tag.removeTagFromDocument($tag, $doc.documentReference))
         #if($result == 'OK' && "$!{request.ajax}" != '')
             $response.setStatus(200)
             #set($responseMessage = 'OK')
@@ -55,11 +55,11 @@
 #end
 ##
 #macro(addTag $tag)
-    #if($xwiki.tag)
-        #set($oldTags = $xwiki.tag.getTagsFromDocument($doc.fullName))
-        #set($result = $xwiki.tag.addTagsToDocument($tag, $doc.fullName))
+    #if($services.tag)
+        #set($oldTags = $services.tag.getTagsFromDocument($doc.documentReference))
+        #set($result = $services.tag.addTagToDocument($tag, $doc.documentReference))
         #if($result == 'OK' && "$!{request.ajax}" != '')
-            #set($newTags = $xwiki.tag.getTagsFromDocument($doc.fullName))
+            #set($newTags = $services.tag.getTagsFromDocument($doc.documentReference))
             #set($discard = $newTags.removeAll($oldTags))
             #foreach($t in $newTags)
                 #if($t != '' && !$oldTags.contains($t))
@@ -110,9 +110,9 @@
     $xwiki.ssfx.use('uicomponents/viewers/tags.css', {'forceSkinAction': true, 'colorTheme': "$!{themeDocFullName}"})##
     $xwiki.jsfx.use('uicomponents/viewers/tags.js', true)##
 <div class="doc-tags" id="${tagsId}">
-    #if($xwiki.tag)
+    #if($services.tag)
         #set($hasTagsPlugin = true)
-        #set($tags = $xwiki.tag.getTagsFromDocument($doc.fullName))
+        #set($tags = $services.tag.getTagsFromDocument($doc.documentReference))
     #else
         #set($hasTagsPlugin = false)
         #set($tags = $doc.getTagList())
@@ -126,7 +126,7 @@
     #end
     ##   #end
     #if($hasedit)
-        #if($xwiki.tag)
+        #if($services.tag)
           <div class="tag-tool tag-add">#if("$!{request.showTagAddForm}" == '')<a href="$doc.getURL('view', "showTagAddForm=true&amp;$!{escapetool.url(${request.queryString})}#${tagsId}")" title="$services.localization.render('core.tags.add.tooltip')" rel="nofollow">[+]</a>#else #displayAddForm()#end</div>
         #else
             ## TODO

--- a/xwiki-platform-distribution/pom.xml
+++ b/xwiki-platform-distribution/pom.xml
@@ -105,7 +105,6 @@
   com.xpn.xwiki.plugin.jodatime.JodaTimePlugin,\
   com.xpn.xwiki.plugin.scheduler.SchedulerPlugin,\
   com.xpn.xwiki.plugin.mailsender.MailSenderPlugin,\
-  com.xpn.xwiki.plugin.tag.TagPlugin,\
   com.xpn.xwiki.plugin.zipexplorer.ZipExplorerPlugin
     </platform.xwiki.cfg.plugins.default>
     <!-- Legacy plugin list -->


### PR DESCRIPTION
https://jira.xwiki.org/browse/XWIKI-17606

- TagPlugin deprecated and replaced by TagScriptService
- Updated calls to the plugin with calls to the service in velocity scripts
- Introduction of the taggedDocument live data source, to list the documents containing a given tag
- Integration of the taggedDocument live data in the tagged documents page