### PR TITLE
XWIKI-18304: Misalignment issue and unneeded scroll bar on the Version conflict box

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/viewers/diff.css
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/viewers/diff.css
@@ -27,12 +27,15 @@
   border: 1px solid $theme.borderColor;
   font-family: Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: 12px;
-  overflow: visible;
+  overflow: auto;
 }
 
 .diff-container table {
   /* Prevent scroll bars when the table fills the entire width. */
   margin: 0;
+  /* Having a table size of 100% leads to the display of an horizontal scroll bar when a td has a border. A 99.99% width
+     is visually indistinguishable but prevent this overflow. */
+  width: 99.99%
 }
 
 .diff-container td {

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/viewers/diff.css
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/viewers/diff.css
@@ -27,7 +27,7 @@
   border: 1px solid $theme.borderColor;
   font-family: Consolas, "Liberation Mono", "Courier New", monospace;
   font-size: 12px;
-  overflow: auto;
+  overflow: visible;
 }
 
 .diff-container table {
@@ -55,10 +55,9 @@ td.diff-line {
   white-space: pre-wrap;
 }
 
-/*
-Prevent the code formatting for diff lines containing a decision form as it breaks the display of the form.
-The code formatting and long line wrapping is instead applied on the proposed decisions preview contained in the line. 
-*/
+/* Prevent the code formatting for diff lines containing a decision form as it breaks the display of the form.
+   The code formatting and long line wrapping is instead applied on the proposed decisions preview contained in the 
+   line. */
 td.diff-line.diff-line-decision {
   white-space: normal;
   padding: 0.5em;

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/viewers/diff.css
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/viewers/diff.css
@@ -55,6 +55,21 @@ td.diff-line {
   white-space: pre-wrap;
 }
 
+/*
+Prevent the code formatting for diff lines containing a decision form as it breaks the display of the form.
+The code formatting and long line wrapping is instead applied on the proposed decisions preview contained in the line. 
+*/
+td.diff-line.diff-line-decision {
+  white-space: normal;
+  padding: 0.5em;
+}
+
+td.diff-line.diff-line-decision span.diff-decision {
+  /* Preserve code formatting and also wrap long lines that exceed the available width. */
+  white-space: pre-wrap;
+  width: 70%;
+}
+
 .diff-line-added {
   background-color: #DDFFDD;
   color: #000;
@@ -91,7 +106,6 @@ td.diff-line-meta {
 }
 
 span.diff-decision {
-  padding-top: 10px;
   display: inline-block;
 }
 

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/viewers/diff.css
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/resources/uicomponents/viewers/diff.css
@@ -34,7 +34,7 @@
   /* Prevent scroll bars when the table fills the entire width. */
   margin: 0;
   /* Having a table size of 100% leads to the display of an horizontal scroll bar when a td has a border. A 99.99% width
-     is visually indistinguishable but prevent this overflow. */
+     is visually indistinguishable but prevents this overflow. */
   width: 99.99%
 }
 

--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/diff_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/diff_macros.vm
@@ -50,7 +50,7 @@
 <tr class="diff-conflict-resolution">
   <td class="diff-line-number"><span class="fa fa-pencil"></span></td>
   <td class="diff-line-number"></td>
-  <td class="diff-line" id="conflict_decision_container_$block.conflict.reference">
+  <td class="diff-line diff-line-decision" id="conflict_decision_container_$block.conflict.reference">
     #displayConflictValue($block.conflict "current")
     #displayConflictValue($block.conflict "previous")
     #displayConflictValue($block.conflict "next")


### PR DESCRIPTION
https://jira.xwiki.org/browse/XWIKI-18304

- Introduction of a new diff-line-decision class to help the css selection
- Prevent the white-space pre-wrap on the diff decision td and apply it on the proposed decisions instead
- Uniformize the padding to keep an uniform view when switching between the proposed decisions.