### PR TITLE
Introduce title attribute into "Go to permalink" modal dialogue

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/commentsinline.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/commentsinline.vm
@@ -338,7 +338,7 @@ $xwiki.ssfx.use('uicomponents/viewers/comments.css', true)
         <div class="modal-body">
           <div class="input-group">
             <div class="input-group-addon">$services.icon.renderHTML('link')</div>
-            <input type="text" class="form-control"/>
+            <input type="text" class="form-control" title="Permalink"/>
           </div>
         </div>
         <div class="modal-footer">

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/commentsinline.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/commentsinline.vm
@@ -338,7 +338,7 @@ $xwiki.ssfx.use('uicomponents/viewers/comments.css', true)
         <div class="modal-body">
           <div class="input-group">
             <div class="input-group-addon">$services.icon.renderHTML('link')</div>
-            <input type="text" class="form-control" title="Permalink"/>
+            <input type="text" class="form-control" title="$services.localization.render('core.viewers.comments.permalink')"/>
           </div>
         </div>
         <div class="modal-footer">


### PR DESCRIPTION
We are working our way through our XWiki instance with the [WAVE plugin](https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh) at the moment to increase accessibility, that is resolve all errors thrown by their standards.We found one very minor issue is a missing label or title attribute in a modal dialogue to copy a comments permalink. This PR is meant to fix this. It is my very first contribution to XWiki and I would be glad if there are any standards I missed, if you could advice me on where to look and what to fix.