### PR TITLE
XWIKI-18363: Auto-detection of language with the code macro is broken

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/pom.xml
@@ -52,7 +52,7 @@
     <dependency>
       <groupId>org.pygments</groupId>
       <artifactId>pygments</artifactId>
-      <version>2.5.1</version>
+      <version>2.4.2</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/pom.xml
@@ -49,10 +49,13 @@
       <groupId>org.python</groupId>
       <artifactId>jython-slim</artifactId>
     </dependency>
-
-    <!-- Pygments must stay in version < 2.5.x because this version and above have issues with the auto-detection of 
-         the language of the code (MIME and SQL are too often detected). Pygments 2.8.0+ present a fix, but is only 
-         compatible with Python 3.0, which we do not support for now. 
+    <!-- We can't upgrade to version higher than 2.4.2 for two reasons:
+         - 2.5.1 and above presents and issue with the auto-detection of the language of the code (MIME and SQL 
+         syntaxes are too often detected).
+         - Pygments 2.6.0+ requires Python 3. 
+         Pygments 2.8.0 presents a fix, but requires Python 3.0.
+         And upgrade to Pygments 2.5.2 is possible by backporting the fix from 
+         Pygments 2.8.0 (https://jira.xwiki.org/browse/XWIKI-18369).   
          See https://jira.xwiki.org/browse/XWIKI-18363 -->
     <dependency>
       <groupId>org.pygments</groupId>

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/pom.xml
@@ -49,6 +49,11 @@
       <groupId>org.python</groupId>
       <artifactId>jython-slim</artifactId>
     </dependency>
+
+    <!-- Pygments must stay in version < 2.5.x because this version and above have issues with the auto-detection of 
+         the language of the code (MIME and SQL are too often detected). Pygments 2.8.0+ present a fix, but is only 
+         compatible with Python 3.0, which we do not support for now. 
+         See https://jira.xwiki.org/browse/XWIKI-18363 -->
     <dependency>
       <groupId>org.pygments</groupId>
       <artifactId>pygments</artifactId>

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/pom.xml
@@ -52,8 +52,8 @@
     <!-- We can't upgrade to version higher than 2.4.2 for two reasons:
          - 2.5.1 and above presents and issue with the auto-detection of the language of the code (MIME and SQL 
          syntaxes are too often detected).
-         - Pygments 2.6.0+ requires Python 3. 
-         Pygments 2.8.0 presents a fix, but requires Python 3.0.
+         - Pygments 2.6.0 and above requires Python 3. 
+         Pygments 2.8.0 presents a fix, but requires Python 3.
          And upgrade to Pygments 2.5.2 is possible by backporting the fix from 
          Pygments 2.8.0 (https://jira.xwiki.org/browse/XWIKI-18369).   
          See https://jira.xwiki.org/browse/XWIKI-18363 -->

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/test/resources/macrocode15.test
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/test/resources/macrocode15.test
@@ -2,31 +2,30 @@
 .#-----------------------------------------------------
 .input|xwiki/2.0
 .# Validates that the code macro accurately identifies the language used in the code macro when not specified.
+.# Pygments 2.4.2 identifies the sample below as SQL, and Pygments 2.8.0 as ECL, both presenting an highlight of the 
+.# values, whereas Pygments 2.5.x to 2.7.0 identified this sample as MIME, consequently proposing a degraded 
+.# highlighting where the text is in black and each line is framed by a red line.
 .#-----------------------------------------------------
 {{code}}
-    <!-- disable to use ajp connector instead
-    <Connector port="8080" protocol="HTTP/1.1"
-               connectionTimeout="20000"
-               URIEncoding="UTF-8"
-               redirectPort="8443" />
-    -->
+<!-- disable to use ajp connector instead
+<Connector port="8080" protocol="HTTP/1.1"
+           connectionTimeout="20000"
+           URIEncoding="UTF-8"
+           redirectPort="8443" />
+-->
 {{/code}}
 .#-----------------------------------------------------
 .expect|event/1.0
 .#-----------------------------------------------------
 beginDocument
-beginMacroMarkerStandalone [code] [] [    <!-- disable to use ajp connector instead
-    <Connector port="8080" protocol="HTTP/1.1"
-               connectionTimeout="20000"
-               URIEncoding="UTF-8"
-               redirectPort="8443" />
-    -->]
+beginMacroMarkerStandalone [code] [] [<!-- disable to use ajp connector instead
+<Connector port="8080" protocol="HTTP/1.1"
+           connectionTimeout="20000"
+           URIEncoding="UTF-8"
+           redirectPort="8443" />
+-->]
 beginGroup [[class]=[box]]
 beginGroup [[class]=[code]]
-onSpace
-onSpace
-onSpace
-onSpace
 beginFormat [NONE] [[style]=[color: #666666; ]]
 onSpecialSymbol [<]
 onSpecialSymbol [!]
@@ -48,10 +47,6 @@ onSpace
 onWord [instead]
 onNewLine
 endFormat [NONE] [[style]=[font-style: italic; color: #408080; ]]
-onSpace
-onSpace
-onSpace
-onSpace
 beginFormat [NONE] [[style]=[color: #666666; ]]
 onSpecialSymbol [<]
 endFormat [NONE] [[style]=[color: #666666; ]]
@@ -92,10 +87,6 @@ onSpace
 onSpace
 onSpace
 onSpace
-onSpace
-onSpace
-onSpace
-onSpace
 onWord [connectionTimeout]
 beginFormat [NONE] [[style]=[color: #666666; ]]
 onSpecialSymbol [=]
@@ -106,10 +97,6 @@ onWord [20000]
 onSpecialSymbol ["]
 endFormat [NONE] [[style]=[color: #19177C; ]]
 onNewLine
-onSpace
-onSpace
-onSpace
-onSpace
 onSpace
 onSpace
 onSpace
@@ -144,10 +131,6 @@ onSpace
 onSpace
 onSpace
 onSpace
-onSpace
-onSpace
-onSpace
-onSpace
 onWord [redirectPort]
 beginFormat [NONE] [[style]=[color: #666666; ]]
 onSpecialSymbol [=]
@@ -163,10 +146,6 @@ onSpecialSymbol [/]
 onSpecialSymbol [>]
 endFormat [NONE] [[style]=[color: #666666; ]]
 onNewLine
-onSpace
-onSpace
-onSpace
-onSpace
 beginFormat [NONE] [[style]=[font-style: italic; color: #408080; ]]
 onSpecialSymbol [-]
 onSpecialSymbol [-]
@@ -175,10 +154,10 @@ onNewLine
 endFormat [NONE] [[style]=[font-style: italic; color: #408080; ]]
 endGroup [[class]=[code]]
 endGroup [[class]=[box]]
-endMacroMarkerStandalone [code] [] [    <!-- disable to use ajp connector instead
-    <Connector port="8080" protocol="HTTP/1.1"
-               connectionTimeout="20000"
-               URIEncoding="UTF-8"
-               redirectPort="8443" />
-    -->]
+endMacroMarkerStandalone [code] [] [<!-- disable to use ajp connector instead
+<Connector port="8080" protocol="HTTP/1.1"
+           connectionTimeout="20000"
+           URIEncoding="UTF-8"
+           redirectPort="8443" />
+-->]
 endDocument

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/test/resources/macrocode15.test
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/test/resources/macrocode15.test
@@ -2,9 +2,9 @@
 .#-----------------------------------------------------
 .input|xwiki/2.0
 .# Validates that the code macro accurately identifies the language used in the code macro when not specified.
-.# Pygments 2.4.2 identifies the sample below as SQL, and Pygments 2.8.0 as ECL, both presenting an highlight of the 
-.# values, whereas Pygments 2.5.x to 2.7.0 identified this sample as MIME, consequently proposing a degraded 
-.# highlighting where the text is in black and each line is framed by a red line.
+.# Pygments 2.4.2 identifies the sample below as SQL syntax, and Pygments 2.8.0 as ECL syntax, both presenting an 
+.# highlight of the values, whereas Pygments 2.5.1 to 2.7.0 identifies this sample as MIME syntax, consequently 
+.# proposing a degraded highlighting where the text is in black and each line is framed by a red line.
 .#-----------------------------------------------------
 {{code}}
 <!-- disable to use ajp connector instead

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/test/resources/macrocode15.test
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/test/resources/macrocode15.test
@@ -1,0 +1,184 @@
+.runTransformations
+.#-----------------------------------------------------
+.input|xwiki/2.0
+.# Validates that the code macro accurately identifies the language used in the code macro when not specified.
+.#-----------------------------------------------------
+{{code}}
+    <!-- disable to use ajp connector instead
+    <Connector port="8080" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               URIEncoding="UTF-8"
+               redirectPort="8443" />
+    -->
+{{/code}}
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+beginMacroMarkerStandalone [code] [] [    <!-- disable to use ajp connector instead
+    <Connector port="8080" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               URIEncoding="UTF-8"
+               redirectPort="8443" />
+    -->]
+beginGroup [[class]=[box]]
+beginGroup [[class]=[code]]
+onSpace
+onSpace
+onSpace
+onSpace
+beginFormat [NONE] [[style]=[color: #666666; ]]
+onSpecialSymbol [<]
+onSpecialSymbol [!]
+endFormat [NONE] [[style]=[color: #666666; ]]
+beginFormat [NONE] [[style]=[font-style: italic; color: #408080; ]]
+onSpecialSymbol [-]
+onSpecialSymbol [-]
+onSpace
+onWord [disable]
+onSpace
+onWord [to]
+onSpace
+onWord [use]
+onSpace
+onWord [ajp]
+onSpace
+onWord [connector]
+onSpace
+onWord [instead]
+onNewLine
+endFormat [NONE] [[style]=[font-style: italic; color: #408080; ]]
+onSpace
+onSpace
+onSpace
+onSpace
+beginFormat [NONE] [[style]=[color: #666666; ]]
+onSpecialSymbol [<]
+endFormat [NONE] [[style]=[color: #666666; ]]
+onWord [Connector]
+onSpace
+onWord [port]
+beginFormat [NONE] [[style]=[color: #666666; ]]
+onSpecialSymbol [=]
+endFormat [NONE] [[style]=[color: #666666; ]]
+beginFormat [NONE] [[style]=[color: #19177C; ]]
+onSpecialSymbol ["]
+onWord [8080]
+onSpecialSymbol ["]
+endFormat [NONE] [[style]=[color: #19177C; ]]
+onSpace
+onWord [protocol]
+beginFormat [NONE] [[style]=[color: #666666; ]]
+onSpecialSymbol [=]
+endFormat [NONE] [[style]=[color: #666666; ]]
+beginFormat [NONE] [[style]=[color: #19177C; ]]
+onSpecialSymbol ["]
+onWord [HTTP]
+onSpecialSymbol [/]
+onWord [1]
+onSpecialSymbol [.]
+onWord [1]
+onSpecialSymbol ["]
+endFormat [NONE] [[style]=[color: #19177C; ]]
+onNewLine
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onWord [connectionTimeout]
+beginFormat [NONE] [[style]=[color: #666666; ]]
+onSpecialSymbol [=]
+endFormat [NONE] [[style]=[color: #666666; ]]
+beginFormat [NONE] [[style]=[color: #19177C; ]]
+onSpecialSymbol ["]
+onWord [20000]
+onSpecialSymbol ["]
+endFormat [NONE] [[style]=[color: #19177C; ]]
+onNewLine
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onWord [URIEncoding]
+beginFormat [NONE] [[style]=[color: #666666; ]]
+onSpecialSymbol [=]
+endFormat [NONE] [[style]=[color: #666666; ]]
+beginFormat [NONE] [[style]=[color: #19177C; ]]
+onSpecialSymbol ["]
+onWord [UTF]
+onSpecialSymbol [-]
+onWord [8]
+onSpecialSymbol ["]
+endFormat [NONE] [[style]=[color: #19177C; ]]
+onNewLine
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onSpace
+onWord [redirectPort]
+beginFormat [NONE] [[style]=[color: #666666; ]]
+onSpecialSymbol [=]
+endFormat [NONE] [[style]=[color: #666666; ]]
+beginFormat [NONE] [[style]=[color: #19177C; ]]
+onSpecialSymbol ["]
+onWord [8443]
+onSpecialSymbol ["]
+endFormat [NONE] [[style]=[color: #19177C; ]]
+onSpace
+beginFormat [NONE] [[style]=[color: #666666; ]]
+onSpecialSymbol [/]
+onSpecialSymbol [>]
+endFormat [NONE] [[style]=[color: #666666; ]]
+onNewLine
+onSpace
+onSpace
+onSpace
+onSpace
+beginFormat [NONE] [[style]=[font-style: italic; color: #408080; ]]
+onSpecialSymbol [-]
+onSpecialSymbol [-]
+onSpecialSymbol [>]
+onNewLine
+endFormat [NONE] [[style]=[font-style: italic; color: #408080; ]]
+endGroup [[class]=[code]]
+endGroup [[class]=[box]]
+endMacroMarkerStandalone [code] [] [    <!-- disable to use ajp connector instead
+    <Connector port="8080" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               URIEncoding="UTF-8"
+               redirectPort="8443" />
+    -->]
+endDocument

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/test/resources/macrocode16.test
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/test/resources/macrocode16.test
@@ -2,8 +2,8 @@
 .#-----------------------------------------------------
 .input|xwiki/2.0
 .# Validates that the code macro accurately identifies the language used in the code macro when not specified.
-.# Pygments 2.4.2, and 2.0.8 identify the sample below as Tera Term macro, presenting an acceptable highlight of
-.# the code, whereas version 2.5.x to 2.7.0 identified this sample as MIME, consequently proposing a degraded 
+.# Pygments 2.4.2, and 2.0.8 identify the sample below as Tera Term macro syntax, presenting an acceptable highlight of
+.# the code, whereas version 2.5.1 to 2.7.0 identifies this sample as MIME syntax, consequently proposing a degraded 
 .# highlighting where the text is in black and each line is framed by a red line.
 .#-----------------------------------------------------
 {{code}}

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/test/resources/macrocode16.test
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/test/resources/macrocode16.test
@@ -1,0 +1,147 @@
+.runTransformations
+.#-----------------------------------------------------
+.input|xwiki/2.0
+.# Validates that the code macro accurately identifies the language used in the code macro when not specified.
+.#-----------------------------------------------------
+{{code}}
+# Admins must wait 3 days before being allowed to permanently delete
+xwiki.store.recyclebin.adminWaitDays=3
+# Normal users must also wait 3 days
+xwiki.store.recyclebin.waitDays=3
+{{/code}}
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+beginMacroMarkerStandalone [code] [] [# Admins must wait 3 days before being allowed to permanently delete
+xwiki.store.recyclebin.adminWaitDays=3
+# Normal users must also wait 3 days
+xwiki.store.recyclebin.waitDays=3]
+beginGroup [[class]=[box]]
+beginGroup [[class]=[code]]
+onSpecialSymbol [#]
+onSpace
+beginFormat [NONE] [[style]=[color: #19177C; ]]
+onWord [Admins]
+endFormat [NONE] [[style]=[color: #19177C; ]]
+onSpace
+beginFormat [NONE] [[style]=[color: #19177C; ]]
+onWord [must]
+endFormat [NONE] [[style]=[color: #19177C; ]]
+onSpace
+beginFormat [NONE] [[style]=[font-weight: bold; color: #008000; ]]
+onWord [wait]
+endFormat [NONE] [[style]=[font-weight: bold; color: #008000; ]]
+onSpace
+beginFormat [NONE] [[style]=[color: #666666; ]]
+onWord [3]
+endFormat [NONE] [[style]=[color: #666666; ]]
+onSpace
+beginFormat [NONE] [[style]=[color: #19177C; ]]
+onWord [days]
+endFormat [NONE] [[style]=[color: #19177C; ]]
+onSpace
+beginFormat [NONE] [[style]=[color: #19177C; ]]
+onWord [before]
+endFormat [NONE] [[style]=[color: #19177C; ]]
+onSpace
+beginFormat [NONE] [[style]=[color: #19177C; ]]
+onWord [being]
+endFormat [NONE] [[style]=[color: #19177C; ]]
+onSpace
+beginFormat [NONE] [[style]=[color: #19177C; ]]
+onWord [allowed]
+endFormat [NONE] [[style]=[color: #19177C; ]]
+onSpace
+beginFormat [NONE] [[style]=[color: #19177C; ]]
+onWord [to]
+endFormat [NONE] [[style]=[color: #19177C; ]]
+onSpace
+beginFormat [NONE] [[style]=[color: #19177C; ]]
+onWord [permanently]
+endFormat [NONE] [[style]=[color: #19177C; ]]
+onSpace
+beginFormat [NONE] [[style]=[color: #19177C; ]]
+onWord [delete]
+endFormat [NONE] [[style]=[color: #19177C; ]]
+onNewLine
+beginFormat [NONE] [[style]=[color: #19177C; ]]
+onWord [xwiki]
+endFormat [NONE] [[style]=[color: #19177C; ]]
+onSpecialSymbol [.]
+beginFormat [NONE] [[style]=[color: #19177C; ]]
+onWord [store]
+endFormat [NONE] [[style]=[color: #19177C; ]]
+onSpecialSymbol [.]
+beginFormat [NONE] [[style]=[color: #19177C; ]]
+onWord [recyclebin]
+endFormat [NONE] [[style]=[color: #19177C; ]]
+onSpecialSymbol [.]
+beginFormat [NONE] [[style]=[color: #19177C; ]]
+onWord [adminWaitDays]
+endFormat [NONE] [[style]=[color: #19177C; ]]
+beginFormat [NONE] [[style]=[color: #666666; ]]
+onSpecialSymbol [=]
+endFormat [NONE] [[style]=[color: #666666; ]]
+beginFormat [NONE] [[style]=[color: #666666; ]]
+onWord [3]
+endFormat [NONE] [[style]=[color: #666666; ]]
+onNewLine
+onSpecialSymbol [#]
+onSpace
+beginFormat [NONE] [[style]=[color: #19177C; ]]
+onWord [Normal]
+endFormat [NONE] [[style]=[color: #19177C; ]]
+onSpace
+beginFormat [NONE] [[style]=[color: #19177C; ]]
+onWord [users]
+endFormat [NONE] [[style]=[color: #19177C; ]]
+onSpace
+beginFormat [NONE] [[style]=[color: #19177C; ]]
+onWord [must]
+endFormat [NONE] [[style]=[color: #19177C; ]]
+onSpace
+beginFormat [NONE] [[style]=[color: #19177C; ]]
+onWord [also]
+endFormat [NONE] [[style]=[color: #19177C; ]]
+onSpace
+beginFormat [NONE] [[style]=[font-weight: bold; color: #008000; ]]
+onWord [wait]
+endFormat [NONE] [[style]=[font-weight: bold; color: #008000; ]]
+onSpace
+beginFormat [NONE] [[style]=[color: #666666; ]]
+onWord [3]
+endFormat [NONE] [[style]=[color: #666666; ]]
+onSpace
+beginFormat [NONE] [[style]=[color: #19177C; ]]
+onWord [days]
+endFormat [NONE] [[style]=[color: #19177C; ]]
+onNewLine
+beginFormat [NONE] [[style]=[color: #19177C; ]]
+onWord [xwiki]
+endFormat [NONE] [[style]=[color: #19177C; ]]
+onSpecialSymbol [.]
+beginFormat [NONE] [[style]=[color: #19177C; ]]
+onWord [store]
+endFormat [NONE] [[style]=[color: #19177C; ]]
+onSpecialSymbol [.]
+beginFormat [NONE] [[style]=[color: #19177C; ]]
+onWord [recyclebin]
+endFormat [NONE] [[style]=[color: #19177C; ]]
+onSpecialSymbol [.]
+beginFormat [NONE] [[style]=[color: #19177C; ]]
+onWord [waitDays]
+endFormat [NONE] [[style]=[color: #19177C; ]]
+beginFormat [NONE] [[style]=[color: #666666; ]]
+onSpecialSymbol [=]
+endFormat [NONE] [[style]=[color: #666666; ]]
+beginFormat [NONE] [[style]=[color: #666666; ]]
+onWord [3]
+endFormat [NONE] [[style]=[color: #666666; ]]
+endGroup [[class]=[code]]
+endGroup [[class]=[box]]
+endMacroMarkerStandalone [code] [] [# Admins must wait 3 days before being allowed to permanently delete
+xwiki.store.recyclebin.adminWaitDays=3
+# Normal users must also wait 3 days
+xwiki.store.recyclebin.waitDays=3]
+endDocument

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/test/resources/macrocode16.test
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/test/resources/macrocode16.test
@@ -2,6 +2,9 @@
 .#-----------------------------------------------------
 .input|xwiki/2.0
 .# Validates that the code macro accurately identifies the language used in the code macro when not specified.
+.# Pygments 2.4.2, and 2.0.8 identify the sample below as Tera Term macro, presenting an acceptable highlight of
+.# the code, whereas version 2.5.x to 2.7.0 identified this sample as MIME, consequently proposing a degraded 
+.# highlighting where the text is in black and each line is framed by a red line.
 .#-----------------------------------------------------
 {{code}}
 # Admins must wait 3 days before being allowed to permanently delete


### PR DESCRIPTION
https://jira.xwiki.org/browse/XWIKI-18363

- Downgrade Pygments from 2.5.1 to 2.4.2 because of regressions in the way Pygment guesses the language of the code.
- Introduction of two non regression tests for future upgrades.