### PR TITLE
XWIKI-16158: Allow admin to access the notification preferences of other users

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/pom.xml
@@ -32,7 +32,8 @@
   <description>Handle notifications user preferences</description>
   <properties>
     <xwiki.jacoco.instructionRatio>0.70</xwiki.jacoco.instructionRatio>
-    </properties>
+    <checkstyle.suppressions.location>${basedir}/src/checkstyle/checkstyle-suppressions.xml</checkstyle.suppressions.location>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.xwiki.platform</groupId>
@@ -45,6 +46,13 @@
       <artifactId>xwiki-commons-tool-test-component</artifactId>
       <version>${commons.version}</version>
       <scope>test</scope>
+    </dependency>
+    <!-- FIXME: This should be removed once NotificationPreferenceScriptService doesn't use
+    DocumentUserReference anymore -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-user-default</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/src/checkstyle/checkstyle-suppressions.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/src/checkstyle/checkstyle-suppressions.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ See the NOTICE file distributed with this work for additional
+  ~ information regarding copyright ownership.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<!DOCTYPE suppressions PUBLIC
+    "-//Puppy Crawl//DTD Suppressions 1.0//EN"
+    "http://www.puppycrawl.com/dtds/suppressions_1_0.dtd">
+
+<suppressions>
+  <!-- Fan-out reached because of the Unstable and of the usage of DocumentUserReference which should be removed
+      in the future -->
+  <suppress checks="ClassFanOutComplexity" files="NotificationPreferenceScriptService.java"/>
+</suppressions>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/src/test/java/org/xwiki/notifications/preferences/script/NotificationPreferenceScriptServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/src/test/java/org/xwiki/notifications/preferences/script/NotificationPreferenceScriptServiceTest.java
@@ -29,13 +29,12 @@ import javax.inject.Provider;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.mutable.MutableBoolean;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.xwiki.bridge.DocumentAccessBridge;
-import org.xwiki.component.util.DefaultParameterizedType;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.WikiReference;
+import org.xwiki.notifications.NotificationException;
 import org.xwiki.notifications.NotificationFormat;
 import org.xwiki.notifications.preferences.NotificationPreference;
 import org.xwiki.notifications.preferences.NotificationPreferenceManager;
@@ -47,17 +46,27 @@ import org.xwiki.security.authorization.AccessDeniedException;
 import org.xwiki.security.authorization.ContextualAuthorizationManager;
 import org.xwiki.security.authorization.Right;
 import org.xwiki.test.annotation.ComponentList;
-import org.xwiki.test.mockito.MockitoComponentMockingRule;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+import org.xwiki.test.mockito.MockitoComponentManager;
+import org.xwiki.user.CurrentUserReference;
+import org.xwiki.user.UserReference;
+import org.xwiki.user.internal.document.DocumentUserReference;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -66,33 +75,33 @@ import static org.mockito.Mockito.when;
  * @since 9.7RC1
  * @version $Id$
  */
-// @formatter:off
 @ComponentList({
-    TargetableNotificationPreferenceBuilder.class
+    DefaultTargetableNotificationPreferenceBuilder.class
 })
-// @formatter:on
-public class NotificationPreferenceScriptServiceTest
+@ComponentTest
+class NotificationPreferenceScriptServiceTest
 {
-    @Rule
-    public final MockitoComponentMockingRule<NotificationPreferenceScriptService> mocker =
-            new MockitoComponentMockingRule<>(NotificationPreferenceScriptService.class);
+    @InjectMockComponents
+    private NotificationPreferenceScriptService scriptService;
 
+    @MockComponent
     private NotificationPreferenceManager notificationPreferenceManager;
+
+    @MockComponent
     private DocumentAccessBridge documentAccessBridge;
+
+    @MockComponent
     private ContextualAuthorizationManager authorizationManager;
+
+    @MockComponent
     private Provider<TargetableNotificationPreferenceBuilder> targetableNotificationPreferenceBuilderProvider;
 
-    @Before
-    public void setUp() throws Exception
+    @BeforeEach
+    void setUp(MockitoComponentManager componentManager) throws Exception
     {
-        notificationPreferenceManager = mocker.getInstance(NotificationPreferenceManager.class);
-        documentAccessBridge = mocker.getInstance(DocumentAccessBridge.class);
-        authorizationManager = mocker.getInstance(ContextualAuthorizationManager.class);
-        targetableNotificationPreferenceBuilderProvider = mock(Provider.class);
+
         when(targetableNotificationPreferenceBuilderProvider.get())
-                .thenReturn(new DefaultTargetableNotificationPreferenceBuilder());
-        mocker.registerComponent(new DefaultParameterizedType(null, Provider.class,
-                TargetableNotificationPreferenceBuilder.class), targetableNotificationPreferenceBuilderProvider);
+            .thenReturn(componentManager.getInstance(TargetableNotificationPreferenceBuilder.class));
     }
 
     private class NotificationPreferenceImpl extends AbstractNotificationPreference
@@ -106,7 +115,7 @@ public class NotificationPreferenceScriptServiceTest
     }
 
     @Test
-    public void saveNotificationPreferences() throws Exception
+    void saveNotificationPreferences() throws Exception
     {
         DocumentReference userRef = new DocumentReference("xwiki", "XWiki", "UserA");
 
@@ -135,20 +144,21 @@ public class NotificationPreferenceScriptServiceTest
                 return true;
         }).when(notificationPreferenceManager).savePreferences(any(List.class));
 
-        mocker.getComponentUnderTest().saveNotificationPreferences(
+        this.scriptService.saveNotificationPreferences(
                 IOUtils.toString(getClass().getResourceAsStream("/preferences.json")), userRef);
 
         assertTrue(isOk.booleanValue());
     }
 
     @Test
-    public void isEventTypeEnabled() throws Exception
+    void isEventTypeEnabled() throws Exception
     {
         DocumentReference user = new DocumentReference("xwiki", "XWiki", "User");
         when(documentAccessBridge.getCurrentUserReference()).thenReturn(user);
+        DocumentUserReference documentUserReference = new DocumentUserReference(user, null);
 
         when(notificationPreferenceManager.getAllPreferences(user)).thenReturn(Collections.emptyList());
-        assertFalse(mocker.getComponentUnderTest().isEventTypeEnabled("update", NotificationFormat.ALERT));
+        assertFalse(this.scriptService.isEventTypeEnabled("update", NotificationFormat.ALERT, documentUserReference));
 
         NotificationPreference pref1 = mock(NotificationPreference.class);
         NotificationPreference pref2 = mock(NotificationPreference.class);
@@ -165,17 +175,40 @@ public class NotificationPreferenceScriptServiceTest
         when(pref2.isNotificationEnabled()).thenReturn(true);
 
         when(notificationPreferenceManager.getAllPreferences(user)).thenReturn(Arrays.asList(pref1, pref2));
-        assertTrue(mocker.getComponentUnderTest().isEventTypeEnabled("update", NotificationFormat.ALERT));
-        assertFalse(mocker.getComponentUnderTest().isEventTypeEnabled("update", NotificationFormat.EMAIL));
+
+        assertTrue(this.scriptService.isEventTypeEnabled("update", NotificationFormat.ALERT, documentUserReference));
+        assertFalse(this.scriptService.isEventTypeEnabled("update", NotificationFormat.EMAIL, documentUserReference));
+        verify(this.documentAccessBridge, never()).getCurrentUserReference();
+
+        assertTrue(this.scriptService.isEventTypeEnabled("update", NotificationFormat.ALERT,
+            CurrentUserReference.INSTANCE));
+        assertFalse(this.scriptService.isEventTypeEnabled("update", NotificationFormat.EMAIL,
+            CurrentUserReference.INSTANCE));
+
+        assertTrue(this.scriptService.isEventTypeEnabled("update", NotificationFormat.ALERT));
+        assertFalse(this.scriptService.isEventTypeEnabled("update", NotificationFormat.EMAIL));
+        verify(this.documentAccessBridge, times(4)).getCurrentUserReference();
+
+        NotificationException notificationException = assertThrows(NotificationException.class,
+            () -> this.scriptService.isEventTypeEnabled("update", NotificationFormat.ALERT, new UserReference()
+            {
+                @Override
+                public boolean isGlobal()
+                {
+                    return false;
+                }
+            }));
+        assertEquals("The method isEventTypeEnabled should only be used with DocumentUserReference, "
+            + "the given reference was a []", notificationException.getMessage());
     }
 
     @Test
-    public void isEventTypeEnabledForWiki() throws Exception
+    void isEventTypeEnabledForWiki() throws Exception
     {
         WikiReference wiki = new WikiReference("whatever");
 
         when(notificationPreferenceManager.getAllPreferences(wiki)).thenReturn(Collections.emptyList());
-        assertFalse(mocker.getComponentUnderTest().isEventTypeEnabled("update", NotificationFormat.ALERT,
+        assertFalse(this.scriptService.isEventTypeEnabled("update", NotificationFormat.ALERT,
                 wiki.getName()));
 
         NotificationPreference pref1 = mock(NotificationPreference.class);
@@ -193,14 +226,14 @@ public class NotificationPreferenceScriptServiceTest
         when(pref2.isNotificationEnabled()).thenReturn(true);
 
         when(notificationPreferenceManager.getAllPreferences(wiki)).thenReturn(Arrays.asList(pref1, pref2));
-        assertTrue(mocker.getComponentUnderTest().isEventTypeEnabled("update", NotificationFormat.ALERT,
+        assertTrue(this.scriptService.isEventTypeEnabled("update", NotificationFormat.ALERT,
                 wiki.getName()));
-        assertFalse(mocker.getComponentUnderTest().isEventTypeEnabled("update", NotificationFormat.EMAIL,
+        assertFalse(this.scriptService.isEventTypeEnabled("update", NotificationFormat.EMAIL,
                 wiki.getName()));
     }
 
     @Test
-    public void saveNotificationPreferencesForCurrentWikiWithoutRight() throws Exception
+    void saveNotificationPreferencesForCurrentWikiWithoutRight() throws Exception
     {
         when(documentAccessBridge.getCurrentDocumentReference()).thenReturn(
                 new DocumentReference("wikiA", "SpaceA", "PageA"));
@@ -210,7 +243,7 @@ public class NotificationPreferenceScriptServiceTest
         String json = "";
         Exception caughtException = null;
         try {
-            mocker.getComponentUnderTest().saveNotificationPreferencesForCurrentWiki(json);
+            this.scriptService.saveNotificationPreferencesForCurrentWiki(json);
         } catch (Exception ex) {
             caughtException = ex;
         }
@@ -220,7 +253,7 @@ public class NotificationPreferenceScriptServiceTest
     }
 
     @Test
-    public void saveNotificationPreferencesWithoutRight() throws Exception
+    void saveNotificationPreferencesWithoutRight() throws Exception
     {
         DocumentReference userDoc = new DocumentReference("wikiA", "SpaceA", "UserA");
         AccessDeniedException e = mock(AccessDeniedException.class);
@@ -229,7 +262,7 @@ public class NotificationPreferenceScriptServiceTest
         String json = "";
         Exception caughtException = null;
         try {
-            mocker.getComponentUnderTest().saveNotificationPreferences(json, userDoc);
+            this.scriptService.saveNotificationPreferences(json, userDoc);
         } catch (Exception ex) {
             caughtException = ex;
         }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/pom.xml
@@ -140,6 +140,13 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <!-- Needed for checking categories -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-user-profile-test-pageobjects</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
     <!-- A wrapper to javax.mail much easier to use -->
     <dependency>
       <groupId>org.simplejavamail</groupId>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-pageobjects/src/main/java/org/xwiki/platform/notifications/test/po/AbstractNotificationsSettingsPage.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-pageobjects/src/main/java/org/xwiki/platform/notifications/test/po/AbstractNotificationsSettingsPage.java
@@ -1,0 +1,335 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.platform.notifications.test.po;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.xwiki.platform.notifications.test.po.preferences.AbstractNotificationPreferences;
+import org.xwiki.platform.notifications.test.po.preferences.ApplicationPreferences;
+import org.xwiki.platform.notifications.test.po.preferences.EventTypePreferences;
+import org.xwiki.platform.notifications.test.po.preferences.filters.NotificationFilterPreference;
+import org.xwiki.stability.Unstable;
+import org.xwiki.test.ui.po.BootstrapSwitch;
+import org.xwiki.test.ui.po.Select;
+import org.xwiki.test.ui.po.ViewPage;
+
+/**
+ * Represents a page for notification settings.
+ * This kind of page can be seen in user profile or in global administration.
+ * 
+ * @version $Id$
+ * @since 13.2RC1
+ */
+@Unstable
+public abstract class AbstractNotificationsSettingsPage extends ViewPage
+{
+    private static final String SAVED_NOTIFICATION_TEXT = "Saved!";
+
+    private static final String ALERT_FORMAT = "alert";
+
+    private static final String EMAIL_FORMAT = "email";
+
+    private static final String VALUE_ATTRIBUTE = "value";
+
+    @FindBy(id = "notificationFilterPreferencesLiveTable-display")
+    protected WebElement notificationFilterPreferencesLivetable;
+
+    @FindBy(id = "notificationsPane")
+    private WebElement notificationsPane;
+
+    @FindBy(className = "notificationAutoWatchMode")
+    private WebElement notificationAutoWatchModeSelect;
+
+    @FindBy(className = "notificationEmailDiffType")
+    private WebElement notificationEmailDiffTypeSelect;
+
+    private Map<String, ApplicationPreferences> applicationPreferences = new HashMap<>();
+
+    /**
+     * Represents the available email changes settings values.
+     * @since 13.2RC1
+     */
+    @Unstable
+    public enum EmailDiffType
+    {
+        /** Represents the standard diff. */
+        STANDARD,
+
+        /** No diff. */
+        NOTHING
+    }
+
+    /**
+     * Represents the available autowatch mode values.
+     * @since 13.2RC1
+     */
+    @Unstable
+    public enum AutowatchMode
+    {
+        /** Never autowatch. */
+        NONE,
+
+        /** Autowatch for any change. */
+        ALL,
+
+        /** Autowatch for major modifications. */
+        MAJOR,
+
+        /** Autowatch for created pages. */
+        NEW
+    }
+
+    /**
+     * Ensure to wait until the preferences switches are loaded.
+     */
+    protected void waitUntilPreferencesAreLoaded()
+    {
+        getDriver().waitUntilElementIsVisible(notificationsPane, By.cssSelector(".notifPreferences .bootstrap-switch"));
+    }
+
+    /**
+     * Initialize the page with applications informations.
+     */
+    protected void initializeApplications()
+    {
+        for (WebElement element : getDriver().findElements(By.cssSelector("tbody.applicationElem"))) {
+            ApplicationPreferences pref = new ApplicationPreferences(element, getDriver());
+            applicationPreferences.put(pref.getApplicationId(), pref);
+        }
+    }
+
+    /**
+     * @return a map of the preferences for each application
+     * @since 9.7RC1
+     */
+    public Map<String, ApplicationPreferences> getApplicationPreferences()
+    {
+        return applicationPreferences;
+    }
+
+    /**
+     * @param applicationId id of the application
+     * @return the preferences for the given application
+     * @throws Exception if the application cannot be found
+     * @since 9.7RC1
+     */
+    public ApplicationPreferences getApplication(String applicationId) throws Exception
+    {
+        ApplicationPreferences pref = applicationPreferences.get(applicationId);
+        if (pref == null) {
+            throw new Exception(String.format("Application [%s] is not present.", applicationId));
+        }
+        return pref;
+    }
+
+    /**
+     * @param applicationId id of the application
+     * @param eventType name of the event type
+     * @return the preferences for the given event type of the given application
+     * @throws Exception if the event type cannot be found
+     * @since 9.7RC1
+     */
+    public EventTypePreferences getEventType(String applicationId, String eventType) throws Exception
+    {
+        EventTypePreferences pref = getApplication(applicationId).getEventTypePreferences().get(eventType);
+        if (pref == null) {
+            throw new Exception(
+                    String.format("Event Type [%s] is not present in the application [%s].", eventType, applicationId));
+        }
+        return pref;
+    }
+
+    /**
+     * @param applicationId id of the application
+     * @param format the format of the notification
+     * @return the state of the switch related to given application and format
+     * @throws Exception if the application cannot be found
+     * @since 9.7RC1
+     */
+    public BootstrapSwitch.State getApplicationState(String applicationId, String format) throws Exception
+    {
+        ApplicationPreferences pref = getApplication(applicationId);
+        if (ALERT_FORMAT.equals(format)) {
+            return pref.getAlertState();
+        } else {
+            return pref.getEmailState();
+        }
+    }
+
+    /**
+     * @param applicationId id of the application
+     * @param eventType name of the event type
+     * @param format the format of the notification
+     * @return the state of the switch related to given event type and format
+     * @throws Exception if the event type cannot be found
+     * @since 9.7RC1
+     */
+    public BootstrapSwitch.State getEventTypeState(String applicationId, String eventType, String format)
+            throws Exception
+    {
+        EventTypePreferences pref = getEventType(applicationId, eventType);
+        if (ALERT_FORMAT.equals(format)) {
+            return pref.getAlertState();
+        } else {
+            return pref.getEmailState();
+        }
+    }
+
+    /**
+     * Set the state of the given application for the given format.
+     * @param applicationId id of the application
+     * @param format the format of the notification
+     * @param state the state to set
+     * @throws Exception if the application is not found
+     * @since 9.7RC1
+     */
+    public void setApplicationState(String applicationId, String format, BootstrapSwitch.State state) throws Exception
+    {
+        AbstractNotificationPreferences pref = getApplication(applicationId);
+        setState(format, state, pref);
+    }
+
+    /**
+     * Set the state of the event type for the given format.
+     * @param applicationId id of the application
+     * @param eventType name of the event type
+     * @param format the format of the notification
+     * @param state the state to set
+     * @throws Exception if the event type cannot be found
+     * @since 9.7RC1
+     */
+    public void setEventTypeState(String applicationId, String eventType, String format, BootstrapSwitch.State state)
+            throws Exception
+    {
+        EventTypePreferences pref = getEventType(applicationId, eventType);
+        setState(format, state, pref);
+    }
+
+    private void setState(String format, BootstrapSwitch.State state, AbstractNotificationPreferences pref)
+            throws Exception
+    {
+        boolean wait = false;
+        if (ALERT_FORMAT.equals(format)) {
+            if (pref.getAlertState() != state) {
+                pref.setAlertState(state);
+                wait = true;
+            }
+        } else {
+            if (pref.getEmailState() != state) {
+                pref.setEmailState(state);
+                wait = true;
+            }
+        }
+        if (wait) {
+            this.waitForNotificationSuccessMessage(SAVED_NOTIFICATION_TEXT);
+        }
+    }
+
+    /**
+     * Disable every notification parameters.
+     */
+    public void disableAllParameters()
+    {
+        WebElement never = notificationAutoWatchModeSelect.findElement(By.xpath("option[@value='NONE']"));
+        never.click();
+        try {
+            for (ApplicationPreferences app : applicationPreferences.values()) {
+                if (app.getAlertState() != BootstrapSwitch.State.OFF) {
+                    app.setAlertState(BootstrapSwitch.State.OFF);
+                    this.waitForNotificationSuccessMessage(SAVED_NOTIFICATION_TEXT);
+                }
+                if (app.getEmailState() != BootstrapSwitch.State.OFF) {
+                    app.setEmailState(BootstrapSwitch.State.OFF);
+                    this.waitForNotificationSuccessMessage(SAVED_NOTIFICATION_TEXT);
+                }
+            }
+        } catch (Exception e) {
+            // Do nothing, the exception is only triggered if we try to use an invalid state
+        }
+    }
+
+    /**
+     * @return the notification filter preferences, as they are described in the corresponding livetable
+     *
+     * @since 10.8RC1
+     * @since 9.11.8
+     */
+    public List<NotificationFilterPreference> getNotificationFilterPreferences()
+    {
+
+        List<NotificationFilterPreference> preferences = new ArrayList<>();
+        for (WebElement row : this.notificationFilterPreferencesLivetable.findElements(By.tagName("tr"))) {
+            preferences.add(new NotificationFilterPreference(this, row, this.getDriver()));
+        }
+        return preferences;
+    }
+
+    /**
+     * @return the value of the email details of change.
+     * @since 13.2RC1
+     */
+    @Unstable
+    public EmailDiffType getNotificationEmailDiffType()
+    {
+        return EmailDiffType.valueOf(
+            new Select(this.notificationEmailDiffTypeSelect).getFirstSelectedOption().getAttribute(VALUE_ATTRIBUTE));
+    }
+
+    /**
+     * Set the email diff type setting.
+     * @param value the diff type to set.
+     * @since 13.2RC1
+     */
+    @Unstable
+    public void setNotificationEmailDiffType(EmailDiffType value)
+    {
+        new Select(this.notificationEmailDiffTypeSelect).selectByValue(value.name());
+        waitForNotificationSuccessMessage(SAVED_NOTIFICATION_TEXT);
+    }
+
+    /**
+     * @return the value of the autowatch mode.
+     * @since 13.2RC1
+     */
+    @Unstable
+    public AutowatchMode getAutoWatchModeValue()
+    {
+        return AutowatchMode.valueOf(
+            new Select(this.notificationAutoWatchModeSelect).getFirstSelectedOption().getAttribute(VALUE_ATTRIBUTE));
+    }
+
+    /**
+     * Set the autowatch mode value.
+     * @param value the autowatch mode to set.
+     * @since 13.2RC1
+     */
+    @Unstable
+    public void setAutoWatchMode(AutowatchMode value)
+    {
+        new Select(this.notificationAutoWatchModeSelect).selectByValue(value.name());
+        waitForNotificationSuccessMessage(SAVED_NOTIFICATION_TEXT);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-pageobjects/src/main/java/org/xwiki/platform/notifications/test/po/NotificationsAdministrationPage.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-pageobjects/src/main/java/org/xwiki/platform/notifications/test/po/NotificationsAdministrationPage.java
@@ -1,6 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
-
-<!--
+/*
  * See the NOTICE file distributed with this work for additional
  * information regarding copyright ownership.
  *
@@ -18,23 +16,35 @@
  * License along with this software; if not, write to the Free
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
--->
+ */
+package org.xwiki.platform.notifications.test.po;
 
-<xwikidoc version="1.4" reference="XWiki.Notifications.Code.WebHome" locale="">
-  <web>XWiki.Notifications.Code</web>
-  <name>WebHome</name>
-  <language/>
-  <defaultLanguage/>
-  <translation>0</translation>
-  <creator>xwiki:XWiki.Admin</creator>
-  <parent>XWiki.Notifications.WebHome</parent>
-  <author>xwiki:XWiki.Admin</author>
-  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <version>1.1</version>
-  <title/>
-  <comment/>
-  <minorEdit>false</minorEdit>
-  <syntaxId>xwiki/2.1</syntaxId>
-  <hidden>true</hidden>
-  <content>{{documentTree root="document:XWiki.Notifications.Code.WebHome" filterHiddenDocuments="false"/}}</content>
-</xwikidoc>
+import org.xwiki.stability.Unstable;
+
+/**
+ * Represents the Notifications preferences in administration.
+ *
+ * @version $Id$
+ * @since 13.2R1
+ */
+@Unstable
+public class NotificationsAdministrationPage extends AbstractNotificationsSettingsPage
+{
+    /**
+     * Default constructor.
+     */
+    public NotificationsAdministrationPage()
+    {
+        this.initializeApplications();
+    }
+
+    /**
+     * Go to the administration page related to notifications and create the appropriate instance.
+     * @return the appropriate instance of {@link NotificationsAdministrationPage}.
+     */
+    public static NotificationsAdministrationPage gotoPage()
+    {
+        getUtil().gotoPage("XWiki", "XWikiPreferences", "admin", "section=Notifications");
+        return new NotificationsAdministrationPage();
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-pageobjects/src/main/java/org/xwiki/platform/notifications/test/po/NotificationsUserProfilePage.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-pageobjects/src/main/java/org/xwiki/platform/notifications/test/po/NotificationsUserProfilePage.java
@@ -20,19 +20,11 @@
 package org.xwiki.platform.notifications.test.po;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.FindBy;
-import org.xwiki.platform.notifications.test.po.preferences.AbstractNotificationPreferences;
-import org.xwiki.platform.notifications.test.po.preferences.ApplicationPreferences;
-import org.xwiki.platform.notifications.test.po.preferences.EventTypePreferences;
 import org.xwiki.platform.notifications.test.po.preferences.filters.NotificationFilterPreference;
-import org.xwiki.test.ui.po.BootstrapSwitch;
-import org.xwiki.test.ui.po.ViewPage;
 
 /**
  * Represents the user profile's Notifications tab.
@@ -40,45 +32,16 @@ import org.xwiki.test.ui.po.ViewPage;
  * @version $Id$
  * @since 9.4RC1
  */
-public class NotificationsUserProfilePage extends ViewPage
+public class NotificationsUserProfilePage extends AbstractNotificationsSettingsPage
 {
-    private static final String SAVED_NOTIFICATION_TEXT = "Saved!";
-
-    private static final String ALERT_FORMAT = "alert";
-
-    private static final String EMAIL_FORMAT = "email";
-
-    @FindBy(id = "notificationsPane")
-    private WebElement notificationsPane;
-
-    @FindBy(className = "notificationAutoWatchMode")
-    private WebElement notificationAutoWatchModeSelect;
-
-    private Map<String, ApplicationPreferences> applicationPreferences = new HashMap<>();
-
-    @FindBy(id = "notificationFilterPreferencesLiveTable-display")
-    private WebElement notificationFilterPreferencesLivetable;
 
     /**
      * Construct a NotificationsUserProfilePage (and for the browser page to be fully loaded).
      */
     public NotificationsUserProfilePage()
     {
-        getDriver().waitUntilElementIsVisible(notificationsPane, By.cssSelector(".notifPreferences .bootstrap-switch"));
-
-        for (WebElement element : getDriver().findElements(By.cssSelector("tbody.applicationElem"))) {
-            ApplicationPreferences pref = new ApplicationPreferences(element, getDriver());
-            applicationPreferences.put(pref.getApplicationId(), pref);
-        }
-    }
-
-    /**
-     * @return a map of the preferences for each application
-     * @since 9.7RC1
-     */
-    public Map<String, ApplicationPreferences> getApplicationPreferences()
-    {
-        return applicationPreferences;
+        this.waitUntilPreferencesAreLoaded();
+        this.initializeApplications();
     }
 
     /**
@@ -90,147 +53,6 @@ public class NotificationsUserProfilePage extends ViewPage
     {
         getUtil().gotoPage("XWiki", username, "view", "category=notifications");
         return new NotificationsUserProfilePage();
-    }
-
-    /**
-     * @param applicationId id of the application
-     * @return the preferences for the given application
-     * @throws Exception if the application cannot be found
-     * @since 9.7RC1
-     */
-    public ApplicationPreferences getApplication(String applicationId) throws Exception
-    {
-        ApplicationPreferences pref = applicationPreferences.get(applicationId);
-        if (pref == null) {
-            throw new Exception(String.format("Application [%s] is not present.", applicationId));
-        }
-        return pref;
-    }
-
-    /**
-     * @param applicationId id of the application
-     * @param eventType name of the event type
-     * @return the preferences for the given event type of the given application
-     * @throws Exception if the event type cannot be found
-     * @since 9.7RC1
-     */
-    public EventTypePreferences getEventType(String applicationId, String eventType) throws Exception
-    {
-        EventTypePreferences pref = getApplication(applicationId).getEventTypePreferences().get(eventType);
-        if (pref == null) {
-            throw new Exception(
-                    String.format("Event Type [%s] is not present in the application [%s].", eventType, applicationId));
-        }
-        return pref;
-    }
-
-    /**
-     * @param applicationId id of the application
-     * @param format the format of the notification
-     * @return the state of the switch related to given application and format
-     * @throws Exception if the application cannot be found
-     * @since 9.7RC1
-     */
-    public BootstrapSwitch.State getApplicationState(String applicationId, String format) throws Exception
-    {
-        ApplicationPreferences pref = getApplication(applicationId);
-        if (ALERT_FORMAT.equals(format)) {
-            return pref.getAlertState();
-        } else {
-            return pref.getEmailState();
-        }
-    }
-
-    /**
-     * @param applicationId id of the application
-     * @param eventType name of the event type
-     * @param format the format of the notification
-     * @return the state of the switch related to given event type and format
-     * @throws Exception if the event type cannot be found
-     * @since 9.7RC1
-     */
-    public BootstrapSwitch.State getEventTypeState(String applicationId, String eventType, String format)
-            throws Exception
-    {
-        EventTypePreferences pref = getEventType(applicationId, eventType);
-        if (ALERT_FORMAT.equals(format)) {
-            return pref.getAlertState();
-        } else {
-            return pref.getEmailState();
-        }
-    }
-
-    /**
-     * Set the state of the given application for the given format.
-     * @param applicationId id of the application
-     * @param format the format of the notification
-     * @param state the state to set
-     * @throws Exception if the application is not found
-     * @since 9.7RC1
-     */
-    public void setApplicationState(String applicationId, String format, BootstrapSwitch.State state) throws Exception
-    {
-        AbstractNotificationPreferences pref = getApplication(applicationId);
-        setState(format, state, pref);
-    }
-
-    /**
-     * Set the state of the event type for the given format.
-     * @param applicationId id of the application
-     * @param eventType name of the event type
-     * @param format the format of the notification
-     * @param state the state to set
-     * @throws Exception if the event type cannot be found
-     * @since 9.7RC1
-     */
-    public void setEventTypeState(String applicationId, String eventType, String format, BootstrapSwitch.State state)
-            throws Exception
-    {
-        EventTypePreferences pref = getEventType(applicationId, eventType);
-        setState(format, state, pref);
-    }
-
-    private void setState(String format, BootstrapSwitch.State state, AbstractNotificationPreferences pref)
-            throws Exception
-    {
-        boolean wait = false;
-        if (ALERT_FORMAT.equals(format)) {
-            if (pref.getAlertState() != state) {
-                pref.setAlertState(state);
-                wait = true;
-            }
-        } else {
-            if (pref.getEmailState() != state) {
-                pref.setEmailState(state);
-                wait = true;
-            }
-        }
-        if (wait) {
-            this.waitForNotificationSuccessMessage(SAVED_NOTIFICATION_TEXT);
-        }
-    }
-
-    /**
-     * Disable every notification parameters.
-     */
-    public void disableAllParameters()
-    {
-        WebElement never = notificationAutoWatchModeSelect.findElement(By.xpath("option[@value='NONE']"));
-        never.click();
-        try {
-            for (ApplicationPreferences app : applicationPreferences.values()) {
-                if (app.getAlertState() != BootstrapSwitch.State.OFF) {
-                    app.setAlertState(BootstrapSwitch.State.OFF);
-                    this.waitForNotificationSuccessMessage(SAVED_NOTIFICATION_TEXT);
-                }
-                if (app.getEmailState() != BootstrapSwitch.State.OFF) {
-                    app.setEmailState(BootstrapSwitch.State.OFF);
-                    this.waitForNotificationSuccessMessage(SAVED_NOTIFICATION_TEXT);
-                }
-            }
-        } catch (Exception e) {
-            // Do nothing, the exception is only triggered if we try to use an invalid state
-        }
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-pageobjects/src/main/java/org/xwiki/platform/notifications/test/po/preferences/filters/NotificationFilterPreference.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-pageobjects/src/main/java/org/xwiki/platform/notifications/test/po/preferences/filters/NotificationFilterPreference.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
-import org.xwiki.platform.notifications.test.po.NotificationsUserProfilePage;
+import org.xwiki.platform.notifications.test.po.AbstractNotificationsSettingsPage;
 import org.xwiki.test.ui.XWikiWebDriver;
 import org.xwiki.test.ui.po.BootstrapSwitch;
 import org.xwiki.test.ui.po.ConfirmationBox;
@@ -40,7 +40,7 @@ public class NotificationFilterPreference
 {
     private static final String LIST_HTML_TAG = "li";
 
-    private NotificationsUserProfilePage parentPage;
+    private AbstractNotificationsSettingsPage parentPage;
 
     private WebElement livetableRow;
 
@@ -60,7 +60,7 @@ public class NotificationFilterPreference
      * @param webElement the livetable row
      * @param driver the current webdriver in used
      */
-    public NotificationFilterPreference(NotificationsUserProfilePage parentPage, WebElement webElement,
+    public NotificationFilterPreference(AbstractNotificationsSettingsPage parentPage, WebElement webElement,
             XWikiWebDriver driver)
     {
         this.parentPage = parentPage;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationFilterPreferenceLivetableResults.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationFilterPreferenceLivetableResults.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.3" reference="XWiki.Notifications.Code.NotificationFilterPreferenceLivetableResults" locale="">
+<xwikidoc version="1.4" reference="XWiki.Notifications.Code.NotificationFilterPreferenceLivetableResults" locale="">
   <web>XWiki.Notifications.Code</web>
   <name>NotificationFilterPreferenceLivetableResults</name>
   <language/>
@@ -62,7 +62,7 @@
 ## We display them first because we don't want them to be hidden by thousands of page filters the autowatch option
 ## might have created. It would be not good to have to go to the last page of the livetable to find out these commonly
 ## used filters.
-#set ($filters = $services.notification.filters.getToggleableNotificationFilters())
+#set ($filters = $services.notification.filters.getToggleableNotificationFilters($request.user))
 #foreach ($filter in $filters)
   #set ($index = $index + 1)
   ## Optimization to render only displayed rows (between $offset and $limitOffset)
@@ -97,12 +97,12 @@
 #set ($elements = $collectiontool.sort($elements, ['name']))
 ## Also get the list of available filters for the user
 #set ($filters = $collectiontool.arrayList)
-#set ($discard = $filters.addAll($services.notification.filters.filters))
+#set ($discard = $filters.addAll($services.notification.filters.getFilters($request.user)))
 #set ($filters = $collectiontool.sort($filters, ['name']))
 #set ($displayHiddenDocument = "$xwiki.getUserPreference('displayHiddenDocuments')" == '1')
 #foreach ($filter in $filters)
   #set ($filtersPreferences = $collectiontool.arrayList)
-  #set ($discard = $filtersPreferences.addAll($services.notification.filters.getFilterPreferences($filter)))
+  #set ($discard = $filtersPreferences.addAll($services.notification.filters.getFilterPreferences($filter, $request.user)))
   #set ($filtersPreferences = $collectiontool.sort($filtersPreferences, ['id']))
   #foreach ($preference in $filtersPreferences)
     #set ($page = $preference.pageOnly)

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationPreferenceService.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationPreferenceService.xml
@@ -37,31 +37,47 @@
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
   <content>{{velocity}}
-#if ("$!request.interval" != '')
-  #set ($userDoc = $xwiki.getDocument($xcontext.userReference))
+#if ("$!request.user" != "")
+    #if ($request.user.contains("."))
+      #set ($targetUser = $request.user)
+    #else
+      #set ($targetUser = "XWiki." + $request.user)
+    #end
+#end
+#if ("$!request.action" == "" &amp;&amp; $request.method.equalsIgnoreCase('get'))
+  This is a technical page for Notifications macro.
+#elseif (!$services.csrf.isTokenValid($request.csrf))
+  #set ($discard = $response.sendError(401, $services.localization.render('notifications.settings.error.badCSRF')))
+#elseif ("$!request.target" == 'wiki' &amp;&amp; !$hasAdmin)
+  #set ($discard = $response.sendError(401))
+#elseif ("$!request.action" == "" || ("$!request.target" == 'user' &amp;&amp; "$!request.user" == ""))
+  #set ($discard = $response.sendError(400, $services.localization.render('notifications.settings.error.badParameters')))
+#elseif ("$!request.action" == "setInterval")
+  #if ("$!request.interval" == '' || "$!request.target" == 'wiki')
+    #set ($discard = $response.sendError(400, $services.localization.render('notifications.settings.error.badParameters')))
+  #end
+  #set ($userDoc = $xwiki.getDocument($targetUser))
   #set ($prefObj = $userDoc.getObject('XWiki.Notifications.Code.NotificationEmailPreferenceClass', true))
   #set ($discard = $prefObj.set('interval', $request.interval))
   #set ($discard = $userDoc.save('Update Notification Email Interval'))
-#elseif ("$!request.diffType" != '')
-  #set ($targetDoc = 0)
-  #if ("$!request.target" == 'wiki' &amp;&amp; $hasAdmin)
+#elseif ("$!request.action" == "setDiffType")
+  #if ("$!request.diffType" == '')
+    #set ($discard = $response.sendError(400, $services.localization.render('notifications.settings.error.badParameters')))
+  #end
+  #if ("$!request.target" == 'wiki')
     #set ($targetDoc = $xwiki.getDocument($services.model.createDocumentReference('', ['XWiki', 'Notifications', 'Code'], 'NotificationAdministration')))
   #elseif ("$!request.target" == 'user')
-    #set ($targetDoc = $xwiki.getDocument($xcontext.userReference))
+    #set ($targetDoc = $xwiki.getDocument($targetUser))
   #end
-  #if ($targetDoc == 0)
-    #set ($discard = $response.sendError(401))
-  #else
-    #set ($prefObj = $targetDoc.getObject('XWiki.Notifications.Code.NotificationEmailPreferenceClass', true))
-    #set ($discard = $prefObj.set('diffType', $request.diffType))
-    #set ($discard = $targetDoc.save('Update Notification Email Diff Type'))
-  #end
+  #set ($prefObj = $targetDoc.getObject('XWiki.Notifications.Code.NotificationEmailPreferenceClass', true))
+  #set ($discard = $prefObj.set('diffType', $request.diffType))
+  #set ($discard = $targetDoc.save('Update Notification Email Diff Type'))
 #elseif ("$!request.action" == 'savePreferences')
   #try()
     #if ("$!request.target" == 'wiki')
       $services.notification.preferences.saveNotificationPreferencesForCurrentWiki($request.json)
     #else
-      $services.notification.preferences.saveNotificationPreferences($request.json)
+      $services.notification.preferences.saveNotificationPreferences($request.json, $targetUser)
     #end
   #end
   #if ("$!exception" != '')
@@ -69,88 +85,66 @@
   #end
 #elseif ("$!request.action" == 'deleteFilterPreference')
   #try()
-    #if ($services.csrf.isTokenValid($request.csrf))
-      $services.notification.filters.deleteFilterPreference($request.filterPreferenceId)
-    #else
-      $response.sendError(401, 'Bad CSRF Token')
-    #end
+    $services.notification.filters.deleteFilterPreference($request.filterPreferenceId, $targetUser)
   #end
   #if ("$!exception" != '')
     $response.sendError(500, "$!exceptiontool.getStackTrace($exception)")
   #end
 #elseif ("$!request.action" == 'setFilterPreferenceEnabled')
   #try()
-    #if ($services.csrf.isTokenValid($request.csrf))
-      $services.notification.filters.setFilterPreferenceEnabled($request.filterPreferenceId, $stringtool.equals("$!request.enabled", 'true'))
-    #else
-      $response.sendError(401, 'Bad CSRF Token')
-    #end
+    $services.notification.filters.setFilterPreferenceEnabled($request.filterPreferenceId, $stringtool.equals("$!request.enabled", 'true'), $targetUser)
   #end
   #if ("$!exception" != '')
     $response.sendError(500, "$!exceptiontool.getStackTrace($exception)")
   #end
 #elseif ("$!request.action" == 'createScopeFilterPreference')
   #try()
-    #if ($services.csrf.isTokenValid($request.csrf))
-      #macro (saveScopeFilterPreference $reference)
-        $services.notification.filters.createScopeFilterPreference($request.filterType, $request.filterFormats.split(','), $request.eventTypes.split(','), $reference)
+    #macro (saveScopeFilterPreference $reference)
+      $services.notification.filters.createScopeFilterPreference($request.filterType, $request.filterFormats.split(','), $request.eventTypes.split(','), $reference, $targetUser)
+    #end
+    #if ("$!request.wiki" != "")
+      #foreach ($wikiRequest in $request.getParameterValues('wiki'))
+        #set ($reference = $services.model.createWikiReference($wikiRequest))
+        #saveScopeFilterPreference($reference)
       #end
-      #if ("$!request.wiki" != "")
-        #foreach ($wikiRequest in $request.getParameterValues('wiki'))
-          #set ($reference = $services.model.createWikiReference($wikiRequest))
-          #saveScopeFilterPreference($reference)
-        #end
+    #end
+    #if ("$!request.space" != "")
+      #foreach ($spaceRequest in $request.getParameterValues('space'))
+        SPACE REQUEST: $spaceRequest
+        #set ($reference = $services.model.resolveSpace($spaceRequest))
+        #saveScopeFilterPreference($reference)
       #end
-      #if ("$!request.space" != "")
-        #foreach ($spaceRequest in $request.getParameterValues('space'))
-          SPACE REQUEST: $spaceRequest
-          #set ($reference = $services.model.resolveSpace($spaceRequest))
-          #saveScopeFilterPreference($reference)
-        #end
+    #end
+    #if ("$!request.page" != "")
+      #foreach ($pageRequest in $request.getParameterValues('page'))
+        #set ($reference = $services.model.resolveDocument($pageRequest))
+        #saveScopeFilterPreference($reference)
       #end
-      #if ("$!request.page" != "")
-        #foreach ($pageRequest in $request.getParameterValues('page'))
-          #set ($reference = $services.model.resolveDocument($pageRequest))
-          #saveScopeFilterPreference($reference)
-        #end
-      #end
-    #else
-      $response.sendError(401, 'Bad CSRF Token')
     #end
   #end
   #if ("$!exception" != '')
     $response.sendError(500, "$!exceptiontool.getStackTrace($exception)")
   #end
-#elseif ("$!request.action" == 'setAutoWatchMode' || "$!request.action" == 'setDefaultAutoWatchMode')
+#elseif ("$!request.action" == 'setAutoWatchMode')
   #try()
-    #if ($services.csrf.isTokenValid($request.csrf))
-      #if ($request.action == 'setAutoWatchMode')
-        #set ($targetDoc = $xwiki.getDocument($xcontext.userReference))
-      #elseif (!$hasAdmin)
-        $response.sendError(401, 'Unauthorized')
-      #else
-        #set ($targetDoc = $xwiki.getDocument($services.model.createDocumentReference('', ['XWiki', 'Notifications', 'Code'], 'NotificationAdministration')))
-      #end
-      #set ($obj = $targetDoc.getObject('XWiki.Notifications.Code.AutomaticWatchModeClass', true))
-      #set ($discard = $obj.set('automaticWatchMode', $request.mode))
-      #set ($discard = $targetDoc.save('Update the automaticWatchMode.'))
+    #if ($request.target == 'user')
+      #set ($targetDoc = $xwiki.getDocument($targetUser))
     #else
-      $response.sendError(401, 'Bad CSRF Token')
+      #set ($targetDoc = $xwiki.getDocument($services.model.createDocumentReference('', ['XWiki', 'Notifications', 'Code'], 'NotificationAdministration')))
     #end
+    #set ($obj = $targetDoc.getObject('XWiki.Notifications.Code.AutomaticWatchModeClass', true))
+    #set ($discard = $obj.set('automaticWatchMode', $request.mode))
+    #set ($discard = $targetDoc.save('Update the automaticWatchMode.'))
   #end
   #if ("$!exception" != '')
     $response.sendError(500, "$!exceptiontool.getStackTrace($exception)")
   #end
 #elseif ("$!request.action" == 'watchUser' || "$!request.action" == 'unwatchUser')
   #try()
-    #if ($services.csrf.isTokenValid($request.csrf))
-      #if ($request.action == 'watchUser')
-        #set ($discard = $services.notification.watch.watchUser($request.userId))
-      #else
-        #set ($discard = $services.notification.watch.unwatchUser($request.userId))
-      #end
+    #if ($request.action == 'watchUser')
+      #set ($discard = $services.notification.watch.watchUser($request.userId))
     #else
-      $response.sendError(401, 'Bad CSRF Token')
+      #set ($discard = $services.notification.watch.unwatchUser($request.userId))
     #end
   #end
   #if ("$!exception" != '')

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsApplicationsPreferencesMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsApplicationsPreferencesMacro.xml
@@ -184,11 +184,18 @@ require(['jquery', 'xwiki-meta', 'ApplicationWidget', 'bootstrap', 'bootstrap-sw
           }
         }
       }
+      var target = $('.notifPreferences').attr('data-target');
+      var targetUser = "";
+      if (target == 'user') {
+        var targetUser = XWiki.Model.serialize(new XWiki.Document().getDocumentReference())
+      }
       var url = "$xwiki.getURL('XWiki.Notifications.Code.NotificationPreferenceService', 'get', 'outputSyntax=plain')";
       $.post(url, {
         action: 'savePreferences',
         target: $('.notifPreferences').attr('data-target'),
-        json: JSON.stringify(data)
+        user: targetUser,
+        json: JSON.stringify(data),
+        csrf: xm.form_token
       }).done(function() {
         notification.hide();
         new XWiki.widgets.Notification("$escapetool.javascript($services.localization.render('notifications.settings.saved'))", 'done');
@@ -771,7 +778,7 @@ require(['jquery', 'xwiki-meta', 'ApplicationWidget', 'bootstrap', 'bootstrap-sw
         <displayFormType>select</displayFormType>
         <displayType/>
         <name>async_cached</name>
-        <number>12</number>
+        <number>13</number>
         <prettyName>Cached</prettyName>
         <unmodifiable>0</unmodifiable>
         <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
@@ -784,14 +791,14 @@ require(['jquery', 'xwiki-meta', 'ApplicationWidget', 'bootstrap', 'bootstrap-sw
         <largeStorage>0</largeStorage>
         <multiSelect>1</multiSelect>
         <name>async_context</name>
-        <number>13</number>
+        <number>14</number>
         <prettyName>Context elements</prettyName>
         <relationalStorage>0</relationalStorage>
-        <separator> </separator>
+        <separator>, </separator>
         <separators>|, </separators>
         <size>5</size>
         <unmodifiable>0</unmodifiable>
-        <values>doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.parameters=Request parameters|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
+        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.parameters=Request parameters|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </async_context>
       <async_enabled>
@@ -800,7 +807,7 @@ require(['jquery', 'xwiki-meta', 'ApplicationWidget', 'bootstrap', 'bootstrap-sw
         <displayFormType>select</displayFormType>
         <displayType/>
         <name>async_enabled</name>
-        <number>11</number>
+        <number>12</number>
         <prettyName>Asynchronous rendering</prettyName>
         <unmodifiable>0</unmodifiable>
         <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
@@ -905,6 +912,16 @@ require(['jquery', 'xwiki-meta', 'ApplicationWidget', 'bootstrap', 'bootstrap-sw
         <unmodifiable>0</unmodifiable>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
+      <priority>
+        <disabled>0</disabled>
+        <name>priority</name>
+        <number>11</number>
+        <numberType>integer</numberType>
+        <prettyName>Priority</prettyName>
+        <size>10</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.NumberClass</classType>
+      </priority>
       <supportsInlineMode>
         <disabled>0</disabled>
         <displayFormType>select</displayFormType>
@@ -947,13 +964,21 @@ require(['jquery', 'xwiki-meta', 'ApplicationWidget', 'bootstrap', 'bootstrap-sw
       <code>{{include reference="XWiki.Notifications.Code.NotificationsPreferencesMacros" /}}
 
 {{velocity}}
-#if (!$xcontext.userReference &amp;&amp; $xcontext.macro.params.target == 'user')
+#if (!$xcontext.userReference &amp;&amp; $wikimacro.parameters.target == 'user')
   {{info}}
     {{translation key="notifications.settings.applications.forGuest" /}}
   {{/info}}
-#elseif ($xcontext.macro.params.target == 'wiki' &amp;&amp; !$services.security.authorization.hasAccess('admin', $services.model.createWikiReference($services.wiki.currentWikiId)))
+#elseif ($wikimacro.parameters.target == 'wiki' &amp;&amp; !$services.security.authorization.hasAccess('admin', $services.model.createWikiReference($services.wiki.currentWikiId)))
   {{error}}
     {{translation key="notifications.settings.error.notAdmin" /}}
+  {{/error}}
+#elseif ($wikimacro.parameters.target == 'user' &amp;&amp; "$!wikimacro.parameters.user" != ""  &amp;&amp; $wikimacro.parameters.user.class.simpleName != 'DocumentUserReference')
+  {{error}}
+    {{translation key="notifications.settings.error.userReferenceNotSupported" /}}
+  {{/error}}
+#elseif ($wikimacro.parameters.target == 'user' &amp;&amp; "$!wikimacro.parameters.user" != "" &amp;&amp; !$services.security.authorization.hasAccess('admin', $wikimacro.parameters.user.reference) &amp;&amp; !$xcontext.userReference.equals($wikimacro.parameters.user.reference))
+  {{error}}
+    {{translation key="notifications.settings.error.userReferenceAdminForbidden" /}}
   {{/error}}
 #else
 ######################################################
@@ -966,14 +991,21 @@ require(['jquery', 'xwiki-meta', 'ApplicationWidget', 'bootstrap', 'bootstrap-sw
 ######################################################
 ### GLOBALS
 ######################################################
-#set ($userDoc = $xwiki.getDocument($xcontext.userReference))
+#if ("$!wikimacro.parameters.user" != "" &amp;&amp; $wikimacro.parameters.target == 'user')
+  #set ($targetUser = $wikimacro.parameters.user.reference)
+  #set ($targetUserReference = $wikimacro.parameters.user)
+#else
+  #set ($targetUser = $xcontext.userReference)
+  #set ($targetUserReference = $services.user.currentUserReference)
+#end
+#set ($userDoc = $xwiki.getDocument($targetUser))
 ######################################################
 ### MACRO CONTENT
 ######################################################
 {{html clean="false"}}
 &lt;div class="xform"&gt;
 &lt;p class="xHint"&gt;$escapetool.xml($services.localization.render('notifications.settings.applications.hint'))&lt;/p&gt;
-&lt;table class="notifPreferences" data-target="$escapetool.xml($xcontext.macro.params.target)"&gt;
+&lt;table class="notifPreferences" data-target="$escapetool.xml($wikimacro.parameters.target)"&gt;
   &lt;thead&gt;
     &lt;tr&gt;
       &lt;th scope="col"&gt;$escapetool.xml($services.localization.render('notifications.settings.applications.appName'))&lt;/th&gt;
@@ -1056,8 +1088,8 @@ require(['jquery', 'xwiki-meta', 'ApplicationWidget', 'bootstrap', 'bootstrap-sw
 #macro(displayPreference $type $format)
   #set ($checked = '')
   #set ($preference = '')
-  #if (($xcontext.macro.params.target == 'wiki' &amp;&amp; $services.notification.preferences.isEventTypeEnabled($type.eventType, $format, $services.wiki.currentWikiId)) ||
-    ($xcontext.macro.params.target == 'user' &amp;&amp; $services.notification.preferences.isEventTypeEnabled($type.eventType, $format)))
+  #if (($wikimacro.parameters.target == 'wiki' &amp;&amp; $services.notification.preferences.isEventTypeEnabled($type.eventType, $format, $services.wiki.currentWikiId)) ||
+    ($wikimacro.parameters.target == 'user' &amp;&amp; $services.notification.preferences.isEventTypeEnabled($type.eventType, $format, $targetUserReference)))
     #set ($checked = 'checked="checked"')
   #end
   &lt;td class="notificationTypeCell loading" data-eventtype="$!escapetool.xml($type.eventType)" data-format="$format" data-filter="${type.filter}"&gt;
@@ -1090,6 +1122,9 @@ require(['jquery', 'xwiki-meta', 'ApplicationWidget', 'bootstrap', 'bootstrap-sw
     </property>
     <property>
       <name>Notifications Applications Preferences</name>
+    </property>
+    <property>
+      <priority/>
     </property>
     <property>
       <supportsInlineMode>0</supportsInlineMode>
@@ -1174,6 +1209,84 @@ require(['jquery', 'xwiki-meta', 'ApplicationWidget', 'bootstrap', 'bootstrap-sw
     </property>
     <property>
       <type/>
+    </property>
+  </object>
+  <object>
+    <name>XWiki.Notifications.Code.NotificationsApplicationsPreferencesMacro</name>
+    <number>1</number>
+    <className>XWiki.WikiMacroParameterClass</className>
+    <guid>79c9b6f0-e62f-493d-9be6-49a58adc9e8d</guid>
+    <class>
+      <name>XWiki.WikiMacroParameterClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <defaultValue>
+        <disabled>0</disabled>
+        <name>defaultValue</name>
+        <number>4</number>
+        <prettyName>Parameter default value</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </defaultValue>
+      <description>
+        <disabled>0</disabled>
+        <name>description</name>
+        <number>2</number>
+        <prettyName>Parameter description</prettyName>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </description>
+      <mandatory>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>mandatory</name>
+        <number>3</number>
+        <prettyName>Parameter mandatory</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </mandatory>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Parameter name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <type>
+        <disabled>0</disabled>
+        <name>type</name>
+        <number>5</number>
+        <prettyName>Parameter type</prettyName>
+        <size>60</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </type>
+    </class>
+    <property>
+      <defaultValue/>
+    </property>
+    <property>
+      <description>User reference of the user for which to display and manipulate the application preferences. This parameter is optional, only used if the target parameter is set to ##user## and default value is the context user. Note that for using this parameter, the context user needs administrator right on the given user reference.</description>
+    </property>
+    <property>
+      <mandatory>0</mandatory>
+    </property>
+    <property>
+      <name>user</name>
+    </property>
+    <property>
+      <type>org.xwiki.user.UserReference</type>
     </property>
   </object>
 </xwikidoc>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsAutoWatchPreferencesMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsAutoWatchPreferencesMacro.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.3" reference="XWiki.Notifications.Code.NotificationsAutoWatchPreferencesMacro" locale="">
+<xwikidoc version="1.4" reference="XWiki.Notifications.Code.NotificationsAutoWatchPreferencesMacro" locale="">
   <web>XWiki.Notifications.Code</web>
   <name>NotificationsAutoWatchPreferencesMacro</name>
   <language/>
@@ -53,8 +53,11 @@
       <validationScript/>
       <cache>
         <cache>0</cache>
+        <defaultValue>long</defaultValue>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>cache</name>
         <number>5</number>
@@ -102,6 +105,8 @@
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>use</name>
         <number>3</number>
@@ -128,8 +133,10 @@
       var notification = new XWiki.widgets.Notification("$escapetool.javascript($services.localization.render('notifications.settings.saving'))", 'inprogress');
       var url = "$xwiki.getURL('XWiki.Notifications.Code.NotificationPreferenceService', 'get', 'outputSyntax=plain')";
       $.post(url, {
-        action: target == 'user' ? 'setAutoWatchMode' : 'setDefaultAutoWatchMode',
+        action: 'setAutoWatchMode',
         mode: $(this).val(),
+        target: target,
+        user: input.data('user'),
         csrf: xm.form_token
       }).done(function() {
         notification.hide();
@@ -167,11 +174,51 @@
       <defaultWeb/>
       <nameField/>
       <validationScript/>
+      <async_cached>
+        <defaultValue>0</defaultValue>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType/>
+        <name>async_cached</name>
+        <number>13</number>
+        <prettyName>Cached</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </async_cached>
+      <async_context>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
+        <name>async_context</name>
+        <number>14</number>
+        <prettyName>Context elements</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator>, </separator>
+        <separators>|, </separators>
+        <size>5</size>
+        <unmodifiable>0</unmodifiable>
+        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.parameters=Request parameters|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </async_context>
+      <async_enabled>
+        <defaultValue>0</defaultValue>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType/>
+        <name>async_enabled</name>
+        <number>12</number>
+        <prettyName>Asynchronous rendering</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </async_enabled>
       <code>
         <disabled>0</disabled>
         <editor>Text</editor>
         <name>code</name>
-        <number>9</number>
+        <number>10</number>
         <prettyName>Macro code</prettyName>
         <rows>20</rows>
         <size>40</size>
@@ -183,21 +230,43 @@
         <disabled>0</disabled>
         <editor>PureText</editor>
         <name>contentDescription</name>
-        <number>8</number>
+        <number>9</number>
         <prettyName>Content description (Not applicable for "No content" type)</prettyName>
         <rows>5</rows>
         <size>40</size>
         <unmodifiable>0</unmodifiable>
         <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
       </contentDescription>
+      <contentJavaType>
+        <cache>0</cache>
+        <defaultValue>Unknown</defaultValue>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <freeText>allowed</freeText>
+        <largeStorage>1</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>contentJavaType</name>
+        <number>8</number>
+        <picker>1</picker>
+        <prettyName>Macro content type</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator>|</separator>
+        <separators>|</separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>Unknown|Wiki</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </contentJavaType>
       <contentType>
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>contentType</name>
         <number>7</number>
-        <prettyName>Macro content type</prettyName>
+        <prettyName>Macro content availability</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator>|</separator>
         <separators>|</separators>
@@ -245,6 +314,16 @@
         <unmodifiable>0</unmodifiable>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
+      <priority>
+        <disabled>0</disabled>
+        <name>priority</name>
+        <number>11</number>
+        <numberType>integer</numberType>
+        <prettyName>Priority</prettyName>
+        <size>10</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.NumberClass</classType>
+      </priority>
       <supportsInlineMode>
         <disabled>0</disabled>
         <displayFormType>select</displayFormType>
@@ -259,6 +338,8 @@
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>visibility</name>
         <number>6</number>
@@ -273,9 +354,50 @@
       </visibility>
     </class>
     <property>
+      <async_cached>0</async_cached>
+    </property>
+    <property>
+      <async_context/>
+    </property>
+    <property>
+      <async_enabled>0</async_enabled>
+    </property>
+    <property>
       <code>{{velocity}}
-#if ($services.notification.watch.isEnabled() &amp;&amp; $xcontext.userReference &amp;&amp; ($xcontext.macro.params.target == 'user' || $hasAdmin))
+#if (!$services.notification.watch.isEnabled())
+  {{warning}}
+    {{localization key="notifications.settings.watch.disabled" /}}
+  {{warning}}
+#elseif (!$xcontext.userReference)
+  {{info}}
+    {{translation key="notifications.settings.watch.forGuest" /}}
+  {{/info}}
+#elseif ($wikimacro.parameters.target == 'wiki' &amp;&amp; !$hasAdmin)
+  {{error}}
+    {{translation key="notifications.settings.error.notAdmin" /}}
+  {{/error}}
+#elseif ($wikimacro.parameters.target == 'user' &amp;&amp; "$!wikimacro.parameters.user" != "" &amp;&amp; $wikimacro.parameters.user.class.simpleName != 'DocumentUserReference')
+  {{error}}
+    {{translation key="notifications.settings.error.userReferenceNotSupported" /}}
+  {{/error}}
+#elseif ($wikimacro.parameters.target == 'user' &amp;&amp; "$!wikimacro.parameters.user" != "" &amp;&amp; !$services.security.authorization.hasAccess('admin', $wikimacro.parameters.user.reference) &amp;&amp; !$xcontext.userReference.equals($wikimacro.parameters.user.reference))
+  {{error}}
+    {{translation key="notifications.settings.error.userReferenceAdminForbidden" parameters="$wikimacro.parameters.user" /}}
+  {{/error}}
+#else
 #set ($discard = $xwiki.jsx.use('XWiki.Notifications.Code.NotificationsAutoWatchPreferencesMacro'))
+#if ("$!wikimacro.parameters.user" != "")
+    #set ($targetUser = $wikimacro.parameters.user.reference)
+#else
+    #set ($targetUser = $xcontext.userReference)
+#end
+#set ($dataUser = "")
+#if ($wikimacro.parameters.target == 'user')
+  #set ($mode = $services.notification.watch.getAutomaticWatchMode($targetUser))
+  #set ($dataUser = "data-user=""$services.model.serialize($targetUser)""")
+#else
+  #set ($mode = $services.notification.watch.defaultAutomaticWatchMode)
+#end
 {{html clean="false"}}
   &lt;div class="xform"&gt;
     &lt;dl&gt;
@@ -283,12 +405,7 @@
       &lt;p class="xHint"&gt;$escapetool.xml($services.localization.render('notifications.settings.watch.autowatchmode.hint'))&lt;/p&gt;
       &lt;/dt&gt;
       &lt;dd&gt;
-        #if ($xcontext.macro.params.target == 'user')
-          #set ($mode = $services.notification.watch.automaticWatchMode)
-        #else
-          #set ($mode = $services.notification.watch.defaultAutomaticWatchMode)
-        #end
-        &lt;select class="notificationAutoWatchMode" data-target="$escapetool.xml($xcontext.macro.params.target)"&gt;
+        &lt;select class="notificationAutoWatchMode" data-target="$escapetool.xml($wikimacro.parameters.target)" $dataUser&gt;
           &lt;option value="NONE" #if($mode == 'NONE')selected="selected"#end&gt;$escapetool.xml($services.localization.render('XWiki.Notifications.Code.AutomaticWatchModeClass_automaticWatchMode_NONE'))&lt;/option&gt;
           &lt;option value="ALL"  #if($mode == 'ALL')selected="selected"#end&gt;$escapetool.xml($services.localization.render('XWiki.Notifications.Code.AutomaticWatchModeClass_automaticWatchMode_ALL'))&lt;/option&gt;
           &lt;option value="MAJOR" #if($mode == 'MAJOR')selected="selected"#end&gt;$escapetool.xml($services.localization.render('XWiki.Notifications.Code.AutomaticWatchModeClass_automaticWatchMode_MAJOR'))&lt;/option&gt;
@@ -298,23 +415,14 @@
     &lt;/dl&gt;
   &lt;/div&gt;
 {{/html}}
-#elseif($xcontext.macro.params.target == 'wiki' &amp;&amp; !$hasAdmin)
-  {{error}}
-    {{translation key="notifications.settings.error.notAdmin" /}}
-  {{/error}}
-#elseif($xcontext.userReference)
-  {{warning}}
-    {{localization key="notifications.settings.watch.disabled" /}}
-  {{warning}}
-#else
-  {{info}}
-    {{translation key="notifications.settings.watch.forGuest" /}}
-  {{/info}}
 #end
 {{/velocity}}</code>
     </property>
     <property>
       <contentDescription/>
+    </property>
+    <property>
+      <contentJavaType/>
     </property>
     <property>
       <contentType>No content</contentType>
@@ -330,6 +438,9 @@
     </property>
     <property>
       <name>Notifications Auto Watch Preferences</name>
+    </property>
+    <property>
+      <priority/>
     </property>
     <property>
       <supportsInlineMode>0</supportsInlineMode>
@@ -390,18 +501,108 @@
         <unmodifiable>0</unmodifiable>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
+      <type>
+        <disabled>0</disabled>
+        <name>type</name>
+        <number>5</number>
+        <prettyName>Parameter type</prettyName>
+        <size>60</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </type>
     </class>
     <property>
       <defaultValue>user</defaultValue>
     </property>
     <property>
-      <description> </description>
+      <description/>
     </property>
     <property>
       <mandatory>0</mandatory>
     </property>
     <property>
       <name>target</name>
+    </property>
+    <property>
+      <type/>
+    </property>
+  </object>
+  <object>
+    <name>XWiki.Notifications.Code.NotificationsAutoWatchPreferencesMacro</name>
+    <number>1</number>
+    <className>XWiki.WikiMacroParameterClass</className>
+    <guid>d9ad825d-7241-4cc5-8ea9-3e4fc008b8a6</guid>
+    <class>
+      <name>XWiki.WikiMacroParameterClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <defaultValue>
+        <disabled>0</disabled>
+        <name>defaultValue</name>
+        <number>4</number>
+        <prettyName>Parameter default value</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </defaultValue>
+      <description>
+        <disabled>0</disabled>
+        <name>description</name>
+        <number>2</number>
+        <prettyName>Parameter description</prettyName>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </description>
+      <mandatory>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>mandatory</name>
+        <number>3</number>
+        <prettyName>Parameter mandatory</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </mandatory>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Parameter name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <type>
+        <disabled>0</disabled>
+        <name>type</name>
+        <number>5</number>
+        <prettyName>Parameter type</prettyName>
+        <size>60</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </type>
+    </class>
+    <property>
+      <defaultValue/>
+    </property>
+    <property>
+      <description>User reference of the user for which to display and manipulate the autowatch preferences. This parameter is optional, only used if the target parameter is set to ##user## and default value is the context user. Note that for using this parameter, the context user needs administrator right on the given user reference.</description>
+    </property>
+    <property>
+      <mandatory>0</mandatory>
+    </property>
+    <property>
+      <name>user</name>
+    </property>
+    <property>
+      <type>org.xwiki.user.UserReference</type>
     </property>
   </object>
 </xwikidoc>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsEmailPreferencesMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsEmailPreferencesMacro.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.3" reference="XWiki.Notifications.Code.NotificationsEmailPreferencesMacro" locale="">
+<xwikidoc version="1.4" reference="XWiki.Notifications.Code.NotificationsEmailPreferencesMacro" locale="">
   <web>XWiki.Notifications.Code</web>
   <name>NotificationsEmailPreferencesMacro</name>
   <language/>
@@ -53,8 +53,11 @@
       <validationScript/>
       <cache>
         <cache>0</cache>
+        <defaultValue>long</defaultValue>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>cache</name>
         <number>5</number>
@@ -102,6 +105,8 @@
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>use</name>
         <number>3</number>
@@ -123,7 +128,7 @@
 /**
  * Start the real script.
  */
-require(['jquery'], function ($) {
+require(['jquery', 'xwiki-meta'], function ($, xm) {
 
   /**
    * Page initialization
@@ -138,10 +143,13 @@ require(['jquery'], function ($) {
       var notification = new XWiki.widgets.Notification("$escapetool.javascript($services.localization.render('notifications.settings.saving'))", 'inprogress');
       var serviceURL = new XWiki.Document(XWiki.Model.resolve('XWiki.Notifications.Code.NotificationPreferenceService', XWiki.EntityType.DOCUMENT)).getURL('get', 'outputSyntax=plain');
       $.post(serviceURL, {
-        'interval': intervalSelect.val()
+        'action': 'setInterval',
+        'interval': intervalSelect.val(),
+        'csrf': xm.form_token
       }).done(function (data) {
-        notification.hide();
-        new XWiki.widgets.Notification("$escapetool.javascript($services.localization.render('notifications.settings.saved'))", 'done');
+        notification.replace(new XWiki.widgets.Notification("$escapetool.javascript($services.localization.render('notifications.settings.saved'))", 'done'));
+      }).fail(function (data) {
+        notification.replace(new XWiki.widgets.Notification("$escapetool.javascript($services.localization.render('notifications.settings.savingfailed'))", 'error'));
       });
     });
 
@@ -152,9 +160,17 @@ require(['jquery'], function ($) {
       var diffTypeSelect = $(this);
       var notification = new XWiki.widgets.Notification("$escapetool.javascript($services.localization.render('notifications.settings.saving'))", 'inprogress');
       var serviceURL = new XWiki.Document(XWiki.Model.resolve('XWiki.Notifications.Code.NotificationPreferenceService', XWiki.EntityType.DOCUMENT)).getURL('get', 'outputSyntax=plain');
+      var target = $('.notifEmailPreferences').attr('data-target');
+      var targetUser = "";
+      if (target == 'user') {
+        var targetUser = $('.notifEmailPreferences').attr('data-user');
+      }
       $.post(serviceURL, {
+        'action': 'setDiffType',
         'diffType': diffTypeSelect.val(),
-        'target': $('.notifEmailPreferences').attr('data-target')
+        'target': $('.notifEmailPreferences').attr('data-target'),
+        'user': targetUser,
+        'csrf': xm.form_token
       }).done(function (data) {
         notification.hide();
         new XWiki.widgets.Notification("$escapetool.javascript($services.localization.render('notifications.settings.saved'))", 'done');
@@ -192,11 +208,51 @@ require(['jquery'], function ($) {
       <defaultWeb/>
       <nameField/>
       <validationScript/>
+      <async_cached>
+        <defaultValue>0</defaultValue>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType/>
+        <name>async_cached</name>
+        <number>13</number>
+        <prettyName>Cached</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </async_cached>
+      <async_context>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
+        <name>async_context</name>
+        <number>14</number>
+        <prettyName>Context elements</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator>, </separator>
+        <separators>|, </separators>
+        <size>5</size>
+        <unmodifiable>0</unmodifiable>
+        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.parameters=Request parameters|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </async_context>
+      <async_enabled>
+        <defaultValue>0</defaultValue>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType/>
+        <name>async_enabled</name>
+        <number>12</number>
+        <prettyName>Asynchronous rendering</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </async_enabled>
       <code>
         <disabled>0</disabled>
         <editor>Text</editor>
         <name>code</name>
-        <number>9</number>
+        <number>10</number>
         <prettyName>Macro code</prettyName>
         <rows>20</rows>
         <size>40</size>
@@ -208,21 +264,43 @@ require(['jquery'], function ($) {
         <disabled>0</disabled>
         <editor>PureText</editor>
         <name>contentDescription</name>
-        <number>8</number>
+        <number>9</number>
         <prettyName>Content description (Not applicable for "No content" type)</prettyName>
         <rows>5</rows>
         <size>40</size>
         <unmodifiable>0</unmodifiable>
         <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
       </contentDescription>
+      <contentJavaType>
+        <cache>0</cache>
+        <defaultValue>Unknown</defaultValue>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <freeText>allowed</freeText>
+        <largeStorage>1</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>contentJavaType</name>
+        <number>8</number>
+        <picker>1</picker>
+        <prettyName>Macro content type</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator>|</separator>
+        <separators>|</separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>Unknown|Wiki</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </contentJavaType>
       <contentType>
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>contentType</name>
         <number>7</number>
-        <prettyName>Macro content type</prettyName>
+        <prettyName>Macro content availability</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator>|</separator>
         <separators>|</separators>
@@ -270,6 +348,16 @@ require(['jquery'], function ($) {
         <unmodifiable>0</unmodifiable>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
+      <priority>
+        <disabled>0</disabled>
+        <name>priority</name>
+        <number>11</number>
+        <numberType>integer</numberType>
+        <prettyName>Priority</prettyName>
+        <size>10</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.NumberClass</classType>
+      </priority>
       <supportsInlineMode>
         <disabled>0</disabled>
         <displayFormType>select</displayFormType>
@@ -284,6 +372,8 @@ require(['jquery'], function ($) {
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>visibility</name>
         <number>6</number>
@@ -298,20 +388,59 @@ require(['jquery'], function ($) {
       </visibility>
     </class>
     <property>
+      <async_cached>0</async_cached>
+    </property>
+    <property>
+      <async_context/>
+    </property>
+    <property>
+      <async_enabled>0</async_enabled>
+    </property>
+    <property>
       <code>{{velocity}}
-#if ($services.notification.areEmailsEnabled() &amp;&amp; $xcontext.userReference &amp;&amp; ($xcontext.macro.params.target == 'user' || $hasAdmin))
+#if (!$services.notification.areEmailsEnabled())
+  {{warning}}
+    {{localization key="notifications.settings.email.disabled" /}}
+  {{warning}}
+#elseif (!$xcontext.userReference)
+  {{info}}
+    {{translation key="notifications.settings.email.forGuest" /}}
+  {{/info}}
+#elseif ($wikimacro.parameters.target == 'wiki' &amp;&amp; !$hasAdmin)
+  {{error}}
+    {{translation key="notifications.settings.error.notAdmin" /}}
+  {{/error}}
+#elseif ($wikimacro.parameters.target == 'user' &amp;&amp; "$!wikimacro.parameters.user" != "" &amp;&amp; $wikimacro.parameters.user.class.simpleName != 'DocumentUserReference')
+  {{error}}
+    {{translation key="notifications.settings.error.userReferenceNotSupported" /}}
+  {{/error}}
+#elseif ($wikimacro.parameters.target == 'user' &amp;&amp; "$!wikimacro.parameters.user" != "" &amp;&amp; !$services.security.authorization.hasAccess('admin', $wikimacro.parameters.user.reference) &amp;&amp; !$xcontext.userReference.equals($wikimacro.parameters.user.reference))
+  {{error}}
+    {{translation key="notifications.settings.error.userReferenceAdminForbidden" parameters="$wikimacro.parameters.user" /}}
+  {{/error}}
+#else
+  
+  #if ("$!wikimacro.parameters.user" != "")
+    #set ($targetUser = $wikimacro.parameters.user.reference)
+  #else
+    #set ($targetUser = $xcontext.userReference)
+  #end
+  #set ($dataUser = "")
+  #if ($wikimacro.parameters.target == 'user')
+    #set ($dataUser = "data-user=""$services.model.serialize($targetUser)""")
+  #end
   #set ($discard = $xwiki.jsx.use('XWiki.Notifications.Code.NotificationsEmailPreferencesMacro'))
   {{html clean="false"}}
-    &lt;div class="notification-top-panel-preferences notifEmailPreferences" data-target="$escapetool.xml($xcontext.macro.params.target)"&gt;
+    &lt;div class="notification-top-panel-preferences notifEmailPreferences" data-target="$escapetool.xml($wikimacro.parameters.target)" $dataUser&gt;
       &lt;div class="xform"&gt;
         ## TODO: handle the interval for the wiki target too
-        #if ($xcontext.macro.params.target == 'user')
+        #if ($wikimacro.parameters.target == 'user')
         &lt;dl&gt;
           &lt;dt&gt;&lt;label&gt;$escapetool.xml($services.localization.render('notifications.settings.email.frequency'))&lt;/label&gt;
           &lt;p class="xHint"&gt;$escapetool.xml($services.localization.render('notifications.settings.email.frequency.hint'))&lt;/p&gt;
           &lt;/dt&gt;
           &lt;dd&gt;
-            #set ($targetDocument = $xwiki.getDocument($xcontext.userReference))
+            #set ($targetDocument = $xwiki.getDocument($targetUser))
             #set ($interval = 'daily')
             #set ($objPref = $targetDocument.getObject('XWiki.Notifications.Code.NotificationEmailPreferenceClass'))
             #if ("$!objPref" != '')
@@ -336,7 +465,11 @@ require(['jquery'], function ($) {
           &lt;p class="xHint"&gt;$escapetool.xml($services.localization.render('notifications.settings.email.diffType.hint'))&lt;/p&gt;
           &lt;/dt&gt;
           &lt;dd&gt;
-            #set ($diffType = $services.notification.preferences.getDiffType())
+            #if ($wikimacro.parameters.target == 'user')
+              #set ($diffType = $services.notification.preferences.getDiffType($targetUser))
+            #else
+              #set ($diffType = $services.notification.preferences.getDiffType())
+            #end
             #set ($objPref = $targetDocument.getObject('XWiki.Notifications.Code.NotificationEmailPreferenceClass'))
             #if ("$!objPref" != '')
               #set ($objDiffType = $objPref.getValue('diffType'))
@@ -353,24 +486,15 @@ require(['jquery'], function ($) {
       &lt;/div&gt;
     &lt;/div&gt;
   {{/html}}
-#elseif($xcontext.macro.params.target == 'wiki' &amp;&amp; !$hasAdmin)
-  {{error}}
-    {{translation key="notifications.settings.error.notAdmin" /}}
-  {{/error}}
-#elseif($xcontext.userReference)
-  {{warning}}
-    {{localization key="notifications.settings.email.disabled" /}}
-  {{warning}}
-#else
-  {{info}}
-    {{translation key="notifications.settings.email.forGuest" /}}
-  {{/info}}
 #end
 {{/velocity}}
 </code>
     </property>
     <property>
       <contentDescription/>
+    </property>
+    <property>
+      <contentJavaType/>
     </property>
     <property>
       <contentType>No content</contentType>
@@ -386,6 +510,9 @@ require(['jquery'], function ($) {
     </property>
     <property>
       <name>Notifications Email Preferences</name>
+    </property>
+    <property>
+      <priority/>
     </property>
     <property>
       <supportsInlineMode>0</supportsInlineMode>
@@ -446,6 +573,15 @@ require(['jquery'], function ($) {
         <unmodifiable>0</unmodifiable>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
+      <type>
+        <disabled>0</disabled>
+        <name>type</name>
+        <number>5</number>
+        <prettyName>Parameter type</prettyName>
+        <size>60</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </type>
     </class>
     <property>
       <defaultValue>user</defaultValue>
@@ -458,6 +594,87 @@ require(['jquery'], function ($) {
     </property>
     <property>
       <name>target</name>
+    </property>
+    <property>
+      <type/>
+    </property>
+  </object>
+  <object>
+    <name>XWiki.Notifications.Code.NotificationsEmailPreferencesMacro</name>
+    <number>1</number>
+    <className>XWiki.WikiMacroParameterClass</className>
+    <guid>4e7e7ddc-bbda-48ac-b9ee-eeb0d2b2afbe</guid>
+    <class>
+      <name>XWiki.WikiMacroParameterClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <defaultValue>
+        <disabled>0</disabled>
+        <name>defaultValue</name>
+        <number>4</number>
+        <prettyName>Parameter default value</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </defaultValue>
+      <description>
+        <disabled>0</disabled>
+        <name>description</name>
+        <number>2</number>
+        <prettyName>Parameter description</prettyName>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </description>
+      <mandatory>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>mandatory</name>
+        <number>3</number>
+        <prettyName>Parameter mandatory</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </mandatory>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Parameter name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <type>
+        <disabled>0</disabled>
+        <name>type</name>
+        <number>5</number>
+        <prettyName>Parameter type</prettyName>
+        <size>60</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </type>
+    </class>
+    <property>
+      <defaultValue/>
+    </property>
+    <property>
+      <description>User reference of the user for which to display and manipulate the email preferences. This parameter is optional, only used if the target parameter is set to ##user## and default value is the context user. Note that for using this parameter, the context user needs administrator right on the given user reference.</description>
+    </property>
+    <property>
+      <mandatory>0</mandatory>
+    </property>
+    <property>
+      <name>user</name>
+    </property>
+    <property>
+      <type>org.xwiki.user.UserReference</type>
     </property>
   </object>
 </xwikidoc>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsFiltersPreferencesMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsFiltersPreferencesMacro.xml
@@ -308,6 +308,8 @@ require(['jquery', 'AddNotificationFilterPreferenceLivetable', 'bootstrap', 'boo
 
       var params = {
         action: 'createScopeFilterPreference',
+        target: 'user',
+        user: self.modal.data('user'),
         filterType: self.filterTypeSelector.val(),
         filterFormats: self.notificationFormatSelector.val().join(','),
         eventTypes: self.eventTypeSelector.val().join(','),
@@ -634,6 +636,7 @@ require(['jquery', 'AddNotificationFilterPreferenceLivetable', 'bootstrap', 'boo
   var serviceReference = XWiki.Model.resolve('XWiki.Notifications.Code.NotificationPreferenceService', XWiki.EntityType.DOCUMENT);
   var serviceURL = new XWiki.Document(serviceReference).getURL('get', 'outputSyntax=plain');
   var userURL = $('.filterPreferences').attr('data-user-url');
+  var targetUser = $('.filterPreferences').attr('data-user');
 
   // Callback on livetable row printing
   $(document).on('xwiki:livetable:notificationFilterPreferencesLiveTable:newrow', function(event, data) {
@@ -645,6 +648,8 @@ require(['jquery', 'AddNotificationFilterPreferenceLivetable', 'bootstrap', 'boo
           var notif = new XWiki.widgets.Notification("$escapetool.javascript($services.localization.render('notifications.filters.preferences.delete.inProgress'))", 'inprogress');
           $.post(serviceURL, {
             action: 'deleteFilterPreference',
+            target: 'user',
+            user: targetUser,
             filterPreferenceId: data.data.filterPreferenceId,
             csrf: xm.form_token
           }).done(function() {
@@ -665,6 +670,8 @@ require(['jquery', 'AddNotificationFilterPreferenceLivetable', 'bootstrap', 'boo
       $.post(serviceURL, {
         action: 'setFilterPreferenceEnabled',
         filterPreferenceId: data.data.filterPreferenceId,
+        target: 'user',
+        user: targetUser,
         enabled: state,
         csrf: xm.form_token
       }).done(function() {
@@ -842,7 +849,7 @@ require(['jquery', 'AddNotificationFilterPreferenceLivetable', 'bootstrap', 'boo
         <displayFormType>select</displayFormType>
         <displayType/>
         <name>async_cached</name>
-        <number>12</number>
+        <number>13</number>
         <prettyName>Cached</prettyName>
         <unmodifiable>0</unmodifiable>
         <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
@@ -855,14 +862,14 @@ require(['jquery', 'AddNotificationFilterPreferenceLivetable', 'bootstrap', 'boo
         <largeStorage>0</largeStorage>
         <multiSelect>1</multiSelect>
         <name>async_context</name>
-        <number>13</number>
+        <number>14</number>
         <prettyName>Context elements</prettyName>
         <relationalStorage>0</relationalStorage>
-        <separator> </separator>
+        <separator>, </separator>
         <separators>|, </separators>
         <size>5</size>
         <unmodifiable>0</unmodifiable>
-        <values>doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.parameters=Request parameters|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
+        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.parameters=Request parameters|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </async_context>
       <async_enabled>
@@ -871,7 +878,7 @@ require(['jquery', 'AddNotificationFilterPreferenceLivetable', 'bootstrap', 'boo
         <displayFormType>select</displayFormType>
         <displayType/>
         <name>async_enabled</name>
-        <number>11</number>
+        <number>12</number>
         <prettyName>Asynchronous rendering</prettyName>
         <unmodifiable>0</unmodifiable>
         <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
@@ -976,6 +983,16 @@ require(['jquery', 'AddNotificationFilterPreferenceLivetable', 'bootstrap', 'boo
         <unmodifiable>0</unmodifiable>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
+      <priority>
+        <disabled>0</disabled>
+        <name>priority</name>
+        <number>11</number>
+        <numberType>integer</numberType>
+        <prettyName>Priority</prettyName>
+        <size>10</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.NumberClass</classType>
+      </priority>
       <supportsInlineMode>
         <disabled>0</disabled>
         <displayFormType>select</displayFormType>
@@ -1024,7 +1041,23 @@ require(['jquery', 'AddNotificationFilterPreferenceLivetable', 'bootstrap', 'boo
   {{info}}
     {{translation key="notifications.settings.filters.preferences.forGuest" /}}
   {{/info}}
+## FIXME: This check should not be needed with a proper API able to check rights on UserReference.
+## This should be improved later with such API.
+#elseif ("$!wikimacro.parameters.user" != "" &amp;&amp; $wikimacro.parameters.user.class.simpleName != 'DocumentUserReference')
+  {{error}}
+    This macro only allows to handle DocumentUserReference references and you specified a $wikimacro.parameters.user.class.simpleName reference.
+  {{/error}}
+#elseif ("$!wikimacro.parameters.user" != "" &amp;&amp; !$services.security.authorization.hasAccess('admin', $wikimacro.parameters.user.reference) &amp;&amp; !$xcontext.userReference.equals($wikimacro.parameters.user.reference))
+  {{error}}
+    You don't have administration right on  $wikimacro.parameters.user.
+  {{/error}}
 #else
+## TODO: We should actually manipulate only UserReferences here.
+#if ("$!wikimacro.parameters.user" != "")
+  #set ($targetUser = $wikimacro.parameters.user.reference)
+#else
+  #set ($targetUser = $xcontext.userReference)
+#end
 ######################################################
 ### CSS and JAVASCRIPTS
 ######################################################
@@ -1036,7 +1069,7 @@ require(['jquery', 'AddNotificationFilterPreferenceLivetable', 'bootstrap', 'boo
 ### MACRO CONTENT
 ######################################################
 {{html clean="false"}}
-&lt;div class="filterPreferences xform" data-user-url="$escapetool.xml($services.rest.url($xcontext.userReference))"&gt;
+&lt;div class="filterPreferences xform" data-user-url="$escapetool.xml($services.rest.url($targetUser))" data-user="$services.model.serialize($targetUser)"&gt;
   &lt;div class="row"&gt;
     &lt;p class="xHint col-xs-12 col-sm-9 col-md-8 col-lg-9"&gt;
       $escapetool.xml($services.localization.render('notifications.settings.filters.preferences.hint'))
@@ -1061,7 +1094,7 @@ require(['jquery', 'AddNotificationFilterPreferenceLivetable', 'bootstrap', 'boo
     'rowCount'          : 10,
     'description'       : 'This table lists every filter registered for the current user.',
     'translationPrefix' : 'notifications.settings.filters.preferences.table.',
-    'extraParams'       : "eventType=&amp;format=&amp;user=${services.model.serialize($xcontext.userReference, 'default')}",
+    'extraParams'       : "eventType=&amp;format=&amp;user=${services.model.serialize($targetUser, 'default')}",
     'outputOnlyHtml'    : true
   })
 
@@ -1070,7 +1103,7 @@ require(['jquery', 'AddNotificationFilterPreferenceLivetable', 'bootstrap', 'boo
 ######################################################
 ### ADD FILTER MODAL
 ######################################################
-&lt;div class="modal fade" tabindex="-1" role="dialog" id="modal-add-filter-preference"&gt;
+&lt;div class="modal fade" tabindex="-1" role="dialog" id="modal-add-filter-preference" data-user="$services.model.serialize($targetUser)"&gt;
   &lt;div class="modal-dialog" role="document"&gt;
     &lt;div class="modal-content"&gt;
       &lt;div class="modal-header"&gt;
@@ -1167,10 +1200,91 @@ require(['jquery', 'AddNotificationFilterPreferenceLivetable', 'bootstrap', 'boo
       <name>Notifications Filters Preferences</name>
     </property>
     <property>
+      <priority/>
+    </property>
+    <property>
       <supportsInlineMode>0</supportsInlineMode>
     </property>
     <property>
       <visibility>Current Wiki</visibility>
+    </property>
+  </object>
+  <object>
+    <name>XWiki.Notifications.Code.NotificationsFiltersPreferencesMacro</name>
+    <number>0</number>
+    <className>XWiki.WikiMacroParameterClass</className>
+    <guid>38b562b3-61ed-40bf-8ab1-088260b579bc</guid>
+    <class>
+      <name>XWiki.WikiMacroParameterClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <defaultValue>
+        <disabled>0</disabled>
+        <name>defaultValue</name>
+        <number>4</number>
+        <prettyName>Parameter default value</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </defaultValue>
+      <description>
+        <disabled>0</disabled>
+        <name>description</name>
+        <number>2</number>
+        <prettyName>Parameter description</prettyName>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </description>
+      <mandatory>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>mandatory</name>
+        <number>3</number>
+        <prettyName>Parameter mandatory</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </mandatory>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Parameter name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <type>
+        <disabled>0</disabled>
+        <name>type</name>
+        <number>5</number>
+        <prettyName>Parameter type</prettyName>
+        <size>60</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </type>
+    </class>
+    <property>
+      <defaultValue/>
+    </property>
+    <property>
+      <description>User reference of the user for which to display and manipulate the filter preferences. This parameter is optional, default value is the context user. Note that for using this parameter, the context user needs administrator right on the given user reference.</description>
+    </property>
+    <property>
+      <mandatory>0</mandatory>
+    </property>
+    <property>
+      <name>user</name>
+    </property>
+    <property>
+      <type>org.xwiki.user.UserReference</type>
     </property>
   </object>
 </xwikidoc>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/Translations.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/Translations.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.3" reference="XWiki.Notifications.Code.Translations" locale="">
+<xwikidoc version="1.4" reference="XWiki.Notifications.Code.Translations" locale="">
   <web>XWiki.Notifications.Code</web>
   <name>Translations</name>
   <language/>
@@ -30,7 +30,6 @@
   <parent>XWiki.Notifications.Code.WebHome</parent>
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
-  <parent>XWiki.Notifications.Code.WebHome</parent>
   <version>1.1</version>
   <title/>
   <comment/>
@@ -182,6 +181,12 @@ XWiki.Notifications.Code.AutomaticWatchModeClass_automaticWatchMode_ALL=Every ti
 XWiki.Notifications.Code.AutomaticWatchModeClass_automaticWatchMode_MAJOR=Every time I make a major modification
 XWiki.Notifications.Code.AutomaticWatchModeClass_automaticWatchMode_NEW=Only when I create a new page
 
+## Common notification settings errors
+notifications.settings.error.userReferenceNotSupported=The given user reference is not supported, only DocumentUserReference are supported for now.
+notifications.settings.error.userReferenceAdminForbidden=You don't have administration right for the given user: {0}.
+notifications.settings.error.badCSRF=Bad CSRF token.
+notifications.settings.badParameters=Bad request parameters.
+
 ## User profile
 notifications.userprofile.following=Following
 notifications.userprofile.notfollowing=Not following
@@ -231,6 +236,8 @@ notifications.switches.changeStatusError=Failed to change the status of the noti
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>scope</name>
         <number>1</number>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/XWikiUserNotificationsSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/XWikiUserNotificationsSheet.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.3" reference="XWiki.Notifications.Code.XWikiUserNotificationsSheet" locale="">
+<xwikidoc version="1.4" reference="XWiki.Notifications.Code.XWikiUserNotificationsSheet" locale="">
   <web>XWiki.Notifications.Code</web>
   <name>XWikiUserNotificationsSheet</name>
   <language/>
@@ -53,8 +53,11 @@
       <validationScript/>
       <cache>
         <cache>0</cache>
+        <defaultValue>long</defaultValue>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>cache</name>
         <number>5</number>
@@ -83,6 +86,8 @@
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>contentType</name>
         <number>6</number>
@@ -118,6 +123,8 @@
         <cache>0</cache>
         <disabled>0</disabled>
         <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>use</name>
         <number>3</number>
@@ -189,11 +196,11 @@
         <number>4</number>
         <prettyName>Context elements</prettyName>
         <relationalStorage>0</relationalStorage>
-        <separator> </separator>
+        <separator>, </separator>
         <separators>|, </separators>
         <size>5</size>
         <unmodifiable>0</unmodifiable>
-        <values>doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.parameters=Request parameters|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
+        <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.parameters=Request parameters|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </async_context>
       <async_enabled>
@@ -296,7 +303,7 @@
       (((
       (% id="Hnotifications.settings.email.title" %)
       = {{translation key="notifications.settings.email.title" /}} =
-      {{notificationsEmailPreferences /}}
+      {{notificationsEmailPreferences user="$doc.documentReference" /}}
       )))
       #end
       ######################################################
@@ -307,7 +314,7 @@
       (((
       (% id="Hnotifications.settings.watch.title" %)
       = {{translation key="notifications.settings.watch.title" /}} =
-      {{notificationsAutoWatchPreferences /}}
+      {{notificationsAutoWatchPreferences user="$doc.documentReference" /}}
       )))
       #end
       ######################################################
@@ -317,7 +324,7 @@
       (((
       (% id="Hnotifications.settings.applications.title" %)
       = {{translation key="notifications.settings.applications.title" /}} =
-      {{notificationsApplicationsPreferences /}}
+      {{notificationsApplicationsPreferences user="$doc.documentReference" /}}
       )))
       ######################################################
       ### FILTERS
@@ -331,7 +338,7 @@
 (((
   (% id="Hnotifications.settings.filters.preferences.title" %)
   = {{translation key="notifications.settings.filters.preferences.title" /}} =
-  {{notificationsFiltersPreferences /}}
+  {{notificationsFiltersPreferences user="$doc.documentReference" /}}
 )))
 #end
       {{/velocity}}
@@ -346,8 +353,8 @@
     <property>
       <parameters>id=notifications
 icon=bell
-# isActive: The user is seeing her own profile
-isActive=#if(($services.model.resolveDocument($xcontext.user) == $doc.documentReference) &amp;&amp; $xwiki.exists($services.model.createDocumentReference('', ['XWiki', 'Notifications', 'Code'], 'XWikiUserNotificationsSheet')))true#{else}false#end
+# isActive: The user is seeing her own profile or can administrate the current document
+isActive=#if(($services.model.resolveDocument($xcontext.user) == $doc.documentReference) || $services.security.authorization.hasAccess('admin', $doc.documentReference))true#{else}false#end
 priority=60</parameters>
     </property>
     <property>

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-test/xwiki-platform-user-profile-test-pageobjects/src/main/java/org/xwiki/user/test/po/AbstractUserProfilePage.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-test/xwiki-platform-user-profile-test-pageobjects/src/main/java/org/xwiki/user/test/po/AbstractUserProfilePage.java
@@ -19,8 +19,13 @@
  */
 package org.xwiki.user.test.po;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
+import org.xwiki.stability.Unstable;
 import org.xwiki.test.ui.po.ViewPage;
 
 /**
@@ -47,6 +52,19 @@ public class AbstractUserProfilePage extends ViewPage
     public String getUsername()
     {
         return this.username;
+    }
+
+    /**
+     * Retrieve the list of menu categories available. Note that if a category is not displayed in the menu, then it
+     * cannot be displayed at all.
+     * @return the list of menu items available.
+     * @since 13.2RC1
+     */
+    @Unstable
+    public List<String> getAvailableCategories()
+    {
+        return getDriver().findElementsWithoutWaiting(By.className("category-tab"))
+            .stream().map(WebElement::getText).collect(Collectors.toList());
     }
 
     public ProfileUserProfilePage switchToProfile()


### PR DESCRIPTION
JIRA: https://jira.xwiki.org/browse/XWIKI-16158

  * Improve various Notification script service to allow using them with
    a given UserReference instead of the context user reference
  * Change the different Notification Preferences Macros to add a user
    parameter which is the reference of the user for which to display
the preferences
  * Change the code of those macros to be able to handle the given user
    and not only the context user
  * Change XWikiUserNotificationsSheet to allow displaying the
    notifications tab in user profile for any user for which current
user has admin rights