### PR TITLE
XWIKI-18255: RegisterFromAdministrationTest#testRegisterExistingUser is flickering

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/AbstractRegistrationPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/AbstractRegistrationPage.java
@@ -48,13 +48,24 @@ public abstract class AbstractRegistrationPage extends BasePage
         fillRegisterForm("John", "Smith", "JohnSmith", "WeakPassword", "WeakPassword", "johnsmith@xwiki.org");
     }
 
+    /**
+     * Fill the registration form for the creation of a new user with the provided parameters. When a parameter is
+     * {@code null}, the corresponding field stays unchanged.
+     *
+     * @param firstName the first name of the new user
+     * @param lastName the last name of the new user
+     * @param username the username of the new user
+     * @param password the password of the new user
+     * @param confirmPassword the confirmation password of the new user
+     * @param email the email of the new user
+     */
     public void fillRegisterForm(final String firstName, final String lastName, final String username,
         final String password, final String confirmPassword, final String email)
     {
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         // remove the onfocus on login, to avoid any problem to put the value.
-        getDriver().executeJavascript("try{ document.getElementById('xwikiname').onfocus = null; " +
-            "}catch(err){}");
+        getDriver().executeJavascript("try{ document.getElementById('xwikiname').onfocus = null; " 
+            + "}catch(err){}");
         if (firstName != null) {
             map.put("register_first_name", firstName);
         }

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/src/test/it/org/xwiki/test/ui/RegisterTest.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/src/test/it/org/xwiki/test/ui/RegisterTest.java
@@ -88,12 +88,13 @@ public class RegisterTest extends AbstractTest
 
     @Test
     @IgnoreBrowsers({
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See https://jira.xwiki.org/browse/XE-1146"),
-    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See https://jira.xwiki.org/browse/XE-1177")
+        @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason = "See https://jira.xwiki.org/browse/XE-1146"),
+        @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason = "See https://jira.xwiki.org/browse/XE-1177")
     })
     public void testRegisterExistingUser()
     {
-        // Uses the empty string instead of the null value to empty the form fields (the null value just keep the value filled from the previously run test).
+        // Uses the empty string instead of the null value to empty the form fields (the null value just keep the value
+        // filled from the previously run test).
         this.registrationPage.fillRegisterForm("", "", "Admin", "password", "password", "");
         // Can't use validateAndRegister here because user existence is not checked by LiveValidation.
         Assert.assertFalse(tryToRegister());

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/src/test/it/org/xwiki/test/ui/RegisterTest.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/src/test/it/org/xwiki/test/ui/RegisterTest.java
@@ -26,14 +26,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.WebDriverException;
-import org.xwiki.administration.test.po.AdministrationSectionPage;
 import org.xwiki.test.ui.browser.IgnoreBrowser;
 import org.xwiki.test.ui.browser.IgnoreBrowsers;
 import org.xwiki.test.ui.po.AbstractRegistrationPage;
 import org.xwiki.test.ui.po.RegistrationPage;
-
-import static org.junit.Assert.assertEquals;
 
 /**
  * Test the user registration feature.
@@ -97,7 +93,8 @@ public class RegisterTest extends AbstractTest
     })
     public void testRegisterExistingUser()
     {
-        registrationPage.fillRegisterForm(null, null, "Admin", null, null, null);
+        // Uses the empty string instead of the null value to empty the form fields (the null value just keep the value filled from the previously run test).
+        this.registrationPage.fillRegisterForm("", "", "Admin", "password", "password", "");
         // Can't use validateAndRegister here because user existence is not checked by LiveValidation.
         Assert.assertFalse(tryToRegister());
         Assert.assertTrue(this.registrationPage.validationFailureMessagesInclude("User already exists."));


### PR DESCRIPTION
Sets explicitly all the registration form fields to be independent of the state of the form before the begining of the test.