### PR TITLE
[Misc] Fixes StaticListClassFieldTest#testItemsEditor for the current integration tests resolution

### DIFF
--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/StaticListClassFieldTest.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/src/test/it/org/xwiki/test/ui/appwithinminutes/StaticListClassFieldTest.java
@@ -114,7 +114,9 @@ public class StaticListClassFieldTest extends AbstractListClassFieldTest
         itemsEditor.add("", "XWiki");
 
         // Change the label of the last added item.
-        itemsEditor.setLabel("XWiki", "XWiki Enterprise");
+        // The label of this item must be short, otherwise the call to moveBefore below fails to move this item in 
+        // first position when the screen width is small (see XWIKI-18343).
+        itemsEditor.setLabel("XWiki", "XS");
 
         // Move the last item before the first.
         itemsEditor.moveBefore("XWiki", "value1");


### PR DESCRIPTION
Reordering items with large label when configuring a static list can be difficult when the item labels are long and the screen width small.
This was making StaticListClassFieldTest#testItemsEditor fail.
We are shortening the reordered item label to make the test pass, until the items UI component is fixed (see XWIKI-18343).