### PR TITLE
XWIKI-18270 Live Data macro styles don't use the color theme

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/config/vue.config.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/config/vue.config.js
@@ -24,6 +24,23 @@ module.exports = {
   // __webpack_public_path__ variable (see https://webpack.js.org/configuration/output/#outputpublicpath).
   publicPath: '',
   filenameHashing: false,
+
+  configureWebpack: config => {
+    // skip less parsing
+    const lessRules = config.module.rules.find(rule => /less/.test(rule.test));
+    lessRules.oneOf.forEach(context => {
+      const loaders = context.use;
+      const lessLoaderIndex = loaders.findIndex(loader => /less-loader/.test(loader.loader));
+      if (lessLoaderIndex !== -1) {
+        loaders.splice(lessLoaderIndex, 1);
+      }
+    });
+    // export style as less files
+    const miniCssExtractPlugin = config.plugins.find(plugin => plugin.constructor.name === "MiniCssExtractPlugin");
+    miniCssExtractPlugin.options.filename = "[name].less";
+    miniCssExtractPlugin.options.chunkFilename = "less/[name].less";
+  },
+
   chainWebpack: config => {
     // Provided dependencies (that shouldn't be bundled).
     config.externals({
@@ -35,6 +52,6 @@ module.exports = {
     })
   },
   css: {
-    extract: false,
+    extract: true,
   },
 };


### PR DESCRIPTION
Export style as less files instead of css

For now, every style file (even only css ones) is built as less file, because the configuration of the MiniCssExtractPlugin plugin only allow to specify the filename globally, and not according to a specific rule. This is not really an issue, as less is a superset of css, but his could lower performance as every css files will have to be parsed through the less compiler.

Also strangely, the `"[name]"` template string of webpack resolves to `xwiki-livedata-vue.umd.min` for the main less filename, instead of `xwiki-livedata-vue`. But this is just a cosmetic issue.