### PR TITLE
XWIKI-18258: AddEntryTest#testEntryNameWithURLSpecialCharacters is flickering

### DIFF
--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-docker/pom.xml
@@ -47,6 +47,13 @@
       <version>${project.version}</version>
       <type>xar</type>
     </dependency>
+    <!-- Required by AddEntryIT. -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-panels-ui</artifactId>
+      <version>${project.version}</version>
+      <type>xar</type>
+    </dependency>
     <!-- ================================
          Test only dependencies
          ================================ -->

--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-docker/src/test/it/org/xwiki/appwithinminutes/test/ui/AddEntryIT.java
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-docker/src/test/it/org/xwiki/appwithinminutes/test/ui/AddEntryIT.java
@@ -17,65 +17,59 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.xwiki.test.ui.appwithinminutes;
+package org.xwiki.appwithinminutes.test.ui;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
 import org.xwiki.appwithinminutes.test.po.ApplicationHomeEditPage;
 import org.xwiki.appwithinminutes.test.po.ApplicationHomePage;
 import org.xwiki.appwithinminutes.test.po.EntryEditPage;
 import org.xwiki.appwithinminutes.test.po.EntryNamePane;
-import org.xwiki.test.ui.AbstractTest;
-import org.xwiki.test.ui.AdminAuthenticationRule;
-import org.xwiki.test.ui.browser.IgnoreBrowser;
-import org.xwiki.test.ui.browser.IgnoreBrowsers;
+import org.xwiki.test.docker.junit5.TestReference;
+import org.xwiki.test.docker.junit5.UITest;
+import org.xwiki.test.ui.TestUtils;
 import org.xwiki.test.ui.po.LiveTableElement;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests the process of adding new application entries.
- * 
+ *
  * @version $Id$
- * @since 4.0M1
+ * @since 13.3RC1
+ * @since 12.10.6
  */
-public class AddEntryTest extends AbstractTest
+@UITest
+class AddEntryIT
 {
-    @Rule
-    public AdminAuthenticationRule adminAuthenticationRule = new AdminAuthenticationRule(getUtil());
-
-    /**
-     * The page being tested.
-     */
-    private ApplicationHomePage homePage;
-
-    @Before
-    public void setUp() throws Exception
-    {
-        getUtil().rest().deletePage(getTestClassName(), getTestMethodName());
-        Map<String, String> editQueryStringParameters = new HashMap<String, String>();
-        editQueryStringParameters.put("editor", "inline");
-        editQueryStringParameters.put("template", "AppWithinMinutes.LiveTableTemplate");
-        editQueryStringParameters.put("AppWithinMinutes.LiveTableClass_0_class", "Panels.PanelClass");
-        getUtil().gotoPage(getTestClassName(), getTestMethodName(), "edit", editQueryStringParameters);
-        // Wait for the page to load before clicking on the save button to make sure the page layout is stable.
-        homePage = new ApplicationHomeEditPage().waitUntilPageIsLoaded().clickSaveAndView();
-    }
+    private static final String DATE_COLUMN_TITLE = "panel.livetable.doc.date";
 
     /**
      * Tests that entry name is URL encoded.
      */
     @Test
-    @IgnoreBrowsers({
-    @IgnoreBrowser(value = "internet.*", version = "8\\.*", reason="See https://jira.xwiki.org/browse/XE-1146"),
-    @IgnoreBrowser(value = "internet.*", version = "9\\.*", reason="See https://jira.xwiki.org/browse/XE-1177")
-    })
-    public void testEntryNameWithURLSpecialCharacters()
+    @Order(1)
+    void entryNameWithURLSpecialCharacters(TestReference testReference, TestUtils testUtils)
     {
+        // Fixture
+        testUtils.loginAsSuperAdmin();
+
+        testUtils.deletePage(testReference);
+
+        Map<String, String> editQueryStringParameters = new HashMap<>();
+        editQueryStringParameters.put("editor", "inline");
+        editQueryStringParameters.put("template", "AppWithinMinutes.LiveTableTemplate");
+        editQueryStringParameters.put("AppWithinMinutes.LiveTableClass_0_class", "Panels.PanelClass");
+        testUtils.gotoPage(testReference, "edit", editQueryStringParameters);
+        // Wait for the page to load before clicking on the save button to make sure the page layout is stable.
+        // The page being tested.
+        ApplicationHomePage homePage = new ApplicationHomeEditPage().waitUntilPageIsLoaded().clickSaveAndView();
+
+        // Test
         EntryNamePane entryNamePane = homePage.clickAddNewEntry();
         String entryName = "A?b=c&d#" + RandomStringUtils.randomAlphanumeric(3);
         entryNamePane.setName(entryName);
@@ -83,11 +77,14 @@ public class AddEntryTest extends AbstractTest
         entryEditPage.setValue("description", "This is a test panel.");
         entryEditPage.clickSaveAndView();
 
-        getUtil().gotoPage(getTestClassName(), getTestMethodName());
+        testUtils.gotoPage(testReference);
         homePage = new ApplicationHomePage();
         LiveTableElement entriesLiveTable = homePage.getEntriesLiveTable();
         entriesLiveTable.waitUntilReady();
+        // Makes sure the test entry is displayed at the top of the first page by sorting the date column by descending
+        // order.
+        entriesLiveTable.sortDescending(DATE_COLUMN_TITLE);
         // The column header is not translated because we haven't generated the document translation bundle.
-        Assert.assertTrue(entriesLiveTable.hasRow("panel.livetable.doc.title", entryName));
+        assertTrue(entriesLiveTable.hasRow("panel.livetable.doc.title", entryName));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-docker/src/test/it/org/xwiki/appwithinminutes/test/ui/AllITs.java
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-docker/src/test/it/org/xwiki/appwithinminutes/test/ui/AllITs.java
@@ -55,4 +55,10 @@ public class AllITs
     class NestedStaticListClassFieldIT extends StaticListClassFieldIT
     {
     }
+
+    @Nested
+    @DisplayName("Add entry test")
+    class NestedAddEntryIT extends AddEntryIT
+    {
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-pageobjects/src/main/java/org/xwiki/appwithinminutes/test/po/ApplicationHomePage.java
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-pageobjects/src/main/java/org/xwiki/appwithinminutes/test/po/ApplicationHomePage.java
@@ -73,7 +73,9 @@ public class ApplicationHomePage extends ViewPage
      */
     public EntryNamePane clickAddNewEntry()
     {
-        addEntryLink.click();
+        this.addEntryLink.click();
+        // Waits for the dialog box to be displayed before continuing.
+        getDriver().waitUntilElementIsVisible(By.cssSelector("div.xdialog-box"));
         return new EntryNamePane();
     }
 

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/LiveTableElement.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/LiveTableElement.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.test.ui.po;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.commons.lang3.StringEscapeUtils;
@@ -284,11 +285,69 @@ public class LiveTableElement extends BaseElement
         getDriver().executeJavascript("return $('" + StringEscapeUtils.escapeEcmaScript(livetableId)
             + "-ajax-loader').removeClassName('hidden')");
 
-        String xpath = String.format("//table[@id = '%s']//th[contains(@class, 'xwiki-livetable-display-header-text')"
-            + " and contains(@class, 'sortable') and normalize-space(.) = '%s']", this.livetableId, columnTitle);
-        getDriver().findElement(By.xpath(xpath)).click();
+        getHeaderByColumnTitle(columnTitle).click();
 
         waitUntilReady();
+    }
+
+    /**
+     * Sorts the live table on the specified column, by ascending order.
+     *
+     * @param columnTitle the column to sort on
+     * @since 13.3RC1
+     * @since 12.10.6
+     */
+    public void sortAscending(String columnTitle)
+    {
+        WebElement element = getHeaderByColumnTitle(columnTitle);
+        List<String> strings = Arrays.asList(element.getAttribute("class").split("\\w+"));
+        boolean isSelected = strings.contains("selected");
+        boolean isAsc = strings.contains("asc");
+
+        /*
+         * isSelected indicates if the column is the one currently sorted.
+         * If the column is the one currently sorted, and is in ascending order, we do nothing.
+         * If the column is already sorted in descending order, or if it is not the one currently sorted, but was
+         * previously sorted in ascending order, we sort only once.
+         * If the column is not already sorted, and was previously sorted in descending order, clicking sorting twice
+         * is required to sort in ascending order.
+         */
+        if (isSelected && !isAsc || (!isSelected && isAsc)) {
+            sortBy(columnTitle);
+        } else if (!isSelected) {
+            sortBy(columnTitle);
+            sortBy(columnTitle);
+        }
+    }
+
+    /**
+     * Sorts the live table on the specified column, by ascending order.
+     *
+     * @param columnTitle the column to sort on
+     * @since 13.3RC1
+     * @since 12.10.6
+     */
+    public void sortDescending(String columnTitle)
+    {
+        WebElement element = getHeaderByColumnTitle(columnTitle);
+        List<String> strings = Arrays.asList(element.getAttribute("class").split("\\w+"));
+        boolean isSelected = strings.contains("selected");
+        boolean isDesc = strings.contains("desc");
+
+        /*
+         * isSelected indicates if the column is the one currently sorted.
+         * If the column is the one currently sorted, and is in descending order, we do nothing.
+         * If the column is already sorted in ascending order, or if it is not the one currently sorted, but was
+         * previously sorted in descending order, we sort only once.
+         * If the column is not already sorted, and was previously sorted in ascending order, clicking sorting twice
+         * is required to sort in descending order.
+         */
+        if (isSelected && !isDesc || (!isSelected && isDesc)) {
+            sortBy(columnTitle);
+        } else if (!isSelected) {
+            sortBy(columnTitle);
+            sortBy(columnTitle);
+        }
     }
 
     /**
@@ -302,5 +361,12 @@ public class LiveTableElement extends BaseElement
     {
         WebElement rowElement = getRow(rowNumber);
         rowElement.findElement(By.xpath("td/form//input[@name = '" + actionName + "']")).click();
+    }
+
+    private WebElement getHeaderByColumnTitle(String columnTitle)
+    {
+        String xpath = String.format("//table[@id = '%s']//th[contains(@class, 'xwiki-livetable-display-header-text')"
+            + " and contains(@class, 'sortable') and normalize-space(.) = '%s']", this.livetableId, columnTitle);
+        return getDriver().findElement(By.xpath(xpath));
     }
 }


### PR DESCRIPTION
- Wait added on ApplicationHomePage#clickAddNewEntry to prevent access to the name field before it is displayed.
- AddEntryTest (in xwiki-platform-distribution-flavor-test-ui) migrated to docker as AddEntryIT (in xwiki-platform-appwithinminutes-test-docker).
- Adding the missing nested test in AllITs
- Improves the sorting page objects