### PR TITLE
XWiki-6316: Remove reference to XWiki.XWikiUserTemplate from XWiki.Registration

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/Registration.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/Registration.xml
@@ -293,17 +293,6 @@
       })
     #set($discard = $fields.add($field))
   #end
-  ##
-  ## Pass the name of the template to $xwiki.createUser so any contained information will be passed in.
-  #set($field =
-    {'name' : 'template',
-      'params' : {
-        'type' : 'hidden',
-        'value' : 'XWiki.XWikiUserTemplate'
-      }
-    })
-  #set($discard = $fields.add($field))
-  ##
   ## Pass the redirect parameter on so that the login page may redirect to the right place.
   ## Not necessary in Firefox 3.0.10 or Opera 9.64, I don't know about IE or Safari.
   #set($field =


### PR DESCRIPTION
Removed redundant code.
Issue link: https://jira.xwiki.org/browse/XWIKI-6316