### PR TITLE
XWIKI-15119: The Applications panel entries are not properly aligned

### DIFF
--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
@@ -530,10 +530,11 @@ $$('.applicationPanelMoreButton').each(function(button) {
 .panel-width-Large .applicationsPanel li .application-img {
   display: block;
   float: left;
+  width: 20px;
 }
 
 .applicationsPanel li .application-label {
-  margin-left: 0.5em;
+  margin-left: 0.1em;
 }
 
 .applicationPanelMoreContainer ul {


### PR DESCRIPTION
Issue: https://jira.xwiki.org/browse/XWIKI-15119

I know it is an old issue but it is still relevant.

![image (1)](https://user-images.githubusercontent.com/12747298/113692324-b9869880-96cd-11eb-8aea-afca9a7b7d04.png)
Old vs new

In the old, the text after an icon is a set amount of pixels after the icon, and this is not aligned with the other titles when the icons are not the same size
In the new, the width property of the icon is a set amount of pixels so the text always starts at the same position.

I set it at 20px since this was also already the height of the box so the icon is in a square now.
Since there is already some space left now as icons are smaller than 20px, the left margin of the following text can be reduced (to .1em).