### PR TITLE
Add round borders to preference boxes

### DIFF
--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserSheet.xml
@@ -555,6 +555,7 @@ div.userDashboard, #dashboardPane .dashboard {
 div.highlighted-profile-section,
 div.userInfo, div.userPreferences, div.watchlistManagement, div.userDashboard {
   background-color: $theme.backgroundSecondaryColor;
+  border-radius: 4px;
 }
 
 .userInfo {


### PR DESCRIPTION
XWIKI-11271: Use round borders on the user profile sections to be consistent with the user profile menu
Link: https://jira.xwiki.org/browse/XWIKI-11271

This PR rounds borders using a border radius of 4 pixels. This value is chosen because it is used in more places in the project.