### PR TITLE
Display fifth step in Distribution Wizard header

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/distribution.vm
+++ b/xwiki-platform-core/xwiki-platform-web/src/main/webapp/templates/distribution.vm
@@ -107,8 +107,7 @@
     #set ($steps = $services.distribution.jobStatus.steps)
     ## Ignore the welcome step.
     #set ($steps = $steps.subList(1, $steps.size()))
-    ## Ignore the report step
-    #set($lastElement = $steps.size() - 1)
+    #set($lastElement = $steps.size())
     #set ($steps = $steps.subList(0, $lastElement))
     <ul class="steps">
       #foreach ($step in $steps)


### PR DESCRIPTION
Issue: Distribution Wizard shows 4 steps but then displays a fifth one for the report
Link: https://jira.xwiki.org/browse/XWIKI-17600

This PR makes sure that the distribution wizard header shows five steps instead of four. The fifth step, the report, is currently namely not listed in the wizard.