### PR TITLE
XWIKI-18510: A right object with like level will not be displayed in page administration

### DIFF
--- a/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-api/src/main/java/org/xwiki/like/internal/LikeRight.java
+++ b/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-api/src/main/java/org/xwiki/like/internal/LikeRight.java
@@ -48,7 +48,7 @@ public final class LikeRight implements RightDescription
     @Override
     public String getName()
     {
-        return "Like";
+        return "like";
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-api/src/test/java/org/xwiki/like/internal/LikeRightTest.java
+++ b/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-api/src/test/java/org/xwiki/like/internal/LikeRightTest.java
@@ -36,7 +36,7 @@ public class LikeRightTest
     @Test
     void getters()
     {
-        assertEquals("Like", LikeRight.INSTANCE.getName());
+        assertEquals("like", LikeRight.INSTANCE.getName());
         assertEquals(RuleState.ALLOW, LikeRight.INSTANCE.getDefaultState());
         assertEquals(RuleState.ALLOW, LikeRight.INSTANCE.getTieResolutionPolicy());
         assertEquals(null, LikeRight.INSTANCE.getImpliedRights());


### PR DESCRIPTION
As it is exposed in https://jira.xwiki.org/browse/XWIKI-18510, there is an inconsistency of naming the Like right with the rest of the rights from the platform (those are with lowercase).

The changing of the name with lowercase will not impact the checking of access (since for those cases we're working with the object itself).


Note that the current PR is only a draft, it was not extensively tested, even if the unit testing are passing.