### PR TITLE
Replaced some JUnit4 imports with JUnit5

### DIFF
--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/test/java/org/xwiki/extension/xar/internal/question/CleanPagesQuestionRecorderTest.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/test/java/org/xwiki/extension/xar/internal/question/CleanPagesQuestionRecorderTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @version $Id$
  * @since 7.1RC1
  */
-public class CleanPagesQuestionRecorderTest
+class CleanPagesQuestionRecorderTest
 {
     @Test
     void recordAndReplay()

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/test/java/org/xwiki/extension/xar/internal/question/CleanPagesQuestionRecorderTest.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/test/java/org/xwiki/extension/xar/internal/question/CleanPagesQuestionRecorderTest.java
@@ -21,11 +21,11 @@ package org.xwiki.extension.xar.internal.question;
 
 import java.util.Arrays;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xwiki.extension.xar.question.CleanPagesQuestion;
 import org.xwiki.model.reference.DocumentReference;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Unit tests for {@link CleanPagesQuestionRecorder}.
@@ -36,7 +36,7 @@ import static org.junit.Assert.*;
 public class CleanPagesQuestionRecorderTest
 {
     @Test
-    public void recordAndReplay()
+    void recordAndReplay()
     {
         DocumentReference aliceReference = new DocumentReference("dev", "Users", "Alice");
         DocumentReference bobReference = new DocumentReference("dev", "Users", "Bob");

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/test/java/org/xwiki/extension/xar/internal/question/ConflictQuestionRecorderTest.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/test/java/org/xwiki/extension/xar/internal/question/ConflictQuestionRecorderTest.java
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.*;
  * @version $Id$
  * @since 7.1RC1
  */
-public class ConflictQuestionRecorderTest
+class ConflictQuestionRecorderTest
 {
     @Test
     void recordAndReplay()

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/test/java/org/xwiki/extension/xar/internal/question/ConflictQuestionRecorderTest.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/test/java/org/xwiki/extension/xar/internal/question/ConflictQuestionRecorderTest.java
@@ -19,14 +19,14 @@
  */
 package org.xwiki.extension.xar.internal.question;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xwiki.extension.xar.question.ConflictQuestion;
 import org.xwiki.extension.xar.question.ConflictQuestion.GlobalAction;
 import org.xwiki.model.reference.DocumentReference;
 
 import com.xpn.xwiki.doc.XWikiDocument;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 /**
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.*;
 public class ConflictQuestionRecorderTest
 {
     @Test
-    public void recordAndReplay()
+    void recordAndReplay()
     {
         XWikiDocument alice = mock(XWikiDocument.class, "Alice");
         when(alice.getDocumentReference()).thenReturn(new DocumentReference("dev", "Users", "Alice"));

--- a/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/test/java/org/xwiki/lesscss/internal/resources/LESSObjectPropertyResourceReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/test/java/org/xwiki/lesscss/internal/resources/LESSObjectPropertyResourceReferenceTest.java
@@ -19,15 +19,15 @@
  */
 package org.xwiki.lesscss.internal.resources;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.xwiki.bridge.DocumentAccessBridge;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReferenceSerializer;
 import org.xwiki.model.reference.ObjectPropertyReference;
 import org.xwiki.model.reference.ObjectReference;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -38,21 +38,21 @@ import static org.mockito.Mockito.when;
  * @since 7.0RC1
  * @version $Id$
  */
-public class LESSObjectPropertyResourceReferenceTest
+class LESSObjectPropertyResourceReferenceTest
 {
     private EntityReferenceSerializer<String> entityReferenceSerializer;
 
     private DocumentAccessBridge bridge;
     
-    @Before
-    public void SetUp() throws Exception
+    @BeforeEach
+    void SetUp() throws Exception
     {
         entityReferenceSerializer = mock(EntityReferenceSerializer.class);
         bridge = mock(DocumentAccessBridge.class);
     }
     
     @Test
-    public void getContent() throws Exception
+    void getContent() throws Exception
     {
         ObjectPropertyReference objectPropertyReference = new ObjectPropertyReference("property",
                 new ObjectReference("class", new DocumentReference("wiki", "Space", "Document")));
@@ -67,7 +67,7 @@ public class LESSObjectPropertyResourceReferenceTest
     }
 
     @Test
-    public void serialize() throws Exception
+    void serialize() throws Exception
     {
         ObjectPropertyReference objectPropertyReference = new ObjectPropertyReference("property",
                 new ObjectReference("class", new DocumentReference("wiki", "Space", "Document")));

--- a/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/test/java/org/xwiki/lesscss/internal/resources/LESSSkinFileResourceReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/test/java/org/xwiki/lesscss/internal/resources/LESSSkinFileResourceReferenceTest.java
@@ -19,8 +19,8 @@
  */
 package org.xwiki.lesscss.internal.resources;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.xwiki.lesscss.compiler.LESSCompilerException;
 import org.xwiki.skin.Skin;
 import org.xwiki.skin.SkinManager;
@@ -28,8 +28,8 @@ import org.xwiki.template.Template;
 import org.xwiki.template.TemplateContent;
 import org.xwiki.template.TemplateManager;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.when;
  * @since 7.0RC1
  * @version $Id$
  */
-public class LESSSkinFileResourceReferenceTest
+class LESSSkinFileResourceReferenceTest
 {
     private TemplateManager templateManager;
 
@@ -47,8 +47,8 @@ public class LESSSkinFileResourceReferenceTest
 
     private Skin skin;
     
-    @Before
-    public void setUp() throws Exception
+    @BeforeEach
+    void setUp() throws Exception
     {
         templateManager = mock(TemplateManager.class);
         skinManager = mock(SkinManager.class);
@@ -57,7 +57,7 @@ public class LESSSkinFileResourceReferenceTest
     }
 
     @Test
-    public void getContent() throws Exception
+    void getContent() throws Exception
     {
         LESSSkinFileResourceReference lessSkinFileResourceReference
                 = new LESSSkinFileResourceReference("style.less", templateManager, skinManager);
@@ -74,7 +74,7 @@ public class LESSSkinFileResourceReferenceTest
     }
 
     @Test
-    public void getContentWhenFileDoesNotExist() throws Exception
+    void getContentWhenFileDoesNotExist() throws Exception
     {
         LESSSkinFileResourceReference lessSkinFileResourceReference
                 = new LESSSkinFileResourceReference("not-existing-file.less", templateManager, skinManager);
@@ -93,7 +93,7 @@ public class LESSSkinFileResourceReferenceTest
     }
 
     @Test
-    public void getContentWhenException() throws Exception
+    void getContentWhenException() throws Exception
     {
         LESSSkinFileResourceReference lessSkinFileResourceReference
                 = new LESSSkinFileResourceReference("file.less", templateManager, skinManager);
@@ -119,7 +119,7 @@ public class LESSSkinFileResourceReferenceTest
     }
 
     @Test
-    public void serialize() throws Exception
+    void serialize() throws Exception
     {
         LESSSkinFileResourceReference lessSkinFileResourceReference
                 = new LESSSkinFileResourceReference("file.less", templateManager, skinManager);

--- a/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/test/java/org/xwiki/lesscss/internal/skin/DocumentSkinReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/test/java/org/xwiki/lesscss/internal/skin/DocumentSkinReferenceTest.java
@@ -19,12 +19,12 @@
  */
 package org.xwiki.lesscss.internal.skin;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReferenceSerializer;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -34,18 +34,18 @@ import static org.mockito.Mockito.when;
  * @since 7.0RC1
  * @version $Id$
  */
-public class DocumentSkinReferenceTest
+class DocumentSkinReferenceTest
 {
     private EntityReferenceSerializer<String> entityReferenceSerializer;
     
-    @Before
-    public void setUp() throws Exception
+    @BeforeEach
+    void setUp() throws Exception
     {
         entityReferenceSerializer = mock(EntityReferenceSerializer.class);
     }
 
     @Test
-    public void serialize() throws Exception
+    void serialize() throws Exception
     {
         DocumentReference documentReference = new DocumentReference("wiki", "space", "page");
         DocumentSkinReference documentSkinReference 

--- a/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/test/java/org/xwiki/lesscss/internal/skin/FSSkinReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/test/java/org/xwiki/lesscss/internal/skin/FSSkinReferenceTest.java
@@ -19,9 +19,9 @@
  */
 package org.xwiki.lesscss.internal.skin;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test class for {@link FSSkinReference}.
@@ -29,10 +29,10 @@ import static org.junit.Assert.assertEquals;
  * @since 7.0RC1
  * @version $Id$
  */
-public class FSSkinReferenceTest
+class FSSkinReferenceTest
 {
     @Test
-    public void serialize() throws Exception
+    void serialize() throws Exception
     {
         assertEquals("SkinFS[skin]", new FSSkinReference("skin").serialize());
     }

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-api/src/test/java/org/xwiki/mail/MailStatusResultSerializerTest.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-api/src/test/java/org/xwiki/mail/MailStatusResultSerializerTest.java
@@ -22,9 +22,9 @@ package org.xwiki.mail;
 import java.util.Arrays;
 import java.util.Date;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -34,10 +34,10 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  * @since 6.4RC1
  */
-public class MailStatusResultSerializerTest
+class MailStatusResultSerializerTest
 {
     @Test
-    public void serializeErrors() throws Exception
+    void serializeErrors() throws Exception
     {
         MailStatusResult statusResult = mock(MailStatusResult.class);
         Date date = new Date();

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-api/src/test/java/org/xwiki/mail/MailStatusTest.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-api/src/test/java/org/xwiki/mail/MailStatusTest.java
@@ -23,10 +23,10 @@ import java.util.Date;
 
 import javax.mail.Message;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for {@link MailStatus}.
@@ -34,10 +34,10 @@ import static org.junit.Assert.assertTrue;
  * @version $Id$
  * @since 6.4RC1
  */
-public class MailStatusTest
+class MailStatusTest
 {
     @Test
-    public void setError()
+    void setError()
     {
         MailStatus status = new MailStatus();
         status.setError(new Exception("outer", new Exception("inner")));
@@ -48,7 +48,7 @@ public class MailStatusTest
     }
 
     @Test
-    public void verifyToStringWhenStatusHasNoError() throws Exception
+    void verifyToStringWhenStatusHasNoError() throws Exception
     {
         ExtendedMimeMessage message = new ExtendedMimeMessage();
         message.setHeader("Message-ID", "<local@domain>");
@@ -64,7 +64,7 @@ public class MailStatusTest
     }
 
     @Test
-    public void verifyToStringWhenStatusHasError() throws Exception
+    void verifyToStringWhenStatusHasError() throws Exception
     {
         ExtendedMimeMessage message = new ExtendedMimeMessage();
         message.setHeader("Message-ID", "<local@domain>");
@@ -82,7 +82,7 @@ public class MailStatusTest
     }
 
     @Test
-    public void verifyToStringWhenWiki() throws Exception
+    void verifyToStringWhenWiki() throws Exception
     {
         ExtendedMimeMessage message = new ExtendedMimeMessage();
         message.setHeader("Message-ID", "<local@domain>");

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-api/src/test/java/org/xwiki/security/authorization/internal/SecurityAccessTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-api/src/test/java/org/xwiki/security/authorization/internal/SecurityAccessTest.java
@@ -19,7 +19,7 @@
  */
 package org.xwiki.security.authorization.internal;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xwiki.security.authorization.Right;
 import org.xwiki.security.authorization.RuleState;
 import org.xwiki.security.authorization.SecurityAccess;
@@ -27,7 +27,7 @@ import org.xwiki.security.authorization.SecurityAccess;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThat;
 import static org.xwiki.security.authorization.RuleState.UNDETERMINED;
 
 /**
@@ -36,7 +36,7 @@ import static org.xwiki.security.authorization.RuleState.UNDETERMINED;
  * @version $Id$
  * @since 4.0M2 
  */
-public class SecurityAccessTest
+class SecurityAccessTest
 {
 
     /**
@@ -58,7 +58,7 @@ public class SecurityAccessTest
      * Assert that access levels can be cleared and set on a SecurityAccess instance.
      */
     @Test
-    public void testAccessLevel() throws Exception
+    void testAccessLevel() throws Exception
     {
         assertDefaultAccessLevel();
 
@@ -150,7 +150,7 @@ public class SecurityAccessTest
      * Assert that the clone method works.
      */
     @Test
-    public void testClone() throws Exception
+    void testClone() throws Exception
     {
         XWikiSecurityAccess l = XWikiSecurityAccess.getDefaultAccess().clone();
         XWikiSecurityAccess k = l.clone();

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/test/java/org/xwiki/wysiwyg/internal/cleaner/HTMLCleanerTest.java
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/test/java/org/xwiki/wysiwyg/internal/cleaner/HTMLCleanerTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * 
  * @version $Id$
  */
-public class HTMLCleanerTest
+class HTMLCleanerTest
 {
     /**
      * The HTML cleaner being tested.
@@ -65,7 +65,7 @@ public class HTMLCleanerTest
      * The actual test.
      */
     @Test
-    public void execute()
+    void execute()
     {
         assertEquals(xhtmlFragment(expected), cleaner.clean(input));
     }

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/test/java/org/xwiki/wysiwyg/internal/cleaner/HTMLCleanerTest.java
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/test/java/org/xwiki/wysiwyg/internal/cleaner/HTMLCleanerTest.java
@@ -19,9 +19,10 @@
  */
 package org.xwiki.wysiwyg.internal.cleaner;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xwiki.wysiwyg.cleaner.HTMLCleaner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * A generic JUnit test used by {@link HTMLCleanerTestSuite} to clean some passed HTML content and verify it matches
@@ -66,7 +67,7 @@ public class HTMLCleanerTest
     @Test
     public void execute()
     {
-        Assert.assertEquals(xhtmlFragment(expected), cleaner.clean(input));
+        assertEquals(xhtmlFragment(expected), cleaner.clean(input));
     }
 
     /**


### PR DESCRIPTION
As a part of generally desirable migration to JUnit5, I've searched for JUnit4 imports and replaced 10 first occurrences (of course, the are many more left).

Changes:

- org.junit.Test -> org.junit.jupiter.api.Test
- org.junit.Assert -> org.junit.jupiter.api.Assertions
- org.junit.Before -> org.junit.jupiter.api.BeforeEach