### PR TITLE
XWIKI-18542: AWM tests failing on chrome

### DIFF
--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-pageobjects/src/main/java/org/xwiki/appwithinminutes/test/po/ApplicationClassEditPage.java
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-pageobjects/src/main/java/org/xwiki/appwithinminutes/test/po/ApplicationClassEditPage.java
@@ -102,9 +102,10 @@ public class ApplicationClassEditPage extends ApplicationEditPage
     {
         String fieldXPath = "//li[@class = 'field' and normalize-space(.) = '%s']";
         WebElement field = palette.findElement(By.xpath(String.format(fieldXPath, fieldType)));
-        // NOTE: We scroll the page up because the drag&drop fails sometimes if the dragged field and the canvas (drop
-        // target) are not fully visible. See https://code.google.com/p/selenium/issues/detail?id=3075 .
-        getDriver().executeScript("window.scrollTo(0, 0)");
+        // NOTE: We scroll to the top of the page (coordinates (0, 0)) because the drag&drop fails sometimes if the 
+        // dragged field and the canvas (drop target) are not fully visible. See
+        // https://code.google.com/p/selenium/issues/detail?id=3075 .
+        getDriver().scrollTo(0, 0);
         getDriver().dragAndDrop(field, fieldsCanvas);
         final WebElement addedField = fieldsCanvas.findElement(By.xpath("./ul[@id='fields']/li[last()]"));
 

--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-pageobjects/src/main/java/org/xwiki/appwithinminutes/test/po/ApplicationClassEditPage.java
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-pageobjects/src/main/java/org/xwiki/appwithinminutes/test/po/ApplicationClassEditPage.java
@@ -20,7 +20,6 @@
 package org.xwiki.appwithinminutes.test.po;
 
 import org.openqa.selenium.By;
-import org.openqa.selenium.Keys;
 import org.openqa.selenium.NotFoundException;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
@@ -97,6 +96,7 @@ public class ApplicationClassEditPage extends ApplicationEditPage
      * Drags a field of the specified type from the field palette to the field canvas.
      *
      * @param fieldType the type of field to add, as displayed on the field palette
+     * @return the newly added field page object
      */
     public ClassFieldEditPane addField(String fieldType)
     {
@@ -104,7 +104,7 @@ public class ApplicationClassEditPage extends ApplicationEditPage
         WebElement field = palette.findElement(By.xpath(String.format(fieldXPath, fieldType)));
         // NOTE: We scroll the page up because the drag&drop fails sometimes if the dragged field and the canvas (drop
         // target) are not fully visible. See https://code.google.com/p/selenium/issues/detail?id=3075 .
-        getDriver().createActions().sendKeys(Keys.HOME).perform();
+        getDriver().executeScript("window.scrollTo(0, 0)");
         getDriver().dragAndDrop(field, fieldsCanvas);
         final WebElement addedField = fieldsCanvas.findElement(By.xpath("./ul[@id='fields']/li[last()]"));
 

--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-pageobjects/src/main/java/org/xwiki/appwithinminutes/test/po/ApplicationClassEditPage.java
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-pageobjects/src/main/java/org/xwiki/appwithinminutes/test/po/ApplicationClassEditPage.java
@@ -102,10 +102,9 @@ public class ApplicationClassEditPage extends ApplicationEditPage
     {
         String fieldXPath = "//li[@class = 'field' and normalize-space(.) = '%s']";
         WebElement field = palette.findElement(By.xpath(String.format(fieldXPath, fieldType)));
-        // NOTE: We scroll to the top of the page (coordinates (0, 0)) because the drag&drop fails sometimes if the 
-        // dragged field and the canvas (drop target) are not fully visible. See
-        // https://code.google.com/p/selenium/issues/detail?id=3075 .
-        getDriver().scrollTo(0, 0);
+        // NOTE: We scroll to the top of the page because the drag&drop fails sometimes if the dragged field and the
+        // canvas (drop target) are not fully visible. See https://code.google.com/p/selenium/issues/detail?id=3075 .
+        scrollToTop();
         getDriver().dragAndDrop(field, fieldsCanvas);
         final WebElement addedField = fieldsCanvas.findElement(By.xpath("./ul[@id='fields']/li[last()]"));
 

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/XWikiWebDriver.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/XWikiWebDriver.java
@@ -649,6 +649,24 @@ public class XWikiWebDriver extends RemoteWebDriver
         return element;
     }
 
+    /**
+     * Scrolls to the given coordinates inside the web page. If you want to scroll to a specific {@link WebElement}, see
+     * {@link #scrollTo(WebElement)}.
+     *
+     * @param xCoord is the pixel along the horizontal axis of the web page that you want displayed in the upper
+     *     left
+     * @param yCoord is the pixel along the vertical axis of the web page that you want displayed in the upper left
+     * @see <a href="https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTo">MDN Web Docs -
+     *     Element.scrollTo()</a>
+     * @see #scrollTo(WebElement)
+     * @since 13.3RC1
+     * @since 12.10.7
+     */
+    public void scrollTo(int xCoord, int yCoord)
+    {
+        executeScript(String.format("window.scrollTo(%d, %d)", xCoord, yCoord));
+    }
+
     @Override
     public WebElement findElement(By by)
     {

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/ViewPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/ViewPage.java
@@ -249,6 +249,17 @@ public class ViewPage extends BasePage
         return getDriver().hasElementWithoutWaiting(this.content, elementLocator);
     }
 
+    /**
+     * Scrolls to the top of the screen.
+     *
+     * @since 13.3RC1
+     * @since 12.10.7
+     */
+    public void scrollToTop()
+    {
+        getDriver().scrollTo(0, 0);
+    }
+
     private void useShortcutForDocExtraPane(String shortcut, String pane)
     {
         getDriver().createActions().sendKeys(shortcut).perform();


### PR DESCRIPTION
Moving to the top of the screen is required for the drag and drop action to work, but using sendKey(HOME) wasn't working on Chrome (the drag and drop action was performed while the scroll up is still moving). sendKey replaced with executeScript("window.scrollTo(0, 0)")