### PR TITLE
[Misc] Page object documentation improvements

### DIFF
--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-pageobjects/src/main/java/org/xwiki/appwithinminutes/test/po/ApplicationClassEditPage.java
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-pageobjects/src/main/java/org/xwiki/appwithinminutes/test/po/ApplicationClassEditPage.java
@@ -102,8 +102,13 @@ public class ApplicationClassEditPage extends ApplicationEditPage
     {
         String fieldXPath = "//li[@class = 'field' and normalize-space(.) = '%s']";
         WebElement field = palette.findElement(By.xpath(String.format(fieldXPath, fieldType)));
-        // NOTE: We scroll to the top of the page because the drag&drop fails sometimes if the dragged field and the
-        // canvas (drop target) are not fully visible. See https://code.google.com/p/selenium/issues/detail?id=3075 .
+        // NOTE: We scroll to the top of the page because the drag&drop fails sometimes if the dragged field and the 
+        // canvas (drop target) are not fully visible. See https://code.google.com/p/selenium/issues/detail?id=3075.
+        // The scroll up action was previously performed by sending a home key pressed action. This action is
+        // asynchronous on Chrome, consequently the drag and drop action below was performed while the screen was still 
+        // moving. This was leading to the wrong type of field being drag and dropped in the edit pane, making the test 
+        // fail. scrollToTop is instantaneous and moves the view to the top of the screen before the drag and drop 
+        // starts.
         scrollToTop();
         getDriver().dragAndDrop(field, fieldsCanvas);
         final WebElement addedField = fieldsCanvas.findElement(By.xpath("./ul[@id='fields']/li[last()]"));

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/XWikiWebDriver.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/XWikiWebDriver.java
@@ -650,8 +650,8 @@ public class XWikiWebDriver extends RemoteWebDriver
     }
 
     /**
-     * Scrolls to the given coordinates inside the web page. If you want to scroll to a specific {@link WebElement}, see
-     * {@link #scrollTo(WebElement)}.
+     * Instantaneously scrolls to the given coordinates inside the web page. If you want to scroll to a specific {@link
+     * WebElement}, see {@link #scrollTo(WebElement)}.
      *
      * @param xCoord is the pixel along the horizontal axis of the web page that you want displayed in the upper
      *     left
@@ -664,6 +664,8 @@ public class XWikiWebDriver extends RemoteWebDriver
      */
     public void scrollTo(int xCoord, int yCoord)
     {
+        // This action is instantaneous, allowing to continue testing while knowing precisely the browser's view of the 
+        // web page.
         executeScript(String.format("window.scrollTo(%d, %d)", xCoord, yCoord));
     }
 

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/ViewPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/ViewPage.java
@@ -250,13 +250,17 @@ public class ViewPage extends BasePage
     }
 
     /**
-     * Scrolls to the top of the screen.
+     * Instantaneously scrolls to the top of the screen.
      *
      * @since 13.3RC1
      * @since 12.10.7
      */
     public void scrollToTop()
     {
+        // scrollTo allows to move the view to the top of the page instantaneously, allowing to safely continue the
+        // browser interactions without risks of seeing the screen moving up during the following test steps.
+        // Note: this action was previously performed by sending a home key pressed event, which was not synchronous on 
+        // Chrome, leading to flickering tests, notably when the scroll was followed by a drag and drop action.
         getDriver().scrollTo(0, 0);
     }
 


### PR DESCRIPTION
- Explains why a call to the javascript window.scrollTo method is the best way to scroll
- Documents why using XWikiWebDriver#scrollTo(int, int) is the best way to move to the top of the page
- Documents why we stopped using a home page key press action to move the view to the top of the page in ApplicationClassEditPage