### PR TITLE
XWIKI-18560: Mentions notification can display a link to the mention with an empty text

### DIFF
--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-notifications/src/main/resources/templates/mentions/mention.vm
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-notifications/src/main/resources/templates/mentions/mention.vm
@@ -83,7 +83,8 @@
             #else
                 #set ($descriptionKey = 'mentions.event.mention.description')
             #end
-            #set ($description = "$services.localization.render($descriptionKey) <a href='$eventParams.getDocumentURL()'>$eventParams.getDocument().getTitle()</a>")
+            #set ($tdoc = $xwiki.getDocument($eventParams.getDocument().getDocumentReference()).getTranslatedDocument())
+            #set ($description = "$services.localization.render($descriptionKey) <a href='$eventParams.getDocumentURL()'>$tdoc.getRenderedTitle('xhtml/1.0')</a>")
             #displayEventDetail($event $description)
         #end
     #end

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-notifications/src/main/resources/templates/mentions/mention.vm
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-notifications/src/main/resources/templates/mentions/mention.vm
@@ -30,18 +30,18 @@
 #end
 
 #macro (displayEventDetail $event $summary)
-    #set ($username = $event.user.name)
-    #set ($eventParams = $compositeEventParams.get($event))
+  #set ($username = $event.user.name)
+  #set ($eventParams = $compositeEventParams.get($event))
 <tr>
-    <td>
+  <td>
         <span class="notification-event-user">
             <a href="$eventParams.getAuthorURL()">$username</a>
         </span>
-    </td>
-    <td class="description">$summary</td>
-    #insertEventDate($event)
+  </td>
+  <td class="description">$summary</td>
+  #insertEventDate($event)
 </tr>
-#if($services.mentions.isQuoteActivated() && $eventParams.getQuote())
+  #if($services.mentions.isQuoteActivated() && $eventParams.getQuote())
   <tr>
     <td colspan="3">
       <blockquote class="mention-quote">
@@ -49,46 +49,49 @@
       </blockquote>
     </td>
   </tr>
-#end
+  #end
 #end
 
 #define ($content)
 <div class="notification-description">
-    <div class="activity-type">$services.localization.render('mentions.event.mention.type')</div>
-    <div class="activity-summary">
-        #if ($compositeEvent.events.size() == 1)
+  <div class="activity-type">$services.localization.render('mentions.event.mention.type')</div>
+  <div class="activity-summary">
+    #if ($compositeEvent.events.size() == 1)
             $services.localization.render('mentions.event.mention.summary.singular')
         #else
-            $services.localization.render('mentions.event.mention.summary.plural', $compositeEvent.events.size())
-        #end
-    </div>
-    <div><small class="text-muted">$compositeEventDate</small></div>
+      $services.localization.render('mentions.event.mention.summary.plural', $compositeEvent.events.size())
+    #end
+  </div>
+  <div><small class="text-muted">$compositeEventDate</small></div>
 </div>
 #end
 
 #define ($details)
-    #define($rows)
-        #foreach($event in $compositeEvent.events)
-            #set ($eventParams = $compositeEventParams.get($event))
-            #set ($location = $eventParams.location)
-            ## TODO: define variation for group mention
-            #if ($location == "DOCUMENT")
-                #set ($descriptionKey = 'mentions.event.mention.description.document')
-            #elseif($location == "COMMENT")
-                #set ($descriptionKey = 'mentions.event.mention.description.comment')
-            #elseif($location == "ANNOTATION")
-                #set ($descriptionKey = 'mentions.event.mention.description.annotation')
-            #elseif($location == "AWM_FIELD")
-                #set ($descriptionKey = 'mentions.event.mention.description.awmField')
-            #else
-                #set ($descriptionKey = 'mentions.event.mention.description')
-            #end
-            #set ($tdoc = $xwiki.getDocument($eventParams.getDocument().getDocumentReference()).getTranslatedDocument())
-            #set ($description = "$services.localization.render($descriptionKey) <a href='$eventParams.getDocumentURL()'>$tdoc.getRenderedTitle('xhtml/1.0')</a>")
-            #displayEventDetail($event $description)
-        #end
+  #define($rows)
+    #foreach($event in $compositeEvent.events)
+      #set ($eventParams = $compositeEventParams.get($event))
+      #set ($location = $eventParams.location)
+      ## TODO: define variation for group mention
+      #if ($location == "DOCUMENT")
+        #set ($descriptionKey = 'mentions.event.mention.description.document')
+      #elseif($location == "COMMENT")
+        #set ($descriptionKey = 'mentions.event.mention.description.comment')
+      #elseif($location == "ANNOTATION")
+        #set ($descriptionKey = 'mentions.event.mention.description.annotation')
+      #elseif($location == "AWM_FIELD")
+        #set ($descriptionKey = 'mentions.event.mention.description.awmField')
+      #else
+        #set ($descriptionKey = 'mentions.event.mention.description')
+      #end
+      #set ($tdoc = $xwiki.getDocument($eventParams.getDocument().getDocumentReference()).getTranslatedDocument())
+      #set ($description =
+        "$services.localization.render($descriptionKey) <a href='$eventParams.getDocumentURL()'>" +
+        "$tdoc.getRenderedTitle( 'xhtml/1.0')" +
+        "</a>")
+      #displayEventDetail($event $description)
     #end
-    #displayNotificationEventDetailsSkeletons($events.size(), $rows)
+  #end
+  #displayNotificationEventDetailsSkeletons($events.size(), $rows)
 #end
 
 #displayNotificationEventSkeleton($mainIcon $smallIcon $content $details)

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-test/xwiki-platform-mentions-test-docker/src/test/it/org/xwiki/mentions/test/ui/MentionsIT.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-test/xwiki-platform-mentions-test-docker/src/test/it/org/xwiki/mentions/test/ui/MentionsIT.java
@@ -192,6 +192,51 @@ class MentionsIT
     }
 
     /**
+     * This test is similar to {@link #comment(TestUtils, TestReference)} but this time the comment is created on a page
+     * with an empty title. In this case, the link to the page displayed in the mention must have the name of the
+     * document displayed instead of an empty title.
+     */
+    @Test
+    @Order(3)
+    void commentOnPageWithEmptyTitle(TestUtils testUtils, TestReference testReference) throws Exception
+    {
+        runAsSuperAdmin(testUtils, () -> {
+            // create the users.
+            testUtils.createUser(U1_USERNAME, USERS_PWD, null);
+            testUtils.createUser(U2_USERNAME, USERS_PWD, null);
+        });
+
+        runAsUser(testUtils, U1_USERNAME, USERS_PWD, () -> {
+            testUtils.deletePage(testReference);
+            testUtils.createPage(testReference, "", null);
+            Map<String, Object> properties = new HashMap<>();
+            properties.put("author", "xwiki:XWiki.U1");
+            properties.put("date", "17/08/2020 14:55:18");
+            properties
+                .put("comment",
+                    "AAAAA\n\n"
+                        + "{{mention reference=\"xwiki:XWiki.U2\" style=\"LOGIN\" anchor=\"test-mention-2\" "
+                        + "type=\"user\" /}} XYZ\n\nBBBBB");
+            testUtils.addObject(testReference, "XWiki.XWikiComments", properties);
+        });
+
+        runAsUser(testUtils, U2_USERNAME, USERS_PWD, () -> {
+            testUtils.gotoPage("Main", "WebHome");
+            waitOnNotificationCount("xwiki:XWiki.U2", "xwiki", 1);
+            // Checks that a notification is well received.
+            NotificationsTrayPage tray = new NotificationsTrayPage();
+            tray.showNotificationTray();
+            MentionNotificationPage mentionNotificationPage =
+                new MentionNotificationPage(tray.getNotificationsButton());
+            mentionNotificationPage.openGroup(0);
+            // Checks that the name of the document is used for the link of the page, and not the empty page title. 
+            assertEquals("mentioned you on a comment on page commentOnPageWithEmptyTitle",
+                mentionNotificationPage.getText(0, 0));
+            tray.clearAllNotifications();
+        });
+    }
+
+    /**
      * Login as some user and perform some actions, then logout.
      *
      * @param setup The test setup.


### PR DESCRIPTION
Uses the translated document to access the rendered title. This has to advantages:
- the name of the document is used if the title is empty
- the title is displayed in the current locale of the user