### PR TITLE
XWIKI-15495: Enable CTRL+CLICK on document tree to open links in new tabs

### DIFF
--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/tree.js
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/tree.js
@@ -493,7 +493,7 @@ define(['jquery', 'JobRunner', 'jsTree', 'tree-finder'], function($, JobRunner) 
       } else if (data.event && !$(data.event.target).hasClass('jstree-no-link') &&
           $(data.event.target).closest('.jstree-no-links').length === 0) {
         // The node selection was triggered by an user event and links are enabled.
-        // When pressing Ctrl key and clicking on a document tree entry that is a link, open link in new window / tab
+        // When pressing Ctrl key and clicking on a tree node that has a link, open the link in new window / tab.
         if (data.event.ctrlKey === true) {
           window.open(selectedNode.a_attr.href, '_blank');
         } else {

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/tree.js
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/tree.js
@@ -493,7 +493,11 @@ define(['jquery', 'JobRunner', 'jsTree', 'tree-finder'], function($, JobRunner) 
       } else if (data.event && !$(data.event.target).hasClass('jstree-no-link') &&
           $(data.event.target).closest('.jstree-no-links').length === 0) {
         // The node selection was triggered by an user event and links are enabled.
-        window.location.href = selectedNode.a_attr.href;
+        if (data.event.ctrlKey === true) {
+          window.open(selectedNode.a_attr.href, '_blank');
+        } else {
+          window.location.href = selectedNode.a_attr.href;
+        }
       }
 
     }).on('open_node.jstree', function(event, data) {

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/tree.js
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/tree.js
@@ -493,6 +493,7 @@ define(['jquery', 'JobRunner', 'jsTree', 'tree-finder'], function($, JobRunner) 
       } else if (data.event && !$(data.event.target).hasClass('jstree-no-link') &&
           $(data.event.target).closest('.jstree-no-links').length === 0) {
         // The node selection was triggered by an user event and links are enabled.
+        // When pressing Ctrl key and clicking on a document tree entry that is a link, open link in new window / tab
         if (data.event.ctrlKey === true) {
           window.open(selectedNode.a_attr.href, '_blank');
         } else {


### PR DESCRIPTION
- When ctrl key is pressed, open link in new window / tab in tree.js  event listener