### PR TITLE
XWIKI-18461: Extension version links are not working from Extension updater

### DIFF
--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-ui/src/main/resources/XWiki/ExtensionUpdater.xml
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-ui/src/main/resources/XWiki/ExtensionUpdater.xml
@@ -49,6 +49,8 @@
 #else
   &lt;div class="full column"&gt;
   #if ($request.extensionId)
+    ## When an extension id is present in the request, display extension info in the updater context
+    ## (same approach as in extensionHistory.vm)
     #handleExtensionRequest()
   #else
     #extensionUpdater()

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-ui/src/main/resources/XWiki/ExtensionUpdater.xml
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-ui/src/main/resources/XWiki/ExtensionUpdater.xml
@@ -48,7 +48,11 @@
   #end
 #else
   &lt;div class="full column"&gt;
+  #if ($request.extensionId)
+    #handleExtensionRequest()
+  #else
     #extensionUpdater()
+  #end
   &lt;/div&gt;
 #end
 {{/html}}


### PR DESCRIPTION
- When an extension id is present in the request, display extension info in the updater context (same approach as in extensionHistory.vm)