### PR TITLE
XWIKI-18546: Inconsistencies between frontend and backend registration check

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/Registration.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/Registration.xml
@@ -192,6 +192,10 @@
         'mandatory' : {
           'failureMessage' : $services.localization.render('core.validation.required.message')
         },
+        'regex' : {
+          'pattern' : '/^[a-zA-Z0-9_]+$/',
+          'failureMessage' : $services.localization.render('xe.admin.registration.invalidUsername')
+        },
         'programmaticValidation' : {
           'code' : '#nameAvailable($request.get("xwikiname"))',
           'failureMessage' : $services.localization.render('core.register.userAlreadyExists')

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -2486,6 +2486,7 @@ xe.admin.configurable.sectionIconNoAccess=(No Access)
 xe.admin.configurable.sectionIconNoAccessTooltip=You don't have permission to configure this section.
 xe.admin.configurable.noViewAccessSomeApplications=Some sections may not be displayed because you do not have view access to some configurable applications including: {0}
 ### XWiki.Registration
+xe.admin.registration.invalidUsername=Please use only letters from the latin alphabet, numbers, and the underscore character '_'.
 xe.admin.registration.passwordTooShort=Please use a longer password.
 xe.admin.registration.passwordMismatch=The passwords do not match.
 xe.admin.registration.invalidEmail=Please enter a valid email address.


### PR DESCRIPTION
- Use regex /^[a-zA-Z0-9_]+$/ to validate a username (same as the
  default one used by XWiki#createUser)
- Add i18n label for notifying the user about an invalid username
  directly in the form live validation step