### PR TITLE
[Misc] Add javadoc to all public methods

### DIFF
--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/query/SortableEventQuery.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/query/SortableEventQuery.java
@@ -37,7 +37,7 @@ import org.xwiki.text.XWikiToStringBuilder;
 public interface SortableEventQuery extends EventQuery
 {
     /**
-     * The sort close to apply to the found events.
+     * The sort clause to apply to the found events.
      * 
      * @version $Id$
      */
@@ -65,6 +65,10 @@ public interface SortableEventQuery extends EventQuery
 
         private final Order order;
 
+        /**
+         * @param property see {@link #getProperty}
+         * @param order see {@link #getOrder}
+         */
         public SortClause(String property, Order order)
         {
             this.property = property;
@@ -80,7 +84,7 @@ public interface SortableEventQuery extends EventQuery
         }
 
         /**
-         * @return the order to apply
+         * @return the order to apply (ascending or descending)
          */
         public Order getOrder()
         {
@@ -121,7 +125,7 @@ public interface SortableEventQuery extends EventQuery
     }
 
     /**
-     * @return the sort closes
+     * @return the sort clauses
      */
     List<SortClause> getSorts();
 }

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-storage/src/main/java/org/xwiki/mail/internal/DatabaseMailResender.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-storage/src/main/java/org/xwiki/mail/internal/DatabaseMailResender.java
@@ -165,6 +165,14 @@ public class DatabaseMailResender implements MailResender
     @FunctionalInterface
     private interface SingleMailResender
     {
+        /**
+         * Resends single message.
+         * 
+         * @param batchId batchId of single message. 
+         * @param messageId messageId of single message.
+         * @return single message that is to be resent.
+         * @throws MailStoreException If an exception occurs.
+         */
         MailStatusResult resendSingleMessage(String batchId, String messageId) throws MailStoreException;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-storage/src/main/java/org/xwiki/mail/script/MailStorageScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-storage/src/main/java/org/xwiki/mail/script/MailStorageScriptService.java
@@ -347,6 +347,15 @@ public class MailStorageScriptService extends AbstractMailScriptService
     @FunctionalInterface
     private interface MultipleMailResender
     {
+        /**
+         * Resends messages.
+         * 
+         * @param filterMap the map of Mail Status parameters to match (e.g. "status", "wiki", "batchId", etc)
+         * @param offset the number of rows to skip (0 means don't skip any row)
+         * @param count the number of rows to return. If 0 then all rows are returned
+         * @return the mail results for the resent mails.
+         * @throws MailStoreException If an exception occurs.
+         */
         List<Pair<MailStatus, MailStatusResult>> resendMessages(Map<String, Object> filterMap, int offset, int count)
             throws MailStoreException;
     }

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/RatingsManager.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/RatingsManager.java
@@ -61,6 +61,9 @@ public interface RatingsManager
             this.fieldName = fieldName;
         }
 
+        /**
+         * @return the name of the field used for filtering Rating queries.
+         */
         public String getFieldName()
         {
             return this.fieldName;


### PR DESCRIPTION
From https://github.com/checkstyle/checkstyle/pull/9884

There was an error while calculating scope, so some methods with `public` scope were not exposed.

While this was fixed in https://github.com/checkstyle/checkstyle/pull/9884, for successful passing of CI, these changes are required.

Please suggest any change in Javadoc if required. Since, I am not familiar with the project, these javadocs might not be perfect.