### PR TITLE
XWIKI-18500: Extension updater propose to upgrade Sandbox to 13.1 when 12.10.5 flavor is installed

### DIFF
--- a/xwiki-platform-core/xwiki-platform-sandbox/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-sandbox/pom.xml
@@ -41,7 +41,6 @@
       <groupId>org.xwiki.platform</groupId>
       <artifactId>xwiki-platform-uiextension-api</artifactId>
       <version>${project.version}</version>
-      <type>xar</type>
     </dependency>
   </dependencies>
   <build>

--- a/xwiki-platform-core/xwiki-platform-sandbox/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-sandbox/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <!-- Needed to display the Sandbox in the Applications panel list -->
       <groupId>org.xwiki.platform</groupId>
-      <artifactId>xwiki-platform-uiextension-ui</artifactId>
+      <artifactId>xwiki-platform-uiextension-api</artifactId>
       <version>${project.version}</version>
       <type>xar</type>
     </dependency>

--- a/xwiki-platform-core/xwiki-platform-sandbox/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-sandbox/pom.xml
@@ -35,6 +35,15 @@
     <!-- Name to display by the Extension Manager -->
     <xwiki.extension.name>Sandbox Application</xwiki.extension.name>
   </properties>
+  <dependencies>
+    <dependency>
+      <!-- Needed to display the Sandbox in the Applications panel list -->
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-uiextension-ui</artifactId>
+      <version>${project.version}</version>
+      <type>xar</type>
+    </dependency>
+  </dependencies>
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
- Add dependency on `xwiki-platform-uiextension-ui`, which is needed by the Sandbox application to get listed in the Applications panel via a `UserExtensionClass` object.