### PR TITLE
XWIKI-18479: Attachment count is not updated when the Attachments tab…

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/viewers/attachments.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/viewers/attachments.js
@@ -256,6 +256,16 @@ require(['jquery', 'xwiki-events-bridge'], function($) {
   $(document).on('xwiki:html5upload:done', function() {
     updateCount();
   });
+
+  /**
+   * Call "updateCount" when the attachment tab content gets loaded, in order to make sure that the counter
+   * reflects the actual number of attachments, which may have changed since the initial page load.
+   */
+  document.observe("xwiki:docextra:loaded", function(event) {
+    if (event.memo.id == 'Attachments') {
+      updateCount();
+    }
+  });
 });
 
 // End JavaScript-only code.

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/viewers/attachments.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/viewers/attachments.js
@@ -261,8 +261,8 @@ require(['jquery', 'xwiki-events-bridge'], function($) {
    * Call "updateCount" when the attachment tab content gets loaded, in order to make sure that the counter
    * reflects the actual number of attachments, which may have changed since the initial page load.
    */
-  document.observe("xwiki:docextra:loaded", function(event) {
-    if (event.memo.id == 'Attachments') {
+  $(document).on('xwiki:docextra:loaded', function(event, data) {
+    if (data.id === 'Attachments') {
       updateCount();
     }
   });


### PR DESCRIPTION
… is loaded

- Listen to event 'xwiki:docextra:loaded' and update attachment counter on attachment tab content loading completion