### PR TITLE
XWIKI-14811: Bad layout when using a font larger than the default one

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/extension.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/extension.vm
@@ -618,7 +618,7 @@ $namespace##
       <span class="extension-namespace">$services.localization.render('extensions.info.dependency.wiki', ["#wikiHomePageLink($extensionNamespace)"])</span>
     #end
     #if ("$!dependencyStatusMessage" != '')
-      <p class="extension-status">$dependencyStatusMessage</p>
+      <span class="extension-status">$dependencyStatusMessage</span>
     #end
   </div>
 #end
@@ -1041,7 +1041,7 @@ $namespace##
         <span class="extension-name">#displayExtensionName($extension)</span>
         <span class="extension-version">$escapetool.xml($extension.id.version)</span>
         #if ($extensionStatusMessage)
-          <p class="extension-status">$escapetool.xml($extensionStatusMessage)</p>
+          <span class="extension-status">$escapetool.xml($extensionStatusMessage)</span>
         #end
       </h2>
       #displayExtensionActionButtons($extension, $readOnly)

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/extension/extension.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/extension/extension.css
@@ -60,6 +60,7 @@
   font-size: 0.8em;
   font-weight: normal;
   margin: 3px 0 0 0;
+  display: block;
 }
 
 h2.extension-title .extension-status {


### PR DESCRIPTION
- Use span instead of paragraph for extension-status element since paragraphs are not authorized in headings