### PR TITLE
XWIKI-14811: Bad layout when using a font larger than the default one

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/extension/extension.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/extension/extension.css
@@ -484,7 +484,7 @@ ul.collapsible.document-tree {
   .extension-title, .dependency-item {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    justify-content: start;
   }
   .extension-status {
     flex-grow: 1;


### PR DESCRIPTION
- Use "justify-content: start" for the "extension-title" and "dependency-item" sections
