### PR TITLE
XWIKI-18628: Field pretty name should not take precedence over the specified translation prefix

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/DefaultLiveDataConfigurationResolver.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/DefaultLiveDataConfigurationResolver.java
@@ -49,7 +49,7 @@ import org.xwiki.localization.ContextualLocalizationManager;
 
 /**
  * Adds missing live data configuration values specific to the live table source.
- * 
+ *
  * @version $Id$
  * @since 12.10.4
  * @since 13.0
@@ -80,7 +80,7 @@ public class DefaultLiveDataConfigurationResolver implements LiveDataConfigurati
     /**
      * Used to merge the default configuration with the provided configuration.
      */
-    private JSONMerge jsonMerge = new JSONMerge();
+    private final JSONMerge jsonMerge = new JSONMerge();
 
     @Override
     public LiveDataConfiguration resolve(LiveDataConfiguration config) throws LiveDataException
@@ -138,9 +138,10 @@ public class DefaultLiveDataConfigurationResolver implements LiveDataConfigurati
             Optional<String> firstNonSpecialProperty = query.getProperties().stream().filter(Objects::nonNull)
                 .filter(property -> !property.startsWith("_")).findFirst();
             if (firstNonSpecialProperty.isPresent()
-                && isPropertySortable(firstNonSpecialProperty.get(), config.getMeta())) {
+                && isPropertySortable(firstNonSpecialProperty.get(), config.getMeta()))
+            {
                 if (query.getSort() == null) {
-                    query.setSort(new ArrayList<SortEntry>());
+                    query.setSort(new ArrayList<>());
                 }
                 if (query.getSort().isEmpty()) {
                     // The sort is not specified.
@@ -179,7 +180,7 @@ public class DefaultLiveDataConfigurationResolver implements LiveDataConfigurati
     {
         Collection<LiveDataPropertyDescriptor> propertyDescriptors = config.getMeta().getPropertyDescriptors();
         Set<String> propertiesWithDescriptor = propertyDescriptors.stream().filter(Objects::nonNull)
-            .map(propertyDescriptor -> propertyDescriptor.getId()).collect(Collectors.toSet());
+            .map(LiveDataPropertyDescriptor::getId).collect(Collectors.toSet());
         List<LiveDataPropertyDescriptor> missingDescriptors =
             properties.stream().filter(property -> !propertiesWithDescriptor.contains(property))
                 .map(this::getDefaultPropertyDescriptor).collect(Collectors.toList());

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/DefaultLiveDataConfigurationResolverTest.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/DefaultLiveDataConfigurationResolverTest.java
@@ -51,7 +51,7 @@ import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link DefaultLiveDataConfigurationResolver}.
- * 
+ *
  * @version $Id$
  */
 @ComponentTest
@@ -67,18 +67,18 @@ class DefaultLiveDataConfigurationResolverTest
     @Named("liveTable")
     private Provider<LiveDataPropertyDescriptorStore> propertyStoreProvider;
 
-    @Mock(extraInterfaces = {LiveDataPropertyDescriptorStore.class})
+    @Mock(extraInterfaces = { LiveDataPropertyDescriptorStore.class })
     private WithParameters propertyStore;
 
     @MockComponent
     @Named("liveTable")
     private Provider<LiveDataConfiguration> defaultConfigProvider;
 
-    private LiveDataConfiguration defaultConfig = new LiveDataConfiguration();
+    private final LiveDataConfiguration defaultConfig = new LiveDataConfiguration();
 
-    private LiveDataConfiguration config = new LiveDataConfiguration();
+    private final LiveDataConfiguration config = new LiveDataConfiguration();
 
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @BeforeEach
     void configure()
@@ -203,7 +203,7 @@ class DefaultLiveDataConfigurationResolverTest
     }
 
     /**
-     * This test asserts that the translation is used for the name of a property, even if the property has a defined 
+     * This test asserts that the translation is used for the name of a property, even if the property has a defined
      * pretty name.
      */
     @Test
@@ -220,14 +220,13 @@ class DefaultLiveDataConfigurationResolverTest
 
         when(this.l10n.getTranslationPlain("release.livetable." + "releaseDate")).thenReturn("Released On");
 
-
         LiveDataConfiguration actualConfig = this.resolver.resolve(this.config);
         assertEquals("[{\"id\":\"releaseDate\",\"name\":\"Released On\"}]",
             this.objectMapper.writeValueAsString(actualConfig.getMeta().getPropertyDescriptors()));
     }
 
     /**
-     * This test asserts that the default name is kept for the name of a property, even if the property has a defined 
+     * This test asserts that the default name is kept for the name of a property, even if the property has a defined
      * pretty name, or if a translation exists for the property.
      */
     @Test
@@ -247,7 +246,7 @@ class DefaultLiveDataConfigurationResolverTest
             .thenReturn(singletonList(propertyDescriptorReleaseDate));
 
         when(this.l10n.getTranslationPlain("release.livetable." + "releaseDate")).thenReturn("Released On");
-        
+
         LiveDataConfiguration actualConfig = this.resolver.resolve(this.config);
         assertEquals("[{\"id\":\"releaseDate\",\"name\":\"Date of release\"}]",
             this.objectMapper.writeValueAsString(actualConfig.getMeta().getPropertyDescriptors()));

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker/src/test/it/org/xwiki/panels/test/ui/docker/PanelIT.java
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker/src/test/it/org/xwiki/panels/test/ui/docker/PanelIT.java
@@ -112,7 +112,7 @@ class PanelIT
         tableLayoutElement.filterColumn("Name", panelName);
         assertEquals(1, tableLayoutElement.countRows());
         tableLayoutElement.assertRow("Description", "Panel Description");
-        tableLayoutElement.assertRow("Panel type", "view");
+        tableLayoutElement.assertRow("Type", "view");
         tableLayoutElement.assertRow("Category", "Information");
 
         // Add the panel to the right column from the administration.

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-docker/src/test/it/org/xwiki/wiki/test/ui/WikiTemplateIT.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-docker/src/test/it/org/xwiki/wiki/test/ui/WikiTemplateIT.java
@@ -42,6 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.xwiki.wiki.test.po.WikiIndexPage.WIKI_NAME_COLUMN_LABEL;
 
 /**
  * UI tests for the wiki templates feature of the Wiki application.
@@ -159,7 +160,7 @@ class WikiTemplateIT
         // Verify the wiki template is displayed in the admin wiki templates list.
         TableLayoutElement tableLayout = AdminWikiTemplatesPage.goToPage().getLiveData().getTableLayout();
         assertEquals(1, tableLayout.countRows());
-        tableLayout.assertCellWithLink("Wiki pretty name", "My new template",
+        tableLayout.assertCellWithLink(WIKI_NAME_COLUMN_LABEL, "My new template",
             setup.getBaseURL() + "wiki/mynewtemplate/view/Main/");
         tableLayout.assertRow("Description", "This is the template I do for the tests");
         tableLayout.assertRow("Owner", "superadmin");

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-pageobjects/src/main/java/org/xwiki/wiki/test/po/WikiIndexPage.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-pageobjects/src/main/java/org/xwiki/wiki/test/po/WikiIndexPage.java
@@ -32,7 +32,10 @@ import org.xwiki.livedata.test.po.TableLayoutElement;
  */
 public class WikiIndexPage extends ExtendedViewPage
 {
-    private static final String WIKI_NAME_COLUMN_LABEL = "Wiki pretty name";
+    /**
+     * Label of the wiki name column.
+     */
+    public static final String WIKI_NAME_COLUMN_LABEL = "Name";
 
     @FindBy(id = "wikis")
     private WebElement wikisTable;


### PR DESCRIPTION
Update the livetable data configuration resolver to apply the following precedence for the property names:
- name defined in the Live Data macro
- name defined in the translations
- pretty name of the property
- identifier of the property