### PR TITLE
XWIKI-18661: Impossible to filter panel type or category with empty value

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/resources/ApplicationResources.properties
@@ -24,6 +24,7 @@ liveData.layout.cards=Cards
 liveData.operator.contains=Contains
 liveData.operator.startsWith=Starts with
 liveData.operator.equals=Equals
+liveData.operator.empty=Empty
 liveData.operator.less=Less than
 liveData.operator.greater=Greater than
 liveData.operator.between=Between

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/resources/liveDataConfiguration.json
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/resources/liveDataConfiguration.json
@@ -35,7 +35,7 @@
       },
       {
         "id": "list",
-        "operators": ["equals", "startsWith", "contains"]
+        "operators": ["equals", "startsWith", "contains", "empty"]
       }
     ],
 

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/test/resources/DefaultLiveDataConfigurationResolver.test
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/test/resources/DefaultLiveDataConfigurationResolver.test
@@ -139,7 +139,8 @@
         "operators":[
           {"id":"equals","name":"Equals"},
           {"id":"startsWith","name":"startsWith"},
-          {"id":"contains","name":"contains"}
+          {"id":"contains","name":"contains"},
+          {"id":"empty","name":"empty"}
         ]
       }
     ],

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataPropertyStore.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataPropertyStore.java
@@ -41,7 +41,6 @@ import org.xwiki.livedata.LiveDataException;
 import org.xwiki.livedata.LiveDataPropertyDescriptor;
 import org.xwiki.livedata.LiveDataPropertyDescriptor.DisplayerDescriptor;
 import org.xwiki.livedata.LiveDataPropertyDescriptor.FilterDescriptor;
-import org.xwiki.livedata.LiveDataPropertyDescriptor.OperatorDescriptor;
 import org.xwiki.livedata.LiveDataPropertyDescriptorStore;
 import org.xwiki.livedata.WithParameters;
 import org.xwiki.model.reference.DocumentReference;
@@ -146,6 +145,7 @@ public class LiveTableLiveDataPropertyStore extends WithParameters implements Li
         descriptor.setDisplayer(new DisplayerDescriptor("xObjectProperty"));
         if (xproperty instanceof ListClass) {
             descriptor.setFilter(new FilterDescriptor("list"));
+            descriptor.getFilter().addOperator("empty", null);
             if (xproperty instanceof LevelsClass) {
                 descriptor.getFilter().setParameter("options", ((LevelsClass) xproperty).getList(xcontext));
             } else {
@@ -155,7 +155,7 @@ public class LiveTableLiveDataPropertyStore extends WithParameters implements Li
                 // The default live table results page currently supports only exact matching for list properties with
                 // multiple selection and no relational storage (selected values are stored concatenated on a single
                 // database column).
-                descriptor.getFilter().setOperators(Collections.singletonList(new OperatorDescriptor("equals", null)));
+                descriptor.getFilter().addOperator("equals", null);
             }
         } else if (xproperty instanceof DateClass) {
             String dateFormat = ((DateClass) xproperty).getDateFormat();

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableRequestHandler.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableRequestHandler.java
@@ -242,7 +242,7 @@ public class LiveTableRequestHandler
                 .map(constraint -> constraint == null ? null : constraint.getOperator())
                 .map(operator -> MATCH_TYPE.getOrDefault(operator, StringUtils.defaultString(operator)))
                 .collect(Collectors.toList());
-            requestParams.put(filter.getProperty() + "_match", matchType.toArray(new String[values.size()]));
+            requestParams.put(filter.getProperty() + "_match", matchType.toArray(new String[matchType.size()]));
 
             // Add a value to the empty fields since otherwise they are dismissed by LiveTableResultMacros.
             // Changing the handling of empty values in the result templates is dangerous and could lead to regressions 

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableRequestHandler.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableRequestHandler.java
@@ -235,20 +235,20 @@ public class LiveTableRequestHandler
         List<String> values = filter.getConstraints().stream().filter(Objects::nonNull).map(Constraint::getValue)
             .filter(Objects::nonNull).map(Object::toString).collect(Collectors.toList());
         if (!values.isEmpty()) {
-            requestParams.put(filter.getProperty(), values.toArray(new String[0]));
+            requestParams.put(filter.getProperty(), values.toArray(new String[values.size()]));
             requestParams.put(filter.getProperty() + "/join_mode", new String[] {filter.isMatchAll() ? "AND" : "OR"});
 
             List<String> matchType = filter.getConstraints().stream()
                 .map(constraint -> constraint == null ? null : constraint.getOperator())
                 .map(operator -> MATCH_TYPE.getOrDefault(operator, StringUtils.defaultString(operator)))
                 .collect(Collectors.toList());
-            requestParams.put(filter.getProperty() + "_match", matchType.toArray(new String[0]));
+            requestParams.put(filter.getProperty() + "_match", matchType.toArray(new String[values.size()]));
 
             // Add a value to the empty fields since otherwise they are dismissed by LiveTableResultMacros.
             // Changing the handling of empty values in the result templates is dangerous and could lead to regressions 
             // when the livetable clients expected empty values to simply be dismissed.
             for (int i = 0; i < matchType.size(); i++) {
-                if (matchType.get(i).equals("empty")) {
+                if (Objects.equals(matchType.get(i), "empty")) {
                     requestParams.get(filter.getProperty())[i] = "-";
                 }
             }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataPropertyStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataPropertyStoreTest.java
@@ -172,10 +172,10 @@ class LiveTableLiveDataPropertyStoreTest
             + "'type':'Computed','displayer':{'id':'xObjectProperty'}},");
         expectedClassProps.append("{'id':'status','name':'Status','description':'The status.',"
             + "'type':'List','sortable':false,'displayer':{'id':'xObjectProperty'},"
-            + "'filter':{'id':'list','operators':[{'id':'equals'}],"
+            + "'filter':{'id':'list','operators':[{'id':'empty'},{'id':'equals'}],"
             + "'searchURL':'/xwiki/rest/wikis/wiki/classes/Some.Class/properties/status/values?fp={encodedQuery}'}},");
         expectedClassProps.append("{'id':'levels','type':'Levels','displayer':{'id':'xObjectProperty'},"
-            + "'filter':{'id':'list','options':['edit','delete']}}");
+            + "'filter':{'id':'list','operators':[{'id':'empty'}],'options':['edit','delete']}}");
 
         Collection<LiveDataPropertyDescriptor> properties = this.propertyStore.get();
 

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/LiveTableRequestHandlerTest.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/LiveTableRequestHandlerTest.java
@@ -64,7 +64,7 @@ import static org.mockito.Mockito.when;
  * @since 12.10
  */
 @ComponentTest
-public class LiveTableRequestHandlerTest
+class LiveTableRequestHandlerTest
 {
     @InjectMockComponents
     private LiveTableRequestHandler handler;
@@ -195,6 +195,28 @@ public class LiveTableRequestHandlerTest
         }));
 
         verify(this.xcontext).setFinished(false);
+    }
+
+    @Test
+    void getLiveTableResultsEmptyFilter()
+    {
+        Map<String, String[]> expectedRequestParams = new HashMap<>();
+        expectedRequestParams.put("title/join_mode", new String[] { "OR" });
+        expectedRequestParams.put("reqNo", new String[] { "1" });
+        expectedRequestParams.put("outputSyntax", new String[] { "plain" });
+        expectedRequestParams.put("title", new String[] { "-" });
+        expectedRequestParams.put("title_match", new String[] { "empty" });
+
+        LiveDataQuery liveDataQuery = new LiveDataQuery();
+        liveDataQuery.setFilters(Collections.singletonList(new Filter("title", "empty", "")));
+        this.handler.getLiveTableResults(liveDataQuery, () -> null);
+
+        ArgumentCaptor<XWikiRequest> requestCaptor = ArgumentCaptor.forClass(XWikiRequest.class);
+        verify(this.xcontext, times(2)).setRequest(requestCaptor.capture());
+        List<XWikiRequest> requests = requestCaptor.getAllValues();
+
+        assertRequestParameters(expectedRequestParams, requests.get(0).getParameterMap());
+        assertSame(this.originalRequest, requests.get(1));
     }
 
     private void assertRequestParameters(Map<String, String[]> expectedParams, Map<String, String[]> actualParams)

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-macro/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-macro/src/main/resources/ApplicationResources.properties
@@ -96,7 +96,6 @@ livedata.panel.filter.addConstraint=Add constraint
 livedata.panel.filter.addProperty=Add filter
 livedata.panel.filter.delete=Delete constraint
 livedata.panel.filter.deleteAll=Delete all constraints
-livedata.panel.filter.emptyLabel=---
 
 livedata.panel.properties.title=Properties
 
@@ -114,3 +113,5 @@ livedata.displayer.boolean.false=False
 
 livedata.displayer.xObjectProperty.missingDocumentName.errorMessage=Can't save an XObject property with a missing document name.
 livedata.displayer.xObjectProperty.failedToRetrieveField.errorMessage=Failed to retrieve the {0} field.
+
+livedata.filter.list.emptyLabel=---

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-macro/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-macro/src/main/resources/ApplicationResources.properties
@@ -96,6 +96,7 @@ livedata.panel.filter.addConstraint=Add constraint
 livedata.panel.filter.addProperty=Add filter
 livedata.panel.filter.delete=Delete constraint
 livedata.panel.filter.deleteAll=Delete all constraints
+livedata.panel.filter.emptyLabel=---
 
 livedata.panel.properties.title=Properties
 

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-pageobjects/src/main/java/org/xwiki/livedata/test/po/TableLayoutElement.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-pageobjects/src/main/java/org/xwiki/livedata/test/po/TableLayoutElement.java
@@ -423,7 +423,7 @@ public class TableLayoutElement extends BaseElement
     {
         int columnIndex = findColumnIndex(columnLabel);
         WebElement element = getRoot()
-            .findElement(By.cssSelector(String.format(".column-filters > th:nth-child(%d) > input", columnIndex)));
+            .findElement(By.cssSelector(String.format(".column-filters > th:nth-child(%d) input", columnIndex)));
 
         List<String> classes = Arrays.asList(getClasses(element));
         if (classes.contains("filter-list")) {

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/mocks/xwiki-selectize.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/mocks/xwiki-selectize.js
@@ -1,0 +1,19 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/filters/FilterList.spec.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/filters/FilterList.spec.js
@@ -1,0 +1,92 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+import FilterList from "../../../filters/FilterList.vue";
+import {mount} from '@vue/test-utils';
+import _ from "lodash";
+import $ from "jquery";
+
+/**
+ * Initialize a FilterList component using default values vue test-utils `mount` parameters.
+ * The default parameters can be overridden using the `mountConfiguration` parameter.
+ *
+ * The default configuration is:
+ * ```
+ * {
+ *   provide: {
+ *     logic: {
+ *       getQueryFilterGroup() {
+ *         return {};
+ *       },
+ *       onEventWhere() {
+ *       },
+ *       getFilterDescriptor() {
+ *         return {options: ''};
+ *       }
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * @param mountConfiguration mount parameters merged over the default configuration
+ * @returns {{options: string}|{}|*} an initialized FilterList Vue component
+ */
+function initWrapper(mountConfiguration = {}) {
+  // Define an empty xwikiSelectize to prevent the component mount to fail.
+  $.fn.xwikiSelectize = () => {
+  };
+
+  return mount(FilterList, _.merge({
+    provide: {
+      logic: {
+        getQueryFilterGroup() {
+          return {};
+        },
+        onEventWhere() {
+        },
+        getFilterDescriptor() {
+          return {options: ''};
+        }
+      }
+    }
+  }, mountConfiguration));
+}
+
+describe('FilterList.vue', () => {
+  it('Render the filter list when visible', () => {
+    const wrapper = initWrapper();
+    expect(wrapper.html()).toBe("<span><input class=\"filter-list livedata-filter\"></span>")
+  })
+
+  it('Render the filter list when Empty filter and advanced', () => {
+    const wrapper = initWrapper({
+      propsData: {index: 0, isAdvanced: true},
+      provide: {
+        logic: {
+          getQueryFilterGroup() {
+            return {
+              constraints: [{value: undefined, operator: 'empty'}]
+            }
+          }
+        }
+      }
+    });
+    expect(wrapper.html()).toBe('<span style="display: none;"><input class="filter-list livedata-filter"></span>')
+  })
+})

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/filters/LivedataFilter.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/filters/LivedataFilter.vue
@@ -48,6 +48,7 @@
     :property-id="propertyId"
     :index="index"
     :is-filtering.sync="isFiltering"
+    :is-advanced="isAdvanced"
   ></component>
 
   <!--
@@ -77,6 +78,10 @@ export default {
   props: {
     propertyId: String,
     index: Number,
+    isAdvanced: {
+      type: Boolean,
+      default: false
+    }
   },
 
   data () {

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/filters/filterMixin.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/filters/filterMixin.js
@@ -69,15 +69,24 @@ export default {
   },
 
   methods: {
-    // This method should be used to apply filter
-    // As only the newValue has to be specified it is less error prone
-    applyFilter: function (newValue) {
+    // This method should be used to apply filter.
+    // Since only the newValue has to be specified it is less error prone.
+    applyFilter: function (newValue, filterOperator=undefined) {
       // Once a filter is applied, the filtering state is switched to true.
       // The filtering state is switched to false only once the filtering is finished.
       this.$emit('update:isFiltering', true);
-      this.logic.filter(this.propertyId, this.index, {value: newValue})
+      this.logic.filter(this.propertyId, this.index, {value: newValue}, {filterOperator})
         .finally(() => {
           // Whatever the filter promise result, the filtering state is switched to false.
+          this.$emit('update:isFiltering', false);
+        });
+    },
+
+    removeFilter: function () {
+      this.$emit('update:isFiltering', true);
+      this.logic.removeFilter(this.propertyId, this.index)
+        .finally(() => {
+          // Whatever the removeFilter promise result, the filtering state is switched to false.
           this.$emit('update:isFiltering', false);
         });
     },

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/panels/LivedataAdvancedPanelFilterEntry.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/panels/LivedataAdvancedPanelFilterEntry.vue
@@ -52,6 +52,7 @@
     <LivedataFilter
       :property-id="propertyId"
       :index="filterIndex"
+      :is-advanced="true"
     />
 
     <!-- Delete filter entry button -->

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/webjar/Logic.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/webjar/Logic.js
@@ -165,7 +165,6 @@ define('xwiki-livedata', [
         "panel.filter.addProperty",
         "panel.filter.delete",
         "panel.filter.deleteAll",
-        "panel.filter.emptyLabel",
         "panel.properties.title",
         "panel.sort.title",
         "panel.sort.noneSortable",
@@ -178,6 +177,7 @@ define('xwiki-livedata', [
         "displayer.boolean.false",
         "displayer.xObjectProperty.missingDocumentName.errorMessage",
         "displayer.xObjectProperty.failedToRetrieveField.errorMessage",
+        "filter.list.emptyLabel",
       ],
     });
 

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/webjar/Logic.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/webjar/Logic.js
@@ -165,6 +165,7 @@ define('xwiki-livedata', [
         "panel.filter.addProperty",
         "panel.filter.delete",
         "panel.filter.deleteAll",
+        "panel.filter.emptyLabel",
         "panel.properties.title",
         "panel.sort.title",
         "panel.sort.noneSortable",
@@ -1190,7 +1191,7 @@ define('xwiki-livedata', [
      * @returns {Object} {oldEntry, newEntry}
      *  with oldEntry / newEntry being {property, index, operator, value}
      */
-    _computeFilterEntries (property, index, filterEntry) {
+    _computeFilterEntries (property, index, filterEntry, {filterOperator} = {}) {
       if (!this.isPropertyFilterable(property)) { return; }
       // default indexes
       index = index || 0;
@@ -1215,6 +1216,9 @@ define('xwiki-livedata', [
         index: 0,
       };
       newEntry = Object.assign({}, defaultEntry, oldEntry, newEntry);
+      if (filterOperator) {
+        newEntry.operator = filterOperator;
+      }
       // check newEntry operator
       const newEntryValidOperator = this.getFilterDescriptor(newEntry.property).operators
         .some(operator => operator.id === newEntry.operator);
@@ -1263,10 +1267,10 @@ define('xwiki-livedata', [
      * @param {String} filterEntry.value Value for the new filter entry
      * @returns {Promise}
      */
-    filter (property, index, filterEntry) {
+    filter(property, index, filterEntry, {filterOperator} = {}) {
       const err = new Error("Property `" + property + "` is not filterable");
       return new Promise ((resolve, reject) => {
-        const filterEntries = this._computeFilterEntries(property, index, filterEntry);
+        const filterEntries = this._computeFilterEntries(property, index, filterEntry, {filterOperator});
         if (!filterEntries) { return void reject(err); }
         const oldEntry = filterEntries.oldEntry;
         const newEntry = filterEntries.newEntry;

--- a/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/main/resources/XWiki/LiveTableResultsMacros.xml
+++ b/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/main/resources/XWiki/LiveTableResultsMacros.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.3" reference="XWiki.LiveTableResultsMacros" locale="">
+<xwikidoc version="1.4" reference="XWiki.LiveTableResultsMacros" locale="">
   <web>XWiki</web>
   <name>LiveTableResultsMacros</name>
   <language/>
@@ -414,7 +414,7 @@
     #set($discard = $row.put('doc_title', $translatedDoc.plainTitle))
     #set($rawTitle = $translatedDoc.title)
     #if($rawTitle != $row['doc_title'])
-	  #set($discard = $row.put('doc_title_raw', $rawTitle))
+   #set($discard = $row.put('doc_title_raw', $rawTitle))
     #end
     #set($discard = $row.put('doc_author', $xwiki.getPlainUserName($translatedDoc.authorReference)))
     #set($discard = $row.put('doc_creationDate', $xwiki.formatDate($translatedDoc.creationDate)))
@@ -907,6 +907,10 @@
   #set ($filterQuery = "#livetable_getFilterQuery($matchTarget 'partial' false $filterValues.size() $paramPrefix)")
   #set ($whereSql = "${whereSql} and ($filterQuery.trim())")
   #foreach ($filterValue in $filterValues)
+    #set ($actualMatchType = $request.getParameterValues("${colname}_match").get($foreach.count - 1))
+    #if ($actualMatchType == 'empty')
+      #set ($filterValue = '')
+    #end
     #if ($whereParams.entrySet())
       #set ($discard = $whereParams.put("${paramPrefix}${foreach.count}", "%|$filterValue|%"))
     #else
@@ -938,7 +942,8 @@
   #set ($filterQuery = "#livetable_getFilterQuery(""${safe_tableAlias}.value"" $matchType false $valueCount $paramPrefix)")
   #set ($whereSql = "${whereSql} and ($filterQuery.trim())")
   #foreach ($filterValue in $filterValues)
-    #livetable_addFilterParam($filterValue $matchType $whereParams "${paramPrefix}${foreach.count}")
+    #set ($actualMatchType = $request.getParameterValues("${colname}_match").get($foreach.count - 1))
+    #livetable_addFilterParam($filterValue $actualMatchType $whereParams "${paramPrefix}${foreach.count}")
   #end
 #end
 
@@ -985,6 +990,12 @@
       #set ($discard = $params.put($paramName, "$!filterValue%"))
     #else
       #set ($discard = $params.add("$!filterValue%"))
+    #end
+  #elseif ($matchType == 'empty')
+    #if ($params.entrySet())
+      #set ($discard = $params.put($paramName, ''))
+    #else
+      #set ($discard = $params.add(''))
     #end
   #else
     #if ($params.entrySet())


### PR DESCRIPTION
https://jira.xwiki.org/browse/XWIKI-18661

- Introduce a new 'empty' filter on Live Data
- Introduce a new 'empty' matcher on Livetable
- Make the conversion for the new filter on Live Data - Live Table Connector
- Hides the select field in the advanced panel when the filter type is 'empty'