### PR TITLE
XWIKI-17533: Allow to set custom rights in administration

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminCustomRightsSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminCustomRightsSheet.xml
@@ -295,7 +295,7 @@
       <propertiesToShow/>
     </property>
     <property>
-      <sectionOrder>10000</sectionOrder>
+      <sectionOrder>375</sectionOrder>
     </property>
   </object>
 </xwikidoc>

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminCustomRightsSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminCustomRightsSheet.xml
@@ -1,0 +1,301 @@
+<?xml version="1.1" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<xwikidoc version="1.4" reference="XWiki.AdminCustomRightsSheet" locale="">
+  <web>XWiki</web>
+  <name>AdminCustomRightsSheet</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <creator>xwiki:XWiki.Admin</creator>
+  <parent>Main.WebHome</parent>
+  <author>xwiki:XWiki.Admin</author>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <version>1.1</version>
+  <title>AdminCustomRightsSheet</title>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>true</hidden>
+  <content>{{velocity}}
+### Sheet used to generically display the XWikiPreferences object fields in the administration sheets.
+{{html}}
+  &lt;form method="post" action="$xwiki.getURL($currentDoc, 'saveandcontinue')" class="xform"&gt;
+    ############################################################################################
+    ## RIGHTS
+    ############################################################################################
+    &lt;fieldset&gt;
+      #template('rightsUI.vm')
+    &lt;/fieldset&gt;
+  &lt;/form&gt;
+{{/html}}
+{{/velocity}}</content>
+  <object>
+    <name>XWiki.AdminCustomRightsSheet</name>
+    <number>0</number>
+    <className>XWiki.ConfigurableClass</className>
+    <guid>bad3af00-4a01-48b8-94ca-2111b758d219</guid>
+    <class>
+      <name>XWiki.ConfigurableClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <categoryIcon>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <hint/>
+        <name>categoryIcon</name>
+        <number>11</number>
+        <picker>0</picker>
+        <prettyName>categoryIcon</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </categoryIcon>
+      <codeToExecute>
+        <contenttype>VelocityWiki</contenttype>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <editor>---</editor>
+        <hint/>
+        <name>codeToExecute</name>
+        <number>7</number>
+        <picker>0</picker>
+        <prettyName>codeToExecute</prettyName>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </codeToExecute>
+      <configurationClass>
+        <cache>0</cache>
+        <classname/>
+        <customDisplay/>
+        <defaultValue/>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <freeText/>
+        <hint/>
+        <idField/>
+        <largeStorage>0</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>configurationClass</name>
+        <number>3</number>
+        <picker>1</picker>
+        <prettyName>configurationClass</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators/>
+        <size>30</size>
+        <sort>none</sort>
+        <sql/>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <valueField/>
+        <classType>com.xpn.xwiki.objects.classes.PageClass</classType>
+      </configurationClass>
+      <configureGlobally>
+        <customDisplay/>
+        <defaultValue/>
+        <disabled>0</disabled>
+        <displayFormType>checkbox</displayFormType>
+        <displayType/>
+        <hint/>
+        <name>configureGlobally</name>
+        <number>4</number>
+        <prettyName>configureGlobally</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </configureGlobally>
+      <displayBeforeCategory>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <hint/>
+        <name>displayBeforeCategory</name>
+        <number>10</number>
+        <picker>0</picker>
+        <prettyName>displayBeforeCategory</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </displayBeforeCategory>
+      <displayInCategory>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <hint/>
+        <name>displayInCategory</name>
+        <number>9</number>
+        <picker>0</picker>
+        <prettyName>displayInCategory</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </displayInCategory>
+      <displayInSection>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <hint/>
+        <name>displayInSection</name>
+        <number>1</number>
+        <picker>0</picker>
+        <prettyName>displayInSection</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </displayInSection>
+      <heading>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <hint/>
+        <name>heading</name>
+        <number>2</number>
+        <picker>0</picker>
+        <prettyName>heading</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </heading>
+      <iconAttachment>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <hint/>
+        <name>iconAttachment</name>
+        <number>8</number>
+        <picker>0</picker>
+        <prettyName>iconAttachment</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </iconAttachment>
+      <linkPrefix>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <hint/>
+        <name>linkPrefix</name>
+        <number>5</number>
+        <picker>0</picker>
+        <prettyName>linkPrefix</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </linkPrefix>
+      <propertiesToShow>
+        <cache>0</cache>
+        <customDisplay/>
+        <defaultValue/>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <freeText/>
+        <hint/>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
+        <name>propertiesToShow</name>
+        <number>6</number>
+        <picker>0</picker>
+        <prettyName>propertiesToShow</prettyName>
+        <relationalStorage>1</relationalStorage>
+        <separator> </separator>
+        <separators> ,|</separators>
+        <size>20</size>
+        <sort>none</sort>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <values/>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </propertiesToShow>
+      <sectionOrder>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <hint/>
+        <name>sectionOrder</name>
+        <number>12</number>
+        <numberType>integer</numberType>
+        <prettyName>sectionOrder</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.NumberClass</classType>
+      </sectionOrder>
+    </class>
+    <property>
+      <categoryIcon/>
+    </property>
+    <property>
+      <codeToExecute>{{include reference="XWiki.AdminCustomRightsSheet" /}}</codeToExecute>
+    </property>
+    <property>
+      <configurationClass/>
+    </property>
+    <property>
+      <configureGlobally>1</configureGlobally>
+    </property>
+    <property>
+      <displayBeforeCategory/>
+    </property>
+    <property>
+      <displayInCategory>usersgroups</displayInCategory>
+    </property>
+    <property>
+      <displayInSection>usersgroups.customrights</displayInSection>
+    </property>
+    <property>
+      <heading/>
+    </property>
+    <property>
+      <iconAttachment/>
+    </property>
+    <property>
+      <linkPrefix/>
+    </property>
+    <property>
+      <propertiesToShow/>
+    </property>
+    <property>
+      <sectionOrder>10000</sectionOrder>
+    </property>
+  </object>
+</xwikidoc>

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminExtensionRightsSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminExtensionRightsSheet.xml
@@ -20,9 +20,9 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.4" reference="XWiki.AdminCustomRightsSheet" locale="">
+<xwikidoc version="1.4" reference="XWiki.AdminExtensionRightsSheet" locale="">
   <web>XWiki</web>
-  <name>AdminCustomRightsSheet</name>
+  <name>AdminExtensionRightsSheet</name>
   <language/>
   <defaultLanguage/>
   <translation>0</translation>
@@ -31,7 +31,7 @@
   <author>xwiki:XWiki.Admin</author>
   <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
   <version>1.1</version>
-  <title>AdminCustomRightsSheet</title>
+  <title>AdminExtensionRightsSheet</title>
   <comment/>
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
@@ -50,7 +50,7 @@
 {{/html}}
 {{/velocity}}</content>
   <object>
-    <name>XWiki.AdminCustomRightsSheet</name>
+    <name>XWiki.AdminExtensionRightsSheet</name>
     <number>0</number>
     <className>XWiki.ConfigurableClass</className>
     <guid>bad3af00-4a01-48b8-94ca-2111b758d219</guid>
@@ -265,7 +265,7 @@
       <categoryIcon/>
     </property>
     <property>
-      <codeToExecute>{{include reference="XWiki.AdminCustomRightsSheet" /}}</codeToExecute>
+      <codeToExecute>{{include reference="XWiki.AdminExtensionRightsSheet" /}}</codeToExecute>
     </property>
     <property>
       <configurationClass/>
@@ -280,7 +280,7 @@
       <displayInCategory>usersgroups</displayInCategory>
     </property>
     <property>
-      <displayInSection>usersgroups.customrights</displayInSection>
+      <displayInSection>usersgroups.extensionrights</displayInSection>
     </property>
     <property>
       <heading/>

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminTranslations.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminTranslations.xml
@@ -140,6 +140,7 @@ administration.section.users.deleteUser.newAuthor.hint=Select an user that has {
 administration.section.users.deleteUser.newAuthor.error=The selected user doesn''t have {0} rights!
 administration.section.users.deleteUser.newAuthor.programming=programming
 administration.section.users.deleteUser.newAuthor.script=script
+admin.usersgroups.customrights=Custom Rights
 
 # Other Category
 admin.other=Other

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminTranslations.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminTranslations.xml
@@ -140,7 +140,7 @@ administration.section.users.deleteUser.newAuthor.hint=Select an user that has {
 administration.section.users.deleteUser.newAuthor.error=The selected user doesn''t have {0} rights!
 administration.section.users.deleteUser.newAuthor.programming=programming
 administration.section.users.deleteUser.newAuthor.script=script
-admin.usersgroups.customrights=Custom Rights
+admin.usersgroups.extensionrights=Extension Rights
 
 # Other Category
 admin.other=Other

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/rightsUI.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/rightsUI.vm
@@ -43,7 +43,8 @@ $xwiki.ssfx.use('js/xwiki/table/livetable.css', true)
 #set ($standardRights = ['view', 'comment', 'edit', 'script', 'delete', 'admin', 'register', 'programming', 'login',
   'createwiki'])
 #set ($sectionWikiRights = "wikis.rights")
-#set ($sectionExtensionRights = "usersgroups.customrights")
+#set ($sectionExtensionRights = "usersgroups.extensionrights")
+#set ($isStandardRights = false)
 #if("$!request.section"==$sectionWikiRights)
   #set ($rightsLevels = {'createwiki': 0})
   #set ($allowWins = [0])
@@ -62,6 +63,7 @@ $xwiki.ssfx.use('js/xwiki/table/livetable.css', true)
 #else
   #set ($rightsLevels = {'view': 0, 'comment': 1, 'edit': 2, 'script': 3, 'delete': 4, 'admin': 5, 'register': 6, 'programming': 7})
   #set ($allowWins = [5, 6, 7])
+  #set ($isStandardRights = true)
 #end
 #set ($levelsRights = {})
 #foreach ($r in $rightsLevels.keySet())
@@ -250,7 +252,7 @@ $xwiki.ssfx.use('js/xwiki/table/livetable.css', true)
   ## Global settings: mandatory authentication for view/edit, captcha
   #set ($guest_comment_captcha_prop = $targetDocument.getObject('XWiki.XWikiPreferences').getxWikiClass().get('guest_comment_requires_captcha'))
   #if (("$!request.editor" == 'globaladmin' || "$!editor" == 'globaladmin' || $guest_comment_captcha_prop)
-  && $request.section != $sectionWikiRights && $request.section != $sectionExtensionRights)
+  && $isStandardRights)
     <dl class="rights-settings">
       #if ("$!request.editor" == 'globaladmin' || "$!editor" == 'globaladmin')
         #set ($auth_view = $targetDocument.getObject('XWiki.XWikiPreferences').getProperty('authenticate_view').getValue())
@@ -357,11 +359,11 @@ $xwiki.ssfx.use('js/xwiki/table/livetable.css', true)
           $('unregistered').removeClassName('hidden');
         }
       });
-    #if("$!editor" == 'globaladmin' && $request.section != $sectionWikiRights && $request.section != $sectionExtensionRights)
+    #if("$!editor" == 'globaladmin' && $isStandardRights)
       Event.observe($('authenticate_view'), 'click', setBooleanPropertyFromLiveCheckbox($('authenticate_view'), '$xwiki.getURL('XWiki.XWikiPreferences', 'save', "form_token=$!{services.csrf.getToken()}")', 'XWiki.XWikiPreferences', 0));
       Event.observe($('authenticate_edit'), 'click', setBooleanPropertyFromLiveCheckbox($('authenticate_edit'), '$xwiki.getURL('XWiki.XWikiPreferences', 'save', "form_token=$!{services.csrf.getToken()}")', 'XWiki.XWikiPreferences', 0));
     #end
-    #if($guest_comment_captcha_prop && $request.section != 'wikis.rights')
+    #if($guest_comment_captcha_prop && $isStandardRights)
       Event.observe($('guest_comment_requires_captcha'), 'click', setBooleanPropertyFromLiveCheckbox($('guest_comment_requires_captcha'), '$targetDocument.getURL('save', "form_token=$!{services.csrf.getToken()}")', 'XWiki.XWikiPreferences', 0));
     #end
       return true;

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/rightsUI.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/rightsUI.vm
@@ -40,13 +40,25 @@ $xwiki.ssfx.use('js/xwiki/usersandgroups/usersandgroups.css', true)
 $xwiki.jsfx.use('js/xwiki/table/livetable.js', true)
 $xwiki.ssfx.use('js/xwiki/table/livetable.css', true)
 ## for admin, register, programming and createwiki, allow preceedes over deny
-#if("$!request.section"=='wikis.rights')
+#set ($standardRights = ['view', 'comment', 'edit', 'script', 'delete', 'admin', 'register', 'programming', 'login',
+  'createwiki'])
+#set ($sectionWikiRights = "wikis.rights")
+#set ($sectionExtensionRights = "usersgroups.customrights")
+#if("$!request.section"==$sectionWikiRights)
   #set ($rightsLevels = {'createwiki': 0})
   #set ($allowWins = [0])
-## This should be changed in the future to include dynamically registered rights.
-#elseif ($services.security.authorization.isRightRegistered('like'))
-  #set ($rightsLevels = {'view': 0, 'like': 1, 'comment': 2, 'edit': 3, 'script': 4, 'delete': 5, 'admin': 6, 'register': 7, 'programming': 8})
-  #set ($allowWins = [5, 6, 7])
+#elseif ("$!request.section"==$sectionExtensionRights)
+  #set ($allRights = $services.security.authorization.allRightsNames)
+  #set ($rightsLevels = {})
+  #set ($allowWins = [])
+  #set ($index = 0)
+  #foreach ($right in $allRights)
+    #if (!$standardRights.contains($right))
+      #set ($discard = $rightsLevels.put($right, $index))
+      #set ($discard = $allowWins.add($index))
+      #set ($index = $index + 1)
+    #end
+  #end
 #else
   #set ($rightsLevels = {'view': 0, 'comment': 1, 'edit': 2, 'script': 3, 'delete': 4, 'admin': 5, 'register': 6, 'programming': 7})
   #set ($allowWins = [5, 6, 7])
@@ -56,7 +68,7 @@ $xwiki.ssfx.use('js/xwiki/table/livetable.css', true)
   #set ($discard = $levelsRights.put($rightsLevels.get($r), $r))
 #end
 #set ($maxlevel = $rightsLevels.get('delete')) ## Default: view, comment, edit, script, delete
-#if("$!request.section"=='wikis.rights')
+#if("$!request.section"==$sectionWikiRights)
   #set ($maxlevel = $rightsLevels.get('createwiki'))
   #set ($clsname = 'XWiki.XWikiGlobalRights')
 #else
@@ -82,7 +94,9 @@ $xwiki.ssfx.use('js/xwiki/table/livetable.css', true)
     #set ($clsname = 'XWiki.XWikiRights')
   #end
 #end
-
+#if ("$!request.section"==$sectionExtensionRights)
+  #set ($maxlevel = $index - 1)
+#end
 ## Get rights allowed for the current user
 #set ($currentAllowed = {})
 #foreach ($i in [0..$maxlevel])
@@ -235,7 +249,8 @@ $xwiki.ssfx.use('js/xwiki/table/livetable.css', true)
   </table>
   ## Global settings: mandatory authentication for view/edit, captcha
   #set ($guest_comment_captcha_prop = $targetDocument.getObject('XWiki.XWikiPreferences').getxWikiClass().get('guest_comment_requires_captcha'))
-  #if (("$!request.editor" == 'globaladmin' || "$!editor" == 'globaladmin' || $guest_comment_captcha_prop) && $request.section != 'wikis.rights')
+  #if (("$!request.editor" == 'globaladmin' || "$!editor" == 'globaladmin' || $guest_comment_captcha_prop)
+  && $request.section != $sectionWikiRights && $request.section != $sectionExtensionRights)
     <dl class="rights-settings">
       #if ("$!request.editor" == 'globaladmin' || "$!editor" == 'globaladmin')
         #set ($auth_view = $targetDocument.getObject('XWiki.XWikiPreferences').getProperty('authenticate_view').getValue())
@@ -342,7 +357,7 @@ $xwiki.ssfx.use('js/xwiki/table/livetable.css', true)
           $('unregistered').removeClassName('hidden');
         }
       });
-    #if("$!editor" == 'globaladmin' && $request.section != 'wikis.rights')
+    #if("$!editor" == 'globaladmin' && $request.section != $sectionWikiRights && $request.section != $sectionExtensionRights)
       Event.observe($('authenticate_view'), 'click', setBooleanPropertyFromLiveCheckbox($('authenticate_view'), '$xwiki.getURL('XWiki.XWikiPreferences', 'save', "form_token=$!{services.csrf.getToken()}")', 'XWiki.XWikiPreferences', 0));
       Event.observe($('authenticate_edit'), 'click', setBooleanPropertyFromLiveCheckbox($('authenticate_edit'), '$xwiki.getURL('XWiki.XWikiPreferences', 'save', "form_token=$!{services.csrf.getToken()}")', 'XWiki.XWikiPreferences', 0));
     #end

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/rightsUI.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/rightsUI.vm
@@ -42,8 +42,8 @@ $xwiki.ssfx.use('js/xwiki/table/livetable.css', true)
 ## for admin, register, programming and createwiki, allow preceedes over deny
 #set ($standardRights = ['view', 'comment', 'edit', 'script', 'delete', 'admin', 'register', 'programming', 'login',
   'createwiki'])
-#set ($sectionWikiRights = "wikis.rights")
-#set ($sectionExtensionRights = "usersgroups.extensionrights")
+#set ($sectionWikiRights = 'wikis.rights')
+#set ($sectionExtensionRights = 'usersgroups.extensionrights')
 #set ($isStandardRights = false)
 #if("$!request.section"==$sectionWikiRights)
   #set ($rightsLevels = {'createwiki': 0})

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-script/src/main/java/org/xwiki/security/authorization/script/SecurityAuthorizationScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-script/src/main/java/org/xwiki/security/authorization/script/SecurityAuthorizationScriptService.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.security.authorization.script;
 
+import java.util.List;
+
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -158,5 +160,15 @@ public class SecurityAuthorizationScriptService implements ScriptService
     public boolean isRightRegistered(String rightName)
     {
         return Right.toRight(rightName) != Right.ILLEGAL;
+    }
+
+    /**
+     * @return all the registered rights names.
+     * @since 13.5RC1
+     */
+    @Unstable
+    public List<String> getAllRightsNames()
+    {
+        return Right.getAllRightsAsString();
     }
 }


### PR DESCRIPTION
## JIRA

https://jira.xwiki.org/browse/XWIKI-17533

## Description

This PR is an experiment to find a trade-off for allowing to set custom rights, without having to rewrite entirely the whole rights UI, and without breaking the existing one. 

Here's what I said about it on the chat:

>  guys I'm thinking about a trade-off solution for the custom right UI problem we currently have. To sum up, right now when a custom right is injected it's not possible to configure it through the Rights UI and there's no extension point to inject it. So currently the only solution is to code a dedicated UI for the custom right. In my case, I'm currently writing an extension that will need at least 2 custom rights and I'm thinking how do I deal with that issue. So far I was seeing 3 options:
> 1. to re-write entirely the rights UI with the custom rights taken into account -> obviously that's a long term solution which will take a lot of time that I don't have right now
> 2. to only perform the work allowing to inject the custom rights in the existing rights UI -> I was checking that one, and it seems not that easy without breaking things, moreover right now we're displaying all the rights as table columns so it will quickly won't fit
> 3. to develop my own UI for configuring the rights elsewhere -> besides the fact that we'd need to fix https://jira.xwiki.org/browse/XWIKI-18723 it also implies a bit of work to allow configuring them properly for all users / groups. I surely could take inspirations from the currently rights UI but I can avoid it I would gladly.
> 
> BUT, now that I looked a bit more the code of the rights UI, I might see a 4th solution:
> 4. to provide a dedicated administration section for the custom rights. So it's basically solution 2, without the problem of the size of the table, and with the advantage that it seems easy to code, since it's almost how the UI for "Create wiki right" has been implemented (cf: https://github.com/xwiki/xwiki-platform/blob/master/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/rightsUI.vm#L43).
> 
> So IMO that solution 4 would be a quickfix allowing to quickly answer a real need we have without implying a big change or to recode something multiple times in the mid-term, even if on the long run it would be discarded in favor of solution 1. WDYT?

## Implementation

  * Provide a new API to retrieve all rights names in
    SecurityAuthorizationScriptService
  * Provide a new administration section to configure the custom rights
  * Edit rightsUI.vm to allow customize custom rights, without breaking
    the existing rights and UIs mechanisms

## Screenshot

Here's a screenshot after the changerequest extension has been installed (which currently misses a translation for its custom right)

![ui-custom-rights](https://user-images.githubusercontent.com/1478232/122013004-0a95c580-cdbe-11eb-86c0-dcd2f3cf4f22.png)

