### PR TITLE
XWIKI-18732: Live Data source should be able to display contextual error/warning messages

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/resources/liveDataConfiguration.json
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/resources/liveDataConfiguration.json
@@ -47,7 +47,8 @@
       {"id": "html"},
       {"id": "xObjectProperty"},
       {"id": "actions"},
-      {"id": "boolean"}
+      {"id": "boolean"},
+      {"id": "docTitle"}
     ],
 
     "defaultDisplayer": "text",

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/resources/liveDataConfiguration.json
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/resources/liveDataConfiguration.json
@@ -45,10 +45,8 @@
       {"id": "text"},
       {"id": "link"},
       {"id": "html"},
-      {"id": "xObjectProperty"},
       {"id": "actions"},
-      {"id": "boolean"},
-      {"id": "docTitle"}
+      {"id": "boolean"}
     ],
 
     "defaultDisplayer": "text",

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/test/resources/DefaultLiveDataConfigurationResolver.test
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/test/resources/DefaultLiveDataConfigurationResolver.test
@@ -151,7 +151,8 @@
       {"id":"html"},
       {"id":"xObjectProperty"},
       {"id":"actions"},
-      {"id":"boolean"}
+      {"id":"boolean"},
+      {"id":"docTitle"}
     ],
     "defaultDisplayer":"text",
     "pagination":{

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/test/resources/DefaultLiveDataConfigurationResolver.test
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/test/resources/DefaultLiveDataConfigurationResolver.test
@@ -149,10 +149,8 @@
       {"id":"text"},
       {"id":"link"},
       {"id":"html"},
-      {"id":"xObjectProperty"},
       {"id":"actions"},
-      {"id":"boolean"},
-      {"id":"docTitle"}
+      {"id":"boolean"}
     ],
     "defaultDisplayer":"text",
     "pagination":{

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/resources/liveTableLiveDataConfiguration.json
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/resources/liveTableLiveDataConfiguration.json
@@ -177,6 +177,7 @@
 
     "displayers": [
       {"id": "link", "propertyHref": "doc.url"},
+      {"id": "xObjectProperty"},
       {"id": "docTitle", "propertyHref": "doc.url"}
     ],
 

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/resources/liveTableLiveDataConfiguration.json
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/resources/liveTableLiveDataConfiguration.json
@@ -12,7 +12,7 @@
 
     "propertyDescriptors": [
       {"id": "doc.name", "type": "String", "editable": false, "displayer": "link"},
-      {"id": "doc.title", "type": "String", "displayer": "link"},
+      {"id": "doc.title", "type": "String", "displayer": "docTitle"},
       {
         "id": "doc.hidden",
         "type": "Boolean",
@@ -176,7 +176,8 @@
     ],
 
     "displayers": [
-      {"id": "link", "propertyHref": "doc.url"}
+      {"id": "link", "propertyHref": "doc.url"},
+      {"id": "docTitle", "propertyHref": "doc.url"}
     ],
 
     "filters": [

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-macro/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-macro/src/main/resources/ApplicationResources.properties
@@ -106,7 +106,7 @@ livedata.panel.sort.direction.descending=Descending
 livedata.panel.sort.add=Add sort
 livedata.panel.sort.delete=Delete sort
 
-livedata.displayer.emptyValue=N/A
+livedata.displayer.emptyValue=N/A<sup>*</sup>
 
 livedata.displayer.link.noValue=(no value)
 
@@ -119,4 +119,4 @@ livedata.displayer.xObjectProperty.failedToRetrieveField.errorMessage=Failed to 
 livedata.filter.list.emptyLabel=---
 
 livedata.footnotes.computedTitle=Some pages have a computed title. Filtering and sorting by title will not work as expected for these pages.
-livedata.footnotes.propertyNotViewable=Displayed when some pages require special rights to be viewed and thus fields cannot be extracted from them.
+livedata.footnotes.propertyNotViewable=Displayed when some entries require special rights to be viewed and thus fields cannot be extracted from them.

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-macro/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-macro/src/main/resources/ApplicationResources.properties
@@ -106,6 +106,8 @@ livedata.panel.sort.direction.descending=Descending
 livedata.panel.sort.add=Add sort
 livedata.panel.sort.delete=Delete sort
 
+livedata.displayer.emptyValue=N/A
+
 livedata.displayer.link.noValue=(no value)
 
 livedata.displayer.boolean.true=True
@@ -117,4 +119,4 @@ livedata.displayer.xObjectProperty.failedToRetrieveField.errorMessage=Failed to 
 livedata.filter.list.emptyLabel=---
 
 livedata.footnotes.computedTitle=Some pages have a computed title. Filtering and sorting by title will not work as expected for these pages.
-livedata.footnotes.propertyNotViewable=Some pages require special rights to be viewed.
+livedata.footnotes.propertyNotViewable=Displayed when some pages require special rights to be viewed and thus fields cannot be extracted from them.

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-macro/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-macro/src/main/resources/ApplicationResources.properties
@@ -115,3 +115,6 @@ livedata.displayer.xObjectProperty.missingDocumentName.errorMessage=Can't save a
 livedata.displayer.xObjectProperty.failedToRetrieveField.errorMessage=Failed to retrieve the {0} field.
 
 livedata.filter.list.emptyLabel=---
+
+livedata.footnotes.computedTitle=Some pages have a computed title. Filtering and sorting by title will not work as expected for these pages.
+livedata.footnotes.propertyNotViewable=Some pages require special rights to be viewed.

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/pom.xml
@@ -71,6 +71,12 @@
       <type>xar</type>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-localization-rest-default</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
   <build>
     <testSourceDirectory>src/test/it</testSourceDirectory>

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/src/test/it/org/xwiki/livedata/test/ui/LiveDataIT.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/src/test/it/org/xwiki/livedata/test/ui/LiveDataIT.java
@@ -91,7 +91,7 @@ class LiveDataIT
             + "pages.";
 
     private static final String FOOTNOTES_PROPERTY_NOT_VIEWABLE =
-        "(N/A) Displayed when some pages require special rights"
+        "(*) Displayed when some entries require special rights"
             + " to be viewed and thus fields cannot be extracted from them.";
 
     /**
@@ -182,7 +182,7 @@ class LiveDataIT
         liveDataElement = new LiveDataElement("test");
         tableLayout = liveDataElement.getTableLayout();
         tableLayout.assertRow(NAME_COLUMN, NAME_LYNDA);
-        tableLayout.assertRow(NAME_COLUMN, "N/A");
+        tableLayout.assertRow(NAME_COLUMN, "N/A*");
         tableLayout.assertRow(NAME_COLUMN, NAME_NIKOLAY);
         assertEquals(2, liveDataElement.countFootnotes());
         assertThat(liveDataElement.getFootnotesText(),

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-pageobjects/src/main/java/org/xwiki/livedata/test/po/LiveDataElement.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-pageobjects/src/main/java/org/xwiki/livedata/test/po/LiveDataElement.java
@@ -73,7 +73,9 @@ public class LiveDataElement extends BaseElement
 
     /**
      * @return the number of displayed footnotes
-     * @since 13.5RC1
+     * @since 13.6RC1
+     * @since 13.5
+     * @since 13.4.1
      */
     public int countFootnotes()
     {
@@ -82,7 +84,9 @@ public class LiveDataElement extends BaseElement
 
     /**
      * @return a list of the text of the footnotes
-     * @since 13.5RC1
+     * @since 13.6RC1
+     * @since 13.5
+     * @since 13.4.1
      */
     public List<String> getFootnotesText()
     {

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-pageobjects/src/main/java/org/xwiki/livedata/test/po/LiveDataElement.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-pageobjects/src/main/java/org/xwiki/livedata/test/po/LiveDataElement.java
@@ -20,10 +20,13 @@
 package org.xwiki.livedata.test.po;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.StaleElementReferenceException;
+import org.openqa.selenium.WebElement;
 import org.xwiki.test.ui.po.BaseElement;
 
 /**
@@ -68,6 +71,24 @@ public class LiveDataElement extends BaseElement
         return new CardLayoutElement(this.id);
     }
 
+    /**
+     * @return the number of displayed footnotes
+     * @since 13.5RC1
+     */
+    public int countFootnotes()
+    {
+        return getFootnotes().size();
+    }
+
+    /**
+     * @return a list of the text of the footnotes
+     * @since 13.5RC1
+     */
+    public List<String> getFootnotesText()
+    {
+        return getFootnotes().stream().map(WebElement::getText).collect(Collectors.toList());
+    }
+
     private void waitUntilReady()
     {
         // First the Live Data macro displays a simple div with the loading class.
@@ -93,5 +114,11 @@ public class LiveDataElement extends BaseElement
             input -> getDriver().findElement(By.id(this.id)).findElements(By.cssSelector(".xwiki-livedata .loading"))
                 .isEmpty()
         );
+    }
+
+    private List<WebElement> getFootnotes()
+    {
+        return getDriver().findElementWithoutWaiting(By.id(this.id))
+            .findElements(By.cssSelector(".footnotes > .footnote"));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/displayers/BaseDisplayer.spec.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/displayers/BaseDisplayer.spec.js
@@ -65,4 +65,58 @@ describe('BaseDisplayer.vue', () => {
     expect(events['update:isView'][0]).toEqual([true]);
   })
 
+  it('Renders an non viewable entry with an empty content', () => {
+    const wrapper = initWrapper(BaseDisplayer, {
+      props: {
+        entry: {
+          color: undefined
+        }
+      }
+    });
+
+    expect(wrapper.find('[tabindex="0"]').html()).toBe('<div tabindex="0"><span></span> <span><sup>*</sup></span></div>');
+  })
+
+  it('Renders a viewable entry with an empty content', () => {
+    const wrapper = initWrapper(BaseDisplayer, {
+      props: {
+        entry: {
+          color: undefined
+        }
+      },
+      logic: {
+        isActionAllowed(action) {
+          return action === 'view';
+        }
+      }
+    });
+
+    expect(wrapper.find('[tabindex="0"]').html()).toBe('<div tabindex="0"><span></span>\n' +
+      '  <!---->\n' +
+      '</div>');
+  })
+
+  it('Renders an entry when isEmpty is set to false', () => {
+    const wrapper = initWrapper(BaseDisplayer, {
+      props: {
+        entry: {
+          color: undefined
+        },
+        isEmpty: false
+      },
+      logic: {
+        isActionAllowed(action) {
+          return action === 'view';
+        }
+      }
+    });
+
+    // Even when the action is not allowed and the property value is undefined, the '*' is not displayed
+    // if the props isEmpty is set to false.
+    // This is useful when a displayed has his own way to present empty values, such as the link displayer.
+    expect(wrapper.find('[tabindex="0"]').html()).toBe('<div tabindex="0"><span></span>\n' +
+      '  <!---->\n' +
+      '</div>');
+  })
+
 })

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/displayers/BaseDisplayer.spec.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/displayers/BaseDisplayer.spec.js
@@ -71,10 +71,16 @@ describe('BaseDisplayer.vue', () => {
         entry: {
           color: undefined
         }
+      },
+      logic: {
+        isActionAllowed()
+        {
+          return false;
+        }
       }
     });
 
-    expect(wrapper.find('[tabindex="0"]').html()).toBe('<div tabindex="0"><span></span> <span><sup>*</sup></span></div>');
+    expect(wrapper.find('[tabindex="0"]').html()).toBe('<div tabindex="0"><span></span> <span>livedata.displayer.emptyValue</span></div>');
   })
 
   it('Renders a viewable entry with an empty content', () => {
@@ -82,11 +88,6 @@ describe('BaseDisplayer.vue', () => {
       props: {
         entry: {
           color: undefined
-        }
-      },
-      logic: {
-        isActionAllowed(action) {
-          return action === 'view';
         }
       }
     });
@@ -103,15 +104,10 @@ describe('BaseDisplayer.vue', () => {
           color: undefined
         },
         isEmpty: false
-      },
-      logic: {
-        isActionAllowed(action) {
-          return action === 'view';
-        }
       }
     });
 
-    // Even when the action is not allowed and the property value is undefined, the '*' is not displayed
+    // Even when the action is not allowed and the property value is undefined, 'N/A' is not displayed
     // if the props isEmpty is set to false.
     // This is useful when a displayed has his own way to present empty values, such as the link displayer.
     expect(wrapper.find('[tabindex="0"]').html()).toBe('<div tabindex="0"><span></span>\n' +

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/displayers/DisplayerActions.spec.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/displayers/DisplayerActions.spec.js
@@ -26,4 +26,17 @@ describe('DisplayerActions.vue', () => {
     const wrapper = initWrapper(DisplayerActions, {})
     expect(wrapper.text()).toMatch('jump')
   })
+
+  it('Renders an entry with not actions to display', () => {
+    const wrapper = initWrapper(DisplayerActions, {
+      logic: {
+        getDisplayerDescriptor() {
+          return {
+            actions: []
+          };
+        }
+      }
+    })
+    expect(wrapper.text()).toMatch('*')
+  })
 })

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/displayers/DisplayerActions.spec.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/displayers/DisplayerActions.spec.js
@@ -27,16 +27,20 @@ describe('DisplayerActions.vue', () => {
     expect(wrapper.text()).toMatch('jump')
   })
 
-  it('Renders an entry with not actions to display', () => {
+  it('Renders an entry with no actions to display', () => {
     const wrapper = initWrapper(DisplayerActions, {
       logic: {
         getDisplayerDescriptor() {
           return {
             actions: []
           };
+        },
+        isActionAllowed()
+        {
+          return false;
         }
       }
     })
-    expect(wrapper.text()).toMatch('*')
+    expect(wrapper.text()).toMatch('livedata.displayer.emptyValue')
   })
 })

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/displayers/DisplayerDocTitle.spec.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/displayers/DisplayerDocTitle.spec.js
@@ -1,0 +1,65 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+import DisplayerDocTitle from "../../../displayers/DisplayerDocTitle";
+import {initWrapper} from "./displayerTestsHelper";
+
+describe('DisplayerDocTitle.vue', () => {
+  it('Renders an entry in view mode with doc.title_raw defined', () => {
+    const wrapper = initWrapper(DisplayerDocTitle, {
+      props: {
+        propertyId: 'doc.title',
+        entry: {
+          'doc.title': 'Test',
+          colorHref: 'entryLink',
+          'doc.title_raw': 'entryLink'
+        }
+      },
+      logic: {
+        getDisplayerDescriptor() {
+          return {
+            propertyHref: 'colorHref'
+          };
+        }
+      }
+    });
+    expect(wrapper.find('a').html()).toBe('<a href="entryLink" class="">Test <sup>1</sup></a>');
+  })
+
+  it('Renders an entry in view mode with doc.title_raw undefined', () => {
+    const wrapper = initWrapper(DisplayerDocTitle, {
+      props: {
+        propertyId: 'doc.title',
+        entry: {
+          'doc.title': 'Test',
+          colorHref: 'entryLink',
+        }
+      },
+      logic: {
+        getDisplayerDescriptor() {
+          return {
+            propertyHref: 'colorHref'
+          };
+        }
+      }
+    });
+    expect(wrapper.find('a').html()).toBe('<a href="entryLink" class="">Test</a>');
+  })
+})

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/displayers/DisplayerLink.spec.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/displayers/DisplayerLink.spec.js
@@ -43,6 +43,55 @@ describe('DisplayerLink.vue', () => {
     expect(wrapper.find('a').element.href).toBe('http://localhost/entryLink');
   })
 
+  it('Renders an entry in view mode with an empty content', () => {
+    const wrapper = initWrapper(DisplayerLink, {
+      props: {
+        entry: {
+          colorHref: 'entryLink'
+        }
+      },
+      logic: {
+        getDisplayerDescriptor() {
+          return {
+            propertyHref: 'colorHref'
+          };
+        }
+      },
+      mocks: {
+        $t: (key) => key
+      }
+    });
+    expect(wrapper.text()).toMatch('livedata.displayer.link.noValue')
+    expect(wrapper.find('a').element.href).toBe('http://localhost/entryLink');
+  })
+
+  it('Renders an entry in view mode when view action is not allowed', () => {
+    const wrapper = initWrapper(DisplayerLink, {
+      props: {
+        entry: {
+          colorHref: 'entryLink'
+        }
+      },
+      logic: {
+        getDisplayerDescriptor() {
+          return {
+            propertyHref: 'colorHref'
+          };
+        },
+        isActionAllowed()
+        {
+          return false;
+        },
+      },
+      mocks: {
+        $t: (key) => key
+      }
+    });
+    expect(wrapper.text()).toMatch('livedata.displayer.emptyValue')
+    expect(wrapper.find('a').element.href).toBe('http://localhost/entryLink');
+  })
+
+
   it('Renders an entry in edit mode', async () => {
     const wrapper = initWrapper(DisplayerLink, {});
     const viewerDiv = wrapper.find('div[tabindex="0"]');

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/displayers/DisplayerLink.spec.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/displayers/DisplayerLink.spec.js
@@ -87,8 +87,7 @@ describe('DisplayerLink.vue', () => {
         $t: (key) => key
       }
     });
-    expect(wrapper.text()).toMatch('livedata.displayer.emptyValue')
-    expect(wrapper.find('a').element.href).toBe('http://localhost/entryLink');
+    expect(wrapper.html()).toMatch('livedata.displayer.emptyValue')
   })
 
 

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/displayers/displayerTestsHelper.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/displayers/displayerTestsHelper.js
@@ -49,8 +49,9 @@ import {mount} from '@vue/test-utils'
  * * `isEditable()` returns the constant `true`
  * The returns object is merged with the `editBus` parameter.
  *
- * The default `mock` parameter of `mount()` is an object with a single `$t()` key which returns the constant 
- * `"default test translation value"`
+ * The default `mock` parameter of `mount()` is an object with a single `$t()` key which returns the parameter key as
+ * the result.
+ *
  *
  * 
  * @param displayer the Vue displayer component to initialize
@@ -94,7 +95,7 @@ export function initWrapper(displayer, {props, logic, editBus, mocks})
         },
         isActionAllowed(action)
         {
-          return action === 'jump';
+          return action === 'jump' || action === 'view';
         },
         getActionDescriptor(action)
         {
@@ -129,7 +130,7 @@ export function initWrapper(displayer, {props, logic, editBus, mocks})
       }, logic),
     },
     mocks: Object.assign({
-      $t: () => 'default test translation value'
+      $t: (key) => key
     }, mocks)
   });
 }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/displayers/displayerTestsHelper.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/displayers/displayerTestsHelper.js
@@ -120,6 +120,11 @@ export function initWrapper(displayer, {props, logic, editBus, mocks})
               return true;
             }
           }, editBus)
+        },
+        footnotes: {
+          put() {},
+          reset() {},
+          list() { return []; }
         }
       }, logic),
     },

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/footnotes/LivedataFootnotes.spec.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/footnotes/LivedataFootnotes.spec.js
@@ -75,7 +75,7 @@ describe('LivedataFootnotes.vue', () => {
         logic: {
           footnotes: {
             list() {
-              return [{prefix: '1', translationKey: 'a.b.c'}]
+              return [{symbol: '1', translationKey: 'a.b.c'}]
             }
           }
         }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/footnotes/LivedataFootnotes.spec.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/footnotes/LivedataFootnotes.spec.js
@@ -1,0 +1,90 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+import LivedataFootnotes from "../../../footnotes/LivedataFootnotes";
+import {mount} from '@vue/test-utils';
+import _ from "lodash";
+
+/**
+ * Initialize a LivedataFootnotes component using default values vue test-utils `mount` parameters.
+ * The default parameters can be overridden using the `mountConfiguration` parameter.
+ *
+ * The default configuration is:
+ * ```
+ * {
+ *   provide: {
+ *     logic: {
+ *       footnotes: {
+ *         list() {
+ *           return [];
+ *         }
+ *       }
+ *     }
+ *   },
+ *   mocks: {
+ *     $t: (key) => key
+ *   }
+ * }
+ * ```
+ *
+ * @param mountConfiguration mount parameters merged over the default configuration
+ * @returns {{options: string}|{}|*} an initialized LivedataFootnotes Vue component
+ */
+function initWrapper(mountConfiguration = {}) {
+  return mount(LivedataFootnotes, _.merge({
+    provide: {
+      logic: {
+        footnotes: {
+          list() {
+            return [];
+          }
+        }
+      }
+    },
+    mocks: {
+      $t: (key) => key
+    }
+  }, mountConfiguration));
+}
+
+describe('LivedataFootnotes.vue', () => {
+  it('Render when no footnote', () => {
+    const wrapper = initWrapper();
+    expect(wrapper.html()).toBe('<div></div>');
+  })
+
+  it('Render when one footnote', () => {
+    const wrapper = initWrapper({
+      provide: {
+        logic: {
+          footnotes: {
+            list() {
+              return [{prefix: '1', translationKey: 'a.b.c'}]
+            }
+          }
+        }
+      }
+    });
+    expect(wrapper.html()).toBe('<div>\n' +
+      '  <div class="box infomessage">\n' +
+      '    (<small>1</small>) a.b.c\n' +
+      '  </div>\n' +
+      '</div>');
+  })
+})

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/footnotes/LivedataFootnotes.spec.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/footnotes/LivedataFootnotes.spec.js
@@ -66,7 +66,7 @@ function initWrapper(mountConfiguration = {}) {
 describe('LivedataFootnotes.vue', () => {
   it('Render when no footnote', () => {
     const wrapper = initWrapper();
-    expect(wrapper.html()).toBe('<div></div>');
+    expect(wrapper.html()).toBe('<div class="footnotes"></div>');
   })
 
   it('Render when one footnote', () => {
@@ -81,8 +81,8 @@ describe('LivedataFootnotes.vue', () => {
         }
       }
     });
-    expect(wrapper.html()).toBe('<div>\n' +
-      '  <div class="box infomessage">\n' +
+    expect(wrapper.html()).toBe('<div class="footnotes">\n' +
+      '  <div class="box infomessage footnote">\n' +
       '    (<small>1</small>) a.b.c\n' +
       '  </div>\n' +
       '</div>');

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/XWikiLivedata.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/XWikiLivedata.vue
@@ -33,6 +33,9 @@
     <!-- Where the layouts are going to be displayed -->
     <LivedataLayout :layout-id="layoutId"/>
 
+    <!-- Displays the footnotes once the layout is loaded. -->
+    <LivedataFootnotes v-if="layoutLoaded" />
+
     <!-- Persistent configuration module (if supported by the config) -->
     <LivedataPersistentConfiguration v-if="data.id"/>
     
@@ -50,6 +53,7 @@ __webpack_public_path__ = window.liveDataBaseURL;
 import LivedataAdvancedPanels from "./panels/LivedataAdvancedPanels.vue";
 import LivedataLayout from "./layouts/LivedataLayout.vue";
 import LivedataPersistentConfiguration from "./LivedataPersistentConfiguration.vue";
+import LivedataFootnotes from "./footnotes/LivedataFootnotes";
 
 
 export default {
@@ -60,6 +64,7 @@ export default {
     LivedataAdvancedPanels,
     LivedataLayout,
     LivedataPersistentConfiguration,
+    LivedataFootnotes
   },
 
   props: {

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/BaseDisplayer.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/BaseDisplayer.vue
@@ -46,7 +46,7 @@
         -->
         <span>{{ value }}</span>
       </slot>
-      <span v-if="!isViewable">{{ $t('livedata.displayer.emptyValue') }}</span>
+      <span v-if="!isViewable" v-html="$t('livedata.displayer.emptyValue')"></span>
     </div>
 
     <!-- The slot containing the displayer Editor widget -->
@@ -135,7 +135,7 @@ export default {
       }
       const isViewable = this.logic.isActionAllowed('view', this.entry) || !empty;
       if (!isViewable) {
-        this.logic.footnotes.put(this.$t('livedata.displayer.emptyValue'), 'livedata.footnotes.propertyNotViewable');
+        this.logic.footnotes.put('*', 'livedata.footnotes.propertyNotViewable');
       }
       return isViewable;
     }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/BaseDisplayer.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/BaseDisplayer.vue
@@ -46,6 +46,7 @@
         -->
         <span>{{ value }}</span>
       </slot>
+      <span v-if="!isViewable"><sup>*</sup></span>
     </div>
 
     <!-- The slot containing the displayer Editor widget -->
@@ -108,6 +109,10 @@ export default {
     isLoading: {
       type: Boolean,
       default: false
+    },
+    isEmpty: {
+      type: Boolean,
+      default: undefined
     }
   },
 
@@ -123,7 +128,17 @@ export default {
       const noOtherEditing = this.logic.getEditBus().isEditable()
       return editable && noOtherEditing;
     },
-    
+    isViewable() {
+      var empty = this.isEmpty;
+      if (empty === undefined) {
+        empty = !this.value
+      }
+      const isViewable = this.logic.isActionAllowed('view', this.entry) || !empty;
+      if (!isViewable) {
+        this.logic.footnotes.put('*', 'livedata.footnotes.propertyNotViewable');
+      }
+      return isViewable;
+    }
   },
 
   // The following methods are only used by the BaseDisplayer component

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/BaseDisplayer.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/BaseDisplayer.vue
@@ -46,7 +46,7 @@
         -->
         <span>{{ value }}</span>
       </slot>
-      <span v-if="!isViewable"><sup>*</sup></span>
+      <span v-if="!isViewable">{{ $t('livedata.displayer.emptyValue') }}</span>
     </div>
 
     <!-- The slot containing the displayer Editor widget -->
@@ -135,7 +135,7 @@ export default {
       }
       const isViewable = this.logic.isActionAllowed('view', this.entry) || !empty;
       if (!isViewable) {
-        this.logic.footnotes.put('*', 'livedata.footnotes.propertyNotViewable');
+        this.logic.footnotes.put(this.$t('livedata.displayer.emptyValue'), 'livedata.footnotes.propertyNotViewable');
       }
       return isViewable;
     }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/DisplayerActions.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/DisplayerActions.vue
@@ -34,6 +34,7 @@
     view-only
     :property-id="propertyId"
     :entry="entry"
+    :is-empty="actions.length === 0"
   >
 
     <!-- Provide the Action Viewer widget to the `viewer` slot -->

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/DisplayerDocTitle.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/DisplayerDocTitle.vue
@@ -1,0 +1,29 @@
+<template>
+  <DisplayerLink v-bind="{...$props, ...$attrs, html}"/>
+</template>
+
+<script>
+import DisplayerLink from "./DisplayerLink.vue";
+import displayerMixin from "./displayerMixin.js";
+import displayerLinkMixin from "./displayerLinkMixin.js";
+
+export default {
+  name: "displayer-docTitle",
+  components: {DisplayerLink},
+  mixins: [displayerMixin, displayerLinkMixin],
+  computed: {
+    html() {
+        if (this.entry['doc.title_raw']) {
+        this.logic.footnotes.put('1', 'livedata.footnotes.computedTitle');
+        return `${this.htmlValue} <sup>1</sup>`;
+      } else {
+        return this.htmlValue;
+      }
+    }
+  }
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/DisplayerLink.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/DisplayerLink.vue
@@ -47,7 +47,7 @@
       <a
         :href="href"
         :class="{'explicit-empty-value': !html && !htmlValue}"
-        v-html="html || htmlValue || $t('livedata.displayer.link.noValue')"
+        v-html="linkContent"
       ></a>
     </template>
 
@@ -95,6 +95,15 @@ export default {
       }
       return values.map(value => this.entry[value]).find(value => value) || '#';
     },
+    linkContent() {
+      if (!this.logic.isActionAllowed('view', this.entry)) {
+        return this.$t('livedata.displayer.emptyValue');
+      } else if (this.html) {
+        return this.html;
+      } else {
+        return this.htmlValue || this.$t('livedata.displayer.link.noValue')
+      }
+    }
   },
 };
 </script>

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/DisplayerLink.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/DisplayerLink.vue
@@ -44,11 +44,12 @@
         If there is no value but still a link, the user should still be able to click the link,
         so we create an explicit "no value" message in that case
       -->
-      <a
+      <a v-if="linkContent && hasViewRight"
         :href="href"
         :class="{'explicit-empty-value': !html && !htmlValue}"
         v-html="linkContent"
       ></a>
+      <span v-else v-html="linkContent"></span>
     </template>
 
 
@@ -96,13 +97,16 @@ export default {
       return values.map(value => this.entry[value]).find(value => value) || '#';
     },
     linkContent() {
-      if (!this.logic.isActionAllowed('view', this.entry)) {
+      if (!this.hasViewRight) {
         return this.$t('livedata.displayer.emptyValue');
       } else if (this.html) {
         return this.html;
       } else {
         return this.htmlValue || this.$t('livedata.displayer.link.noValue')
       }
+    },
+    hasViewRight() {
+      return this.logic.isActionAllowed('view', this.entry)
     }
   },
 };

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/DisplayerLink.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/DisplayerLink.vue
@@ -34,6 +34,7 @@
     :property-id="propertyId"
     :entry="entry"
     :is-view.sync="isView"
+    :is-empty="false"
     @saveEdit="genericSave"
   >
 
@@ -45,8 +46,8 @@
       -->
       <a
         :href="href"
-        :class="{'explicit-empty-value': !htmlValue}"
-        v-html="htmlValue || $t('livedata.displayer.link.noValue')"
+        :class="{'explicit-empty-value': !html && !htmlValue}"
+        v-html="html || htmlValue || $t('livedata.displayer.link.noValue')"
       ></a>
     </template>
 
@@ -60,6 +61,7 @@
 
 <script>
 import displayerMixin from "./displayerMixin.js";
+import displayerLinkMixin from "./displayerLinkMixin.js";
 import displayerStatesMixin from "./displayerStatesMixin";
 import BaseDisplayer from "./BaseDisplayer.vue";
 
@@ -72,7 +74,14 @@ export default {
   },
 
   // Add the displayerMixin to get access to all the displayers methods and computed properties inside this component
-  mixins: [displayerMixin, displayerStatesMixin],
+  mixins: [displayerMixin, displayerLinkMixin, displayerStatesMixin],
+  
+  props: {
+    // An optional html to use instead of the computed htmlValue when displaying the inner html of the link.
+    html: {
+      optional: true
+    }
+  },
 
   computed: {
     // The link href taken from the propertyHref property of the entry
@@ -86,18 +95,6 @@ export default {
       }
       return values.map(value => this.entry[value]).find(value => value) || '#';
     },
-
-    htmlValue () {
-      const container = document.createElement('div');
-      container[this.config.html ? 'innerHTML' : 'textContent'] = this.value;
-      // Remove the interactive content because it isn't allowed inside an anchor element.
-      // See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#properties
-      // See https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#interactive_content
-      const interactiveContent = 'a, button, details, embed, iframe, keygen, label, select, textarea, audio[controls],'
-        + 'img[usemap], input, menu[type=toolbar], object[usemap], video[controls]';
-      [...container.querySelectorAll(interactiveContent)].forEach(node => node.parentNode.removeChild(node));
-      return container.innerHTML.trim();
-    }
   },
 };
 </script>

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/displayerLinkMixin.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/displayerLinkMixin.js
@@ -1,0 +1,39 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+/**
+ * The displayerLinkMixin is a vue mixin containing the computed values required for the DisplayerLink component
+ * or other components reusing it (for instance, DisplayerDocTitle).
+ */
+export default {
+  computed: {
+    htmlValue() {
+      const container = document.createElement('div');
+      container[this.config.html ? 'innerHTML' : 'textContent'] = this.value;
+      // Remove the interactive content because it isn't allowed inside an anchor element.
+      // See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#properties
+      // See https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories#interactive_content
+      const interactiveContent = 'a, button, details, embed, iframe, keygen, label, select, textarea, audio[controls],'
+        + 'img[usemap], input, menu[type=toolbar], object[usemap], video[controls]';
+      [...container.querySelectorAll(interactiveContent)].forEach(node => node.parentNode.removeChild(node));
+      return container.innerHTML.trim();
+    }
+  }
+};

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/footnotes/LivedataFootnotes.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/footnotes/LivedataFootnotes.vue
@@ -1,0 +1,26 @@
+<template>
+  <div>
+    <div v-for="footnote in list"
+         :key="`footnote-${footnote.prefix}-${footnote.translationKey}`"
+         class="box infomessage">
+      (<small>{{ footnote.prefix }}</small>) {{ $t(footnote.translationKey) }}
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "LivedataFootnotes",
+  inject: ["logic"],
+
+  computed: {
+    list() {
+      return this.logic.footnotes.list();
+    }
+  }
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/footnotes/LivedataFootnotes.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/footnotes/LivedataFootnotes.vue
@@ -1,8 +1,8 @@
 <template>
-  <div>
+  <div class="footnotes">
     <div v-for="footnote in list"
          :key="`footnote-${footnote.prefix}-${footnote.translationKey}`"
-         class="box infomessage">
+         class="box infomessage footnote">
       (<small>{{ footnote.prefix }}</small>) {{ $t(footnote.translationKey) }}
     </div>
   </div>

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/footnotes/LivedataFootnotes.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/footnotes/LivedataFootnotes.vue
@@ -1,9 +1,9 @@
 <template>
   <div class="footnotes">
-    <div v-for="footnote in list"
+    <div v-for="footnote in footnotes.list()"
          :key="`footnote-${footnote.prefix}-${footnote.translationKey}`"
          class="box infomessage footnote">
-      (<small>{{ footnote.prefix }}</small>) {{ $t(footnote.translationKey) }}
+      (<small>{{ footnote.symbol }}</small>) {{ $t(footnote.translationKey) }}
     </div>
   </div>
 </template>
@@ -12,10 +12,9 @@
 export default {
   name: "LivedataFootnotes",
   inject: ["logic"],
-
-  computed: {
-    list() {
-      return this.logic.footnotes.list();
+  data() {
+    return {
+      footnotes: this.logic.footnotes
     }
   }
 }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/webjar/Logic.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/webjar/Logic.js
@@ -67,6 +67,33 @@ define('xwiki-livedata', [
     return instancesMap.get(element);
   };
 
+  /**
+   * A service providing footnotes related operations. 
+   */
+  class FootnotesService {
+    constructor(logic) {
+      this._logic = logic;
+    }
+
+    /**
+     * Register a new footnote. If a footnote with the same translationKey is already registered the new  
+     * @param prefix
+     * @param translationKey
+     */
+    put(prefix, translationKey) {
+      if (!this._logic.data.footnotesSet.some(footnote => footnote.translationKey === translationKey)) {
+        this._logic.data.footnotesSet.push({prefix, translationKey});
+      }
+    }
+    
+    reset() {
+      this._logic.data.footnotesSet.splice(0);
+    }
+    
+    list() {
+      return this._logic.data.footnotesSet;
+    }
+  }
 
   /**
    * Class for a logic element
@@ -76,7 +103,9 @@ define('xwiki-livedata', [
    */
   const Logic = function (element) {
     this.element = element;
-    this.data = JSON.parse(element.getAttribute("data-config") || "{}");
+    const data = JSON.parse(element.getAttribute("data-config") || "{}");
+    data.footnotesSet = [];
+    this.data = data;
     this.currentLayoutId = "";
     this.changeLayout(this.data.meta.defaultLayout);
     this.entrySelection = {
@@ -85,6 +114,7 @@ define('xwiki-livedata', [
       isGlobal: false,
     };
     this.openedPanels = [];
+    this.footnotes = new FootnotesService(this);
 
     element.removeAttribute("data-config");
 
@@ -178,6 +208,8 @@ define('xwiki-livedata', [
         "displayer.xObjectProperty.missingDocumentName.errorMessage",
         "displayer.xObjectProperty.failedToRetrieveField.errorMessage",
         "filter.list.emptyLabel",
+        "footnotes.computedTitle",
+        "footnotes.propertyNotViewable"
       ],
     });
 
@@ -477,7 +509,11 @@ define('xwiki-livedata', [
 
     updateEntries () {
       return this.fetchEntries()
-        .then(data => this.data.data = data)
+        .then(data => {
+          this.data.data = data
+          // Remove the outdated footnotes, they will be recomputed by the new entries.
+          this.footnotes.reset()
+        })
         .catch(err => console.error(err));
     },
 

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/webjar/Logic.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/webjar/Logic.js
@@ -202,6 +202,7 @@ define('xwiki-livedata', [
         "panel.sort.direction.descending",
         "panel.sort.add",
         "panel.sort.delete",
+        "displayer.emptyValue",
         "displayer.link.noValue",
         "displayer.boolean.true",
         "displayer.boolean.false",

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/webjar/Logic.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/webjar/Logic.js
@@ -71,27 +71,28 @@ define('xwiki-livedata', [
    * A service providing footnotes related operations. 
    */
   class FootnotesService {
-    constructor(logic) {
-      this._logic = logic;
+    constructor() {
+      this._footnotes = [];
     }
 
     /**
-     * Register a new footnote. If a footnote with the same translationKey is already registered the new  
-     * @param prefix
-     * @param translationKey
+     * Register a new footnote. If a footnote with the same translationKey is already registered this method has no
+     * effect on the list of registered footnotes.
+     * @param symbol the symbol to identify the entries related to the footnote 
+     * @param translationKey the translation key of the footnote text 
      */
-    put(prefix, translationKey) {
-      if (!this._logic.data.footnotesSet.some(footnote => footnote.translationKey === translationKey)) {
-        this._logic.data.footnotesSet.push({prefix, translationKey});
+    put(symbol, translationKey) {
+      if (!this._footnotes.some(footnote => footnote.translationKey === translationKey)) {
+        this._footnotes.push({symbol, translationKey});
       }
     }
     
     reset() {
-      this._logic.data.footnotesSet.splice(0);
+      this._footnotes.splice(0);
     }
     
     list() {
-      return this._logic.data.footnotesSet;
+      return this._footnotes;
     }
   }
 
@@ -103,9 +104,7 @@ define('xwiki-livedata', [
    */
   const Logic = function (element) {
     this.element = element;
-    const data = JSON.parse(element.getAttribute("data-config") || "{}");
-    data.footnotesSet = [];
-    this.data = data;
+    this.data = JSON.parse(element.getAttribute("data-config") || "{}");
     this.currentLayoutId = "";
     this.changeLayout(this.data.meta.defaultLayout);
     this.entrySelection = {
@@ -114,7 +113,7 @@ define('xwiki-livedata', [
       isGlobal: false,
     };
     this.openedPanels = [];
-    this.footnotes = new FootnotesService(this);
+    this.footnotes = new FootnotesService();
 
     element.removeAttribute("data-config");
 


### PR DESCRIPTION
Introduce a DocTitle component dedicated to displaying the doc.title property.
Introduce a Footnotes component to display footnotes
Introduce the logic to check if an entry is empty because the current user does not have the right to view it