### PR TITLE
XWIKI-17571: Allow to unregister a right

### DIFF
--- a/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-api/src/main/java/org/xwiki/like/internal/DefaultLikeManager.java
+++ b/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-api/src/main/java/org/xwiki/like/internal/DefaultLikeManager.java
@@ -58,6 +58,7 @@ import org.xwiki.ratings.Rating;
 import org.xwiki.ratings.RatingsException;
 import org.xwiki.ratings.RatingsManager;
 import org.xwiki.ratings.RatingsManagerFactory;
+import org.xwiki.security.authorization.AuthorizationException;
 import org.xwiki.security.authorization.AuthorizationManager;
 import org.xwiki.security.authorization.Right;
 import org.xwiki.security.authorization.UnableToRegisterRightException;
@@ -203,6 +204,11 @@ public class DefaultLikeManager implements LikeManager, Initializable, Disposabl
     {
         this.likeExistCache.dispose();
         this.likeCountCache.dispose();
+        try {
+            this.authorizationManager.unregister(this.likeRight);
+        } catch (AuthorizationException e) {
+            throw new ComponentLifecycleException("Error while unregistering like right", e);
+        }
     }
 
     private String getExistCacheKey(UserReference source, EntityReference target)

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-api/src/main/java/org/xwiki/security/authorization/AuthorizationManager.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-api/src/main/java/org/xwiki/security/authorization/AuthorizationManager.java
@@ -102,4 +102,16 @@ public interface AuthorizationManager
     {
         return register(rightDescription);
     }
+
+    /**
+     * Unregister the given custom {@link Right}.
+     *
+     * @param right the custom right to unregister.
+     * @throws AuthorizationException if the right is not custom.
+     * @since 13.5RC1
+     */
+    @Unstable
+    default void unregister(Right right) throws AuthorizationException
+    {
+    };
 }

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-api/src/main/java/org/xwiki/security/authorization/DefaultAuthorizationManager.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-api/src/main/java/org/xwiki/security/authorization/DefaultAuthorizationManager.java
@@ -210,6 +210,18 @@ public class DefaultAuthorizationManager implements AuthorizationManager
         }
     }
 
+    @Override
+    public void unregister(Right right) throws AuthorizationException
+    {
+        if (Right.getStandardRights().contains(right)) {
+            throw new AuthorizationException(
+                String.format("Attempt to unregister the static right [%s]", right.getName()));
+        }
+        right.unregister();
+        // cleanup the cache since a new right scheme enter in action
+        securityCache.remove(securityReferenceFactory.newEntityReference(xwikiBridge.getMainWikiReference()));
+    }
+
     /**
      * Obtain the access for the user on the given entity and load it into the cache if unavailable.
      *

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-api/src/test/java/org/xwiki/security/authorization/AbstractAuthorizationTestCase.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-api/src/test/java/org/xwiki/security/authorization/AbstractAuthorizationTestCase.java
@@ -43,6 +43,8 @@ import org.xwiki.security.authorization.testwikis.TestWiki;
 import org.xwiki.security.authorization.testwikis.internal.parser.DefaultTestDefinitionParser;
 import org.xwiki.security.authorization.testwikis.internal.parser.XWikiConstants;
 import org.xwiki.test.annotation.ComponentList;
+import org.xwiki.test.junit5.mockito.InjectComponentManager;
+import org.xwiki.test.mockito.MockitoComponentManager;
 import org.xwiki.test.mockito.MockitoComponentManagerRule;
 
 import static org.xwiki.security.authorization.Right.ADMIN;
@@ -119,8 +121,8 @@ public abstract class AbstractAuthorizationTestCase
         }
     }
 
-    @Rule
-    public final MockitoComponentManagerRule componentManager = new MockitoComponentManagerRule();
+    @InjectComponentManager
+    public MockitoComponentManager componentManager;
 
     /** Current wiki mock. */
     protected TestDefinition testDefinition;


### PR DESCRIPTION
## JIRA

https://jira.xwiki.org/browse/XWIKI-17571

## Work done

  * Add a new API in AuthorizationManager to unregister a right
  * Provide some new package private method in Right to unregister it
  * Refactor tests to use junit5 and provide new tests for
    register/unregister
  * Use the new API when the DefaultLikeManager is disposed to
    unregister the right.

## Tests

Unit tests provided, also tested manually by uninstalling Like API and checking the UI for Extension Rights.