### PR TITLE
XWIKI-16544: Improve getdocuments template

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/getdocuments.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/getdocuments.vm
@@ -23,70 +23,11 @@
 ### XWiki.LivetableResults. It supports basic document listing, sorting and pagination.
 ###
 $response.setContentType("application/json")
-##
-## WHERE
-##
-#set ($whereQueryPart = 'WHERE 1=1')
-#set ($queryParams = [])
-## Display all documents in an exact given space (doesn't support Nested Spaces). Can be useful for backward
-## compatibility for example or if there's a need to list exactly the content of a given space.
-#if ("$!request.space" != '')
-  #set ($discard = $queryParams.add($request.space))
-  #set ($whereQueryPart = "${whereQueryPart} AND doc.space = ?${queryParams.size()}")
-#end
-## Display all documents in a space, including Nested Spaces
-#if ("$!request.childrenOf" != '')
-  #set ($discard = $queryParams.add($services.query.parameter().literal("$!{request.childrenOf}.").anyChars()))
-  #set ($whereQueryPart = "${whereQueryPart} AND doc.fullName LIKE ?${queryParams.size()}")
-  #set ($discard = $queryParams.add("${request.childrenOf}.WebHome"))
-  #set ($whereQueryPart = "${whereQueryPart} AND doc.fullName <> ?${queryParams.size()}")
-#end
-## Exclude some documents
-#set ($excludes = $request.getParameterValues('exclude'))
-#if ("$!excludes" != '')
-  #foreach ($exclude in $excludes)
-    #set ($discard = $queryParams.add($exclude))
-    #set ($whereQueryPart = "${whereQueryPart} AND doc.fullName <> ?${queryParams.size()}")
-  #end
-#end
-#addLocationFilter($whereQueryPart, $queryParams, $!request.get('doc.location'))
-#addLocationFilter($whereQueryPart, $queryParams, $!request.get('doc.title'))
-##
-## date filter
-##
-#set ($dateFilter = $request.get("doc.date"))
-#if("$!{dateFilter}" != '')
-  #set ($dates = $dateFilter.split('-'))
-  #if ($dates.size() == 2)
-    ## Date range matching
-    #set ($discard = $queryParams.add($datetool.toDate($numbertool.toNumber($dates[0]))))
-    #set ($whereQueryPart = "${whereQueryPart} and doc.date between ?$queryParams.size()")
-    #set ($discard = $queryParams.add($datetool.toDate($numbertool.toNumber($dates[1]))))
-    #set ($whereQueryPart = "${whereQueryPart} and ?$queryParams.size()")
-  #else
-    ## Single value matching
-    #set ($discard = $queryParams.add($dateFilter))
-    #set ($whereQueryPart = "${whereQueryPart} and upper(str(doc.date)) like upper(str(?$queryParams.size()))")
-  #end
-#end
-##
-## ORDER
-##
-#set ($order = "$!request.sort")
-#set ($orderQueryPart = '')
-#if ($order != '')
-  #set ($orderDirection = "$!{request.get('dir').toLowerCase()}")
-  #if ("$!orderDirection" != '' && "$!orderDirection" != 'asc')
-    #set($orderDirection = 'desc')
-  #end
-  ## Sorting by doc.location is not supported by the DB, since the location field does not exist.
-  #if ($order == 'doc.location')
-    ## So we filter on the document full name instead, which is the expected behavior.
-    #set ($order = 'doc.fullName')
-  #end
-  ## Weird things happen if we use "ORDER BY" (upper case), at least on HSQLDB. Other DBs may behave differently
-  #set ($orderQueryPart = "order by ${order} ${orderDirection}")
-#end
+
+#set ($rows = [])
+#set ($map = {})
+#set ($informationsadded = false)
+#set ($totalrows = 0)
 ##
 ## OFFSET and LIMIT
 ##
@@ -96,113 +37,202 @@ $response.setContentType("application/json")
 #if (!$offset || $offset < 0)
   #set($offset = 0)
 #end
+#set ($checkedrows = $offset)
 #set ($limit = $numbertool.toNumber($request.get('limit')).intValue())
 #if (!$limit)
   #set ($limit = 15)
 #end
-##
-## Build the query
-##
-#set ($queryString = "$!{whereQueryPart} $!{orderQueryPart}")
-#set ($query = $services.query.hql($queryString))
-## Apply query filters if defined. Otherwise use default
-#foreach ($queryFilter in $stringtool.split($!request.queryFilters, ', '))
-  #set ($query = $query.addFilter($queryFilter))
-#end
-#set ($query = $query.setLimit($limit).setOffset($offset).bindValues($queryParams))
-#if ("$!request.wiki" != '')
-  #set ($query = $query.setWiki($request.wiki))
-#end
-##
-## Execute the query and build the results
-##
-#set ($items = $query.execute())
-#set ($map = {})
-#set ($discard = $map.put('totalrows', $query.count()))
-#set ($discard = $map.put('returnedrows', $mathtool.min($items.size(), $limit)))
-#set ($discard = $map.put('offset', $mathtool.add($offset, 1)))
-#if("$!request.sql" != '')
-  ## Add debug infos
-  #set($discard = $map.put('sql', $queryString))
-  #set($discard = $map.put('params', $queryParams))
-#end
+
 #template('hierarchy_macros.vm')
-#set ($rows = [])
-#foreach ($item in $items)
-  ## Handle both the case where the "language" filter is used and thus languages are returned too and the case where
-  ## only the document name is returned. When more than the document name is returned the $item variable is a list
-  #if ($item.size())
-    ## Extract doc name and doc language from $item
-    #set ($docName = $item[0])
-    #set ($docLanguage = $item[1])
-  #else
-    #set ($docName = $item)
-    #set ($docLanguage = '')
+## Loop while limit has not been reached
+#foreach($i in [0..$limit])
+  ##
+  ## WHERE
+  ##
+  #set ($whereQueryPart = 'WHERE 1=1')
+  #set ($queryParams = [])
+  ## Display all documents in an exact given space (doesn't support Nested Spaces). Can be useful for backward
+  ## compatibility for example or if there's a need to list exactly the content of a given space.
+  #if ("$!request.space" != '')
+    #set ($discard = $queryParams.add($request.space))
+    #set ($whereQueryPart = "${whereQueryPart} AND doc.space = ?${queryParams.size()}")
   #end
-  #set ($viewable = $xwiki.hasAccessLevel('view', $xcontext.user, "${xcontext.database}:${docName}"))
-  #set ($row = {'doc_viewable' : $viewable})
-  #if (!$viewable)
-    #set ($discard = $row.put('doc_fullName', "${xcontext.database}:${item}"))
-  #else
-    #set ($itemDoc = $xwiki.getDocument($docName))
-    ## Handle translations. We need to make sure we display the data associated to the correct document if the returned
-    ## result is a translation
-    #if ("$!docLanguage" != "" && $xwiki.getLanguagePreference() != $docLanguage)
-      #set ($translatedDoc = $itemDoc.getTranslatedDocument($docLanguage))
-      #set ($isTranslation = true)
-    #else
-      #set ($translatedDoc = $itemDoc.translatedDocument)
-      #set ($isTranslation = false)
-    #end
-    #set ($fullname = $services.model.serialize($itemDoc.documentReference, 'default'))
-    #if ($isTranslation)
-      ## Display the language after the document name so that not all translated documents have the same name displayed
-      #set ($discard = $row.put('doc_name', "$itemDoc.documentReference.name ($docLanguage)"))
-    #else
-      #set ($discard = $row.put('doc_name', $itemDoc.documentReference.name))
-    #end
-    #set ($discard = $row.put('doc_fullName', $fullname))
-    #set ($location = "#hierarchy($itemDoc.documentReference, {'limit': 5, 'plain': false, 'local': true, 'displayTitle': false})")
-    #set ($discard = $row.put('doc_location', $location))
-    #set ($discard = $row.put('doc_space', $itemDoc.space))
-    #set ($discard = $row.put('doc_url', $xwiki.getURL($docName)))
-    #set ($discard = $row.put('doc_space_url', $xwiki.getURL($services.model.createDocumentReference($!itemDoc.wiki, $!itemDoc.space, 'WebHome'))))
-    #set ($discard = $row.put('doc_wiki', $itemDoc.wiki))
-    #set ($discard = $row.put('doc_wiki_url', $xwiki.getURL($services.model.resolveDocument('', 'default', $itemDoc.documentReference.extractReference('WIKI')))))
-    #set ($discard = $row.put('doc_hasadmin', $xwiki.hasAdminRights()))
-    #set ($discard = $row.put('doc_hasedit', $xwiki.hasAccessLevel('edit', $xcontext.user, $fullname)))
-    #set ($discard = $row.put('doc_hasdelete', $xwiki.hasAccessLevel('delete', $xcontext.user, $fullname)))
-    #set ($discard = $row.put('doc_hasrename', $row.doc_hasdelete))
-    #set ($row.doc_hasrights = $row.doc_hasedit && $isAdvancedUser)
-    #set ($discard = $row.put('doc_edit_url', $itemDoc.getURL($itemDoc.defaultEditMode)))
-    #set ($discard = $row.put('doc_copy_url', $itemDoc.getURL('view', 'xpage=copy')))
-    #set ($discard = $row.put('doc_delete_url', $itemDoc.getURL('delete')))
-    #set ($discard = $row.put('doc_rename_url', $itemDoc.getURL('view', 'xpage=rename&step=1')))
-    ## Compute the 'edit rights' URL
-    #if($itemDoc.documentReference.name == 'WebHome')
-      ## For nested pages, use the page administration
-      #set($webPreferencesReference = $services.model.createEntityReference('WebPreferences', 'DOCUMENT', $itemDoc.documentReference.lastSpaceReference))
-      #set($editRightsURL = $xwiki.getURL($webPreferencesReference, 'admin', 'editor=spaceadmin&section=PageRights'))
-    #else
-      ## For terminal pages, use the old rights editor
-      ## TODO: we should create a page administration for terminal pages too
-      #set($editRightsURL = $itemDoc.getURL('edit', 'editor=rights'))
-    #end
-    #set ($discard = $row.put('doc_rights_url', $editRightsURL))
-    #set ($discard = $row.put('doc_author_url', $xwiki.getURL($translatedDoc.author)))
-    #set ($discard = $row.put('doc_date', $xwiki.formatDate($translatedDoc.date)))
-    #set ($discard = $row.put('doc_title', $translatedDoc.plainTitle))
-    #set ($rawTitle = $translatedDoc.title)
-    #if ($rawTitle != $row['doc_title'])
-      #set ($discard = $row.put('doc_title_raw', $rawTitle))
-    #end
-    #set ($discard = $row.put('doc_author', $xwiki.getUserName($translatedDoc.author, false)))
-    #set ($discard = $row.put('doc_creationDate', $xwiki.formatDate($translatedDoc.creationDate)))
-    #set ($discard = $row.put('doc_creator', $xwiki.getUserName($translatedDoc.creator, false)))
-    ## Ignore other columns
+  ## Display all documents in a space, including Nested Spaces
+  #if ("$!request.childrenOf" != '')
+    #set ($discard = $queryParams.add($services.query.parameter().literal("$!{request.childrenOf}.").anyChars()))
+    #set ($whereQueryPart = "${whereQueryPart} AND doc.fullName LIKE ?${queryParams.size()}")
+    #set ($discard = $queryParams.add("${request.childrenOf}.WebHome"))
+    #set ($whereQueryPart = "${whereQueryPart} AND doc.fullName <> ?${queryParams.size()}")
   #end
-  #set ($discard = $rows.add($row))
+  ## Exclude some documents
+  #set ($excludes = $request.getParameterValues('exclude'))
+  #if ("$!excludes" != '')
+    #foreach ($exclude in $excludes)
+      #set ($discard = $queryParams.add($exclude))
+      #set ($whereQueryPart = "${whereQueryPart} AND doc.fullName <> ?${queryParams.size()}")
+    #end
+  #end
+  #addLocationFilter($whereQueryPart, $queryParams, $!request.get('doc.location'))
+  #addLocationFilter($whereQueryPart, $queryParams, $!request.get('doc.title'))
+  ##
+  ## date filter
+  ##
+  #set ($dateFilter = $request.get("doc.date"))
+  #if("$!{dateFilter}" != '')
+    #set ($dates = $dateFilter.split('-'))
+    #if ($dates.size() == 2)
+      ## Date range matching
+      #set ($discard = $queryParams.add($datetool.toDate($numbertool.toNumber($dates[0]))))
+      #set ($whereQueryPart = "${whereQueryPart} and doc.date between ?$queryParams.size()")
+      #set ($discard = $queryParams.add($datetool.toDate($numbertool.toNumber($dates[1]))))
+      #set ($whereQueryPart = "${whereQueryPart} and ?$queryParams.size()")
+    #else
+      ## Single value matching
+      #set ($discard = $queryParams.add($dateFilter))
+      #set ($whereQueryPart = "${whereQueryPart} and upper(str(doc.date)) like upper(str(?$queryParams.size()))")
+    #end
+  #end
+  ##
+  ## ORDER
+  ##
+  #set ($order = "$!request.sort")
+  #set ($orderQueryPart = '')
+  #if ($order != '')
+    #set ($orderDirection = "$!{request.get('dir').toLowerCase()}")
+    #if ("$!orderDirection" != '' && "$!orderDirection" != 'asc')
+      #set($orderDirection = 'desc')
+    #end
+    ## Sorting by doc.location is not supported by the DB, since the location field does not exist.
+    #if ($order == 'doc.location')
+      ## So we filter on the document full name instead, which is the expected behavior.
+      #set ($order = 'doc.fullName')
+    #end
+    ## Weird things happen if we use "ORDER BY" (upper case), at least on HSQLDB. Other DBs may behave differently
+    #set ($orderQueryPart = "order by ${order} ${orderDirection}")
+  #end
+  ##
+  ## Build the query
+  ##
+  #set ($queryString = "$!{whereQueryPart} $!{orderQueryPart}")
+  #set ($query = $services.query.hql($queryString))
+  ## Apply query filters if defined. Otherwise use default
+  #foreach ($queryFilter in $stringtool.split($!request.queryFilters, ', '))
+    #set ($query = $query.addFilter($queryFilter))
+  #end
+  #set ($query = $query.setLimit($limit).setOffset($offset).bindValues($queryParams))
+  #if ("$!request.wiki" != '')
+    #set ($query = $query.setWiki($request.wiki))
+  #end
+  ##
+  ## Execute the query and build the results
+  ##
+  #set ($items = $query.execute())
+  ## Ensure to add informations only in first iteration
+  #if($informationsadded == false)
+    #set ($totalrows = $query.count())
+    #set ($discard = $map.put('totalrows', $totalrows))
+    #set ($discard = $map.put('offset', $mathtool.add($offset, 1)))
+    #if("$!request.sql" != '')
+      ## Add debug infos
+      #set($discard = $map.put('sql', $queryString))
+      #set($discard = $map.put('params', $queryParams))
+    #end
+    #set ($informationsadded = true)
+  #end
+
+  #foreach ($item in $items)
+  ## Ensure as much as requested item are processed
+    #if($rows.size() == $limit)
+      #break
+    #end
+    ## Handle both the case where the "language" filter is used and thus languages are returned too and the case where
+    ## only the document name is returned. When more than the document name is returned the $item variable is a list
+    #if ($item.size())
+      ## Extract doc name and doc language from $item
+      #set ($docName = $item[0])
+      #set ($docLanguage = $item[1])
+    #else
+      #set ($docName = $item)
+      #set ($docLanguage = '')
+    #end
+    #set ($viewable = $xwiki.hasAccessLevel('view', $xcontext.user, "${xcontext.database}:${docName}"))
+    #if ($viewable)
+      #set ($row = {'doc_viewable' : $viewable})
+      #set ($discard = $row.put('doc_fullName', "${xcontext.database}:${item}"))
+      #set ($itemDoc = $xwiki.getDocument($docName))
+      ## Handle translations. We need to make sure we display the data associated to the correct document if the returned
+      ## result is a translation
+      #if ("$!docLanguage" != "" && $xwiki.getLanguagePreference() != $docLanguage)
+        #set ($translatedDoc = $itemDoc.getTranslatedDocument($docLanguage))
+        #set ($isTranslation = true)
+      #else
+        #set ($translatedDoc = $itemDoc.translatedDocument)
+        #set ($isTranslation = false)
+      #end
+      #set ($fullname = $services.model.serialize($itemDoc.documentReference, 'default'))
+      #if ($isTranslation)
+        ## Display the language after the document name so that not all translated documents have the same name displayed
+        #set ($discard = $row.put('doc_name', "$itemDoc.documentReference.name ($docLanguage)"))
+      #else
+        #set ($discard = $row.put('doc_name', $itemDoc.documentReference.name))
+      #end
+      #set ($discard = $row.put('doc_fullName', $fullname))
+      #set ($location = "#hierarchy($itemDoc.documentReference, {'limit': 5, 'plain': false, 'local': true, 'displayTitle': false})")
+      #set ($discard = $row.put('doc_location', $location))
+      #set ($discard = $row.put('doc_space', $itemDoc.space))
+      #set ($discard = $row.put('doc_url', $xwiki.getURL($docName)))
+      #set ($discard = $row.put('doc_space_url', $xwiki.getURL($services.model.createDocumentReference($!itemDoc.wiki, $!itemDoc.space, 'WebHome'))))
+      #set ($discard = $row.put('doc_wiki', $itemDoc.wiki))
+      #set ($discard = $row.put('doc_wiki_url', $xwiki.getURL($services.model.resolveDocument('', 'default', $itemDoc.documentReference.extractReference('WIKI')))))
+      #set ($discard = $row.put('doc_hasadmin', $xwiki.hasAdminRights()))
+      #set ($discard = $row.put('doc_hasedit', $xwiki.hasAccessLevel('edit', $xcontext.user, $fullname)))
+      #set ($discard = $row.put('doc_hasdelete', $xwiki.hasAccessLevel('delete', $xcontext.user, $fullname)))
+      #set ($discard = $row.put('doc_hasrename', $row.doc_hasdelete))
+      #set ($row.doc_hasrights = $row.doc_hasedit && $isAdvancedUser)
+      #set ($discard = $row.put('doc_edit_url', $itemDoc.getURL($itemDoc.defaultEditMode)))
+      #set ($discard = $row.put('doc_copy_url', $itemDoc.getURL('view', 'xpage=copy')))
+        #set ($discard = $row.put('doc_delete_url', $itemDoc.getURL('delete')))
+      #set ($discard = $row.put('doc_rename_url', $itemDoc.getURL('view', 'xpage=rename&step=1')))
+      ## Compute the 'edit rights' URL
+      #if($itemDoc.documentReference.name == 'WebHome')
+        ## For nested pages, use the page administration
+        #set($webPreferencesReference = $services.model.createEntityReference('WebPreferences', 'DOCUMENT', $itemDoc.documentReference.lastSpaceReference))
+        #set($editRightsURL = $xwiki.getURL($webPreferencesReference, 'admin', 'editor=spaceadmin&section=PageRights'))
+      #else
+        ## For terminal pages, use the old rights editor
+        ## TODO: we should create a page administration for terminal pages too
+        #set($editRightsURL = $itemDoc.getURL('edit', 'editor=rights'))
+      #end
+      #set ($discard = $row.put('doc_rights_url', $editRightsURL))
+      #set ($discard = $row.put('doc_author_url', $xwiki.getURL($translatedDoc.author)))
+      #set ($discard = $row.put('doc_date', $xwiki.formatDate($translatedDoc.date)))
+      #set ($discard = $row.put('doc_title', $translatedDoc.plainTitle))
+      #set ($rawTitle = $translatedDoc.title)
+      #if ($rawTitle != $row['doc_title'])
+        #set ($discard = $row.put('doc_title_raw', $rawTitle))
+      #end
+      #set ($discard = $row.put('doc_author', $xwiki.getUserName($translatedDoc.author, false)))
+      #set ($discard = $row.put('doc_creationDate', $xwiki.formatDate($translatedDoc.creationDate)))
+      #set ($discard = $row.put('doc_creator', $xwiki.getUserName($translatedDoc.creator, false)))
+      ## Ignore other columns
+      #set ($discard = $rows.add($row))
+    #end
+	## Increment checked rows number
+    #set($checkedrows = $checkedrows + 1)
+  #end
+  ## If whether limit has been reached or queried items are fewer than requested, end of loop
+  #if ($rows.size() == $limit || $items && $items.size() < $limit)
+    #break
+  #end
+  # Update offset
+  #set($offset = $offset + $limit)
+  # Update checked rows number
+  #set($checkedrows = $offset)
 #end
+## Add informations about result processing
+#set ($discard = $map.put('returnedrows', $rows.size()))
+#set ($discard = $map.put('checkedrows', $checkedrows))
+#set ($discord = $map.put('limit', $limit))
 #set ($discard = $map.put('rows', $rows))
 ##
 ## Serialize the JSON

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/getdocuments.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/getdocuments.vm
@@ -23,11 +23,70 @@
 ### XWiki.LivetableResults. It supports basic document listing, sorting and pagination.
 ###
 $response.setContentType("application/json")
-
-#set ($rows = [])
-#set ($map = {})
-#set ($informationsadded = false)
-#set ($totalrows = 0)
+##
+## WHERE
+##
+#set ($whereQueryPart = 'WHERE 1=1')
+#set ($queryParams = [])
+## Display all documents in an exact given space (doesn't support Nested Spaces). Can be useful for backward
+## compatibility for example or if there's a need to list exactly the content of a given space.
+#if ("$!request.space" != '')
+  #set ($discard = $queryParams.add($request.space))
+  #set ($whereQueryPart = "${whereQueryPart} AND doc.space = ?${queryParams.size()}")
+#end
+## Display all documents in a space, including Nested Spaces
+#if ("$!request.childrenOf" != '')
+  #set ($discard = $queryParams.add($services.query.parameter().literal("$!{request.childrenOf}.").anyChars()))
+  #set ($whereQueryPart = "${whereQueryPart} AND doc.fullName LIKE ?${queryParams.size()}")
+  #set ($discard = $queryParams.add("${request.childrenOf}.WebHome"))
+  #set ($whereQueryPart = "${whereQueryPart} AND doc.fullName <> ?${queryParams.size()}")
+#end
+## Exclude some documents
+#set ($excludes = $request.getParameterValues('exclude'))
+#if ("$!excludes" != '')
+  #foreach ($exclude in $excludes)
+    #set ($discard = $queryParams.add($exclude))
+    #set ($whereQueryPart = "${whereQueryPart} AND doc.fullName <> ?${queryParams.size()}")
+  #end
+#end
+#addLocationFilter($whereQueryPart, $queryParams, $!request.get('doc.location'))
+#addLocationFilter($whereQueryPart, $queryParams, $!request.get('doc.title'))
+##
+## date filter
+##
+#set ($dateFilter = $request.get("doc.date"))
+#if("$!{dateFilter}" != '')
+  #set ($dates = $dateFilter.split('-'))
+  #if ($dates.size() == 2)
+    ## Date range matching
+    #set ($discard = $queryParams.add($datetool.toDate($numbertool.toNumber($dates[0]))))
+    #set ($whereQueryPart = "${whereQueryPart} and doc.date between ?$queryParams.size()")
+    #set ($discard = $queryParams.add($datetool.toDate($numbertool.toNumber($dates[1]))))
+    #set ($whereQueryPart = "${whereQueryPart} and ?$queryParams.size()")
+  #else
+    ## Single value matching
+    #set ($discard = $queryParams.add($dateFilter))
+    #set ($whereQueryPart = "${whereQueryPart} and upper(str(doc.date)) like upper(str(?$queryParams.size()))")
+  #end
+#end
+##
+## ORDER
+##
+#set ($order = "$!request.sort")
+#set ($orderQueryPart = '')
+#if ($order != '')
+  #set ($orderDirection = "$!{request.get('dir').toLowerCase()}")
+  #if ("$!orderDirection" != '' && "$!orderDirection" != 'asc')
+    #set($orderDirection = 'desc')
+  #end
+  ## Sorting by doc.location is not supported by the DB, since the location field does not exist.
+  #if ($order == 'doc.location')
+    ## So we filter on the document full name instead, which is the expected behavior.
+    #set ($order = 'doc.fullName')
+  #end
+  ## Weird things happen if we use "ORDER BY" (upper case), at least on HSQLDB. Other DBs may behave differently
+  #set ($orderQueryPart = "order by ${order} ${orderDirection}")
+#end
 ##
 ## OFFSET and LIMIT
 ##
@@ -37,204 +96,126 @@ $response.setContentType("application/json")
 #if (!$offset || $offset < 0)
   #set($offset = 0)
 #end
-#set ($checkedrows = $offset)
 #set ($limit = $numbertool.toNumber($request.get('limit')).intValue())
 #if (!$limit)
   #set ($limit = 15)
 #end
-
-#template('hierarchy_macros.vm')
-## Loop while limit has not been reached
-#foreach($i in [0..$limit])
-  ##
-  ## WHERE
-  ##
-  #set ($whereQueryPart = 'WHERE 1=1')
-  #set ($queryParams = [])
-  ## Display all documents in an exact given space (doesn't support Nested Spaces). Can be useful for backward
-  ## compatibility for example or if there's a need to list exactly the content of a given space.
-  #if ("$!request.space" != '')
-    #set ($discard = $queryParams.add($request.space))
-    #set ($whereQueryPart = "${whereQueryPart} AND doc.space = ?${queryParams.size()}")
-  #end
-  ## Display all documents in a space, including Nested Spaces
-  #if ("$!request.childrenOf" != '')
-    #set ($discard = $queryParams.add($services.query.parameter().literal("$!{request.childrenOf}.").anyChars()))
-    #set ($whereQueryPart = "${whereQueryPart} AND doc.fullName LIKE ?${queryParams.size()}")
-    #set ($discard = $queryParams.add("${request.childrenOf}.WebHome"))
-    #set ($whereQueryPart = "${whereQueryPart} AND doc.fullName <> ?${queryParams.size()}")
-  #end
-  ## Exclude some documents
-  #set ($excludes = $request.getParameterValues('exclude'))
-  #if ("$!excludes" != '')
-    #foreach ($exclude in $excludes)
-      #set ($discard = $queryParams.add($exclude))
-      #set ($whereQueryPart = "${whereQueryPart} AND doc.fullName <> ?${queryParams.size()}")
-    #end
-  #end
-  #addLocationFilter($whereQueryPart, $queryParams, $!request.get('doc.location'))
-  #addLocationFilter($whereQueryPart, $queryParams, $!request.get('doc.title'))
-  ##
-  ## date filter
-  ##
-  #set ($dateFilter = $request.get("doc.date"))
-  #if("$!{dateFilter}" != '')
-    #set ($dates = $dateFilter.split('-'))
-    #if ($dates.size() == 2)
-      ## Date range matching
-      #set ($discard = $queryParams.add($datetool.toDate($numbertool.toNumber($dates[0]))))
-      #set ($whereQueryPart = "${whereQueryPart} and doc.date between ?$queryParams.size()")
-      #set ($discard = $queryParams.add($datetool.toDate($numbertool.toNumber($dates[1]))))
-      #set ($whereQueryPart = "${whereQueryPart} and ?$queryParams.size()")
-    #else
-      ## Single value matching
-      #set ($discard = $queryParams.add($dateFilter))
-      #set ($whereQueryPart = "${whereQueryPart} and upper(str(doc.date)) like upper(str(?$queryParams.size()))")
-    #end
-  #end
-  ##
-  ## ORDER
-  ##
-  #set ($order = "$!request.sort")
-  #set ($orderQueryPart = '')
-  #if ($order != '')
-    #set ($orderDirection = "$!{request.get('dir').toLowerCase()}")
-    #if ("$!orderDirection" != '' && "$!orderDirection" != 'asc')
-      #set($orderDirection = 'desc')
-    #end
-    ## Sorting by doc.location is not supported by the DB, since the location field does not exist.
-    #if ($order == 'doc.location')
-      ## So we filter on the document full name instead, which is the expected behavior.
-      #set ($order = 'doc.fullName')
-    #end
-    ## Weird things happen if we use "ORDER BY" (upper case), at least on HSQLDB. Other DBs may behave differently
-    #set ($orderQueryPart = "order by ${order} ${orderDirection}")
-  #end
-  ##
-  ## Build the query
-  ##
-  #set ($queryString = "$!{whereQueryPart} $!{orderQueryPart}")
-  #set ($query = $services.query.hql($queryString))
-  ## Apply query filters if defined. Otherwise use default
-  #foreach ($queryFilter in $stringtool.split($!request.queryFilters, ', '))
-    #set ($query = $query.addFilter($queryFilter))
-  #end
-  #set ($query = $query.setLimit($limit).setOffset($offset).bindValues($queryParams))
-  #if ("$!request.wiki" != '')
-    #set ($query = $query.setWiki($request.wiki))
-  #end
-  ##
-  ## Execute the query and build the results
-  ##
-  #set ($items = $query.execute())
-  ## Ensure to add informations only in first iteration
-  #if($informationsadded == false)
-    #set ($totalrows = $query.count())
-    #set ($discard = $map.put('totalrows', $totalrows))
-    #set ($discard = $map.put('offset', $mathtool.add($offset, 1)))
-    #if("$!request.sql" != '')
-      ## Add debug infos
-      #set($discard = $map.put('sql', $queryString))
-      #set($discard = $map.put('params', $queryParams))
-    #end
-    #set ($informationsadded = true)
-  #end
-
-  #foreach ($item in $items)
-  ## Ensure as much as requested item are processed
-    #if($rows.size() == $limit)
-      #break
-    #end
-    ## Handle both the case where the "language" filter is used and thus languages are returned too and the case where
-    ## only the document name is returned. When more than the document name is returned the $item variable is a list
-    #if ($item.size())
-      ## Extract doc name and doc language from $item
-      #set ($docName = $item[0])
-      #set ($docLanguage = $item[1])
-    #else
-      #set ($docName = $item)
-      #set ($docLanguage = '')
-    #end
-    #set ($viewable = $xwiki.hasAccessLevel('view', $xcontext.user, "${xcontext.database}:${docName}"))
-    #if ($viewable)
-      #set ($row = {'doc_viewable' : $viewable})
-      #set ($discard = $row.put('doc_fullName', "${xcontext.database}:${item}"))
-      #set ($itemDoc = $xwiki.getDocument($docName))
-      ## Handle translations. We need to make sure we display the data associated to the correct document if the returned
-      ## result is a translation
-      #if ("$!docLanguage" != "" && $xwiki.getLanguagePreference() != $docLanguage)
-        #set ($translatedDoc = $itemDoc.getTranslatedDocument($docLanguage))
-        #set ($isTranslation = true)
-      #else
-        #set ($translatedDoc = $itemDoc.translatedDocument)
-        #set ($isTranslation = false)
-      #end
-      #set ($fullname = $services.model.serialize($itemDoc.documentReference, 'default'))
-      #if ($isTranslation)
-        ## Display the language after the document name so that not all translated documents have the same name displayed
-        #set ($discard = $row.put('doc_name', "$itemDoc.documentReference.name ($docLanguage)"))
-      #else
-        #set ($discard = $row.put('doc_name', $itemDoc.documentReference.name))
-      #end
-      #set ($discard = $row.put('doc_fullName', $fullname))
-      #set ($location = "#hierarchy($itemDoc.documentReference, {'limit': 5, 'plain': false, 'local': true, 'displayTitle': false})")
-      #set ($discard = $row.put('doc_location', $location))
-      #set ($discard = $row.put('doc_space', $itemDoc.space))
-      #set ($discard = $row.put('doc_url', $xwiki.getURL($docName)))
-      #set ($discard = $row.put('doc_space_url', $xwiki.getURL($services.model.createDocumentReference($!itemDoc.wiki, $!itemDoc.space, 'WebHome'))))
-      #set ($discard = $row.put('doc_wiki', $itemDoc.wiki))
-      #set ($discard = $row.put('doc_wiki_url', $xwiki.getURL($services.model.resolveDocument('', 'default', $itemDoc.documentReference.extractReference('WIKI')))))
-      #set ($discard = $row.put('doc_hasadmin', $xwiki.hasAdminRights()))
-      #set ($discard = $row.put('doc_hasedit', $xwiki.hasAccessLevel('edit', $xcontext.user, $fullname)))
-      #set ($discard = $row.put('doc_hasdelete', $xwiki.hasAccessLevel('delete', $xcontext.user, $fullname)))
-      #set ($discard = $row.put('doc_hasrename', $row.doc_hasdelete))
-      #set ($row.doc_hasrights = $row.doc_hasedit && $isAdvancedUser)
-      #set ($discard = $row.put('doc_edit_url', $itemDoc.getURL($itemDoc.defaultEditMode)))
-      #set ($discard = $row.put('doc_copy_url', $itemDoc.getURL('view', 'xpage=copy')))
-        #set ($discard = $row.put('doc_delete_url', $itemDoc.getURL('delete')))
-      #set ($discard = $row.put('doc_rename_url', $itemDoc.getURL('view', 'xpage=rename&step=1')))
-      ## Compute the 'edit rights' URL
-      #if($itemDoc.documentReference.name == 'WebHome')
-        ## For nested pages, use the page administration
-        #set($webPreferencesReference = $services.model.createEntityReference('WebPreferences', 'DOCUMENT', $itemDoc.documentReference.lastSpaceReference))
-        #set($editRightsURL = $xwiki.getURL($webPreferencesReference, 'admin', 'editor=spaceadmin&section=PageRights'))
-      #else
-        ## For terminal pages, use the old rights editor
-        ## TODO: we should create a page administration for terminal pages too
-        #set($editRightsURL = $itemDoc.getURL('edit', 'editor=rights'))
-      #end
-      #set ($discard = $row.put('doc_rights_url', $editRightsURL))
-      #set ($discard = $row.put('doc_author_url', $xwiki.getURL($translatedDoc.author)))
-      #set ($discard = $row.put('doc_date', $xwiki.formatDate($translatedDoc.date)))
-      #set ($discard = $row.put('doc_title', $translatedDoc.plainTitle))
-      #set ($rawTitle = $translatedDoc.title)
-      #if ($rawTitle != $row['doc_title'])
-        #set ($discard = $row.put('doc_title_raw', $rawTitle))
-      #end
-      #set ($discard = $row.put('doc_author', $xwiki.getUserName($translatedDoc.author, false)))
-      #set ($discard = $row.put('doc_creationDate', $xwiki.formatDate($translatedDoc.creationDate)))
-      #set ($discard = $row.put('doc_creator', $xwiki.getUserName($translatedDoc.creator, false)))
-      ## Ignore other columns
-      #set ($discard = $rows.add($row))
-    #end
-	## Increment checked rows number
-    #set($checkedrows = $checkedrows + 1)
-  #end
-  ## If whether limit has been reached or queried items are fewer than requested, end of loop
-  #if ($rows.size() == $limit || $items && $items.size() < $limit)
-    #break
-  #end
-  # Update offset
-  #set($offset = $offset + $limit)
-  # Update checked rows number
-  #set($checkedrows = $offset)
+##
+## Build the query
+##
+#set ($queryString = "$!{whereQueryPart} $!{orderQueryPart}")
+#set ($query = $services.query.hql($queryString))
+## Apply query filters if defined. Otherwise use default
+#foreach ($queryFilter in $stringtool.split($!request.queryFilters, ', '))
+  #set ($query = $query.addFilter($queryFilter))
 #end
-## Add informations about result processing
-#set ($discard = $map.put('returnedrows', $rows.size()))
-#set ($discard = $map.put('checkedrows', $checkedrows))
-#set ($discord = $map.put('limit', $limit))
+#set ($query = $query.setLimit($limit).setOffset($offset).bindValues($queryParams))
+#if ("$!request.wiki" != '')
+  #set ($query = $query.setWiki($request.wiki))
+#end
+##
+## Execute the query and build the results
+##
+#set ($items = $query.execute())
+#set ($map = {})
+#set ($discard = $map.put('totalrows', $query.count()))
+#set ($discard = $map.put('returnedrows', $mathtool.min($items.size(), $limit)))
+#set ($discard = $map.put('offset', $mathtool.add($offset, 1)))
+#if("$!request.sql" != '')
+  ## Add debug infos
+  #set($discard = $map.put('sql', $queryString))
+  #set($discard = $map.put('params', $queryParams))
+#end
+#template('hierarchy_macros.vm')
+#set ($rows = [])
+#foreach ($item in $items)
+  ## Handle both the case where the "language" filter is used and thus languages are returned too and the case where
+  ## only the document name is returned. When more than the document name is returned the $item variable is a list
+  #if ($item.size())
+    ## Extract doc name and doc language from $item
+    #set ($docName = $item[0])
+    #set ($docLanguage = $item[1])
+  #else
+    #set ($docName = $item)
+    #set ($docLanguage = '')
+  #end
+  #set ($viewable = $xwiki.hasAccessLevel('view', $xcontext.user, "${xcontext.database}:${docName}"))
+  #set ($row = {'doc_viewable' : $viewable})
+  #if (!$viewable)
+    #set ($discard = $row.put('doc_fullName', "${xcontext.database}:${item}"))
+  #else
+    #set ($itemDoc = $xwiki.getDocument($docName))
+    ## Handle translations. We need to make sure we display the data associated to the correct document if the returned
+    ## result is a translation
+    #if ("$!docLanguage" != "" && $xwiki.getLanguagePreference() != $docLanguage)
+      #set ($translatedDoc = $itemDoc.getTranslatedDocument($docLanguage))
+      #set ($isTranslation = true)
+    #else
+      #set ($translatedDoc = $itemDoc.translatedDocument)
+      #set ($isTranslation = false)
+    #end
+    #set ($fullname = $services.model.serialize($itemDoc.documentReference, 'default'))
+    #if ($isTranslation)
+      ## Display the language after the document name so that not all translated documents have the same name displayed
+      #set ($discard = $row.put('doc_name', "$itemDoc.documentReference.name ($docLanguage)"))
+    #else
+      #set ($discard = $row.put('doc_name', $itemDoc.documentReference.name))
+    #end
+    #set ($discard = $row.put('doc_fullName', $fullname))
+    #set ($location = "#hierarchy($itemDoc.documentReference, {'limit': 5, 'plain': false, 'local': true, 'displayTitle': false})")
+    #set ($discard = $row.put('doc_location', $location))
+    #set ($discard = $row.put('doc_space', $itemDoc.space))
+    #set ($discard = $row.put('doc_url', $xwiki.getURL($docName)))
+    #set ($discard = $row.put('doc_space_url', $xwiki.getURL($services.model.createDocumentReference($!itemDoc.wiki, $!itemDoc.space, 'WebHome'))))
+    #set ($discard = $row.put('doc_wiki', $itemDoc.wiki))
+    #set ($discard = $row.put('doc_wiki_url', $xwiki.getURL($services.model.resolveDocument('', 'default', $itemDoc.documentReference.extractReference('WIKI')))))
+    #set ($discard = $row.put('doc_hasadmin', $xwiki.hasAdminRights()))
+    #set ($discard = $row.put('doc_hasedit', $xwiki.hasAccessLevel('edit', $xcontext.user, $fullname)))
+    #set ($discard = $row.put('doc_hasdelete', $xwiki.hasAccessLevel('delete', $xcontext.user, $fullname)))
+    #set ($discard = $row.put('doc_hasrename', $row.doc_hasdelete))
+    #set ($row.doc_hasrights = $row.doc_hasedit && $isAdvancedUser)
+    #set ($discard = $row.put('doc_edit_url', $itemDoc.getURL($itemDoc.defaultEditMode)))
+    #set ($discard = $row.put('doc_copy_url', $itemDoc.getURL('view', 'xpage=copy')))
+    #set ($discard = $row.put('doc_delete_url', $itemDoc.getURL('delete')))
+    #set ($discard = $row.put('doc_rename_url', $itemDoc.getURL('view', 'xpage=rename&step=1')))
+    ## Compute the 'edit rights' URL
+    #if($itemDoc.documentReference.name == 'WebHome')
+      ## For nested pages, use the page administration
+      #set($webPreferencesReference = $services.model.createEntityReference('WebPreferences', 'DOCUMENT', $itemDoc.documentReference.lastSpaceReference))
+      #set($editRightsURL = $xwiki.getURL($webPreferencesReference, 'admin', 'editor=spaceadmin&section=PageRights'))
+    #else
+      ## For terminal pages, use the old rights editor
+      ## TODO: we should create a page administration for terminal pages too
+      #set($editRightsURL = $itemDoc.getURL('edit', 'editor=rights'))
+    #end
+    #set ($discard = $row.put('doc_rights_url', $editRightsURL))
+    #set ($discard = $row.put('doc_author_url', $xwiki.getURL($translatedDoc.author)))
+    #set ($discard = $row.put('doc_date', $xwiki.formatDate($translatedDoc.date)))
+    #set ($discard = $row.put('doc_title', $translatedDoc.plainTitle))
+    #set ($rawTitle = $translatedDoc.title)
+    #if ($rawTitle != $row['doc_title'])
+      #set ($discard = $row.put('doc_title_raw', $rawTitle))
+    #end
+    #set ($viewauthor = $xwiki.hasAccessLevel('view', $xcontext.user, "${xcontext.database}:${$xwiki.getUserName($translatedDoc.author, false)}"))
+    #if (!$viewauthor)
+        #set ($discard = $row.put('doc_author', 'Anonymous'))
+    #else
+        #set ($discard = $row.put('doc_author', $xwiki.getUserName($translatedDoc.author, false)))
+    #end
+    #set ($discard = $row.put('doc_creationDate', $xwiki.formatDate($translatedDoc.creationDate)))
+    #set ($viewcreator = $xwiki.hasAccessLevel('view', $xcontext.user, "${xcontext.database}:${$xwiki.getUserName($translatedDoc.creator, false)}"))
+    #if (!$viewcreator)
+        #set ($discard = $row.put('doc_creator', 'Anonymous'))
+    #else
+        #set ($discard = $row.put('doc_creator', $xwiki.getUserName($translatedDoc.creator, false)))
+    #end
+    ## Ignore other columns
+  #end
+  #set ($discard = $rows.add($row))
+#end
 #set ($discard = $map.put('rows', $rows))
 ##
 ## Serialize the JSON
 ##
 $jsontool.serialize($map)
+


### PR DESCRIPTION
Previously, `getdocuments` was permitting to retrieve non-viewable
documents reference whereas this update does not include these results.
A drawback of this change is that a pagination relying on `getdocuments`
can not use offset number and returnedrows as previously. Since the
number of undisclosed items is unknown, the total number of checked rows
is included in the answer in order to be used as the next offset in the
pagination.

Also, totalrows can not be used reliably since it does not differentiate
between viewable and non-viewable documents because this verification is
done after the query.

About concrete changes, most of the query-related code is now wrapped in a for loop that looks for documents in order to reach the limit. The loop stops if queried items are fewer than the limit or if the limit is reached.