### PR TITLE
[Misc] Javadoc fixes

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/RatingsManager.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/RatingsManager.java
@@ -44,14 +44,41 @@ public interface RatingsManager
      */
     enum RatingQueryField
     {
+        /**
+         * Represents the 'id' field.
+         */
         IDENTIFIER("id"),
+        /**
+         * Represents the 'id' field.
+         */
         ENTITY_REFERENCE("reference"),
+        /**
+         * Represents the 'parents' field.
+         */
         PARENTS_REFERENCE("parents"),
+        /**
+         * Represents the 'author' field.
+         */
         USER_REFERENCE("author"),
+        /**
+         * Represents the 'vote' field.
+         */
         VOTE("vote"),
+        /**
+         * Represents the 'createdDate' field.
+         */
         CREATED_DATE("createdDate"),
+        /**
+         * Represents the 'updatedDate' field.
+         */
         UPDATED_DATE("updatedDate"),
+        /**
+         * Represents the 'managerId' field.
+         */
         MANAGER_ID("managerId"),
+        /**
+         * Represents the 'scale' field.
+         */
         SCALE("scale");
 
         private final String fieldName;


### PR DESCRIPTION
The enum `RatingQueryField` is public, so all fields should be documented.

Related checkstyle issue https://github.com/checkstyle/checkstyle/issues/9876

The link to the failed build: https://github.com/checkstyle/checkstyle/pull/10200/checks?check_run_id=2928353421#step:6:8170