### PR TITLE
XWIKI-18003: Pencil buttons on profile page are not consistent with the used icon theme and missing contrast

### DIFF
--- a/xwiki-platform-core/xwiki-platform-dashboard/xwiki-platform-dashboard-ui/src/main/resources/Dashboard/XWikiUserDashboardSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-dashboard/xwiki-platform-dashboard-ui/src/main/resources/Dashboard/XWikiUserDashboardSheet.xml
@@ -286,6 +286,7 @@
             &lt;div class="editProfileCategory"&gt;
               &lt;a title="$escapetool.xml($services.localization.render('platform.core.profile.category.dashboard.edit'))"
                   href="$doc.getURL('edit', 'category=dashboard')" class="btn btn-xs"&gt;
+                &lt;span class="action-icon"&gt;$services.icon.renderHTML('pencil')&lt;/span&gt;
                 &lt;span class='sr-only'&gt;$escapetool.xml($services.localization.render('platform.core.profile.category.dashboard.edit'))&lt;/span&gt;
               &lt;/a&gt;
             &lt;/div&gt;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserPreferencesSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserPreferencesSheet.xml
@@ -282,6 +282,7 @@
         &lt;div class="editProfileCategory"&gt;
           &lt;a title="$escapetool.xml($services.localization.render('platform.core.profile.category.preferences.edit'))"
               href="$doc.getURL('edit', 'category=preferences')" class="btn btn-xs"&gt;
+            &lt;span class="action-icon"&gt;$services.icon.renderHTML('pencil')&lt;/span&gt;
             &lt;span class='sr-only'&gt;$escapetool.xml($services.localization.render('platform.core.profile.category.preferences.edit'))&lt;/span&gt;
           &lt;/a&gt;
         &lt;/div&gt;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
@@ -567,8 +567,9 @@ $services.localization.render('platform.core.profile.category.profile.disabled')
     &lt;div class='userInfo'&gt;
     #if($xcontext.action == 'view' &amp;&amp; $hasEdit)
       &lt;div class='editProfileCategory'&gt;
-        &lt;a title="$escapetool.xml($services.localization.render('platform.core.profile.category.profile.edit'))" 
-              href="$doc.getURL('edit', 'editor=inline&amp;amp;category=profile')"&gt;
+        &lt;a title="$escapetool.xml($services.localization.render('platform.core.profile.category.profile.edit'))"
+           href="$doc.getURL('edit', 'editor=inline&amp;amp;category=profile')" class="btn btn-xs"&gt;
+          &lt;span class="action-icon"&gt;$services.icon.renderHTML('pencil')&lt;/span&gt;
           &lt;span class='sr-only'&gt;$escapetool.xml($services.localization.render('platform.core.profile.category.profile.edit'))&lt;/span&gt;
         &lt;/a&gt;
       &lt;/div&gt;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserSheet.xml
@@ -572,6 +572,7 @@ div.userInfo, div.userPreferences, div.watchlistManagement, div.userDashboard {
 .userInfo h2 {
   font-size: larger;
   font-weight: bolder;
+  margin-top: 10px;
 }
         
 div.userInfo input[type="text"], div.userInfo input[type="password"], div.userInfo textarea, div.userInfo select, div.userPreferences select {
@@ -582,12 +583,21 @@ div.editProfileCategory {
   float:right;
 }
 
-div.editProfileCategory a {
-  display:block;
-  width: 16px;
-  height: 16px;
-  background: url("$xwiki.getSkinFile('icons/silk/pencil.png')") no-repeat;
+div.editProfileCategory {
+  float:right;
+  a.btn-xs {
+    background-color: @xwiki-page-content-bg;
+    border: 1px solid @xwiki-border-color;
+    .action-icon {
+      font-size: larger;
+      color: @btn-default-color;
+    }
+    &amp;:hover, &amp;:active, &amp;:focus {
+      border-color: darken(@dropdown-divider-bg, 10%);
+    }
+  }
 }
+
 
 /* Watchlist */
 
@@ -677,6 +687,9 @@ span#avatarUpload {
 .dashboard .clearfloats:after, .dashboard .clearfloats:before {
   clear: right;
 }</code>
+    </property>
+    <property>
+      <contentType>LESS</contentType>
     </property>
     <property>
       <name>userprofile</name>


### PR DESCRIPTION
This pull request:
* Adds a pencil icon in profile edit link
* Updates the profile edit link style with btn btn-xs classes and dedicated CSS rules

The contrast has been checked with Firefox accessibility tools (7.29 : 1)