### PR TITLE
XWIKI-18847: Add role=img to Font Awesome icons

### DIFF
--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-fontawesome/src/main/resources/IconThemes/FontAwesome.xml
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-fontawesome/src/main/resources/IconThemes/FontAwesome.xml
@@ -40,8 +40,8 @@
 xwiki.iconset.type = font
 xwiki.iconset.ssx = IconThemes.FontAwesome
 xwiki.iconset.jsx = IconThemes.FontAwesome
-xwiki.iconset.render.wiki = {{html clean="false"}}&lt;span class="fa fa-$icon"&gt;&lt;/span&gt;{{/html}}
-xwiki.iconset.render.html = &lt;span class="fa fa-$icon"&gt;&lt;/span&gt;
+xwiki.iconset.render.wiki = {{html clean="false"}}&lt;span class="fa fa-$icon" role="img"&gt;&lt;/span&gt;{{/html}}
+xwiki.iconset.render.html = &lt;span class="fa fa-$icon" role="img"&gt;&lt;/span&gt;
 xwiki.iconset.icon.cssClass = fa fa-$icon
 
 ## XWiki Icon Set (see: http://design.xwiki.org/xwiki/bin/view/Proposal/XWiki+Icon+Set).


### PR DESCRIPTION
* Add role="img" to html and wiki renderers in page IconThemes.FontAwesome

NB: this PR relates to an issue whose id was updated after it was submitted since it referenced a wrong project (ICONTHEMES instead of XWIKI). The commit message when merging the PR should hence mention XWIKI-18847 instead of ICONTHEMES-11.