### PR TITLE
XWIKI-18897 - User Picker doesn't appear when inserting a macro that uses it

### DIFF
--- a/xwiki-platform-core/xwiki-platform-sharepage/xwiki-platform-sharepage-ui/src/main/resources/XWiki/SharePage.xml
+++ b/xwiki-platform-core/xwiki-platform-sharepage/xwiki-platform-sharepage-ui/src/main/resources/XWiki/SharePage.xml
@@ -731,7 +731,7 @@ Guten Tag ${recipientName},
 }
 
 body &gt; .selectize-dropdown {
-  z-index: 1051;
+  z-index: 10051;
 }</code>
     </property>
     <property>


### PR DESCRIPTION
[XWIKI-18897](https://jira.xwiki.org/browse/XWIKI-18897)

The picker did work properly but it was affected by two conflicting CSS selectors. One in the SharePage ssx and one in the EditSheet ssx.

![image](https://user-images.githubusercontent.com/45433221/129048178-07d7756c-0099-4070-b569-87ef40e67f24.png)

The solution was to have the SharePage selector have the same value as the EditSheet one.