### PR TITLE
XWIKI-18892: Properties that does not correspond to XClass properties should not be editable

### DIFF
--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-mainwiki/src/main/resources/WikiManager/WebHome.xml
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-mainwiki/src/main/resources/WikiManager/WebHome.xml
@@ -59,7 +59,7 @@
     'propertyDescriptors': [
       { 'id': 'wikiprettyname', 'displayer': { 'id': 'link', 'propertyHref': 'wikiprettyname_url' } },
       { 'id': 'owner', 'editable': false},
-      { 'id': 'membershipType', 'sortable': false, 'filterable': false },
+      { 'id': 'membershipType', 'sortable': false, 'filterable': false, 'editable': false },
       { 
         'id': '_actions',
         'displayer': {

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-mainwiki/src/test/java/org/xwiki/wiki/WikiManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-mainwiki/src/test/java/org/xwiki/wiki/WikiManagerTest.java
@@ -87,9 +87,11 @@ class WikiManagerTest extends PageTest
             new JSONObject(htmlDocument.getElementById("wikis").attr("data-config"))
                 .getJSONObject("meta")
                 .getJSONArray("propertyDescriptors");
-        Optional<JSONObject> propertyDescriptor = findObjectById(propertyDescriptors, "owner");
+        Optional<JSONObject> ownerPropertyDescriptor = findObjectById(propertyDescriptors, "owner");
+        assertFalse(ownerPropertyDescriptor.get().getBoolean("editable"));
 
-        assertFalse(propertyDescriptor.map(it -> it.optBoolean("editable", true)).orElse(true));
+        Optional<JSONObject> membershipTypePropertyDescriptor = findObjectById(propertyDescriptors, "membershipType");
+        assertFalse(membershipTypePropertyDescriptor.get().getBoolean("editable"));
     }
 
     /**


### PR DESCRIPTION
Make the properties that are requested by the LD macro but do not correspond to a document or XClass property not-editable by default.