### PR TITLE
XWIKI-18910: Errors appear in the wiki console after selecting the "Forgot your username or password option", on a Multilingual wiki

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/layoutvars.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/layoutvars.vm
@@ -120,7 +120,7 @@
 #end
 
 ## Check that the doc velocity variable is defined: it might not be the case when using some resource handlers.
-#set ($docIsDefined = ("$!doc" != ''))
+#set ($docIsDefined = ($doc != $NULL))
 
 #set($displayContentMenu = true) ## menu on the top of the page with create/edit/more actions
 #set($displayCreateMenu = true) ## create menu

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/layoutvars.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/layoutvars.vm
@@ -135,7 +135,7 @@
 #set($displayPageHeader = false) ## page header containing the logo and the banner taken from ColorTheme
 #set ($displayQuickSearch = true)
 
-## the language choice only makes sense when a doc is declared.
+## The language choice only makes sense when a doc is declared.
 #set ($displayLanguageChoice = $docIsDefined)
 
 #if ($xcontext.action=='preview')

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/layoutvars.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/layoutvars.vm
@@ -119,6 +119,9 @@
  #end
 #end
 
+## Check that the doc velocity variable is defined: it might not be the case when using some resource handlers.
+#set ($docIsDefined = ("$!doc" != ''))
+
 #set($displayContentMenu = true) ## menu on the top of the page with create/edit/more actions
 #set($displayCreateMenu = true) ## create menu
 #set($displayEditMenu = true) ## edit menu
@@ -131,7 +134,9 @@
 #set($displayShortcuts = true)
 #set($displayPageHeader = false) ## page header containing the logo and the banner taken from ColorTheme
 #set ($displayQuickSearch = true)
-#set ($displayLanguageChoice = true)
+
+## the language choice only makes sense when a doc is declared.
+#set ($displayLanguageChoice = $docIsDefined)
 
 #if ($xcontext.action=='preview')
   #set($displayContentMenu = false)


### PR DESCRIPTION
JIRA: https://jira.xwiki.org/browse/XWIKI-18910

Proposed solution:
  * Ensure to display the language menu only if $doc is defined in the
    current context.