### PR TITLE
[Misc] Change maven deployment URL to use https

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1355,7 +1355,7 @@
     <repository>
       <id>nexus.xwiki.org</id>
       <name>XWiki Maven Remote Repository for Releases</name>
-      <url>http://nexus.xwiki.org/nexus/content/repositories/releases/</url>
+      <url>https://nexus.xwiki.org/nexus/content/repositories/releases/</url>
     </repository>
   </distributionManagement>
 </project>


### PR DESCRIPTION
This may or may not fix issues with Maven not accepting http URLs anymore during dependency resolution. Independently of that, https should be used everywhere.