### PR TITLE
XWIKI-19044: Provide real property names in Diff html as data attributes

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/diff_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/diff_macros.vm
@@ -145,9 +145,6 @@
     <dt id="#diffAnchor($documentReference)" #diffDataReference($documentReference)>
       #diffIcon('file-text' 'change')
       $services.localization.render('web.history.changes.summary.documentProperties')
-      <span class="hint">
-        $escapetool.xml($services.model.serialize($documentReference, 'local'))
-      </span>
     </dt>
     <dd>
       <dl>
@@ -292,12 +289,9 @@
       #set ($classReference = $services.model.resolveDocument($className))
       #set ($classPropertyReference = $services.model.createEntityReference($propertyDiff.propName, 'CLASS_PROPERTY',
         $classReference))
-      <dt id="#diffAnchor($classPropertyReference)" #diffDataReference($classPropertyReference)>
+      <dt id="#diffAnchor($classPropertyReference)" #diffDataReference($classPropertyReference) title="$escapetool.xml($className)">
         #diffIcon('cube' $propertyDiff.action)
         $propertyDiff.propName
-        <span class="hint">
-          ($escapetool.xml($className))
-        </span>
       </dt>
       ## Unfortunately the class property diff doesn't tell us much except for the action.
       #set ($oldProperty = $oldClass.get($propertyDiff.propName))


### PR DESCRIPTION
## JIRA

https://jira.xwiki.org/browse/XWIKI-19044

## Solution

  * Provide two new data-attributes in diff UI: data-reference when
    starting the diff details of an element, providing the reference of
the element and data-property-name containing the real name of a
property.
  * Display back the serialized reference of the displayed element as
    hint in the diff (was previously commented)

## Screenshots

There's not much to see in the screenshots except for the hints that were previously hidden.

Document diff before:
![diff-page-before](https://user-images.githubusercontent.com/1478232/137148443-b68c1e96-7dbb-4200-961d-da5a1f56c564.png)

Document diff after:
![diff-page-after](https://user-images.githubusercontent.com/1478232/137148471-e18400e1-4d05-448e-953d-95c7369aa365.png)

XClass diff before:
![diff-xclass-before](https://user-images.githubusercontent.com/1478232/137148538-27d0f00f-dd3a-4124-874c-4acef48af3dd.png)
 
XClass diff after:
![diff-xclass-after](https://user-images.githubusercontent.com/1478232/137148588-e13f060f-ff80-48d8-9a68-99591757708c.png)

