### PR TITLE
XWIKI-19051: Some attachments of the help application are packaged without mime type

### DIFF
--- a/xwiki-platform-tools/xwiki-platform-tool-xmldoc-update-plugin/src/main/java/com/xpn/xwiki/tool/doc/AttachMojo.java
+++ b/xwiki-platform-tools/xwiki-platform-tool-xmldoc-update-plugin/src/main/java/com/xpn/xwiki/tool/doc/AttachMojo.java
@@ -113,6 +113,7 @@ public class AttachMojo extends AbstractDocumentMojo
 
             attachment.setAuthor(author);
             attachment.setFilename(file.getName());
+            attachment.resetMimeType(null);
 
             return attachment;
         } catch (Exception e) {

--- a/xwiki-platform-tools/xwiki-platform-tool-xmldoc-update-plugin/src/test/java/com/xpn/xwiki/tool/doc/DocumentUpdateMojoTest.java
+++ b/xwiki-platform-tools/xwiki-platform-tool-xmldoc-update-plugin/src/test/java/com/xpn/xwiki/tool/doc/DocumentUpdateMojoTest.java
@@ -85,6 +85,8 @@ public class DocumentUpdateMojoTest
         String outputContent = IOUtils.toString(new FileReader(outputFile));
         assertTrue(outputContent.contains("<attachment>\n    <filename>fileToAttach.txt</filename>"));
         assertTrue(outputContent.contains("<attachment>\n    <filename>fileToAttach.js</filename>"));
+        assertTrue(outputContent.contains("<attachment>\n    <filename>fileToAttach.txt</filename>\n    "
+            + "<mimetype>text/plain</mimetype>"));
     }
 
     private void set(AttachMojo mojo, String fieldName, Object value) throws Exception


### PR DESCRIPTION
This adds a reset of the mime type after setting the content in xmldoc-update-plugin.

JIRA issue: https://jira.xwiki.org/browse/XWIKI-19051