### PR TITLE
XWIKI-19048: Live data list filter should display and filter by (translated) labels for static list properties

### DIFF
--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -321,6 +321,19 @@
                 </item>
               </differences>
             </revapi.differences>
+            <revapi.differences>
+              <justification>Not a breakage, new annotation on existing protected and now public method.</justification>
+              <criticality>allowed</criticality>
+              <ignore>true</ignore>
+              <differences>
+                <item>
+                  <code>java.annotation.added</code>
+                  <old>method java.lang.String com.xpn.xwiki.objects.classes.ListClass::getDisplayValue(java.lang.String, java.lang.String, java.util.Map&lt;java.lang.String, com.xpn.xwiki.objects.classes.ListItem&gt;, com.xpn.xwiki.XWikiContext) @ com.xpn.xwiki.objects.classes.StaticListClass</old>
+                  <new>method java.lang.String com.xpn.xwiki.objects.classes.ListClass::getDisplayValue(java.lang.String, java.lang.String, java.util.Map&lt;java.lang.String, com.xpn.xwiki.objects.classes.ListItem&gt;, com.xpn.xwiki.XWikiContext) @ com.xpn.xwiki.objects.classes.StaticListClass</new>
+                  <annotation>@org.xwiki.stability.Unstable</annotation>
+                </item>
+              </differences>
+            </revapi.differences>
           </analysisConfiguration>
         </configuration>
       </plugin>

--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -321,19 +321,6 @@
                 </item>
               </differences>
             </revapi.differences>
-            <revapi.differences>
-              <justification>Not a breakage, new annotation on existing protected and now public method.</justification>
-              <criticality>allowed</criticality>
-              <ignore>true</ignore>
-              <differences>
-                <item>
-                  <code>java.annotation.added</code>
-                  <old>method java.lang.String com.xpn.xwiki.objects.classes.ListClass::getDisplayValue(java.lang.String, java.lang.String, java.util.Map&lt;java.lang.String, com.xpn.xwiki.objects.classes.ListItem&gt;, com.xpn.xwiki.XWikiContext) @ com.xpn.xwiki.objects.classes.StaticListClass</old>
-                  <new>method java.lang.String com.xpn.xwiki.objects.classes.ListClass::getDisplayValue(java.lang.String, java.lang.String, java.util.Map&lt;java.lang.String, com.xpn.xwiki.objects.classes.ListItem&gt;, com.xpn.xwiki.XWikiContext) @ com.xpn.xwiki.objects.classes.StaticListClass</new>
-                  <annotation>@org.xwiki.stability.Unstable</annotation>
-                </item>
-              </differences>
-            </revapi.differences>
           </analysisConfiguration>
         </configuration>
       </plugin>

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-pageobjects/src/main/java/org/xwiki/livedata/test/po/TableLayoutElement.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-pageobjects/src/main/java/org/xwiki/livedata/test/po/TableLayoutElement.java
@@ -435,9 +435,7 @@ public class TableLayoutElement extends BaseElement
      */
     public void filterColumn(String columnLabel, String content, boolean wait)
     {
-        int columnIndex = findColumnIndex(columnLabel);
-        WebElement element = getRoot()
-            .findElement(By.cssSelector(String.format(".column-filters > th:nth-child(%d) input", columnIndex)));
+        WebElement element = getFilter(columnLabel);
 
         List<String> classes = Arrays.asList(getClasses(element));
         if (classes.contains("filter-list")) {
@@ -519,6 +517,20 @@ public class TableLayoutElement extends BaseElement
         int columnNumber = findColumnIndex(columnLabel);
         return getRoot().findElement(
             By.cssSelector(String.format("tbody tr:nth-child(%d) td:nth-child(%d)", rowNumber, columnNumber)));
+    }
+
+    /**
+     * Get the filter for the given column.
+     *
+     * @param columnLabel the label of the column to get the filter element for, for instance {@code "Title"}
+     * @return The {@link WebElement} for the given column filter.
+     * @since 13.10RC1
+     */
+    public WebElement getFilter(String columnLabel)
+    {
+        int columnIndex = findColumnIndex(columnLabel);
+        return getRoot()
+            .findElement(By.cssSelector(String.format(".column-filters > th:nth-child(%d) input", columnIndex)));
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
@@ -35,6 +35,7 @@ import org.apache.ecs.xhtml.select;
 import org.dom4j.Element;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.xwiki.model.reference.EntityReference;
+import org.xwiki.stability.Unstable;
 import org.xwiki.xar.internal.property.ListXarObjectPropertySerializer;
 import org.xwiki.xml.XMLUtils;
 
@@ -639,7 +640,9 @@ public abstract class ListClass extends PropertyClass
      * @param map The value=name mapping specified in the "values" parameter of the property.
      * @param context The request context.
      * @return The text that should be displayed, representing a human-understandable name for the internal value.
+     * @since 13.10RC1
      */
+    @Unstable
     public String getDisplayValue(String value, String name, Map<String, ListItem> map, XWikiContext context)
     {
         return getDisplayValue(value, name, map, value, context);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
@@ -640,7 +640,7 @@ public abstract class ListClass extends PropertyClass
      * @param context The request context.
      * @return The text that should be displayed, representing a human-understandable name for the internal value.
      */
-    protected String getDisplayValue(String value, String name, Map<String, ListItem> map, XWikiContext context)
+    public String getDisplayValue(String value, String name, Map<String, ListItem> map, XWikiContext context)
     {
         return getDisplayValue(value, name, map, value, context);
     }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/StaticListClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/StaticListClassPropertyValuesProvider.java
@@ -24,10 +24,13 @@ import java.util.List;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.apache.commons.text.StringEscapeUtils;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.rest.model.jaxb.PropertyValue;
 import org.xwiki.rest.model.jaxb.PropertyValues;
 
+import com.xpn.xwiki.objects.BaseObject;
+import com.xpn.xwiki.objects.StringProperty;
 import com.xpn.xwiki.objects.classes.StaticListClass;
 
 /**
@@ -49,13 +52,68 @@ public class StaticListClassPropertyValuesProvider extends AbstractListClassProp
 
     @Override
     protected PropertyValues getAllowedValues(StaticListClass propertyDefinition, int limit, String filter)
-        throws Exception
     {
         final PropertyValues result = new PropertyValues();
         List<String> allValues = StaticListClass.getListFromString(propertyDefinition.getValues());
 
-        allValues.stream().filter(s -> s.toLowerCase().contains(filter.toLowerCase())).limit(limit)
-            .forEach(item -> result.withPropertyValues(new PropertyValue(item)));
+        String lowerFilter = filter.toLowerCase();
+
+        allValues.stream().map(id -> constructPropertyValueForId(id, propertyDefinition))
+            // Filter both by key and by (translated) label (that's why we construct a PropertyValue first)
+            .filter(val -> val.getValue().toString().toLowerCase().contains(lowerFilter)
+                || (val.getMetaData().containsKey(META_DATA_LABEL)
+                && val.getMetaData().get(META_DATA_LABEL).toString().toLowerCase().contains(lowerFilter)))
+            .limit(limit).forEach((result::withPropertyValues));
+
         return result;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @since 13.10RC1
+     */
+    @Override
+    protected PropertyValue getValueFromQueryResult(Object result, StaticListClass propertyDefinition)
+    {
+        PropertyValue value = super.getValueFromQueryResult(result, propertyDefinition);
+
+        if (value != null && value.getValue() instanceof String) {
+            String stringKey = (String) value.getValue();
+
+            return constructPropertyValueForId(stringKey, propertyDefinition);
+        }
+
+        return value;
+    }
+
+    /**
+     * Constructs a {@code PropertyValue} for the given id of the given {@code StaticListClass}.
+     *
+     * @param id The id/value of the item
+     * @param propertyDefinition The definition of the property
+     * @return The result, may contain a label if it is different from the id
+     * @since 13.10RC1
+     */
+    private PropertyValue constructPropertyValueForId(String id, StaticListClass propertyDefinition)
+    {
+        PropertyValue val = new PropertyValue(id);
+
+        BaseObject xObject = new BaseObject();
+        String propertyName = propertyDefinition.getName();
+        StringProperty stringProperty = new StringProperty();
+        stringProperty.setValue(id);
+        xObject.addField(propertyName, stringProperty);
+
+        String displayValue = propertyDefinition.displayView(propertyName, xObject, this.xcontextProvider.get());
+
+        // displayView uses XML escaping, but the label should not be escaped
+        displayValue = StringEscapeUtils.unescapeXml(displayValue);
+
+        if (!id.equals(displayValue)) {
+            val.getMetaData().put(META_DATA_LABEL, displayValue);
+        }
+
+        return val;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/StaticListClassPropertyValuesProviderTest.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/StaticListClassPropertyValuesProviderTest.java
@@ -23,14 +23,23 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.xwiki.localization.ContextualLocalizationManager;
 import org.xwiki.rest.model.jaxb.PropertyValue;
 import org.xwiki.rest.model.jaxb.PropertyValues;
-import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
 
+import com.xpn.xwiki.XWiki;
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.objects.classes.BaseClass;
 import com.xpn.xwiki.objects.classes.StaticListClass;
+import com.xpn.xwiki.test.junit5.mockito.OldcoreTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.xwiki.rest.internal.resources.classes.AbstractClassPropertyValuesProvider.META_DATA_LABEL;
 
 /**
  * Test for {@link StaticListClassPropertyValuesProvider}.
@@ -38,43 +47,149 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @since 11.5RC1
  * @version $Id$
  */
-@ComponentTest
+@OldcoreTest
 public class StaticListClassPropertyValuesProviderTest
 {
     @InjectMockComponents
     private StaticListClassPropertyValuesProvider staticListClassPropertyValuesProvider;
 
+    @MockComponent
+    private ContextualLocalizationManager localization;
+
+    @MockComponent
+    private XWikiContext context;
+
+    @Mock
+    private BaseClass baseClass;
+
     @Test
-    public void getAllowedValues() throws Exception
+    void getAllowedValues()
     {
+        // Needed to build localization string
+        when(this.baseClass.getName()).thenReturn("XWiki.TestClass");
+        // Needed to actually consider the localization in the display code
+        when(this.context.getWiki()).thenReturn(mock(XWiki.class));
+
         StaticListClass staticListClass = new StaticListClass();
-        staticListClass.setValues("Foo|Bar|Toto|Tata|Foobar");
-        PropertyValues allowedValues = staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 1, "f");
+        staticListClass.setName("Test");
+        staticListClass.setObject(this.baseClass);
+
+        staticListClass.setValues("Foo|Bar|Toto|Tata|Foobar|Id=Display Value");
+        PropertyValues allowedValues = this.staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 1,
+            "f");
         assertEquals(Collections.singletonList(new PropertyValue("Foo")), allowedValues.getPropertyValues());
 
-        allowedValues = staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 2, "f");
+        allowedValues = this.staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 2, "f");
         assertEquals(Arrays.asList(new PropertyValue("Foo"), new PropertyValue("Foobar")),
             allowedValues.getPropertyValues());
 
-        allowedValues = staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 1, "");
+        allowedValues = this.staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 1, "");
         assertEquals(Collections.singletonList(new PropertyValue("Foo")),
             allowedValues.getPropertyValues());
 
-        allowedValues = staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 5, "");
+        allowedValues = this.staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 5, "");
         assertEquals(Arrays.asList(new PropertyValue("Foo"), new PropertyValue("Bar"), new PropertyValue("Toto"),
             new PropertyValue("Tata"), new PropertyValue("Foobar")),
             allowedValues.getPropertyValues());
 
-        allowedValues = staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 2, "foobar");
+        allowedValues = this.staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 2, "foobar");
         assertEquals(Collections.singletonList(new PropertyValue("Foobar")),
             allowedValues.getPropertyValues());
 
-        allowedValues = staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 1, "baz");
+        allowedValues = this.staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 1, "baz");
         assertEquals(Collections.emptyList(),
             allowedValues.getPropertyValues());
 
-        allowedValues = staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 3, "o");
+        allowedValues = this.staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 3, "o");
         assertEquals(Arrays.asList(new PropertyValue("Foo"), new PropertyValue("Toto"), new PropertyValue("Foobar")),
             allowedValues.getPropertyValues());
+
+        allowedValues = this.staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 3, "iD");
+        PropertyValue expected = new PropertyValue("Id");
+        expected.getMetaData().put(META_DATA_LABEL, "Display Value");
+        assertEquals(Collections.singletonList(expected), allowedValues.getPropertyValues());
+
+        // Test filter by label
+        allowedValues = this.staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 3, "Display");
+        assertEquals(Collections.singletonList(expected), allowedValues.getPropertyValues());
+
+        String translatedLabel = "Translated";
+        expected.getMetaData().put(META_DATA_LABEL, translatedLabel);
+        when(this.localization.getTranslationPlain("XWiki.TestClass_Test_Id")).thenReturn(translatedLabel);
+
+        // Test filter by translated label
+        allowedValues = this.staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 3, "ansl");
+        assertEquals(Collections.singletonList(expected), allowedValues.getPropertyValues());
+    }
+
+    @Test
+    void getValueFromQueryResult()
+    {
+        // Needed to build localization string
+        when(this.baseClass.getName()).thenReturn("XWiki.TestQueryResult");
+        // Needed to actually consider the localization in the display code
+        when(this.context.getWiki()).thenReturn(mock(XWiki.class));
+
+        StaticListClass staticListClass = new StaticListClass();
+        staticListClass.setName("Query");
+        staticListClass.setObject(this.baseClass);
+
+        staticListClass.setValues("Foo|Bar|Toto|Tata|Foobar|Id=Display Value");
+
+        PropertyValue actual = this.staticListClassPropertyValuesProvider.getValueFromQueryResult("Foo",
+            staticListClass);
+        assertEquals(new PropertyValue("Foo"), actual);
+
+        // For values without definition, the given id should be returned
+        actual = this.staticListClassPropertyValuesProvider.getValueFromQueryResult("Baz", staticListClass);
+        assertEquals(new PropertyValue("Baz"), actual);
+
+        actual = this.staticListClassPropertyValuesProvider.getValueFromQueryResult("Id", staticListClass);
+        PropertyValue expected = new PropertyValue("Id");
+        expected.getMetaData().put(META_DATA_LABEL, "Display Value");
+        assertEquals(expected, actual);
+
+        String translatedLabel = "Translated";
+        expected.getMetaData().put(META_DATA_LABEL, translatedLabel);
+        when(this.localization.getTranslationPlain("XWiki.TestQueryResult_Query_Id")).thenReturn(translatedLabel);
+
+        // Test filter by translated label
+        actual = this.staticListClassPropertyValuesProvider.getValueFromQueryResult("Id", staticListClass);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void getValueFromQueryResultWithSpecialCharacter()
+    {
+        // Needed to build localization string
+        when(this.baseClass.getName()).thenReturn("XWiki.TestQueryResultSpecial");
+        // Needed to actually consider the localization in the display code
+        when(this.context.getWiki()).thenReturn(mock(XWiki.class));
+
+        StaticListClass staticListClass = new StaticListClass();
+        staticListClass.setName("Query");
+        staticListClass.setObject(this.baseClass);
+
+        staticListClass.setValues("Foo&bar|Id=Display & Value");
+
+        PropertyValue actual = this.staticListClassPropertyValuesProvider.getValueFromQueryResult("Foo",
+            staticListClass);
+        assertEquals(new PropertyValue("Foo"), actual);
+
+        actual = this.staticListClassPropertyValuesProvider.getValueFromQueryResult("Foo&bar", staticListClass);
+        assertEquals(new PropertyValue("Foo&bar"), actual);
+
+        actual = this.staticListClassPropertyValuesProvider.getValueFromQueryResult("Id", staticListClass);
+        PropertyValue expected = new PropertyValue("Id");
+        expected.getMetaData().put(META_DATA_LABEL, "Display & Value");
+        assertEquals(expected, actual);
+
+        String translatedLabel = "<Translated & &amp; Label>";
+        expected.getMetaData().put(META_DATA_LABEL, translatedLabel);
+        when(this.localization.getTranslationPlain("XWiki.TestQueryResultSpecial_Query_Id")).thenReturn(translatedLabel);
+
+        // Test filter by translated label
+        actual = this.staticListClassPropertyValuesProvider.getValueFromQueryResult("Id", staticListClass);
+        assertEquals(expected, actual);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/StaticListClassPropertyValuesProviderTest.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/StaticListClassPropertyValuesProviderTest.java
@@ -65,16 +65,8 @@ public class StaticListClassPropertyValuesProviderTest
     @Test
     void getAllowedValues()
     {
-        // Needed to build localization string
-        when(this.baseClass.getName()).thenReturn("XWiki.TestClass");
-        // Needed to actually consider the localization in the display code
-        when(this.context.getWiki()).thenReturn(mock(XWiki.class));
-
         StaticListClass staticListClass = new StaticListClass();
-        staticListClass.setName("Test");
-        staticListClass.setObject(this.baseClass);
-
-        staticListClass.setValues("Foo|Bar|Toto|Tata|Foobar|Id=Display Value");
+        staticListClass.setValues("Foo|Bar|Toto|Tata|Foobar");
         PropertyValues allowedValues = this.staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 1,
             "f");
         assertEquals(Collections.singletonList(new PropertyValue("Foo")), allowedValues.getPropertyValues());
@@ -89,7 +81,7 @@ public class StaticListClassPropertyValuesProviderTest
 
         allowedValues = this.staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 5, "");
         assertEquals(Arrays.asList(new PropertyValue("Foo"), new PropertyValue("Bar"), new PropertyValue("Toto"),
-            new PropertyValue("Tata"), new PropertyValue("Foobar")),
+                new PropertyValue("Tata"), new PropertyValue("Foobar")),
             allowedValues.getPropertyValues());
 
         allowedValues = this.staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 2, "foobar");
@@ -103,8 +95,24 @@ public class StaticListClassPropertyValuesProviderTest
         allowedValues = this.staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 3, "o");
         assertEquals(Arrays.asList(new PropertyValue("Foo"), new PropertyValue("Toto"), new PropertyValue("Foobar")),
             allowedValues.getPropertyValues());
+    }
 
-        allowedValues = this.staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 3, "iD");
+    @Test
+    void getAllowedValuesWithLabel()
+    {
+        // Needed to build localization string
+        when(this.baseClass.getName()).thenReturn("XWiki.TestClass");
+        // Needed to actually consider the localization in the display code
+        when(this.context.getWiki()).thenReturn(mock(XWiki.class));
+
+        StaticListClass staticListClass = new StaticListClass();
+        staticListClass.setName("Test");
+        staticListClass.setObject(this.baseClass);
+
+        staticListClass.setValues("Foo|Bar|Toto|Tata|Foobar|Id=Display Value");
+
+        PropertyValues allowedValues =
+            this.staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 3, "iD");
         PropertyValue expected = new PropertyValue("Id");
         expected.getMetaData().put(META_DATA_LABEL, "Display Value");
         assertEquals(Collections.singletonList(expected), allowedValues.getPropertyValues());
@@ -113,11 +121,10 @@ public class StaticListClassPropertyValuesProviderTest
         allowedValues = this.staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 3, "Display");
         assertEquals(Collections.singletonList(expected), allowedValues.getPropertyValues());
 
-        String translatedLabel = "Translated";
-        expected.getMetaData().put(META_DATA_LABEL, translatedLabel);
-        when(this.localization.getTranslationPlain("XWiki.TestClass_Test_Id")).thenReturn(translatedLabel);
-
         // Test filter by translated label
+        String translatedLabel = "Translated";
+        when(this.localization.getTranslationPlain("XWiki.TestClass_Test_Id")).thenReturn(translatedLabel);
+        expected.getMetaData().put(META_DATA_LABEL, translatedLabel);
         allowedValues = this.staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 3, "ansl");
         assertEquals(Collections.singletonList(expected), allowedValues.getPropertyValues());
     }
@@ -133,7 +140,6 @@ public class StaticListClassPropertyValuesProviderTest
         StaticListClass staticListClass = new StaticListClass();
         staticListClass.setName("Query");
         staticListClass.setObject(this.baseClass);
-
         staticListClass.setValues("Foo|Bar|Toto|Tata|Foobar|Id=Display Value");
 
         PropertyValue actual = this.staticListClassPropertyValuesProvider.getValueFromQueryResult("Foo",

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/StaticListClassPropertyValuesProviderTest.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/classes/StaticListClassPropertyValuesProviderTest.java
@@ -100,9 +100,9 @@ public class StaticListClassPropertyValuesProviderTest
     @Test
     void getAllowedValuesWithLabel()
     {
-        // Needed to build localization string
+        // Needed to build localization string.
         when(this.baseClass.getName()).thenReturn("XWiki.TestClass");
-        // Needed to actually consider the localization in the display code
+        // Needed to actually consider the localization in the display code.
         when(this.context.getWiki()).thenReturn(mock(XWiki.class));
 
         StaticListClass staticListClass = new StaticListClass();
@@ -117,11 +117,11 @@ public class StaticListClassPropertyValuesProviderTest
         expected.getMetaData().put(META_DATA_LABEL, "Display Value");
         assertEquals(Collections.singletonList(expected), allowedValues.getPropertyValues());
 
-        // Test filter by label
+        // Test filter by label.
         allowedValues = this.staticListClassPropertyValuesProvider.getAllowedValues(staticListClass, 3, "Display");
         assertEquals(Collections.singletonList(expected), allowedValues.getPropertyValues());
 
-        // Test filter by translated label
+        // Test filter by translated label.
         String translatedLabel = "Translated";
         when(this.localization.getTranslationPlain("XWiki.TestClass_Test_Id")).thenReturn(translatedLabel);
         expected.getMetaData().put(META_DATA_LABEL, translatedLabel);
@@ -132,9 +132,9 @@ public class StaticListClassPropertyValuesProviderTest
     @Test
     void getValueFromQueryResult()
     {
-        // Needed to build localization string
+        // Needed to build localization string.
         when(this.baseClass.getName()).thenReturn("XWiki.TestQueryResult");
-        // Needed to actually consider the localization in the display code
+        // Needed to actually consider the localization in the display code.
         when(this.context.getWiki()).thenReturn(mock(XWiki.class));
 
         StaticListClass staticListClass = new StaticListClass();
@@ -146,7 +146,7 @@ public class StaticListClassPropertyValuesProviderTest
             staticListClass);
         assertEquals(new PropertyValue("Foo"), actual);
 
-        // For values without definition, the given id should be returned
+        // For values without definition, the given id should be returned.
         actual = this.staticListClassPropertyValuesProvider.getValueFromQueryResult("Baz", staticListClass);
         assertEquals(new PropertyValue("Baz"), actual);
 
@@ -159,7 +159,7 @@ public class StaticListClassPropertyValuesProviderTest
         expected.getMetaData().put(META_DATA_LABEL, translatedLabel);
         when(this.localization.getTranslationPlain("XWiki.TestQueryResult_Query_Id")).thenReturn(translatedLabel);
 
-        // Test filter by translated label
+        // Test filter by translated label.
         actual = this.staticListClassPropertyValuesProvider.getValueFromQueryResult("Id", staticListClass);
         assertEquals(expected, actual);
     }
@@ -167,9 +167,9 @@ public class StaticListClassPropertyValuesProviderTest
     @Test
     void getValueFromQueryResultWithSpecialCharacter()
     {
-        // Needed to build localization string
+        // Needed to build localization string.
         when(this.baseClass.getName()).thenReturn("XWiki.TestQueryResultSpecial");
-        // Needed to actually consider the localization in the display code
+        // Needed to actually consider the localization in the display code.
         when(this.context.getWiki()).thenReturn(mock(XWiki.class));
 
         StaticListClass staticListClass = new StaticListClass();
@@ -194,7 +194,7 @@ public class StaticListClassPropertyValuesProviderTest
         expected.getMetaData().put(META_DATA_LABEL, translatedLabel);
         when(this.localization.getTranslationPlain("XWiki.TestQueryResultSpecial_Query_Id")).thenReturn(translatedLabel);
 
-        // Test filter by translated label
+        // Test filter by translated label.
         actual = this.staticListClassPropertyValuesProvider.getValueFromQueryResult("Id", staticListClass);
         assertEquals(expected, actual);
     }


### PR DESCRIPTION
This uses the view displayer to populate the metadata that is returned by the REST service.

Jira issue: https://jira.xwiki.org/browse/XWIKI-19048

I would like to get feedback on two questions here:

* The unit test (`StaticListClassPropertyValuesProviderTest`) is not just testing `StaticListClassPropertyValuesProvider` but also its interaction with `ListClass` using an actual `ListClass` object and not a mock. This really helped me during the development to ensure that I'm correctly using the interface and, e.g., handling the XML-encoded result value correctly. However, this is kind of against the idea of an isolated unit test. What do you think, is this kind of test okay or should I change it to, e.g., mock the results of the `ListClass`-methods?
* The implementation of `StaticListClassPropertyValuesProvider::constructPropertyValueForId` is currently quite ugly as it uses the public method `ListClass::displayView`. This involves constructing an additional object with a property just to fulfill the requirements of the parameters and XML-unescaping the result. Its code could be simplified a lot using [`ListClass::getDisplayValue`](https://github.com/xwiki/xwiki-platform/blob/dcfb67ad6b5b78d7d506760ce78d9a3d44b125af/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java#L625), which is currently protected or private, depending on the variant. This method could be used just with the values we already have and a map from values to labels that we can easily obtain and also doesn't require unescaping the result. What do you think about making one of the variants of `ListClass::getDisplayValue` public?