### PR TITLE
[Misc] Fix reloading of entries after editing LD cells in integration tests

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-pageobjects/src/main/java/org/xwiki/livedata/test/po/TableLayoutElement.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-pageobjects/src/main/java/org/xwiki/livedata/test/po/TableLayoutElement.java
@@ -713,7 +713,7 @@ public class TableLayoutElement extends BaseElement
             return element.findElements(selector).isEmpty();
         });
 
-        // Wait for reload after saving
+        // Wait for reload after saving.
         if (save) {
             waitUntilReady();
         }


### PR DESCRIPTION
The page object now properly waits for the reloading of the entries.
This also fixes waiting for the live data to load when the live data is empty and a related code style issue (method only used in negated form).