### PR TITLE
XWIKI-18752: Replace the livetable from the restore deleted page form with a Live Data

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/pom.xml
@@ -168,6 +168,19 @@
       <version>${project.version}</version>
       <scope>runtime</scope>
     </dependency>
+    <!-- Live Data macro -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-livedata-macro</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-livedata-livetable</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/restore.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/restore.vm
@@ -1,3 +1,7 @@
+##!source.syntax=xwiki/2.1
+{{template name='refactoringStatus_macros.vm' output='false' /}}
+
+{{velocity}}
 ## ---------------------------------------------------------------------------
 ## See the NOTICE file distributed with this work for additional
 ## information regarding copyright ownership.
@@ -32,23 +36,26 @@
 #######################################################
 ##                     DISPLAY
 #######################################################
+{{html wiki='true' clean='false'}}
 #if ($xcontext.action == 'get' && "$!request.jobId" != '')
   #handleStatusRequest()
 #else
-  #template("startpage.vm")
+  {{template name='startpage.vm' /}}
   <div class="main">
     <div id="mainContentArea">
-      #define($title)<a href="$doc.getURL('view')">$!escapetool.xml($doc.plainTitle)</a>#end
-      #set($titleToDisplay = $services.localization.render('core.restore.title', [$title]))
+      #define($titleLink)<a href="$doc.getURL('view')">$!escapetool.xml($doc.plainTitle)</a>#end
+      #set($titleToDisplay = $services.localization.render('core.restore.title', [$titleLink]))
       <div class="xcontent">
-        #template('contentheader.vm')
+        {{template name='contentheader.vm' /}}
         #controller()
         <div class="clearfloats"></div>
       </div> ## xcontent
     </div>## mainContentArea
   </div>## main
-  #template("endpage.vm")
+  {{template name='endpage.vm' /}}
 #end
+{{/html}}
+
 #######################################################
 ##                    CONTROLLER
 #######################################################
@@ -78,7 +85,7 @@
   #handleStatusRequest()
 #end
 #macro (handleStatusRequest)
-  #template('job_macros.vm')
+  {{template name='job_macros.vm' /}}
   #set ($jobStatus = $services.job.getJobStatus($stringtool.split($request.jobId, '/')))
   #if ($jobStatus)
     #if ($xcontext.action == 'get')
@@ -97,10 +104,10 @@
   #getJobStatusJSON($jobStatus $json)
   #set ($json.message = "#displayJobFinishedMessage($jobStatus)")
   $response.setContentType('application/json')
-  $jsontool.serialize($json)
+  #jsonResponse($json)
 #end
 #macro (displayJobFinishedMessage $jobStatus)
-  #template('refactoringStatus_macros.vm')
+  {{template name='refactoringStatus_macros.vm' /}}
   #displayRefactoringJobFinishedMessage($jobStatus 'core.restore.status.success' 'core.restore.status.failure')
 #end
 #######################################################
@@ -147,22 +154,47 @@
         </div>
       </div>
       ##
-      ## List the deleted documents in the batch using a livetable.
+      ## List the deleted documents in the batch using a live data.
       ##
-      #set ($collist = ['doc.name', 'doc.location', '_actions'])
-      #set ($colprops = {
-        'doc.name'     : { 'link' : 'view', 'filterable': false, 'sortable' : 'false' },
-        'doc.location' : { 'type' : 'text', 'link' : false, 'filterable': true, 'html': true},
-        '_actions'     : { 'actions' : ['restore', 'delete'] }
+      #set ($sourceParameters = $escapetool.url({
+        'template': 'getdeleteddocuments.vm',
+        'doc.batchId': $deletedDocument.batchId,
+        'translationPrefix' : 'core.restore.batch.'
+      }))
+      #set ($liveDataConfig = {
+        'meta': {
+          'propertyDescriptors': [
+            {
+              'id': '_actions',
+              'displayer': {
+                'id': 'actions',
+                'actions': ['restore', 'delete']
+              }
+            },
+            {
+              'id': 'doc.name',
+              'filterable': false,
+              'sortable': false
+            }
+          ],
+          'actions': [
+            {
+              'id': 'restore',
+              'icon': 'refresh',
+              'allowProperty': 'doc.hasrestore',
+              'urlProperty': 'doc.restore_url'
+            }
+          ]
+        }
       })
-      #set ($urlParameters = "xpage=getdeleteddocuments&doc.batchId=$!{escapetool.url($deletedDocument.batchId)}")
-      #set ($options = { 
-        'url' : "$doc.getURL('get', $urlParameters)",
-        'translationPrefix' : 'core.restore.batch.',
-        'outputOnlyHtml' : true,
-        'selectedColumn' : 'doc.location'
-      })
-      #livetable('deletedBatch' $collist $colprops $options)
+
+      {{liveData
+        id='deletedBatch'
+        source='liveTable'
+        sourceParameters="$sourceParameters"
+        properties='doc.name,doc.location,_actions'
+        sort='doc.location'}}$jsontool.serialize($liveDataConfig){{/liveData}}
+
     #end
     #displayPanel('panel-batch', 'panel-default', $heading, $body)
   #end
@@ -187,3 +219,4 @@
   #end
   <a class="btn btn-default" href="$cancelUrl">$services.localization.render('core.restore.confirm.no')</a>
 #end
+{{/velocity}}

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/restore.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/restore.vm
@@ -36,23 +36,23 @@
 #######################################################
 ##                     DISPLAY
 #######################################################
-{{html wiki='true' clean='false'}}
+{{html clean="false"}}
 #if ($xcontext.action == 'get' && "$!request.jobId" != '')
   #handleStatusRequest()
 #else
-  {{template name='startpage.vm' /}}
+  #template("startpage.vm")
   <div class="main">
     <div id="mainContentArea">
       #define($titleLink)<a href="$doc.getURL('view')">$!escapetool.xml($doc.plainTitle)</a>#end
       #set($titleToDisplay = $services.localization.render('core.restore.title', [$titleLink]))
       <div class="xcontent">
-        {{template name='contentheader.vm' /}}
+        #template('contentheader.vm')
         #controller()
         <div class="clearfloats"></div>
       </div> ## xcontent
     </div>## mainContentArea
   </div>## main
-  {{template name='endpage.vm' /}}
+  #template("endpage.vm")
 #end
 {{/html}}
 
@@ -85,7 +85,7 @@
   #handleStatusRequest()
 #end
 #macro (handleStatusRequest)
-  {{template name='job_macros.vm' /}}
+  #template('job_macros.vm')
   #set ($jobStatus = $services.job.getJobStatus($stringtool.split($request.jobId, '/')))
   #if ($jobStatus)
     #if ($xcontext.action == 'get')
@@ -103,11 +103,9 @@
 #macro (outputJobStatusJSON $jobStatus)
   #getJobStatusJSON($jobStatus $json)
   #set ($json.message = "#displayJobFinishedMessage($jobStatus)")
-  $response.setContentType('application/json')
   #jsonResponse($json)
 #end
 #macro (displayJobFinishedMessage $jobStatus)
-  {{template name='refactoringStatus_macros.vm' /}}
   #displayRefactoringJobFinishedMessage($jobStatus 'core.restore.status.success' 'core.restore.status.failure')
 #end
 #######################################################
@@ -187,6 +185,7 @@
           ]
         }
       })
+      {{/html}}
 
       {{liveData
         id='deletedBatch'
@@ -195,6 +194,7 @@
         properties='doc.name,doc.location,_actions'
         sort='doc.location'}}$jsontool.serialize($liveDataConfig){{/liveData}}
 
+      {{html clean="false"}}
     #end
     #displayPanel('panel-batch', 'panel-default', $heading, $body)
   #end

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-pageobjects/src/main/java/org/xwiki/flamingo/skin/test/po/RestoreStatusPage.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-pageobjects/src/main/java/org/xwiki/flamingo/skin/test/po/RestoreStatusPage.java
@@ -28,7 +28,7 @@ import org.xwiki.test.ui.po.ViewPage;
  * Represents the status page of the restore refactoring action.
  *
  * @version $Id$
- * @since 13.10RC1
+ * @since 15.8RC1
  */
 public class RestoreStatusPage extends RefactoringStatusPage
 {

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-pageobjects/src/main/java/org/xwiki/flamingo/skin/test/po/RestoreStatusPage.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-pageobjects/src/main/java/org/xwiki/flamingo/skin/test/po/RestoreStatusPage.java
@@ -17,41 +17,35 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.xwiki.test.ui.po;
+package org.xwiki.flamingo.skin.test.po;
 
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
+import org.xwiki.test.ui.po.RefactoringStatusPage;
+import org.xwiki.test.ui.po.ViewPage;
 
 /**
- * Represents the page that displays the status of a copy operation. This page is normally loaded after the user clicks
- * on the Copy button (i.e. after the copy parameters have been submitted).
- * 
+ * Represents the status page of the restore refactoring action.
+ *
  * @version $Id$
- * @since 7.4.1
- * @since 8.0M1
+ * @since 13.10RC1
  */
-public class CopyOrRenameOrDeleteStatusPage extends RefactoringStatusPage
+public class RestoreStatusPage extends RefactoringStatusPage
 {
-    @FindBy(css = ".job-status .col-lg-6:first-child .breadcrumb > li:last-child a")
-    private WebElement oldPage;
+    @FindBy(xpath = "//div[@id='document-title']/h1/a")
+    private WebElement viewLink;
 
-    @FindBy(css = ".job-status .col-lg-6:last-child .breadcrumb > li:last-child a")
-    private WebElement newPage;
-
-    public ViewPage gotoOriginalPage()
+    /**
+     * @return The restored page.
+     */
+    public ViewPage gotoRestoredPage()
     {
-        this.oldPage.click();
-        return new ViewPage();
-    }
-
-    public ViewPage gotoNewPage()
-    {
-        this.newPage.click();
+        this.viewLink.click();
         return new ViewPage();
     }
 
     @Override
-    public CopyOrRenameOrDeleteStatusPage waitUntilFinished()
+    public RestoreStatusPage waitUntilFinished()
     {
         super.waitUntilFinished();
         return this;

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-pageobjects/src/main/java/org/xwiki/flamingo/skin/test/po/UndeletePage.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-pageobjects/src/main/java/org/xwiki/flamingo/skin/test/po/UndeletePage.java
@@ -1,0 +1,158 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.flamingo.skin.test.po;
+
+import java.util.List;
+
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.xwiki.livedata.test.po.LiveDataElement;
+import org.xwiki.test.ui.po.BasePage;
+import org.xwiki.test.ui.po.DeletePageOutcomePage;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Represents the undelete action where a single page or a whole batch of pages can be restored.
+ *
+ * @version $Id$
+ * @since 13.10RC1
+ */
+public class UndeletePage extends BasePage
+{
+    /**
+     * Name of the page Live Data column.
+     */
+    public static final String LIVE_DATA_PAGE = "Page";
+
+    /**
+     * Name of the location Live Data column.
+     */
+    public static final String LIVE_DATA_LOCATION = "Location";
+
+    /**
+     * Name of the actions Live Data column.
+     */
+    public static final String LIVE_DATA_ACTIONS = "Actions";
+
+    private static final String DELETER_PREFIX = "Deleted by:\n";
+
+    private static final String DELETED_BATCH_ID_PREFIX = "Deleted Batch ID\n";
+
+    @FindBy(xpath = "//input[@id = 'includeBatch']")
+    private List<WebElement> includeBatchCheckBoxes;
+
+    @FindBy(xpath = "//div[@id = 'mainContentArea']/div[@class='xcontent']/form//a[@class = 'panel-collapse-carret']")
+    private WebElement panelToggleLink;
+
+    @FindBy(xpath = "//div[@id = 'panel-batch']/div[@class = 'row']/div[@class='col-xs-12 col-lg-4']")
+    private WebElement deleter;
+
+    @FindBy(xpath = "//div[@id = 'panel-batch']/div[@class = 'row']/div[last()]")
+    private WebElement deletedBatchId;
+
+    @FindBy(xpath = "//div[@id = 'mainContentArea']/div[@class = 'xcontent']/form/a[text() = 'Cancel']")
+    private WebElement cancelLink;
+
+    @FindBy(xpath = "//div[@id = 'mainContentArea']/div[@class = 'xcontent']/form/button[text() = 'Restore']")
+    private WebElement restoreButton;
+
+    /**
+     * @return If there is a batch of pages that can be restored (otherwise it's just a single page).
+     */
+    public boolean hasBatch()
+    {
+        return !this.includeBatchCheckBoxes.isEmpty();
+    }
+
+    /**
+     * @return If the whole batch will be restored.
+     */
+    public boolean isBatchIncluded()
+    {
+        return this.includeBatchCheckBoxes.get(0).isSelected();
+    }
+
+    /**
+     * @param includeBatch Set if the whole batch shall be included when restoring.
+     */
+    public void setBatchIncluded(boolean includeBatch)
+    {
+        if (isBatchIncluded() != includeBatch) {
+            this.includeBatchCheckBoxes.get(0).click();
+        }
+    }
+
+    /**
+     * Toggles the visibility of the panel with the batch of documents.
+     */
+    public void toggleBatchPanel()
+    {
+        this.panelToggleLink.click();
+    }
+
+    /**
+     * @return The live data element with the deleted pages.
+     */
+    public LiveDataElement getDeletedBatchLiveData()
+    {
+        return new LiveDataElement("deletedBatch");
+    }
+
+    /**
+     * @return The name of the user who deleted the batch.
+     */
+    public String getPageDeleter()
+    {
+        return getTextAfterPrefix(DELETER_PREFIX, this.deleter.getText());
+    }
+
+    /**
+     * @return The id of the deleted batch.
+     */
+    public String getDeletedBatchId()
+    {
+        return getTextAfterPrefix(DELETED_BATCH_ID_PREFIX, this.deletedBatchId.getText());
+    }
+
+    private String getTextAfterPrefix(String prefix, String fullText)
+    {
+        assertTrue(fullText.startsWith(prefix));
+        return fullText.substring(prefix.length());
+    }
+
+    /**
+     * @return The page with the result of the deletion.
+     */
+    public DeletePageOutcomePage clickCancel()
+    {
+        this.cancelLink.click();
+        return new DeletePageOutcomePage();
+    }
+
+    /**
+     * @return The status page of the restore refactoring job.
+     */
+    public RestoreStatusPage clickRestore()
+    {
+        this.restoreButton.click();
+        return new RestoreStatusPage();
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-pageobjects/src/main/java/org/xwiki/flamingo/skin/test/po/UndeletePage.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-pageobjects/src/main/java/org/xwiki/flamingo/skin/test/po/UndeletePage.java
@@ -19,8 +19,9 @@
  */
 package org.xwiki.flamingo.skin.test.po;
 
-import java.util.List;
+import java.util.Optional;
 
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.xwiki.livedata.test.po.LiveDataElement;
@@ -33,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Represents the undelete action where a single page or a whole batch of pages can be restored.
  *
  * @version $Id$
- * @since 13.10RC1
+ * @since 15.8RC1
  */
 public class UndeletePage extends BasePage
 {
@@ -56,9 +57,6 @@ public class UndeletePage extends BasePage
 
     private static final String DELETED_BATCH_ID_PREFIX = "Deleted Batch ID\n";
 
-    @FindBy(xpath = "//input[@id = 'includeBatch']")
-    private List<WebElement> includeBatchCheckBoxes;
-
     @FindBy(xpath = "//div[@id = 'mainContentArea']/div[@class='xcontent']/form//a[@class = 'panel-collapse-carret']")
     private WebElement panelToggleLink;
 
@@ -75,11 +73,19 @@ public class UndeletePage extends BasePage
     private WebElement restoreButton;
 
     /**
+     * @return the checkbox for including the whole batch if there is any
+     */
+    private Optional<WebElement> getIncludeBatchCheckBox()
+    {
+        return getDriver().findElementsWithoutWaiting(By.id("includeBatch")).stream().findFirst();
+    }
+
+    /**
      * @return If there is a batch of pages that can be restored (otherwise it's just a single page).
      */
     public boolean hasBatch()
     {
-        return !this.includeBatchCheckBoxes.isEmpty();
+        return getIncludeBatchCheckBox().isPresent();
     }
 
     /**
@@ -87,7 +93,7 @@ public class UndeletePage extends BasePage
      */
     public boolean isBatchIncluded()
     {
-        return this.includeBatchCheckBoxes.get(0).isSelected();
+        return getIncludeBatchCheckBox().map(WebElement::isSelected).orElse(false);
     }
 
     /**
@@ -96,7 +102,7 @@ public class UndeletePage extends BasePage
     public void setBatchIncluded(boolean includeBatch)
     {
         if (isBatchIncluded() != includeBatch) {
-            this.includeBatchCheckBoxes.get(0).click();
+            getIncludeBatchCheckBox().orElseThrow().click();
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/DeletePageOutcomePage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/DeletePageOutcomePage.java
@@ -203,7 +203,7 @@ public class DeletePageOutcomePage extends ViewPage
     /**
      * Clicks on the batch link. Goes to the undelete action.
      *
-     * @since 13.10RC1
+     * @since 15.8RC1
      */
     public void clickBatchLink()
     {

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/DeletePageOutcomePage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/DeletePageOutcomePage.java
@@ -39,6 +39,9 @@ public class DeletePageOutcomePage extends ViewPage
     @FindBy(xpath = "//p[@class='xwikimessage']")
     private WebElement message;
 
+    @FindBy(xpath = "//table[@class='centered']/tbody/tr/td[3]/a")
+    private WebElement batchLink;
+
     /**
      * Return first page deleted deleter.
      * @since 3.2M3
@@ -195,5 +198,15 @@ public class DeletePageOutcomePage extends ViewPage
         } else {
             return deletedPagesEntries.get(actualEntryNumber).clickView();
         }
+    }
+
+    /**
+     * Clicks on the batch link. Goes to the undelete action.
+     *
+     * @since 13.10RC1
+     */
+    public void clickBatchLink()
+    {
+        this.batchLink.click();
     }
 }

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/RefactoringStatusPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/RefactoringStatusPage.java
@@ -27,7 +27,7 @@ import org.openqa.selenium.support.FindBy;
  * Represents the status page of a refactoring job.
  *
  * @version $Id$
- * @since 13.10RC1
+ * @since 15.8RC1
  */
 public class RefactoringStatusPage extends BasePage
 {
@@ -51,6 +51,9 @@ public class RefactoringStatusPage extends BasePage
         return this;
     }
 
+    /**
+     * @return the status message displayed on the page after the job finished
+     */
     public String getInfoMessage()
     {
         return this.message.getText();

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/RefactoringStatusPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/RefactoringStatusPage.java
@@ -19,41 +19,40 @@
  */
 package org.xwiki.test.ui.po;
 
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
 /**
- * Represents the page that displays the status of a copy operation. This page is normally loaded after the user clicks
- * on the Copy button (i.e. after the copy parameters have been submitted).
- * 
+ * Represents the status page of a refactoring job.
+ *
  * @version $Id$
- * @since 7.4.1
- * @since 8.0M1
+ * @since 13.10RC1
  */
-public class CopyOrRenameOrDeleteStatusPage extends RefactoringStatusPage
+public class RefactoringStatusPage extends BasePage
 {
-    @FindBy(css = ".job-status .col-lg-6:first-child .breadcrumb > li:last-child a")
-    private WebElement oldPage;
+    private static final String MESSAGE_CSS_SELECTOR =
+        ".xcontent.job-status .box.successmessage, .xcontent.job-status .box.errormessage";
 
-    @FindBy(css = ".job-status .col-lg-6:last-child .breadcrumb > li:last-child a")
-    private WebElement newPage;
+    @FindBy(css = MESSAGE_CSS_SELECTOR)
+    private WebElement message;
 
-    public ViewPage gotoOriginalPage()
+    /**
+     * Waits until the operation finishes.
+     *
+     * @return this page
+     */
+    public RefactoringStatusPage waitUntilFinished()
     {
-        this.oldPage.click();
-        return new ViewPage();
-    }
-
-    public ViewPage gotoNewPage()
-    {
-        this.newPage.click();
-        return new ViewPage();
-    }
-
-    @Override
-    public CopyOrRenameOrDeleteStatusPage waitUntilFinished()
-    {
-        super.waitUntilFinished();
+        // Waits for a success or error message to be displayed before continuing. Previously, this method was waiting
+        // for the job progress bar to be "missing" before continuing, which could happen too early, before the bar was
+        // even displayed once.
+        getDriver().waitUntilElementIsVisible(By.cssSelector(MESSAGE_CSS_SELECTOR));
         return this;
+    }
+
+    public String getInfoMessage()
+    {
+        return this.message.getText();
     }
 }

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/getdeleteddocuments.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/getdeleteddocuments.vm
@@ -119,6 +119,8 @@ $response.setContentType("application/json")
     #set ($discard = $row.put('doc_name', $title))
     #set ($location = "#hierarchy($documentReference, {'limit': 5, 'plain': false, 'local': true, 'displayTitle': false})")
     #set ($discard = $row.put('doc_location', $location))
+    ## Include fullName as it is used as the id of the entry in Live Data.
+    #set ($discard = $row.put('doc_fullName', $deletedDocument.fullName))
     #set ($discard = $row.put('doc_date', $xwiki.formatDate($deletedDocument.date)))
     #set ($discard = $row.put('doc_deleter', $xwiki.getUserName($deletedDocument.deleter, false)))
     #set ($discard = $row.put('doc_deleter_url', $xwiki.getURL($deletedDocument.deleter)))


### PR DESCRIPTION
* Change `restore.vm` to use wiki syntax and add the live data macro
* Add an integration test for the undelete action
* Introduce a new page object class `RefactoringStatusPage` class that takes parts of `CopyOrRenameOrDeleteStatusPage`
* Introduce a new page object class `RestoreStatusPage` inheriting from `RefactoringStatusPage`
* Introduce a new page object class `UndeletePage`

JIRA issue: https://jira.xwiki.org/browse/XWIKI-18752

Before:
![XWIKI-18752-Before](https://user-images.githubusercontent.com/198317/138678247-18729db5-f682-4e5d-a9cc-7d2112261a1d.png)

After:
![XWIKI-18752-After](https://user-images.githubusercontent.com/198317/138678244-3aa8607d-d6c3-4cd8-9700-81eace86c38d.png)

