### PR TITLE
XWIKI-11169: Annotations can not be displayed on content generated by the HTML macro

### DIFF
--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Script.xml
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Script.xml
@@ -985,7 +985,8 @@ XWiki.Annotation = Class.create({
     // Check if the annotation was found.
     var plainTextStartOffset = ann.fields.find(field =&gt; field.name == 'plainTextStartOffset');
     var plainTextEndOffset = ann.fields.find(field =&gt; field.name == 'plainTextEndOffset');
-    if (!plainTextStartOffset.value || !plainTextEndOffset.value) {
+    if ((!plainTextStartOffset.value &amp;&amp; plainTextStartOffset.value !== 0) ||
+        (!plainTextEndOffset.value &amp;&amp; plainTextEndOffset.value !== 0)) {
       return false;
     }
 
@@ -1961,7 +1962,8 @@ require(['jquery', 'xwiki-text-offset-updater', 'xwiki-events-bridge'], function
         var plainTextStartOffset = ann.fields.find(field =&gt; field.name == 'plainTextStartOffset');
         var plainTextEndOffset = ann.fields.find(field =&gt; field.name == 'plainTextEndOffset');
         // Check if the annotation was found.
-        if (!plainTextStartOffset.value || !plainTextEndOffset.value) {
+        if ((!plainTextStartOffset.value &amp;&amp; plainTextStartOffset.value !== 0) ||
+            (!plainTextEndOffset.value &amp;&amp; plainTextEndOffset.value !== 0)) {
           return;
         }
         plainTextStartOffset.value = offsetUpdater.findOffsetAfterChanges(changes, parseInt(plainTextStartOffset.value));

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Script.xml
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Script.xml
@@ -985,8 +985,7 @@ XWiki.Annotation = Class.create({
     // Check if the annotation was found.
     var plainTextStartOffset = ann.fields.find(field =&gt; field.name == 'plainTextStartOffset');
     var plainTextEndOffset = ann.fields.find(field =&gt; field.name == 'plainTextEndOffset');
-    if ((!plainTextStartOffset.value &amp;&amp; plainTextStartOffset.value !== 0) ||
-        (!plainTextEndOffset.value &amp;&amp; plainTextEndOffset.value !== 0)) {
+    if (plainTextStartOffset.value === null || plainTextEndOffset.value === null) {
       return false;
     }
 
@@ -1962,8 +1961,7 @@ require(['jquery', 'xwiki-text-offset-updater', 'xwiki-events-bridge'], function
         var plainTextStartOffset = ann.fields.find(field =&gt; field.name == 'plainTextStartOffset');
         var plainTextEndOffset = ann.fields.find(field =&gt; field.name == 'plainTextEndOffset');
         // Check if the annotation was found.
-        if ((!plainTextStartOffset.value &amp;&amp; plainTextStartOffset.value !== 0) ||
-            (!plainTextEndOffset.value &amp;&amp; plainTextEndOffset.value !== 0)) {
+        if (plainTextStartOffset.value === null || plainTextEndOffset.value === null) {
           return;
         }
         plainTextStartOffset.value = offsetUpdater.findOffsetAfterChanges(changes, parseInt(plainTextStartOffset.value));


### PR DESCRIPTION
* fix AnnotationsIT: the js condition to check if an annotation exists was failing when an anotation started at the beginning of the text since `!plainTextStartOffset.value` returns true for `0`