### PR TITLE
XWIKI-19201: XWikiDocument.getXObject(EntityReference, int, boolean, XWikiContext) ignores the given number when checking for an existing object

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -2891,7 +2891,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
     {
         DocumentReference absoluteClassReference = resolveClassReference(classReference);
 
-        BaseObject xobject = getXObject(absoluteClassReference);
+        BaseObject xobject = getXObject(absoluteClassReference, number);
 
         if (xobject == null && create) {
             xobject = BaseClass.newCustomClassInstance(absoluteClassReference, xcontext);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentMockitoTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentMockitoTest.java
@@ -615,6 +615,25 @@ public class XWikiDocumentMockitoTest
     }
 
     @Test
+    void testGetXObjectCreateWithNumber() throws XWikiException
+    {
+        assertSame(this.baseObject, this.document.getXObject(CLASS_REFERENCE, this.baseObject.getNumber(), true,
+            this.oldcore.getXWikiContext()));
+        assertSame(this.baseObject2, this.document.getXObject(CLASS_REFERENCE, this.baseObject2.getNumber(), true,
+            this.oldcore.getXWikiContext()));
+        assertSame(this.baseObject, this.document.getXObject((EntityReference) CLASS_REFERENCE,
+            this.baseObject.getNumber(), true, this.oldcore.getXWikiContext()));
+        assertSame(this.baseObject2, this.document.getXObject((EntityReference) CLASS_REFERENCE,
+            this.baseObject2.getNumber(), true, this.oldcore.getXWikiContext()));
+
+        BaseObject newObject = this.document.getXObject(CLASS_REFERENCE, 42, true, this.oldcore.getXWikiContext());
+        assertNotSame(this.baseObject, newObject);
+        assertNotSame(this.baseObject2, newObject);
+        assertEquals(42, newObject.getNumber());
+        assertSame(newObject, this.document.getXObject(CLASS_REFERENCE, newObject.getNumber()));
+    }
+
+    @Test
     void testGetXObjectsWhenClassDoesNotExist()
     {
         assertEquals(Collections.emptyList(),


### PR DESCRIPTION
* Use the provided number for getting the object
* Add a unit test to check the desired behavior and avoid a regression

Jira issue: https://jira.xwiki.org/browse/XWIKI-19201