### PR TITLE
XWIKI-19202: XWikiDocument.readObjectsFromFormUpdateOrCreate() creates duplicate objects when ids are non-continuous

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -4034,12 +4034,9 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
 
     /**
      * Create and/or update objects in a document given a list of HTTP parameters of the form {@code
-     * <spacename>.<classname>_<number>_<propertyname>}. If the object already exists, the field is replace by the given
-     * value. If the object doesn't exist in the document, it is created then the property {@code <propertyname>} is
-     * initialized with the given value. An object is only created if the given {@code <number>} is 'one-more' than the
-     * existing number of objects. For example, if the document already has 2 objects of type {@code Space.Class}, then
-     * it will create a new object only with {@code Space.Class_2_prop=something}. Every other parameter like {@code
-     * Space.Class_42_prop=foobar} for example, will be ignore.
+     * <spacename>.<classname>_<number>_<propertyname>}. If the object already exists, the field is replaced by the
+     * given value. If the object doesn't exist in the document, it is created and the property {@code <propertyname>}
+     * is initialized with the given value.
      *
      * @param eform is form information that contains all the query parameters
      * @param context
@@ -4077,11 +4074,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
                 }
 
                 if (!requestObjectPropertyMap.isEmpty()) {
-                    BaseObject oldObject = getXObject(requestClassReference, requestObjectNumber);
-                    if (oldObject == null) {
-                        // Create the object only if it has been numbered one more than the number of existing objects
-                        oldObject = newXObject(requestClassReference, context);
-                    }
+                    BaseObject oldObject = getXObject(requestClassReference, requestObjectNumber, true, context);
                     BaseClass baseClass = oldObject.getXClass(context);
                     BaseObject newObject = (BaseObject) baseClass.fromMap(requestObjectPropertyMap, oldObject);
                     newObject.setNumber(oldObject.getNumber());

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentMockitoTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentMockitoTest.java
@@ -376,6 +376,7 @@ public class XWikiDocumentMockitoTest
         assertNotNull(this.document.getXObject(baseClass.getDocumentReference(), 3));
         assertEquals("blabla", this.document.getXObject(baseClass.getDocumentReference(), 3).getStringValue("string"));
         assertEquals(13, this.document.getXObject(baseClass.getDocumentReference(), 3).getIntValue("int"));
+        assertNull(this.document.getXObject(baseClass.getDocumentReference(), 4));
         assertNotNull(this.document.getXObject(baseClass.getDocumentReference(), 42));
         assertEquals("bloublou",
             this.document.getXObject(baseClass.getDocumentReference(), 42).getStringValue("string"));


### PR DESCRIPTION
* Create objects directly with the correct number
* Add an assertion in the test that no duplicate object is created
* Change the JavaDoc comment to match the implementation

Jira issue: https://jira.xwiki.org/browse/XWIKI-19202

Note: this depends on #1722 as the used `getXObject` variant is buggy without it.