### PR TITLE
XWIKI-19203: The xobjectNumbers from the addedObjects parameter are ignored

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -4099,12 +4099,8 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
             DocumentReference classReference = resolveClassReference(className);
             List<Integer> classIds = objectsToAdd.get(className);
             for (Integer classId : classIds) {
-                BaseObject xObject = getXObject(classReference, classId);
-
                 // we ensure that the object has not been added yet, for example because of the update or create.
-                if (xObject == null) {
-                    newXObject(classReference, context);
-                }
+                getXObject(classReference, classId, true, context);
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentMockitoTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentMockitoTest.java
@@ -402,14 +402,11 @@ public class XWikiDocumentMockitoTest
             mocker.registerMockComponent(DocumentReferenceResolver.TYPE_REFERENCE, "current");
 
         Map<String, String[]> parameters = generateFakeRequestMap();
-        parameters.put("space.page_32_string", new String[] {"thirty two"});
-        parameters.put("space.page_32_int", new String[] {"32"});
         BaseClass baseClass = generateFakeClass();
         generateFakeObjects();
         EditForm eform = new EditForm();
 
-        when(request.getParameter("objectPolicy")).thenReturn("updateOrCreate");
-        when(request.getParameterValues("addedObjects")).thenReturn(new String[] {"space.page_1", "space.page_32"});
+        when(request.getParameterValues("addedObjects")).thenReturn(new String[] {"space.page_1", "space.page_42"});
         when(request.getParameterValues("deletedObjects")).thenReturn(new String[] {"space.page_2"});
         when(request.getParameterMap()).thenReturn(parameters);
         when(documentReferenceResolverString.resolve("space.page")).thenReturn(this.document.getDocumentReference());
@@ -433,14 +430,8 @@ public class XWikiDocumentMockitoTest
         assertEquals("string2", this.document.getXObject(baseClass.getDocumentReference(), 1).getStringValue("string"));
         assertEquals(7, this.document.getXObject(baseClass.getDocumentReference(), 1).getIntValue("int"));
         assertNull(this.document.getXObject(baseClass.getDocumentReference(), 2));
-        assertNotNull(this.document.getXObject(baseClass.getDocumentReference(), 3));
-        assertEquals("blabla", this.document.getXObject(baseClass.getDocumentReference(), 3).getStringValue("string"));
-        assertEquals(13, this.document.getXObject(baseClass.getDocumentReference(), 3).getIntValue("int"));
+        assertNull(this.document.getXObject(baseClass.getDocumentReference(), 3));
         assertNull(this.document.getXObject(baseClass.getDocumentReference(), 4));
-        assertNotNull(this.document.getXObject(baseClass.getDocumentReference(), 32));
-        assertEquals("thirty two",
-            this.document.getXObject(baseClass.getDocumentReference(), 32).getStringValue("string"));
-        assertEquals(32, this.document.getXObject(baseClass.getDocumentReference(), 32).getIntValue("int"));
         assertNotNull(this.document.getXObject(baseClass.getDocumentReference(), 42));
         assertEquals("bloublou",
             this.document.getXObject(baseClass.getDocumentReference(), 42).getStringValue("string"));

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentMockitoTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentMockitoTest.java
@@ -383,6 +383,70 @@ public class XWikiDocumentMockitoTest
         assertEquals(7, this.document.getXObject(baseClass.getDocumentReference(), 42).getIntValue("int"));
     }
 
+    /**
+     * Unit test for {@link XWikiDocument#readFromForm(EditForm, XWikiContext)} .
+     */
+    @Test
+    void readAddedUpdatedAndRemovedObjectsFromForm() throws Exception
+    {
+        this.document = new XWikiDocument(new DocumentReference(DOCWIKI, DOCSPACE, DOCNAME));
+        this.oldcore.getSpyXWiki().saveDocument(this.document, "", true, this.oldcore.getXWikiContext());
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        MockitoComponentManager mocker = this.oldcore.getMocker();
+        XWikiContext context = this.oldcore.getXWikiContext();
+        DocumentReferenceResolver<String> documentReferenceResolverString =
+            mocker.registerMockComponent(DocumentReferenceResolver.TYPE_STRING, "current");
+        // Entity Reference resolver is used in <BaseObject>.getXClass()
+        DocumentReferenceResolver<EntityReference> documentReferenceResolverEntity =
+            mocker.registerMockComponent(DocumentReferenceResolver.TYPE_REFERENCE, "current");
+
+        Map<String, String[]> parameters = generateFakeRequestMap();
+        parameters.put("space.page_32_string", new String[] {"thirty two"});
+        parameters.put("space.page_32_int", new String[] {"32"});
+        BaseClass baseClass = generateFakeClass();
+        generateFakeObjects();
+        EditForm eform = new EditForm();
+
+        when(request.getParameter("objectPolicy")).thenReturn("updateOrCreate");
+        when(request.getParameterValues("addedObjects")).thenReturn(new String[] {"space.page_1", "space.page_32"});
+        when(request.getParameterValues("deletedObjects")).thenReturn(new String[] {"space.page_2"});
+        when(request.getParameterMap()).thenReturn(parameters);
+        when(documentReferenceResolverString.resolve("space.page")).thenReturn(this.document.getDocumentReference());
+        when(documentReferenceResolverString.resolve("InvalidSpace.InvalidPage"))
+            .thenReturn(new DocumentReference("wiki", "InvalidSpace", "InvalidPage"));
+        // This entity resolver with this 'resolve' method is used in
+        // <BaseCollection>.getXClassReference()
+        when(documentReferenceResolverEntity.resolve(any(EntityReference.class), any(DocumentReference.class)))
+            .thenReturn(this.document.getDocumentReference());
+        doReturn(this.document).when(this.oldcore.getSpyXWiki()).getDocument(this.document.getDocumentReference(),
+            context);
+
+        eform.setRequest(request);
+        eform.readRequest();
+        this.document.readFromForm(eform, context);
+
+        assertEquals(43, this.document.getXObjectSize(baseClass.getDocumentReference()));
+        assertEquals("bloublou",
+            this.document.getXObject(baseClass.getDocumentReference(), 0).getStringValue("string"));
+        assertEquals(42, this.document.getXObject(baseClass.getDocumentReference(), 0).getIntValue("int"));
+        assertEquals("string2", this.document.getXObject(baseClass.getDocumentReference(), 1).getStringValue("string"));
+        assertEquals(7, this.document.getXObject(baseClass.getDocumentReference(), 1).getIntValue("int"));
+        assertNull(this.document.getXObject(baseClass.getDocumentReference(), 2));
+        assertNotNull(this.document.getXObject(baseClass.getDocumentReference(), 3));
+        assertEquals("blabla", this.document.getXObject(baseClass.getDocumentReference(), 3).getStringValue("string"));
+        assertEquals(13, this.document.getXObject(baseClass.getDocumentReference(), 3).getIntValue("int"));
+        assertNull(this.document.getXObject(baseClass.getDocumentReference(), 4));
+        assertNotNull(this.document.getXObject(baseClass.getDocumentReference(), 32));
+        assertEquals("thirty two",
+            this.document.getXObject(baseClass.getDocumentReference(), 32).getStringValue("string"));
+        assertEquals(32, this.document.getXObject(baseClass.getDocumentReference(), 32).getIntValue("int"));
+        assertNotNull(this.document.getXObject(baseClass.getDocumentReference(), 42));
+        assertEquals("bloublou",
+            this.document.getXObject(baseClass.getDocumentReference(), 42).getStringValue("string"));
+        assertEquals(7, this.document.getXObject(baseClass.getDocumentReference(), 42).getIntValue("int"));
+    }
+
     @Test
     void testDeprecatedConstructors()
     {


### PR DESCRIPTION
* Create objects with the correct number
* Add a test case to test adding, updating and removing objects

Jira issue: https://jira.xwiki.org/browse/XWIKI-19203

Note: this depends on #1722 as `getXObject` has been buggy before.