### PR TITLE
XWIKI-19193: Objects are not created or removed during preview

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -146,6 +146,7 @@ import org.xwiki.rendering.transformation.TransformationManager;
 import org.xwiki.rendering.util.ErrorBlockGenerator;
 import org.xwiki.security.authorization.ContextualAuthorizationManager;
 import org.xwiki.security.authorization.Right;
+import org.xwiki.stability.Unstable;
 import org.xwiki.store.merge.MergeDocumentResult;
 import org.xwiki.store.merge.MergeManager;
 import org.xwiki.velocity.VelocityContextFactory;
@@ -4093,6 +4094,20 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
         readDocMetaFromForm(eform, context);
         readTranslationMetaFromForm(eform, context);
 
+        readAddedUpdatedAndRemovedObjectsFromForm(eform, context);
+    }
+
+    /**
+     * Adds objects, applies property updates and removes objects as specified in the form.
+     *
+     * @param eform The form from which the values shall be read.
+     * @param context The XWiki context.
+     * @throws XWikiException If an error occurs.
+     * @since 14.0RC1
+     */
+    @Unstable
+    public void readAddedUpdatedAndRemovedObjectsFromForm(EditForm eform, XWikiContext context) throws XWikiException
+    {
         // We add the new objects that have been submitted in the form, before filling them with their values.
         Map<String, List<Integer>> objectsToAdd = eform.getObjectsToAdd();
         for (String className : objectsToAdd.keySet()) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -4009,6 +4009,13 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
         }
     }
 
+    /**
+     * Updates properties of existing objects with the values from the given form.
+     *
+     * @param eform The form to read the values from
+     * @param context The context used for getting the classes of objects
+     * @throws XWikiException On errors
+     */
     public void readObjectsFromForm(EditForm eform, XWikiContext context) throws XWikiException
     {
         for (DocumentReference reference : getXObjects().keySet()) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/EditAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/EditAction.java
@@ -106,7 +106,7 @@ public class EditAction extends XWikiAction
 
         // The default values from the template can be overwritten by additional request parameters.
         updateDocumentTitleAndContentFromRequest(editedDocument, context);
-        editedDocument.readObjectsFromForm(editForm, context);
+        editedDocument.readAddedUpdatedAndRemovedObjectsFromForm(editForm, context);
 
         // Set the current user as creator, author and contentAuthor when the edited document is newly created to avoid
         // using XWikiGuest instead (because those fields were not previously initialized).

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentMockitoTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentMockitoTest.java
@@ -384,7 +384,7 @@ public class XWikiDocumentMockitoTest
     }
 
     /**
-     * Unit test for {@link XWikiDocument#readFromForm(EditForm, XWikiContext)} .
+     * Unit test for {@link XWikiDocument#readAddedUpdatedAndRemovedObjectsFromForm(EditForm, XWikiContext)}.
      */
     @Test
     void readAddedUpdatedAndRemovedObjectsFromForm() throws Exception
@@ -421,7 +421,7 @@ public class XWikiDocumentMockitoTest
 
         eform.setRequest(request);
         eform.readRequest();
-        this.document.readFromForm(eform, context);
+        this.document.readAddedUpdatedAndRemovedObjectsFromForm(eform, context);
 
         assertEquals(43, this.document.getXObjectSize(baseClass.getDocumentReference()));
         assertEquals("bloublou",


### PR DESCRIPTION
* Extract a new method `XWikiDocument.readAddedUpdatedAndRemovedObjectsFromForm()` from `readFromForm()`
* Change the existing unit test of `readFromForm()` to test this method instead (as it only tested the extracted code, anyways)
* Use this new method during preview/edit actions instead of `XWikiDocument.readObjectsFromForm()`

Jira issue: https://jira.xwiki.org/browse/XWIKI-19193