### PR TITLE
XWIKI-17568: clean sort parameter value

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/getdocuments.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/getdocuments.vm
@@ -81,7 +81,7 @@ $response.setContentType("application/json")
 ##
 #set ($order = "$!request.sort")
 #if (!$regextool.compile('^(doc\.)?\w+$').matcher($order).matches())
-  #set($order = '')
+  #set ($order = '')
 #end
 #set ($orderQueryPart = '')
 #if ($order != '')

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/getdocuments.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/getdocuments.vm
@@ -81,7 +81,8 @@ $response.setContentType("application/json")
 ##
 #set ($order = "$!request.sort")
 #if (!$regextool.compile('^(doc\.)?\w+$').matcher($order).matches())
-  #set ($order = '')
+  { "error" : "invalid sort parameter" }
+  #stop ("invalid sort parameter [$order] found")
 #end
 #set ($orderQueryPart = '')
 #if ($order != '')

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/getdocuments.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/getdocuments.vm
@@ -80,12 +80,12 @@ $response.setContentType("application/json")
 ## ORDER
 ##
 #set ($order = "$!request.sort")
-#if (!$regextool.compile('^(doc\.)?\w+$').matcher($order).matches())
-  { "error" : "invalid sort parameter" }
-  #stop ("invalid sort parameter [$order] found")
-#end
 #set ($orderQueryPart = '')
 #if ($order != '')
+  #if (!$regextool.compile('^(doc\.)?\w+$').matcher($order).matches())
+    { "error" : "invalid sort parameter" }
+    #stop ("invalid sort parameter [$order] found")
+  #end
   #set ($orderDirection = "$!{request.get('dir').toLowerCase()}")
   #if ("$!orderDirection" != '' && "$!orderDirection" != 'asc')
     #set($orderDirection = 'desc')

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/getdocuments.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/getdocuments.vm
@@ -80,6 +80,9 @@ $response.setContentType("application/json")
 ## ORDER
 ##
 #set ($order = "$!request.sort")
+#if (!$regextool.compile('^(doc\.)?\w+$').matcher($order).matches())
+  #set($order = '')
+#end
 #set ($orderQueryPart = '')
 #if ($order != '')
   #set ($orderDirection = "$!{request.get('dir').toLowerCase()}")


### PR DESCRIPTION
if the "sort" parameter does not look like a property name or any other accepted value then just scrap it.

Note: this also removes the `sort` parameter if it is a comma separated list of values, like `doc.fullName, doc.date`. As the `dir` parameter to define the sort direction would only applied to the last value (I think), this is unlikely to be a use case which has been supported. Should I take this into account, anyway? (It will make the regexp to check the parameter somewhat more complicated, however.)