### PR TITLE
XWIKI-19308: Modularize the redirection logic in XWikiAction

### DIFF
--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/web/XWikiActionCompatibilityAspect.aj
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/web/XWikiActionCompatibilityAspect.aj
@@ -17,15 +17,11 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package com.xpn.xwiki.internal.redirection;
+package com.xpn.xwiki.web;
 
 import java.io.IOException;
 
-import javax.inject.Named;
-import javax.inject.Singleton;
-
 import org.apache.commons.lang3.StringUtils;
-import org.xwiki.component.annotation.Component;
 import org.xwiki.model.EntityType;
 import org.xwiki.model.reference.DocumentReferenceResolver;
 import org.xwiki.model.reference.EntityReference;
@@ -39,22 +35,42 @@ import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.internal.mandatory.RedirectClassDocumentInitializer;
 import com.xpn.xwiki.objects.BaseObject;
-import com.xpn.xwiki.redirection.RedirectionFilter;
-import com.xpn.xwiki.web.Utils;
 
 /**
- * Perform a redirection based on the presence of a {@code XWiki.RedirectClass} XClass.
- *
+ * Add a backward compatibility layer to {@link XWikiAction}.
+ * 
  * @version $Id$
- * @since 14.0RC1
  */
-@Component
-@Singleton
-@Named("XWiki.RedirectClass")
-public class RedirectClassRedirectionFilter implements RedirectionFilter
+public privileged aspect XWikiActionCompatibilityAspect
 {
-    @Override
-    public boolean redirect(XWikiContext context) throws XWikiException
+    // handleRedirectObject and handleRedirectObject while previously {@code protected} are now {@code public} due of 
+    // technical limitations of AspectJ.
+    // See https://doanduyhai.wordpress.com/2011/12/12/advanced-aspectj-part-ii-inter-type-declaration/
+    // "If their is one thing to remember from access modifier, it’s that their semantic applies with respect to the
+    // declaring aspect, and not to the target."
+    // They must still be used as if {@code protected}.
+    /**
+     * Indicate if the XWiki.RedirectClass is handled by the action (see handleRedirectObject()).
+     * 
+     * @deprecated since 14.0RC1, see {@link XWikiAction#supportRedirections()}
+     */
+    @Deprecated
+    public boolean XWikiAction.handleRedirectObject = false;
+
+    /**
+     * Redirect the user to an other location if the document holds an XWiki.RedirectClass instance (used when a
+     * document is moved).
+     *
+     * @param context the XWiki context
+     * @return either or not a redirection have been sent
+     * @throws XWikiException if error occurs
+     * @since 8.0RC1
+     * @since 7.4.2
+     * 
+     * @deprecated since 14.0RC1, not used anymore
+     */
+    @Deprecated
+    public boolean XWikiAction.handleRedirectObject(XWikiContext context) throws XWikiException
     {
         WikiReference wikiReference = context.getWikiReference();
 
@@ -86,6 +102,9 @@ public class RedirectClassRedirectionFilter implements RedirectionFilter
             locationReference = entityReference.replaceParent(parentDocument, locationReference);
         }
 
+        // Get the URL corresponding to the location
+        // Note: the anchor part is lost in the process, because it is not sent to the server
+        // (see: http://stackoverflow.com/a/4276491)
         String url = context.getWiki().getURL(locationReference, context.getAction(),
             context.getRequest().getQueryString(), null, context);
 

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/web/XWikiActionCompatibilityAspect.aj
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/web/XWikiActionCompatibilityAspect.aj
@@ -19,25 +19,11 @@
  */
 package com.xpn.xwiki.web;
 
-import java.io.IOException;
-
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import org.apache.commons.lang3.StringUtils;
-import org.xwiki.model.EntityType;
-import org.xwiki.model.reference.DocumentReferenceResolver;
-import org.xwiki.model.reference.EntityReference;
-import org.xwiki.model.reference.WikiReference;
-import org.xwiki.resource.ResourceReference;
-import org.xwiki.resource.ResourceReferenceManager;
-import org.xwiki.resource.entity.EntityResourceReference;
-
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
-import com.xpn.xwiki.doc.XWikiDocument;
-import com.xpn.xwiki.internal.mandatory.RedirectClassDocumentInitializer;
-import com.xpn.xwiki.objects.BaseObject;
 import com.xpn.xwiki.redirection.RedirectionFilter;
 
 /**

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/web/ViewrevAction.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/web/ViewrevAction.java
@@ -42,7 +42,6 @@ public class ViewrevAction extends XWikiAction
     public ViewrevAction()
     {
         this.waitForXWikiInitialization = false;
-        this.handleRedirectObject = true;
     }
 
     @Override
@@ -61,5 +60,11 @@ public class ViewrevAction extends XWikiAction
         }
 
         return "view";
+    }
+
+    @Override
+    protected boolean supportRedirections()
+    {
+        return true;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/redirection/RedirectClassRedirectionFilter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/redirection/RedirectClassRedirectionFilter.java
@@ -1,0 +1,102 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xpn.xwiki.internal.redirection;
+
+import java.io.IOException;
+
+import javax.inject.Singleton;
+
+import org.apache.commons.lang3.StringUtils;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.model.EntityType;
+import org.xwiki.model.reference.DocumentReferenceResolver;
+import org.xwiki.model.reference.EntityReference;
+import org.xwiki.model.reference.WikiReference;
+import org.xwiki.resource.ResourceReference;
+import org.xwiki.resource.ResourceReferenceManager;
+import org.xwiki.resource.entity.EntityResourceReference;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.internal.mandatory.RedirectClassDocumentInitializer;
+import com.xpn.xwiki.objects.BaseObject;
+import com.xpn.xwiki.redirection.RedirectionFilter;
+import com.xpn.xwiki.web.Utils;
+
+/**
+ * Perform a redirection based on the presence of a {@code XWiki.RedirectClass} XClass.
+ *
+ * @version $Id$
+ * @since 14.0RC1
+ */
+@Component
+@Singleton
+public class RedirectClassRedirectionFilter implements RedirectionFilter
+{
+    @Override
+    public boolean redirect(XWikiContext context) throws XWikiException
+    {
+        WikiReference wikiReference = context.getWikiReference();
+
+        // Look if the document has a redirect object
+        XWikiDocument doc = context.getDoc();
+        BaseObject redirectObj = doc.getXObject(RedirectClassDocumentInitializer.REFERENCE);
+        if (redirectObj == null) {
+            return false;
+        }
+
+        // Get the location
+        String location = redirectObj.getStringValue("location");
+        if (StringUtils.isBlank(location)) {
+            return false;
+        }
+
+        // Resolve the location to get a reference
+        DocumentReferenceResolver<String> resolver = Utils.getComponent(DocumentReferenceResolver.TYPE_STRING);
+        EntityReference locationReference = resolver.resolve(location, wikiReference);
+
+        // Get the type of the current target
+        ResourceReference resourceReference = Utils.getComponent(ResourceReferenceManager.class).getResourceReference();
+        EntityResourceReference entityResource = (EntityResourceReference) resourceReference;
+        EntityReference entityReference = entityResource.getEntityReference();
+
+        // If the entity is inside a document, compute the new entity with the new document part.
+        if (entityReference.getType().ordinal() > EntityType.DOCUMENT.ordinal()) {
+            EntityReference parentDocument = entityReference.extractReference(EntityType.DOCUMENT);
+            locationReference = entityReference.replaceParent(parentDocument, locationReference);
+        }
+
+        // Get the URL corresponding to the location
+        // Note: the anchor part is lost in the process, because it is not sent to the server
+        // (see: http://stackoverflow.com/a/4276491)
+        String url = context.getWiki().getURL(locationReference, context.getAction(),
+            context.getRequest().getQueryString(), null, context);
+
+        // Send the redirection
+        try {
+            context.getResponse().sendRedirect(url);
+        } catch (IOException e) {
+            throw new XWikiException("Failed to redirect.", e);
+        }
+
+        return true;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/redirection/RedirectClassRedirectionFilter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/redirection/RedirectClassRedirectionFilter.java
@@ -21,6 +21,7 @@ package com.xpn.xwiki.internal.redirection;
 
 import java.io.IOException;
 
+import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
@@ -40,7 +41,6 @@ import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.internal.mandatory.RedirectClassDocumentInitializer;
 import com.xpn.xwiki.objects.BaseObject;
 import com.xpn.xwiki.redirection.RedirectionFilter;
-import com.xpn.xwiki.web.Utils;
 
 /**
  * Perform a redirection based on the presence of a {@code XWiki.RedirectClass} XClass.
@@ -53,6 +53,12 @@ import com.xpn.xwiki.web.Utils;
 @Named("XWiki.RedirectClass")
 public class RedirectClassRedirectionFilter implements RedirectionFilter
 {
+    @Inject
+    private DocumentReferenceResolver<String> resolver;
+    
+    @Inject
+    private ResourceReferenceManager resourceReferenceManager;
+    
     @Override
     public boolean redirect(XWikiContext context) throws XWikiException
     {
@@ -71,12 +77,11 @@ public class RedirectClassRedirectionFilter implements RedirectionFilter
             return false;
         }
 
-        // Resolve the location to get a reference
-        DocumentReferenceResolver<String> resolver = Utils.getComponent(DocumentReferenceResolver.TYPE_STRING);
-        EntityReference locationReference = resolver.resolve(location, wikiReference);
+        // Resolve the location to get a reference.
+        EntityReference locationReference = this.resolver.resolve(location, wikiReference);
 
         // Get the type of the current target
-        ResourceReference resourceReference = Utils.getComponent(ResourceReferenceManager.class).getResourceReference();
+        ResourceReference resourceReference = this.resourceReferenceManager.getResourceReference();
         EntityResourceReference entityResource = (EntityResourceReference) resourceReference;
         EntityReference entityReference = entityResource.getEntityReference();
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/redirection/RedirectionFilter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/redirection/RedirectionFilter.java
@@ -29,7 +29,7 @@ import com.xpn.xwiki.XWikiException;
  * Allows to perform a redirection according to the context.
  *
  * @version $Id$
- * @since 13.4RC1
+ * @since 14.0RC1
  */
 @Role
 @Unstable

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/redirection/RedirectionFilter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/redirection/RedirectionFilter.java
@@ -1,0 +1,46 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xpn.xwiki.redirection;
+
+import org.xwiki.component.annotation.Role;
+import org.xwiki.stability.Unstable;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+
+/**
+ * Allows to perform a redirection according to the context.
+ *
+ * @version $Id$
+ * @since 13.4RC1
+ */
+@Role
+@Unstable
+public interface RedirectionFilter
+{
+    /**
+     * Possibly perform a redirection according to the context.
+     *
+     * @param context the XWiki context
+     * @return {@code true} if a redirection has been performed, {@code false} otherwise
+     * @throws XWikiException in case of error during the analysis of the context
+     */
+    boolean redirect(XWikiContext context) throws XWikiException;
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/DownloadAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/DownloadAction.java
@@ -105,14 +105,6 @@ public class DownloadAction extends XWikiAction
     /** The format of a valid range header. */
     private static final Pattern RANGE_HEADER_PATTERN = Pattern.compile("bytes=([0-9]+)?-([0-9]+)?");
 
-    /**
-     * Default constructor.
-     */
-    public DownloadAction()
-    {
-        this.handleRedirectObject = true;
-    }
-
     @Override
     public String render(XWikiContext context) throws XWikiException
     {
@@ -199,6 +191,12 @@ public class DownloadAction extends XWikiAction
                 popDocumentFromContext(backwardCompatibilityContextObjects);
             }
         }
+    }
+
+    @Override
+    protected boolean supportRedirections()
+    {
+        return true;
     }
 
     private void throwNotFoundException(String filename) throws XWikiException

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/GetAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/GetAction.java
@@ -46,14 +46,6 @@ public class GetAction extends XWikiAction
      */
     public static final String GET_ACTION = "get";
 
-    /**
-     * Default constructor.
-     */
-    public GetAction()
-    {
-        this.handleRedirectObject = true;
-    }
-
     @Override
     public boolean action(XWikiContext context) throws XWikiException
     {
@@ -74,5 +66,11 @@ public class GetAction extends XWikiAction
         context.getResponse().setHeader("Content-Location", context.getDoc().getURL("view", context));
 
         return GET_ACTION;
+    }
+
+    @Override
+    protected boolean supportRedirections()
+    {
+        return true;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/ViewAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/ViewAction.java
@@ -51,7 +51,6 @@ public class ViewAction extends XWikiAction
     public ViewAction()
     {
         this.waitForXWikiInitialization = false;
-        this.handleRedirectObject = true;
     }
 
     @Override
@@ -77,5 +76,11 @@ public class ViewAction extends XWikiAction
         } else {
             return VIEW_ACTION;
         }
+    }
+
+    @Override
+    protected boolean supportRedirections()
+    {
+        return true;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/ViewAttachRevAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/ViewAttachRevAction.java
@@ -47,7 +47,6 @@ public class ViewAttachRevAction extends XWikiAction
     public ViewAttachRevAction()
     {
         this.waitForXWikiInitialization = false;
-        this.handleRedirectObject = true;
     }
 
     @Override
@@ -86,6 +85,12 @@ public class ViewAttachRevAction extends XWikiAction
             ScriptContext.ENGINE_SCOPE);
 
         return "viewattachrev";
+    }
+
+    @Override
+    protected boolean supportRedirections()
+    {
+        return true;
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/META-INF/components.txt
@@ -146,7 +146,7 @@ com.xpn.xwiki.internal.template.TemplateListener
 com.xpn.xwiki.internal.template.VelocityTemplateEvaluator
 com.xpn.xwiki.internal.query.ConfiguredQueryExecutorProvider
 com.xpn.xwiki.internal.query.CurrentLanguageQueryFilter
-500:com.xpn.xwiki.internal.redirection.RedirectClassRedirectionFilter
+com.xpn.xwiki.internal.redirection.RedirectClassRedirectionFilter
 com.xpn.xwiki.script.sheet.SheetScriptService
 com.xpn.xwiki.internal.sheet.ClassSheetBinder
 com.xpn.xwiki.internal.sheet.DocumentSheetBinder

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/META-INF/components.txt
@@ -146,6 +146,7 @@ com.xpn.xwiki.internal.template.TemplateListener
 com.xpn.xwiki.internal.template.VelocityTemplateEvaluator
 com.xpn.xwiki.internal.query.ConfiguredQueryExecutorProvider
 com.xpn.xwiki.internal.query.CurrentLanguageQueryFilter
+500:com.xpn.xwiki.internal.redirection.RedirectClassRedirectionFilter
 com.xpn.xwiki.script.sheet.SheetScriptService
 com.xpn.xwiki.internal.sheet.ClassSheetBinder
 com.xpn.xwiki.internal.sheet.DocumentSheetBinder

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/redirection/RedirectClassRedirectionFilterTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/redirection/RedirectClassRedirectionFilterTest.java
@@ -1,4 +1,4 @@
-package com.xpn.xwiki.internal.redirection;/*
+/*
  * See the NOTICE file distributed with this work for additional
  * information regarding copyright ownership.
  *
@@ -17,15 +17,37 @@ package com.xpn.xwiki.internal.redirection;/*
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
+package com.xpn.xwiki.internal.redirection;
 
-import static org.junit.jupiter.api.Assertions.*;
-
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.DocumentReferenceResolver;
+import org.xwiki.model.reference.EntityReference;
+import org.xwiki.model.reference.WikiReference;
+import org.xwiki.resource.ResourceReferenceManager;
+import org.xwiki.resource.entity.EntityResourceAction;
+import org.xwiki.resource.entity.EntityResourceReference;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
 
+import com.xpn.xwiki.XWiki;
 import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.internal.mandatory.RedirectClassDocumentInitializer;
+import com.xpn.xwiki.objects.BaseObject;
+import com.xpn.xwiki.web.XWikiRequest;
+import com.xpn.xwiki.web.XWikiResponse;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Test of {@link RedirectClassRedirectionFilter}.
@@ -36,14 +58,76 @@ import com.xpn.xwiki.XWikiContext;
 @ComponentTest
 class RedirectClassRedirectionFilterTest
 {
+    private static final WikiReference WIKI_TEST = new WikiReference("wikiTest");
+
+    private static final DocumentReference NEW_LOCATION = new DocumentReference("wikiTest", "location", "newLocation");
+
     @InjectMockComponents
-    private RedirectClassRedirectionFilter target;
+    private RedirectClassRedirectionFilter redirectClassRedirectionFilter;
+
+    @MockComponent
+    private DocumentReferenceResolver<String> resolver;
+
+    @MockComponent
+    private ResourceReferenceManager resourceReferenceManager;
 
     @Mock
     private XWikiContext context;
 
-    @Test
-    void redirect()
+    @Mock
+    private XWikiDocument doc;
+
+    @Mock
+    private BaseObject redirectObj;
+
+    @Mock
+    private XWikiRequest request;
+
+    @Mock
+    private XWiki wiki;
+
+    @Mock
+    private XWikiResponse response;
+
+    @BeforeEach
+    void setUp()
     {
+        when(this.context.getWikiReference()).thenReturn(WIKI_TEST);
+        when(this.context.getDoc()).thenReturn(this.doc);
+        when(this.context.getAction()).thenReturn("view");
+        when(this.context.getRequest()).thenReturn(this.request);
+        when(this.context.getResponse()).thenReturn(this.response);
+        when(this.context.getWiki()).thenReturn(this.wiki);
+        when(this.resolver.resolve("newLocation", WIKI_TEST)).thenReturn(NEW_LOCATION);
+        EntityResourceReference entityResourceReference =
+            new EntityResourceReference(new DocumentReference("wikiTest", "location", "WebHome"),
+                new EntityResourceAction("view"));
+        when(this.resourceReferenceManager.getResourceReference()).thenReturn(entityResourceReference);
+    }
+
+    @Test
+    void redirectNoObject() throws Exception
+    {
+        assertFalse(this.redirectClassRedirectionFilter.redirect(this.context));
+    }
+
+    @Test
+    void redirectNoLocation() throws Exception
+    {
+        when(this.doc.getXObject(RedirectClassDocumentInitializer.REFERENCE)).thenReturn(this.redirectObj);
+        assertFalse(this.redirectClassRedirectionFilter.redirect(this.context));
+        verify(this.redirectObj).getStringValue("location");
+    }
+
+    @Test
+    void redirect() throws Exception
+    {
+        when(this.doc.getXObject(RedirectClassDocumentInitializer.REFERENCE)).thenReturn(this.redirectObj);
+        when(this.redirectObj.getStringValue("location")).thenReturn("newLocation");
+        when(this.request.getQueryString()).thenReturn("key=value");
+        when(this.wiki.getURL(any(EntityReference.class), eq("view"), eq("key=value"), isNull(),
+            eq(this.context))).thenReturn("http://newurl");
+        assertTrue(this.redirectClassRedirectionFilter.redirect(this.context));
+        verify(this.response).sendRedirect("http://newurl");
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/redirection/RedirectClassRedirectionFilterTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/redirection/RedirectClassRedirectionFilterTest.java
@@ -1,0 +1,49 @@
+package com.xpn.xwiki.internal.redirection;/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+
+import com.xpn.xwiki.XWikiContext;
+
+/**
+ * Test of {@link RedirectClassRedirectionFilter}.
+ *
+ * @version $Id$
+ * @since 14.0RC1
+ */
+@ComponentTest
+class RedirectClassRedirectionFilterTest
+{
+    @InjectMockComponents
+    private RedirectClassRedirectionFilter target;
+
+    @Mock
+    private XWikiContext context;
+
+    @Test
+    void redirect()
+    {
+    }
+}


### PR DESCRIPTION
- Introduce RedirectionFilter role
- Move the existing redirection logic in a new RedirectClassRedirectionFilter component
- XWikiAction#execute loads and execute the RedirectionFilter components by order of priority
- Make RedirectClassRedirectionFilter with a 500 priority to make it executed early