### PR TITLE
XWIKI-19309: The notification clean link should not navigate to an empty anchor

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsDisplayerUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsDisplayerUIX.xml
@@ -319,6 +319,8 @@ Get the actual notifications.
       .addClass('notification-event-clean')
       .html('$services.icon.renderHTML("trash")&amp;nbsp;$escapetool.xml($escapetool.javascript($services.localization.render('notifications.menu.clear')))')
       .click(function (event) {
+        // Avoid navigating to href="#"
+        event.preventDefault();
         // Avoid the menu closing
         event.stopPropagation();
         // Ask confirmation


### PR DESCRIPTION
* Prevent notification clean action event to navigate to distinct URL