### PR TITLE
XWIKI-19323: Upgrade to Bootstrap Select 1.13.18

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/LocalizationAdministrationSectionPage.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/LocalizationAdministrationSectionPage.java
@@ -22,7 +22,6 @@ package org.xwiki.administration.test.po;
 import java.util.Arrays;
 import java.util.List;
 
-import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.xwiki.test.ui.po.BootstrapSelect;
@@ -52,7 +51,8 @@ public class LocalizationAdministrationSectionPage extends AdministrationSection
         super("Localization");
         waitUntilActionButtonIsLoaded();
         // Wait for asynchronous widgets to be loaded
-        getDriver().waitUntilElementIsVisible(By.xpath("(//div[contains(@class, 'bootstrap-select')])[3]"));
+        getDriver().waitUntilCondition(driver -> multiLingualSelect.isDisplayed() && defaultLanguageSelect.isDisplayed()
+            && supportedLanguagesSelect.isDisplayed());
     }
 
     public void setMultiLingual(boolean isMultiLingual)

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/LocalizationAdministrationSectionPage.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/LocalizationAdministrationSectionPage.java
@@ -35,13 +35,16 @@ import org.xwiki.test.ui.po.BootstrapSelect;
  */
 public class LocalizationAdministrationSectionPage extends AdministrationSectionPage
 {
-    @FindBy(xpath = "(//div[contains(@class, 'bootstrap-select')])[1]")
+    @FindBy(xpath = "//div[contains(@class, 'bootstrap-select')"
+        + " and ./select[@id='XWiki.XWikiPreferences_0_multilingual']]")
     private WebElement multiLingualSelect;
 
-    @FindBy(xpath = "(//div[contains(@class, 'bootstrap-select')])[3]")
+    @FindBy(xpath = "//div[contains(@class, 'bootstrap-select')"
+        + " and ./select[@id='XWiki.XWikiPreferences_0_default_language']]")
     private WebElement defaultLanguageSelect;
 
-    @FindBy(xpath = "(//div[contains(@class, 'bootstrap-select')])[2]")
+    @FindBy(xpath = "//div[contains(@class, 'bootstrap-select')"
+        + " and ../input[@id='XWiki.XWikiPreferences_0_languages']]")
     private WebElement supportedLanguagesSelect;
 
     public LocalizationAdministrationSectionPage()
@@ -49,7 +52,7 @@ public class LocalizationAdministrationSectionPage extends AdministrationSection
         super("Localization");
         waitUntilActionButtonIsLoaded();
         // Wait for asynchronous widgets to be loaded
-        getDriver().waitUntilElementIsVisible(By.cssSelector(".bootstrap-select"));
+        getDriver().waitUntilElementIsVisible(By.xpath("(//div[contains(@class, 'bootstrap-select')])[3]"));
     }
 
     public void setMultiLingual(boolean isMultiLingual)

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BootstrapSelect.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BootstrapSelect.java
@@ -21,14 +21,15 @@ package org.xwiki.test.ui.po;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 import org.xwiki.test.ui.XWikiWebDriver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Represent an select field enhanced with the "bootstrap-select" plugin.
@@ -67,66 +68,79 @@ public class BootstrapSelect
 
     public void selectByValues(List<String> values)
     {
-        Map<String, String> valueTitles = new HashMap<>();
+        boolean multipleSelect = isMultiple();
 
-        // Get the list of all possible values in the hidden <select> field
-        // WARN: the order of the values is imported since their index will help us to identify
-        // them in the enhanced bootstrap-select widget.
-        List<String> options = new ArrayList<>();
-        for (WebElement element : this.hiddenSelect.findElements(By.tagName("option"))) {
-            String value = element.getAttribute("value");
-            options.add(value);
-            valueTitles.put(value, element.getText());
+        if (!multipleSelect && values.size() > 1) {
+            throw new AssertionError("More than one value specified for a select that does not allow multiple values.");
+        }
+
+        List<String> valuesToToggle = new ArrayList<>();
+
+        // The list of values is usually small while the list of all options can be huge - use one XPath query per
+        // value.
+        for (String value : values) {
+            assertFalse(value.contains("\""), "Value must not contain a double quote");
+            WebElement element = this.hiddenSelect.findElement(By.xpath("option[@value = \"" + value + "\"]"));
+
+            if (element.getAttribute("selected") == null) {
+                // FIXME: this is a workaround as our <option>-tag contains child tags which is invalid HTML and not
+                //  supported by WebElement#getText(). The <option>-tag should be fixed.
+                valuesToToggle.add(element.getAttribute("textContent"));
+            }
+        }
+
+        if (multipleSelect) {
+            // Find all currently selected elements using a single XPath query to deselect them.
+            for (WebElement element : this.hiddenSelect.findElements(By.xpath("option[@selected = \"selected\"]"))) {
+                String value = element.getAttribute("value");
+
+                // Toggle the selection state if the value should not be selected anymore.
+                if (!values.contains(value)) {
+                    // FIXME: this is a workaround as our <option>-tag contains child tags which is invalid HTML and not
+                    //  supported by WebElement#getText(). The <option>-tag should be fixed.
+                    valuesToToggle.add(element.getAttribute("textContent"));
+                }
+            }
         }
 
         // Open the enhanced bootstrap-select widget
         WebElement menu = openMenu();
 
-        if (isMultiple()) {
-            // For each of its option
-            for (WebElement element : menu.findElements(By.tagName("li"))) {
-                // We find the language associated to this item thanks to the attribute "data-original-index"
-                int index = Integer.parseInt(element.getAttribute("data-original-index"));
-                String value = options.get(index);
-
-                // Now, click on the element to select/unselect it if its status is different from what we want
-                if (isElementSelected(element) != values.contains(value)) {
-                    element.findElement(By.tagName("a")).click();
-
-                    // If the element is not displayed inside the window (selenium does not handle scrolling inside an
-                    // element) the previous action has actually closed the menu, without changing the state of the
-                    // element. So we need to check if the menu has been close.
-                    if (!isMenuOpen()) {
-                        // If that was the case, we reopen it.
-                        openMenu();
-                        // When we reopen the menu, the element is now contained inside the viewport (the previous click
-                        // had some effect) so we can click it.
-                        // TODO: make this less hacky.
-                        element.findElement(By.tagName("a")).click();
-                    }
-                }
-            }
-        } else {
+        for (String title : valuesToToggle) {
             WebElement filterInput = getFilterInput(menu);
             if (filterInput != null) {
-                filterInput.sendKeys(valueTitles.get(values.get(0)));
+                filterInput.clear();
+                filterInput.sendKeys(title);
             }
-            // For each of its option
-            for (WebElement element : menu.findElements(By.tagName("li"))) {
-                // We find the language associated to this item thanks to the attribute "data-original-index"
-                int index = Integer.parseInt(element.getAttribute("data-original-index"));
-                String value = options.get(index);
 
-                // Now, click on the element to select the value
-                if (element.isDisplayed() && values.contains(value)) {
+            // Find the element to select.
+            for (WebElement element : menu.findElements(By.tagName("li"))) {
+                String elementText = element.getText();
+
+                if (title.equals(elementText)) {
+                // Now, click on the element to (un) select the value
                     element.findElement(By.tagName("a")).click();
-                    waitUntilMenuIsClosed();
-                    if (!button.getAttribute("title").startsWith(valueTitles.get(value))) {
-                        throw new RuntimeException(
-                            String.format("Failed to set the value [%s] with the title [%s]. Got [%s] instead.", value,
-                                valueTitles.get(value), button.getAttribute("title")));
+
+                    if (!multipleSelect) {
+                        waitUntilMenuIsClosed();
+                        assertEquals(elementText, button.getAttribute("title"),
+                            String.format("Failed to set the value with the title [%s]. Got [%s] instead.",
+                                elementText,
+                                button.getAttribute("title")));
+                        break;
+                    } else {
+                        // If the element is not displayed inside the window (selenium does not handle scrolling inside an
+                        // element) the previous action has actually closed the menu, without changing the state of the
+                        // element. So we need to check if the menu has been close.
+                        if (!isMenuOpen()) {
+                            // If that was the case, we reopen it.
+                            openMenu();
+                            // When we reopen the menu, the element is now contained inside the viewport (the previous click
+                            // had some effect) so we can click it.
+                            // TODO: make this less hacky.
+                            element.findElement(By.tagName("a")).click();
+                        }
                     }
-                    break;
                 }
             }
         }

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BootstrapSelect.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BootstrapSelect.java
@@ -84,7 +84,8 @@ public class BootstrapSelect
 
             if (element.getAttribute("selected") == null) {
                 // FIXME: this is a workaround as our <option>-tag contains child tags which is invalid HTML and not
-                //  supported by WebElement#getText(). The <option>-tag should be fixed.
+                //  supported by WebElement#getText(). The <option>-tag should be fixed, see
+                //  https://jira.xwiki.org/browse/XWIKI-19342.
                 valuesToToggle.add(element.getAttribute("textContent"));
             }
         }
@@ -97,7 +98,8 @@ public class BootstrapSelect
                 // Toggle the selection state if the value should not be selected anymore.
                 if (!values.contains(value)) {
                     // FIXME: this is a workaround as our <option>-tag contains child tags which is invalid HTML and not
-                    //  supported by WebElement#getText(). The <option>-tag should be fixed.
+                    //  supported by WebElement#getText(). The <option>-tag should be fixed, see
+                    //  https://jira.xwiki.org/browse/XWIKI-19342.
                     valuesToToggle.add(element.getAttribute("textContent"));
                 }
             }


### PR DESCRIPTION
* Adapt BootstrapSelect page object to no longer rely on removed attribute.
* Make selectors in LocalizationAdministrationSectionPage more robust.
* Improve performance of BootstrapSelect.

This fixes test failures introduced in https://jira.xwiki.org/browse/XWIKI-19323 and improves the performance of the BootstrapSelect page object by reducing the number of calls to the web driver.