### PR TITLE
XWIKI-19343: Add ability to exclude some locations when using the location picker

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/locationPicker_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/locationPicker_macros.vm
@@ -219,7 +219,8 @@
             'showRoot': $showRoot,
             'showTerminalDocuments': $showTerminalDocuments,
             'showTranslations': false,
-            'showWikis': $showWikis
+            'showWikis': $showWikis,
+            'exclusions': "$!options.exclusions"
           })
         </div>
         <div class="modal-footer">


### PR DESCRIPTION
* Add 'exclusions': "$!options.exclusions" to the map of options passed to the documentTree macro
