### PR TITLE
XWIKI-19026: The <head> is full of invalid HTML <link> and <script> elements

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/javascript.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/javascript.vm
@@ -26,13 +26,13 @@
 ## JavaScript libraries
 ##
 ## We load RequireJS first because it is used by other JavaScript modules to load their dependencies.
-<script src="$services.webjars.url('requirejs', "require$jsExtension")" data-wysiwyg="true"></script>
+<script src="$escapetool.xml($services.webjars.url('requirejs', "require$jsExtension"))" data-wysiwyg="true"></script>
 ## FIXME: We still have code depending on Prototype.js without declaring it (i.e. without using RequireJS). Short term
 ## goal is to stop loading Prototype.js by default and change the existing code to load it when needed. Long term goal is
 ## to stop relying on Prototype.js . Note that we load Prototype.js before the following inline script because we have to
 ## fix some incompatibilities between Bootstrap and Prototype.js . In the future we should use the 'deferred' RequireJS
 ## plugin to fix the incompatibilities only if / when Prototype.js is loaded.
-<script src="$xwiki.getSkinFile('js/prototype/prototype.js')"></script>
+<script src="$escapetool.xml($xwiki.getSkinFile('js/prototype/prototype.js'))"></script>
 ##
 ## Define the global require.js configuration
 ##
@@ -255,6 +255,6 @@ $xwiki.jsfx.use("flamingo$jsExtension", {'forceSkinAction' : true, 'language' : 
 ## Compatibility "aspect" file for deprecated code.
 ## Placed at the very end of the stream so that skin file extensions code can be deprecated easily as well.
 ##
-<script src="$xwiki.getSkinFile("js/xwiki/compatibility.js", false)" defer="defer"></script>
+<script src="$escapetool.xml($xwiki.getSkinFile("js/xwiki/compatibility.js", false))" defer="defer"></script>
 ## Marker script that signals that all the deferred scripts have indeed been executed, guarding against a premature dom:loaded event
-<script src="$xwiki.getSkinFile("js/xwiki/markerScript.js", false)" defer="defer"></script>
+<script src="$escapetool.xml($xwiki.getSkinFile("js/xwiki/markerScript.js", false))" defer="defer"></script>

--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/AbstractDocumentSkinExtensionPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/AbstractDocumentSkinExtensionPlugin.java
@@ -455,7 +455,7 @@ public abstract class AbstractDocumentSkinExtensionPlugin extends AbstractSkinEx
     protected String getDocumentSkinExtensionURL(DocumentReference documentReference, String documentName,
             String pluginName, XWikiContext context)
     {
-        String queryString = String.format("%s&amp;%s%s",
+        String queryString = String.format("%s&%s%s",
                 getLanguageQueryString(context),
                 getDocumentVersionQueryString(documentReference, context),
                 parametersAsQueryString(documentName, context));

--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/AbstractSkinExtensionPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/AbstractSkinExtensionPlugin.java
@@ -29,6 +29,8 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
 
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xwiki.model.reference.DocumentReferenceResolver;
@@ -67,12 +69,26 @@ import com.xpn.xwiki.web.Utils;
 public abstract class AbstractSkinExtensionPlugin extends XWikiDefaultPlugin implements RenderingCacheAware
 {
     /**
+     * The name of the preference (in the configuration file) specifying what is the default value of the defer, in case
+     * nothing is specified in the parameters of this extension.
+     */
+    public static final String DEFER_DEFAULT_PARAM = "xwiki.plugins.skinx.deferred.default";
+
+    /**
      * The URL delimiter part of query parameters.
      */
     protected static final String QUERY_PARAMETER_DELIMITER = "?";
 
+    /**
+     * The separator between parameters.
+     */
+    protected static final String PARAMETER_SEPARATOR = "&";
+
     /** Log object to log messages in this class. */
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractSkinExtensionPlugin.class);
+
+    /** Parameter name force skin action. */
+    private static final String FORCE_SKIN_ACTION = "forceSkinAction";
 
     /** The name of the context key for the list of pulled extensions. */
     protected final String contextKey = this.getClass().getCanonicalName();
@@ -162,6 +178,32 @@ public abstract class AbstractSkinExtensionPlugin extends XWikiDefaultPlugin imp
     public Api getPluginApi(XWikiPluginInterface plugin, XWikiContext context)
     {
         return new SkinExtensionPluginApi((AbstractSkinExtensionPlugin) plugin, context);
+    }
+
+    /**
+     * @param filename The name of the file to get the URL for.
+     * @param context The current request context.
+     * @return The (unescaped) URL of the skin file.
+     * @since 14.0RC1
+     */
+    protected String getSkinFileURL(String filename, XWikiContext context)
+    {
+        boolean forceSkinAction = BooleanUtils.toBoolean((Boolean) getParameter(FORCE_SKIN_ACTION, filename,
+            context));
+
+        StringBuilder url = new StringBuilder(context.getWiki().getSkinFile(filename, forceSkinAction, context));
+        if (forceSkinAction) {
+            String parameters =
+                StringUtils.removeStart(parametersAsQueryString(filename, context), PARAMETER_SEPARATOR);
+            if (!StringUtils.isEmpty(parameters)) {
+                String queryParamDelimiter =
+                    StringUtils.contains(url, QUERY_PARAMETER_DELIMITER) ? PARAMETER_SEPARATOR
+                        : QUERY_PARAMETER_DELIMITER;
+                url.append(queryParamDelimiter).append(parameters);
+            }
+        }
+
+        return url.toString();
     }
 
     private void useResource(String resource, XWikiContext context)
@@ -332,8 +374,8 @@ public abstract class AbstractSkinExtensionPlugin extends XWikiDefaultPlugin imp
     /**
      * This method converts the parameters for an extension to a query string that can be used with
      * {@link com.xpn.xwiki.doc.XWikiDocument#getURL(String, String, String, XWikiContext) getURL()} and printed in the
-     * XHTML result. The parameters separator is the escaped &amp;amp;. The query string already starts with an
-     * &amp;amp; if at least one parameter exists.
+     * XHTML result. The parameters separator is the escaped &amp;. The query string already starts with an
+     * &amp; if at least one parameter exists.
      *
      * @param resource The pulled resource whose parameters should be converted.
      * @param context The current request context.
@@ -345,17 +387,17 @@ public abstract class AbstractSkinExtensionPlugin extends XWikiDefaultPlugin imp
         StringBuilder query = new StringBuilder();
         for (Entry<String, Object> parameter : parameters.entrySet()) {
             // Skip the parameter that forces the file extensions to be sent through the /skin/ action
-            if ("forceSkinAction".equals(parameter.getKey())) {
+            if (FORCE_SKIN_ACTION.equals(parameter.getKey())) {
                 continue;
             }
-            query.append("&amp;");
+            query.append(PARAMETER_SEPARATOR);
             query.append(sanitize(parameter.getKey()));
             query.append("=");
             query.append(sanitize(Objects.toString(parameter.getValue(), "")));
         }
         // If the main page is requested unminified, also send unminified extensions
         if ("false".equals(context.getRequest().getParameter("minify"))) {
-            query.append("&amp;minify=false");
+            query.append("&minify=false");
         }
         return query.toString();
     }
@@ -444,5 +486,13 @@ public abstract class AbstractSkinExtensionPlugin extends XWikiDefaultPlugin imp
         }
 
         return this.async;
+    }
+
+    protected boolean isDefer(String name, XWikiContext context)
+    {
+        // check if js should be deferred, defaults to the preference configured in the cfg file, which defaults to true
+        String defaultDeferString = context.getWiki().Param(DEFER_DEFAULT_PARAM);
+        boolean defaultDefer = StringUtils.isEmpty(defaultDeferString) || Boolean.parseBoolean(defaultDeferString);
+        return BooleanUtils.toBooleanDefaultIfNull((Boolean) getParameter("defer", name, context), defaultDefer);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/AbstractSkinExtensionPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/AbstractSkinExtensionPlugin.java
@@ -184,7 +184,7 @@ public abstract class AbstractSkinExtensionPlugin extends XWikiDefaultPlugin imp
      * @param filename The name of the file to get the URL for.
      * @param context The current request context.
      * @return The (unescaped) URL of the skin file.
-     * @since 14.0RC1
+     * @since 14.1RC1
      */
     protected String getSkinFileURL(String filename, XWikiContext context)
     {

--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/AbstractSkinExtensionPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/AbstractSkinExtensionPlugin.java
@@ -71,16 +71,23 @@ public abstract class AbstractSkinExtensionPlugin extends XWikiDefaultPlugin imp
     /**
      * The name of the preference (in the configuration file) specifying what is the default value of the defer, in case
      * nothing is specified in the parameters of this extension.
+     *
+     * @since 14.1RC1
      */
     public static final String DEFER_DEFAULT_PARAM = "xwiki.plugins.skinx.deferred.default";
 
     /**
      * The URL delimiter part of query parameters.
+     *
+     * @since 11.6RC1
+     * @since 11.3.2
      */
     protected static final String QUERY_PARAMETER_DELIMITER = "?";
 
     /**
      * The separator between parameters.
+     *
+     * @since 14.1RC1
      */
     protected static final String PARAMETER_SEPARATOR = "&";
 
@@ -488,9 +495,17 @@ public abstract class AbstractSkinExtensionPlugin extends XWikiDefaultPlugin imp
         return this.async;
     }
 
+    /**
+     * If the loading of given JavaScript script shall be deferred.
+     *
+     * @param name Name of the script to be loaded (page, file or resource name).
+     * @param context The context to get the parameter from.
+     * @return If the loading shall be deferred, defaults to the preference in the configuration file, which defaults
+     * to true.
+     * @since 14.1RC1
+     */
     protected boolean isDefer(String name, XWikiContext context)
     {
-        // check if js should be deferred, defaults to the preference configured in the cfg file, which defaults to true
         String defaultDeferString = context.getWiki().Param(DEFER_DEFAULT_PARAM);
         boolean defaultDefer = StringUtils.isEmpty(defaultDeferString) || Boolean.parseBoolean(defaultDeferString);
         return BooleanUtils.toBooleanDefaultIfNull((Boolean) getParameter("defer", name, context), defaultDefer);

--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/CssResourceSkinExtensionPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/CssResourceSkinExtensionPlugin.java
@@ -19,6 +19,8 @@
  */
 package com.xpn.xwiki.plugin.skinx;
 
+import org.xwiki.xml.XMLUtils;
+
 import com.xpn.xwiki.XWikiContext;
 
 /**
@@ -57,7 +59,7 @@ public class CssResourceSkinExtensionPlugin extends AbstractResourceSkinExtensio
     @Override
     protected String generateLink(String url, String resourceName, XWikiContext context)
     {
-        return "<link rel='stylesheet' type='text/css' href='" + url + "'/>\n";
+        return "<link rel='stylesheet' type='text/css' href='" + XMLUtils.escapeAttributeValue(url) + "'/>\n";
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/CssSkinExtensionPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/CssSkinExtensionPlugin.java
@@ -21,6 +21,7 @@ package com.xpn.xwiki.plugin.skinx;
 
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.LocalDocumentReference;
+import org.xwiki.xml.XMLUtils;
 
 import com.xpn.xwiki.XWikiContext;
 
@@ -83,8 +84,9 @@ public class CssSkinExtensionPlugin extends AbstractDocumentSkinExtensionPlugin
             return "";
         }
 
-        return String.format("<link rel=\"stylesheet\" type=\"text/css\" href=\"%s\" />",
-                getDocumentSkinExtensionURL(documentReference, documentName, PLUGIN_NAME, context));
+        return "<link rel=\"stylesheet\" type=\"text/css\" href=\"" + XMLUtils.escapeAttributeValue(
+            getDocumentSkinExtensionURL(documentReference, documentName, PLUGIN_NAME,
+                context)) + "\" />\n";
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/CssSkinFileExtensionPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/CssSkinFileExtensionPlugin.java
@@ -23,7 +23,7 @@ package com.xpn.xwiki.plugin.skinx;
 import java.util.Collections;
 import java.util.Set;
 
-import org.apache.commons.lang3.StringUtils;
+import org.xwiki.xml.XMLUtils;
 
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.api.Api;
@@ -31,7 +31,7 @@ import com.xpn.xwiki.plugin.XWikiPluginInterface;
 
 /**
  * CSs Skin File Extension plugin to use css files from the skin.
- * 
+ *
  * @version $Id$
  * @since 1.6
  */
@@ -45,11 +45,11 @@ public class CssSkinFileExtensionPlugin extends AbstractSkinExtensionPlugin
 
     /**
      * XWiki plugin constructor.
-     * 
+     *
      * @param name The name of the plugin, which can be used for retrieving the plugin API from velocity. Unused.
      * @param className The canonical classname of the plugin. Unused.
      * @param context The current request context.
-     * @see com.xpn.xwiki.plugin.XWikiDefaultPlugin#XWikiDefaultPlugin(String,String,com.xpn.xwiki.XWikiContext)
+     * @see com.xpn.xwiki.plugin.XWikiDefaultPlugin#XWikiDefaultPlugin(String, String, com.xpn.xwiki.XWikiContext)
      */
     public CssSkinFileExtensionPlugin(String name, String className, XWikiContext context)
     {
@@ -71,19 +71,8 @@ public class CssSkinFileExtensionPlugin extends AbstractSkinExtensionPlugin
     @Override
     public String getLink(String filename, XWikiContext context)
     {
-        boolean forceSkinAction = (Boolean) getParametersForResource(filename, context).get("forceSkinAction");
-        StringBuilder result = new StringBuilder("<link rel='stylesheet' type='text/css' href='");
-        result.append(context.getWiki().getSkinFile(filename, forceSkinAction, context));
-        if (forceSkinAction) {
-            String parameters = StringUtils.removeStart(parametersAsQueryString(filename, context), "&amp;");
-            if (!StringUtils.isEmpty(parameters)) {
-                String queryParamDelimiter =
-                    StringUtils.contains(result, QUERY_PARAMETER_DELIMITER) ? "&" : QUERY_PARAMETER_DELIMITER;
-                result.append(queryParamDelimiter).append(parameters);
-            }
-        }
-        result.append("'/>");
-        return result.toString();
+        return "<link rel='stylesheet' type='text/css' href='"
+            + XMLUtils.escapeAttributeValue(getSkinFileURL(filename, context)) + "'/>\n";
     }
 
     /**
@@ -92,7 +81,7 @@ public class CssSkinFileExtensionPlugin extends AbstractSkinExtensionPlugin
      * We must override this method since the plugin manager only calls it for classes that provide their own
      * implementation, and not an inherited one.
      * </p>
-     * 
+     *
      * @see AbstractSkinExtensionPlugin#endParsing(String, XWikiContext)
      */
     @Override
@@ -106,7 +95,7 @@ public class CssSkinFileExtensionPlugin extends AbstractSkinExtensionPlugin
      * <p>
      * There is no support for always used skinfile-based extensions.
      * </p>
-     * 
+     *
      * @see AbstractSkinExtensionPlugin#getAlwaysUsedExtensions(XWikiContext)
      */
     @Override
@@ -120,7 +109,7 @@ public class CssSkinFileExtensionPlugin extends AbstractSkinExtensionPlugin
      * <p>
      * Not supported for skinfile-based extensions.
      * </p>
-     * 
+     *
      * @see com.xpn.xwiki.plugin.skinx.AbstractSkinExtensionPlugin#hasPageExtensions(com.xpn.xwiki.XWikiContext)
      */
     @Override

--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/JsResourceSkinExtensionPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/JsResourceSkinExtensionPlugin.java
@@ -19,32 +19,25 @@
  */
 package com.xpn.xwiki.plugin.skinx;
 
-import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.StringUtils;
+import org.xwiki.xml.XMLUtils;
 
 import com.xpn.xwiki.XWikiContext;
 
 /**
  * Skin Extension plugin that allows pulling javascript files from JAR resources.
- * 
+ *
  * @version $Id$
  * @since 1.3
  */
 public class JsResourceSkinExtensionPlugin extends AbstractResourceSkinExtensionPlugin
 {
     /**
-     * The name of the preference (in the configuration file) specifying what is the default value of the defer, in case
-     * nothing is specified in the parameters of this extension.
-     */
-    public static final String DEFER_DEFAULT_PARAM = "xwiki.plugins.skinx.deferred.default";
-
-    /**
      * XWiki plugin constructor.
-     * 
+     *
      * @param name The name of the plugin, which can be used for retrieving the plugin API from velocity. Unused.
      * @param className The canonical classname of the plugin. Unused.
      * @param context The current request context.
-     * @see com.xpn.xwiki.plugin.XWikiDefaultPlugin#XWikiDefaultPlugin(String,String,com.xpn.xwiki.XWikiContext)
+     * @see com.xpn.xwiki.plugin.XWikiDefaultPlugin#XWikiDefaultPlugin(String, String, com.xpn.xwiki.XWikiContext)
      */
     public JsResourceSkinExtensionPlugin(String name, String className, XWikiContext context)
     {
@@ -66,13 +59,13 @@ public class JsResourceSkinExtensionPlugin extends AbstractResourceSkinExtension
     @Override
     protected String generateLink(String url, String resourceName, XWikiContext context)
     {
-        StringBuilder result = new StringBuilder("<script src='").append(url).append("'");
-        // check if js should be deferred, defaults to the preference configured in the cfg file, which defaults to true
-        String defaultDeferString = context.getWiki().Param(DEFER_DEFAULT_PARAM);
-        Boolean defaultDefer = (!StringUtils.isEmpty(defaultDeferString)) ? Boolean.valueOf(defaultDeferString) : true;
-        if (BooleanUtils.toBooleanDefaultIfNull((Boolean) getParameter("defer", resourceName, context), defaultDefer)) {
+        StringBuilder result =
+            new StringBuilder("<script src='").append(XMLUtils.escapeAttributeValue(url)).append("'");
+
+        if (isDefer(resourceName, context)) {
             result.append(" defer='defer'");
         }
+
         result.append("></script>\n");
         return result.toString();
     }
@@ -83,7 +76,7 @@ public class JsResourceSkinExtensionPlugin extends AbstractResourceSkinExtension
      * We must override this method since the plugin manager only calls it for classes that provide their own
      * implementation, and not an inherited one.
      * </p>
-     * 
+     *
      * @see AbstractSkinExtensionPlugin#endParsing(String, XWikiContext)
      */
     @Override

--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/JsSkinExtensionPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/JsSkinExtensionPlugin.java
@@ -19,25 +19,28 @@
  */
 package com.xpn.xwiki.plugin.skinx;
 
-import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.LocalDocumentReference;
+import org.xwiki.xml.XMLUtils;
 
 import com.xpn.xwiki.XWikiContext;
 
 /**
  * Skin Extension plugin that allows pulling javascript code stored inside wiki documents as
  * <code>XWiki.JavaScriptExtension</code> objects.
- * 
+ *
  * @version $Id$
  */
 public class JsSkinExtensionPlugin extends AbstractDocumentSkinExtensionPlugin
 {
-    /** The name of the XClass storing the code for this type of extensions. */
+    /**
+     * The name of the XClass storing the code for this type of extensions.
+     */
     public static final String JSX_CLASS_NAME = "XWiki.JavaScriptExtension";
 
-    /** The local reference of the XClass storing the code for this type of extensions. */
+    /**
+     * The local reference of the XClass storing the code for this type of extensions.
+     */
     public static final LocalDocumentReference JSX_CLASS_REFERENCE = new LocalDocumentReference("XWiki",
         "JavaScriptExtension");
 
@@ -48,18 +51,12 @@ public class JsSkinExtensionPlugin extends AbstractDocumentSkinExtensionPlugin
     public static final String PLUGIN_NAME = "jsx";
 
     /**
-     * The name of the preference (in the configuration file) specifying what is the default value of the defer, in case
-     * nothing is specified in the parameters of this extension.
-     */
-    public static final String DEFER_DEFAULT_PARAM = "xwiki.plugins.skinx.deferred.default";
-
-    /**
      * XWiki plugin constructor.
-     * 
+     *
      * @param name The name of the plugin, which can be used for retrieving the plugin API from velocity. Unused.
      * @param className The canonical classname of the plugin. Unused.
      * @param context The current request context.
-     * @see com.xpn.xwiki.plugin.XWikiDefaultPlugin#XWikiDefaultPlugin(String,String,com.xpn.xwiki.XWikiContext)
+     * @see com.xpn.xwiki.plugin.XWikiDefaultPlugin#XWikiDefaultPlugin(String, String, com.xpn.xwiki.XWikiContext)
      */
     public JsSkinExtensionPlugin(String name, String className, XWikiContext context)
     {
@@ -72,7 +69,7 @@ public class JsSkinExtensionPlugin extends AbstractDocumentSkinExtensionPlugin
      * We must override this method since the plugin manager only calls it for classes that provide their own
      * implementation, and not an inherited one.
      * </p>
-     * 
+     *
      * @see com.xpn.xwiki.plugin.XWikiPluginInterface#virtualInit(com.xpn.xwiki.XWikiContext)
      */
     @Override
@@ -92,14 +89,13 @@ public class JsSkinExtensionPlugin extends AbstractDocumentSkinExtensionPlugin
         }
 
         StringBuilder result = new StringBuilder("<script src='");
-        result.append(getDocumentSkinExtensionURL(documentReference, documentName, PLUGIN_NAME, context));
-        // check if js should be deferred, defaults to the preference configured in the cfg file, which defaults to true
-        String defaultDeferString = context.getWiki().Param(DEFER_DEFAULT_PARAM);
-        Boolean defaultDefer = (!StringUtils.isEmpty(defaultDeferString)) ? Boolean.valueOf(defaultDeferString) : true;
-        if (BooleanUtils.toBooleanDefaultIfNull((Boolean) getParameter("defer", documentName, context), defaultDefer)) {
+        result.append(XMLUtils.escapeAttributeValue(
+            getDocumentSkinExtensionURL(documentReference, documentName, PLUGIN_NAME, context)));
+        if (isDefer(documentName, context)) {
             result.append("' defer='defer");
         }
         result.append("'></script>\n");
+
         return result.toString();
     }
 
@@ -121,7 +117,7 @@ public class JsSkinExtensionPlugin extends AbstractDocumentSkinExtensionPlugin
      * We must override this method since the plugin manager only calls it for classes that provide their own
      * implementation, and not an inherited one.
      * </p>
-     * 
+     *
      * @see AbstractSkinExtensionPlugin#endParsing(String, XWikiContext)
      */
     @Override

--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/JsSkinFileExtensionPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/JsSkinFileExtensionPlugin.java
@@ -23,8 +23,7 @@ package com.xpn.xwiki.plugin.skinx;
 import java.util.Collections;
 import java.util.Set;
 
-import org.apache.commons.lang3.BooleanUtils;
-import org.apache.commons.lang3.StringUtils;
+import org.xwiki.xml.XMLUtils;
 
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.api.Api;
@@ -43,12 +42,6 @@ public class JsSkinFileExtensionPlugin extends AbstractSkinExtensionPlugin
      * extension content.
      */
     public static final String PLUGIN_NAME = "jsfx";
-
-    /**
-     * The name of the preference (in the configuration file) specifying what is the default value of the defer, in case
-     * nothing is specified in the parameters of this extension.
-     */
-    public static final String DEFER_DEFAULT_PARAM = "xwiki.plugins.skinx.deferred.default";
 
     /**
      * XWiki plugin constructor.
@@ -78,23 +71,13 @@ public class JsSkinFileExtensionPlugin extends AbstractSkinExtensionPlugin
     @Override
     public String getLink(String filename, XWikiContext context)
     {
-        boolean forceSkinAction = BooleanUtils.toBoolean((Boolean) getParameter("forceSkinAction", filename, context));
         StringBuilder result = new StringBuilder("<script src='");
-        result.append(context.getWiki().getSkinFile(filename, forceSkinAction, context));
-        if (forceSkinAction) {
-            String parameters = StringUtils.removeStart(parametersAsQueryString(filename, context), "&amp;");
-            if (!StringUtils.isEmpty(parameters)) {
-                String queryParamDelimiter =
-                    StringUtils.contains(result, QUERY_PARAMETER_DELIMITER) ? "&" : QUERY_PARAMETER_DELIMITER;
-                result.append(queryParamDelimiter).append(parameters);
-            }
-        }
-        // check if js should be deferred, defaults to the preference configured in the cfg file, which defaults to true
-        String defaultDeferString = context.getWiki().Param(DEFER_DEFAULT_PARAM);
-        Boolean defaultDefer = (!StringUtils.isEmpty(defaultDeferString)) ? Boolean.valueOf(defaultDeferString) : true;
-        if (BooleanUtils.toBooleanDefaultIfNull((Boolean) getParameter("defer", filename, context), defaultDefer)) {
+        result.append(XMLUtils.escapeAttributeValue(getSkinFileURL(filename, context)));
+
+        if (isDefer(filename, context)) {
             result.append("' defer='defer");
         }
+
         result.append("'></script>\n");
         return result.toString();
     }

--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/LinkExtensionPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/LinkExtensionPlugin.java
@@ -69,7 +69,7 @@ public class LinkExtensionPlugin extends AbstractSkinExtensionPlugin
             result.append(StringEscapeUtils.escapeXml(entry.getValue().toString()));
             result.append("'");
         }
-        result.append("/>");
+        result.append("/>\n");
         return result.toString();
     }
 

--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/test/java/com/xpn/xwiki/plugin/skinx/CssSkinExtensionPluginTest.java
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/test/java/com/xpn/xwiki/plugin/skinx/CssSkinExtensionPluginTest.java
@@ -189,7 +189,7 @@ public class CssSkinExtensionPluginTest
         context.setLocale(Locale.ITALY);
         when(ext1.getVersion()).thenReturn("3.2");
 
-        String expectedQueryString = "language=it_IT&amp;docVersion=3.2";
+        String expectedQueryString = "language=it_IT&docVersion=3.2";
         String extensionLink1 = "https://myextension1";
         URL extensionLink1Url = new URL(extensionLink1);
 
@@ -198,7 +198,7 @@ public class CssSkinExtensionPluginTest
         when(this.urlFactory.getURL(extensionLink1Url, context)).thenReturn(extensionLink1);
 
         String expectedStyle =
-            String.format("<link rel=\"stylesheet\" type=\"text/css\" href=\"%s\" />", extensionLink1);
+            String.format("<link rel=\"stylesheet\" type=\"text/css\" href=\"%s\" />\n", extensionLink1);
 
         String expectedContent = String.format("<body><head>%s</head><body><!-- %s --></body>",
             expectedStyle,

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/stylesheets.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/stylesheets.vm
@@ -20,11 +20,12 @@
 #template('colorThemeInit.vm')
 
 #macro(concatenateQueryParameter $originalUrl $queryString)
-  #if ($originalUrl.contains("?"))
-$originalUrl&#38;$queryString
-  #else
-$originalUrl?$queryString
-  #end
+## No indent here as it causes whitespace in the output.
+#if ($originalUrl.contains("?"))
+$originalUrl&#38;$queryString## prevent line break in output
+#else
+$originalUrl?$queryString## prevent line break in output
+#end
 #end
 
 ## The default stylesheet configuration option allows to override the default style.css CSS

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/stylesheets.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/stylesheets.vm
@@ -21,9 +21,9 @@
 
 #macro(concatenateQueryParameter $originalUrl $queryString)
   #if ($originalUrl.contains("?"))
-    $originalUrl&$queryString
+$originalUrl&#38;$queryString
   #else
-    $originalUrl?$queryString
+$originalUrl?$queryString
   #end
 #end
 
@@ -41,16 +41,16 @@
   #set ($discard = $urlParametersMap.put("colorThemeVersion", $themeDoc.version))
 #end
 #set ($urlParameters = $escapetool.xml($escapetool.url($urlParametersMap)))
-#set ($defaultStyleURL = $xwiki.getSkinFile($defaultstyle, true))
+#set ($defaultStyleURL = $escapetool.xml($xwiki.getSkinFile($defaultstyle, true)))
 
 <link href="#concatenateQueryParameter($defaultStyleURL, $urlParameters)" rel="stylesheet" type="text/css" media="all" />
-<link href="#concatenateQueryParameter($xwiki.getSkinFile('print.css', true), $urlParameters)" rel="stylesheet" type="text/css" media="#if ($printss)all#{else}print#{end}" />
+<link href="#concatenateQueryParameter($escapetool.xml($xwiki.getSkinFile('print.css', true)), $urlParameters)" rel="stylesheet" type="text/css" media="#if ($printss)all#{else}print#{end}" />
 #set ($a11y = "$!{request.getCookie('a11y').getValue()}")
 #if ($a11y == '')
   #set ($a11y = "$!{xwiki.getUserPreference('accessibility')}")
 #end
 #if ($a11y == '1')
-  <link href="$xwiki.getSkinFile('css/accessibility.css', true)" rel="stylesheet" type="text/css" media="all" />
+  <link href="$escapetool.xml($xwiki.getSkinFile('css/accessibility.css', true))" rel="stylesheet" type="text/css" media="all" />
 #end
 ## The stylesheets configuration option allows to override the alternate stylesheets
 ## style1.css, style2.css and style3.css
@@ -58,7 +58,7 @@
 #if ($stylesheets != '')
   #foreach ($stylesheet in $stylesheets.split(','))
     #if (!$stylesheet.equalsIgnoreCase($defaultstyle))
-      <link href="#concatenateQueryParameter($xwiki.getSkinFile($stylesheet, true), $urlParameters)" rel="alternate stylesheet" type="text/css" title="Alternate StyleSheet ${foreach.count}" />
+      <link href="#concatenateQueryParameter($escapetool.xml($xwiki.getSkinFile($stylesheet, true)), $urlParameters)" rel="alternate stylesheet" type="text/css" title="Alternate StyleSheet ${foreach.count}" />
     #end
   #end
 #end


### PR DESCRIPTION
* XML-escape all URLs in script/link-tags.
* Do not escape URLs during assembly as helper methods add parameters with & as separator.
* Ensure that "\n" is printed after every link/script.
* Cleanup duplicate code.

I have introduced some new helper methods for code deduplication in the parent class which is only relevant for some child classes. I'm wondering if it would be better to move them into separate helper classes. What do you think?

In this code I'm following the principle to XML-escape text the moment it is inserted into an XML tag and not earlier. In my opinion this is the best approach and necessary here as some other methods that are called just add additional parameters using `&` as separator and thus escaping the `&` early just creates the mess we previously had.

Jira issue: https://jira.xwiki.org/browse/XWIKI-19026