### PR TITLE
XWIKI-19341: commentfield.vm should not manipulate the XWikiComment class

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/commentfield.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/commentfield.vm
@@ -26,7 +26,6 @@
 #set ($number = $numbertool.toNumber($request.number).intValue())
 
 #set ($xCommentClass = 'XWiki.XWikiComments')
-#set ($commentClass = $xwiki.getDocument($xCommentClass).getxWikiClass())
 
 ## If a content is provided, we use it. If a comment number is provided, we use the content of the corresponding 
 ## comment. Otherwise, the content is an empty string.
@@ -45,24 +44,19 @@
 <input type='hidden' name='defaultEditorId' value="$escapetool.xml($defaultEditorId)" />
 
 #if ($number && $number > -1)
-  #set ($commentPrefix = "XWiki.XWikiComments_${number}")
+  #set ($commentPrefix = "XWiki.XWikiComments_${number}_")
 #else
-  #set ($commentPrefix = 'XWiki.XWikiComments')
+  #set ($commentPrefix = 'XWiki.XWikiComments_')
 #end
-<label for="${commentPrefix}_comment">$services.localization.render('core.viewers.comments.add.comment.label')</label>
+<label for="${commentPrefix}comment">$services.localization.render('core.viewers.comments.add.comment.label')</label>
 #initRequiredSkinExtensions()
 ## Display of the comment field.
-#set ($commentProperty = $commentClass.get('comment'))
-#set ($properties = {
-  'id': "${commentPrefix}_comment",
-  'name': "${commentPrefix}_comment",
-  'rows': $commentProperty.getProperty('rows').value,
-  'cols': $commentProperty.getProperty('cols').value
-})
-#if ($commentProperty.getPropertyClass().isWysiwyg($xcontext.context))
-  $services.edit.syntaxContent.wysiwyg($value, $doc.syntax, $properties)
-#else
-  $services.edit.syntaxContent.text($value, $doc.syntax, $properties)
-#end
+#set ($xWikiCommentsClass = $xwiki.getClass($xCommentClass))
+### Creates a new in-memory object, then use it to render the comment field in edit mode.
+#set ($newObj = $xWikiCommentsClass.newObject())
+## Having an owner document is required to set a property value.
+#set ($discard = $newObj.getXWikiObject().setOwnerDocument($doc))
+#set ($discard = $newObj.set('comment', $value))
+$doc.displayEdit($xwiki.getClass($xCommentClass).get('comment'), $commentPrefix, $newObj)
 #getRequiredSkinExtensions($requiredSkinExtensions)
 #set ($discard = $response.setHeader('X-XWIKI-HTML-HEAD', $requiredSkinExtensions))

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/commentfield.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/commentfield.vm
@@ -22,63 +22,47 @@
 ### Return a single comment field
 ###
 ###
-## requested field name containing the comment number
-## (e.g. XWiki.XWikiComments_42_comment)
-#set ($name = $escapetool.xml($request.name))
-## the number of the comment, if no number is provided we generate a field for a new comment.
+## The number of the comment, if no number is provided we generate a field for a new comment.
 #set ($number = $numbertool.toNumber($request.number).intValue())
 
-## the 'comment' field from the XWikiComments class is used as a template for the field to display
 #set ($xCommentClass = 'XWiki.XWikiComments')
 #set ($commentClass = $xwiki.getDocument($xCommentClass).getxWikiClass())
 
-
-## the number of the comment, if no number is provided we generate a field for a new comment.
-#if ($number && $number > -1)
-  #set ($commentObj = $doc.getObject($xCommentClass, $number))
-  #set ($value = $commentObj.getValue('comment'))
+## If a content is provided, we use it. If a comment number is provided, we use the content of the corresponding 
+## comment. Otherwise, the content is an empty string.
+#if ($request.content)
+  ## Forces the value of the comment to the content from the request if it exists (for instance in case of error 
+  ## during the captcha validation).
+  #set ($value = $request.content)
+#elseif ($number && $number > -1)
+  #set ($value = $doc.getObject($xCommentClass, $number).getValue('comment'))
 #else
-  #set ($commentObj = $doc.newObject($xCommentClass))
   #set ($value = '')
 #end
-
-## Forces the value of the comment to the content from the request if it exists.
-#if ($request.content)
-  #set ($value = $request.content)
-#end
-
-## We can't simply call $doc.display() on this object because we would get comment as the
-## field name. Instead we want the field name to be XWiki.XWikiComments_comment for new comments
-## and XWiki.XWikiComments_N_comment for edited comments.
-## To achieve this we add a new property to the comment class by copying the comment property and changing the name.
-#set ($commentObjClass = $commentObj.getxWikiClass())
-#set ($commentObjBaseClass = $commentObjClass.getXWikiClass())
-#set ($commentField = $commentClass.getXWikiClass().get('comment'))
-
-## In theory this should never occur, but apparently it happened in XWIKI-18717 in weird conditions,
-## so we're bullet-proofing
-#if ("$!commentField" != '')
-#set ($discard = $commentObjBaseClass.put($name, $commentField))
-#set ($discard = $commentObjBaseClass.get($name).setName($name))
-
-## attribution of the value to the new field in the object.
-#set ($discard = $commentObj.set($name, $value))
-
-#set ($fieldToDisplay = $commentObjClass.get($name))
 
 ## We need to know the type of editor used for comments in order to hide/display the preview button.
 #set ($defaultEditorId = $services.edit.syntaxContent.defaultEditorId)
 <input type='hidden' name='defaultEditorId' value="$escapetool.xml($defaultEditorId)" />
 
-<label for="$name">$services.localization.render('core.viewers.comments.add.comment.label')</label>
+#if ($number && $number > -1)
+  #set ($commentPrefix = "XWiki.XWikiComments_${number}")
+#else
+  #set ($commentPrefix = 'XWiki.XWikiComments')
+#end
+<label for="${commentPrefix}_comment">$services.localization.render('core.viewers.comments.add.comment.label')</label>
 #initRequiredSkinExtensions()
-## display of the comment field
-$doc.displayEdit($fieldToDisplay, '', $commentObj)
-
-## ensure to load the appropriate JSX for the editor.
+## Display of the comment field.
+#set ($commentProperty = $commentClass.get('comment'))
+#set ($properties = {
+  'id': "${commentPrefix}_comment",
+  'name': "${commentPrefix}_comment",
+  'rows': $commentProperty.getProperty('rows').value,
+  'cols': $commentProperty.getProperty('cols').value
+})
+#if ($commentProperty.getPropertyClass().isWysiwyg($xcontext.context))
+  $services.edit.syntaxContent.wysiwyg($value, $doc.syntax, $properties)
+#else
+  $services.edit.syntaxContent.text($value, $doc.syntax, $properties)
+#end
 #getRequiredSkinExtensions($requiredSkinExtensions)
 #set ($discard = $response.setHeader('X-XWIKI-HTML-HEAD', $requiredSkinExtensions))
-
-## reset the temporary added field.
-#set ($discard = $commentObjBaseClass.removeField($name))
-#end


### PR DESCRIPTION
Use the edit script service to display the editor instead of XWikiDocument.displayEdit.

Jira issue: https://jira.xwiki.org/browse/XWIKI-19341