### PR TITLE
XWIKI-19149: id likers: invalid attributes in german localization

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_macros.vm
@@ -142,7 +142,10 @@
     #set($linkName = $linkWords.get(1))
     #set($linkTitle = "${linkWords.get(0)}: ${linkWords.get(1)}")
   #end
-  <li class="$!class"><a href="$actionurl" #if(!$stringtool.isBlank($linkid))id="$linkid"#end title="$linkTitle" $!extraAttributes>$services.icon.renderHTML($icon) $linkName</a></li>
+  <li class="$!class">
+    <a href="$actionurl" #if(!$stringtool.isBlank($linkid))id="$linkid"#end title="$escapetool.xml($linkTitle)"
+      $!extraAttributes>$services.icon.renderHTML($icon) $escapetool.xml($linkName)</a>
+  </li>
 #end
 
 ###


### PR DESCRIPTION
* Escape title and content in #submenuitem - they are always unescaped from a localization.

Jira issue: https://jira.xwiki.org/browse/XWIKI-19149