### PR TITLE
XWIKI-19342: The locale picker generates invalid child tag in option-element

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/misc.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/misc.less
@@ -501,8 +501,3 @@ a.html-diff-context-toggle {
     color: @text-color;
   }
 }
-
-// Locale Picker
-.bootstrap-select.btn-group .dropdown-menu li.active small.text-muted {
-  color: inherit;
-}

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/localePicker.js
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/localePicker.js
@@ -30,8 +30,8 @@
 #set ($currentLocale = $services.localization.currentLocale)
 #foreach ($locale in $collectiontool.sort($services.localization.availableLocales, 'displayName'))
   #if ("$!locale" != '')
-    #set ($localeName = $escapetool.xml($stringtool.capitalize($locale.getDisplayName($locale))) +
-      ' <small class="text-muted">(' + $stringtool.capitalize($locale.getDisplayName($currentLocale)) + ')</small>')
+    #set ($localeName = $escapetool.xml($stringtool.capitalize($locale.getDisplayName($locale)) +
+      ' (' + $stringtool.capitalize($locale.getDisplayName($currentLocale)) + ')'))
     #set ($discard = $locales.add({'code': $locale.toString(), 'name': $localeName}))
   #end
 #end

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BootstrapSelect.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BootstrapSelect.java
@@ -83,10 +83,7 @@ public class BootstrapSelect
             WebElement element = this.hiddenSelect.findElement(By.xpath("option[@value = \"" + value + "\"]"));
 
             if (element.getAttribute("selected") == null) {
-                // FIXME: this is a workaround as our <option>-tag contains child tags which is invalid HTML and not
-                //  supported by WebElement#getText(). The <option>-tag should be fixed, see
-                //  https://jira.xwiki.org/browse/XWIKI-19342.
-                valuesToToggle.add(element.getAttribute("textContent"));
+                valuesToToggle.add(element.getText());
             }
         }
 
@@ -97,10 +94,7 @@ public class BootstrapSelect
 
                 // Toggle the selection state if the value should not be selected anymore.
                 if (!values.contains(value)) {
-                    // FIXME: this is a workaround as our <option>-tag contains child tags which is invalid HTML and not
-                    //  supported by WebElement#getText(). The <option>-tag should be fixed, see
-                    //  https://jira.xwiki.org/browse/XWIKI-19342.
-                    valuesToToggle.add(element.getAttribute("textContent"));
+                    valuesToToggle.add(element.getText());
                 }
             }
         }


### PR DESCRIPTION
* Remove invalid child tag.
* Escape the language in both translations.
* Remove now unused CSS rule.
* Remove workaround in BootstrapSelect object.

Jira issue: https://jira.xwiki.org/browse/XWIKI-19342