### PR TITLE
XWIKI-19271: Change HTMLConverter to parse and render HTML5

### DIFF
--- a/xwiki-platform-core/xwiki-platform-edit/xwiki-platform-edit-ui/src/main/resources/XWiki/InplaceEditing.xml
+++ b/xwiki-platform-core/xwiki-platform-edit/xwiki-platform-edit-ui/src/main/resources/XWiki/InplaceEditing.xml
@@ -1593,6 +1593,7 @@ $url#if ($url.contains('?'))&amp;#else?#end$escapetool.url($params)
       'translateButtonSelector': '#tmTranslate &gt; a',
       'enableSourceMode': true,
       'enableOfficeImport': $services.officemanager.isConnected(),
+      'syntax': $services.wysiwyg.HTMLSyntax.toIdString(),
       'paths': {
         'js': {
           'xwiki-actionButtons': "#getSkinFileWithParams('js/xwiki/actionbuttons/actionButtons.js' $jsParams)",

--- a/xwiki-platform-core/xwiki-platform-edit/xwiki-platform-edit-ui/src/main/resources/XWiki/InplaceEditing.xml
+++ b/xwiki-platform-core/xwiki-platform-edit/xwiki-platform-edit-ui/src/main/resources/XWiki/InplaceEditing.xml
@@ -235,9 +235,10 @@ define('xwiki-document-api', ['jquery'], function($) {
         timestamp: new Date().getTime()
       };
       if (!forView) {
-        // We need the annotated XHTML when editing in order to be able to protect the rendering transformations and to
+        // We need the annotated HTML when editing in order to be able to protect the rendering transformations and to
         // be able to recreate the wiki syntax.
-        queryString.outputSyntax = 'annotatedxhtml';
+        queryString.outputSyntax = 'annotatedhtml';
+        queryString.outputSyntaxVersion = '5.0'
         // Currently, only the macro transformations are protected and thus can be edited.
         // See XRENDERING-78: Add markers to modified XDOM by Transformations/Macros
         queryString.transformations = 'macro';

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/internal/cleaner/DefaultHTMLCleaner.java
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/internal/cleaner/DefaultHTMLCleaner.java
@@ -21,8 +21,10 @@ package org.xwiki.wysiwyg.internal.cleaner;
 
 import java.io.StringReader;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -58,7 +60,7 @@ public class DefaultHTMLCleaner implements HTMLCleaner
     public String clean(String dirtyHTML)
     {
         // Sort the list of specific filters based on their priority.
-        Collections.sort(specificFilters, (alice, bob) -> alice.getPriority() - bob.getPriority());
+        specificFilters.sort(Comparator.comparingInt(HTMLFilter::getPriority));
 
         // We have to remove or replace the HTML elements that were added by the WYSIWYG editor only for internal
         // reasons, before any cleaning filter is applied. Otherwise cleaning filters might transform these
@@ -70,6 +72,9 @@ public class DefaultHTMLCleaner implements HTMLCleaner
         filters.addAll(specificFilters);
         filters.addAll(config.getFilters());
         config.setFilters(filters);
+        Map<String, String> parameters = new HashMap<>(config.getParameters());
+        parameters.put(HTMLCleanerConfiguration.HTML_VERSION, "5");
+        config.setParameters(parameters);
 
         Document document = cleaner.clean(new StringReader(dirtyHTML), config);
         return HTMLUtils.toString(document);

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/internal/converter/DefaultHTMLConverter.java
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/internal/converter/DefaultHTMLConverter.java
@@ -76,14 +76,14 @@ public class DefaultHTMLConverter implements HTMLConverter
      * The component used to parse the XHTML obtained after cleaning.
      */
     @Inject
-    @Named("xhtml/1.0")
+    @Named("xhtml/5")
     private Parser xhtmlParser;
 
     /**
      * The component used to parse the XHTML obtained after cleaning, when transformations are not executed.
      */
     @Inject
-    @Named("xhtml/1.0")
+    @Named("xhtml/5")
     private StreamParser xhtmlStreamParser;
 
     /**
@@ -113,7 +113,7 @@ public class DefaultHTMLConverter implements HTMLConverter
      * The component used to render a XDOM to XHTML.
      */
     @Inject
-    @Named("annotatedxhtml/1.0")
+    @Named("annotatedhtml/5.0")
     private BlockRenderer xhtmlRenderer;
 
     /**
@@ -256,7 +256,7 @@ public class DefaultHTMLConverter implements HTMLConverter
         TransformationContext txContext = new TransformationContext();
         txContext.setXDOM(xdom);
         txContext.setSyntax(syntax);
-        txContext.setTargetSyntax(Syntax.ANNOTATED_XHTML_1_0);
+        txContext.setTargetSyntax(Syntax.ANNOTATED_HTML_5_0);
 
         // It's very important to set a Transformation id as otherwise if any Velocity Macro is executed it'll be
         // executed in isolation (and if you have, say, 2 velocity macros, the second one will not 'see' what's defined

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/script/WysiwygEditorScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/script/WysiwygEditorScriptService.java
@@ -122,6 +122,14 @@ public class WysiwygEditorScriptService implements ScriptService
     }
 
     /**
+     * @return The syntax identifier of the rendered HTML.
+     */
+    public Syntax getHTMLSyntax()
+    {
+        return Syntax.ANNOTATED_HTML_5_0;
+    }
+
+    /**
      * Parses the given HTML fragment and renders the result in annotated XHTML syntax.
      * <p>
      * This method is currently used in {@code wysiwyginput.vm} and its purpose is to refresh the content of the WYSIWYG

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/script/WysiwygEditorScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/script/WysiwygEditorScriptService.java
@@ -41,6 +41,7 @@ import org.xwiki.rendering.syntax.Syntax;
 import org.xwiki.script.service.ScriptService;
 import org.xwiki.security.authorization.ContextualAuthorizationManager;
 import org.xwiki.security.authorization.Right;
+import org.xwiki.stability.Unstable;
 import org.xwiki.wysiwyg.converter.HTMLConverter;
 import org.xwiki.wysiwyg.importer.AttachmentImporter;
 
@@ -123,7 +124,9 @@ public class WysiwygEditorScriptService implements ScriptService
 
     /**
      * @return The syntax identifier of the rendered HTML.
+     * @since 14.1RC1
      */
+    @Unstable
     public Syntax getHTMLSyntax()
     {
         return Syntax.ANNOTATED_HTML_5_0;

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/test/java/org/xwiki/wysiwyg/internal/cleaner/HTMLCleanerTest.java
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/test/java/org/xwiki/wysiwyg/internal/cleaner/HTMLCleanerTest.java
@@ -78,8 +78,7 @@ public class HTMLCleanerTest
     private String xhtmlFragment(String fragment)
     {
         return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-            + "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" "
-            + "\"http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n" + "<html><head></head><body>" + fragment
+            + "<!DOCTYPE html>\n" + "<html><head></head><body>" + fragment
             + "</body></html>\n";
     }
 }

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/test/java/org/xwiki/wysiwyg/internal/converter/DefaultHTMLConverterTest.java
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/test/java/org/xwiki/wysiwyg/internal/converter/DefaultHTMLConverterTest.java
@@ -103,7 +103,7 @@ public class DefaultHTMLConverterTest
         assertEquals("", this.converter.fromHTML(html, syntaxId));
 
         // Verify the HTML is converted to the specified syntax.
-        StreamParser xhtmlStreamParser = this.componentManager.getInstance(StreamParser.class, "xhtml/1.0");
+        StreamParser xhtmlStreamParser = this.componentManager.getInstance(StreamParser.class, "html/5.0");
         verify(xhtmlStreamParser).parse(any(StringReader.class), same(printRenderer));
     }
 
@@ -136,7 +136,7 @@ public class DefaultHTMLConverterTest
         assertEquals("wysiwygtxid", txContextArgument.getValue().getId());
 
         // Verify the XDOM is rendered to Annotated XHTML.
-        BlockRenderer xhtmlRenderer = this.componentManager.getInstance(BlockRenderer.class, "annotatedxhtml/1.0");
+        BlockRenderer xhtmlRenderer = this.componentManager.getInstance(BlockRenderer.class, "annotatedhtml/5.0");
         verify(xhtmlRenderer).render(same(xdom), any(WikiPrinter.class));
     }
 
@@ -155,7 +155,7 @@ public class DefaultHTMLConverterTest
 
         // Verify the HTML is parsed into XDOM.
         XDOM xdom = new XDOM(Collections.emptyList());
-        Parser xhtmlParser = this.componentManager.getInstance(Parser.class, "xhtml/1.0");
+        Parser xhtmlParser = this.componentManager.getInstance(Parser.class, "html/5.0");
         when(xhtmlParser.parse(any(StringReader.class))).thenReturn(xdom);
 
         assertEquals("", this.converter.parseAndRender(html, syntaxId));
@@ -173,7 +173,7 @@ public class DefaultHTMLConverterTest
         assertEquals("wysiwygtxid", txContextArgument.getValue().getId());
 
         // Verify the XDOM is rendered to Annotated XHTML.
-        BlockRenderer xhtmlRenderer = this.componentManager.getInstance(BlockRenderer.class, "annotatedxhtml/1.0");
+        BlockRenderer xhtmlRenderer = this.componentManager.getInstance(BlockRenderer.class, "annotatedhtml/5.0");
         verify(xhtmlRenderer).render(same(xdom), any(WikiPrinter.class));
 
         // Verify that the syntax meta data has been set.


### PR DESCRIPTION
* Use HTML5 for inplace editing
* Use HTML in DefaultHTMLConverter
* Configure HTMLCleaner to accept HTML5

Jira issue: https://jira.xwiki.org/browse/XWIKI-19271

This depends on xwiki/xwiki-rendering#195 (XRENDERING-375: Add a parser for HTML 5/XHTML 5).
Further, this also depends on xwiki-contrib/application-ckeditor#46 as without the changes in CKEditor this will break the editing experience.