### PR TITLE
Fixes for XWIKI-14928: Upgrade to jQuery 3.6.0

### DIFF
--- a/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-webjar/src/main/webjar/loader.js
+++ b/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-webjar/src/main/webjar/loader.js
@@ -201,9 +201,9 @@ define('xwiki-realtime-loader', [
   createModalContent = function(message, primaryActionLabel) {
     var content = $(
       '<div class="modal-popup">' +
-        '<p/>' +
+        '<p></p>' +
         '<div class="realtime-buttons">' +
-          '<button class="btn btn-primary"/>' +
+          '<button class="btn btn-primary"></button>' +
         '</div>' +
       '</div>'
     );

--- a/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-webjar/src/main/webjar/toolbar.js
+++ b/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-webjar/src/main/webjar/toolbar.js
@@ -32,8 +32,8 @@ define('xwiki-realtime-toolbar', [
   var createRealtimeToolbar = function($container) {
     return $(
       '<div class="rt-toolbar">' +
-        '<div class="rt-toolbar-leftside"/>' +
-        '<div class="rt-toolbar-rightside"/>' +
+        '<div class="rt-toolbar-leftside"></div>' +
+        '<div class="rt-toolbar-rightside"></div>' +
       '</div>'
     ).attr('id', uid()).prependTo($container.first());
   };

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/xwiki.selectize.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/xwiki.selectize.js
@@ -39,8 +39,8 @@ require.config({
 define('xwiki-selectize', ['jquery', 'selectize', 'xwiki-events-bridge'], function($, Selectize) {
   var optionTemplate = [
     '<div class="xwiki-selectize-option" data-value="">',
-      '<span class="xwiki-selectize-option-icon" />',
-      '<span class="xwiki-selectize-option-label" />',
+      '<span class="xwiki-selectize-option-icon"></span>',
+      '<span class="xwiki-selectize-option-label"></span>',
     '</div>'
   ].join('');
 
@@ -70,7 +70,7 @@ define('xwiki-selectize', ['jquery', 'selectize', 'xwiki-events-bridge'], functi
     }
     var url = option && option.url;
     if (typeof url === 'string') {
-      var anchor = $('<a class="xwiki-selectize-option-label" />').attr('href', url);
+      var anchor = $('<a class="xwiki-selectize-option-label"></a>').attr('href', url);
       output.find('.xwiki-selectize-option-label').replaceWith(anchor);
     }
     var label = (option && typeof option === 'object') ? (option.label || option.value) : option;
@@ -85,10 +85,10 @@ define('xwiki-selectize', ['jquery', 'selectize', 'xwiki-events-bridge'], functi
     // We need a wrapper around the icon in order to center it because it looks better if the labels are aligned when
     // the suggestions are displayed on separate lines in the drop down list. We don't need to center the icon for the
     // selected suggestions because they are displayed in-line so the labels don't have to be aligned.
-    output.find('.xwiki-selectize-option-icon').wrap('<span class="xwiki-selectize-option-icon-wrapper"/>');
+    output.find('.xwiki-selectize-option-icon').wrap('<span class="xwiki-selectize-option-icon-wrapper"></span>');
     var hint = option && option.hint;
     if (typeof hint === 'string' && hint !== '') {
-      output.append($('<div class="xwiki-selectize-option-hint"/>').text(hint));
+      output.append($('<div class="xwiki-selectize-option-hint"></div>').text(hint));
     }
     return output;
   }
@@ -126,9 +126,9 @@ define('xwiki-selectize', ['jquery', 'selectize', 'xwiki-events-bridge'], functi
       item: renderItem,
       option: renderOption,
       option_create: function(data, escapeHTML) {
-        var label = escapeHTML(l10n.selectTypedText).replace('{0}', '<em/>');
+        var label = escapeHTML(l10n.selectTypedText).replace('{0}', '<em></em>');
         // The 'option' class is needed starting with v0.12.5 in order to have proper styling.
-        var output = $('<div class="create option"/>').html(label);
+        var output = $('<div class="create option"></div>').html(label);
         output.find('em').text(data.input);
         return output;
       }


### PR DESCRIPTION
* Fix invalid self-closing HTML tags, see https://jquery.com/upgrade-guide/3.5/. Note that apart from xwiki.selectize.js, this leaves single tags as-is as they should be okay.

Jira issue: https://jira.xwiki.org/browse/XWIKI-14928