### PR TITLE
XRENDERING-375: Add a parser for HTML 5/XHTML 5

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/EditIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/EditIT.java
@@ -934,7 +934,7 @@ public class EditIT
     {
         // Fixture: enable the XHTML syntax.
         setup.addObject("Rendering", "RenderingConfig", "Rendering.RenderingConfigClass",
-            "disabledSyntaxes", "plain/1.0,xdom+xml/current,xwiki/2.0");
+            "disabledSyntaxes", "plain/1.0,xdom+xml/current,xwiki/2.0,xhtml/5,html/5.0");
         setup.deletePage(testReference);
 
         String pageContent = "= First heading =\n"


### PR DESCRIPTION
* Fix EditIT for additional available parsers.

Jira issue for the original issue: https://jira.xwiki.org/browse/XRENDERING-375