### PR TITLE
 XRENDERING-375: Add a parser for HTML 5/XHTML 5

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-configuration/xwiki-platform-rendering-configuration-default/src/main/java/org/xwiki/rendering/internal/configuration/migrations/R140100000XRENDERING375DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-configuration/xwiki-platform-rendering-configuration-default/src/main/java/org/xwiki/rendering/internal/configuration/migrations/R140100000XRENDERING375DataMigration.java
@@ -43,9 +43,9 @@ import com.xpn.xwiki.store.migration.hibernate.AbstractHibernateDataMigration;
  * @since 14.1RC1
  */
 @Component
-@Named("R140100000XRENDERING375")
+@Named("R140100000XRENDERING375DataMigration")
 @Singleton
-public class HTML5ParserDisabledByDefaultMigrator extends AbstractHibernateDataMigration
+public class R140100000XRENDERING375DataMigration extends AbstractHibernateDataMigration
 {
     private static final String DISABLED_SYNTAXES_PROPERTY = "disabledSyntaxes";
 

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-configuration/xwiki-platform-rendering-configuration-default/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-configuration/xwiki-platform-rendering-configuration-default/src/main/resources/META-INF/components.txt
@@ -1,4 +1,4 @@
 500:org.xwiki.rendering.internal.configuration.XWikiRenderingConfiguration
 org.xwiki.rendering.internal.configuration.DefaultExtendedRenderingConfiguration
 org.xwiki.rendering.internal.configuration.RenderingConfigClassDocumentConfigurationSource
-org.xwiki.rendering.internal.configuration.migrations.HTML5ParserDisabledByDefaultMigrator
+org.xwiki.rendering.internal.configuration.migrations.R140100000XRENDERING375DataMigration

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-configuration/xwiki-platform-rendering-configuration-default/src/test/java/org/xwiki/rendering/internal/configuration/migrations/R140100000XRENDERING375DataMigrationTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-configuration/xwiki-platform-rendering-configuration-default/src/test/java/org/xwiki/rendering/internal/configuration/migrations/R140100000XRENDERING375DataMigrationTest.java
@@ -40,13 +40,13 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 /**
- * Unit tests for {@link HTML5ParserDisabledByDefaultMigrator}.
+ * Unit tests for {@link R140100000XRENDERING375DataMigration}.
  *
  * @version $Id$
  * @since 14.1RC1
  */
 @ComponentTest
-class HTML5ParserDisabledByDefaultMigratorTest
+class R140100000XRENDERING375DataMigrationTest
 {
     private static final String DISABLED_SYNTAXES_PROPERTY = "disabledSyntaxes";
 
@@ -55,14 +55,14 @@ class HTML5ParserDisabledByDefaultMigratorTest
     private ConfigurationSource renderingConfiguration;
 
     @InjectMockComponents(role = HibernateDataMigration.class)
-    private HTML5ParserDisabledByDefaultMigrator html5ParserDisabledByDefaultMigrator;
+    private R140100000XRENDERING375DataMigration r140100000XRENDERING375DataMigration;
 
     @Test
     void doNothingWhenEmpty() throws DataMigrationException
     {
         when(this.renderingConfiguration.getProperty(DISABLED_SYNTAXES_PROPERTY)).thenReturn(null);
 
-        this.html5ParserDisabledByDefaultMigrator.migrate();
+        this.r140100000XRENDERING375DataMigration.migrate();
 
         verify(this.renderingConfiguration).getProperty(DISABLED_SYNTAXES_PROPERTY);
         verifyNoMoreInteractions(this.renderingConfiguration);
@@ -74,7 +74,7 @@ class HTML5ParserDisabledByDefaultMigratorTest
         when(this.renderingConfiguration.getProperty(DISABLED_SYNTAXES_PROPERTY)).thenReturn(
             List.of(Syntax.XWIKI_2_0.toIdString(), Syntax.HTML_5_0.toIdString(), Syntax.XHTML_5.toIdString()));
 
-        this.html5ParserDisabledByDefaultMigrator.migrate();
+        this.r140100000XRENDERING375DataMigration.migrate();
 
         verify(this.renderingConfiguration).getProperty(DISABLED_SYNTAXES_PROPERTY);
         verifyNoMoreInteractions(this.renderingConfiguration);
@@ -86,7 +86,7 @@ class HTML5ParserDisabledByDefaultMigratorTest
         when(this.renderingConfiguration.getProperty(DISABLED_SYNTAXES_PROPERTY)).thenReturn(
             List.of(Syntax.XWIKI_2_0.toIdString()));
 
-        this.html5ParserDisabledByDefaultMigrator.migrate();
+        this.r140100000XRENDERING375DataMigration.migrate();
 
         verify(this.renderingConfiguration).setProperties(Map.of(DISABLED_SYNTAXES_PROPERTY,
             List.of(Syntax.XWIKI_2_0.toIdString(), Syntax.HTML_5_0.toIdString(), Syntax.XHTML_5.toIdString())));


### PR DESCRIPTION
 * Add a migration to disable the HTML 5.0 and XHTML 5 syntaxes by default on upgrades.

I have manually tested the migration starting at 14.0 and it seems to work.

Original Jira issue: https://jira.xwiki.org/browse/XRENDERING-375