### PR TITLE
XWIKI-19172: Display rendered images in view mode inside a lightbox

### DIFF
--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-pageobjects/src/main/java/org/xwiki/image/lightbox/test/po/Lightbox.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-pageobjects/src/main/java/org/xwiki/image/lightbox/test/po/Lightbox.java
@@ -57,8 +57,15 @@ public class Lightbox extends BaseElement
     public boolean waitForSlide(int index)
     {
         try {
+            int thumbnailIndex = index + 1;
+            By thumbnailSelector = By.xpath(
+                ".//div[@id=\"blueimp-gallery\"]/ol[contains(@class, \"indicator\")]/li[" + thumbnailIndex + " ]");
+            getDriver().waitUntilElementIsVisible(thumbnailSelector);
+            getDriver().waitUntilElementHasAttributeValue(thumbnailSelector, "class", "active");
+
             By slideSelector = By.cssSelector("#blueimp-gallery .slide-active");
             getDriver().waitUntilCondition(attributeToBe(slideSelector, "data-index", String.valueOf(index)));
+
             return getDriver().findElement(slideSelector).isDisplayed();
         } catch (TimeoutException e) {
             return false;


### PR DESCRIPTION
* fix lightboxIT#navigateThroughImages test that was failing on chrome browse 