### PR TITLE
XWIKI-19172: Display rendered images in view mode inside a lightbox

### DIFF
--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-docker/src/test/it/org/xwiki/image/lightbox/test/ui/LightboxIT.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-docker/src/test/it/org/xwiki/image/lightbox/test/ui/LightboxIT.java
@@ -80,6 +80,7 @@ class LightboxIT
 
         // Make sure that the images are displayed.
         testUtils.getDriver().navigate().refresh();
+        lightboxPage = new LightboxPage();
 
         Optional<ImagePopover> imagePopover = lightboxPage.hoverImage(0);
         assertFalse(imagePopover.isPresent());
@@ -101,6 +102,7 @@ class LightboxIT
 
         // Make sure that the images are displayed.
         testUtils.getDriver().navigate().refresh();
+        lightboxPage = new LightboxPage();
 
         Lightbox lightbox = lightboxPage.openLightboxAtImage(0);
         assertTrue(lightbox.isDisplayed());
@@ -128,6 +130,7 @@ class LightboxIT
 
         // Make sure that the images are displayed.
         testUtils.getDriver().navigate().refresh();
+        lightboxPage = new LightboxPage();
 
         Lightbox lightbox = lightboxPage.openLightboxAtImage(0);
         assertTrue(lightbox.isDisplayed());
@@ -155,6 +158,7 @@ class LightboxIT
 
         // Make sure that the images are displayed.
         testUtils.getDriver().navigate().refresh();
+        lightboxPage = new LightboxPage();
 
         Lightbox lightbox = lightboxPage.openLightboxAtImage(0);
         assertTrue(lightbox.isDisplayed());
@@ -199,6 +203,7 @@ class LightboxIT
 
         // Make sure that the images are displayed.
         testUtils.getDriver().navigate().refresh();
+        lightboxPage = new LightboxPage();
 
         Lightbox lightbox = lightboxPage.openLightboxAtImage(0);
         assertTrue(lightbox.isDisplayed());
@@ -222,6 +227,7 @@ class LightboxIT
 
         // Make sure that the images are displayed.
         testUtils.getDriver().navigate().refresh();
+        lightboxPage = new LightboxPage();
 
         Lightbox lightbox = lightboxPage.openLightboxAtImage(0);
         assertTrue(lightbox.isDisplayed());
@@ -255,6 +261,7 @@ class LightboxIT
 
         // Make sure that the images are displayed.
         testUtils.getDriver().navigate().refresh();
+        lightboxPage = new LightboxPage();
 
         Lightbox lightbox = lightboxPage.openLightboxAtImage(0);
         assertTrue(lightbox.isDisplayed());
@@ -282,6 +289,7 @@ class LightboxIT
 
         // Make sure that the images are displayed.
         testUtils.getDriver().navigate().refresh();
+        lightboxPage = new LightboxPage();
 
         Lightbox lightbox = lightboxPage.openLightboxAtImage(0);
         assertTrue(lightbox.isDisplayed());
@@ -308,6 +316,7 @@ class LightboxIT
 
         // Make sure that the images are displayed.
         testUtils.getDriver().navigate().refresh();
+        lightboxPage = new LightboxPage();
 
         Lightbox lightbox = lightboxPage.openLightboxAtImage(0);
         assertTrue(lightbox.isDisplayed());
@@ -331,6 +340,7 @@ class LightboxIT
 
         // Make sure that the images are displayed.
         testUtils.getDriver().navigate().refresh();
+        lightboxPage = new LightboxPage();
 
         // Verify the image popover download action.
         Optional<ImagePopover> imagePopover = lightboxPage.hoverImage(0);

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-docker/src/test/it/org/xwiki/image/lightbox/test/ui/LightboxIT.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-docker/src/test/it/org/xwiki/image/lightbox/test/ui/LightboxIT.java
@@ -79,8 +79,7 @@ class LightboxIT
         lightboxPage.attachFile(testConfiguration.getBrowser().getTestResourcesPath(), images.get(0));
 
         // Make sure that the images are displayed.
-        testUtils.getDriver().navigate().refresh();
-        lightboxPage = new LightboxPage();
+        lightboxPage.reloadPage();
 
         Optional<ImagePopover> imagePopover = lightboxPage.hoverImage(0);
         assertFalse(imagePopover.isPresent());
@@ -101,8 +100,7 @@ class LightboxIT
             lightboxPage.attachFile(testConfiguration.getBrowser().getTestResourcesPath(), images.get(0));
 
         // Make sure that the images are displayed.
-        testUtils.getDriver().navigate().refresh();
-        lightboxPage = new LightboxPage();
+        lightboxPage.reloadPage();
 
         Lightbox lightbox = lightboxPage.openLightboxAtImage(0);
         assertTrue(lightbox.isDisplayed());
@@ -129,8 +127,7 @@ class LightboxIT
             lightboxPage.attachFile(testConfiguration.getBrowser().getTestResourcesPath(), images.get(0));
 
         // Make sure that the images are displayed.
-        testUtils.getDriver().navigate().refresh();
-        lightboxPage = new LightboxPage();
+        lightboxPage.reloadPage();
 
         Lightbox lightbox = lightboxPage.openLightboxAtImage(0);
         assertTrue(lightbox.isDisplayed());
@@ -157,8 +154,7 @@ class LightboxIT
             lightboxPage.attachFile(testConfiguration.getBrowser().getTestResourcesPath(), images.get(0));
 
         // Make sure that the images are displayed.
-        testUtils.getDriver().navigate().refresh();
-        lightboxPage = new LightboxPage();
+        lightboxPage.reloadPage();
 
         Lightbox lightbox = lightboxPage.openLightboxAtImage(0);
         assertTrue(lightbox.isDisplayed());
@@ -202,8 +198,7 @@ class LightboxIT
         lightboxPage.attachFile(testConfiguration.getBrowser().getTestResourcesPath(), images.get(0));
 
         // Make sure that the images are displayed.
-        testUtils.getDriver().navigate().refresh();
-        lightboxPage = new LightboxPage();
+        lightboxPage.reloadPage();
 
         Lightbox lightbox = lightboxPage.openLightboxAtImage(0);
         assertTrue(lightbox.isDisplayed());
@@ -226,8 +221,7 @@ class LightboxIT
         lightboxPage.attachFile(testConfiguration.getBrowser().getTestResourcesPath(), images.get(1));
 
         // Make sure that the images are displayed.
-        testUtils.getDriver().navigate().refresh();
-        lightboxPage = new LightboxPage();
+        lightboxPage.reloadPage();
 
         Lightbox lightbox = lightboxPage.openLightboxAtImage(0);
         assertTrue(lightbox.isDisplayed());
@@ -260,8 +254,7 @@ class LightboxIT
         lightboxPage.attachFile(testConfiguration.getBrowser().getTestResourcesPath(), images.get(1));
 
         // Make sure that the images are displayed.
-        testUtils.getDriver().navigate().refresh();
-        lightboxPage = new LightboxPage();
+        lightboxPage.reloadPage();
 
         Lightbox lightbox = lightboxPage.openLightboxAtImage(0);
         assertTrue(lightbox.isDisplayed());
@@ -288,8 +281,7 @@ class LightboxIT
         lightboxPage = new LightboxPage();
 
         // Make sure that the images are displayed.
-        testUtils.getDriver().navigate().refresh();
-        lightboxPage = new LightboxPage();
+        lightboxPage.reloadPage();
 
         Lightbox lightbox = lightboxPage.openLightboxAtImage(0);
         assertTrue(lightbox.isDisplayed());
@@ -315,8 +307,7 @@ class LightboxIT
         lightboxPage.attachFile(testConfiguration.getBrowser().getTestResourcesPath(), images.get(0));
 
         // Make sure that the images are displayed.
-        testUtils.getDriver().navigate().refresh();
-        lightboxPage = new LightboxPage();
+        lightboxPage.reloadPage();
 
         Lightbox lightbox = lightboxPage.openLightboxAtImage(0);
         assertTrue(lightbox.isDisplayed());
@@ -339,8 +330,7 @@ class LightboxIT
         lightboxPage.attachFile(testConfiguration.getBrowser().getTestResourcesPath(), images.get(0));
 
         // Make sure that the images are displayed.
-        testUtils.getDriver().navigate().refresh();
-        lightboxPage = new LightboxPage();
+        lightboxPage.reloadPage();
 
         // Verify the image popover download action.
         Optional<ImagePopover> imagePopover = lightboxPage.hoverImage(0);

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-pageobjects/src/main/java/org/xwiki/image/lightbox/test/po/LightboxPage.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-pageobjects/src/main/java/org/xwiki/image/lightbox/test/po/LightboxPage.java
@@ -41,6 +41,12 @@ import org.xwiki.test.ui.po.ViewPage;
  */
 public class LightboxPage extends ViewPage
 {
+    public void reloadPage()
+    {
+        getDriver().navigate().refresh();
+        waitUntilPageJSIsLoaded();
+    }
+
     public Optional<ImagePopover> hoverImage(int index)
     {
         try {

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-pageobjects/src/main/java/org/xwiki/image/lightbox/test/po/LightboxPage.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-pageobjects/src/main/java/org/xwiki/image/lightbox/test/po/LightboxPage.java
@@ -41,6 +41,9 @@ import org.xwiki.test.ui.po.ViewPage;
  */
 public class LightboxPage extends ViewPage
 {
+    /**
+     * Make sure that the javascript is also loaded after page refresh since lightbox actions depend on it.
+     */
     public void reloadPage()
     {
         getDriver().navigate().refresh();

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-pageobjects/src/main/java/org/xwiki/image/lightbox/test/po/LightboxPage.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-pageobjects/src/main/java/org/xwiki/image/lightbox/test/po/LightboxPage.java
@@ -41,15 +41,6 @@ import org.xwiki.test.ui.po.ViewPage;
  */
 public class LightboxPage extends ViewPage
 {
-    /**
-     * Make sure that the javascript is also loaded after page refresh since lightbox actions depend on it.
-     */
-    public void reloadPage()
-    {
-        getDriver().navigate().refresh();
-        waitUntilPageJSIsLoaded();
-    }
-
     public Optional<ImagePopover> hoverImage(int index)
     {
         try {

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BasePage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BasePage.java
@@ -282,6 +282,16 @@ public class BasePage extends BaseElement
     }
 
     /**
+     * Refresh the page and wait for the javascript to be also loaded.
+     */
+    public BasePage reloadPage()
+    {
+        getDriver().navigate().refresh();
+        waitUntilPageJSIsLoaded();
+        return this;
+    }
+
+    /**
      * @since 7.2M3
      */
     public void toggleDrawer()

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BasePage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BasePage.java
@@ -283,6 +283,8 @@ public class BasePage extends BaseElement
 
     /**
      * Refresh the page and wait for the javascript to be also loaded.
+     *
+     * @since 14.1
      */
     public BasePage reloadPage()
     {


### PR DESCRIPTION
* try to fix hoverImage() flickering problems, that might be caused by the fact that after a refresh the JS was not yet fully loaded