### PR TITLE
XWIKI-19352: Indexing of the attachments usage on the wiki

### DIFF
--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-api/src/main/java/org/xwiki/index/migration/R140200001XWIKI19352DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-api/src/main/java/org/xwiki/index/migration/R140200001XWIKI19352DataMigration.java
@@ -48,13 +48,13 @@ import static org.xwiki.index.internal.DefaultLinksTaskConsumer.LINKS_TASK_TYPE;
 // TODO: Implement DataMigration once XWIKI-19399 is fixed.
 @Component
 @Singleton
-@Named(R1402000XWIKI19352DataMigration.HINT)
-public class R1402000XWIKI19352DataMigration implements HibernateDataMigration
+@Named(R140200001XWIKI19352DataMigration.HINT)
+public class R140200001XWIKI19352DataMigration implements HibernateDataMigration
 {
     /**
      * The hint for this component.
      */
-    public static final String HINT = "R1402000XWIKI19352";
+    public static final String HINT = "140200001XWIKI19352";
 
     @Inject
     private QueryManager queryManager;
@@ -80,7 +80,7 @@ public class R1402000XWIKI19352DataMigration implements HibernateDataMigration
     @Override
     public XWikiDBVersion getVersion()
     {
-        return new XWikiDBVersion(140200000);
+        return new XWikiDBVersion(140200001);
     }
 
     @Override
@@ -113,10 +113,8 @@ public class R1402000XWIKI19352DataMigration implements HibernateDataMigration
     @Override
     public String getPreHibernateLiquibaseChangeLog()
     {
-        return "<changeSet author=\"xwikiorg\"  id=\"" + HINT + "\">\n"
-            + "  <dropTable tableName=\"xwikilinks\"/>\n"
-            + "</changeSet>\n"
-            + "\n";
+        // TODO: Remove once XWIKI-19399 is fixed.
+        return null;
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-api/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-api/src/main/resources/META-INF/components.txt
@@ -4,4 +4,4 @@ org.xwiki.index.internal.TaskExecutor
 org.xwiki.index.internal.TaskApplicationReadyListener
 org.xwiki.index.internal.DefaultLinksTaskConsumer
 org.xwiki.index.internal.listener.LinksUpdateListener
-org.xwiki.index.migration.R1402000XWIKI19352DataMigration
+org.xwiki.index.migration.R140200001XWIKI19352DataMigration

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-api/src/test/java/org/xwiki/index/migration/R140200001XWIKI19352DataMigrationTest.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-api/src/test/java/org/xwiki/index/migration/R140200001XWIKI19352DataMigrationTest.java
@@ -47,16 +47,16 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
- * Test of {@link R1402000XWIKI19352DataMigration}.
+ * Test of {@link R140200001XWIKI19352DataMigration}.
  *
  * @version $Id$
  * @since 14.2RC1
  */
 @ComponentTest
-class R1402000XWIKI19352DataMigrationTest
+class R140200001XWIKI19352DataMigrationTest
 {
     @InjectMockComponents(role = HibernateDataMigration.class)
-    private R1402000XWIKI19352DataMigration migration;
+    private R140200001XWIKI19352DataMigration migration;
 
     @MockComponent
     private QueryManager queryManager;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R140200000XWIKI19352DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R140200000XWIKI19352DataMigration.java
@@ -1,0 +1,79 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xpn.xwiki.store.migration.hibernate;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.store.migration.DataMigrationException;
+import com.xpn.xwiki.store.migration.XWikiDBVersion;
+
+/**
+ * Remove the xwikilinks table to allow it to be recreated from scratch. This is needed because we migrate from a 
+ * composite id to a unique id key, and the composite id index is not removed automatically. While we could selectively
+ * remove the deprecated index, it is easier to remove the table and let it be recreated automatically, since 
+ * {@code R140200001XWIKI19352DataMigration} would drop all the table content anyway. 
+ *
+ * @version $Id$
+ * @since 14.2
+ */
+@Component
+@Singleton
+@Named(R140200000XWIKI19352DataMigration.HINT)
+public class R140200000XWIKI19352DataMigration extends AbstractHibernateDataMigration
+{
+    /**
+     * The hint for this component.
+     */
+    public static final String HINT = "140200000XWIKI19352";
+
+    @Override
+    public String getDescription()
+    {
+        return "Drop the xwikilinks table if it exists.";
+    }
+
+    @Override
+    protected void hibernateMigrate() throws DataMigrationException, XWikiException
+    {
+        // Nothing to do here, all the work is done as Liquibase changes
+    }
+
+    @Override
+    public XWikiDBVersion getVersion()
+    {
+        return new XWikiDBVersion(140200000);
+    }
+
+    @Override
+    public String getPreHibernateLiquibaseChangeLog() throws DataMigrationException
+    {
+        return "<changeSet author=\"xwikiorg\" id=\"" + HINT + "\">\n"
+            + "  <preConditions onFail=\"CONTINUE\">\n"
+            + "    <tableExists tableName=\"xwikilinks\"/>\n"
+            + "  </preConditions>"
+            + "  <dropTable tableName=\"xwikilinks\"/>\n"
+            + "</changeSet>\n"
+            + "\n";
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R140200000XWIKI19352DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R140200000XWIKI19352DataMigration.java
@@ -69,7 +69,7 @@ public class R140200000XWIKI19352DataMigration extends AbstractHibernateDataMigr
     public String getPreHibernateLiquibaseChangeLog() throws DataMigrationException
     {
         return "<changeSet author=\"xwikiorg\" id=\"" + HINT + "\">\n"
-            + "  <preConditions onFail=\"CONTINUE\">\n"
+            + "  <preConditions onFail=\"MARK_RAN\">\n"
             + "    <tableExists tableName=\"xwikilinks\"/>\n"
             + "  </preConditions>"
             + "  <dropTable tableName=\"xwikilinks\"/>\n"

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/META-INF/components.txt
@@ -210,6 +210,7 @@ com.xpn.xwiki.store.migration.hibernate.R1138000XWIKI16709DataMigration
 com.xpn.xwiki.store.migration.hibernate.R130200000XWIKI17200DataMigration
 com.xpn.xwiki.store.migration.hibernate.R140000000XWIKI19125DataMigration
 com.xpn.xwiki.store.migration.hibernate.R140200010XWIKI19207DataMigration
+com.xpn.xwiki.store.migration.hibernate.R140200000XWIKI19352DataMigration
 com.xpn.xwiki.store.VoidAttachmentVersioningStore
 com.xpn.xwiki.store.XWikiHibernateStore
 com.xpn.xwiki.store.XWikiHibernateVersioningStore


### PR DESCRIPTION
Split the migration in two distinct steps:
- remove the xwikilink table in oldcore
- repopulate it with up to date entries in index-api