### PR TITLE
XWIKI-15776: The groups displayer store values with a coma at the end

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/GroupsClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/GroupsClass.java
@@ -51,6 +51,8 @@ public class GroupsClass extends ListClass
     /** Logging helper object. */
     private static final Logger LOGGER = LoggerFactory.getLogger(GroupsClass.class);
 
+    private static final String COMMA = ",";
+
     /**
      * The meta property that specifies if the list box that is used to select the groups should be filled with all the
      * available groups. This property should not be set when the number of groups is very large.
@@ -69,6 +71,8 @@ public class GroupsClass extends ListClass
         setSize(20);
         setDisplayType("input");
         setPicker(true);
+        setSeparator(COMMA);
+        setSeparators(COMMA);
     }
 
     /**
@@ -169,7 +173,7 @@ public class GroupsClass extends ListClass
      */
     public static List<String> getListFromString(String value)
     {
-        return getListFromString(value, ",", false, true);
+        return getListFromString(value, COMMA, false, true);
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/GroupsClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/GroupsClass.java
@@ -26,7 +26,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang3.StringUtils;
 import org.dom4j.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -145,7 +144,7 @@ public class GroupsClass extends ListClass
         List<String> list = Arrays.asList(strings);
 
         BaseProperty prop = newProperty();
-        fromList(prop, list);
+        fromList(prop, list, true);
         return prop;
     }
 
@@ -170,7 +169,7 @@ public class GroupsClass extends ListClass
      */
     public static List<String> getListFromString(String value)
     {
-        return getListFromString(value, ",", false);
+        return getListFromString(value, ",", false, true);
     }
 
     @Override
@@ -192,16 +191,6 @@ public class GroupsClass extends ListClass
         }
 
         return selectlist;
-    }
-
-    @Override
-    public void fromList(BaseProperty<?> property, List<String> list)
-    {
-        if (isMultiSelect()) {
-            property.setValue(list != null ? StringUtils.join(list, ',') : null);
-        } else {
-            property.setValue(list != null && !list.isEmpty() ? list.get(0) : null);
-        }
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/GroupsClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/GroupsClass.java
@@ -71,8 +71,6 @@ public class GroupsClass extends ListClass
         setSize(20);
         setDisplayType("input");
         setPicker(true);
-        setSeparator(COMMA);
-        setSeparators(COMMA);
     }
 
     /**
@@ -81,6 +79,12 @@ public class GroupsClass extends ListClass
     public GroupsClass()
     {
         this(null);
+    }
+
+    @Override
+    protected String getFirstSeparator()
+    {
+        return COMMA;
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/GroupsClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/GroupsClass.java
@@ -152,8 +152,14 @@ public class GroupsClass extends ListClass
         List<String> list = Arrays.asList(strings);
 
         BaseProperty prop = newProperty();
-        fromList(prop, list, true);
+        fromList(prop, list);
         return prop;
+    }
+
+    @Override
+    public void fromList(BaseProperty<?> property, List<String> list)
+    {
+        fromList(property, list, true);
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/LevelsClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/LevelsClass.java
@@ -56,13 +56,17 @@ public class LevelsClass extends ListClass
     {
         super(XCLASSNAME, "Levels List", wclass);
         setSize(6);
-        setSeparator(COMMA);
-        setSeparators(COMMA);
     }
 
     public LevelsClass()
     {
         this(null);
+    }
+
+    @Override
+    protected String getFirstSeparator()
+    {
+        return COMMA;
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/LevelsClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/LevelsClass.java
@@ -50,10 +50,14 @@ public class LevelsClass extends ListClass
 
     private static final String XCLASSNAME = "levelslist";
 
+    private static final String COMMA = ",";
+
     public LevelsClass(PropertyMetaClass wclass)
     {
         super(XCLASSNAME, "Levels List", wclass);
         setSize(6);
+        setSeparator(COMMA);
+        setSeparators(COMMA);
     }
 
     public LevelsClass()
@@ -121,7 +125,7 @@ public class LevelsClass extends ListClass
 
     public static List<String> getListFromString(String value)
     {
-        return getListFromString(value, ",", false, true);
+        return getListFromString(value, COMMA, false, true);
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/LevelsClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/LevelsClass.java
@@ -20,12 +20,12 @@
 package com.xpn.xwiki.objects.classes;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.ecs.xhtml.input;
 import org.apache.ecs.xhtml.option;
 import org.apache.ecs.xhtml.select;
@@ -116,10 +116,16 @@ public class LevelsClass extends ListClass
     @Override
     public BaseProperty fromStringArray(String[] strings)
     {
-        List<String> list = new ArrayList<String>();
+        List<String> list = Arrays.asList(strings);
         BaseProperty prop = newProperty();
         fromList(prop, list, true);
         return prop;
+    }
+
+    @Override
+    public void fromList(BaseProperty<?> property, List<String> list)
+    {
+        fromList(property, list, true);
     }
 
     public String getText(String value, XWikiContext context)

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/LevelsClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/LevelsClass.java
@@ -109,13 +109,8 @@ public class LevelsClass extends ListClass
     public BaseProperty fromStringArray(String[] strings)
     {
         List<String> list = new ArrayList<String>();
-        for (int i = 0; i < strings.length; i++) {
-            if (!strings[i].trim().equals("")) {
-                list.add(strings[i]);
-            }
-        }
         BaseProperty prop = newProperty();
-        fromList(prop, list);
+        fromList(prop, list, true);
         return prop;
     }
 
@@ -126,7 +121,7 @@ public class LevelsClass extends ListClass
 
     public static List<String> getListFromString(String value)
     {
-        return getListFromString(value, ",", false);
+        return getListFromString(value, ",", false, true);
     }
 
     @Override
@@ -192,12 +187,6 @@ public class LevelsClass extends ListClass
         }
 
         return selectlist;
-    }
-
-    @Override
-    public void fromList(BaseProperty<?> property, List<String> list)
-    {
-        property.setValue(list != null ? StringUtils.join(list, ',') : null);
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
@@ -559,6 +559,7 @@ public abstract class ListClass extends PropertyClass
     {
         BaseProperty lprop;
 
+        // FIXME: this if is actually wrong: it means a multiselect static list cannot be stored with a large storage.
         if (isRelationalStorage() && isMultiSelect()) {
             lprop = new DBStringListProperty();
         } else if (isMultiSelect()) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
@@ -316,6 +316,21 @@ public abstract class ListClass extends PropertyClass
     }
 
     /**
+     * @return the first separator of the list of separators, or fallback on {@link #DEFAULT_SEPARATOR}.
+     * @since 14.2RC1
+     */
+    protected String getFirstSeparator()
+    {
+        String separator;
+        if (!StringUtils.isEmpty(getSeparators())) {
+            separator = String.valueOf(getSeparators().charAt(0));
+        } else {
+            separator = DEFAULT_SEPARATOR;
+        }
+        return separator;
+    }
+
+    /**
      * @param value the string holding a serialized list
      * @param separators the separator characters (given as a string) used to delimit the list's items inside the input
      *            string. These separators can also be present, in escaped ({@value #SEPARATOR_ESCAPE}) form, inside
@@ -1024,17 +1039,7 @@ public abstract class ListClass extends PropertyClass
             if (property instanceof ListProperty) {
                 ((ListProperty) property).setList(actualList);
             } else if (isMultiSelect()) {
-                // We don't rely on the default separator here, as we want to use the given separator from the class
-                // which not might the default.
-                // TODO: maybe we should do the same in #getStringFromList which takes a single argument?
-                String separator;
-                if (!StringUtils.isEmpty(getSeparators())) {
-                    separator = String.valueOf(getSeparators().charAt(0));
-                } else {
-                    separator = DEFAULT_SEPARATOR;
-                }
-
-                property.setValue(getStringFromList(actualList, separator));
+                property.setValue(getStringFromList(actualList, getFirstSeparator()));
             } else {
                 property.setValue(actualList.isEmpty() ? null : actualList.get(0));
             }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/UsersClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/UsersClass.java
@@ -19,7 +19,7 @@
  */
 package com.xpn.xwiki.objects.classes;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -164,10 +164,16 @@ public class UsersClass extends ListClass
     @Override
     public BaseProperty fromStringArray(String[] strings)
     {
-        List<String> list = new ArrayList<>();
+        List<String> list = Arrays.asList(strings);
         BaseProperty prop = newProperty();
-        fromList(prop, list, true);
+        fromList(prop, list);
         return prop;
+    }
+
+    @Override
+    public void fromList(BaseProperty<?> property, List<String> list)
+    {
+        fromList(property, list, true);
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/UsersClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/UsersClass.java
@@ -50,13 +50,13 @@ public class UsersClass extends ListClass
     /** Logging helper object. */
     private static final Logger LOGGER = LoggerFactory.getLogger(UsersClass.class);
 
-    private static final String COMMA = ",";
-
     /**
      * The meta property that specifies if the list box that is used to select the users should be filled with all the
      * available users. This property should not be set when the number of users is very large.
      */
     private static final String META_PROPERTY_USES_LIST = "usesList";
+
+    private static final String COMMA = ",";
 
     /**
      * Creates a new Users List property that is described by the given meta class.
@@ -70,8 +70,6 @@ public class UsersClass extends ListClass
         setSize(20);
         setDisplayType("input");
         setPicker(true);
-        setSeparator(COMMA);
-        setSeparators(COMMA);
     }
 
     /**
@@ -80,6 +78,12 @@ public class UsersClass extends ListClass
     public UsersClass()
     {
         this(null);
+    }
+
+    @Override
+    protected String getFirstSeparator()
+    {
+        return COMMA;
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/UsersClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/UsersClass.java
@@ -50,6 +50,8 @@ public class UsersClass extends ListClass
     /** Logging helper object. */
     private static final Logger LOGGER = LoggerFactory.getLogger(UsersClass.class);
 
+    private static final String COMMA = ",";
+
     /**
      * The meta property that specifies if the list box that is used to select the users should be filled with all the
      * available users. This property should not be set when the number of users is very large.
@@ -68,6 +70,8 @@ public class UsersClass extends ListClass
         setSize(20);
         setDisplayType("input");
         setPicker(true);
+        setSeparator(COMMA);
+        setSeparators(COMMA);
     }
 
     /**
@@ -180,7 +184,7 @@ public class UsersClass extends ListClass
      */
     public static List<String> getListFromString(String value)
     {
-        return getListFromString(value, ",", false, true);
+        return getListFromString(value, COMMA, false, true);
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/UsersClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/UsersClass.java
@@ -25,7 +25,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang3.StringUtils;
 import org.dom4j.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -158,13 +157,8 @@ public class UsersClass extends ListClass
     public BaseProperty fromStringArray(String[] strings)
     {
         List<String> list = new ArrayList<>();
-        for (int i = 0; i < strings.length; i++) {
-            if (!StringUtils.isBlank(strings[i])) {
-                list.add(strings[i]);
-            }
-        }
         BaseProperty prop = newProperty();
-        prop.setValue(StringUtils.join(list, ','));
+        fromList(prop, list, true);
         return prop;
     }
 
@@ -186,7 +180,7 @@ public class UsersClass extends ListClass
      */
     public static List<String> getListFromString(String value)
     {
-        return getListFromString(value, ",", false);
+        return getListFromString(value, ",", false, true);
     }
 
     @Override
@@ -208,16 +202,6 @@ public class UsersClass extends ListClass
         }
 
         return selectlist;
-    }
-
-    @Override
-    public void fromList(BaseProperty<?> property, List<String> list)
-    {
-        if (isMultiSelect()) {
-            property.setValue(list != null ? StringUtils.join(list, ',') : null);
-        } else {
-            property.setValue(list != null && !list.isEmpty() ? list.get(0) : null);
-        }
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/GroupsClassTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/GroupsClassTest.java
@@ -1,0 +1,64 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xpn.xwiki.objects.classes;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.xpn.xwiki.objects.BaseProperty;
+import com.xpn.xwiki.objects.LargeStringProperty;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link GroupsClass}.
+ *
+ * @version $Id$
+ * @since 14.2RC1
+ */
+public class GroupsClassTest
+{
+    @Test
+    void fromList()
+    {
+        BaseProperty baseProperty = mock(LargeStringProperty.class);
+        List<String> list = Arrays.asList("XWiki.Foo", null, "XWiki.Bar", "");
+        GroupsClass groupsClass = new GroupsClass();
+        groupsClass.setMultiSelect(true);
+        groupsClass.fromList(baseProperty, list);
+        verify(baseProperty).setValue("XWiki.Foo,XWiki.Bar");
+    }
+
+    @Test
+    void fromStringArray()
+    {
+        String[] array = new String[] {"XWiki.Foo", null, "XWiki.Bar", ""};
+        GroupsClass groupsClass = new GroupsClass();
+        groupsClass.setMultiSelect(true);
+        LargeStringProperty expectedProperty = new LargeStringProperty();
+        expectedProperty.setValue("XWiki.Foo,XWiki.Bar");
+        expectedProperty.setName("groupslist");
+        assertEquals(expectedProperty, groupsClass.fromStringArray(array));
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/LevelsClassTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/LevelsClassTest.java
@@ -30,11 +30,14 @@ import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.objects.BaseCollection;
 import com.xpn.xwiki.objects.BaseProperty;
+import com.xpn.xwiki.objects.LargeStringProperty;
+import com.xpn.xwiki.objects.StringProperty;
 import com.xpn.xwiki.user.api.XWikiRightService;
 import com.xpn.xwiki.web.XWikiRequest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -98,5 +101,28 @@ public class LevelsClassTest
             + "<option value='delete' label='delete'>delete</option>"
             + "</select><input name='authorizationrights' type='hidden'/>";
         assertEquals(expectedString, stringBuffer.toString());
+    }
+
+    @Test
+    void fromList()
+    {
+        BaseProperty baseProperty = mock(LargeStringProperty.class);
+        List<String> list = Arrays.asList("admin", null, "view", "");
+        LevelsClass levelsClass = new LevelsClass();
+        levelsClass.setMultiSelect(true);
+        levelsClass.fromList(baseProperty, list);
+        verify(baseProperty).setValue("admin,view");
+    }
+
+    @Test
+    void fromStringArray()
+    {
+        String[] array = new String[] {"admin", null, "view", ""};
+        LevelsClass levelsClass = new LevelsClass();
+        levelsClass.setMultiSelect(true);
+        StringProperty expectedProperty = new StringProperty();
+        expectedProperty.setValue("admin,view");
+        expectedProperty.setName("levelslist");
+        assertEquals(expectedProperty, levelsClass.fromStringArray(array));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/ListClassTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/ListClassTest.java
@@ -31,13 +31,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * 
  * @version $Id$
  */
-public class ListClassTest
+class ListClassTest
 {
     /**
      * Test that the default separator {@link ListClass#DEFAULT_SEPARATOR} is used when not specified.
      */
     @Test
-    public void testGetListFromStringDefaultSeparator()
+    void getListFromStringDefaultSeparator()
     {
         assertEquals(Arrays.asList("a", "b", "c"), ListClass.getListFromString("a|b|c"));
     }
@@ -46,7 +46,7 @@ public class ListClassTest
      * Test that the separator can be escaped inside the list item.
      */
     @Test
-    public void testGetListFromStringSeparatorInValues()
+    void getListFromStringSeparatorInValues()
     {
         assertEquals(Arrays.asList("a", "|b", "c|", "|"), ListClass.getListFromString("a|\\|b|c\\||\\|"));
     }
@@ -55,7 +55,7 @@ public class ListClassTest
      * Test that custom separators work.
      */
     @Test
-    public void testGetListFromStringNonDefaultSeparator()
+    void getListFromStringNonDefaultSeparator()
     {
         assertEquals(Arrays.asList("a", "b", "c"), ListClass.getListFromString("a*b*c", "*", false));
     }
@@ -64,7 +64,7 @@ public class ListClassTest
      * Test that we can use more than one separator.
      */
     @Test
-    public void testGetListFromStringMultipleSeparators()
+    void getListFromStringMultipleSeparators()
     {
         assertEquals(Arrays.asList("a", "b", "c", "d", "e"), ListClass.getListFromString("a*b,c,d*e", "*,", false));
     }
@@ -73,7 +73,7 @@ public class ListClassTest
      * Test the behaviour when multiple separators are used in concatenation.
      */
     @Test
-    public void testGetListFromStringConcatenatedSeparators()
+    void getListFromStringConcatenatedSeparators()
     {
         assertEquals(Arrays.asList("a", "b"), ListClass.getListFromString("a, b", ", ", false));
         assertEquals(Arrays.asList("a", "b"), ListClass.getListFromString("a ,b", ", ", false));
@@ -89,7 +89,7 @@ public class ListClassTest
      * Test that escaped separators in list values work with multipel separators as well.
      */
     @Test
-    public void testGetListFromStringMultipleSeparatorsWithSeparatorsInValues()
+    void getListFromStringMultipleSeparatorsWithSeparatorsInValues()
     {
         assertEquals(Arrays.asList("a*b", "c,d", "e*f"),
             ListClass.getListFromString("a\\*b,c\\,d*e\\*f", "*,", false));
@@ -99,7 +99,7 @@ public class ListClassTest
      * Test that the default separator {@link ListClass#DEFAULT_SEPARATOR} is used when not specified.
      */
     @Test
-    public void testGetStringFromListDefaultSeparator()
+    void getStringFromListDefaultSeparator()
     {
         assertEquals("a|b|c", ListClass.getStringFromList(Arrays.asList("a", "b", "c")));
     }
@@ -108,7 +108,7 @@ public class ListClassTest
      * Test that the separator can be escaped inside the list item.
      */
     @Test
-    public void testGetStringFromListSeparatorInValues()
+    void getStringFromListSeparatorInValues()
     {
         assertEquals("a|\\|b|c\\||\\|", ListClass.getStringFromList(Arrays.asList("a", "|b", "c|", "|")));
     }
@@ -117,7 +117,7 @@ public class ListClassTest
      * Test that custom separators work.
      */
     @Test
-    public void testGetStringFromListNonDefaultSeparator()
+    void getStringFromListNonDefaultSeparator()
     {
         assertEquals("a*b*c", ListClass.getStringFromList(Arrays.asList("a", "b", "c"), "*"));
     }
@@ -126,7 +126,7 @@ public class ListClassTest
      * Test that we can use more than one separator.
      */
     @Test
-    public void testGetStringFromListMultipleSeparators()
+    void getStringFromListMultipleSeparators()
     {
         assertEquals("a*b*c*d*e", ListClass.getStringFromList(Arrays.asList("a", "b", "c", "d", "e"), "*,"));
     }
@@ -135,20 +135,26 @@ public class ListClassTest
      * Test that escaped separators in list values work with multipel separators as well.
      */
     @Test
-    public void testGetStringFromListMultipleSeparatorsWithSeparatorsInValues()
+    void getStringFromListMultipleSeparatorsWithSeparatorsInValues()
     {
         assertEquals("a\\*b*c\\,d*e\\*f", ListClass.getStringFromList(Arrays.asList("a*b", "c,d", "e*f"), "*,"));
     }
 
     @Test
-    public void testGetStringFromListWithNullValue()
+    void getStringFromListWithNullValue()
     {
         assertEquals("a.c", ListClass.getStringFromList(Arrays.asList("a", null, "c"), "."));
         assertEquals("a..c", ListClass.getStringFromList(Arrays.asList("a", "", "c"), "."));
     }
 
     @Test
-    public void getMapFromString()
+    void getStringFromListFinalEmptyValue()
+    {
+        assertEquals("a|b|c|", ListClass.getStringFromList(Arrays.asList("a", "b", "c", ""), "|"));
+    }
+
+    @Test
+    void getMapFromString()
     {
         Map<String, ListItem> map = ListClass.getMapFromString("a=1|b");
         assertEquals(2, map.size());
@@ -159,7 +165,7 @@ public class ListClassTest
     }
 
     @Test
-    public void getMapFromStringWithEmptyValue()
+    void getMapFromStringWithEmptyValue()
     {
         Map<String, ListItem> map = ListClass.getMapFromString("|a");
         assertEquals(2, map.size());
@@ -170,7 +176,7 @@ public class ListClassTest
     }
 
     @Test
-    public void getMapFromStringWithEmptyValueWithLabel()
+    void getMapFromStringWithEmptyValueWithLabel()
     {
         Map<String, ListItem> map = ListClass.getMapFromString("=None|a");
         assertEquals(2, map.size());
@@ -181,7 +187,7 @@ public class ListClassTest
     }
 
     @Test
-    public void listWithBackslash()
+    void listWithBackslash()
     {
         assertEquals(Arrays.asList("a\\b", "c"), ListClass.getListFromString("a\\b|c"));
         assertEquals(Arrays.asList("a", "\\", "c"), ListClass.getListFromString("a|\\\\|c"));
@@ -196,5 +202,12 @@ public class ListClassTest
         assertEquals(Arrays.asList("a", "\\", "c"), ListClass.getListFromString("a,\\\\,c", ",", false));
         assertEquals(Arrays.asList("a", ",c"), ListClass.getListFromString("a,\\,c", ",", false));
         assertEquals(Arrays.asList("a", "\\,c"), ListClass.getListFromString("a,\\\\\\,c", ",", false));
+    }
+
+    @Test
+    void getListFromStringFilterEmptyValues()
+    {
+        assertEquals(Arrays.asList("a", "b", "", "c", ""), ListClass.getListFromString("a|b||c|", "|", false, false));
+        assertEquals(Arrays.asList("a", "b", "c"), ListClass.getListFromString("a|b||c|", "|", false, true));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/UsersClassTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/UsersClassTest.java
@@ -23,23 +23,27 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xwiki.model.reference.DocumentReferenceResolver;
 import org.xwiki.model.reference.EntityReferenceResolver;
 import org.xwiki.model.reference.EntityReferenceSerializer;
-import org.xwiki.test.mockito.MockitoComponentManagerRule;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectComponentManager;
+import org.xwiki.test.mockito.MockitoComponentManager;
 
 import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.objects.BaseProperty;
+import com.xpn.xwiki.objects.LargeStringProperty;
 import com.xpn.xwiki.user.api.XWikiGroupService;
 import com.xpn.xwiki.web.Utils;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -48,13 +52,14 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  * @since 5.1M2
  */
-public class UsersClassTest
+@ComponentTest
+class UsersClassTest
 {
-    @Rule
-    public MockitoComponentManagerRule componentManager = new MockitoComponentManagerRule();
+    @InjectComponentManager
+    private MockitoComponentManager componentManager;
 
     @Test
-    public void getMap() throws Exception
+    void getMap() throws Exception
     {
         XWikiContext context = mock(XWikiContext.class);
         com.xpn.xwiki.XWiki xwiki = mock(com.xpn.xwiki.XWiki.class);
@@ -75,5 +80,28 @@ public class UsersClassTest
         assertEquals(1, results.size());
         assertEquals("XWiki.Admin", results.get("XWiki.Admin").getId());
         assertEquals("Administrator", results.get("XWiki.Admin").getValue());
+    }
+
+    @Test
+    void fromList()
+    {
+        BaseProperty baseProperty = mock(LargeStringProperty.class);
+        List<String> list = Arrays.asList("XWiki.Foo", null, "XWiki.Bar", "");
+        UsersClass usersClass = new UsersClass();
+        usersClass.setMultiSelect(true);
+        usersClass.fromList(baseProperty, list);
+        verify(baseProperty).setValue("XWiki.Foo,XWiki.Bar");
+    }
+
+    @Test
+    void fromStringArray()
+    {
+        String[] array = new String[] {"XWiki.Foo", null, "XWiki.Bar", ""};
+        UsersClass usersClass = new UsersClass();
+        usersClass.setMultiSelect(true);
+        LargeStringProperty expectedProperty = new LargeStringProperty();
+        expectedProperty.setValue("XWiki.Foo,XWiki.Bar");
+        expectedProperty.setName("userslist");
+        assertEquals(expectedProperty, usersClass.fromStringArray(array));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/EditFormTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/EditFormTest.java
@@ -97,6 +97,7 @@ class EditFormTest
         String[] paramValue1 = { "value1", "value2" };
         String[] paramValue2 = { "value1" };
         String[] paramValue3 = { "value2" };
+        String[] emptyValue = {""};
 
         parameterMap.put("someParam", paramValue2);
         parameterMap.put("XWiki.XWikiRights_42_baz", paramValue1);
@@ -108,6 +109,7 @@ class EditFormTest
         parameterMap.put("foobar_18_buz", paramValue1);
         parameterMap.put("foo_48bar_buz", paramValue1);
         parameterMap.put("A class.With Some spaces_42_myProp", paramValue1);
+        parameterMap.put("XWiki.XWikiRights_2_foo",  emptyValue);
 
         // Note that this one might be ambiguous, page name could be WebHome or WebHome_0_Something
         // This should be fixed as part of https://jira.xwiki.org/browse/XWIKI-17302
@@ -122,6 +124,7 @@ class EditFormTest
         Map<String, SortedMap<Integer, Map<String, String[]>>> expectedMap = new HashMap<>();
         TreeMap<Integer, Map<String, String[]>> treeMap = new TreeMap<>();
         treeMap.put(0, Collections.singletonMap("foo", paramValue1));
+        treeMap.put(2, Collections.singletonMap("foo", emptyValue));
         treeMap.put(42, Collections.singletonMap("baz", paramValue1));
         Map<String, String[]> parametersValues = new HashMap<>();
         parametersValues.put("foo", paramValue2);


### PR DESCRIPTION
  * Refactor ListClass#fromList to take into account multiselect
  * Provide a new ListClass#fromList API with a parameter to filter out
    empty values
  * Provide a new ListClass#getListFromString API with a parameter to
    filter out empty values
  * Use those new APIS in UsersClass/GroupsClass/LevelsClass
  * Add some new tests