### PR TITLE
XWIKI-19535: Heading ids are not necessarily unique when using the include or display macro

### DIFF
--- a/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-macro/src/main/java/org/xwiki/rendering/internal/macro/display/DisplayMacro.java
+++ b/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-macro/src/main/java/org/xwiki/rendering/internal/macro/display/DisplayMacro.java
@@ -138,7 +138,10 @@ public class DisplayMacro extends AbstractIncludeMacro<DisplayMacroParameters>
             excludeFirstHeading(result);
         }
 
-        // Step 6: Wrap Blocks in a MetaDataBlock with the "source" meta data specified so that we know from where the
+        // Step 6: Make sure heading and image ids are unique.
+        makeIdsUnique(context, result);
+
+        // Step 7: Wrap Blocks in a MetaDataBlock with the "source" meta data specified so that we know from where the
         // content comes and "base" meta data so that reference are properly resolved
         MetaDataBlock metadata = new MetaDataBlock(result.getChildren(), result.getMetaData());
         String source = this.defaultEntityReferenceSerializer.serialize(displayedReference);

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
@@ -152,7 +152,10 @@ public class IncludeMacro extends AbstractIncludeMacro<IncludeMacroParameters>
             excludeFirstHeading(result);
         }
 
-        // Step 6: Wrap Blocks in a MetaDataBlock with the "source" meta data specified so that we know from where the
+        // Step 6: Make sure heading and image ids are unique.
+        makeIdsUnique(context, result);
+
+        // Step 7: Wrap Blocks in a MetaDataBlock with the "source" meta data specified so that we know from where the
         // content comes and "base" meta data so that reference are properly resolved
         MetaDataBlock metadata = new MetaDataBlock(result.getChildren(), result.getMetaData());
         String source = this.defaultEntityReferenceSerializer.serialize(includedReference);

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/include/IncludeMacroTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/include/IncludeMacroTest.java
@@ -290,6 +290,51 @@ public class IncludeMacroTest
         verify(this.dab).popDocumentFromContext(any(Map.class));
     }
 
+    /**
+     * Verify that ids are adapted if they would duplicate an id of the parent document.
+     */
+    @Test
+    void adaptIdsOfIncludedHeadingsAndImages() throws Exception
+    {
+        // @formatter:off
+        String expected = "beginDocument\n"
+            + "beginMetaData [[base]=[includedWiki:includedSpace.includedPage][source]=[includedWiki:includedSpace.includedPage][syntax]=[XWiki 2.0]]\n"
+            + "beginSection\n"
+            + "beginHeader [1, HHeading-1]\n"
+            + "onWord [Heading]\n"
+            + "endHeader [1, HHeading-1]\n"
+            + "beginParagraph\n"
+            + "onImage [Typed = [false] Type = [attach] Reference = [test.png]] [true] [Itest.png-1]\n"
+            + "endParagraph\n"
+            + "endSection\n"
+            + "endMetaData [[base]=[includedWiki:includedSpace.includedPage][source]=[includedWiki:includedSpace.includedPage][syntax]=[XWiki 2.0]]\n"
+            + "endDocument";
+        // @formatter:on
+
+        String documentContent = "= Heading =\n"
+            + "image:test.png";
+
+        DocumentReference includedDocumentReference =
+            new DocumentReference("includedWiki", "includedSpace", "includedPage");
+        setupDocumentMocks("includedWiki:includedSpace.includedPage", includedDocumentReference,
+            documentContent);
+        when(this.dab.getCurrentDocumentReference()).thenReturn(includedDocumentReference);
+
+        IncludeMacroParameters parameters = new IncludeMacroParameters();
+        parameters.setReference("includedWiki:includedSpace.includedPage");
+        parameters.setContext(Context.NEW);
+
+        MacroTransformationContext context = createMacroTransformationContext("whatever", false);
+        // Initialize XDOM with ids from the including page.
+        context.setXDOM(getXDOM(documentContent));
+
+        List<Block> blocks = this.includeMacro.execute(parameters, null, context);
+
+        assertBlocks(expected, blocks, this.rendererFactory);
+        verify(this.dab).pushDocumentInContext(any(Map.class), any(DocumentModelBridge.class));
+        verify(this.dab).popDocumentFromContext(any(Map.class));
+    }
+
     @Test
     void executeWithRecursiveIncludeContextCurrent() throws Exception
     {


### PR DESCRIPTION
* Adapt heading and image ids when including or displaying pages.

Jira issue: https://jira.xwiki.org/browse/XWIKI-19535