### PR TITLE
XRENDERING-6: Id are not unique when included document or macro content has the same headers as the top document

### DIFF
--- a/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-api/src/main/java/org/xwiki/display/internal/DocumentDisplayerParameters.java
+++ b/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-api/src/main/java/org/xwiki/display/internal/DocumentDisplayerParameters.java
@@ -20,6 +20,7 @@
 package org.xwiki.display.internal;
 
 import org.xwiki.rendering.syntax.Syntax;
+import org.xwiki.rendering.util.IdGenerator;
 
 /**
  * {@link DocumentDisplayer} parameters.
@@ -77,6 +78,13 @@ public class DocumentDisplayerParameters implements Cloneable
     private Syntax targetSyntax;
 
     private boolean asyncAllowed = true;
+
+    /**
+     * The id generator to generate ids that are unique also in the parent document.
+     *
+     * @since 14.2RC1
+     */
+    private IdGenerator idGenerator;
 
     /**
      * @return the id of the document section to display
@@ -246,6 +254,24 @@ public class DocumentDisplayerParameters implements Cloneable
         this.asyncAllowed = asyncAllowed;
     }
 
+    /**
+     * @return the id generator to use for unique ids
+     * @since 14.2RC1
+     */
+    public IdGenerator getIdGenerator()
+    {
+        return this.idGenerator;
+    }
+
+    /**
+     * @param idGenerator the id generator to make sure ids are unique
+     * @since 14.2RC1
+     */
+    public void setIdGenerator(IdGenerator idGenerator)
+    {
+        this.idGenerator = idGenerator;
+    }
+
     @Override
     public DocumentDisplayerParameters clone()
     {
@@ -262,6 +288,8 @@ public class DocumentDisplayerParameters implements Cloneable
         clone.setSectionId(sectionId);
         clone.setTitleDisplayed(titleDisplayed);
         clone.setTransformationContextIsolated(transformationContextIsolated);
+        // No copy of the id generator as we explicitly want that it is shared.
+        clone.setIdGenerator(this.idGenerator);
         return clone;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-macro/src/main/java/org/xwiki/rendering/internal/macro/display/DisplayMacro.java
+++ b/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-macro/src/main/java/org/xwiki/rendering/internal/macro/display/DisplayMacro.java
@@ -111,6 +111,9 @@ public class DisplayMacro extends AbstractIncludeMacro<DisplayMacroParameters>
         displayParameters.setTransformationContextIsolated(displayParameters.isContentTransformed());
         displayParameters.setTargetSyntax(context.getTransformationContext().getTargetSyntax());
         displayParameters.setContentTranslated(true);
+        if (context.getXDOM() != null) {
+            displayParameters.setIdGenerator(context.getXDOM().getIdGenerator());
+        }
 
         Stack<Object> references = this.macrosBeingExecuted.get();
         if (references == null) {

--- a/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-macro/src/test/java/org/xwiki/rendering/internal/macro/DisplayMacroTest.java
+++ b/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-macro/src/test/java/org/xwiki/rendering/internal/macro/DisplayMacroTest.java
@@ -290,6 +290,44 @@ public class DisplayMacroTest
     }
 
     @Test
+    void adaptIdsOfDisplayedHeadingsAndImages() throws Exception
+    {
+        // @formatter:off
+        String expected = "beginDocument\n"
+            + "beginMetaData [[base]=[includedWiki:includedSpace.includedPage][source]=[includedWiki:includedSpace.includedPage][syntax]=[XWiki 2.0]]\n"
+            + "beginSection\n"
+            + "beginHeader [1, HHeading-1]\n"
+            + "onWord [Heading]\n"
+            + "endHeader [1, HHeading-1]\n"
+            + "beginParagraph\n"
+            + "onImage [Typed = [false] Type = [attach] Reference = [test.png]] [true] [Itest.png-1]\n"
+            + "endParagraph\n"
+            + "endSection\n"
+            + "endMetaData [[base]=[includedWiki:includedSpace.includedPage][source]=[includedWiki:includedSpace.includedPage][syntax]=[XWiki 2.0]]\n"
+            + "endDocument";
+        // @formatter:on
+
+        String documentContent = "= Heading =\n"
+            + "image:test.png";
+
+        DocumentReference includedDocumentReference =
+            new DocumentReference("includedWiki", "includedSpace", "includedPage");
+        setupDocumentMocks("includedWiki:includedSpace.includedPage", includedDocumentReference,
+            documentContent);
+
+        DisplayMacroParameters parameters = new DisplayMacroParameters();
+        parameters.setReference("includedWiki:includedSpace.includedPage");
+
+        MacroTransformationContext context = createMacroTransformationContext("whatever", false);
+        // Initialize XDOM with ids from the including page.
+        context.setXDOM(getXDOM(documentContent));
+
+        List<Block> blocks = this.displayMacro.execute(parameters, null, context);
+
+        BlockAssert.assertBlocks(expected, blocks, this.rendererFactory);
+    }
+
+    @Test
     public void executeWhenSectionSpecified() throws Exception
     {
         // @formatter:off

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacro.java
@@ -125,6 +125,9 @@ public class IncludeMacro extends AbstractIncludeMacro<IncludeMacroParameters>
         displayParameters.setTransformationContextRestricted(context.getTransformationContext().isRestricted());
         displayParameters.setTargetSyntax(context.getTransformationContext().getTargetSyntax());
         displayParameters.setContentTranslated(true);
+        if (context.getXDOM() != null) {
+            displayParameters.setIdGenerator(context.getXDOM().getIdGenerator());
+        }
 
         Stack<Object> references = this.macrosBeingExecuted.get();
         if (parametersContext == Context.NEW) {

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/include/IncludeMacroTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/include/IncludeMacroTest.java
@@ -290,6 +290,51 @@ public class IncludeMacroTest
         verify(this.dab).popDocumentFromContext(any(Map.class));
     }
 
+    /**
+     * Verify that ids are adapted if they would duplicate an id of the parent document.
+     */
+    @Test
+    void adaptIdsOfIncludedHeadingsAndImages() throws Exception
+    {
+        // @formatter:off
+        String expected = "beginDocument\n"
+            + "beginMetaData [[base]=[includedWiki:includedSpace.includedPage][source]=[includedWiki:includedSpace.includedPage][syntax]=[XWiki 2.0]]\n"
+            + "beginSection\n"
+            + "beginHeader [1, HHeading-1]\n"
+            + "onWord [Heading]\n"
+            + "endHeader [1, HHeading-1]\n"
+            + "beginParagraph\n"
+            + "onImage [Typed = [false] Type = [attach] Reference = [test.png]] [true] [Itest.png-1]\n"
+            + "endParagraph\n"
+            + "endSection\n"
+            + "endMetaData [[base]=[includedWiki:includedSpace.includedPage][source]=[includedWiki:includedSpace.includedPage][syntax]=[XWiki 2.0]]\n"
+            + "endDocument";
+        // @formatter:on
+
+        String documentContent = "= Heading =\n"
+            + "image:test.png";
+
+        DocumentReference includedDocumentReference =
+            new DocumentReference("includedWiki", "includedSpace", "includedPage");
+        setupDocumentMocks("includedWiki:includedSpace.includedPage", includedDocumentReference,
+            documentContent);
+        when(this.dab.getCurrentDocumentReference()).thenReturn(includedDocumentReference);
+
+        IncludeMacroParameters parameters = new IncludeMacroParameters();
+        parameters.setReference("includedWiki:includedSpace.includedPage");
+        parameters.setContext(Context.NEW);
+
+        MacroTransformationContext context = createMacroTransformationContext("whatever", false);
+        // Initialize XDOM with ids from the including page.
+        context.setXDOM(getXDOM(documentContent));
+
+        List<Block> blocks = this.includeMacro.execute(parameters, null, context);
+
+        assertBlocks(expected, blocks, this.rendererFactory);
+        verify(this.dab).pushDocumentInContext(any(Map.class), any(DocumentModelBridge.class));
+        verify(this.dab).popDocumentFromContext(any(Map.class));
+    }
+
     @Test
     void executeWithRecursiveIncludeContextCurrent() throws Exception
     {


### PR DESCRIPTION
* Add the id generator as document displayer parameter.
* Adapt heading and image ids when loading the XDOM in the DocumentContentAsyncExecutor and set it on the XDOM.
* Set the id generator in the include and display macro.

Jira issue: https://jira.xwiki.org/browse/XRENDERING-6