### PR TITLE
XWIKI-19463: Display image ids in the Lightbox

### DIFF
--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-docker/src/test/it/org/xwiki/image/lightbox/test/ui/LightboxIT.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-docker/src/test/it/org/xwiki/image/lightbox/test/ui/LightboxIT.java
@@ -100,6 +100,20 @@ class LightboxIT
         // Make sure that the images are displayed.
         lightboxPage.reloadPage();
 
+        // Verify the image popover permalink action.
+        Optional<ImagePopover> imagePopover = lightboxPage.hoverImage(0);
+        if (imagePopover.isPresent()) {
+            ImagePopover currentImagePopover = imagePopover.get();
+            assertTrue(currentImagePopover.isImagePopoverDisplayed());
+
+            WebElement imagePermalinkButton = currentImagePopover.getImagePermalinkButton();
+            String[] elements = imagePermalinkButton.getAttribute("href").split("#");
+            assertEquals("Iimage1.png", elements[elements.length - 1]);
+
+            imagePermalinkButton.click();
+            assertEquals(testUtils.getDriver().getCurrentUrl(), imagePermalinkButton.getAttribute("href"));
+        }
+
         Lightbox lightbox = lightboxPage.openLightboxAtImage(0);
         assertTrue(lightbox.isDisplayed());
 
@@ -126,6 +140,20 @@ class LightboxIT
 
         // Make sure that the images are displayed.
         lightboxPage.reloadPage();
+
+        // Verify the image popover permalink action.
+        Optional<ImagePopover> imagePopover = lightboxPage.hoverImage(0);
+        if (imagePopover.isPresent()) {
+            ImagePopover currentImagePopover = imagePopover.get();
+            assertTrue(currentImagePopover.isImagePopoverDisplayed());
+
+            WebElement imagePermalinkButton = currentImagePopover.getImagePermalinkButton();
+            String[] elements = imagePermalinkButton.getAttribute("href").split("#");
+            assertEquals("manuallyAddedImageId", elements[elements.length - 1]);
+
+            imagePermalinkButton.click();
+            assertEquals(testUtils.getDriver().getCurrentUrl(), imagePermalinkButton.getAttribute("href"));
+        }
 
         Lightbox lightbox = lightboxPage.openLightboxAtImage(0);
         assertTrue(lightbox.isDisplayed());
@@ -364,6 +392,33 @@ class LightboxIT
         assertTrue(imagePopover.isPresent());
     }
 
+    @Test
+    @Order(13)
+    void openImageWithoutId(TestUtils testUtils, TestReference testReference, TestConfiguration testConfiguration)
+        throws Exception
+    {
+        enableLightbox(testUtils, true);
+
+        testUtils.createPage(testReference, this.getImageWithoutId(images.get(0)));
+        lightboxPage = new LightboxPage();
+
+        lightboxPage.attachFile(testConfiguration.getBrowser().getTestResourcesPath(), images.get(0));
+
+        // Make sure that the images are displayed.
+        lightboxPage.reloadPage();
+
+        Optional<ImagePopover> imagePopover = lightboxPage.hoverImage(0);
+        if (imagePopover.isPresent()) {
+            ImagePopover currentImagePopover = imagePopover.get();
+            assertTrue(currentImagePopover.isImagePopoverDisplayed());
+            assertFalse(currentImagePopover.getImagePermalinkButton().isDisplayed());
+        }
+
+        Lightbox lightbox = lightboxPage.openLightboxAtImage(0);
+        assertTrue(lightbox.isDisplayed());
+        assertFalse(lightbox.getCopyImageIdButton().isDisplayed());
+    }
+
     private void enableLightbox(TestUtils testUtils, boolean enable)
     {
         testUtils.updateObject(LIGHTBOX_CONFIGURATION_REFERENCE, LIGHTBOX_CONFIGURATION_CLASSNAME, 0,
@@ -389,6 +444,20 @@ class LightboxIT
         sb.append(image);
         sb.append("||width=120 height=120]]\n\n");
         sb.append("{{figureCaption}}{{id name=\"manuallyAddedImageId\"/}}\n");
+        sb.append("Caption{{/figureCaption}}\n\n");
+        sb.append("{{/figure}}\n\n");
+
+        return sb.toString();
+    }
+
+    private String getImageWithoutId(String image)
+    {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("{{figure}}\n[[image:");
+        sb.append(image);
+        sb.append("||width=120 height=120]]\n\n");
+        sb.append("{{figureCaption}}{{id name=''/}}\n");
         sb.append("Caption{{/figureCaption}}\n\n");
         sb.append("{{/figure}}\n\n");
 

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-docker/src/test/it/org/xwiki/image/lightbox/test/ui/LightboxIT.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-docker/src/test/it/org/xwiki/image/lightbox/test/ui/LightboxIT.java
@@ -102,18 +102,17 @@ class LightboxIT
 
         // Verify the image ID popover actions.
         Optional<ImagePopover> imagePopover = lightboxPage.hoverImage(0);
-        if (imagePopover.isPresent()) {
-            ImagePopover currentImagePopover = imagePopover.get();
-            assertTrue(currentImagePopover.isImagePopoverDisplayed());
+        assertTrue(imagePopover.isPresent());
+        ImagePopover currentImagePopover = imagePopover.get();
+        assertTrue(currentImagePopover.isImagePopoverDisplayed());
 
-            WebElement imagePermalinkButton = currentImagePopover.getImagePermalinkButton();
-            String[] elements = imagePermalinkButton.getAttribute("href").split("#");
-            assertEquals("Iimage1.png", elements[elements.length - 1]);
+        WebElement imagePermalinkButton = currentImagePopover.getImagePermalinkButton();
+        String[] elements = imagePermalinkButton.getAttribute("href").split("#");
+        assertEquals("Iimage1.png", elements[elements.length - 1]);
 
-            imagePermalinkButton.click();
-            assertEquals(testUtils.getDriver().getCurrentUrl(), imagePermalinkButton.getAttribute("href"));
-            assertEquals("Iimage1.png", currentImagePopover.getImageId());
-        }
+        imagePermalinkButton.click();
+        assertEquals(testUtils.getDriver().getCurrentUrl(), imagePermalinkButton.getAttribute("href"));
+        assertEquals("Iimage1.png", currentImagePopover.getImageId());
 
         Lightbox lightbox = lightboxPage.openLightboxAtImage(0);
         assertTrue(lightbox.isDisplayed());
@@ -144,18 +143,17 @@ class LightboxIT
 
         // Verify the image ID popover actions.
         Optional<ImagePopover> imagePopover = lightboxPage.hoverImage(0);
-        if (imagePopover.isPresent()) {
-            ImagePopover currentImagePopover = imagePopover.get();
-            assertTrue(currentImagePopover.isImagePopoverDisplayed());
+        assertTrue(imagePopover.isPresent());
+        ImagePopover currentImagePopover = imagePopover.get();
+        assertTrue(currentImagePopover.isImagePopoverDisplayed());
 
-            WebElement imagePermalinkButton = currentImagePopover.getImagePermalinkButton();
-            String[] elements = imagePermalinkButton.getAttribute("href").split("#");
-            assertEquals("manuallyAddedImageId", elements[elements.length - 1]);
+        WebElement imagePermalinkButton = currentImagePopover.getImagePermalinkButton();
+        String[] elements = imagePermalinkButton.getAttribute("href").split("#");
+        assertEquals("manuallyAddedImageId", elements[elements.length - 1]);
 
-            imagePermalinkButton.click();
-            assertEquals(testUtils.getDriver().getCurrentUrl(), imagePermalinkButton.getAttribute("href"));
-            assertEquals("manuallyAddedImageId", currentImagePopover.getImageId());
-        }
+        imagePermalinkButton.click();
+        assertEquals(testUtils.getDriver().getCurrentUrl(), imagePermalinkButton.getAttribute("href"));
+        assertEquals("manuallyAddedImageId", currentImagePopover.getImageId());
 
         Lightbox lightbox = lightboxPage.openLightboxAtImage(0);
         assertTrue(lightbox.isDisplayed());
@@ -357,15 +355,13 @@ class LightboxIT
 
         // Verify the image popover download action.
         Optional<ImagePopover> imagePopover = lightboxPage.hoverImage(0);
+        assertTrue(imagePopover.isPresent());
+        ImagePopover currentImagePopover = imagePopover.get();
+        assertTrue(currentImagePopover.isImagePopoverDisplayed());
 
-        if (imagePopover.isPresent()) {
-            ImagePopover currentImagePopover = imagePopover.get();
-            assertTrue(currentImagePopover.isImagePopoverDisplayed());
-
-            WebElement popoverDownload = currentImagePopover.getDownloadButton();
-            assertEquals(lightboxPage.getImageElement(0).getAttribute("src"), popoverDownload.getAttribute("href"));
-            assertEquals("image1.png", popoverDownload.getAttribute("download"));
-        }
+        WebElement popoverDownload = currentImagePopover.getDownloadButton();
+        assertEquals(lightboxPage.getImageElement(0).getAttribute("src"), popoverDownload.getAttribute("href"));
+        assertEquals("image1.png", popoverDownload.getAttribute("download"));
 
         // Verify the image lightbox download action.
         Lightbox lightbox = lightboxPage.openLightboxAtImage(0);
@@ -410,12 +406,11 @@ class LightboxIT
         lightboxPage.reloadPage();
 
         Optional<ImagePopover> imagePopover = lightboxPage.hoverImage(0);
-        if (imagePopover.isPresent()) {
-            ImagePopover currentImagePopover = imagePopover.get();
-            assertTrue(currentImagePopover.isImagePopoverDisplayed());
-            assertFalse(currentImagePopover.getImagePermalinkButton().isDisplayed());
-            assertFalse(currentImagePopover.getCopyImageIdButton().isDisplayed());
-        }
+        assertTrue(imagePopover.isPresent());
+        ImagePopover currentImagePopover = imagePopover.get();
+        assertTrue(currentImagePopover.isImagePopoverDisplayed());
+        assertFalse(currentImagePopover.getImagePermalinkButton().isDisplayed());
+        assertFalse(currentImagePopover.getCopyImageIdButton().isDisplayed());
 
         Lightbox lightbox = lightboxPage.openLightboxAtImage(0);
         assertTrue(lightbox.isDisplayed());

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-docker/src/test/it/org/xwiki/image/lightbox/test/ui/LightboxIT.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-docker/src/test/it/org/xwiki/image/lightbox/test/ui/LightboxIT.java
@@ -113,12 +113,12 @@ class LightboxIT
 
     @Test
     @Order(3)
-    void openImageWithCaption(TestUtils testUtils, TestReference testReference, TestConfiguration testConfiguration)
-        throws Exception
+    void openImageWithCaptionAndManuallyAddedId(TestUtils testUtils, TestReference testReference,
+        TestConfiguration testConfiguration) throws Exception
     {
         enableLightbox(testUtils, true);
 
-        testUtils.createPage(testReference, this.getImageWithCaption(images.get(0)));
+        testUtils.createPage(testReference, this.getImageWithCaptionAndManuallyAddedId(images.get(0)));
         lightboxPage = new LightboxPage();
 
         String lastUploadDate =
@@ -135,7 +135,7 @@ class LightboxIT
         assertEquals(images.get(0), lightbox.getTitle());
         assertEquals("Posted by JohnDoe", lightbox.getPublisher());
         assertEquals(lastUploadDate, lightbox.getDate());
-        assertEquals("Iimage1.png", lightbox.getImageId());
+        assertEquals("manuallyAddedImageId", lightbox.getImageId());
     }
 
     @Test
@@ -364,27 +364,6 @@ class LightboxIT
         assertTrue(imagePopover.isPresent());
     }
 
-    @Test
-    @Order(13)
-    void openImageWithManuallyAddedImageId(TestUtils testUtils, TestReference testReference,
-        TestConfiguration testConfiguration) throws Exception
-    {
-        enableLightbox(testUtils, true);
-
-        testUtils.createPage(testReference, this.getImageWithManuallyAddedImageId(images.get(0)));
-        lightboxPage = new LightboxPage();
-
-        lightboxPage.attachFile(testConfiguration.getBrowser().getTestResourcesPath(), images.get(0));
-
-        // Make sure that the images are displayed.
-        lightboxPage.reloadPage();
-
-        Lightbox lightbox = lightboxPage.openLightboxAtImage(0);
-        assertTrue(lightbox.isDisplayed());
-
-        assertEquals("manuallyAddedImageId", lightbox.getImageId());
-    }
-
     private void enableLightbox(TestUtils testUtils, boolean enable)
     {
         testUtils.updateObject(LIGHTBOX_CONFIGURATION_REFERENCE, LIGHTBOX_CONFIGURATION_CLASSNAME, 0,
@@ -402,14 +381,15 @@ class LightboxIT
         return sb.toString();
     }
 
-    private String getImageWithCaption(String image)
+    private String getImageWithCaptionAndManuallyAddedId(String image)
     {
         StringBuilder sb = new StringBuilder();
 
         sb.append("{{figure}}\n[[image:");
         sb.append(image);
         sb.append("||width=120 height=120]]\n\n");
-        sb.append("{{figureCaption}}Caption{{/figureCaption}}\n\n");
+        sb.append("{{figureCaption}}{{id name=\"manuallyAddedImageId\"/}}\n");
+        sb.append("Caption{{/figureCaption}}\n\n");
         sb.append("{{/figure}}\n\n");
 
         return sb.toString();
@@ -434,20 +414,6 @@ class LightboxIT
         sb.append("<div data-xwiki-lightbox='false'><img src='/xwiki/resources/icons/silk/accept.png'/></div>\n");
         sb.append("<div><img src='/xwiki/resources/icons/silk/accept.png'/></div>\n");
         sb.append("{{/html}}");
-
-        return sb.toString();
-    }
-
-    private String getImageWithManuallyAddedImageId(String image)
-    {
-        StringBuilder sb = new StringBuilder();
-
-        sb.append("{{figure}}\n[[image:");
-        sb.append(image);
-        sb.append("||width=120 height=120]]\n\n");
-        sb.append("{{figureCaption}}{{id name=\"manuallyAddedImageId\"/}}\n");
-        sb.append("Caption{{/figureCaption}}\n\n");
-        sb.append("{{/figure}}\n\n");
 
         return sb.toString();
     }

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-docker/src/test/it/org/xwiki/image/lightbox/test/ui/LightboxIT.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-docker/src/test/it/org/xwiki/image/lightbox/test/ui/LightboxIT.java
@@ -108,6 +108,7 @@ class LightboxIT
         assertEquals("", lightbox.getTitle());
         assertEquals("Posted by JohnDoe", lightbox.getPublisher());
         assertEquals(lastUploadDate, lightbox.getDate());
+        assertEquals("Iimage1.png", lightbox.getImageId());
     }
 
     @Test
@@ -134,6 +135,7 @@ class LightboxIT
         assertEquals(images.get(0), lightbox.getTitle());
         assertEquals("Posted by JohnDoe", lightbox.getPublisher());
         assertEquals(lastUploadDate, lightbox.getDate());
+        assertEquals("Iimage1.png", lightbox.getImageId());
     }
 
     @Test
@@ -160,6 +162,7 @@ class LightboxIT
         assertEquals("", lightbox.getTitle());
         assertEquals("Posted by JohnDoe", lightbox.getPublisher());
         assertEquals(lastUploadDate, lightbox.getDate());
+        assertEquals("Iimage1.png", lightbox.getImageId());
     }
 
     @Test
@@ -178,6 +181,7 @@ class LightboxIT
         assertEquals("", lightbox.getTitle());
         assertEquals("", lightbox.getPublisher());
         assertEquals("", lightbox.getDate());
+        assertEquals("Iaccept", lightbox.getImageId());
     }
 
     @Test
@@ -360,6 +364,27 @@ class LightboxIT
         assertTrue(imagePopover.isPresent());
     }
 
+    @Test
+    @Order(13)
+    void openImageWithManuallyAddedImageId(TestUtils testUtils, TestReference testReference,
+        TestConfiguration testConfiguration) throws Exception
+    {
+        enableLightbox(testUtils, true);
+
+        testUtils.createPage(testReference, this.getImageWithManuallyAddedImageId(images.get(0)));
+        lightboxPage = new LightboxPage();
+
+        lightboxPage.attachFile(testConfiguration.getBrowser().getTestResourcesPath(), images.get(0));
+
+        // Make sure that the images are displayed.
+        lightboxPage.reloadPage();
+
+        Lightbox lightbox = lightboxPage.openLightboxAtImage(0);
+        assertTrue(lightbox.isDisplayed());
+
+        assertEquals("manuallyAddedImageId", lightbox.getImageId());
+    }
+
     private void enableLightbox(TestUtils testUtils, boolean enable)
     {
         testUtils.updateObject(LIGHTBOX_CONFIGURATION_REFERENCE, LIGHTBOX_CONFIGURATION_CLASSNAME, 0,
@@ -409,6 +434,20 @@ class LightboxIT
         sb.append("<div data-xwiki-lightbox='false'><img src='/xwiki/resources/icons/silk/accept.png'/></div>\n");
         sb.append("<div><img src='/xwiki/resources/icons/silk/accept.png'/></div>\n");
         sb.append("{{/html}}");
+
+        return sb.toString();
+    }
+
+    private String getImageWithManuallyAddedImageId(String image)
+    {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("{{figure}}\n[[image:");
+        sb.append(image);
+        sb.append("||width=120 height=120]]\n\n");
+        sb.append("{{figureCaption}}{{id name=\"manuallyAddedImageId\"/}}\n");
+        sb.append("Caption{{/figureCaption}}\n\n");
+        sb.append("{{/figure}}\n\n");
 
         return sb.toString();
     }

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-docker/src/test/it/org/xwiki/image/lightbox/test/ui/LightboxIT.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-docker/src/test/it/org/xwiki/image/lightbox/test/ui/LightboxIT.java
@@ -100,7 +100,7 @@ class LightboxIT
         // Make sure that the images are displayed.
         lightboxPage.reloadPage();
 
-        // Verify the image popover permalink action.
+        // Verify the image ID popover actions.
         Optional<ImagePopover> imagePopover = lightboxPage.hoverImage(0);
         if (imagePopover.isPresent()) {
             ImagePopover currentImagePopover = imagePopover.get();
@@ -112,6 +112,7 @@ class LightboxIT
 
             imagePermalinkButton.click();
             assertEquals(testUtils.getDriver().getCurrentUrl(), imagePermalinkButton.getAttribute("href"));
+            assertEquals("Iimage1.png", currentImagePopover.getImageId());
         }
 
         Lightbox lightbox = lightboxPage.openLightboxAtImage(0);
@@ -141,7 +142,7 @@ class LightboxIT
         // Make sure that the images are displayed.
         lightboxPage.reloadPage();
 
-        // Verify the image popover permalink action.
+        // Verify the image ID popover actions.
         Optional<ImagePopover> imagePopover = lightboxPage.hoverImage(0);
         if (imagePopover.isPresent()) {
             ImagePopover currentImagePopover = imagePopover.get();
@@ -153,6 +154,7 @@ class LightboxIT
 
             imagePermalinkButton.click();
             assertEquals(testUtils.getDriver().getCurrentUrl(), imagePermalinkButton.getAttribute("href"));
+            assertEquals("manuallyAddedImageId", currentImagePopover.getImageId());
         }
 
         Lightbox lightbox = lightboxPage.openLightboxAtImage(0);
@@ -412,6 +414,7 @@ class LightboxIT
             ImagePopover currentImagePopover = imagePopover.get();
             assertTrue(currentImagePopover.isImagePopoverDisplayed());
             assertFalse(currentImagePopover.getImagePermalinkButton().isDisplayed());
+            assertFalse(currentImagePopover.getCopyImageIdButton().isDisplayed());
         }
 
         Lightbox lightbox = lightboxPage.openLightboxAtImage(0);

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-pageobjects/src/main/java/org/xwiki/image/lightbox/test/po/ImagePopover.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-pageobjects/src/main/java/org/xwiki/image/lightbox/test/po/ImagePopover.java
@@ -60,6 +60,11 @@ public class ImagePopover extends BaseElement
         return getDriver().findElement(downloadSelector);
     }
 
+    public WebElement getImagePermalinkButton()
+    {
+        return getDriver().findElement(By.cssSelector(".popover .imageId"));
+    }
+
     private ImagePopover waitUntilReady()
     {
         getDriver().waitUntilElementIsVisible(By.cssSelector(".popover .imageDownload"));

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-pageobjects/src/main/java/org/xwiki/image/lightbox/test/po/ImagePopover.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-pageobjects/src/main/java/org/xwiki/image/lightbox/test/po/ImagePopover.java
@@ -54,6 +54,16 @@ public class ImagePopover extends BaseElement
         }
     }
 
+    public String getImageId()
+    {
+        return getCopyImageIdButton().getAttribute("data-imageId");
+    }
+
+    public WebElement getCopyImageIdButton()
+    {
+        return getDriver().findElement(By.cssSelector(".popover .copyImageId"));
+    }
+
     public WebElement getDownloadButton()
     {
         By downloadSelector = By.cssSelector(".popover .imageDownload");
@@ -62,7 +72,7 @@ public class ImagePopover extends BaseElement
 
     public WebElement getImagePermalinkButton()
     {
-        return getDriver().findElement(By.cssSelector(".popover .imageId"));
+        return getDriver().findElement(By.cssSelector(".popover .permalink"));
     }
 
     private ImagePopover waitUntilReady()

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-pageobjects/src/main/java/org/xwiki/image/lightbox/test/po/Lightbox.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-pageobjects/src/main/java/org/xwiki/image/lightbox/test/po/Lightbox.java
@@ -102,6 +102,12 @@ public class Lightbox extends BaseElement
         return getDriver().findElement(publisherSelector).getText();
     }
 
+    public String getImageId()
+    {
+        By imageIdSelector = By.cssSelector("#blueimp-gallery .imageId");
+        return getDriver().findElement(imageIdSelector).getAttribute("value");
+    }
+
     public String getDate()
     {
         By dateSelector = By.cssSelector("#blueimp-gallery .date");

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-pageobjects/src/main/java/org/xwiki/image/lightbox/test/po/Lightbox.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-pageobjects/src/main/java/org/xwiki/image/lightbox/test/po/Lightbox.java
@@ -102,10 +102,14 @@ public class Lightbox extends BaseElement
         return getDriver().findElement(publisherSelector).getText();
     }
 
+    public WebElement getCopyImageIdButton()
+    {
+        return getDriver().findElement(By.cssSelector("#blueimp-gallery .copyImageId"));
+    }
+
     public String getImageId()
     {
-        By imageIdSelector = By.cssSelector("#blueimp-gallery .imageId");
-        return getDriver().findElement(imageIdSelector).getAttribute("value");
+        return getCopyImageIdButton().getAttribute("data-imageId");
     }
 
     public String getDate()

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-ui/src/main/resources/XWiki/Lightbox/LightboxTranslations.xml
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-ui/src/main/resources/XWiki/Lightbox/LightboxTranslations.xml
@@ -48,6 +48,7 @@ image.lightbox.caption.label=Caption
 image.lightbox.imageId.title=Image ID
 image.lightbox.imageId.copy.title=Copy image ID
 image.lightbox.imageId.copy.copied=Copied to clipboard
+image.lightbox.imageId.permalink=Permalink
 image.lightbox.date.label=Date
 image.lightbox.download.title=Download
 image.lightbox.escape.title=Escape

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-ui/src/main/resources/XWiki/Lightbox/LightboxTranslations.xml
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-ui/src/main/resources/XWiki/Lightbox/LightboxTranslations.xml
@@ -45,6 +45,9 @@ XWiki.Lightbox.LightboxConfigurationClass_isLightboxEnabled.hint=Enable the poss
 # Gallery template
 image.lightbox.autoPlay.title=Slideshow
 image.lightbox.caption.label=Caption
+image.lightbox.imageId.title=Image ID
+image.lightbox.imageId.copy.title=Copy image ID
+image.lightbox.imageId.copy.copied=Copied to clipboard
 image.lightbox.date.label=Date
 image.lightbox.download.title=Download
 image.lightbox.escape.title=Escape

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-ui/src/main/resources/XWiki/Lightbox/WebHome.xml
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-ui/src/main/resources/XWiki/Lightbox/WebHome.xml
@@ -463,6 +463,18 @@ bundles=blueimp-gallery,blueimp-helper,blueimp-gallery-fullscreen,blueimp-galler
         &lt;span class="date" data-dateFormat="$dateFormat"
           aria-label="$escapetool.xml($services.localization.render('image.lightbox.date.label'))"&gt;&lt;/span&gt;
       &lt;/div&gt;
+      &lt;div class="descriptionRow"&gt;
+        &lt;div class="input-group"
+            title="$escapetool.xml($services.localization.render('image.lightbox.imageId.copy.title'))"&gt;
+          ## This title attribute will be used as tooltip content, so the displayed title is added to a parent element.
+          &lt;a class="copyImageId input-group-addon" data-toggle="tooltip" data-placement="bottom"
+            data-trigger="manual" data-original-title="$escapetool.xml(
+            $services.localization.render('image.lightbox.imageId.copy.copied'))"
+          &gt;$services.icon.renderHTML('copy')&lt;/a&gt;
+          &lt;input type="text" class="imageId form-control" readonly
+            title="$escapetool.xml($services.localization.render('image.lightbox.imageId.title'))"/&gt;
+        &lt;/div&gt;
+      &lt;/div&gt;
     &lt;/div&gt;
   &lt;/div&gt;
   &lt;ol class="indicator"&gt;&lt;/ol&gt;

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-ui/src/main/resources/XWiki/Lightbox/WebHome.xml
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-ui/src/main/resources/XWiki/Lightbox/WebHome.xml
@@ -428,24 +428,33 @@ bundles=blueimp-gallery,blueimp-helper,blueimp-gallery-fullscreen,blueimp-galler
   &gt;&lt;/a&gt;
   &lt;div class="controls btn-group"&gt;
     &lt;a
-      class="btn fullscreen" id="lightboxFullscreen" aria-controls="blueimp-gallery"
+      class="btn action fullscreen" id="lightboxFullscreen" aria-controls="blueimp-gallery"
       aria-label="$escapetool.xml($services.localization.render('image.lightbox.fullscreen.title'))"
       title="$escapetool.xml($services.localization.render('image.lightbox.fullscreen.title'))"
       aria-keyshortcuts="F11"
     &gt;$services.icon.renderHTML('arrows')&lt;/a&gt;
     &lt;a
-      class="btn download" id="lightboxDownload" aria-controls="blueimp-gallery" target="_blank"
+      class="btn action download" id="lightboxDownload" aria-controls="blueimp-gallery" target="_blank"
       aria-label="$escapetool.xml($services.localization.render('image.lightbox.download.title'))"
       title="$escapetool.xml($services.localization.render('image.lightbox.download.title'))"
     &gt;$services.icon.renderHTML('download')&lt;/a&gt;
+    &lt;span class="btn" title="$escapetool.xml(
+        $services.localization.render('image.lightbox.imageId.copy.title'))"&gt;
+      ## The title attribute will be used as tooltip content, so the displayed title is added to a parent element.
+      &lt;a class="action copyImageId" aria-controls="blueimp-gallery" aria-label="$escapetool.xml(
+        $services.localization.render('image.lightbox.imageId.copy.title'))" data-original-title="$escapetool.xml(
+        $services.localization.render('image.lightbox.imageId.copy.copied'))" data-toggle="tooltip"
+        data-placement="bottom" data-trigger="manual"
+      &gt;$services.icon.renderHTML('anchor')&lt;/a&gt;
+    &lt;/span&gt;
     &lt;a
-      class="btn autoPlay" aria-controls="blueimp-gallery"
+      class="btn action autoPlay" aria-controls="blueimp-gallery"
       aria-label="$escapetool.xml($services.localization.render('image.lightbox.autoPlay.title'))"
       title="$escapetool.xml($services.localization.render('image.lightbox.autoPlay.title'))"
       aria-keyshortcuts="Space" aria-pressed="false"
     &gt;$services.icon.renderHTML('play')&lt;/a&gt;
     &lt;a
-      class="btn escape" aria-controls="blueimp-gallery"
+      class="btn action escape" aria-controls="blueimp-gallery"
       aria-label="$escapetool.xml($services.localization.render('image.lightbox.escape.title'))"
       title="$escapetool.xml($services.localization.render('image.lightbox.escape.title'))"
       aria-keyshortcuts="Escape"
@@ -463,18 +472,6 @@ bundles=blueimp-gallery,blueimp-helper,blueimp-gallery-fullscreen,blueimp-galler
         &lt;span class="date" data-dateFormat="$dateFormat"
           aria-label="$escapetool.xml($services.localization.render('image.lightbox.date.label'))"&gt;&lt;/span&gt;
       &lt;/div&gt;
-      &lt;div class="descriptionRow"&gt;
-        &lt;div class="input-group"
-            title="$escapetool.xml($services.localization.render('image.lightbox.imageId.copy.title'))"&gt;
-          ## This title attribute will be used as tooltip content, so the displayed title is added to a parent element.
-          &lt;a class="copyImageId input-group-addon" data-toggle="tooltip" data-placement="bottom"
-            data-trigger="manual" data-original-title="$escapetool.xml(
-            $services.localization.render('image.lightbox.imageId.copy.copied'))"
-          &gt;$services.icon.renderHTML('copy')&lt;/a&gt;
-          &lt;input type="text" class="imageId form-control" readonly
-            title="$escapetool.xml($services.localization.render('image.lightbox.imageId.title'))"/&gt;
-        &lt;/div&gt;
-      &lt;/div&gt;
     &lt;/div&gt;
   &lt;/div&gt;
   &lt;ol class="indicator"&gt;&lt;/ol&gt;
@@ -483,13 +480,14 @@ bundles=blueimp-gallery,blueimp-helper,blueimp-gallery-fullscreen,blueimp-galler
 &lt;div id="imageToolbarTemplate"&gt;
   &lt;div class="btn-group imageToolbar" hidden&gt;
     &lt;a class="openLightbox"
-      title="$escapetool.xml($services.localization.render('image.lightbox.gallery.title'))"&gt;
-      $services.icon.renderHTML("arrows")
-    &lt;/a&gt;
+      title="$escapetool.xml($services.localization.render('image.lightbox.gallery.title'))"
+    &gt;$services.icon.renderHTML("arrows")&lt;/a&gt;
     &lt;a class="imageDownload" target="_blank"
-      title="$escapetool.xml($services.localization.render('image.lightbox.download.title'))"&gt;
-      $services.icon.renderHTML("download")
-    &lt;/a&gt;
+      title="$escapetool.xml($services.localization.render('image.lightbox.download.title'))"
+    &gt;$services.icon.renderHTML("download")&lt;/a&gt;
+    &lt;a class="imageId hidden"
+      title="$escapetool.xml($services.localization.render('image.lightbox.imageId.title'))"
+    &gt;$services.icon.renderHTML('link')&lt;/a&gt;
   &lt;/div&gt;
 &lt;/div&gt;
 #end

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-ui/src/main/resources/XWiki/Lightbox/WebHome.xml
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-ui/src/main/resources/XWiki/Lightbox/WebHome.xml
@@ -479,15 +479,22 @@ bundles=blueimp-gallery,blueimp-helper,blueimp-gallery-fullscreen,blueimp-galler
 &lt;!-- The image toolbar popover template. --&gt;
 &lt;div id="imageToolbarTemplate"&gt;
   &lt;div class="btn-group imageToolbar" hidden&gt;
-    &lt;a class="openLightbox"
+    &lt;a class="openLightbox" href=""
       title="$escapetool.xml($services.localization.render('image.lightbox.gallery.title'))"
     &gt;$services.icon.renderHTML("arrows")&lt;/a&gt;
     &lt;a class="imageDownload" target="_blank"
       title="$escapetool.xml($services.localization.render('image.lightbox.download.title'))"
     &gt;$services.icon.renderHTML("download")&lt;/a&gt;
-    &lt;a class="imageId hidden"
-      title="$escapetool.xml($services.localization.render('image.lightbox.imageId.title'))"
+    &lt;a class="permalink hidden"
+      title="$escapetool.xml($services.localization.render('image.lightbox.imageId.permalink'))"
     &gt;$services.icon.renderHTML('link')&lt;/a&gt;
+    &lt;span class="hidden" title="$escapetool.xml($services.localization.render('image.lightbox.imageId.copy.title'))"&gt;
+      ## The title attribute will be used as tooltip content, so the displayed title is added to a parent element.
+      &lt;a class="copyImageId" href="" data-original-title="$escapetool.xml(
+        $services.localization.render('image.lightbox.imageId.copy.copied'))"
+        data-toggle="tooltip" data-placement="bottom" data-trigger="manual"
+      &gt;$services.icon.renderHTML('anchor')&lt;/a&gt;
+    &lt;/span&gt;
   &lt;/div&gt;
 &lt;/div&gt;
 #end

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/less/lightbox.less
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/less/lightbox.less
@@ -52,27 +52,23 @@
   }
 }
 .blueimp-gallery {
-  .fullscreen:hover,
-  .download:hover,
-  .autoPlay:hover,
-  .escape:hover {
+  .action:hover {
     color: @text-color;
     opacity: 1;
   }
 
-  .fullscreen,
-  .download,
-  .autoPlay,
-  .escape {
+  .action {
     color: @xwiki-page-content-bg;
     display: none;
   }
+
+  .tooltip-inner {
+    white-space:nowrap;
+  }
 }
+
 .blueimp-gallery-controls {
-  .fullscreen,
-  .download,
-  .autoPlay,
-  .escape {
+  .action {
     display: block;
     /* Fix z-index issues (controls behind slide element) on Android: */
     -webkit-transform: translateZ(0);

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/less/lightbox.less
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/less/lightbox.less
@@ -81,3 +81,12 @@
 #imageToolbarTemplate {
   display: none;
 }
+.imageToolbar {
+  > * {
+    margin: .5em;
+  }
+
+  .tooltip-inner {
+    white-space:nowrap;
+  }
+}

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/less/lightbox.less
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/less/lightbox.less
@@ -44,6 +44,10 @@
 
     .descriptionMetadata {
       padding-top: 1%;
+
+      .copyImageId {
+        width: fit-content;
+      }
     }
   }
 }

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/lightbox.js
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/lightbox.js
@@ -103,7 +103,6 @@ define('xwiki-lightbox-description', [
    * Update lightbox description using given information.
    */
   var updateDescriptionData = function(imageData, attachmentData) {
-    $('.lightboxDescription .imageId').val(imageData.id);
     updateDescriptionCaption(imageData, attachmentData);
 
     if (attachmentData) {
@@ -209,9 +208,14 @@ define('xwiki-lightbox', [
       $('#lightboxDownload').attr('download', getImageName(img.src));
       // Remember the index of the image to show first.
       $('.openLightbox').data('index', [...lightboxImages].indexOf(img));
-    }).on('shown.bs.popover', function(e) {
-      $('.popover .imageDownload').attr('href', e.target.src);
-      $('.popover .imageDownload').attr('download', getImageName(e.target.src));
+    }).on('inserted.bs.popover', function() {
+      $('.popover .imageDownload').attr('href', this.src);
+      $('.popover .imageDownload').attr('download', getImageName(this.src));
+      var imageId = getImageId(this);
+      if (imageId) {
+        $('.popover .imageId').attr('href', '#' + imageId);
+        $('.popover .imageId').removeClass('hidden');
+      }
     }).on('mouseenter', function() {
       clearTimeout(timeout);
       $(this).popover('show');
@@ -317,6 +321,15 @@ define('xwiki-lightbox', [
         // Set the attributes for the download button inside lightbox.
         $('#lightboxDownload').attr('href', imageData.href);
         $('#lightboxDownload').attr('download', imageData.fileName);
+        // Save the image ID, or hide the action in case it doesn't exist.
+        var copyImageId = $('#blueimp-gallery .copyImageId');
+        if (imageData.id) {
+          copyImageId.parent().removeClass('hidden');
+          copyImageId.attr('data-imageId', imageData.id);
+        } else {
+          copyImageId.parent().addClass('hidden');
+          copyImageId.removeAttr('data-imageId');
+        }
       }
     };
     openedLightbox = gallery(slidesData, options);
@@ -354,8 +367,7 @@ define('xwiki-lightbox', [
   $(document).on('click', '#blueimp-gallery .copyImageId', function(event) {
     event.preventDefault();
     var copyIdButton = this;
-    var imageId = $(copyIdButton).siblings('.imageId');
-    navigator.clipboard.writeText(imageId.val()).then(function() {
+    navigator.clipboard.writeText($(copyIdButton).attr('data-imageId')).then(function() {
       // Inform the user that the image ID was copied to clipboard.
       $(copyIdButton).tooltip('show');
       setTimeout(function() {

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/lightbox.js
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/lightbox.js
@@ -195,6 +195,8 @@ define('xwiki-lightbox', [
         return $('#imageToolbarTemplate').html();
       },
       html: true,
+      // The copyImageId tooltip attributes are deleted by sanitization.
+      sanitize: false,
       // The popover needs to be placed outside of the xwiki content to not depend on it's overflow.
       container: 'body',
       placement: 'bottom',
@@ -213,8 +215,10 @@ define('xwiki-lightbox', [
       $('.popover .imageDownload').attr('download', getImageName(this.src));
       var imageId = getImageId(this);
       if (imageId) {
-        $('.popover .imageId').attr('href', '#' + imageId);
-        $('.popover .imageId').removeClass('hidden');
+        $('.popover .permalink').attr('href', '#' + imageId);
+        $('.popover .permalink').removeClass('hidden');
+        $('.popover .copyImageId').attr('data-imageId', imageId);
+        $('.popover .copyImageId').parent().removeClass('hidden');
       }
     }).on('mouseenter', function() {
       clearTimeout(timeout);
@@ -306,7 +310,8 @@ define('xwiki-lightbox', [
   /**
    * Open Gallery lightbox at the current index.
    */
-  var openLightbox = function() {
+  var openLightbox = function(e) {
+    e.preventDefault();
     var options = {
       container: '#blueimp-gallery',
       index: parseInt($('.openLightbox').data('index')),
@@ -364,7 +369,7 @@ define('xwiki-lightbox', [
     initLightboxFunctionality();
   });
 
-  $(document).on('click', '#blueimp-gallery .copyImageId', function(event) {
+  $(document).on('click', '.copyImageId', function(event) {
     event.preventDefault();
     var copyIdButton = this;
     navigator.clipboard.writeText($(copyIdButton).attr('data-imageId')).then(function() {

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/lightbox.js
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/lightbox.js
@@ -103,6 +103,7 @@ define('xwiki-lightbox-description', [
    * Update lightbox description using given information.
    */
   var updateDescriptionData = function(imageData, attachmentData) {
+    $('.lightboxDescription .imageId').val(imageData.id);
     updateDescriptionCaption(imageData, attachmentData);
 
     if (attachmentData) {
@@ -231,6 +232,18 @@ define('xwiki-lightbox', [
   };
 
   /**
+   * Extract the image id. Prefer the id manually added to the caption over the automatically generated one.
+   */
+  var getImageId = function(img) {
+    // Select the first caption child element which specifies an id.
+    var figureCaptionIdElement = $(img).closest('figure').find('figcaption').find('[id]')[0];
+    if (figureCaptionIdElement) {
+      return $(figureCaptionIdElement).attr('id');
+    }
+    return $(img).attr('id');
+  };
+
+  /**
    * Rescale image to original size.
    */
   var removeResizeParams = function(imageURL) {
@@ -279,7 +292,8 @@ define('xwiki-lightbox', [
         caption: caption,
         fileName: getImageName(imageURL),
         alt: $(this).attr('alt'),
-        title: $(this).attr('title')
+        title: $(this).attr('title'),
+        id: getImageId(this)
       });
     });
     return slidesData;
@@ -335,6 +349,19 @@ define('xwiki-lightbox', [
 
   $(function() {
     initLightboxFunctionality();
+  });
+
+  $(document).on('click', '#blueimp-gallery .copyImageId', function(event) {
+    event.preventDefault();
+    var copyIdButton = this;
+    var imageId = $(copyIdButton).siblings('.imageId');
+    navigator.clipboard.writeText(imageId.val()).then(function() {
+      // Inform the user that the image ID was copied to clipboard.
+      $(copyIdButton).tooltip('show');
+      setTimeout(function() {
+        $(copyIdButton).tooltip('hide');
+      }, 2000);
+    });
   });
 
   $(document).on('xwiki:dom:updated', function() {


### PR DESCRIPTION
* extracted the image id, prioritizing the manually added one, and display it as part of the lightbox description
* provide a button to copy the displayed image id to clipboard

![imageIDFull](https://user-images.githubusercontent.com/22794181/159419363-66f27c24-839a-47aa-946f-d91f8624163b.png)

