### PR TITLE
XWIKI-19565: PowerPoint slides aren't ordered as the file imported

### DIFF
--- a/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/test/java/org/xwiki/officeimporter/internal/builder/DefaultPresentationBuilderTest.java
+++ b/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/test/java/org/xwiki/officeimporter/internal/builder/DefaultPresentationBuilderTest.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.inject.Named;
 
@@ -78,7 +79,7 @@ import static org.mockito.Mockito.when;
  * @since 2.1M1
  */
 @ComponentTest
-public class DefaultPresentationBuilderTest
+class DefaultPresentationBuilderTest
 {
     @InjectMockComponents
     private DefaultPresentationBuilder presentationBuilder;
@@ -116,7 +117,7 @@ public class DefaultPresentationBuilderTest
     }
 
     @Test
-    public void build() throws Exception
+    void build() throws Exception
     {
         DocumentReference documentReference = new DocumentReference("wiki", Arrays.asList("Path", "To"), "Page");
         when(this.entityReferenceSerializer.serialize(documentReference)).thenReturn("wiki:Path.To.Page");
@@ -130,17 +131,18 @@ public class DefaultPresentationBuilderTest
 
         OfficeConverterResult officeConverterResult = mock(OfficeConverterResult.class);
         when(officeConverterResult.getOutputDirectory()).thenReturn(this.outputDirectory);
+        // Slide numbers including 10 so that we can validate that XWIKI-19565 has been fixed.
+        List<Integer> slideNumbers = Arrays.asList(0, 1, 2, 10);
         File firstSlide = new File(this.outputDirectory, "img0.html");
-        File secondSlide = new File(this.outputDirectory, "img1.html");
         when(officeConverterResult.getOutputFile()).thenReturn(firstSlide);
-        Set<File> allFiles = new HashSet<>();
+
         // list of files usually created by jodconverter for a presentation
-        allFiles.add(firstSlide);
-        allFiles.add(new File(this.outputDirectory, "img0.jpg"));
-        allFiles.add(new File(this.outputDirectory, "text0.html"));
-        allFiles.add(secondSlide);
-        allFiles.add(new File(this.outputDirectory, "img1.jpg"));
-        allFiles.add(new File(this.outputDirectory, "text1.html"));
+        Set<File> allFiles = new HashSet<>();
+        slideNumbers.forEach(slideNumber -> {
+            allFiles.add(new File(this.outputDirectory, String.format("img%d.html", slideNumber)));
+            allFiles.add(new File(this.outputDirectory, String.format("text%d.html", slideNumber)));
+            allFiles.add(new File(this.outputDirectory, String.format("img%d.jpg", slideNumber)));
+        });
 
         // We create the files since some IO operations will happen on them
         for (File file : allFiles) {
@@ -157,7 +159,8 @@ public class DefaultPresentationBuilderTest
 
         Document xhtmlDoc = XMLUtils.createDOMDocument();
         xhtmlDoc.appendChild(xhtmlDoc.createElement("html"));
-        String presentationHTML = "<p><img src=\"file-slide0.jpg\"/></p><p><img src=\"file-slide1.jpg\"/></p>";
+        String presentationHTML = slideNumbers.stream().map(slideNumber ->
+            String.format("<p><img src=\"file-slide%d.jpg\"/></p>", slideNumber)).collect(Collectors.joining());
         when(this.officeHTMLCleaner.clean(any(Reader.class), eq(config)))
             .then(returnMatchingDocument(presentationHTML, xhtmlDoc));
 
@@ -167,9 +170,8 @@ public class DefaultPresentationBuilderTest
         XDOMOfficeDocument result = this.presentationBuilder.build(officeFileStream, "file.odp", documentReference);
 
         verify(config).setParameters(Collections.singletonMap("targetDocument", "wiki:Path.To.Page"));
-        Set<File> expectedArtifacts = new HashSet<>();
-        expectedArtifacts.add(new File(this.outputDirectory, "file-slide0.jpg"));
-        expectedArtifacts.add(new File(this.outputDirectory, "file-slide1.jpg"));
+        Set<File> expectedArtifacts = slideNumbers.stream().map(slideNumber ->
+            new File(this.outputDirectory, String.format("file-slide%d.jpg", slideNumber))).collect(Collectors.toSet());
         assertEquals(expectedArtifacts, result.getArtifactsFiles());
 
         assertEquals("wiki:Path.To.Page", result.getContentDocument().getMetaData().getMetaData(MetaData.BASE));


### PR DESCRIPTION
* Sort slides by numeric id and not by file name.
* Extend the test to validate the bug fix.

Jira issue: https://jira.xwiki.org/browse/XWIKI-19565