### PR TITLE
XWIKI-19614: The locale is ignored when indexing documents

### DIFF
--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -146,7 +146,7 @@
                   <code>java.class.removed</code>
                   <old>class org.xwiki.index.migration.R140200001XWIKI19352DataMigration</old>
                   <justification>R140200001XWIKI19352DataMigration replaced by R140300000XWIKI19614DataMigration because a link reindexing is required by XWIKI-19614, making an additional reindexing for migrations from version lower than 14.2RC1 useless.</justification>
-                  <criticality>highlight</criticality>
+                  <criticality>allowed</criticality>
                 </item>
               </differences>
             </revapi.differences>

--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -138,7 +138,18 @@
             -->
             <!-- Difference related to the Security refactoring. Start a new <revapi.differences> entry for other
                  differences -->
-            
+
+            <revapi.differences>
+              <differences>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.removed</code>
+                  <old>class org.xwiki.index.migration.R140200001XWIKI19352DataMigration</old>
+                  <justification>R140200001XWIKI19352DataMigration replaced by R140300000XWIKI19614DataMigration because a link reindexing is required by XWIKI-19614, making an additional reindexing for migrations from version lower than 14.2RC1 useless.</justification>
+                  <criticality>highlight</criticality>
+                </item>
+              </differences>
+            </revapi.differences>
           </analysisConfiguration>
         </configuration>
       </plugin>

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-api/src/main/java/org/xwiki/index/internal/TaskExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-api/src/main/java/org/xwiki/index/internal/TaskExecutor.java
@@ -98,6 +98,6 @@ public class TaskExecutor
             doc = this.documentRevisionProvider.getRevision(document, task.getVersion());
         }
         this.componentManager.get().<TaskConsumer>getInstance(TaskConsumer.class, task.getType())
-            .consume(doc.getDocumentReference(), doc.getVersion());
+            .consume(doc.getDocumentReferenceWithLocale(), doc.getVersion());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-api/src/main/java/org/xwiki/index/migration/R140300000XWIKI19614DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-api/src/main/java/org/xwiki/index/migration/R140300000XWIKI19614DataMigration.java
@@ -48,13 +48,13 @@ import static org.xwiki.index.internal.DefaultLinksTaskConsumer.LINKS_TASK_TYPE;
 // TODO: Implement DataMigration once XWIKI-19399 is fixed.
 @Component
 @Singleton
-@Named(R140200001XWIKI19352DataMigration.HINT)
-public class R140200001XWIKI19352DataMigration implements HibernateDataMigration
+@Named(R140300000XWIKI19614DataMigration.HINT)
+public class R140300000XWIKI19614DataMigration implements HibernateDataMigration
 {
     /**
      * The hint for this component.
      */
-    public static final String HINT = "140200001XWIKI19352";
+    public static final String HINT = "R140300000XWIKI19614";
 
     @Inject
     private QueryManager queryManager;
@@ -80,7 +80,7 @@ public class R140200001XWIKI19352DataMigration implements HibernateDataMigration
     @Override
     public XWikiDBVersion getVersion()
     {
-        return new XWikiDBVersion(140200001);
+        return new XWikiDBVersion(140300000);
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-api/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-api/src/main/resources/META-INF/components.txt
@@ -4,5 +4,5 @@ org.xwiki.index.internal.TaskExecutor
 org.xwiki.index.internal.TaskApplicationReadyListener
 org.xwiki.index.internal.DefaultLinksTaskConsumer
 org.xwiki.index.internal.listener.LinksUpdateListener
-org.xwiki.index.migration.R140200001XWIKI19352DataMigration
+org.xwiki.index.migration.R140300000XWIKI19614DataMigration
 org.xwiki.index.TaskConsumerScriptService

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-api/src/test/java/org/xwiki/index/internal/TaskExecutorTest.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-api/src/test/java/org/xwiki/index/internal/TaskExecutorTest.java
@@ -111,7 +111,7 @@ class TaskExecutorTest
         when(this.tasksStore.getDocument("wikiId", 42)).thenReturn(this.xwikiDocument);
         when(this.documentRevisionProvider.getRevision(this.xwikiDocument, "1.5")).thenReturn(this.xwikiDocument);
 
-        when(this.xwikiDocument.getDocumentReference()).thenReturn(DOCUMENT_REFERENCE);
+        when(this.xwikiDocument.getDocumentReferenceWithLocale()).thenReturn(DOCUMENT_REFERENCE);
         when(this.xwikiDocument.getVersion()).thenReturn("1.5");
 
         this.taskExecutor.execute(task);

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-api/src/test/java/org/xwiki/index/migration/R140300000XWIKI19614DataMigrationTest.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-api/src/test/java/org/xwiki/index/migration/R140300000XWIKI19614DataMigrationTest.java
@@ -47,16 +47,16 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
- * Test of {@link R140200001XWIKI19352DataMigration}.
+ * Test of {@link R140300000XWIKI19614DataMigration}.
  *
  * @version $Id$
  * @since 14.2RC1
  */
 @ComponentTest
-class R140200001XWIKI19352DataMigrationTest
+class R140300000XWIKI19614DataMigrationTest
 {
     @InjectMockComponents(role = HibernateDataMigration.class)
-    private R140200001XWIKI19352DataMigration migration;
+    private R140300000XWIKI19614DataMigration migration;
 
     @MockComponent
     private QueryManager queryManager;

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/DefaultMentionsDataConsumer.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/DefaultMentionsDataConsumer.java
@@ -93,7 +93,8 @@ public class DefaultMentionsDataConsumer implements TaskConsumer
                 } else {
                     // UPDATE
                     XWikiDocument oldDoc =
-                        this.documentRevisionProvider.getRevision(doc.getDocumentReference(), doc.getPreviousVersion());
+                        this.documentRevisionProvider.getRevision(doc.getDocumentReferenceWithLocale(),
+                            doc.getPreviousVersion());
                     mentionNotificationParameters = this.updatedDocumentMentionsAnalyzer
                         .analyze(oldDoc, doc, documentReference, doc.getVersion(), authorReference);
                 }

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/DefaultMentionsDataConsumerTest.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/DefaultMentionsDataConsumerTest.java
@@ -110,7 +110,7 @@ class DefaultMentionsDataConsumerTest
     {
         when(this.documentRevisionProvider.getRevision(DOCUMENT_REFERENCE, "1.1")).thenReturn(this.doc);
         when(this.doc.getPreviousVersion()).thenReturn(null);
-        when(this.doc.getDocumentReference()).thenReturn(DOCUMENT_REFERENCE);
+        when(this.doc.getDocumentReferenceWithLocale()).thenReturn(DOCUMENT_REFERENCE);
         when(this.createdDocumentMentionsAnalyzer.analyze(this.doc, DOCUMENT_REFERENCE, "1.1", AUTHOR_REFERENCE))
             .thenReturn(emptyList());
 
@@ -126,7 +126,7 @@ class DefaultMentionsDataConsumerTest
     {
         when(this.documentRevisionProvider.getRevision(DOCUMENT_REFERENCE, "1.1")).thenReturn(this.doc);
         when(this.doc.getPreviousVersion()).thenReturn(null);
-        when(this.doc.getDocumentReference()).thenReturn(DOCUMENT_REFERENCE);
+        when(this.doc.getDocumentReferenceWithLocale()).thenReturn(DOCUMENT_REFERENCE);
         MentionNotificationParameters mentionNotificationParameters =
             new MentionNotificationParameters(AUTHOR_REFERENCE, DOCUMENT_REFERENCE, MentionLocation.DOCUMENT,
                 "1.1")
@@ -153,7 +153,7 @@ class DefaultMentionsDataConsumerTest
         when(this.documentRevisionProvider.getRevision(DOCUMENT_REFERENCE, "1.1")).thenReturn(this.doc);
 
         when(this.doc.getPreviousVersion()).thenReturn("1.0");
-        when(this.doc.getDocumentReference()).thenReturn(DOCUMENT_REFERENCE);
+        when(this.doc.getDocumentReferenceWithLocale()).thenReturn(DOCUMENT_REFERENCE);
         when(
             this.updatedDocumentMentionsAnalyzer.analyze(oldDoc, this.doc, DOCUMENT_REFERENCE, "1.1", AUTHOR_REFERENCE))
             .thenReturn(emptyList());
@@ -173,7 +173,7 @@ class DefaultMentionsDataConsumerTest
         when(this.documentRevisionProvider.getRevision(DOCUMENT_REFERENCE, "1.0")).thenReturn(oldDoc);
         when(this.documentRevisionProvider.getRevision(DOCUMENT_REFERENCE, "1.1")).thenReturn(this.doc);
         when(this.doc.getPreviousVersion()).thenReturn("1.0");
-        when(this.doc.getDocumentReference()).thenReturn(DOCUMENT_REFERENCE);
+        when(this.doc.getDocumentReferenceWithLocale()).thenReturn(DOCUMENT_REFERENCE);
         MentionNotificationParameters mentionNotificationParameters =
             new MentionNotificationParameters(AUTHOR_REFERENCE, DOCUMENT_REFERENCE, MentionLocation.DOCUMENT,
                 "1.1")


### PR DESCRIPTION
- Use getDocumentReferenceWithLocale instead of getDocumentReference when:
  - passing the DocumentReference to the task consumers.
  - resolving the previous version of a documentation during mentions analysis
- Reindex the links and attachments they are missing for localized pages