### PR TITLE
XWIKI-19626: Add extension point for inserting content before page header

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/contentview.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/contentview.vm
@@ -41,6 +41,9 @@ $services.progress.endStep()
 ## ----------------------------
 $services.progress.startStep('Display the title and content')
 <div class="xcontent">
+  #foreach ($uix in $services.uix.getExtensions('org.xwiki.platform.template.content.header.before'))
+    $services.rendering.render($uix.execute(), 'xhtml/1.0')
+  #end
   #template('contentheader.vm')
   #foreach ($uix in $services.uix.getExtensions('org.xwiki.platform.template.content.header.after'))
     $services.rendering.render($uix.execute(), 'xhtml/1.0')


### PR DESCRIPTION
* Update flamingo/contentview.vm to add UI extension point "org.xwiki.platform.template.content.header.before"