### PR TITLE
XWIKI-19637: XWiki.widgets.Notification messages are hidden when a modal is opened

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/notification.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/notification.css
@@ -6,7 +6,7 @@
   right: 0;
   margin: auto;
   text-align: center;
-  z-index: 1200;
+  z-index: 10051; /* One more than the z-index of bootstrap's modal. */
   display: block !important;
   max-width: 80%;
 }


### PR DESCRIPTION
https://jira.xwiki.org/browse/XWIKI-19637