### PR TITLE
XWIKI-19636: The image popup can be hard to follow on large images

### DIFF
--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-pageobjects/src/main/java/org/xwiki/image/lightbox/test/po/LightboxPage.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-pageobjects/src/main/java/org/xwiki/image/lightbox/test/po/LightboxPage.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Optional;
 
 import org.openqa.selenium.By;
-import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
@@ -50,20 +49,10 @@ public class LightboxPage extends ViewPage
             Actions action = new Actions(getDriver().getWrappedDriver());
             action.moveToElement(image).build().perform();
 
-            // Workaround to manually display the popup since in firefox the hover is not always triggered even if the
-            // mouse is moved over the image.
-            showPopup(image);
-
             return Optional.of(new ImagePopover());
         } catch (TimeoutException e) {
             return Optional.empty();
         }
-    }
-
-    private void showPopup(WebElement image)
-    {
-        JavascriptExecutor js = (JavascriptExecutor) getDriver();
-        js.executeScript("jQuery(arguments[0]).popover('show');", image);
     }
 
     public WebElement getImageElement(int index)

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-ui/src/main/resources/XWiki/Lightbox/WebHome.xml
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-ui/src/main/resources/XWiki/Lightbox/WebHome.xml
@@ -497,6 +497,7 @@ bundles=blueimp-gallery,blueimp-helper,blueimp-gallery-fullscreen,blueimp-galler
     &lt;/span&gt;
   &lt;/div&gt;
 &lt;/div&gt;
+&lt;div id='imagePopoverContainer'&gt;&lt;/div&gt;
 #end
 #set ($lightboxConfigDoc = $xwiki.getDocument('XWiki.Lightbox.LightboxConfiguration'))
 #set ($lightboxConfigObj = $lightboxConfigDoc.getObject('XWiki.Lightbox.LightboxConfigurationClass'))

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/less/lightbox.less
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/less/lightbox.less
@@ -89,3 +89,10 @@
     white-space:nowrap;
   }
 }
+#imagePopoverContainer {
+  position: absolute;
+
+  .popover {
+    white-space: nowrap;
+  }
+}

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/lightbox.js
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/lightbox.js
@@ -172,16 +172,20 @@ define('xwiki-lightbox', [
   /*
    * Make sure that the toolbar will remain open also while hovering it, not just the image.
    */
-  var keepToolbarOpenOnHover = function(image, hideTimeout) {
-    hideTimeout = setTimeout(function() {
+  var keepToolbarOpenOnHover = function() {
+    // Hide the image popover after 3 seconds (if the mouse doesn't enter the popover).
+    var hideTimeout = setTimeout(function() {
       $('#imagePopoverContainer').popover('hide');
     }, 3000);
+    // Don't hide the image popover when the mouse is over it.
     $('#imagePopoverContainer .popover').on('mouseenter', function() {
       clearTimeout(hideTimeout);
     });
+    // Hide the image popover when the mouse leaves its area.
     $('#imagePopoverContainer .popover').on('mouseleave', function() {
       $(this).popover('hide');
     });
+    return hideTimeout;
   };
 
   /**
@@ -235,10 +239,10 @@ define('xwiki-lightbox', [
       showTimeout = setTimeout(function() {
         popoverContainer.css({top: e.pageY, left: e.pageX });
         popoverContainer.popover('show');
-      }, 800);
+      }, 400);
     }).on('mouseleave', function() {
       clearTimeout(showTimeout);
-      keepToolbarOpenOnHover($(this), hideTimeout);
+      hideTimeout = keepToolbarOpenOnHover();
     });
   };
 

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/lightbox.js
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/lightbox.js
@@ -231,7 +231,6 @@ define('xwiki-lightbox', [
     lightboxImages.on('mouseenter', function(e) {
       clearTimeout(hideTimeout);
       popoverContainer.data('target', e.target);
-      $(this).popover('show');
     }).on('mousemove', function(e) {
       popoverContainer.popover('hide');
       // Delay to show the popover until the mouse stops moving.

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/lightbox.js
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/lightbox.js
@@ -172,15 +172,15 @@ define('xwiki-lightbox', [
   /*
    * Make sure that the toolbar will remain open also while hovering it, not just the image.
    */
-  var keepToolbarOpenOnHover = function(image, timeout) {
-    timeout = setTimeout(function() {
-      image.popover('hide');
+  var keepToolbarOpenOnHover = function(image, hideTimeout) {
+    hideTimeout = setTimeout(function() {
+      $('#imagePopoverContainer').popover('hide');
     }, 3000);
-    $('.popover').on('mouseenter', function() {
-      clearTimeout(timeout);
+    $('#imagePopoverContainer .popover').on('mouseenter', function() {
+      clearTimeout(hideTimeout);
     });
-    $('.popover').on('mouseleave', function() {
-      image.popover('hide');
+    $('#imagePopoverContainer .popover').on('mouseleave', function() {
+      $(this).popover('hide');
     });
   };
 
@@ -188,20 +188,23 @@ define('xwiki-lightbox', [
    * Assign to each selected image a toolbar popover with download and lightbox options.
    */
   var enableToolbarPopovers = function() {
-    var timeout;
-    lightboxImages.popover({
+    var hideTimeout;
+    var showTimeout;
+    // In order to place the popover at cursor location, it would be added to an element that changes its position
+    // based on mouse events.
+    var popoverContainer = $('#imagePopoverContainer');
+    popoverContainer.popover({
       content: function() {
         return $('#imageToolbarTemplate').html();
       },
       html: true,
       // The copyImageId tooltip attributes are deleted by sanitization.
       sanitize: false,
-      // The popover needs to be placed outside of the xwiki content to not depend on it's overflow.
-      container: 'body',
+      container: '#imagePopoverContainer',
       placement: 'bottom',
       trigger: 'manual'
-    }).on("show.bs.popover", function(e){
-      var img = e.target;
+    }).on("show.bs.popover", function(){
+      var img = $("#imagePopoverContainer").data('target');
       // Hide all other popovers.
       $('.popover').hide();
       // Set the attributes for the download button inside lightbox.
@@ -210,20 +213,32 @@ define('xwiki-lightbox', [
       // Remember the index of the image to show first.
       $('.openLightbox').data('index', [...lightboxImages].indexOf(img));
     }).on('inserted.bs.popover', function() {
-      $('.popover .imageDownload').attr('href', this.src);
-      $('.popover .imageDownload').attr('download', getImageName(this.src));
-      var imageId = getImageId(this);
+      var img = $("#imagePopoverContainer").data('target');
+      $('.popover .imageDownload').attr('href', img.src);
+      $('.popover .imageDownload').attr('download', getImageName(img.src));
+      var imageId = getImageId(img);
       if (imageId) {
         $('.popover .permalink').attr('href', '#' + imageId);
         $('.popover .permalink').removeClass('hidden');
         $('.popover .copyImageId').attr('data-imageId', imageId);
         $('.popover .copyImageId').parent().removeClass('hidden');
       }
-    }).on('mouseenter', function() {
-      clearTimeout(timeout);
+    });
+    lightboxImages.on('mouseenter', function(e) {
+      clearTimeout(hideTimeout);
+      popoverContainer.data('target', e.target);
       $(this).popover('show');
+    }).on('mousemove', function(e) {
+      popoverContainer.popover('hide');
+      // Delay to show the popover until the mouse stops moving.
+      clearTimeout(showTimeout);
+      showTimeout = setTimeout(function() {
+        popoverContainer.css({top: e.pageY, left: e.pageX });
+        popoverContainer.popover('show');
+      }, 800);
     }).on('mouseleave', function() {
-      keepToolbarOpenOnHover($(this), timeout);
+      clearTimeout(showTimeout);
+      keepToolbarOpenOnHover($(this), hideTimeout);
     });
   };
 


### PR DESCRIPTION
* open the popover close to the mouse location by adding it to a container that changes position based on mouse events

Small demo:
https://user-images.githubusercontent.com/22794181/163386780-150a0b66-69a8-4579-82a2-efe82c730e23.mp4


