### PR TITLE
XWIKI-19660: LightboxIT#playSlideshow is flickering

### DIFF
--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-pageobjects/src/main/java/org/xwiki/image/lightbox/test/po/ImagePopover.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-pageobjects/src/main/java/org/xwiki/image/lightbox/test/po/ImagePopover.java
@@ -83,9 +83,7 @@ public class ImagePopover extends BaseElement
 
     private ImagePopover waitUntilReady()
     {
-        getDriver().waitUntilElementIsVisible(By.cssSelector(".popover .imageDownload"));
-        // This attribute is set when the show transition of the popover is complete.
-        getDriver().waitUntilElementHasNonEmptyAttributeValue(By.cssSelector(".popover .imageDownload"), "download");
+        getDriver().waitUntilElementIsVisible(By.cssSelector("#imagePopoverContainer .popover"));
 
         return this;
     }


### PR DESCRIPTION
XWIKI-19659: LightboxIT#navigateThroughImages is flickering
* the download attribute is no longer added on popover show event, so wait instead for the actual popover, which is now added as child to the #imagePopoverContainer element