### PR TITLE
XWIKI-19682: Solr ParseException from SimpleEventQuery when comparing with equality to empty string

### DIFF
--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/main/java/org/xwiki/eventstream/store/solr/internal/SolrEventStore.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/main/java/org/xwiki/eventstream/store/solr/internal/SolrEventStore.java
@@ -584,7 +584,7 @@ public class SolrEventStore extends AbstractAsynchronousEventStore
         } else {
             builder.append('(');
             builder.append(StringUtils
-                .join(condition.getValues().stream().map(this.utils::toFilterQueryString).iterator(), " OR "));
+                .join(condition.getValues().stream().map(this.utils::toCompleteFilterQueryString).iterator(), " OR "));
             builder.append(')');
 
             return builder.toString();
@@ -676,13 +676,11 @@ public class SolrEventStore extends AbstractAsynchronousEventStore
 
         switch (condition.getType()) {
             case EQUALS:
-                String queryString = toFilterQueryString(condition.getProperty(), condition.getValue());
+                String queryString = toCompleteFilterQueryString(condition.getProperty(), condition.getValue());
                 if (queryString == null) {
                     // See https://stackoverflow.com/a/28859224, -myfield:* is not composable thus combine with *:*.
                     builder.insert(0, "(*:* NOT ");
                     builder.append("*)");
-                } else if ("".equals(queryString)) {
-                    builder.append("\"\"");
                 } else {
                     builder.append(queryString);
                 }
@@ -718,14 +716,14 @@ public class SolrEventStore extends AbstractAsynchronousEventStore
         return builder.toString();
     }
 
-    private String toFilterQueryString(String propertyName, Object propertyValue)
+    private String toCompleteFilterQueryString(String propertyName, Object propertyValue)
     {
         SearchFieldMapping mapping = SEARCH_FIELD_MAPPING.get(propertyName);
 
         if (mapping != null && mapping.type != null) {
-            return this.utils.toFilterQueryString(propertyValue, mapping.type);
+            return this.utils.toCompleteFilterQueryString(propertyValue, mapping.type);
         } else {
-            return this.utils.toFilterQueryString(propertyValue);
+            return this.utils.toCompleteFilterQueryString(propertyValue);
         }
     }
 
@@ -751,7 +749,7 @@ public class SolrEventStore extends AbstractAsynchronousEventStore
                 builder.append('[');
             }
 
-            builder.append(this.utils.toFilterQueryString(greater.getValue()));
+            builder.append(this.utils.toCompleteFilterQueryString(greater.getValue()));
         } else {
             builder.append("[*");
         }
@@ -759,7 +757,7 @@ public class SolrEventStore extends AbstractAsynchronousEventStore
         builder.append(" TO ");
 
         if (less != null) {
-            builder.append(this.utils.toFilterQueryString(less.getValue()));
+            builder.append(this.utils.toCompleteFilterQueryString(less.getValue()));
 
             if (less.getType() == CompareType.LESS) {
                 builder.append('}');

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/main/java/org/xwiki/eventstream/store/solr/internal/SolrEventStore.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/main/java/org/xwiki/eventstream/store/solr/internal/SolrEventStore.java
@@ -522,7 +522,7 @@ public class SolrEventStore extends AbstractAsynchronousEventStore
                 builder.append(condition.getStatusRead() ? EventsSolrCoreInitializer.SOLR_FIELD_READLISTENERS
                     : EventsSolrCoreInitializer.SOLR_FIELD_UNREADLISTENERS);
                 builder.append(':');
-                builder.append(this.utils.toFilterQueryString(condition.getStatusEntityId()));
+                builder.append(this.utils.toCompleteFilterQueryString(condition.getStatusEntityId()));
             } else {
                 builder.append('(');
                 builder.append(EventsSolrCoreInitializer.SOLR_FIELD_READLISTENERS);
@@ -541,11 +541,11 @@ public class SolrEventStore extends AbstractAsynchronousEventStore
             builder.append('(');
             builder.append(EventsSolrCoreInitializer.SOLR_FIELD_READLISTENERS);
             builder.append(':');
-            builder.append(this.utils.toFilterQueryString(condition.getStatusEntityId()));
+            builder.append(this.utils.toCompleteFilterQueryString(condition.getStatusEntityId()));
             builder.append(" OR ");
             builder.append(EventsSolrCoreInitializer.SOLR_FIELD_UNREADLISTENERS);
             builder.append(':');
-            builder.append(this.utils.toFilterQueryString(condition.getStatusEntityId()));
+            builder.append(this.utils.toCompleteFilterQueryString(condition.getStatusEntityId()));
             builder.append(')');
 
             return builder.toString();
@@ -561,7 +561,7 @@ public class SolrEventStore extends AbstractAsynchronousEventStore
             StringBuilder builder = new StringBuilder();
             builder.append(EventsSolrCoreInitializer.SOLR_FIELD_MAILLISTENERS);
             builder.append(':');
-            builder.append(this.utils.toFilterQueryString(condition.getStatusEntityId()));
+            builder.append(this.utils.toCompleteFilterQueryString(condition.getStatusEntityId()));
 
             return builder.toString();
         }

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/main/java/org/xwiki/eventstream/store/solr/internal/SolrEventStore.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/main/java/org/xwiki/eventstream/store/solr/internal/SolrEventStore.java
@@ -83,7 +83,7 @@ import org.xwiki.search.solr.SolrUtils;
 
 /**
  * Solr based implementation of {@link EventStore}.
- * 
+ *
  * @version $Id$
  * @since 12.4RC1
  */
@@ -678,7 +678,9 @@ public class SolrEventStore extends AbstractAsynchronousEventStore
             case EQUALS:
                 String queryString = toCompleteFilterQueryString(condition.getProperty(), condition.getValue());
                 if (queryString == null) {
-                    // See https://stackoverflow.com/a/28859224, -myfield:* is not composable thus combine with *:*.
+                    // Negative queries in Solr can only remove results so a simple negative field existence query
+                    // doesn't match anything. Thus, use the more compatible query "all events except for those where
+                    // the field exists". See also https://stackoverflow.com/a/28859224
                     builder.insert(0, "(*:* NOT ");
                     builder.append("*)");
                 } else {

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/main/java/org/xwiki/eventstream/store/solr/internal/SolrEventStore.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/main/java/org/xwiki/eventstream/store/solr/internal/SolrEventStore.java
@@ -681,6 +681,8 @@ public class SolrEventStore extends AbstractAsynchronousEventStore
                     // See https://stackoverflow.com/a/28859224.
                     builder.insert(0, "(*:* NOT ");
                     builder.append("*)");
+                } else if ("".equals(queryString)) {
+                    builder.append("\"\"");
                 } else {
                     builder.append(queryString);
                 }

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/main/java/org/xwiki/eventstream/store/solr/internal/SolrEventStore.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/main/java/org/xwiki/eventstream/store/solr/internal/SolrEventStore.java
@@ -676,7 +676,14 @@ public class SolrEventStore extends AbstractAsynchronousEventStore
 
         switch (condition.getType()) {
             case EQUALS:
-                builder.append(toFilterQueryString(condition.getProperty(), condition.getValue()));
+                String queryString = toFilterQueryString(condition.getProperty(), condition.getValue());
+                if (queryString == null) {
+                    // See https://stackoverflow.com/a/28859224.
+                    builder.insert(0, "(*:* NOT ");
+                    builder.append("*)");
+                } else {
+                    builder.append(queryString);
+                }
                 break;
 
             case LESS:

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/main/java/org/xwiki/eventstream/store/solr/internal/SolrEventStore.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/main/java/org/xwiki/eventstream/store/solr/internal/SolrEventStore.java
@@ -678,7 +678,7 @@ public class SolrEventStore extends AbstractAsynchronousEventStore
             case EQUALS:
                 String queryString = toFilterQueryString(condition.getProperty(), condition.getValue());
                 if (queryString == null) {
-                    // See https://stackoverflow.com/a/28859224.
+                    // See https://stackoverflow.com/a/28859224, -myfield:* is not composable thus combine with *:*.
                     builder.insert(0, "(*:* NOT ");
                     builder.append("*)");
                 } else if ("".equals(queryString)) {

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/main/java/org/xwiki/eventstream/store/solr/internal/WikiDeletedListener.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/main/java/org/xwiki/eventstream/store/solr/internal/WikiDeletedListener.java
@@ -74,7 +74,7 @@ public class WikiDeletedListener extends AbstractEventListener
             SolrClient client = this.solr.getClient(EventsSolrCoreInitializer.NAME);
 
             client.deleteByQuery(org.xwiki.eventstream.Event.FIELD_WIKI + ':'
-                + this.utils.toFilterQueryString(wikiDeletedEvent.getWikiId()));
+                + this.utils.toCompleteFilterQueryString(wikiDeletedEvent.getWikiId()));
             client.commit();
         } catch (Exception e) {
             this.logger.error("Failed to delete events associated with wiki [{}]", wikiDeletedEvent.getWikiId(), e);

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/test/java/org/xwiki/eventstream/store/solr/internal/EventStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/test/java/org/xwiki/eventstream/store/solr/internal/EventStoreTest.java
@@ -472,6 +472,8 @@ public class EventStoreTest
             .eq(Event.FIELD_ID, EVENT1.getId()).or().eq(Event.FIELD_ID, EVENT2.getId()).close());
 
         assertSearch(Collections.singletonList(EVENT3), new SimpleEventQuery().eq(Event.FIELD_DOCUMENTVERSION, ""));
+        assertSearch(Arrays.asList(EVENT1, EVENT3, EVENT4),
+            new SimpleEventQuery().startsWith(Event.FIELD_DOCUMENTVERSION, ""));
         assertSearch(Collections.singletonList(EVENT2), new SimpleEventQuery().eq(Event.FIELD_DOCUMENTVERSION, null));
 
         assertSearch(Arrays.asList(EVENT1, EVENT2),

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/test/java/org/xwiki/eventstream/store/solr/internal/EventStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/test/java/org/xwiki/eventstream/store/solr/internal/EventStoreTest.java
@@ -431,6 +431,10 @@ public class EventStoreTest
         EVENT3.setDocumentTitle("title3");
         EVENT4.setDocumentTitle("title4");
 
+        EVENT1.setDocumentVersion("2.1");
+        EVENT3.setDocumentVersion("");
+        EVENT4.setDocumentVersion(" foo");
+
         this.eventStore.saveEvent(EVENT1);
         this.eventStore.saveEvent(EVENT2);
         this.eventStore.saveEvent(EVENT3);
@@ -466,6 +470,9 @@ public class EventStoreTest
 
         assertSearch(Arrays.asList(EVENT1), new SimpleEventQuery().eq(Event.FIELD_ID, EVENT1.getId()).open()
             .eq(Event.FIELD_ID, EVENT1.getId()).or().eq(Event.FIELD_ID, EVENT2.getId()).close());
+
+        assertSearch(Collections.singletonList(EVENT3), new SimpleEventQuery().eq(Event.FIELD_DOCUMENTVERSION, ""));
+        assertSearch(Collections.singletonList(EVENT2), new SimpleEventQuery().eq(Event.FIELD_DOCUMENTVERSION, null));
 
         assertSearch(Arrays.asList(EVENT1, EVENT2),
             new SimpleEventQuery().in(Event.FIELD_ID, EVENT1.getId(), EVENT2.getId()));

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/test/java/org/xwiki/eventstream/store/solr/internal/EventStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/test/java/org/xwiki/eventstream/store/solr/internal/EventStoreTest.java
@@ -476,6 +476,13 @@ public class EventStoreTest
             new SimpleEventQuery().startsWith(Event.FIELD_DOCUMENTVERSION, ""));
         assertSearch(Collections.singletonList(EVENT2), new SimpleEventQuery().eq(Event.FIELD_DOCUMENTVERSION, null));
 
+        assertSearch(Collections.singletonList(EVENT3), new SimpleEventQuery().eq(Event.FIELD_DOCUMENTVERSION, ""));
+        assertSearch(Arrays.asList(EVENT1, EVENT3, EVENT4),
+            new SimpleEventQuery().startsWith(Event.FIELD_DOCUMENTVERSION, ""));
+        assertSearch(Collections.singletonList(EVENT2), new SimpleEventQuery().eq(Event.FIELD_DOCUMENTVERSION, null));
+        assertSearch(Collections.singletonList(EVENT1),
+            new SimpleEventQuery().greaterOrEq(Event.FIELD_DOCUMENTVERSION, ""));
+
         assertSearch(Arrays.asList(EVENT1, EVENT2),
             new SimpleEventQuery().in(Event.FIELD_ID, EVENT1.getId(), EVENT2.getId()));
 

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/internal/ExtensionIndexStore.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/internal/ExtensionIndexStore.java
@@ -233,7 +233,7 @@ public class ExtensionIndexStore implements Initializable
         SolrQuery solrQuery = new SolrQuery();
 
         solrQuery.addFilterQuery(ExtensionIndexSolrCoreInitializer.SOLR_FIELD_ID + ':'
-            + this.utils.toFilterQueryString(toSolrId(extensionId)));
+            + this.utils.toCompleteFilterQueryString(toSolrId(extensionId)));
 
         if (local != null) {
             solrQuery.addFilterQuery(Extension.FIELD_REPOSITORY + ":local");
@@ -305,7 +305,7 @@ public class ExtensionIndexStore implements Initializable
         // Get the version to copy
         SolrQuery solrQuery = new SolrQuery();
         solrQuery.addFilterQuery(ExtensionIndexSolrCoreInitializer.SOLR_FIELD_ID + ':'
-            + this.utils.toFilterQueryString(toSolrId(new ExtensionId(extensionId.getId(), copyVersion))));
+            + this.utils.toCompleteFilterQueryString(toSolrId(new ExtensionId(extensionId.getId(), copyVersion))));
         solrQuery.setFields(RemoteExtension.FIELD_RECOMMENDED, RatingExtension.FIELD_TOTAL_VOTES,
             RatingExtension.FIELD_AVERAGE_VOTE);
         solrQuery.setRows(1);
@@ -414,7 +414,7 @@ public class ExtensionIndexStore implements Initializable
         SolrQuery solrQuery = new SolrQuery();
 
         solrQuery.addFilterQuery(ExtensionIndexSolrCoreInitializer.SOLR_FIELD_ID + ':'
-            + this.utils.toFilterQueryString(toSolrId(extensionId)));
+            + this.utils.toCompleteFilterQueryString(toSolrId(extensionId)));
 
         solrQuery.setFields(ExtensionIndexSolrCoreInitializer.SOLR_FIELD_COMPATIBLE_NAMESPACES,
             ExtensionIndexSolrCoreInitializer.SOLR_FIELD_INCOMPATIBLE_NAMESPACES);
@@ -757,7 +757,7 @@ public class ExtensionIndexStore implements Initializable
 
                 builder.append('(');
                 builder.append(StringUtils.join(indexedQuery.getCompatibleNamespaces().stream()
-                    .map(n -> this.utils.toFilterQueryString(toStoredNamespace(n))).iterator(), " OR "));
+                    .map(n -> this.utils.toCompleteFilterQueryString(toStoredNamespace(n))).iterator(), " OR "));
                 builder.append(')');
 
                 solrQuery.addFilterQuery(builder.toString());
@@ -775,7 +775,7 @@ public class ExtensionIndexStore implements Initializable
 
                 builder.append('(');
                 builder.append(StringUtils.join(indexedQuery.getInstalledNamespaces().stream()
-                    .map(n -> this.utils.toFilterQueryString(toStoredNamespace(n))).iterator(), " OR "));
+                    .map(n -> this.utils.toCompleteFilterQueryString(toStoredNamespace(n))).iterator(), " OR "));
                 builder.append(')');
 
                 solrQuery.addFilterQuery(builder.toString());
@@ -798,10 +798,10 @@ public class ExtensionIndexStore implements Initializable
         builder.append(':');
         if (filter.getComparison() == COMPARISON.MATCH) {
             builder.append('*');
-        }
-        builder.append(toFilterQueryString(filter));
-        if (filter.getComparison() == COMPARISON.MATCH) {
+            builder.append(toFilterQueryString(filter));
             builder.append('*');
+        } else {
+            builder.append(toCompleteFilterQueryString(filter));
         }
 
         return builder.toString();
@@ -834,6 +834,17 @@ public class ExtensionIndexStore implements Initializable
             return this.utils.toFilterQueryString(filter.getValue(), mapping.type);
         } else {
             return this.utils.toFilterQueryString(filter.getValue());
+        }
+    }
+
+    private String toCompleteFilterQueryString(Filter filter)
+    {
+        SearchFieldMapping mapping = SEARCH_FIELD_MAPPING.get(filter.getField());
+
+        if (mapping != null && mapping.type != null) {
+            return this.utils.toCompleteFilterQueryString(filter.getValue(), mapping.type);
+        } else {
+            return this.utils.toCompleteFilterQueryString(filter.getValue());
         }
     }
 
@@ -888,7 +899,7 @@ public class ExtensionIndexStore implements Initializable
         solrQuery.setFields(Extension.FIELD_VERSION);
 
         solrQuery.addFilterQuery(ExtensionIndexSolrCoreInitializer.SOLR_FIELD_EXTENSIONID + ':'
-            + this.utils.toFilterQueryString(extensionId));
+            + this.utils.toCompleteFilterQueryString(extensionId));
 
         QueryResponse response = search(solrQuery);
 
@@ -940,11 +951,11 @@ public class ExtensionIndexStore implements Initializable
         solrQuery.setFields(Extension.FIELD_VERSION);
 
         solrQuery.addFilterQuery(ExtensionIndexSolrCoreInitializer.SOLR_FIELD_EXTENSIONID + ':'
-            + this.utils.toFilterQueryString(extensionId));
+            + this.utils.toCompleteFilterQueryString(extensionId));
 
         if (withNamespace) {
             solrQuery.addFilterQuery(ExtensionIndexSolrCoreInitializer.SOLR_FIELD_COMPATIBLE_NAMESPACES + ":"
-                + this.utils.toFilterQueryString(toStoredNamespace(namespace)));
+                + this.utils.toCompleteFilterQueryString(toStoredNamespace(namespace)));
         } else {
             solrQuery.addFilterQuery(ExtensionIndexSolrCoreInitializer.SOLR_FIELD_COMPATIBLE_NAMESPACES + ":[* TO *]");
         }

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/internal/job/ExtensionIndexJob.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/internal/job/ExtensionIndexJob.java
@@ -643,7 +643,7 @@ public class ExtensionIndexJob extends AbstractJob<ExtensionIndexRequest, Defaul
                     // Make sure only one version is tagged as "last"
                     SolrQuery solrQuery = new SolrQuery();
                     solrQuery.addFilterQuery(ExtensionIndexSolrCoreInitializer.SOLR_FIELD_EXTENSIONID + ':'
-                        + this.solrUtils.toFilterQueryString(extension.getId().getId()));
+                        + this.solrUtils.toCompleteFilterQueryString(extension.getId().getId()));
                     solrQuery.addFilterQuery(ExtensionIndexSolrCoreInitializer.SOLR_FIELD_LAST + ':' + true);
                     for (ExtensionId extensionid : this.indexStore.searchExtensionIds(solrQuery)) {
                         boolean last =

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/SolrRatingsManager.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/SolrRatingsManager.java
@@ -216,11 +216,11 @@ public class SolrRatingsManager implements RatingsManager
 
             Object value = queryParameter.getValue();
             if (value instanceof String || value instanceof Date) {
-                result.append(solrUtils.toFilterQueryString(value));
+                result.append(this.solrUtils.toCompleteFilterQueryString(value));
             } else if (value instanceof UserReference) {
-                result.append(solrUtils.toFilterQueryString(value, UserReference.class));
+                result.append(this.solrUtils.toCompleteFilterQueryString(value, UserReference.class));
             } else if (value instanceof EntityReference) {
-                result.append(solrUtils.toFilterQueryString(value, EntityReference.class));
+                result.append(this.solrUtils.toCompleteFilterQueryString(value, EntityReference.class));
             } else if (value != null) {
                 result.append(value);
             }
@@ -424,9 +424,11 @@ public class SolrRatingsManager implements RatingsManager
     @Override
     public long removeRatings(EntityReference entityReference) throws RatingsException
     {
-        String escapedEntityReference = this.solrUtils.toFilterQueryString(entityReference, EntityReference.class);
+        String escapedEntityReference =
+            this.solrUtils.toCompleteFilterQueryString(entityReference, EntityReference.class);
         String filterQuery = String.format(FILTER_REFERENCE_OR_PARENTS,
-            RatingQueryField.MANAGER_ID.getFieldName(), solrUtils.toFilterQueryString(this.getIdentifier()),
+            RatingQueryField.MANAGER_ID.getFieldName(),
+            this.solrUtils.toCompleteFilterQueryString(this.getIdentifier()),
             RatingQueryField.ENTITY_REFERENCE.getFieldName(), escapedEntityReference,
             RatingQueryField.PARENTS_REFERENCE.getFieldName(), escapedEntityReference);
         SolrQuery solrQuery = new SolrQuery()
@@ -453,9 +455,10 @@ public class SolrRatingsManager implements RatingsManager
     public long moveRatings(EntityReference oldReference, EntityReference newReference)
         throws RatingsException
     {
-        String escapedEntityReference = this.solrUtils.toFilterQueryString(oldReference, EntityReference.class);
+        String escapedEntityReference = this.solrUtils.toCompleteFilterQueryString(oldReference, EntityReference.class);
         String filterQuery = String.format(FILTER_REFERENCE_OR_PARENTS,
-            RatingQueryField.MANAGER_ID.getFieldName(), solrUtils.toFilterQueryString(this.getIdentifier()),
+            RatingQueryField.MANAGER_ID.getFieldName(),
+            this.solrUtils.toCompleteFilterQueryString(this.getIdentifier()),
             RatingQueryField.ENTITY_REFERENCE.getFieldName(), escapedEntityReference,
             RatingQueryField.PARENTS_REFERENCE.getFieldName(), escapedEntityReference);
         int offset = 0;

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/averagerating/SolrAverageRatingManager.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/main/java/org/xwiki/ratings/internal/averagerating/SolrAverageRatingManager.java
@@ -105,9 +105,10 @@ public class SolrAverageRatingManager extends AbstractAverageRatingManager
     {
         SolrQuery solrQuery = new SolrQuery()
             .addFilterQuery(String.format("filter(%s:%s) AND filter(%s:%s)",
-                AverageRatingQueryField.MANAGER_ID.getFieldName(), solrUtils.toFilterQueryString(this.getIdentifier()),
+                AverageRatingQueryField.MANAGER_ID.getFieldName(),
+                this.solrUtils.toCompleteFilterQueryString(this.getIdentifier()),
                 AverageRatingQueryField.ENTITY_REFERENCE.getFieldName(),
-                solrUtils.toFilterQueryString(entityReference, EntityReference.class)))
+                this.solrUtils.toCompleteFilterQueryString(entityReference, EntityReference.class)))
             .setStart(0)
             .setRows(1)
             .setSort(AverageRatingQueryField.UPDATED_AT.getFieldName(), this.getOrder(true));
@@ -138,9 +139,11 @@ public class SolrAverageRatingManager extends AbstractAverageRatingManager
     @Override
     public long removeAverageRatings(EntityReference entityReference) throws RatingsException
     {
-        String escapedEntityReference = this.solrUtils.toFilterQueryString(entityReference, EntityReference.class);
+        String escapedEntityReference =
+            this.solrUtils.toCompleteFilterQueryString(entityReference, EntityReference.class);
         String filterQuery = String.format(FILTER_REFERENCE_OR_PARENTS,
-            AverageRatingQueryField.MANAGER_ID.getFieldName(), solrUtils.toFilterQueryString(this.getIdentifier()),
+            AverageRatingQueryField.MANAGER_ID.getFieldName(),
+            this.solrUtils.toCompleteFilterQueryString(this.getIdentifier()),
             AverageRatingQueryField.ENTITY_REFERENCE.getFieldName(), escapedEntityReference,
             AverageRatingQueryField.PARENTS.getFieldName(), escapedEntityReference);
         SolrQuery solrQuery = new SolrQuery()
@@ -164,9 +167,10 @@ public class SolrAverageRatingManager extends AbstractAverageRatingManager
     public long moveAverageRatings(EntityReference oldReference, EntityReference newReference)
         throws RatingsException
     {
-        String escapedEntityReference = this.solrUtils.toFilterQueryString(oldReference, EntityReference.class);
+        String escapedEntityReference = this.solrUtils.toCompleteFilterQueryString(oldReference, EntityReference.class);
         String filterQuery = String.format(FILTER_REFERENCE_OR_PARENTS,
-            AverageRatingQueryField.MANAGER_ID.getFieldName(), solrUtils.toFilterQueryString(this.getIdentifier()),
+            AverageRatingQueryField.MANAGER_ID.getFieldName(),
+            this.solrUtils.toCompleteFilterQueryString(this.getIdentifier()),
             AverageRatingQueryField.ENTITY_REFERENCE.getFieldName(), escapedEntityReference,
             AverageRatingQueryField.PARENTS.getFieldName(), escapedEntityReference);
         int offset = 0;

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/SolrRatingsManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/SolrRatingsManagerTest.java
@@ -123,9 +123,9 @@ public class SolrRatingsManagerTest
     void setup(MockitoComponentManager componentManager) throws Exception
     {
         this.manager.setRatingConfiguration(configuration);
-        when(this.solrUtils.toFilterQueryString(any()))
+        when(this.solrUtils.toCompleteFilterQueryString(any()))
             .then(invocationOnMock -> invocationOnMock.getArgument(0).toString().replaceAll(":", "\\\\:"));
-        when(this.solrUtils.toFilterQueryString(any(), any()))
+        when(this.solrUtils.toCompleteFilterQueryString(any(), any()))
             .then(invocationOnMock -> invocationOnMock.getArgument(0).toString().replaceAll(":", "\\\\:"));
         when(this.solrUtils.getId(any()))
             .then(invocationOnMock -> ((SolrDocument) invocationOnMock.getArgument(0)).get("id"));

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/averagerating/SolrAverageRatingManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/averagerating/SolrAverageRatingManagerTest.java
@@ -92,9 +92,9 @@ class SolrAverageRatingManagerTest
     @BeforeEach
     void setup()
     {
-        when(this.solrUtils.toFilterQueryString(any()))
+        when(this.solrUtils.toCompleteFilterQueryString(any()))
             .then(invocationOnMock -> invocationOnMock.getArgument(0).toString().replaceAll(":", "\\\\:"));
-        when(this.solrUtils.toFilterQueryString(any(), any()))
+        when(this.solrUtils.toCompleteFilterQueryString(any(), any()))
             .then(invocationOnMock -> invocationOnMock.getArgument(0).toString().replaceAll(":", "\\\\:"));
         when(this.solrUtils.getId(any()))
             .then(invocationOnMock -> ((SolrDocument) invocationOnMock.getArgument(0)).get("id"));

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/SolrUtils.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/SolrUtils.java
@@ -259,6 +259,38 @@ public interface SolrUtils
     }
 
     /**
+     * Serialize the value into a string that is a complete query string, i.e., cannot be combined with other strings.
+     * <p>
+     * For example, this serializes the empty string as "".
+     *
+     * @param fieldValue the value of a field
+     * @return the Solr query version of the passed value
+     * @since 13.10.6
+     * @since 14.4RC1
+     */
+    default String toCompleteFilterQueryString(Object fieldValue)
+    {
+        return toFilterQueryString(fieldValue);
+    }
+
+    /**
+     * Serialize the value into a string that is a complete query string, i.e., cannot be combined with other strings.
+     * <p>
+     * For example, this serializes the empty string as "".
+     *
+     * @param fieldValue the value of a field
+     * @param valueType the type to use as reference to serialize the value
+     * @return the Solr query version of the passed value
+     * @since 13.10.6
+     * @since 14.4RC1
+     */
+    default String toCompleteFilterQueryString(Object fieldValue, Type valueType)
+    {
+        return toFilterQueryString(fieldValue, valueType);
+    }
+
+
+    /**
      * Extract from the document the value associated with the passed field name.
      * 
      * @param <T> the of the value to return

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/SolrUtils.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/SolrUtils.java
@@ -266,8 +266,9 @@ public interface SolrUtils
      *
      * @param fieldValue the value of a field
      * @return the Solr query version of the passed value
-     * @since 13.10.6
-     * @since 14.4RC1
+     * @since 13.10.7
+     * @since 14.4.2
+     * @since 14.5RC1
      */
     @Unstable
     default String toCompleteFilterQueryString(Object fieldValue)
@@ -283,8 +284,9 @@ public interface SolrUtils
      * @param fieldValue the value of a field
      * @param valueType the type to use as reference to serialize the value
      * @return the Solr query version of the passed value
-     * @since 13.10.6
-     * @since 14.4RC1
+     * @since 13.10.7
+     * @since 14.4.2
+     * @since 14.5RC1
      */
     @Unstable
     default String toCompleteFilterQueryString(Object fieldValue, Type valueType)

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/SolrUtils.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/SolrUtils.java
@@ -29,6 +29,7 @@ import org.apache.solr.client.solrj.beans.DocumentObjectBinder;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrInputDocument;
 import org.xwiki.component.annotation.Role;
+import org.xwiki.stability.Unstable;
 
 /**
  * Various helpers around the Solr API.
@@ -268,6 +269,7 @@ public interface SolrUtils
      * @since 13.10.6
      * @since 14.4RC1
      */
+    @Unstable
     default String toCompleteFilterQueryString(Object fieldValue)
     {
         return toFilterQueryString(fieldValue);
@@ -284,6 +286,7 @@ public interface SolrUtils
      * @since 13.10.6
      * @since 14.4RC1
      */
+    @Unstable
     default String toCompleteFilterQueryString(Object fieldValue, Type valueType)
     {
         return toFilterQueryString(fieldValue, valueType);

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/DefaultSolrUtils.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/DefaultSolrUtils.java
@@ -49,7 +49,7 @@ import org.xwiki.search.solr.SolrUtils;
 
 /**
  * Default implementation of {@link SolrUtils}.
- * 
+ *
  * @version $Id$
  * @since 12.3RC1
  */
@@ -147,6 +147,8 @@ public class DefaultSolrUtils implements SolrUtils
     public static final String SOLR_TYPE_TEXT_GENERALS = "text_generals";
 
     private static final String PATTERN_GROUP = "(.+)";
+
+    private static final String PATTERN_EMPTY_STRING = "\"\"";
 
     private static final Pattern PATTERN_OR_AND_NOT = Pattern.compile("(OR|AND|NOT)");
 
@@ -562,6 +564,30 @@ public class DefaultSolrUtils implements SolrUtils
         }
 
         return str;
+    }
+
+    @Override
+    public String toCompleteFilterQueryString(Object fieldValue)
+    {
+        String result = toFilterQueryString(fieldValue);
+
+        if ("".equals(result)) {
+            result = PATTERN_EMPTY_STRING;
+        }
+
+        return result;
+    }
+
+    @Override
+    public String toCompleteFilterQueryString(Object fieldValue, Type valueType)
+    {
+        String result = toFilterQueryString(fieldValue, valueType);
+
+        if ("".equals(result)) {
+            result = PATTERN_EMPTY_STRING;
+        }
+
+        return result;
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/DefaultSolrUtils.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/DefaultSolrUtils.java
@@ -522,6 +522,10 @@ public class DefaultSolrUtils implements SolrUtils
         // ClientUtils does not escape OR/AND/NOT
         escaped = PATTERN_OR_AND_NOT.matcher(escaped).replaceAll("\\\\$1");
 
+        if ("".equals(escaped)) {
+            escaped = "\"\"";
+        }
+
         return escaped;
     }
 

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/DefaultSolrUtils.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/DefaultSolrUtils.java
@@ -522,10 +522,6 @@ public class DefaultSolrUtils implements SolrUtils
         // ClientUtils does not escape OR/AND/NOT
         escaped = PATTERN_OR_AND_NOT.matcher(escaped).replaceAll("\\\\$1");
 
-        if ("".equals(escaped)) {
-            escaped = "\"\"";
-        }
-
         return escaped;
     }
 

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/test/java/org/xwiki/search/solr/internal/DefaultSolrUtilsTest.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/test/java/org/xwiki/search/solr/internal/DefaultSolrUtilsTest.java
@@ -47,6 +47,12 @@ class DefaultSolrUtilsTest
     }
 
     @Test
+    void toCompleteFilterQueryString()
+    {
+        assertEquals("\"\"", this.utils.toCompleteFilterQueryString(""));
+    }
+
+    @Test
     void getMapFieldName()
     {
         assertEquals("key__map_string", this.utils.getMapFieldName("key", "map", (Type) null));


### PR DESCRIPTION
* Escape empty strings as "" for equality queries
* Match missing values when the value is `null` (previously, it matched the string "null")

Jira issue: https://jira.xwiki.org/browse/XWIKI-19682