### PR TITLE
XWIKI-19634: Live Data triggers JavaScript events on a detached DOM element

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/XWikiLivedata.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/XWikiLivedata.vue
@@ -24,7 +24,7 @@
   totally autonomous.
 -->
 <template>
-  <div class="xwiki-livedata" :id="data.id">
+  <div class="xwiki-livedata">
 
     <!-- Import the Livedata advanced configuration panels -->
     <LivedataAdvancedPanels/>

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/webjar/Logic.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/webjar/Logic.js
@@ -129,9 +129,13 @@ define('xwiki-livedata', [
       silentFallbackWarn: true,
     });
 
+    // Vue.js replaces the container - prevent this by creating a placeholder for Vue.js to replace.
+    const placeholderElement = document.createElement('div');
+    this.element.appendChild(placeholderElement);
+
     // create Vuejs instance
     const vue = new Vue({
-      el: this.element,
+      el: placeholderElement,
       components: {
         "XWikiLivedata": XWikiLivedata,
       },
@@ -140,6 +144,10 @@ define('xwiki-livedata', [
       data: {
         logic: this
       },
+      mounted()
+      {
+        element.classList.remove('loading');
+      }
     });
 
     // Fetch the data if we don't have any. This call must be made just after the main Vue component is initialized as 


### PR DESCRIPTION
* Do not replace the original container but instead update it accordingly once Vue.js has been loaded.
* Remove the id from the root component as it is now on the wrapping container.

Jira issue: https://jira.xwiki.org/browse/XWIKI-19634