### PR TITLE
XWIKI-19724: LiveData should trigger an event when an instance has been created

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/webjar/Logic.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/webjar/Logic.js
@@ -147,6 +147,11 @@ define('xwiki-livedata', [
       mounted()
       {
         element.classList.remove('loading');
+        // Trigger the "instanceCreated" event on the next tick to ensure that the constructor has returned and thus
+        // all references to the logic instance have been initialized.
+        this.$nextTick(function () {
+          this.logic.triggerEvent('instanceCreated', {});
+        });
       }
     });
 


### PR DESCRIPTION
* Add the xwiki:livedata:instanceCreated event.

Jira issue: https://jira.xwiki.org/browse/XWIKI-19724