### PR TITLE
XWIKI-19719: Attachments added via copy & paste state that they've been by admin instead of the user editing the page

### DIFF
--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/pom.xml
@@ -31,7 +31,7 @@
   <name>XWiki Platform - Store - Filesystem - Old Core</name>
   <description>Implement various oldcore store APIs based on filesystem.</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.32</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.37</xwiki.jacoco.instructionRatio>
     <!-- Old names of this module used for retro compatibility when resolving dependencies of old extensions -->
     <xwiki.extension.features>org.xwiki.platform:xwiki-platform-store-filesystem-attachments</xwiki.extension.features>
   </properties>

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/DefaultTemporaryAttachmentSessionsManager.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/DefaultTemporaryAttachmentSessionsManager.java
@@ -149,7 +149,7 @@ public class DefaultTemporaryAttachmentSessionsManager
             xWikiAttachment = new XWikiAttachment();
             xWikiAttachment.setFilename(part.getSubmittedFileName());
             xWikiAttachment.setContent(part.getInputStream());
-            xWikiAttachment.setAuthorReference(context.getAuthorReference());
+            xWikiAttachment.setAuthorReference(context.getUserReference());
             temporaryAttachmentSession.addAttachment(documentReference, xWikiAttachment);
         } catch (IOException e) {
             throw new TemporaryAttachmentException("Error while reading the content of a request part", e);

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/test/java/org/xwiki/store/filesystem/internal/DefaultTemporaryAttachmentSessionsManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/test/java/org/xwiki/store/filesystem/internal/DefaultTemporaryAttachmentSessionsManagerTest.java
@@ -100,7 +100,7 @@ class DefaultTemporaryAttachmentSessionsManagerTest
     void uploadAttachment() throws Exception
     {
         String sessionId = "mySession";
-        when(httpSession.getId()).thenReturn(sessionId);
+        when(this.httpSession.getId()).thenReturn(sessionId);
 
         DocumentReference documentReference = mock(DocumentReference.class);
         SpaceReference spaceReference = mock(SpaceReference.class);
@@ -113,14 +113,17 @@ class DefaultTemporaryAttachmentSessionsManagerTest
         when(part.getInputStream()).thenReturn(inputStream);
 
         XWiki xwiki = mock(XWiki.class);
-        when(context.getWiki()).thenReturn(xwiki);
-        when(xwiki.getSpacePreference(FileUploadPlugin.UPLOAD_MAXSIZE_PARAMETER, spaceReference, context))
+        when(this.context.getWiki()).thenReturn(xwiki);
+        DocumentReference userReference = new DocumentReference("xwiki", "XWiki", "User");
+        when(this.context.getUserReference()).thenReturn(userReference);
+        when(xwiki.getSpacePreference(FileUploadPlugin.UPLOAD_MAXSIZE_PARAMETER, spaceReference, this.context))
             .thenReturn("42");
         when(part.getSize()).thenReturn(41L);
 
         XWikiAttachment attachment = this.attachmentManager.uploadAttachment(documentReference, part);
         assertNotNull(attachment);
         assertEquals(filename, attachment.getFilename());
+        assertEquals(userReference, attachment.getAuthorReference());
 
         Map<String, TemporaryAttachmentSession> attachmentSessionMap =
             this.attachmentManager.getTemporaryAttachmentSessionMap();


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-19719