### PR TITLE
XWIKI-19745: Going diagonally towards the image popover closes it

### DIFF
--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/lightbox.js
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/lightbox.js
@@ -173,17 +173,21 @@ define('xwiki-lightbox', [
    * Make sure that the toolbar will remain open also while hovering it, not just the image.
    */
   var keepToolbarOpenOnHover = function() {
+    var hideTimeout;
     // Hide the image popover after 3 seconds (if the mouse doesn't enter the popover).
-    var hideTimeout = setTimeout(function() {
+    hideTimeout = setTimeout(function() {
       $('#imagePopoverContainer').popover('hide');
     }, 3000);
     // Don't hide the image popover when the mouse is over it.
     $('#imagePopoverContainer .popover').on('mouseenter', function() {
       clearTimeout(hideTimeout);
     });
-    // Hide the image popover when the mouse leaves its area.
+    // Hide the image popover when the mouse leaves its area, but with a delay since it's easy to go out
+    // without wanting to (e.g. when going diagonally towards the image popover, to click on the anchor button).
     $('#imagePopoverContainer .popover').on('mouseleave', function() {
-      $(this).popover('hide');
+      hideTimeout = setTimeout(function() {
+        $('#imagePopoverContainer').popover('hide');
+      }, 500);
     });
     return hideTimeout;
   };
@@ -232,13 +236,12 @@ define('xwiki-lightbox', [
       clearTimeout(hideTimeout);
       popoverContainer.data('target', e.target);
     }).on('mousemove', function(e) {
-      popoverContainer.popover('hide');
       // Delay to show the popover until the mouse stops moving.
       clearTimeout(showTimeout);
       showTimeout = setTimeout(function() {
         popoverContainer.css({top: e.pageY, left: e.pageX });
         popoverContainer.popover('show');
-      }, 400);
+      }, 500);
     }).on('mouseleave', function() {
       clearTimeout(showTimeout);
       hideTimeout = keepToolbarOpenOnHover();


### PR DESCRIPTION
• don't hide the popover immediately on image mousemove since popover('show') will close it anyway
• on popover mouseleave hide it with a delay, since it's easy to go out without wanting to
![keep5](https://user-images.githubusercontent.com/22794181/169472794-1d8dcc1f-f65b-47a3-a007-0ea7860852ea.gif)

