### PR TITLE
XWIKI-18397: Notification filter preferences are never cleaned for deleted users

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/pom.xml
@@ -31,7 +31,7 @@
   <name>XWiki Platform - Notifications - Filters - API</name>
   <description>Handle the filters that can be applied on notifications</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.65</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.66</xwiki.jacoco.instructionRatio>
     <!-- Name to display by the Extension Manager -->
     <xwiki.extension.name>Notifications Filters API</xwiki.extension.name>
     <checkstyle.suppressions.location>${basedir}/src/checkstyle/checkstyle-suppressions.xml</checkstyle.suppressions.location>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/CachedModelBridge.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/CachedModelBridge.java
@@ -149,6 +149,13 @@ public class CachedModelBridge implements ModelBridge, Initializable
     }
 
     @Override
+    public void deleteFilterPreferences(DocumentReference user) throws NotificationException
+    {
+        this.modelBridge.deleteFilterPreferences(user);
+        invalidateUserPreferencesFilters(user);
+    }
+
+    @Override
     public void deleteFilterPreference(WikiReference wikiReference, String filterPreferenceId)
         throws NotificationException
     {
@@ -235,5 +242,15 @@ public class CachedModelBridge implements ModelBridge, Initializable
     {
         this.preferenceFilterCache.values()
             .forEach(set -> set.removeIf(filter -> filter.isFromWiki(wikiReference.getName())));
+    }
+
+    /**
+     * Remove all the {@link  NotificationFilterPreference}s related to the given user form the coche.
+     *
+     * @param user the document reference of the user to remove from the cache
+     */
+    private void invalidateUserPreferencesFilters(DocumentReference user)
+    {
+        this.preferenceFilterCache.remove(user);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/CachedModelBridge.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/CachedModelBridge.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -36,6 +37,7 @@ import org.xwiki.component.phase.InitializationException;
 import org.xwiki.model.internal.reference.EntityReferenceFactory;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
+import org.xwiki.model.reference.EntityReferenceSerializer;
 import org.xwiki.model.reference.WikiReference;
 import org.xwiki.notifications.NotificationException;
 import org.xwiki.notifications.NotificationFormat;
@@ -67,6 +69,9 @@ public class CachedModelBridge implements ModelBridge, Initializable
 
     @Inject
     private EntityReferenceFactory referenceFactory;
+
+    @Inject
+    private EntityReferenceSerializer<String> entityReferenceSerializer;
 
     private Map<EntityReference, Set<NotificationFilterPreference>> preferenceFilterCache;
 
@@ -251,6 +256,11 @@ public class CachedModelBridge implements ModelBridge, Initializable
      */
     private void invalidateUserPreferencesFilters(DocumentReference user)
     {
+        String serializedUserReference = this.entityReferenceSerializer.serialize(user);
+        // Remove the filter preferences of the user from the cache.
         this.preferenceFilterCache.remove(user);
+        // Remove the user from the filter preferences of the other entities of the cache. 
+        this.preferenceFilterCache.values()
+            .forEach(set -> set.removeIf(filter -> Objects.equals(filter.getUser(), serializedUserReference)));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/CachedModelBridge.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/CachedModelBridge.java
@@ -245,7 +245,7 @@ public class CachedModelBridge implements ModelBridge, Initializable
     }
 
     /**
-     * Remove all the {@link  NotificationFilterPreference}s related to the given user form the coche.
+     * Remove all the {@link  NotificationFilterPreference}s related to the given user form the cache.
      *
      * @param user the document reference of the user to remove from the cache
      */

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/ModelBridge.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/ModelBridge.java
@@ -90,6 +90,22 @@ public interface ModelBridge
     void deleteFilterPreference(DocumentReference user, String filterPreferenceId) throws NotificationException;
 
     /**
+     * Delete all the filter preferences related to a given user.
+     *
+     * @param user the document reference of a wiki user
+     * @throws NotificationException in case of error when deleting the filter preferences
+     * @since 14.5RC1
+     * @since 14.4.1
+     * @since 13.10.7
+     */
+    @Unstable
+    default void deleteFilterPreferences(DocumentReference user) throws NotificationException
+    {
+        throw new UnsupportedOperationException(
+            "ModelBridge.deleteFilterPreferences(DocumentReference) Not implemented");
+    }
+
+    /**
      * Delete a filter preference.
      * @param wikiReference reference of the wiki concerned by the filter preference
      * @param filterPreferenceId name of the filter preference
@@ -111,7 +127,7 @@ public interface ModelBridge
     @Unstable
     default void deleteFilterPreferences(WikiReference wikiReference) throws NotificationException
     {
-        throw new UnsupportedOperationException("Not implemented");
+        throw new UnsupportedOperationException("ModelBridge.deleteFilterPreference(WikiReference) Not implemented");
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/ModelBridge.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/ModelBridge.java
@@ -34,7 +34,6 @@ import org.xwiki.notifications.NotificationException;
 import org.xwiki.notifications.NotificationFormat;
 import org.xwiki.notifications.filters.NotificationFilterPreference;
 import org.xwiki.notifications.filters.NotificationFilterType;
-import org.xwiki.stability.Unstable;
 
 /**
  * Internal role that make requests to the model and avoid a direct dependency to oldcore.
@@ -62,7 +61,6 @@ public interface ModelBridge
      * @throws NotificationException if an error happens
      * @since 13.3RC1
      */
-    @Unstable
     default Set<NotificationFilterPreference> getFilterPreferences(WikiReference wikiReference)
         throws NotificationException
     {
@@ -98,7 +96,6 @@ public interface ModelBridge
      * @since 14.4.1
      * @since 13.10.7
      */
-    @Unstable
     default void deleteFilterPreferences(DocumentReference user) throws NotificationException
     {
         throw new UnsupportedOperationException(
@@ -124,7 +121,6 @@ public interface ModelBridge
      * @since 14.4.1
      * @since 13.10.7
      */
-    @Unstable
     default void deleteFilterPreferences(WikiReference wikiReference) throws NotificationException
     {
         throw new UnsupportedOperationException("ModelBridge.deleteFilterPreference(WikiReference) Not implemented");

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/listener/DeleteUserEventListener.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/listener/DeleteUserEventListener.java
@@ -1,0 +1,81 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.notifications.filters.internal.listener;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.slf4j.Logger;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.notifications.NotificationException;
+import org.xwiki.notifications.filters.internal.ModelBridge;
+import org.xwiki.observation.AbstractEventListener;
+import org.xwiki.observation.event.Event;
+
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.internal.event.XObjectDeletedEvent;
+import com.xpn.xwiki.internal.mandatory.XWikiUsersDocumentInitializer;
+import com.xpn.xwiki.objects.BaseObjectReference;
+
+import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCauseMessage;
+
+/**
+ * Delete the user preferences of the deleted users.
+ *
+ * @version $Id$
+ * @since 14.5RC1
+ * @since 14.4.1
+ * @since 13.10.7
+ */
+@Component
+@Singleton
+@Named("org.xwiki.notifications.filters.internal.listener.DeleteUserEventListener")
+public class DeleteUserEventListener extends AbstractEventListener
+{
+    @Named("cached")
+    @Inject
+    private ModelBridge modelBridge;
+
+    @Inject
+    private Logger logger;
+
+    /**
+     * Default constructor.
+     */
+    public DeleteUserEventListener()
+    {
+        super(DeleteUserEventListener.class.getName(),
+            new XObjectDeletedEvent(BaseObjectReference.any(XWikiUsersDocumentInitializer.CLASS_REFERENCE_STRING)));
+    }
+
+    @Override
+    public void onEvent(Event event, Object source, Object data)
+    {
+        DocumentReference user = ((XWikiDocument) source).getDocumentReference();
+        try {
+            this.modelBridge.deleteFilterPreferences(user);
+        } catch (NotificationException e) {
+            this.logger.warn("Failed to delete notification preferences for user [{}]. Cause: [{}].", user,
+                getRootCauseMessage(e));
+        }
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/listener/DeletedWikiEventListener.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/listener/DeletedWikiEventListener.java
@@ -17,7 +17,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.xwiki.notifications.filters.internal;
+package org.xwiki.notifications.filters.internal.listener;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -28,6 +28,7 @@ import org.xwiki.bridge.event.WikiDeletedEvent;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.WikiReference;
 import org.xwiki.notifications.NotificationException;
+import org.xwiki.notifications.filters.internal.ModelBridge;
 import org.xwiki.observation.AbstractEventListener;
 import org.xwiki.observation.event.Event;
 
@@ -43,7 +44,7 @@ import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCauseMess
  */
 @Component
 @Singleton
-@Named("org.xwiki.notifications.filters.internal.DeletedWikiEventListener")
+@Named("org.xwiki.notifications.filters.internal.listener.DeletedWikiEventListener")
 public class DeletedWikiEventListener extends AbstractEventListener
 {
     @Named("cached")

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/resources/META-INF/components.txt
@@ -16,5 +16,6 @@ org.xwiki.notifications.filters.internal.DefaultNotificationFilterPreferenceMana
 org.xwiki.notifications.filters.internal.LocationOperatorNodeGenerator
 org.xwiki.notifications.filters.internal.SystemUserNotificationFilter
 org.xwiki.notifications.filters.internal.UserProfileNotificationFilterPreferenceProvider
-org.xwiki.notifications.filters.internal.DeletedWikiEventListener
+org.xwiki.notifications.filters.internal.listener.DeletedWikiEventListener
+org.xwiki.notifications.filters.internal.listener.DeleteUserEventListener
 org.xwiki.notifications.filters.script.NotificationFiltersScriptService

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/CachedModelBridgeTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/CachedModelBridgeTest.java
@@ -50,7 +50,7 @@ import static org.mockito.Mockito.when;
 
 /**
  * Validate {@link CachedModelBridge}.
- * 
+ *
  * @version $Id$
  */
 @ComponentTest
@@ -163,7 +163,7 @@ class CachedModelBridgeTest
     }
 
     @Test
-    void deleteFilterPreferences() throws Exception
+    void deleteFilterPreferencesWiki() throws Exception
     {
         WikiReference wikiReference = new WikiReference("wikiId");
 
@@ -190,5 +190,22 @@ class CachedModelBridgeTest
             this.preferenceFilterCache);
 
         verify(this.modelBridge).deleteFilterPreferences(wikiReference);
+    }
+
+    @Test
+    void deleteFilterPreferencesUser() throws Exception
+    {
+        DocumentReference deleteUserDocumentReference = new DocumentReference("xwiki", "XWiki", "DeleteUser");
+
+        this.preferenceFilterCache.put(deleteUserDocumentReference, new HashSet<>());
+        this.preferenceFilterCache.put(new DocumentReference("xwiki", "XWiki", "OtherUser"), new HashSet<>());
+
+        this.cachedModelBridge.deleteFilterPreferences(deleteUserDocumentReference);
+        
+        Map<Object, Object> expected = new HashMap<>();
+        expected.put(new DocumentReference("xwiki", "XWiki", "OtherUser"), new HashSet<>());
+        assertEquals(expected, this.preferenceFilterCache);
+        
+        verify(this.modelBridge).deleteFilterPreferences(deleteUserDocumentReference);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/CachedModelBridgeTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/CachedModelBridgeTest.java
@@ -50,7 +50,7 @@ import static org.mockito.Mockito.when;
 
 /**
  * Validate {@link CachedModelBridge}.
- *
+ * 
  * @version $Id$
  */
 @ComponentTest

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/listener/DeleteUserEventListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/listener/DeleteUserEventListenerTest.java
@@ -1,0 +1,96 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.notifications.filters.internal.listener;
+
+import javax.inject.Named;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.Mock;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.notifications.NotificationException;
+import org.xwiki.notifications.filters.internal.ModelBridge;
+import org.xwiki.test.LogLevel;
+import org.xwiki.test.junit5.LogCaptureExtension;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import com.xpn.xwiki.doc.XWikiDocument;
+
+import static ch.qos.logback.classic.Level.WARN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test of {@link DeleteUserEventListener}.
+ *
+ * @version $Id$
+ * @since 14.5RC1
+ * @since 14.4.1
+ * @since 13.10.7
+ */
+@ComponentTest
+class DeleteUserEventListenerTest
+{
+    private static final DocumentReference REMOVED_USER_DOCUMENT_REFERENCE =
+        new DocumentReference("xwiki", "XWiki", "RemovedUser");
+
+    @InjectMockComponents
+    private DeleteUserEventListener listener;
+
+    @Named("cached")
+    @MockComponent
+    private ModelBridge modelBridge;
+
+    @RegisterExtension
+    LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.WARN);
+
+    @Mock
+    private XWikiDocument xWikiDocument;
+
+    @BeforeEach
+    void setUp()
+    {
+        when(this.xWikiDocument.getDocumentReference()).thenReturn(REMOVED_USER_DOCUMENT_REFERENCE);
+    }
+
+    @Test
+    void onEvent() throws Exception
+    {
+        this.listener.onEvent(null, this.xWikiDocument, null);
+        verify(this.modelBridge).deleteFilterPreferences(REMOVED_USER_DOCUMENT_REFERENCE);
+    }
+
+    @Test
+    void onEventException() throws Exception
+    {
+        doThrow(NotificationException.class).when(this.modelBridge)
+            .deleteFilterPreferences(REMOVED_USER_DOCUMENT_REFERENCE);
+        this.listener.onEvent(null, this.xWikiDocument, null);
+        assertEquals(1, this.logCapture.size());
+        assertEquals("Failed to delete notification preferences for user [xwiki:XWiki.RemovedUser]. "
+            + "Cause: [NotificationException: ].", this.logCapture.getMessage(0));
+        assertEquals(WARN, this.logCapture.getLogEvent(0).getLevel());
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/listener/DeletedWikiEventListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/listener/DeletedWikiEventListenerTest.java
@@ -17,7 +17,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.xwiki.notifications.filters.internal;
+package org.xwiki.notifications.filters.internal.listener;
 
 import javax.inject.Named;
 
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.xwiki.model.reference.WikiReference;
 import org.xwiki.notifications.NotificationException;
+import org.xwiki.notifications.filters.internal.ModelBridge;
 import org.xwiki.test.LogLevel;
 import org.xwiki.test.junit5.LogCaptureExtension;
 import org.xwiki.test.junit5.mockito.ComponentTest;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/pom.xml
@@ -31,7 +31,8 @@
   <name>XWiki Platform - Notifications - Filters - Default implementation</name>
   <description>Default bridge to oldcore for the notifications filters API module.</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.49</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.50</xwiki.jacoco.instructionRatio>
+    <checkstyle.suppressions.location>${basedir}/src/checkstyle/checkstyle-suppressions.xml</checkstyle.suppressions.location>
     </properties>
   <dependencies>
     <dependency>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/pom.xml
@@ -31,7 +31,7 @@
   <name>XWiki Platform - Notifications - Filters - Default implementation</name>
   <description>Default bridge to oldcore for the notifications filters API module.</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.47</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.49</xwiki.jacoco.instructionRatio>
     </properties>
   <dependencies>
     <dependency>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/DefaultModelBridge.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/DefaultModelBridge.java
@@ -140,6 +140,12 @@ public class DefaultModelBridge implements ModelBridge
     }
 
     @Override
+    public void deleteFilterPreferences(DocumentReference user) throws NotificationException
+    {
+        this.notificationFilterPreferenceStore.deleteFilterPreferences(user);
+    }
+
+    @Override
     public void deleteFilterPreference(WikiReference wikiReference, String filterPreferenceId)
         throws NotificationException
     {

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/NotificationFilterPreferenceStore.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/NotificationFilterPreferenceStore.java
@@ -63,7 +63,7 @@ import com.xpn.xwiki.store.XWikiHibernateStore;
 @Singleton
 public class NotificationFilterPreferenceStore
 {
-    private static final String OWNER_QUERY_PARAM = "owner";
+    private static final String USER_QUERY_PARAM = "user";
 
     @Inject
     private NotificationFilterPreferenceConfiguration filterPreferenceConfiguration;
@@ -198,7 +198,7 @@ public class NotificationFilterPreferenceStore
         Query query = queryManager.createQuery(
             "select nfp from DefaultNotificationFilterPreference nfp where nfp.owner = :owner " + "order by nfp.id",
             Query.HQL);
-        query.bindValue(OWNER_QUERY_PARAM, serializedEntity);
+        query.bindValue(USER_QUERY_PARAM, serializedEntity);
         if (filterPreferenceConfiguration.useMainStore()) {
             query.setWiki(context.getMainXWiki());
         }
@@ -247,8 +247,9 @@ public class NotificationFilterPreferenceStore
         try {
             hibernateStore.beginTransaction(context);
             Session session = hibernateStore.getSession(context);
-            session.createQuery("delete from DefaultNotificationFilterPreference where owner = :owner")
-                .setParameter(OWNER_QUERY_PARAM, serializedUser)
+            session.createQuery("delete from DefaultNotificationFilterPreference where owner = :user "
+                    + "or user = :user")
+                .setParameter(USER_QUERY_PARAM, serializedUser)
                 .executeUpdate();
             hibernateStore.endTransaction(context, true);
         } catch (XWikiException e) {

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/NotificationFilterPreferenceStore.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/NotificationFilterPreferenceStore.java
@@ -63,8 +63,6 @@ import com.xpn.xwiki.store.XWikiHibernateStore;
 @Singleton
 public class NotificationFilterPreferenceStore
 {
-    private static final String USER_QUERY_PARAM = "user";
-
     @Inject
     private NotificationFilterPreferenceConfiguration filterPreferenceConfiguration;
 
@@ -198,7 +196,7 @@ public class NotificationFilterPreferenceStore
         Query query = queryManager.createQuery(
             "select nfp from DefaultNotificationFilterPreference nfp where nfp.owner = :owner " + "order by nfp.id",
             Query.HQL);
-        query.bindValue(USER_QUERY_PARAM, serializedEntity);
+        query.bindValue("owner", serializedEntity);
         if (filterPreferenceConfiguration.useMainStore()) {
             query.setWiki(context.getMainXWiki());
         }
@@ -251,7 +249,7 @@ public class NotificationFilterPreferenceStore
             Session session = hibernateStore.getSession(context);
             session.createQuery("delete from DefaultNotificationFilterPreference where owner = :user "
                     + "or user = :user")
-                .setParameter(USER_QUERY_PARAM, serializedUser)
+                .setParameter("user", serializedUser)
                 .executeUpdate();
             hibernateStore.endTransaction(context, true);
         } catch (XWikiException e) {

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/NotificationFilterPreferenceStore.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/NotificationFilterPreferenceStore.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -80,7 +81,7 @@ public class NotificationFilterPreferenceStore
 
     /**
      * Get the notification preference that corresponds to the given id and user.
-     * 
+     *
      * @param user a user
      * @param filterPreferenceId a filter preference id
      * @return the corresponding preference
@@ -165,53 +166,54 @@ public class NotificationFilterPreferenceStore
     public Set<DefaultNotificationFilterPreference> getPaginatedFilterPreferences(int limit, int offset)
         throws NotificationException
     {
-        try {
-            List<DefaultNotificationFilterPreference> list = this.queryManager
-                .createQuery("select nfp from DefaultNotificationFilterPreference nfp "
-                    + "order by nfp.internalId", Query.HQL)
-                .setLimit(limit)
-                .setOffset(offset)
-                .execute();
-            // We return DefaultNotificationFilterPreference instead of NotificationFilterPreference because we need to 
-            // have access to the owner of the notification filter preferences.
-            return new HashSet<>(list);
-        } catch (QueryException e) {
-            String message = String.format("Error while loading all the notification filter preferences on wiki [%s].",
-                this.contextProvider.get().getWikiId());
-            throw new NotificationException(message, e);
-        }
+        return configureContextWrapper(() -> {
+            try {
+                List<DefaultNotificationFilterPreference> list = this.queryManager
+                    .createQuery("select nfp from DefaultNotificationFilterPreference nfp "
+                        + "order by nfp.internalId", Query.HQL)
+                    .setLimit(limit)
+                    .setOffset(offset)
+                    .execute();
+                // We return DefaultNotificationFilterPreference instead of NotificationFilterPreference because we 
+                // need to have access to the owner of the notification filter preferences.
+                return new HashSet<>(list);
+            } catch (QueryException e) {
+                String message =
+                    String.format("Error while loading all the notification filter preferences on wiki [%s].",
+                        this.contextProvider.get().getWikiId());
+                throw new NotificationException(message, e);
+            }
+        });
     }
 
     private List<DefaultNotificationFilterPreference> getPreferencesOfEntity(EntityReference entityReference,
         String providerHint) throws QueryException
     {
-        if (entityReference == null) {
-            return Collections.emptyList();
-        }
+        return configureContextWrapper(() -> {
+            if (entityReference == null) {
+                return Collections.emptyList();
+            }
 
-        String serializedEntity = entityReferenceSerializer.serialize(entityReference);
+            String serializedEntity = this.entityReferenceSerializer.serialize(entityReference);
 
-        XWikiContext context = contextProvider.get();
+            Query query = this.queryManager.createQuery(
+                "select nfp from DefaultNotificationFilterPreference nfp where nfp.owner = :owner order by nfp.id",
+                Query.HQL);
+            query.bindValue("owner", serializedEntity);
 
-        Query query = queryManager.createQuery(
-            "select nfp from DefaultNotificationFilterPreference nfp where nfp.owner = :owner " + "order by nfp.id",
-            Query.HQL);
-        query.bindValue("owner", serializedEntity);
-        if (filterPreferenceConfiguration.useMainStore()) {
-            query.setWiki(context.getMainXWiki());
-        }
-        List<DefaultNotificationFilterPreference> results = query.execute();
+            List<DefaultNotificationFilterPreference> results = query.execute();
 
-        for (DefaultNotificationFilterPreference preference : results) {
-            preference.setProviderHint(providerHint);
-        }
+            for (DefaultNotificationFilterPreference preference : results) {
+                preference.setProviderHint(providerHint);
+            }
 
-        return results;
+            return results;
+        });
     }
 
     /**
      * Delete a filter preference.
-     * 
+     *
      * @param user reference of the user concerned by the filter preference
      * @param filterPreferenceId name of the filter preference
      * @throws NotificationException if an error happens
@@ -233,33 +235,29 @@ public class NotificationFilterPreferenceStore
      */
     public void deleteFilterPreferences(DocumentReference user) throws NotificationException
     {
-        XWikiContext context = this.contextProvider.get();
+        configureContextWrapper(() -> {
+            XWikiContext context = this.contextProvider.get();
 
-        String oriDatabase = context.getWikiId();
+            XWikiHibernateStore hibernateStore = context.getWiki().getHibernateStore();
 
-        if (this.filterPreferenceConfiguration.useMainStore()) {
-            context.setWikiId(context.getMainXWiki());
-        }
-        XWikiHibernateStore hibernateStore = context.getWiki().getHibernateStore();
+            String serializedUser = this.entityReferenceSerializer.serialize(user);
 
-        String serializedUser = this.entityReferenceSerializer.serialize(user);
-
-        try {
-            hibernateStore.beginTransaction(context);
-            Session session = hibernateStore.getSession(context);
-            session.createQuery("delete from DefaultNotificationFilterPreference where owner = :user "
-                    + "or user = :user")
-                .setParameter("user", serializedUser)
-                .executeUpdate();
-            hibernateStore.endTransaction(context, true);
-        } catch (XWikiException e) {
-            hibernateStore.endTransaction(context, false);
-            throw new NotificationException(
-                String.format("Failed to delete the notification preferences for user [%s]", user),
-                e);
-        } finally {
-            context.setWikiId(oriDatabase);
-        }
+            try {
+                hibernateStore.beginTransaction(context);
+                Session session = hibernateStore.getSession(context);
+                session.createQuery("delete from DefaultNotificationFilterPreference where owner = :user "
+                        + "or user = :user")
+                    .setParameter("user", serializedUser)
+                    .executeUpdate();
+                hibernateStore.endTransaction(context, true);
+            } catch (XWikiException e) {
+                hibernateStore.endTransaction(context, false);
+                throw new NotificationException(
+                    String.format("Failed to delete the notification preferences for user [%s]", user),
+                    e);
+            }
+            return null;
+        });
     }
 
     /**
@@ -288,35 +286,33 @@ public class NotificationFilterPreferenceStore
      */
     public void deleteFilterPreference(WikiReference wikiReference) throws NotificationException
     {
-        XWikiContext context = this.contextProvider.get();
+        configureContextWrapper(() -> {
+            XWikiContext context = this.contextProvider.get();
 
-        String oriDatabase = context.getWikiId();
+            XWikiHibernateStore hibernateStore = context.getWiki().getHibernateStore();
 
-        if (this.filterPreferenceConfiguration.useMainStore()) {
-            context.setWikiId(context.getMainXWiki());
-        }
-        XWikiHibernateStore hibernateStore = context.getWiki().getHibernateStore();
+            try {
+                hibernateStore.beginTransaction(context);
+                Session session = hibernateStore.getSession(context);
+                session.createQuery("delete from DefaultNotificationFilterPreference "
+                        + "where page like :wikiPrefix "
+                        + "or pageOnly like :wikiPrefix "
+                        + "or user like :wikiPrefix "
+                        + "or wiki = :wikiId")
+                    .setParameter("wikiPrefix", wikiReference.getName() + ":%")
+                    .setParameter("wikiId", wikiReference.getName())
+                    .executeUpdate();
+                hibernateStore.endTransaction(context, true);
+            } catch (XWikiException e) {
+                hibernateStore.endTransaction(context, false);
+                throw new NotificationException(
+                    String.format("Failed to delete the notification preferences for wiki [%s]",
+                        wikiReference.getName()),
+                    e);
+            }
 
-        try {
-            hibernateStore.beginTransaction(context);
-            Session session = hibernateStore.getSession(context);
-            session.createQuery("delete from DefaultNotificationFilterPreference "
-                    + "where page like :wikiPrefix "
-                    + "or pageOnly like :wikiPrefix "
-                    + "or user like :wikiPrefix "
-                    + "or wiki = :wikiId")
-                .setParameter("wikiPrefix", wikiReference.getName() + ":%")
-                .setParameter("wikiId", wikiReference.getName())
-                .executeUpdate();
-            hibernateStore.endTransaction(context, true);
-        } catch (XWikiException e) {
-            hibernateStore.endTransaction(context, false);
-            throw new NotificationException(
-                String.format("Failed to delete the notification preferences for wiki [%s]", wikiReference.getName()),
-                e);
-        } finally {
-            context.setWikiId(oriDatabase);
-        }
+            return null;
+        });
     }
 
     /**
@@ -326,41 +322,33 @@ public class NotificationFilterPreferenceStore
      */
     private void deleteFilterPreference(NotificationFilterPreference preference)
     {
-        if (preference == null) {
-            return;
-        }
-
-        XWikiContext context = contextProvider.get();
-
-        // store event in the main database
-        String oriDatabase = context.getWikiId();
-
-        if (filterPreferenceConfiguration.useMainStore()) {
-            context.setWikiId(context.getMainXWiki());
-        }
-
-        context.setWikiId(context.getMainXWiki());
-        XWikiHibernateStore hibernateStore = context.getWiki().getHibernateStore();
-        try {
-            hibernateStore.beginTransaction(context);
-            Session session = hibernateStore.getSession(context);
-            session.delete(preference);
-            hibernateStore.endTransaction(context, true);
-        } catch (XWikiException e) {
-            hibernateStore.endTransaction(context, false);
-        } finally {
-            if (!context.getWikiId().equals(oriDatabase)) {
-                context.setWikiId(oriDatabase);
+        configureContextWrapper(() -> {
+            if (preference == null) {
+                return null;
             }
-        }
 
-        // Notify listeners about the delete
-        this.observation.notify(new NotificationFilterPreferenceDeletedEvent(), preference);
+            XWikiContext context = this.contextProvider.get();
+
+            XWikiHibernateStore hibernateStore = context.getWiki().getHibernateStore();
+            try {
+                hibernateStore.beginTransaction(context);
+                Session session = hibernateStore.getSession(context);
+                session.delete(preference);
+                hibernateStore.endTransaction(context, true);
+            } catch (XWikiException e) {
+                hibernateStore.endTransaction(context, false);
+            }
+
+            // Notify listeners about the delete.
+            this.observation.notify(new NotificationFilterPreferenceDeletedEvent(), preference);
+
+            return null;
+        });
     }
 
     /**
      * Save a collection of NotificationFilterPreferences.
-     * 
+     *
      * @param user reference of the user concerned by the filter preference
      * @param filterPreferences a list of NotificationFilterPreference
      * @throws NotificationException if an error happens
@@ -395,56 +383,79 @@ public class NotificationFilterPreferenceStore
     private void saveFilterPreferences(EntityReference entityReference,
         Collection<NotificationFilterPreference> filterPreferences) throws NotificationException
     {
-        if (entityReference == null) {
-            return;
+        configureContextWrapper(() -> {
+            if (entityReference == null) {
+                return null;
+            }
+
+            String serializedEntity = this.entityReferenceSerializer.serialize(entityReference);
+
+            XWikiContext context = this.contextProvider.get();
+
+            XWikiHibernateStore hibernateStore = null;
+
+            try {
+                hibernateStore = context.getWiki().getHibernateStore();
+                hibernateStore.beginTransaction(context);
+                Session session = hibernateStore.getSession(context);
+
+                List<DefaultNotificationFilterPreference> preferencesToSend = new ArrayList<>(filterPreferences.size());
+                for (NotificationFilterPreference preference : filterPreferences) {
+                    // Hibernate mapping only describes how to save NotificationFilterPreference objects and does not
+                    // handle extended objects (like ScopeNotificationFilterPreference).
+                    // So we create a copy just in case we are not saving a basic NotificationFilterPreference object.
+                    DefaultNotificationFilterPreference copy = new DefaultNotificationFilterPreference(preference);
+                    copy.setOwner(serializedEntity);
+                    session.saveOrUpdate(copy);
+                    preferencesToSend.add(copy);
+                }
+
+                hibernateStore.endTransaction(context, true);
+
+                // Notify listeners about the update
+                for (DefaultNotificationFilterPreference filterPreference : preferencesToSend) {
+                    this.observation.notify(new NotificationFilterPreferenceAddOrUpdatedEvent(), filterPreference,
+                        entityReference);
+                }
+            } catch (Exception e) {
+                if (hibernateStore != null) {
+                    hibernateStore.endTransaction(context, false);
+                }
+                throw new NotificationException("Failed to save the notification filter preferences.", e);
+            }
+            return null;
+        });
+    }
+
+    /**
+     * Set the right wikiId in the context according to the configuration.
+     *
+     * @param supplier the supplier to execute in the configured context
+     * @param <T> the type of the result of the supplier
+     * @param <E> the type of exception thrown by the supplier
+     * @return the result of the supplier
+     * @throws E in case of error during the execution of the supplier
+     */
+    private <T, E extends Throwable> T configureContextWrapper(SupplierErr<T, E> supplier) throws E
+    {
+        XWikiContext context = this.contextProvider.get();
+        String currentWikiId = context.getWikiId();
+        if (this.filterPreferenceConfiguration.useMainStore()) {
+            context.setWikiId(context.getMainXWiki());
         }
-
-        String serializedEntity = entityReferenceSerializer.serialize(entityReference);
-
-        XWikiContext context = contextProvider.get();
-
-        // store event in the main database
-        String currentWiki = context.getWikiId();
-
-        XWikiHibernateStore hibernateStore = null;
 
         try {
-            if (filterPreferenceConfiguration.useMainStore()) {
-                // store event in the main database
-                context.setWikiId(context.getMainXWiki());
-            }
-
-            hibernateStore = context.getWiki().getHibernateStore();
-            hibernateStore.beginTransaction(context);
-            Session session = hibernateStore.getSession(context);
-
-            List<DefaultNotificationFilterPreference> preferencesToSend = new ArrayList<>(filterPreferences.size());
-            for (NotificationFilterPreference preference : filterPreferences) {
-                // Hibernate mapping only describes how to save NotificationFilterPreference objects and does not
-                // handle extended objects (like ScopeNotificationFilterPreference).
-                // So we create a copy just in case we are not saving a basic NotificationFilterPreference object.
-                DefaultNotificationFilterPreference copy = new DefaultNotificationFilterPreference(preference);
-                copy.setOwner(serializedEntity);
-                session.saveOrUpdate(copy);
-                preferencesToSend.add(copy);
-            }
-
-            hibernateStore.endTransaction(context, true);
-
-            // Notify listeners about the update
-            for (DefaultNotificationFilterPreference filterPreference : preferencesToSend) {
-                this.observation.notify(new NotificationFilterPreferenceAddOrUpdatedEvent(), filterPreference,
-                    entityReference);
-            }
-        } catch (Exception e) {
-            if (hibernateStore != null) {
-                hibernateStore.endTransaction(context, false);
-            }
-            throw new NotificationException("Failed to save the notification filter preferences.", e);
+            return supplier.get();
         } finally {
-            if (!currentWiki.equals(context.getWikiId())) {
-                context.setWikiId(currentWiki);
+            if (!Objects.equals(currentWikiId, context.getWikiId())) {
+                context.setWikiId(currentWikiId);
             }
         }
+    }
+
+    @FunctionalInterface
+    private interface SupplierErr<T, E extends Throwable>
+    {
+        T get() throws E;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/NotificationFilterPreferenceStore.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/NotificationFilterPreferenceStore.java
@@ -239,7 +239,9 @@ public class NotificationFilterPreferenceStore
 
         String oriDatabase = context.getWikiId();
 
-        context.setWikiId(context.getMainXWiki());
+        if (this.filterPreferenceConfiguration.useMainStore()) {
+            context.setWikiId(context.getMainXWiki());
+        }
         XWikiHibernateStore hibernateStore = context.getWiki().getHibernateStore();
 
         String serializedUser = this.entityReferenceSerializer.serialize(user);
@@ -292,7 +294,9 @@ public class NotificationFilterPreferenceStore
 
         String oriDatabase = context.getWikiId();
 
-        context.setWikiId(context.getMainXWiki());
+        if (this.filterPreferenceConfiguration.useMainStore()) {
+            context.setWikiId(context.getMainXWiki());
+        }
         XWikiHibernateStore hibernateStore = context.getWiki().getHibernateStore();
 
         try {

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/migration/R140500000XWIKI15460DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/migration/R140500000XWIKI15460DataMigration.java
@@ -52,7 +52,7 @@ import com.xpn.xwiki.store.migration.hibernate.AbstractHibernateDataMigration;
 
 /**
  * Cleanup the notification filters preferences remaining on the main wiki from previously removed sub-wikis and users.
- * Note: this class is named {@code R131006000XWIKI1546} in branch {@code 13.10.6+}. This class also covers
+ * Note: this class is named {@code R131007000XWIKI1546} in branch {@code 13.10.7+}. This class also covers
  * {@code XWIKI-18397} to prevent having an almost identical migration executed again.
  *
  * @version $Id$
@@ -142,7 +142,7 @@ public class R140500000XWIKI15460DataMigration extends AbstractHibernateDataMigr
                 this.store.deleteFilterPreference(new WikiReference(unknownWikiId));
             }
 
-            // Keep the user that where not found on the wiki.
+            // List the users that were not found on the wiki.
             Set<String> unknownUsers = usersStatus.entrySet().stream()
                     .filter(entry -> !entry.getValue())
                     .map(Map.Entry::getKey)

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/migration/R140500000XWIKI15460DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/migration/R140500000XWIKI15460DataMigration.java
@@ -20,9 +20,12 @@
 package org.xwiki.notifications.filters.migration;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -30,11 +33,16 @@ import javax.inject.Singleton;
 
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.DocumentReferenceResolver;
 import org.xwiki.model.reference.WikiReference;
 import org.xwiki.notifications.NotificationException;
-import org.xwiki.notifications.filters.NotificationFilterPreference;
+import org.xwiki.notifications.filters.internal.DefaultNotificationFilterPreference;
 import org.xwiki.notifications.filters.internal.NotificationFilterPreferenceStore;
 import org.xwiki.stability.Unstable;
+import org.xwiki.user.UserManager;
+import org.xwiki.user.UserReference;
+import org.xwiki.user.UserReferenceResolver;
 import org.xwiki.wiki.descriptor.WikiDescriptorManager;
 import org.xwiki.wiki.manager.WikiManagerException;
 
@@ -43,12 +51,15 @@ import com.xpn.xwiki.store.migration.XWikiDBVersion;
 import com.xpn.xwiki.store.migration.hibernate.AbstractHibernateDataMigration;
 
 /**
- * Cleanup the notification filters preferences remaining on the main wiki from previously removed sub-wikis. Note: this
- * class is named {@code R131006000XWIKI1546} in branch {@code 13.10.6+}.
+ * Cleanup the notification filters preferences remaining on the main wiki from previously removed sub-wikis and users.
+ * Note: this class is named {@code R131006000XWIKI1546} in branch {@code 13.10.6+}. This class also covers
+ * {@code XWIKI-18397} to prevent having an almost identical migration executed again.
  *
  * @version $Id$
  * @see <a href="https://jira.xwiki.org/browse/XWIKI-15460">XWIKI-15460: Notification filter preferences are not cleaned
  *     when a wiki is deleted</a>
+ * @see <a href="https://jira.xwiki.org/browse/XWIKI-18397">XWIKI-18397: Notification filter preferences are never
+ *     cleaned for deleted users</a>
  * @since 14.5RC1
  * @since 14.4.1
  * @since 13.10.7
@@ -64,6 +75,16 @@ public class R140500000XWIKI15460DataMigration extends AbstractHibernateDataMigr
 
     @Inject
     private NotificationFilterPreferenceStore store;
+
+    @Inject
+    private DocumentReferenceResolver<String> resolver;
+
+    @Inject
+    @Named("document")
+    private UserReferenceResolver<DocumentReference> documentReferenceUserReferenceResolver;
+
+    @Inject
+    private UserManager userManager;
 
     @Inject
     private Logger logger;
@@ -85,11 +106,6 @@ public class R140500000XWIKI15460DataMigration extends AbstractHibernateDataMigr
     {
         boolean shouldExecute = super.shouldExecute(startupVersion);
         if (shouldExecute) {
-            shouldExecute = Objects.equals(this.wikiDescriptorManager.getCurrentWikiId(),
-                this.wikiDescriptorManager.getMainWikiId());
-        }
-
-        if (shouldExecute) {
             int version = startupVersion.getVersion();
             shouldExecute = !(version >= 131006000 && version < 140000000);
         }
@@ -102,18 +118,21 @@ public class R140500000XWIKI15460DataMigration extends AbstractHibernateDataMigr
         try {
             Collection<String> knownWikiIds = this.wikiDescriptorManager.getAllIds();
             Set<String> unknownWikiIds = new HashSet<>();
+            // The keys are user identifiers, the values are true if the user exists on the wiki, false otherwise.
+            Map<String, Boolean> usersStatus = new HashMap<>();
 
             int limit = 1000;
             int offset = 0;
-            Set<NotificationFilterPreference> allNotificationFilterPreferences = this.store
+            Set<DefaultNotificationFilterPreference> allNotificationFilterPreferences = this.store
                 .getPaginatedFilterPreferences(limit, offset);
+            boolean isMainWiki = isMainWiki();
             while (!allNotificationFilterPreferences.isEmpty()) {
-                for (NotificationFilterPreference filterPreference : allNotificationFilterPreferences) {
-                    filterPreference.getWikiId().ifPresent(wikiId -> {
-                        if (!knownWikiIds.contains(wikiId)) {
-                            unknownWikiIds.add(wikiId);
-                        }
-                    });
+                for (DefaultNotificationFilterPreference filterPreference : allNotificationFilterPreferences) {
+                    // Filters remaining from previously removed wikis can only be found on the main wiki.
+                    if (isMainWiki) {
+                        identifyFiltersFromRemovedWikis(knownWikiIds, unknownWikiIds, filterPreference);
+                    }
+                    identifyFiltersFromRemovedUsers(usersStatus, filterPreference);
                 }
                 offset += limit;
                 allNotificationFilterPreferences = this.store.getPaginatedFilterPreferences(limit, offset);
@@ -122,10 +141,48 @@ public class R140500000XWIKI15460DataMigration extends AbstractHibernateDataMigr
             for (String unknownWikiId : unknownWikiIds) {
                 this.store.deleteFilterPreference(new WikiReference(unknownWikiId));
             }
+
+            // Keep the user that where not found on the wiki.
+            Set<String> unknownUsers = usersStatus.entrySet().stream()
+                    .filter(entry -> !entry.getValue())
+                    .map(Map.Entry::getKey)
+                    .collect(Collectors.toSet());
+            for (String userReference : unknownUsers) {
+                this.store.deleteFilterPreferences(this.resolver.resolve(userReference));
+            }
         } catch (NotificationException e) {
             throw new DataMigrationException("Failed to retrieve the notification filters preferences.", e);
         } catch (WikiManagerException e) {
             throw new DataMigrationException("Failed to retrieve the ids of wikis of the farm.", e);
         }
+    }
+
+    private void identifyFiltersFromRemovedWikis(Collection<String> knownWikiIds, Set<String> unknownWikiIds,
+        DefaultNotificationFilterPreference filterPreference)
+    {
+        filterPreference.getWikiId().ifPresent(wikiId -> {
+            if (!knownWikiIds.contains(wikiId)) {
+                unknownWikiIds.add(wikiId);
+            }
+        });
+    }
+
+    private void identifyFiltersFromRemovedUsers(Map<String, Boolean> usersStatus,
+        DefaultNotificationFilterPreference filterPreference)
+    {
+        String owner = filterPreference.getOwner();
+        usersStatus.computeIfAbsent(owner, key -> {
+            DocumentReference entityReference = this.resolver.resolve(key);
+            UserReference userReference =
+                this.documentReferenceUserReferenceResolver.resolve(entityReference);
+
+            return this.userManager.exists(userReference);
+        });
+    }
+
+    private boolean isMainWiki()
+    {
+        return Objects.equals(this.wikiDescriptorManager.getCurrentWikiId(),
+            this.wikiDescriptorManager.getMainWikiId());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/migration/R140500000XWIKI15460DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/migration/R140500000XWIKI15460DataMigration.java
@@ -130,9 +130,9 @@ public class R140500000XWIKI15460DataMigration extends AbstractHibernateDataMigr
                 for (DefaultNotificationFilterPreference filterPreference : allNotificationFilterPreferences) {
                     // Filters remaining from previously removed wikis can only be found on the main wiki.
                     if (isMainWiki) {
-                        identifyFiltersFromRemovedWikis(knownWikiIds, unknownWikiIds, filterPreference);
+                        identifyRemovedWikis(knownWikiIds, unknownWikiIds, filterPreference);
                     }
-                    identifyFiltersFromRemovedUsers(usersStatus, filterPreference);
+                    identifiyRemovedUsers(usersStatus, filterPreference);
                 }
                 offset += limit;
                 allNotificationFilterPreferences = this.store.getPaginatedFilterPreferences(limit, offset);
@@ -157,7 +157,7 @@ public class R140500000XWIKI15460DataMigration extends AbstractHibernateDataMigr
         }
     }
 
-    private void identifyFiltersFromRemovedWikis(Collection<String> knownWikiIds, Set<String> unknownWikiIds,
+    private void identifyRemovedWikis(Collection<String> knownWikiIds, Set<String> unknownWikiIds,
         DefaultNotificationFilterPreference filterPreference)
     {
         filterPreference.getWikiId().ifPresent(wikiId -> {
@@ -167,7 +167,7 @@ public class R140500000XWIKI15460DataMigration extends AbstractHibernateDataMigr
         });
     }
 
-    private void identifyFiltersFromRemovedUsers(Map<String, Boolean> usersStatus,
+    private void identifiyRemovedUsers(Map<String, Boolean> usersStatus,
         DefaultNotificationFilterPreference filterPreference)
     {
         String owner = filterPreference.getOwner();

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/migration/R140500000XWIKI15460DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/migration/R140500000XWIKI15460DataMigration.java
@@ -39,6 +39,7 @@ import org.xwiki.model.reference.DocumentReferenceResolver;
 import org.xwiki.model.reference.WikiReference;
 import org.xwiki.notifications.NotificationException;
 import org.xwiki.notifications.filters.internal.DefaultNotificationFilterPreference;
+import org.xwiki.notifications.filters.internal.NotificationFilterPreferenceConfiguration;
 import org.xwiki.notifications.filters.internal.NotificationFilterPreferenceStore;
 import org.xwiki.stability.Unstable;
 import org.xwiki.user.UserManager;
@@ -85,6 +86,9 @@ public class R140500000XWIKI15460DataMigration extends AbstractHibernateDataMigr
     private UserReferenceResolver<DocumentReference> documentReferenceUserReferenceResolver;
 
     @Inject
+    private NotificationFilterPreferenceConfiguration filterPreferenceConfiguration;
+
+    @Inject
     private UserManager userManager;
 
     @Inject
@@ -106,6 +110,11 @@ public class R140500000XWIKI15460DataMigration extends AbstractHibernateDataMigr
     public boolean shouldExecute(XWikiDBVersion startupVersion)
     {
         boolean shouldExecute = super.shouldExecute(startupVersion);
+
+        if (shouldExecute && this.filterPreferenceConfiguration.useMainStore() && !isMainWiki()) {
+            shouldExecute = false;
+        }
+
         if (shouldExecute) {
             int version = startupVersion.getVersion();
             shouldExecute = !(version >= 131006000 && version < 140000000);

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/DefaultModelBridgeTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/DefaultModelBridgeTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class DefaultModelBridgeTest
+class DefaultModelBridgeTest
 {
     @InjectMockComponents
     private DefaultModelBridge defaultModelBridge;
@@ -134,9 +134,17 @@ public class DefaultModelBridgeTest
     }
 
     @Test
-    void deleteFilterPreferences() throws Exception
+    void deleteFilterPreferencesWiki() throws Exception
     {
         this.defaultModelBridge.deleteFilterPreferences(this.wikiReference);
         verify(this.notificationFilterPreferenceStore).deleteFilterPreference(this.wikiReference);
+    }
+
+    @Test
+    void deleteFilterPreferencesUser() throws Exception
+    {
+        DocumentReference deletedUserDocumentReference = new DocumentReference("xwiki", "wXWiki", "DeletedUser");
+        this.defaultModelBridge.deleteFilterPreferences(deletedUserDocumentReference);
+        verify(this.notificationFilterPreferenceStore).deleteFilterPreferences(deletedUserDocumentReference);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/NotificationFilterPreferenceStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/NotificationFilterPreferenceStoreTest.java
@@ -145,8 +145,9 @@ class NotificationFilterPreferenceStoreTest
         this.notificationFilterPreferenceStore.deleteFilterPreferences(unknownUserDocumentReference);
         verify(this.context).setWikiId(MAIN_WIKI_ID);
         verify(this.hibernateStore).beginTransaction(this.context);
-        verify(this.session).createQuery("delete from DefaultNotificationFilterPreference where owner = :owner");
-        verify(this.query).setParameter("owner", "xwiki:XWiki.UnknownUser");
+        verify(this.session).createQuery("delete from DefaultNotificationFilterPreference where owner = :user " 
+            + "or user = :user");
+        verify(this.query).setParameter("user", "xwiki:XWiki.UnknownUser");
         verify(this.query).executeUpdate();
         verify(this.hibernateStore).endTransaction(this.context, true);
         verify(this.context).setWikiId(PREVIOUS_WIKI_ID);

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/NotificationFilterPreferenceStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/NotificationFilterPreferenceStoreTest.java
@@ -24,7 +24,8 @@ import javax.inject.Provider;
 import org.hibernate.Session;
 import org.hibernate.query.Query;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReferenceSerializer;
@@ -71,6 +72,9 @@ class NotificationFilterPreferenceStoreTest
     @MockComponent
     private EntityReferenceSerializer<String> entityReferenceSerializer;
 
+    @MockComponent
+    private NotificationFilterPreferenceConfiguration filterPreferenceConfiguration;
+
     @Mock
     private XWikiContext context;
 
@@ -97,11 +101,15 @@ class NotificationFilterPreferenceStoreTest
         when(this.query.setParameter(anyString(), any())).thenReturn(this.query);
     }
 
-    @Test
-    void deleteFilterPreference() throws Exception
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void deleteFilterPreference(boolean useMainStore) throws Exception
     {
+        when(this.filterPreferenceConfiguration.useMainStore()).thenReturn(useMainStore);
         this.notificationFilterPreferenceStore.deleteFilterPreference(new WikiReference("wikiid"));
-        verify(this.context).setWikiId(MAIN_WIKI_ID);
+        if (useMainStore) {
+            verify(this.context).setWikiId(MAIN_WIKI_ID);
+        }
         verify(this.hibernateStore).beginTransaction(this.context);
         verify(this.session).createQuery("delete from DefaultNotificationFilterPreference "
             + "where page like :wikiPrefix "
@@ -115,9 +123,11 @@ class NotificationFilterPreferenceStoreTest
         verify(this.context).setWikiId(PREVIOUS_WIKI_ID);
     }
 
-    @Test
-    void deleteFilterPreferenceHibernateException() throws Exception
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void deleteFilterPreferenceHibernateException(boolean useMainStore) throws Exception
     {
+        when(this.filterPreferenceConfiguration.useMainStore()).thenReturn(useMainStore);
         WikiReference wikiReference = new WikiReference("wikiid");
 
         when(this.hibernateStore.beginTransaction(this.context)).thenThrow(XWikiException.class);
@@ -130,22 +140,29 @@ class NotificationFilterPreferenceStoreTest
             notificationException.getMessage());
         assertEquals(XWikiException.class, notificationException.getCause().getClass());
 
-        verify(this.context).setWikiId(MAIN_WIKI_ID);
+        if (useMainStore) {
+            verify(this.context).setWikiId(MAIN_WIKI_ID);
+        }
         verify(this.hibernateStore).beginTransaction(this.context);
         verify(this.hibernateStore).endTransaction(this.context, false);
         verify(this.context).setWikiId(PREVIOUS_WIKI_ID);
     }
 
-    @Test
-    void deleteFilterPreferences() throws Exception
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void deleteFilterPreferences(boolean useMainStore) throws Exception
     {
+        when(this.filterPreferenceConfiguration.useMainStore()).thenReturn(useMainStore);
         DocumentReference unknownUserDocumentReference = new DocumentReference("xwiki", "XWiki", "UnknownUser");
         when(this.entityReferenceSerializer.serialize(unknownUserDocumentReference))
             .thenReturn("xwiki:XWiki.UnknownUser");
         this.notificationFilterPreferenceStore.deleteFilterPreferences(unknownUserDocumentReference);
-        verify(this.context).setWikiId(MAIN_WIKI_ID);
+
+        if (useMainStore) {
+            verify(this.context).setWikiId(MAIN_WIKI_ID);
+        }
         verify(this.hibernateStore).beginTransaction(this.context);
-        verify(this.session).createQuery("delete from DefaultNotificationFilterPreference where owner = :user " 
+        verify(this.session).createQuery("delete from DefaultNotificationFilterPreference where owner = :user "
             + "or user = :user");
         verify(this.query).setParameter("user", "xwiki:XWiki.UnknownUser");
         verify(this.query).executeUpdate();
@@ -153,23 +170,27 @@ class NotificationFilterPreferenceStoreTest
         verify(this.context).setWikiId(PREVIOUS_WIKI_ID);
     }
 
-    @Test
-    void deleteFilterPreferencesHibernateException() throws Exception
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void deleteFilterPreferencesHibernateException(boolean useMainStore) throws Exception
     {
+        when(this.filterPreferenceConfiguration.useMainStore()).thenReturn(useMainStore);
         DocumentReference unknownUserDocumentReference = new DocumentReference("xwiki", "XWiki", "UnknownUser");
-        
+
         when(this.entityReferenceSerializer.serialize(unknownUserDocumentReference))
             .thenReturn("xwiki:XWiki.UnknownUser");
         when(this.hibernateStore.beginTransaction(this.context)).thenThrow(XWikiException.class);
-        
+
         NotificationException notificationException = assertThrows(NotificationException.class,
             () -> this.notificationFilterPreferenceStore.deleteFilterPreferences(unknownUserDocumentReference));
-        
+
         assertEquals("Failed to delete the notification preferences for user [xwiki:XWiki.UnknownUser]",
             notificationException.getMessage());
         assertEquals(XWikiException.class, notificationException.getCause().getClass());
-        
-        verify(this.context).setWikiId(MAIN_WIKI_ID);
+
+        if (useMainStore) {
+            verify(this.context).setWikiId(MAIN_WIKI_ID);
+        }
         verify(this.hibernateStore).beginTransaction(this.context);
         verify(this.hibernateStore).endTransaction(this.context, false);
         verify(this.context).setWikiId(PREVIOUS_WIKI_ID);

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/NotificationFilterPreferenceStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/NotificationFilterPreferenceStoreTest.java
@@ -106,7 +106,12 @@ class NotificationFilterPreferenceStoreTest
     void deleteFilterPreference(boolean useMainStore) throws Exception
     {
         when(this.filterPreferenceConfiguration.useMainStore()).thenReturn(useMainStore);
+        if (useMainStore) {
+            when(this.context.getWikiId()).thenReturn(PREVIOUS_WIKI_ID, MAIN_WIKI_ID);
+        }
+
         this.notificationFilterPreferenceStore.deleteFilterPreference(new WikiReference("wikiid"));
+
         if (useMainStore) {
             verify(this.context).setWikiId(MAIN_WIKI_ID);
         }
@@ -120,7 +125,9 @@ class NotificationFilterPreferenceStoreTest
         verify(this.query).setParameter("wikiId", "wikiid");
         verify(this.query).executeUpdate();
         verify(this.hibernateStore).endTransaction(this.context, true);
-        verify(this.context).setWikiId(PREVIOUS_WIKI_ID);
+        if (useMainStore) {
+            verify(this.context).setWikiId(PREVIOUS_WIKI_ID);
+        }
     }
 
     @ParameterizedTest
@@ -128,13 +135,15 @@ class NotificationFilterPreferenceStoreTest
     void deleteFilterPreferenceHibernateException(boolean useMainStore) throws Exception
     {
         when(this.filterPreferenceConfiguration.useMainStore()).thenReturn(useMainStore);
-        WikiReference wikiReference = new WikiReference("wikiid");
 
         when(this.hibernateStore.beginTransaction(this.context)).thenThrow(XWikiException.class);
+        if (useMainStore) {
+            when(this.context.getWikiId()).thenReturn(PREVIOUS_WIKI_ID, MAIN_WIKI_ID);
+        }
 
         NotificationException notificationException = assertThrows(NotificationException.class,
             () -> this.notificationFilterPreferenceStore.deleteFilterPreference(
-                wikiReference));
+                new WikiReference("wikiid")));
 
         assertEquals("Failed to delete the notification preferences for wiki [wikiid]",
             notificationException.getMessage());
@@ -145,17 +154,24 @@ class NotificationFilterPreferenceStoreTest
         }
         verify(this.hibernateStore).beginTransaction(this.context);
         verify(this.hibernateStore).endTransaction(this.context, false);
-        verify(this.context).setWikiId(PREVIOUS_WIKI_ID);
+        if (useMainStore) {
+            verify(this.context).setWikiId(PREVIOUS_WIKI_ID);
+        }
     }
 
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
     void deleteFilterPreferences(boolean useMainStore) throws Exception
     {
-        when(this.filterPreferenceConfiguration.useMainStore()).thenReturn(useMainStore);
         DocumentReference unknownUserDocumentReference = new DocumentReference("xwiki", "XWiki", "UnknownUser");
+
+        when(this.filterPreferenceConfiguration.useMainStore()).thenReturn(useMainStore);
         when(this.entityReferenceSerializer.serialize(unknownUserDocumentReference))
             .thenReturn("xwiki:XWiki.UnknownUser");
+        if (useMainStore) {
+            when(this.context.getWikiId()).thenReturn(PREVIOUS_WIKI_ID, MAIN_WIKI_ID);
+        }
+
         this.notificationFilterPreferenceStore.deleteFilterPreferences(unknownUserDocumentReference);
 
         if (useMainStore) {
@@ -167,19 +183,24 @@ class NotificationFilterPreferenceStoreTest
         verify(this.query).setParameter("user", "xwiki:XWiki.UnknownUser");
         verify(this.query).executeUpdate();
         verify(this.hibernateStore).endTransaction(this.context, true);
-        verify(this.context).setWikiId(PREVIOUS_WIKI_ID);
+        if (useMainStore) {
+            verify(this.context).setWikiId(PREVIOUS_WIKI_ID);
+        }
     }
 
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
     void deleteFilterPreferencesHibernateException(boolean useMainStore) throws Exception
     {
-        when(this.filterPreferenceConfiguration.useMainStore()).thenReturn(useMainStore);
         DocumentReference unknownUserDocumentReference = new DocumentReference("xwiki", "XWiki", "UnknownUser");
 
+        when(this.filterPreferenceConfiguration.useMainStore()).thenReturn(useMainStore);
         when(this.entityReferenceSerializer.serialize(unknownUserDocumentReference))
             .thenReturn("xwiki:XWiki.UnknownUser");
         when(this.hibernateStore.beginTransaction(this.context)).thenThrow(XWikiException.class);
+        if (useMainStore) {
+            when(this.context.getWikiId()).thenReturn(PREVIOUS_WIKI_ID, MAIN_WIKI_ID);
+        }
 
         NotificationException notificationException = assertThrows(NotificationException.class,
             () -> this.notificationFilterPreferenceStore.deleteFilterPreferences(unknownUserDocumentReference));
@@ -193,6 +214,8 @@ class NotificationFilterPreferenceStoreTest
         }
         verify(this.hibernateStore).beginTransaction(this.context);
         verify(this.hibernateStore).endTransaction(this.context, false);
-        verify(this.context).setWikiId(PREVIOUS_WIKI_ID);
+        if (useMainStore) {
+            verify(this.context).setWikiId(PREVIOUS_WIKI_ID);
+        }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/migration/R140500000XWIKI15460DataMigrationTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/migration/R140500000XWIKI15460DataMigrationTest.java
@@ -33,6 +33,7 @@ import org.xwiki.model.reference.DocumentReferenceResolver;
 import org.xwiki.model.reference.WikiReference;
 import org.xwiki.notifications.NotificationException;
 import org.xwiki.notifications.filters.internal.DefaultNotificationFilterPreference;
+import org.xwiki.notifications.filters.internal.NotificationFilterPreferenceConfiguration;
 import org.xwiki.notifications.filters.internal.NotificationFilterPreferenceStore;
 import org.xwiki.test.LogLevel;
 import org.xwiki.test.junit5.LogCaptureExtension;
@@ -89,6 +90,9 @@ class R140500000XWIKI15460DataMigrationTest
     @MockComponent
     private UserManager userManager;
 
+    @MockComponent
+    private NotificationFilterPreferenceConfiguration filterPreferenceConfiguration;
+
     @RegisterExtension
     LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.INFO);
 
@@ -110,6 +114,15 @@ class R140500000XWIKI15460DataMigrationTest
     void shouldExecute()
     {
         assertTrue(this.dataMigration.shouldExecute(new XWikiDBVersion(0)));
+    }
+
+    @ParameterizedTest
+    @CsvSource({ "true,mainwikiid,true", "false,mainwikiid,true", "true,anotherwiki,false", "false,anotherwiki,true" })
+    void shouldExecutedConfiguration(boolean useMainStore, String currentWikiId, boolean expected)
+    {
+        when(this.wikiDescriptorManager.getCurrentWikiId()).thenReturn(currentWikiId);
+        when(this.filterPreferenceConfiguration.useMainStore()).thenReturn(useMainStore);
+        assertEquals(expected, this.dataMigration.shouldExecute(new XWikiDBVersion(0)));
     }
 
     /**


### PR DESCRIPTION
- Listen for deleted users and remove the corresponding notification filter preferences from the store and from the cache
- Update R140500000XWIKI15460DataMigration to also cleanup remaining notification filter preferences for previously removed users

Jira: https://jira.xwiki.org/browse/XWIKI-18397