### PR TITLE
XWIKI-19767: Make the security cache capacity configurable

### DIFF
--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/pom.xml
@@ -32,8 +32,6 @@
   <description>Controls permissions to all the wiki elements</description>
   <properties>
     <xwiki.jacoco.instructionRatio>0.76</xwiki.jacoco.instructionRatio>
-    <!-- TODO: Remove once the tests have been fixed to not output anything to the console! -->
-    <xwiki.surefire.captureconsole.skip>true</xwiki.surefire.captureconsole.skip>
     <!-- Name to display by the Extension Manager -->
     <xwiki.extension.name>Authorization API</xwiki.extension.name>
   </properties>

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/DefaultAuthorizationManagerIntegrationTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/DefaultAuthorizationManagerIntegrationTest.java
@@ -32,6 +32,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.xwiki.cache.CacheManager;
 import org.xwiki.cache.config.CacheConfiguration;
+import org.xwiki.configuration.ConfigurationSource;
 import org.xwiki.model.EntityType;
 import org.xwiki.model.internal.DefaultModelConfiguration;
 import org.xwiki.model.internal.reference.DefaultEntityReferenceProvider;
@@ -83,6 +84,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.xwiki.security.authorization.Right.ADMIN;
@@ -157,6 +159,17 @@ class DefaultAuthorizationManagerIntegrationTest extends AbstractAuthorizationTe
             });
 
         when(xWikiBridge.getMainWikiReference()).thenReturn(new WikiReference("xwiki"));
+
+        final ConfigurationSource configurationSource = componentManager.registerMockComponent(ConfigurationSource.class, "xwikiproperties");
+        when(configurationSource.getProperty(anyString(), any(Object.class)))
+            .thenAnswer(new Answer<Object>()
+            {
+                @Override
+                public Object answer(InvocationOnMock invocation) throws Throwable
+                {
+                    return invocation.getArgument(1);
+                }
+            });
     }
 
     @BeforeEach

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/cache/internal/DefaultSecurityCacheTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/cache/internal/DefaultSecurityCacheTest.java
@@ -34,6 +34,7 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.xwiki.cache.CacheManager;
 import org.xwiki.cache.config.CacheConfiguration;
+import org.xwiki.configuration.ConfigurationSource;
 import org.xwiki.model.EntityType;
 import org.xwiki.model.internal.reference.DefaultStringEntityReferenceSerializer;
 import org.xwiki.model.internal.reference.DefaultSymbolScheme;
@@ -67,6 +68,8 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -115,6 +118,9 @@ public class DefaultSecurityCacheTest extends AbstractSecurityTestCase
             final CacheManager cacheManager = securityCacheMocker.getInstance(CacheManager.class);
             when(cacheManager.createNewCache(any(CacheConfiguration.class))).thenReturn(cache);
         }
+
+        final ConfigurationSource cs = securityCacheMocker.getInstance(ConfigurationSource.class, "xwikiproperties");
+        when(cs.getProperty(eq("security.authorization.cache.capacity"), anyInt())).thenReturn(0);
 
         XWikiBridge xwikiBridge = securityReferenceFactoryMocker.getInstance(XWikiBridge.class);
         when(xwikiBridge.getMainWikiReference()).thenReturn(new WikiReference("xwiki"));

--- a/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.properties.vm
+++ b/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.properties.vm
@@ -666,6 +666,14 @@ extension.versioncheck.environment.enabled=$xwikiPropertiesEnvironmentVersionChe
 #-# The default is:
 # security.authorization.settler = default
 
+#-# [Since 14.5]
+#-# Define the maximal number of entries of the cache which caches the results of security checks.
+#-# If the wiki has a lot of users and/or local right assignments the capacity can be increased
+#-# to improve performance.
+#-#
+#-# The default is:
+# security.authorization.cache.capacity = 10000
+
 #-# [Since 13.0]
 #-# Control if document save API should also check the right of the script author when saving a document.
 #-# When false only the current user right is checked.


### PR DESCRIPTION
the new configuration setting is named:  "security.authorization.cache.capacity"
