### PR TITLE
XWIKI-19774: Temporary attachments aren't deleted when the session is destroyed

### DIFF
--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -101,46 +101,23 @@
                  Don't forget to '\'-escape dots and other special characters in this case ;)
 
                  Common justification example:
-
-            <revapi.differences>
-              <justification>This change is necessary to fix bug #1234</justification>
-              <criticality>highlight</criticality>
-              <differences>
-                <item>
-                  <code>java.method.addToInterface</code>
-                  <fullQualifiedClassName>com.acme.ToolInterface</fullyQualifiedClassName>
-                  <new>method void com.acme.ToolInterface::setup()</new>
-                </item>
-                <item>
-                  <code>java.method.removed</code>
-                  <fullQualifiedClassName>com.acme.ToolInterface</fullyQualifiedClassName>
-                  <old>method void com.acme.ToolInterface::initialize()</old>
-                  <justification>...</justification>
-                </item>
-              </differences>
-            </revapi.differences>
-            <revapi.differences>
-              ... other difference group here...
-            </revapi.differences>
-
-                 Single justification example:
-
-            <revapi.differences>
-              <differences>
-                <item>
-                  <code>java.method.removed</code>
-                  <old>method void org.xwiki.diff.xml.XMLDiff::xxx()</old>
-                  <justification>Unstable API added by mistake.</justification>
-                  <criticality>highlight</criticality>
-                </item>
-              </differences>
-            </revapi.differences>
             -->
-            <!-- Difference related to the Security refactoring. Start a new <revapi.differences> entry for other
-                 differences -->
-
-            
-            
+            <revapi.differences>
+              <justification>Unstable API for TemporaryAttachmentSessionManager.</justification>
+              <criticality>allowed</criticality>
+              <differences>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.addedToInterface</code>
+                  <new>method void javax.servlet.http.HttpSessionListener::sessionCreated(javax.servlet.http.HttpSessionEvent) @ org.xwiki.store.TemporaryAttachmentSessionsManager</new>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.addedToInterface</code>
+                  <new>method void javax.servlet.http.HttpSessionListener::sessionDestroyed(javax.servlet.http.HttpSessionEvent) @ org.xwiki.store.TemporaryAttachmentSessionsManager</new>
+                </item>
+              </differences>
+            </revapi.differences>
           </analysisConfiguration>
         </configuration>
       </plugin>

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/LegacyActionServlet.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/LegacyActionServlet.java
@@ -38,6 +38,7 @@ import org.xwiki.resource.ResourceType;
 import org.xwiki.resource.ResourceTypeResolver;
 import org.xwiki.resource.entity.EntityResourceReference;
 import org.xwiki.stability.Unstable;
+import org.xwiki.store.TemporaryAttachmentSessionsManager;
 import org.xwiki.url.ExtendedURL;
 
 import com.xpn.xwiki.internal.web.LegacyAction;
@@ -85,6 +86,14 @@ public class LegacyActionServlet extends HttpServlet
             throw new ServletException("Failed to lookup the resource reference resolve for ExtendedURL", e);
         }
 
+        // Note that this might need to be done in ResourceReferenceHandlerServlet in the future.
+        try {
+            TemporaryAttachmentSessionsManager temporaryAttachmentSessionsManager =
+                this.rootComponentManager.getInstance(TemporaryAttachmentSessionsManager.class);
+            getServletContext().addListener(temporaryAttachmentSessionsManager);
+        } catch (ComponentLookupException e) {
+            throw new ServletException("Error when trying to add a listener in the servlet context.", e);
+        }
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/TemporaryAttachmentSessionsManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/TemporaryAttachmentSessionsManager.java
@@ -22,6 +22,7 @@ package org.xwiki.store;
 import java.util.Collection;
 import java.util.Optional;
 
+import javax.servlet.http.HttpSessionListener;
 import javax.servlet.http.Part;
 
 import org.xwiki.component.annotation.Role;
@@ -36,13 +37,15 @@ import com.xpn.xwiki.doc.XWikiAttachment;
  * The idea of this API is to allow obtaining directly a temporary {@link XWikiAttachment} from a {@link Part} and to
  * keep it in cache until it's saved.
  * The manager is handling a separated map of attachments for each {@link javax.servlet.http.HttpSession}.
+ * Note that this manager extends an {@link HttpSessionListener} so that the session destruction can be listen to,
+ * in order to clean the temporary attachments.
  *
  * @version $Id$
  * @since 14.3RC1
  */
 @Unstable
 @Role
-public interface TemporaryAttachmentSessionsManager
+public interface TemporaryAttachmentSessionsManager extends HttpSessionListener
 {
     /**
      * Temporary store the given {@link Part} to a cached {@link XWikiAttachment} attached to the given

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/DefaultTemporaryAttachmentSessionsManager.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/DefaultTemporaryAttachmentSessionsManager.java
@@ -57,9 +57,8 @@ import com.xpn.xwiki.plugin.fileupload.FileUploadPlugin;
  */
 @Component
 @Singleton
-public class DefaultTemporaryAttachmentSessionsManager
-    implements TemporaryAttachmentSessionsManager, Initializable, Disposable,
-    HttpSessionListener
+public class DefaultTemporaryAttachmentSessionsManager implements TemporaryAttachmentSessionsManager, Initializable,
+    Disposable
 {
     private Map<String, TemporaryAttachmentSession> temporaryAttachmentSessionMap;
 


### PR DESCRIPTION

  * Ensure to listen to the session destruction for cleaning temporary
    attachments