### PR TITLE
XWIKI-19653: Ability to redirect deleted page link to a new page

### DIFF
--- a/xwiki-platform-core/xwiki-platform-bridge/src/main/java/org/xwiki/bridge/event/AbstractDocumentEvent.java
+++ b/xwiki-platform-core/xwiki-platform-bridge/src/main/java/org/xwiki/bridge/event/AbstractDocumentEvent.java
@@ -24,6 +24,7 @@ import org.xwiki.model.internal.reference.DefaultSymbolScheme;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.observation.event.AbstractCancelableEvent;
 import org.xwiki.observation.event.filter.EventFilter;
+import org.xwiki.stability.Unstable;
 
 /**
  * Base class for all document related {@link org.xwiki.observation.event.Event}.
@@ -46,11 +47,22 @@ public abstract class AbstractDocumentEvent extends AbstractCancelableEvent
         new DefaultStringEntityReferenceSerializer(new DefaultSymbolScheme());
 
     /**
-     * This event will match any other document event of the same type.
+     * The reference of the targeted document.
+     * 
+     * @since 14.4.1
+     * @since 14.5RC1
+     */
+    private final DocumentReference documentReference;
+
+    /**
+     * This event will match any other document event of the same type. Since listeners may expect to find the document
+     * reference in the event, it is recommended to use the constructor with the explicit parameter when generating the
+     * event.
      */
     public AbstractDocumentEvent()
     {
         super();
+        this.documentReference = null;
     }
 
     /**
@@ -61,6 +73,7 @@ public abstract class AbstractDocumentEvent extends AbstractCancelableEvent
     public AbstractDocumentEvent(DocumentReference documentReference)
     {
         super(SERIALIZER.serialize(documentReference));
+        this.documentReference = documentReference;
     }
 
     /**
@@ -71,5 +84,17 @@ public abstract class AbstractDocumentEvent extends AbstractCancelableEvent
     public AbstractDocumentEvent(EventFilter eventFilter)
     {
         super(eventFilter);
+        this.documentReference = null;
+    }
+
+    /**
+     * @return the reference of the document targeted by this event, or {@code null} if it was not specified
+     * @since 14.4.1
+     * @since 14.5RC1
+     */
+    @Unstable
+    public DocumentReference getDocumentReference()
+    {
+        return this.documentReference;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-bridge/src/main/java/org/xwiki/bridge/event/AbstractDocumentEvent.java
+++ b/xwiki-platform-core/xwiki-platform-bridge/src/main/java/org/xwiki/bridge/event/AbstractDocumentEvent.java
@@ -49,7 +49,7 @@ public abstract class AbstractDocumentEvent extends AbstractCancelableEvent
     /**
      * The reference of the targeted document.
      * 
-     * @since 14.4.1
+     * @since 14.4.2
      * @since 14.5RC1
      */
     private final DocumentReference documentReference;
@@ -89,7 +89,7 @@ public abstract class AbstractDocumentEvent extends AbstractCancelableEvent
 
     /**
      * @return the reference of the document targeted by this event, or {@code null} if it was not specified
-     * @since 14.4.1
+     * @since 14.4.2
      * @since 14.5RC1
      */
     @Unstable

--- a/xwiki-platform-core/xwiki-platform-bridge/src/main/java/org/xwiki/bridge/event/DocumentDeletedEvent.java
+++ b/xwiki-platform-core/xwiki-platform-bridge/src/main/java/org/xwiki/bridge/event/DocumentDeletedEvent.java
@@ -42,7 +42,12 @@ public class DocumentDeletedEvent extends AbstractDocumentEvent
      * changes.
      */
     private static final long serialVersionUID = 1L;
-    
+
+    /**
+     * The reference of the deleted document.
+     */
+    private final DocumentReference sourceReference;
+
     /**
      * Constructor initializing the event filter with an
      * {@link org.xwiki.observation.event.filter.AlwaysMatchingEventFilter}, meaning that this event will match any
@@ -50,20 +55,21 @@ public class DocumentDeletedEvent extends AbstractDocumentEvent
      */
     public DocumentDeletedEvent()
     {
-        
+        this.sourceReference = null;
     }
-    
+
     /**
      * Constructor initializing the event filter with a {@link org.xwiki.observation.event.filter.FixedNameEventFilter},
      * meaning that this event will match only delete events affecting the same document.
      * 
      * @param documentReference the reference of the document to match
      */
-    public DocumentDeletedEvent(DocumentReference documentReference)    
+    public DocumentDeletedEvent(DocumentReference documentReference)
     {
         super(documentReference);
+        this.sourceReference = documentReference;
     }
-    
+
     /**
      * Constructor using a custom {@link EventFilter}.
      * 
@@ -72,6 +78,15 @@ public class DocumentDeletedEvent extends AbstractDocumentEvent
     public DocumentDeletedEvent(EventFilter eventFilter)
     {
         super(eventFilter);
+        this.sourceReference = null;
+    }
+
+    /**
+     * @return the reference of the deleted document
+     */
+    public DocumentReference getSourceReference()
+    {
+        return this.sourceReference;
     }
 
 }

--- a/xwiki-platform-core/xwiki-platform-bridge/src/main/java/org/xwiki/bridge/event/DocumentDeletedEvent.java
+++ b/xwiki-platform-core/xwiki-platform-bridge/src/main/java/org/xwiki/bridge/event/DocumentDeletedEvent.java
@@ -43,19 +43,16 @@ public class DocumentDeletedEvent extends AbstractDocumentEvent
      */
     private static final long serialVersionUID = 1L;
 
-    /**
-     * The reference of the deleted document.
-     */
-    private final DocumentReference sourceReference;
+    
 
     /**
      * Constructor initializing the event filter with an
      * {@link org.xwiki.observation.event.filter.AlwaysMatchingEventFilter}, meaning that this event will match any
-     * other document delete event.
+     * other document delete event. Since listeners may expect to find the document reference in the event, it is
+     * recommended to use the constructor with the explicit parameter when generating the event.
      */
     public DocumentDeletedEvent()
     {
-        this.sourceReference = null;
     }
 
     /**
@@ -67,7 +64,6 @@ public class DocumentDeletedEvent extends AbstractDocumentEvent
     public DocumentDeletedEvent(DocumentReference documentReference)
     {
         super(documentReference);
-        this.sourceReference = documentReference;
     }
 
     /**
@@ -78,15 +74,5 @@ public class DocumentDeletedEvent extends AbstractDocumentEvent
     public DocumentDeletedEvent(EventFilter eventFilter)
     {
         super(eventFilter);
-        this.sourceReference = null;
     }
-
-    /**
-     * @return the reference of the deleted document
-     */
-    public DocumentReference getSourceReference()
-    {
-        return this.sourceReference;
-    }
-
 }

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/delete.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/delete.vm
@@ -32,7 +32,10 @@
 #######################################################
 ##                     DISPLAY
 #######################################################
+#set ($discard = $xwiki.jsfx.use('js/xwiki/delete.js'))
 #template('refactoringStatus_macros.vm')
+#template('refactoring_macros.vm')
+#template('xwikivars.vm')
 
 #controller()
 #macro(displayContent $deletecontent)
@@ -117,7 +120,7 @@
 ##            DISPLAY CONFIRMATION PAGE
 #######################################################
 #macro(displayConfirmationPage)
-  <form action="$doc.getURL('delete', "$!{languageparams}")" method="post">
+  <form id="delete" class="xform" action="$doc.getURL('delete', "$!{languageparams}")" method="post">
     #getChildren()
     #getBacklinks()
     #getChildren_legacy()
@@ -228,7 +231,36 @@
       #end
       </ul>
     #end
-    #set($body = $services.localization.render('core.delete.backlinksWarning', [$message]))
+    #define($body)
+      <p class="noitems">
+        $services.localization.render('core.delete.backlinksInfo', [$doc.backlinks.size()])
+      </p>
+      <dl>
+        <dt>
+          <label for="newTarget">$services.localization.render('core.delete.target.label')</label>
+          <span class="xHint">$services.localization.render('core.delete.target.hint')</span>
+        </dt>
+        <dd>
+          #set ($pagePickerParams = {
+            'id': 'newTarget',
+            'name': 'newTarget'
+          })
+          #pagePicker($pagePickerParams)
+        </dd>
+        ##------------
+        ## Links field
+        ##------------
+        #displayLinksCheckbox({
+          'label': 'core.delete.updateLinks.label',
+          'hint': 'core.delete.updateLinks.hint',
+          'hidden': true
+        })
+        #displayAutoRedirectCheckbox({
+          'label': 'core.delete.autoRedirect.label',
+          'hint': 'core.delete.autoRedirect.hint',
+          'hidden': true
+        })
+    #end
     #displayPanel('panel-backlinks', 'panel-default', $heading, $body)
     #set($hasInlinks = true)
   #end

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/delete.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/delete.vm
@@ -233,12 +233,14 @@
     #end
     #define($body)
       <p class="noitems">
-        $services.localization.render('core.delete.backlinksInfo', [$doc.backlinks.size()])
+        $escapetool.xml($services.localization.render('core.delete.backlinksInfo', [$doc.backlinks.size()]))
       </p>
       <dl>
         <dt>
-          <label for="newBacklinkTarget">$services.localization.render('core.delete.backlinkTarget.label')</label>
-          <span class="xHint">$services.localization.render('core.delete.backlinkTarget.hint')</span>
+          <label for="newBacklinkTarget">
+            $escapetool.xml($services.localization.render('core.delete.backlinkTarget.label'))
+          </label>
+          <span class="xHint">$escapetool.xml($services.localization.render('core.delete.backlinkTarget.hint'))</span>
         </dt>
         <dd>
           #set ($pagePickerParams = {

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/delete.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/delete.vm
@@ -237,13 +237,13 @@
       </p>
       <dl>
         <dt>
-          <label for="newTarget">$services.localization.render('core.delete.target.label')</label>
-          <span class="xHint">$services.localization.render('core.delete.target.hint')</span>
+          <label for="newBacklinkTarget">$services.localization.render('core.delete.backlinkTarget.label')</label>
+          <span class="xHint">$services.localization.render('core.delete.backlinkTarget.hint')</span>
         </dt>
         <dd>
           #set ($pagePickerParams = {
-            'id': 'newTarget',
-            'name': 'newTarget'
+            'id': 'newBacklinkTarget',
+            'name': 'newBacklinkTarget'
           })
           #pagePicker($pagePickerParams)
         </dd>
@@ -260,6 +260,7 @@
           'hint': 'core.delete.autoRedirect.hint',
           'hidden': true
         })
+      </dl>
     #end
     #displayPanel('panel-backlinks', 'panel-default', $heading, $body)
     #set($hasInlinks = true)

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/refactoring_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/refactoring_macros.vm
@@ -126,13 +126,13 @@
   <dt #if ($hidden) class="hidden"#end>
     <label>
       <input type="checkbox" name="autoRedirect" value="true" #if ($checked)checked="checked"#end />
-      $services.localization.render($options.label)
+      $escapetool.xml($services.localization.render($options.label))
     </label>
     ## The value submitted when the checkbox is not checked, used to preserve the form state.
     <input type="hidden" name="autoRedirect" value="false" />
   </dt>
   <dd #if ($hidden) class="hidden"#end>
-    <span class="xHint">$services.localization.render($options.hint)</span>
+    <span class="xHint">$escapetool.xml($services.localization.render($options.hint))</span>
   </dd>
 #end
 

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/refactoring_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/refactoring_macros.vm
@@ -85,7 +85,7 @@
 #end
 
 #macro (displayLinksCheckbox $options)
-  #set ($hidden = !$isAdvancedUser && !$isSuperAdmin)
+  #set ($hidden = (!$isAdvancedUser && !$isSuperAdmin) || $options.hidden)
   ## We hide this option for simple users (instead of simply removing it) because we want to submit the default value
   ## (i.e. we want to make sure the links are updated for simple users).
   <dt#if ($hidden) class="hidden"#end>
@@ -103,6 +103,36 @@
     <span class="xHint">
       $services.localization.render($options.hint, ["<a href='$backLinksURL'>", $backLinksCount, '</a>'])
     </span>
+  </dd>
+#end
+
+#macro(displayAutoRedirectCheckbox $options)
+  ##--------------------
+  ## Auto redirect field
+  ##--------------------
+  ## We set Autoredirect to off by default for the following reasons:
+  ## - Several users have reported a usability issue about automatic redirects. The way they express it is the
+  ##   following: "I have duplicates pages in my wiki. I don't understand why this is happening. I'm choosing to
+  ##   rename pages and not to copy them but I still get duplicates in the Navigation panel".
+  ## - Automatic redirects are especially useful for public wikis where users can have bookmark on pages and you
+  ##   don't want to break them. It can also be useful for internal wikis but it's less an issue.
+  ## - Even for public wikis not all pages need automatic redirects. Technical pages don't need them for example.
+  ## - We don't have management UIs for redirects FTM and reducing the number of redirects make the wiki easier
+  ##   to manage.
+  ## In the future we'll offer a config option to define the default behavior, see
+  ## http://jira.xwiki.org/browse/XWIKI-13384
+  #set ($checked = $request.autoRedirect == 'true')
+  #set ($hidden = $options.hidden)
+  <dt #if ($hidden) class="hidden"#end>
+    <label>
+      <input type="checkbox" name="autoRedirect" value="true" #if ($checked)checked="checked"#end />
+      $services.localization.render($options.label)
+    </label>
+    ## The value submitted when the checkbox is not checked, used to preserve the form state.
+    <input type="hidden" name="autoRedirect" value="false" />
+  </dt>
+  <dd #if ($hidden) class="hidden"#end>
+    <span class="xHint">$services.localization.render($options.hint)</span>
   </dd>
 #end
 

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/renameStep1.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/renameStep1.vm
@@ -65,32 +65,10 @@
           'label': 'core.rename.links.label',
           'hint': 'core.rename.links.hint'
         })
-        ##--------------------
-        ## Auto redirect field
-        ##--------------------
-        ## We set Autoredirect to off by default for the following reasons:
-        ## - Several users have reported a usability issue about automatic redirects. The way they express it is the
-        ##   following: "I have duplicates pages in my wiki. I don't understand why this is happening. I'm choosing to
-        ##   rename pages and not to copy them but I still get duplicates in the Navigation panel".
-        ## - Automatic redirects are especially useful for public wikis where users can have bookmark on pages and you
-        ##   don't want to break them. It can also be useful for internal wikis but it's less an issue.
-        ## - Even for public wikis not all pages need automatic redirects. Technical pages don't need them for example.
-        ## - We don't have management UIs for redirects FTM and reducing the number of redirects make the wiki easier
-        ##   to manage.
-        ## In the future we'll offer a config option to define the default behavior, see
-        ## http://jira.xwiki.org/browse/XWIKI-13384
-        #set ($checked = $request.autoRedirect == 'true')
-        <dt>
-          <label>
-            <input type="checkbox" name="autoRedirect" value="true" #if ($checked)checked="checked"#end />
-            $services.localization.render('core.rename.autoRedirect.label')
-          </label>
-          ## The value submitted when the checkbox is not checked, used to preserve the form state.
-          <input type="hidden" name="autoRedirect" value="false" />
-        </dt>
-        <dd>
-          <span class="xHint">$services.localization.render('core.rename.autoRedirect.hint')</span>
-        </dd>
+        #displayAutoRedirectCheckbox({
+          'label': 'core.rename.autoRedirect.label',
+          'hint': 'core.rename.autoRedirect.hint'
+        })
       </dl>
     </div>
     <div class="col-xs-12 col-lg-6">

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/DeletePageIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/DeletePageIT.java
@@ -654,7 +654,7 @@ class DeletePageIT
      * Check that when a new target document is selected, the backlinks are updated to the new value and the redirect is
      * working when accessing the old page.
      *
-     * @since 14.4.1
+     * @since 14.4.2
      * @since 14.5RC1
      */
     @Test
@@ -673,7 +673,7 @@ class DeletePageIT
         // Delete page and provide a new target, with updateLinks and autoRedirect enabled.
         ViewPage viewPage = testUtils.gotoPage(reference);
         DeletePageConfirmationPage confirmationPage = viewPage.deletePage();
-        confirmationPage.toggleBacklinksPanel();
+        confirmationPage.toggleBacklinksPane();
         confirmationPage.setNewBacklinkTarget(testUtils.serializeReference(newTargetReference));
         confirmationPage.setUpdateLinks(true);
         confirmationPage.setAutoRedirect(true);
@@ -692,7 +692,7 @@ class DeletePageIT
     /**
      * Check that if a new target is not selected, the backlinks are not altered and no redirect is added.
      *
-     * @since 14.4.1
+     * @since 14.4.2
      * @since 14.5RC1
      */
     @Test
@@ -726,7 +726,7 @@ class DeletePageIT
      * Test that when you delete a page and you select "affect children" along with a new target document, only the
      * parent page has the backlinks updated a the redirect added.
      *
-     * @since 14.4.1
+     * @since 14.4.2
      * @since 14.5RC1
      */
     @Test
@@ -750,7 +750,7 @@ class DeletePageIT
         ViewPage parentPage = testUtils.gotoPage(parentReference);
         DeletePageConfirmationPage confirmationPage = parentPage.deletePage();
         confirmationPage.setAffectChildren(true);
-        confirmationPage.toggleBacklinksPanel();
+        confirmationPage.toggleBacklinksPane();
         confirmationPage.setNewBacklinkTarget(testUtils.serializeReference(newTargetReference));
         confirmationPage.setUpdateLinks(true);
         confirmationPage.setAutoRedirect(true);

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/DeletePageIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/DeletePageIT.java
@@ -654,7 +654,8 @@ class DeletePageIT
      * Check that when a new target document is selected, the backlinks are updated to the new value and the redirect is
      * working when accessing the old page.
      *
-     * @since 14.4RC1
+     * @since 14.4.1
+     * @since 14.5RC1
      */
     @Test
     @Order(13)
@@ -672,18 +673,18 @@ class DeletePageIT
         // Delete page and provide a new target, with updateLinks and autoRedirect enabled.
         ViewPage viewPage = testUtils.gotoPage(reference);
         DeletePageConfirmationPage confirmationPage = viewPage.deletePage();
-        confirmationPage.getBacklinkPanelExpandButton().click();
-        confirmationPage.setNewTarget(testUtils.serializeReference(newTargetReference));
+        confirmationPage.toggleBacklinksPanel();
+        confirmationPage.setNewBacklinkTarget(testUtils.serializeReference(newTargetReference));
         confirmationPage.setUpdateLinks(true);
         confirmationPage.setAutoRedirect(true);
         confirmationPage.clickYes();
         DeletingPage deletingPage = new DeletingPage();
         deletingPage.waitUntilFinished();
+        assertEquals(DELETE_SUCCESSFUL, deletingPage.getInfoMessage());
 
         // Verify that a redirect was added and the link was updated.
         viewPage = testUtils.gotoPage(reference);
         assertEquals("New target", this.viewPage.getDocumentTitle());
-        assertEquals(DELETE_SUCCESSFUL, deletingPage.getInfoMessage());
         assertEquals("[[Link>>doc:NewTarget.WebHome]]",
             testUtils.rest().<Page>get(backlinkDocumentReference).getContent());
     }
@@ -691,7 +692,8 @@ class DeletePageIT
     /**
      * Check that if a new target is not selected, the backlinks are not altered and no redirect is added.
      *
-     * @since 14.4RC1
+     * @since 14.4.1
+     * @since 14.5RC1
      */
     @Test
     @Order(14)
@@ -724,7 +726,8 @@ class DeletePageIT
      * Test that when you delete a page and you select "affect children" along with a new target document, only the
      * parent page has the backlinks updated a the redirect added.
      *
-     * @since 14.4RC1
+     * @since 14.4.1
+     * @since 14.5RC1
      */
     @Test
     @Order(15)
@@ -747,8 +750,8 @@ class DeletePageIT
         ViewPage parentPage = testUtils.gotoPage(parentReference);
         DeletePageConfirmationPage confirmationPage = parentPage.deletePage();
         confirmationPage.setAffectChildren(true);
-        confirmationPage.getBacklinkPanelExpandButton().click();
-        confirmationPage.setNewTarget(testUtils.serializeReference(newTargetReference));
+        confirmationPage.toggleBacklinksPanel();
+        confirmationPage.setNewBacklinkTarget(testUtils.serializeReference(newTargetReference));
         confirmationPage.setUpdateLinks(true);
         confirmationPage.setAutoRedirect(true);
         confirmationPage.clickYes();

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-docker/src/test/it/org/xwiki/index/test/ui/docker/DeletedDocsIT.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-docker/src/test/it/org/xwiki/index/test/ui/docker/DeletedDocsIT.java
@@ -37,6 +37,7 @@ import org.xwiki.test.ui.po.ViewPage;
 /**
  * Tests for Deleted Pages tab from Page Index (XWiki.AllDocs).
  *
+ * @version $Id$
  * @since 14.4.2
  * @since 14.5RC1
  */

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-docker/src/test/it/org/xwiki/index/test/ui/docker/DeletedDocsIT.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-docker/src/test/it/org/xwiki/index/test/ui/docker/DeletedDocsIT.java
@@ -22,8 +22,6 @@ package org.xwiki.index.test.ui.docker;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Optional;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -37,13 +35,14 @@ import org.xwiki.test.ui.po.DeletingPage;
 import org.xwiki.test.ui.po.ViewPage;
 
 /**
- * Tests for Deleted Pages page.
+ * Tests for Deleted Pages tab from Page Index (XWiki.AllDocs).
  *
  * @version $Id$
- * @since 14.4RC1
+ * @since 14.4.1
+ * @since 14.5RC1
  */
 @UITest
-public class DeletedDocsIT
+class DeletedDocsIT
 {
     @BeforeEach
     void setUp(TestUtils setup)
@@ -53,7 +52,7 @@ public class DeletedDocsIT
 
     @Test
     @Order(1)
-    void restoreAfterDocumentWasReacreated(TestUtils testUtils, TestReference reference) throws Exception
+    void restoreOriginalDocumentAfterDeletionAndRecreation(TestUtils testUtils, TestReference reference)
     {
         // Delete and create a new version of a document.
         ViewPage viewPage = testUtils.createPage(reference, "original", "Original page");
@@ -66,10 +65,10 @@ public class DeletedDocsIT
 
         // Go to deleted pages and try to restore the original document.
         DeletedDocsPage deletedDocs = DeletedDocsPage.gotoPage();
-        Optional<RestoreDocumentConfirmationModal> confirmationModal =
+        RestoreDocumentConfirmationModal confirmationModal =
             deletedDocs.tryReplaceDoc(reference.toString().split(":")[1]);
-        assertTrue(confirmationModal.isPresent());
-        viewPage = confirmationModal.get().clickReplace();
+        assertTrue(confirmationModal.isDisplayed());
+        viewPage = confirmationModal.clickReplace();
 
         assertEquals("Original page", viewPage.getDocumentTitle());
         assertEquals("original", viewPage.getContent());

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-docker/src/test/it/org/xwiki/index/test/ui/docker/DeletedDocsIT.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-docker/src/test/it/org/xwiki/index/test/ui/docker/DeletedDocsIT.java
@@ -37,8 +37,7 @@ import org.xwiki.test.ui.po.ViewPage;
 /**
  * Tests for Deleted Pages tab from Page Index (XWiki.AllDocs).
  *
- * @version $Id$
- * @since 14.4.1
+ * @since 14.4.2
  * @since 14.5RC1
  */
 @UITest

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-docker/src/test/it/org/xwiki/index/test/ui/docker/DeletedDocsIT.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-docker/src/test/it/org/xwiki/index/test/ui/docker/DeletedDocsIT.java
@@ -1,0 +1,77 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.index.test.ui.docker;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.xwiki.index.test.po.DeletedDocsPage;
+import org.xwiki.index.test.po.RestoreDocumentConfirmationModal;
+import org.xwiki.test.docker.junit5.TestReference;
+import org.xwiki.test.docker.junit5.UITest;
+import org.xwiki.test.ui.TestUtils;
+import org.xwiki.test.ui.po.DeletePageConfirmationPage;
+import org.xwiki.test.ui.po.DeletingPage;
+import org.xwiki.test.ui.po.ViewPage;
+
+/**
+ * Tests for Deleted Pages page.
+ *
+ * @version $Id$
+ * @since 14.4RC1
+ */
+@UITest
+public class DeletedDocsIT
+{
+    @BeforeEach
+    void setUp(TestUtils setup)
+    {
+        setup.loginAsSuperAdmin();
+    }
+
+    @Test
+    @Order(1)
+    void restoreAfterDocumentWasReacreated(TestUtils testUtils, TestReference reference) throws Exception
+    {
+        // Delete and create a new version of a document.
+        ViewPage viewPage = testUtils.createPage(reference, "original", "Original page");
+        DeletePageConfirmationPage confirmationPage = viewPage.deletePage();
+        confirmationPage.clickYes();
+        DeletingPage deletingPage = new DeletingPage();
+        deletingPage.waitUntilFinished();
+        assertEquals("Done.", deletingPage.getInfoMessage());
+        testUtils.createPage(reference, "new", "New page");
+
+        // Go to deleted pages and try to restore the original document.
+        DeletedDocsPage deletedDocs = DeletedDocsPage.gotoPage();
+        Optional<RestoreDocumentConfirmationModal> confirmationModal =
+            deletedDocs.tryReplaceDoc(reference.toString().split(":")[1]);
+        assertTrue(confirmationModal.isPresent());
+        viewPage = confirmationModal.get().clickReplace();
+
+        assertEquals("Original page", viewPage.getDocumentTitle());
+        assertEquals("original", viewPage.getContent());
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-pageobjects/src/main/java/org/xwiki/index/test/po/DeletedDocsPage.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-pageobjects/src/main/java/org/xwiki/index/test/po/DeletedDocsPage.java
@@ -28,7 +28,7 @@ import org.xwiki.test.ui.po.ViewPage;
  * Represents the actions possible on the Deleted Pages page.
  *
  * @version $Id$
- * @since 14.4.1
+ * @since 14.4.2
  * @since 14.5RC1
  */
 public class DeletedDocsPage extends ViewPage

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-pageobjects/src/main/java/org/xwiki/index/test/po/DeletedDocsPage.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-pageobjects/src/main/java/org/xwiki/index/test/po/DeletedDocsPage.java
@@ -19,13 +19,9 @@
  */
 package org.xwiki.index.test.po;
 
-import java.util.Optional;
-
 import org.openqa.selenium.By;
-import org.openqa.selenium.TimeoutException;
-import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.xwiki.stability.Unstable;
 import org.xwiki.test.ui.po.LiveTableElement;
 import org.xwiki.test.ui.po.ViewPage;
 
@@ -33,37 +29,24 @@ import org.xwiki.test.ui.po.ViewPage;
  * Represents the actions possible on the Deleted Pages page.
  *
  * @version $Id$
- * @since 14.4RC1
+ * @since 14.4.1
+ * @since 14.5RC1
  */
+@Unstable
 public class DeletedDocsPage extends ViewPage
 {
     private LiveTableElement documentsTrashLivetable;
 
-    DeletedDocsPage()
+    public DeletedDocsPage()
     {
         this.documentsTrashLivetable = new LiveTableElement("documentsTrash");
-        waitForDeletedDocumentsLivetable();
+        this.documentsTrashLivetable.waitUntilReady();
     }
 
     public static DeletedDocsPage gotoPage()
     {
         getUtil().gotoPage("Main", "AllDocs", "view", "view=deletedDocs");
         return new DeletedDocsPage();
-    }
-
-    /**
-     * Wait for the deleted documents livetable to be ready.
-     */
-    public void waitForDeletedDocumentsLivetable()
-    {
-        getDriver().waitUntilCondition(new ExpectedCondition<Boolean>()
-        {
-            @Override
-            public Boolean apply(WebDriver driver)
-            {
-                return documentsTrashLivetable.isReady();
-            }
-        });
     }
 
     public int getRowIndexByDocName(String docName)
@@ -77,15 +60,10 @@ public class DeletedDocsPage extends ViewPage
             .findElement(By.className("replace"));
     }
 
-    public Optional<RestoreDocumentConfirmationModal> tryReplaceDoc(String docName)
+    public RestoreDocumentConfirmationModal tryReplaceDoc(String docName)
     {
-        try {
-            getReplaceAction(docName).click();
-            RestoreDocumentConfirmationModal restoreModal = new RestoreDocumentConfirmationModal();
-            return Optional.of(restoreModal);
-        } catch (TimeoutException e) {
-            return Optional.empty();
-        }
+        getReplaceAction(docName).click();
+        RestoreDocumentConfirmationModal restoreModal = new RestoreDocumentConfirmationModal();
+        return restoreModal;
     }
-
 }

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-pageobjects/src/main/java/org/xwiki/index/test/po/DeletedDocsPage.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-pageobjects/src/main/java/org/xwiki/index/test/po/DeletedDocsPage.java
@@ -21,7 +21,6 @@ package org.xwiki.index.test.po;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
-import org.xwiki.stability.Unstable;
 import org.xwiki.test.ui.po.LiveTableElement;
 import org.xwiki.test.ui.po.ViewPage;
 
@@ -32,7 +31,6 @@ import org.xwiki.test.ui.po.ViewPage;
  * @since 14.4.1
  * @since 14.5RC1
  */
-@Unstable
 public class DeletedDocsPage extends ViewPage
 {
     private LiveTableElement documentsTrashLivetable;

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-pageobjects/src/main/java/org/xwiki/index/test/po/DeletedDocsPage.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-pageobjects/src/main/java/org/xwiki/index/test/po/DeletedDocsPage.java
@@ -1,0 +1,91 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.index.test.po;
+
+import java.util.Optional;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.TimeoutException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.xwiki.test.ui.po.LiveTableElement;
+import org.xwiki.test.ui.po.ViewPage;
+
+/**
+ * Represents the actions possible on the Deleted Pages page.
+ *
+ * @version $Id$
+ * @since 14.4RC1
+ */
+public class DeletedDocsPage extends ViewPage
+{
+    private LiveTableElement documentsTrashLivetable;
+
+    DeletedDocsPage()
+    {
+        this.documentsTrashLivetable = new LiveTableElement("documentsTrash");
+        waitForDeletedDocumentsLivetable();
+    }
+
+    public static DeletedDocsPage gotoPage()
+    {
+        getUtil().gotoPage("Main", "AllDocs", "view", "view=deletedDocs");
+        return new DeletedDocsPage();
+    }
+
+    /**
+     * Wait for the deleted documents livetable to be ready.
+     */
+    public void waitForDeletedDocumentsLivetable()
+    {
+        getDriver().waitUntilCondition(new ExpectedCondition<Boolean>()
+        {
+            @Override
+            public Boolean apply(WebDriver driver)
+            {
+                return documentsTrashLivetable.isReady();
+            }
+        });
+    }
+
+    public int getRowIndexByDocName(String docName)
+    {
+        return this.documentsTrashLivetable.getRowNumberForElement(By.xpath("//a[text()='" + docName + "']"));
+    }
+
+    private WebElement getReplaceAction(String docName)
+    {
+        return this.documentsTrashLivetable.getCell(getRowIndexByDocName(docName), 6)
+            .findElement(By.className("replace"));
+    }
+
+    public Optional<RestoreDocumentConfirmationModal> tryReplaceDoc(String docName)
+    {
+        try {
+            getReplaceAction(docName).click();
+            RestoreDocumentConfirmationModal restoreModal = new RestoreDocumentConfirmationModal();
+            return Optional.of(restoreModal);
+        } catch (TimeoutException e) {
+            return Optional.empty();
+        }
+    }
+
+}

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-pageobjects/src/main/java/org/xwiki/index/test/po/RestoreDocumentConfirmationModal.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-pageobjects/src/main/java/org/xwiki/index/test/po/RestoreDocumentConfirmationModal.java
@@ -20,7 +20,6 @@
 package org.xwiki.index.test.po;
 
 import org.openqa.selenium.By;
-import org.xwiki.stability.Unstable;
 import org.xwiki.test.ui.po.ConfirmationModal;
 import org.xwiki.test.ui.po.ViewPage;
 
@@ -32,7 +31,6 @@ import org.xwiki.test.ui.po.ViewPage;
  * @since 14.4.1
  * @since 14.5RC1
  */
-@Unstable
 public class RestoreDocumentConfirmationModal extends ConfirmationModal
 {
     public RestoreDocumentConfirmationModal()

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-pageobjects/src/main/java/org/xwiki/index/test/po/RestoreDocumentConfirmationModal.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-pageobjects/src/main/java/org/xwiki/index/test/po/RestoreDocumentConfirmationModal.java
@@ -27,6 +27,7 @@ import org.xwiki.test.ui.po.ViewPage;
  * Represents the actions possible on the restore document confirmation modal. The modal is displayed on the Deleted
  * Pages tab from the Page Index when restoring a document after delete and recreation.
  *
+ * @version $Id$
  * @since 14.4.2
  * @since 14.5RC1
  */

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-pageobjects/src/main/java/org/xwiki/index/test/po/RestoreDocumentConfirmationModal.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-pageobjects/src/main/java/org/xwiki/index/test/po/RestoreDocumentConfirmationModal.java
@@ -1,0 +1,52 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.index.test.po;
+
+import org.openqa.selenium.By;
+import org.xwiki.test.ui.po.ConfirmationModal;
+import org.xwiki.test.ui.po.ViewPage;
+
+/**
+ * Represents the actions possible on the restore document confirmation modal.
+ *
+ * @version $Id$
+ * @since 14.4RC1
+ */
+public class RestoreDocumentConfirmationModal extends ConfirmationModal
+{
+    public RestoreDocumentConfirmationModal()
+    {
+        super(By.id("restoreDocumentConfirmModal"));
+        waitUntilReady();
+    }
+
+    private void waitUntilReady()
+    {
+        getDriver().waitUntilElementIsVisible(RestoreDocumentConfirmationModal.this.container,
+            By.cssSelector(".modal-footer .btn-danger"));
+    }
+
+    public ViewPage clickReplace()
+    {
+        getDriver().findElementWithoutWaiting(this.container,
+            By.cssSelector(".modal-footer .btn-primary, .modal-footer .btn-danger")).click();
+        return new ViewPage();
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-pageobjects/src/main/java/org/xwiki/index/test/po/RestoreDocumentConfirmationModal.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-pageobjects/src/main/java/org/xwiki/index/test/po/RestoreDocumentConfirmationModal.java
@@ -20,33 +20,31 @@
 package org.xwiki.index.test.po;
 
 import org.openqa.selenium.By;
+import org.xwiki.stability.Unstable;
 import org.xwiki.test.ui.po.ConfirmationModal;
 import org.xwiki.test.ui.po.ViewPage;
 
 /**
- * Represents the actions possible on the restore document confirmation modal.
+ * Represents the actions possible on the restore document confirmation modal. The modal is displayed on the Deleted
+ * Pages tab from the Page Index when restoring a document after delete and recreation.
  *
  * @version $Id$
- * @since 14.4RC1
+ * @since 14.4.1
+ * @since 14.5RC1
  */
+@Unstable
 public class RestoreDocumentConfirmationModal extends ConfirmationModal
 {
     public RestoreDocumentConfirmationModal()
     {
         super(By.id("restoreDocumentConfirmModal"));
-        waitUntilReady();
-    }
-
-    private void waitUntilReady()
-    {
-        getDriver().waitUntilElementIsVisible(RestoreDocumentConfirmationModal.this.container,
-            By.cssSelector(".modal-footer .btn-danger"));
     }
 
     public ViewPage clickReplace()
     {
         getDriver().findElementWithoutWaiting(this.container,
             By.cssSelector(".modal-footer .btn-primary, .modal-footer .btn-danger")).click();
+        getDriver().waitUntilPageIsReloaded();
         return new ViewPage();
     }
 }

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-pageobjects/src/main/java/org/xwiki/index/test/po/RestoreDocumentConfirmationModal.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-pageobjects/src/main/java/org/xwiki/index/test/po/RestoreDocumentConfirmationModal.java
@@ -27,8 +27,7 @@ import org.xwiki.test.ui.po.ViewPage;
  * Represents the actions possible on the restore document confirmation modal. The modal is displayed on the Deleted
  * Pages tab from the Page Index when restoring a document after delete and recreation.
  *
- * @version $Id$
- * @since 14.4.1
+ * @since 14.4.2
  * @since 14.5RC1
  */
 public class RestoreDocumentConfirmationModal extends ConfirmationModal
@@ -42,6 +41,7 @@ public class RestoreDocumentConfirmationModal extends ConfirmationModal
     {
         getDriver().findElementWithoutWaiting(this.container,
             By.cssSelector(".modal-footer .btn-primary, .modal-footer .btn-danger")).click();
+        // We need to wait for the deletion of the old page before the redirect to the restored one will occur.
         getDriver().waitUntilPageIsReloaded();
         return new ViewPage();
     }

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/XWiki/DeletedDocuments.xml
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/XWiki/DeletedDocuments.xml
@@ -36,7 +36,80 @@
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.0</syntaxId>
   <hidden>true</hidden>
-  <content>{{velocity}}##
+  <content>{{velocity}}
+#macro(showRestoreDocumentConfirmModal)
+  &lt;div class="modal" id="restoreDocumentConfirmModal" tabindex="-1" role="dialog"
+      aria-labelledby="restoreDocumentConfirmModal-label"&gt;
+    &lt;div class="modal-dialog" role="document"&gt;
+      &lt;div class="modal-content"&gt;
+        &lt;div class="modal-header"&gt;
+          &lt;button type="button" class="close" data-dismiss="modal" aria-label="Close"&gt;
+            &lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;
+          &lt;/button&gt;
+          &lt;div class="modal-title" id="restoreDocumentConfirmModal-label"&gt;
+            $escapetool.xml($services.localization.render('platform.index.trashDocumentsReplacePageTitle'))
+          &lt;/div&gt;
+        &lt;/div&gt;
+        &lt;div class="modal-body"&gt;
+          &lt;p&gt;
+            $escapetool.xml($services.localization.render('platform.index.trashDocumentsReplacePageText'))
+          &lt;/p&gt;
+        &lt;/div&gt;
+        &lt;div class="modal-footer"&gt;
+          &lt;button type="button" class="btn btn-default" data-dismiss="modal"&gt;
+            $escapetool.xml($services.localization.render('cancel'))
+          &lt;/button&gt;
+          &lt;button type="button" class="btn btn-danger" data-dismiss="modal"&gt;
+            $escapetool.xml($services.localization.render('platform.index.trashDocumentsActionsRestoreText'))
+          &lt;/button&gt;
+        &lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+#end
+#macro(deletedDocsActionsTemplate)
+&lt;div class='hidden'&gt;
+  &lt;div class='deleteDocsActionsRestoreTemplate'&gt;
+    &lt;a href="" class="action restore"
+        title="$services.localization.render('platform.index.trashDocumentsActionsRestoreTooltip')"&gt;
+      &lt;span class="action-icon"&gt;$services.icon.renderHTML('refresh')&lt;/span&gt;&lt;span
+        class="action-label"&gt;$escapetool.xml(
+        $services.localization.render('platform.index.trashDocumentsActionsRestoreText'))
+      &lt;/span&gt;
+    &lt;/a&gt;
+  &lt;/div&gt;
+  &lt;div class='deleteDocsActionsOrphanedTranslationTemplate'&gt;
+    &lt;a href="" class="action cannot-restore" title="$services.localization.render(
+        'platform.index.trashDocumentsActionsCannotRestoreCausesOrphanedTranslationTooltip')"&gt;
+      &lt;span class="action-icon"&gt;$services.icon.renderHTML('refresh')&lt;/span&gt;&lt;span
+        class="action-label"&gt;$escapetool.xml(
+        $services.localization.render('platform.index.trashDocumentsActionsCannotRestoreText'))
+      &lt;/span&gt;
+    &lt;/a&gt;
+  &lt;/div&gt;
+  &lt;div class='deleteDocsActionsReplaceTemplate'&gt;
+    &lt;a href="" class="action replace" data-toggle='modal' data-target='#restoreDocumentConfirmModal'
+        title="$services.localization.render('platform.index.trashDocumentsActionsReplaceTooltip')"&gt;
+      &lt;span class="action-icon"&gt;$services.icon.renderHTML('refresh')&lt;/span&gt;&lt;span
+        class="action-label"&gt;$escapetool.xml(
+        $services.localization.render('platform.index.trashDocumentsActionsReplaceText'))
+      &lt;/span&gt;
+    &lt;/a&gt;
+  &lt;/div&gt;
+  &lt;div class='deleteDocsActionsDeleteTemplate'&gt;
+    &lt;a href="" class="action actiondelete"
+        title="$services.localization.render('platform.index.trashDocumentsActionsDeleteTooltip')"&gt;
+      &lt;span class="action-icon"&gt;$services.icon.renderHTML('cross')&lt;/span&gt;&lt;span
+        class="action-label"&gt;$escapetool.xml(
+        $services.localization.render('platform.index.trashDocumentsActionsDeleteText'))
+      &lt;/span&gt;
+    &lt;/a&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+#end
+{{/velocity}}
+
+{{velocity}}##
 #set($dateFormat = 'yyyy MMMM d, HH:mm')
 $xwiki.ssx.use('XWiki.DeletedDocuments')##
 $xwiki.jsx.use('XWiki.DeletedDocuments')##
@@ -87,7 +160,9 @@ $xwiki.jsx.use('XWiki.DeletedDocuments')##
         &lt;/div&gt;
       &lt;/div&gt;
     &lt;/div&gt;
+#showRestoreDocumentConfirmModal()
 #livetable('documentsTrash' $columns $columnsProperties $options)
+#deletedDocsActionsTemplate()
 &lt;/div&gt;
 {{/html}}
 ##
@@ -282,40 +357,32 @@ XWiki.index.trash.documents.displayEntry = function (row, i, table) {
     if(row.canRestore) {
       if (row.causesOrphanedTranslation) {
         // Can not restore: It would cause the translation to be inaccessible from the UI until the main document is restored/created.
-        var restore = new Element('a', {
-            'href' : row.originalUrl,
-            'class' : 'tool cannot-restore',
-            'title' : "$services.localization.render('platform.index.trashDocumentsActionsCannotRestoreCausesOrphanedTranslationTooltip')"
-          }).update("$services.localization.render('platform.index.trashDocumentsActionsCannotRestoreText')");
-        actions.appendChild(restore);
+        var restore = document.getElementsByClassName('deleteDocsActionsOrphanedTranslationTemplate')[0]
+          .getElementsByTagName('a')[0].cloneNode(true);
+        restore.href = row.originalUrl;
+        actions.append(restore);
       } else {
         // Restore the document.
-        var restore = new Element('a', {
-            'href' : row.restoreUrl,
-            'class' : 'tool restore',
-            'title' : "$services.localization.render('platform.index.trashDocumentsActionsRestoreTooltip')"
-          }).update("$services.localization.render('platform.index.trashDocumentsActionsRestoreText')");
-        actions.appendChild(restore);
+        var restore = document.getElementsByClassName('deleteDocsActionsRestoreTemplate')[0]
+          .getElementsByTagName('a')[0].cloneNode(true);
+        restore.href = row.restoreUrl;
+        actions.append(restore);
       }
     }
   } else {
-    // Can not restore: A document was already restored at that location.
-    // TODO: Add an overwrite dialog here.
-    var restore = new Element('a', {
-        'href' : row.originalUrl,
-        'class' : "tool cannot-restore",
-        'title' : "$services.localization.render('platform.index.trashDocumentsActionsCannotRestoreTooltip')"
-      }).update("$services.localization.render('platform.index.trashDocumentsActionsCannotRestoreText')");
-    actions.appendChild(restore);
+    // Replace: A document was already restored at that location.
+    var replace = document.getElementsByClassName('deleteDocsActionsReplaceTemplate')[0]
+      .getElementsByTagName('a')[0].cloneNode(true);
+    replace.href = '#';
+    replace.setAttribute('data-deleteUrl', row.deleteExistingDocUrl);
+    replace.setAttribute('data-restoreUrl', row.restoreUrl);
+    actions.append(replace);
   }
   if(row.canDelete) {
-    var delete_ = new Element('a', {
-        'href' : row.deleteUrl,
-        'class' : "tool delete",
-        'title' : "$services.localization.render('platform.index.trashDocumentsActionsDeleteTooltip')"
-      }).update("$services.localization.render('platform.index.trashDocumentsActionsDeleteText')");
-    actions.appendChild(document.createTextNode(' '));
-    actions.appendChild(delete_);
+    var delete_ = document.getElementsByClassName('deleteDocsActionsDeleteTemplate')[0]
+      .getElementsByTagName('a')[0].cloneNode(true);
+    delete_.href = row.deleteUrl;
+    actions.append(delete_);
     delete_.observe('click', XWiki.index.trash.documents.confirmDelete.bindAsEventListener(delete_, table, i));
   }
   tr.appendChild(actions);
@@ -411,6 +478,28 @@ require(['jquery', 'xwiki-meta', 'xwiki-events-bridge'], function($, xm) {
     }
     $('#trashAllDeleted').toggleClass('disabled', trashDocumentsLivetable.totalRows &lt;= 0);
   };
+
+  // Restore a document which has been recreated at the original location.
+  var restoreDocumentConfirmModal = $('#restoreDocumentConfirmModal');
+  restoreDocumentConfirmModal.find('.btn-danger').on('click', function() {
+    var relatedTarget = restoreDocumentConfirmModal.data('relatedTarget');
+    $.post(relatedTarget.attr('data-deleteUrl'), {
+      'confirm': 1,
+      'form_token': xm.form_token,
+      'ajax': 1
+    }).then(() =&gt; {
+      window.location.replace(relatedTarget.attr('data-restoreUrl'));
+    }).catch(() =&gt; {
+      new XWiki.widgets.Notification(
+        $jsontool.serialize($services.localization.render('platform.index.trashDocumentsReplacePageFailed')),
+        'failed'
+      );
+    });
+  });
+
+  $(document).on('show.bs.modal', '#restoreDocumentConfirmModal', function(event) {
+    $(this).data('relatedTarget', $(event.relatedTarget));
+  });
 
   var displayLivetable = function () {
     $('#documentsTrash').parents('.hidden').removeClass('hidden');
@@ -536,23 +625,19 @@ require(['jquery', 'xwiki-meta', 'xwiki-events-bridge'], function($, xm) {
       <cache>long</cache>
     </property>
     <property>
-      <code>.itemActions .tool {
-  width: 16px;
-  height: 16px;
-  margin: 0 2px;
-  float: left;
-  text-indent: -1000em;
-  overflow: hidden;
-  background: transparent no-repeat center center;
+      <code>#template('colorThemeInit.vm')
+
+.itemActions .restore .action-icon{
+   color: $theme.notificationSuccessColor;
 }
-.itemActions .delete {
-  background-image: url("$xwiki.getSkinFile('icons/silk/cross.png')") !important;
+.itemActions .cannot-restore .action-icon {
+   color: $theme.notificationErrorColor;
 }
-.itemActions .restore {
-   background-image: url("$xwiki.getSkinFile('icons/silk/arrow_refresh.png')") !important;
+.itemActions .replace .action-icon {
+   color: $theme.notificationErrorColor;
 }
-.itemActions .cannot-restore {
-   background-image: url("$xwiki.getSkinFile('icons/silk/page_error.png')") !important;
+#restoreDocumentConfirmModal .btn-danger {
+  text-transform: capitalize;
 }</code>
     </property>
     <property>

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/XWiki/DeletedDocuments.xml
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/XWiki/DeletedDocuments.xml
@@ -36,14 +36,15 @@
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.0</syntaxId>
   <hidden>true</hidden>
-  <content>{{velocity}}
+  <content>{{velocity output="false"}}
 #macro(showRestoreDocumentConfirmModal)
   &lt;div class="modal" id="restoreDocumentConfirmModal" tabindex="-1" role="dialog"
       aria-labelledby="restoreDocumentConfirmModal-label"&gt;
     &lt;div class="modal-dialog" role="document"&gt;
       &lt;div class="modal-content"&gt;
         &lt;div class="modal-header"&gt;
-          &lt;button type="button" class="close" data-dismiss="modal" aria-label="Close"&gt;
+          &lt;button type="button" class="close" data-dismiss="modal" aria-label="$escapetool.xml(
+              $services.localization.render('core.viewers.share.cancel'))"&gt;
             &lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;
           &lt;/button&gt;
           &lt;div class="modal-title" id="restoreDocumentConfirmModal-label"&gt;
@@ -68,8 +69,8 @@
   &lt;/div&gt;
 #end
 #macro(deletedDocsActionsTemplate)
-&lt;div class='hidden'&gt;
-  &lt;div class='deleteDocsActionsRestoreTemplate'&gt;
+  &lt;div class="hidden deletedDocsActionsTemplate"&gt;
+    ## Restore document action template.
     &lt;a href="" class="action restore"
         title="$services.localization.render('platform.index.trashDocumentsActionsRestoreTooltip')"&gt;
       &lt;span class="action-icon"&gt;$services.icon.renderHTML('refresh')&lt;/span&gt;&lt;span
@@ -77,8 +78,7 @@
         $services.localization.render('platform.index.trashDocumentsActionsRestoreText'))
       &lt;/span&gt;
     &lt;/a&gt;
-  &lt;/div&gt;
-  &lt;div class='deleteDocsActionsOrphanedTranslationTemplate'&gt;
+    ## Orphaned translations: cannot restore action template.
     &lt;a href="" class="action cannot-restore" title="$services.localization.render(
         'platform.index.trashDocumentsActionsCannotRestoreCausesOrphanedTranslationTooltip')"&gt;
       &lt;span class="action-icon"&gt;$services.icon.renderHTML('refresh')&lt;/span&gt;&lt;span
@@ -86,8 +86,7 @@
         $services.localization.render('platform.index.trashDocumentsActionsCannotRestoreText'))
       &lt;/span&gt;
     &lt;/a&gt;
-  &lt;/div&gt;
-  &lt;div class='deleteDocsActionsReplaceTemplate'&gt;
+    ## Replace document action template.
     &lt;a href="" class="action replace" data-toggle='modal' data-target='#restoreDocumentConfirmModal'
         title="$services.localization.render('platform.index.trashDocumentsActionsReplaceTooltip')"&gt;
       &lt;span class="action-icon"&gt;$services.icon.renderHTML('refresh')&lt;/span&gt;&lt;span
@@ -95,8 +94,7 @@
         $services.localization.render('platform.index.trashDocumentsActionsReplaceText'))
       &lt;/span&gt;
     &lt;/a&gt;
-  &lt;/div&gt;
-  &lt;div class='deleteDocsActionsDeleteTemplate'&gt;
+    ## Delete document action template.
     &lt;a href="" class="action actiondelete"
         title="$services.localization.render('platform.index.trashDocumentsActionsDeleteTooltip')"&gt;
       &lt;span class="action-icon"&gt;$services.icon.renderHTML('cross')&lt;/span&gt;&lt;span
@@ -105,7 +103,6 @@
       &lt;/span&gt;
     &lt;/a&gt;
   &lt;/div&gt;
-&lt;/div&gt;
 #end
 {{/velocity}}
 
@@ -352,38 +349,35 @@ XWiki.index.trash.documents.displayEntry = function (row, i, table) {
   tr.appendChild(new Element('td').update(deleter));
   var batchId = new Element('a', {'href' : row.batchId_url}).update(row.batchId);
   tr.appendChild(new Element('td').update(batchId));
-  var actions = new Element('td', {'class' : 'itemActions'});
+  var actions = new Element('td', {'class' : 'actions'});
   if(!row.alreadyExists) {
     if(row.canRestore) {
       if (row.causesOrphanedTranslation) {
         // Can not restore: It would cause the translation to be inaccessible from the UI until the main document is restored/created.
-        var restore = document.getElementsByClassName('deleteDocsActionsOrphanedTranslationTemplate')[0]
-          .getElementsByTagName('a')[0].cloneNode(true);
+        var restore = document.querySelector('.deletedDocsActionsTemplate .cannot-restore').cloneNode(true);
         restore.href = row.originalUrl;
         actions.append(restore);
       } else {
         // Restore the document.
-        var restore = document.getElementsByClassName('deleteDocsActionsRestoreTemplate')[0]
-          .getElementsByTagName('a')[0].cloneNode(true);
+        var restore = document.querySelector('.deletedDocsActionsTemplate .restore').cloneNode(true);
         restore.href = row.restoreUrl;
         actions.append(restore);
       }
     }
   } else {
     // Replace: A document was already restored at that location.
-    var replace = document.getElementsByClassName('deleteDocsActionsReplaceTemplate')[0]
-      .getElementsByTagName('a')[0].cloneNode(true);
+    var replace = document.querySelector('.deletedDocsActionsTemplate .replace').cloneNode(true);
     replace.href = '#';
-    replace.setAttribute('data-deleteUrl', row.deleteExistingDocUrl);
-    replace.setAttribute('data-restoreUrl', row.restoreUrl);
+    var deletedDocRef = XWiki.Model.resolve(row.fullname, XWiki.EntityType.DOCUMENT);
+    replace.setAttribute('data-deleteurl', new XWiki.Document(deletedDocRef).getURL('delete'));
+    replace.setAttribute('data-restoreurl', row.restoreUrl);
     actions.append(replace);
   }
   if(row.canDelete) {
-    var delete_ = document.getElementsByClassName('deleteDocsActionsDeleteTemplate')[0]
-      .getElementsByTagName('a')[0].cloneNode(true);
-    delete_.href = row.deleteUrl;
-    actions.append(delete_);
-    delete_.observe('click', XWiki.index.trash.documents.confirmDelete.bindAsEventListener(delete_, table, i));
+    var deleteAction = document.querySelector('.deletedDocsActionsTemplate .actiondelete').cloneNode(true);
+    deleteAction.href = row.deleteUrl;
+    actions.append(deleteAction);
+    deleteAction.observe('click', XWiki.index.trash.documents.confirmDelete.bindAsEventListener(deleteAction, table, i));
   }
   tr.appendChild(actions);
   return tr;
@@ -483,12 +477,12 @@ require(['jquery', 'xwiki-meta', 'xwiki-events-bridge'], function($, xm) {
   var restoreDocumentConfirmModal = $('#restoreDocumentConfirmModal');
   restoreDocumentConfirmModal.find('.btn-danger').on('click', function() {
     var relatedTarget = restoreDocumentConfirmModal.data('relatedTarget');
-    $.post(relatedTarget.attr('data-deleteUrl'), {
+    $.post(relatedTarget.attr('data-deleteurl'), {
       'confirm': 1,
       'form_token': xm.form_token,
       'ajax': 1
     }).then(() =&gt; {
-      window.location.replace(relatedTarget.attr('data-restoreUrl'));
+      window.location.replace(relatedTarget.attr('data-restoreurl'));
     }).catch(() =&gt; {
       new XWiki.widgets.Notification(
         $jsontool.serialize($services.localization.render('platform.index.trashDocumentsReplacePageFailed')),
@@ -625,29 +619,29 @@ require(['jquery', 'xwiki-meta', 'xwiki-events-bridge'], function($, xm) {
       <cache>long</cache>
     </property>
     <property>
-      <code>#template('colorThemeInit.vm')
-
-.itemActions .restore .action-icon{
-   color: $theme.notificationSuccessColor;
-}
-.itemActions .cannot-restore .action-icon {
-   color: $theme.notificationErrorColor;
-}
-.itemActions .replace .action-icon {
-   color: $theme.notificationErrorColor;
+      <code>.actions {
+  .restore .action-icon {
+   color: @brand-success;
+  }
+  .cannot-restore .action-icon {
+     color: @brand-danger;
+  }
+  .replace .action-icon {
+     color: @brand-danger;
+  }
 }
 #restoreDocumentConfirmModal .btn-danger {
   text-transform: capitalize;
 }</code>
     </property>
     <property>
-      <contentType>CSS</contentType>
+      <contentType>LESS</contentType>
     </property>
     <property>
       <name/>
     </property>
     <property>
-      <parse>1</parse>
+      <parse>0</parse>
     </property>
     <property>
       <use>onDemand</use>

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/XWiki/DeletedDocuments.xml
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/XWiki/DeletedDocuments.xml
@@ -72,15 +72,15 @@
   &lt;div class="hidden deletedDocsActionsTemplate"&gt;
     ## Restore document action template.
     &lt;a href="" class="action restore"
-        title="$services.localization.render('platform.index.trashDocumentsActionsRestoreTooltip')"&gt;
+        title="$escapetool.xml($services.localization.render('platform.index.trashDocumentsActionsRestoreTooltip'))"&gt;
       &lt;span class="action-icon"&gt;$services.icon.renderHTML('refresh')&lt;/span&gt;&lt;span
         class="action-label"&gt;$escapetool.xml(
         $services.localization.render('platform.index.trashDocumentsActionsRestoreText'))
       &lt;/span&gt;
     &lt;/a&gt;
     ## Orphaned translations: cannot restore action template.
-    &lt;a href="" class="action cannot-restore" title="$services.localization.render(
-        'platform.index.trashDocumentsActionsCannotRestoreCausesOrphanedTranslationTooltip')"&gt;
+    &lt;a href="" class="action cannot-restore" title="$escapetool.xml($services.localization.render(
+        'platform.index.trashDocumentsActionsCannotRestoreCausesOrphanedTranslationTooltip'))"&gt;
       &lt;span class="action-icon"&gt;$services.icon.renderHTML('refresh')&lt;/span&gt;&lt;span
         class="action-label"&gt;$escapetool.xml(
         $services.localization.render('platform.index.trashDocumentsActionsCannotRestoreText'))
@@ -88,7 +88,7 @@
     &lt;/a&gt;
     ## Replace document action template.
     &lt;a href="" class="action replace" data-toggle='modal' data-target='#restoreDocumentConfirmModal'
-        title="$services.localization.render('platform.index.trashDocumentsActionsReplaceTooltip')"&gt;
+        title="$escapetool.xml($services.localization.render('platform.index.trashDocumentsActionsReplaceTooltip'))"&gt;
       &lt;span class="action-icon"&gt;$services.icon.renderHTML('refresh')&lt;/span&gt;&lt;span
         class="action-label"&gt;$escapetool.xml(
         $services.localization.render('platform.index.trashDocumentsActionsReplaceText'))
@@ -96,7 +96,7 @@
     &lt;/a&gt;
     ## Delete document action template.
     &lt;a href="" class="action actiondelete"
-        title="$services.localization.render('platform.index.trashDocumentsActionsDeleteTooltip')"&gt;
+        title="$escapetool.xml($services.localization.render('platform.index.trashDocumentsActionsDeleteTooltip'))"&gt;
       &lt;span class="action-icon"&gt;$services.icon.renderHTML('cross')&lt;/span&gt;&lt;span
         class="action-label"&gt;$escapetool.xml(
         $services.localization.render('platform.index.trashDocumentsActionsDeleteText'))

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/XWiki/DeletedDocumentsJSON.xml
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/XWiki/DeletedDocumentsJSON.xml
@@ -122,7 +122,6 @@ $response.setContentType('application/json')
      "canRestore" : #if($originalDocument)$ddoc.canUndelete()#{else}false#end,
      #set ($exists = $xwiki.exists($ddoc.documentReference))
      "alreadyExists" : ${exists},
-     "deleteExistingDocUrl": "$escapetool.javascript($xwiki.getURL($ddoc.documentReference, 'delete'))",
      ## If a document to be undeleted is a translation and the main document of that translation is not yet created or undeleted, restoring this translation 
      ## will leave it inaccessible from the UI, thus "orphaned", until the main document is created or undeleted.
      #set ($causesOrphanedTranslation = false)

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/XWiki/DeletedDocumentsJSON.xml
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/XWiki/DeletedDocumentsJSON.xml
@@ -122,6 +122,7 @@ $response.setContentType('application/json')
      "canRestore" : #if($originalDocument)$ddoc.canUndelete()#{else}false#end,
      #set ($exists = $xwiki.exists($ddoc.documentReference))
      "alreadyExists" : ${exists},
+     "deleteExistingDocUrl": "$escapetool.javascript($xwiki.getURL($ddoc.documentReference, 'delete'))",
      ## If a document to be undeleted is a translation and the main document of that translation is not yet created or undeleted, restoring this translation 
      ## will leave it inaccessible from the UI, thus "orphaned", until the main document is created or undeleted.
      #set ($causesOrphanedTranslation = false)

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/web/DeleteActionCompatibilityAspect.aj
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/web/DeleteActionCompatibilityAspect.aj
@@ -80,7 +80,7 @@ public privileged aspect DeleteActionCompatibilityAspect
      *            the entity is preferably deleted permanently
      * @return {@code true} if the user is redirected, {@code false} otherwise
      * @throws XWikiException if anything goes wrong during the document deletion
-     * @deprecated since 14.4.1, 14.5RC1, use {@link #deleteDocument(EntityReference, XWikiContext, boolean,
+     * @deprecated since 14.4.2, 14.5RC1, use {@link #deleteDocument(EntityReference, XWikiContext, boolean,
      *             DocumentReference, boolean, boolean)} instead
      * @since 12.8RC1
      */

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/web/DeleteActionCompatibilityAspect.aj
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/web/DeleteActionCompatibilityAspect.aj
@@ -34,8 +34,8 @@ import org.xwiki.stability.Unstable;
  */
 public privileged aspect DeleteActionCompatibilityAspect
 {
-    // This method, while previously {@code protected} is now {@code public} due of some technical limitations of
-    // AspectJ.
+    // deleteToRecycleBin and deleteDocument, while previously {@code protected} are now {@code public} due to some
+    // technical limitations of AspectJ.
     // See https://doanduyhai.wordpress.com/2011/12/12/advanced-aspectj-part-ii-inter-type-declaration/
     // "If their is one thing to remember from access modifier, it’s that their semantic applies with respect to the
     // declaring aspect, and not to the target."
@@ -59,5 +59,35 @@ public privileged aspect DeleteActionCompatibilityAspect
         throws XWikiException
     {
         return this.deleteDocument(entityReference, context, false, null, false, false);
+    }
+    
+    /**
+     * Create a job to delete an entity.
+     *
+     * An entity can either be deleted permanently or moved to the recycle bin.
+     * The preference of the user deleting the entity is stored in the {@code shouldSkipRecycleBin} parameter.
+     * When {@code shouldSkipRecycleBin} is {@code true} the entity is preferably permanently deleted.
+     * Otherwise, the entity is preferably moved to the recycle bin.
+     * Note that it only express a choice made by the user.
+     * If the user does not have the right to remove an entity permanently, the entity might still be saved in the
+     * recycle bin.
+     * If the wiki does not have access to a recycle bin, the entity might be permanently removed, regardless of the
+     * user's preferences.
+     *
+     * @param entityReference the entity to delete
+     * @param context the current context, used to access the user's request
+     * @param shouldSkipRecycleBin if {@code false} the entity is preferably sent to the recycle bin, if {@code true},
+     *            the entity is preferably deleted permanently
+     * @return {@code true} if the user is redirected, {@code false} otherwise
+     * @throws XWikiException if anything goes wrong during the document deletion
+     * @deprecated since 14.4.1, 14.5RC1, use {@link #deleteDocument(EntityReference, XWikiContext, boolean,
+     *             DocumentReference, boolean, boolean)} instead
+     * @since 12.8RC1
+     */
+    @Deprecated
+    public boolean DeleteAction.deleteDocument(EntityReference entityReference, XWikiContext context,
+        boolean shouldSkipRecycleBin) throws XWikiException
+    {
+    	return deleteDocument(entityReference, context, shouldSkipRecycleBin, null, false, false);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/web/DeleteActionCompatibilityAspect.aj
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/web/DeleteActionCompatibilityAspect.aj
@@ -58,6 +58,6 @@ public privileged aspect DeleteActionCompatibilityAspect
     public boolean DeleteAction.deleteToRecycleBin(EntityReference entityReference, XWikiContext context)
         throws XWikiException
     {
-        return this.deleteDocument(entityReference, context, false);
+        return this.deleteDocument(entityReference, context, false, null, false, false);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/DeleteAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/DeleteAction.java
@@ -324,7 +324,7 @@ public class DeleteAction extends XWikiAction
         RefactoringScriptService refactoring =
             (RefactoringScriptService) Utils.getComponent(ScriptService.class, "refactoring");
         DeleteRequest deleteRequest =
-            refactoring.getRequestFactory().createDeleteRequest(Arrays.asList(entityReference));
+            (DeleteRequest) refactoring.getRequestFactory().createDeleteRequest(Arrays.asList(entityReference));
         deleteRequest.setInteractive(isAsync(context.getRequest()));
         deleteRequest.setCheckAuthorRights(false);
         deleteRequest.setShouldSkipRecycleBin(shouldSkipRecycleBin);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/DeleteAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/DeleteAction.java
@@ -251,13 +251,6 @@ public class DeleteAction extends XWikiAction
             autoRedirect);
     }
 
-    protected boolean deleteDocument(EntityReference entityReference, XWikiContext context,
-        boolean shouldSkipRecycleBin) throws XWikiException
-    {
-        return deleteDocument(entityReference, context, shouldSkipRecycleBin,
-            getCurrentStringDocumentReferenceResolver().resolve(""), false, false);
-    }
-
     /**
      * Create a job to delete an entity.
      *

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/DeleteAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/DeleteAction.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
@@ -39,7 +40,6 @@ import org.xwiki.refactoring.job.PermanentlyDeleteRequest;
 import org.xwiki.refactoring.job.RefactoringJobs;
 import org.xwiki.refactoring.script.RefactoringScriptService;
 import org.xwiki.script.service.ScriptService;
-import org.xwiki.stability.Unstable;
 
 import com.xpn.xwiki.XWiki;
 import com.xpn.xwiki.XWikiContext;
@@ -69,7 +69,9 @@ public class DeleteAction extends XWikiAction
 
     protected static final String EMPTY_RECYCLE_BIN = "emptybin";
 
-    private DocumentReferenceResolver<String> currentReferenceDocumentReferenceResolver;
+    @Inject
+    @Named("current")
+    private DocumentReferenceResolver<String> currentStringDocumentReferenceResolver;
 
     private boolean isAsync(XWikiRequest request)
     {
@@ -164,7 +166,7 @@ public class DeleteAction extends XWikiAction
             // document is sent to the recycle bin.
             boolean shouldSkipRecycleBin =
                 Boolean.parseBoolean(request.getParameter(DeleteRequest.SHOULD_SKIP_RECYCLE_BIN));
-            DocumentReference newBacklinkTarget = getCurrentStringDocumentReferenceResolver()
+            DocumentReference newBacklinkTarget = currentStringDocumentReferenceResolver
                 .resolve(request.getParameter(DeleteRequest.NEW_BACKLINK_TARGET));
             boolean updateLinks = Boolean.parseBoolean(request.getParameter(DeleteRequest.UPDATE_LINKS));
             boolean autoRedirect = Boolean.parseBoolean(request.getParameter(DeleteRequest.AUTO_REDIRECT));
@@ -333,21 +335,5 @@ public class DeleteAction extends XWikiAction
         } catch (JobException e) {
             throw new XWikiException(String.format("Failed to schedule the delete job for [%s]", entityReference), e);
         }
-    }
-
-    /**
-     * @return the current document reference resolver to be used to resolve a string document into a
-     *         {@link org.xwiki.model.reference.DocumentReference}
-     * @since 14.4.1
-     * @since 14.5RC1
-     */
-    private DocumentReferenceResolver<String> getCurrentStringDocumentReferenceResolver()
-    {
-        if (this.currentReferenceDocumentReferenceResolver == null) {
-            this.currentReferenceDocumentReferenceResolver =
-                Utils.getComponent(DocumentReferenceResolver.TYPE_STRING, "current");
-        }
-
-        return this.currentReferenceDocumentReferenceResolver;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/DeleteAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/DeleteAction.java
@@ -166,8 +166,8 @@ public class DeleteAction extends XWikiAction
             // document is sent to the recycle bin.
             boolean shouldSkipRecycleBin =
                 Boolean.parseBoolean(request.getParameter(DeleteRequest.SHOULD_SKIP_RECYCLE_BIN));
-            DocumentReference newBacklinkTarget = currentStringDocumentReferenceResolver
-                .resolve(request.getParameter(DeleteRequest.NEW_BACKLINK_TARGET));
+            DocumentReference newBacklinkTarget =
+                currentStringDocumentReferenceResolver.resolve(request.getParameter("newBacklinkTarget"));
             boolean updateLinks = Boolean.parseBoolean(request.getParameter(DeleteRequest.UPDATE_LINKS));
             boolean autoRedirect = Boolean.parseBoolean(request.getParameter(DeleteRequest.AUTO_REDIRECT));
             return deleteDocument(context, shouldSkipRecycleBin, newBacklinkTarget, updateLinks, autoRedirect);
@@ -325,7 +325,8 @@ public class DeleteAction extends XWikiAction
         deleteRequest.setInteractive(isAsync(context.getRequest()));
         deleteRequest.setCheckAuthorRights(false);
         deleteRequest.setShouldSkipRecycleBin(shouldSkipRecycleBin);
-        deleteRequest.setNewBacklinkTarget(newBacklinkTarget);
+        deleteRequest.setNewBacklinkTargets(Collections.singletonMap(context.getDoc().getDocumentReference(),
+            newBacklinkTarget));
         deleteRequest.setUpdateLinks(updateLinks);
         deleteRequest.setAutoRedirect(autoRedirect);
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/DeleteSpaceAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/DeleteSpaceAction.java
@@ -41,7 +41,8 @@ public class DeleteSpaceAction extends DeleteAction
     @Override
     protected boolean delete(XWikiContext context) throws XWikiException
     {
-        return deleteDocument(context.getDoc().getDocumentReference().getLastSpaceReference(), context, false);
+        return deleteDocument(context.getDoc().getDocumentReference().getLastSpaceReference(), context, false, null,
+            false, false);
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -1491,10 +1491,10 @@ core.delete.affectChildren=Affect children
 core.delete.autoRedirect.hint=Redirect the user to the new page when accessing the old page. Select this option if you don't want to break external links to the deleted page.
 core.delete.autoRedirect.label=Create an automatic redirect
 core.delete.backlinks=Backlinks
-core.delete.updateLinks.hint=Update the target of {0}{1} {1,choice,0#incoming links|1#incoming link|1<incoming links}{2} to this page
+core.delete.updateLinks.hint=Update the target of {0}{1} {1,choice,0#incoming links|1#incoming link|1<incoming links}{2} to this page.
 core.delete.updateLinks.label=Update links
-core.delete.target.hint=Select an existing page as the new target. Leave empty for no action.
-core.delete.target.label=New target
+core.delete.backlinkTarget.hint=Select an existing page as the new target. Leave empty for no action.
+core.delete.backlinkTarget.label=New target
 
 ### Restoring a page
 core.restore.title=Restore {0}
@@ -5515,6 +5515,11 @@ xe.admin.forgotUsername.error.noAccount=No account is registered using this emai
 ## until 12.10.9, 13.6RC1, 13.4.1
 #######################################
 xe.admin.passwordReset.emailSent=An e-mail was sent to {0}. Please follow the instructions in that e-mail to complete the password reset procedure.
+
+#######################################
+## until 14.4.1, 14.5RC1
+#######################################
+core.delete.backlinksWarning=The following pages contain links to the current page:{0}After deleting this page, those links will point to an empty page.
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -5517,7 +5517,7 @@ xe.admin.forgotUsername.error.noAccount=No account is registered using this emai
 xe.admin.passwordReset.emailSent=An e-mail was sent to {0}. Please follow the instructions in that e-mail to complete the password reset procedure.
 
 #######################################
-## until 14.4.1, 14.5RC1
+## until 14.4.2, 14.5RC1
 #######################################
 core.delete.backlinksWarning=The following pages contain links to the current page:{0}After deleting this page, those links will point to an empty page.
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -1468,7 +1468,7 @@ activitystream.event.deleteComment.rss.body=A comment has been deleted from the 
 ### Deleting a page
 core.delete=Delete
 core.delete.title=Delete {0}
-core.delete.backlinksWarning=The following pages contain links to the current page:{0}After deleting this page, those links will point to an empty page.
+core.delete.backlinksInfo=After deleting this page, the {0,choice,0#incoming links|1#incoming link|1<incoming links} will point to an empty page. To avoid this, you can select a new target.
 core.delete.orphansWarning=The following pages have this page specified as a parent:{0}After deleting this page, they will become orphaned.
 core.delete.confirm=The deletion of a page is not reversible. Are you sure you wish to continue?
 core.delete.confirmWithInlinks=In addition, the deletion of a page is not reversible. Are you sure you wish to continue?
@@ -1488,7 +1488,13 @@ core.delete.warningExtensions.canceling=Canceling the delete action
 core.delete.warningExtensions.canceled=Delete action canceled
 core.delete.warningExtensions.timeout=The action has been canceled because we have not received any answer after 5 minutes.
 core.delete.affectChildren=Affect children
+core.delete.autoRedirect.hint=Redirect the user to the new page when accessing the old page. Select this option if you don't want to break external links to the deleted page.
+core.delete.autoRedirect.label=Create an automatic redirect
 core.delete.backlinks=Backlinks
+core.delete.updateLinks.hint=Update the target of {0}{1} {1,choice,0#incoming links|1#incoming link|1<incoming links}{2} to this page
+core.delete.updateLinks.label=Update links
+core.delete.target.hint=Select an existing page as the new target. Leave empty for no action.
+core.delete.target.label=New target
 
 ### Restoring a page
 core.restore.title=Restore {0}
@@ -2934,12 +2940,13 @@ platform.index.trashDocuments.ddoc.batchId=Deleted Batch ID
 platform.index.trashDocuments.actions=Actions
 
 platform.index.trashDocumentsActionsRestoreTooltip=Restore page
-platform.index.trashDocumentsActionsRestoreText=[restore]
+platform.index.trashDocumentsActionsRestoreText=restore
+platform.index.trashDocumentsActionsReplaceText=replace
 platform.index.trashDocumentsActionsCannotRestoreTooltip=The page cannot be restored to its original location because it has been recreated.
 platform.index.trashDocumentsActionsCannotRestoreText=[cannot restore]
 platform.index.trashDocumentsActionsCannotRestoreCausesOrphanedTranslationTooltip=The translation can not be restored to its original location before its original page is restored or re-created.
 platform.index.trashDocumentsActionsDeleteTooltip=Permanently delete page
-platform.index.trashDocumentsActionsDeleteText=[delete]
+platform.index.trashDocumentsActionsDeleteText=delete
 platform.index.trashDocumentsDeleteInProgress=Permanently deleting page...
 platform.index.trashDocumentsDeleteDone=Page permanently deleted
 platform.index.trashDocumentsDeleteFailed=Failed to delete:

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -2941,9 +2941,10 @@ platform.index.trashDocuments.actions=Actions
 
 platform.index.trashDocumentsActionsRestoreTooltip=Restore page
 platform.index.trashDocumentsActionsRestoreText=restore
+platform.index.trashDocumentsActionsReplaceTooltip=Replace the page that has been created at the original location
 platform.index.trashDocumentsActionsReplaceText=replace
 platform.index.trashDocumentsActionsCannotRestoreTooltip=The page cannot be restored to its original location because it has been recreated.
-platform.index.trashDocumentsActionsCannotRestoreText=[cannot restore]
+platform.index.trashDocumentsActionsCannotRestoreText=cannot restore
 platform.index.trashDocumentsActionsCannotRestoreCausesOrphanedTranslationTooltip=The translation can not be restored to its original location before its original page is restored or re-created.
 platform.index.trashDocumentsActionsDeleteTooltip=Permanently delete page
 platform.index.trashDocumentsActionsDeleteText=delete
@@ -2951,6 +2952,9 @@ platform.index.trashDocumentsDeleteInProgress=Permanently deleting page...
 platform.index.trashDocumentsDeleteDone=Page permanently deleted
 platform.index.trashDocumentsDeleteFailed=Failed to delete:
 platform.index.trashDocumentsDeleteInformation=Deleted by {0} on {1}
+platform.index.trashDocumentsReplacePageFailed=Failed to replace
+platform.index.trashDocumentsReplacePageText=The deleted page was recreated, possibly for adding a redirect to another document. Are you sure you want to replace it with the old page?
+platform.index.trashDocumentsReplacePageTitle=Replace existing page
 
 platform.index.attachmentsTrash=Deleted Attachments
 platform.index.trashAttachmentsEmpty=No deleted attachments

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/DeleteJob.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/DeleteJob.java
@@ -147,4 +147,14 @@ public class DeleteJob extends AbstractEntityJobWithChecks<EntityRequest, Entity
             this.logger.debug("[{}] has been successfully deleted.", documentReference);
         }
     }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * @see org.xwiki.refactoring.internal.job.AbstractEntityJob#getCommonParent()
+     */
+    public EntityReference getCommonParent()
+    {
+        return getCommonParent(this.request.getEntityReferences());
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/DeleteJob.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/DeleteJob.java
@@ -147,14 +147,4 @@ public class DeleteJob extends AbstractEntityJobWithChecks<EntityRequest, Entity
             this.logger.debug("[{}] has been successfully deleted.", documentReference);
         }
     }
-
-    /**
-     * {@inheritDoc}
-     * 
-     * @see org.xwiki.refactoring.internal.job.AbstractEntityJob#getCommonParent()
-     */
-    public EntityReference getCommonParent()
-    {
-        return getCommonParent(this.request.getEntityReferences());
-    }
 }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/listener/AutomaticRedirectCreatorListener.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/listener/AutomaticRedirectCreatorListener.java
@@ -24,15 +24,23 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.slf4j.Logger;
+import org.xwiki.bridge.event.DocumentDeletedEvent;
 import org.xwiki.component.annotation.Component;
-import org.xwiki.observation.event.AbstractLocalEventListener;
+import org.xwiki.job.JobContext;
+import org.xwiki.model.EntityType;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.EntityReference;
+import org.xwiki.model.reference.SpaceReference;
+import org.xwiki.observation.event.AbstractEventListener;
 import org.xwiki.observation.event.Event;
 import org.xwiki.refactoring.event.DocumentRenamedEvent;
 import org.xwiki.refactoring.internal.ModelBridge;
+import org.xwiki.refactoring.internal.job.DeleteJob;
+import org.xwiki.refactoring.job.DeleteRequest;
 import org.xwiki.refactoring.job.MoveRequest;
 
 /**
- * Creates an automatic redirect from the old location to the new location after a document has been renamed.
+ * Creates an automatic redirect from the old location to the new location after a document has been renamed or deleted.
  * 
  * @version $Id$
  * @since 11.1RC1
@@ -47,33 +55,63 @@ public class AutomaticRedirectCreatorListener extends AbstractLocalEventListener
      */
     public static final String NAME = "refactoring.automaticRedirectCreator";
 
+    private static final String CREATING_AUTOMATIC_REDIRECT_FROM_TO = "Creating automatic redirect from [{}] to [{}].";
+
     @Inject
     private Logger logger;
 
     @Inject
     private ModelBridge modelBridge;
 
+    @Inject
+    private JobContext jobContext;
+
     /**
      * Default constructor.
      */
     public AutomaticRedirectCreatorListener()
     {
-        super(NAME, new DocumentRenamedEvent());
+        super(NAME, new DocumentRenamedEvent(), new DocumentDeletedEvent());
     }
 
     @Override
     public void processLocalEvent(Event event, Object source, Object data)
     {
-        boolean autoRedirect = true;
-        if (data instanceof MoveRequest) {
-            autoRedirect = ((MoveRequest) data).isAutoRedirect();
+        if (event instanceof DocumentRenamedEvent) {
+            boolean autoRedirect = true;
+            if (data instanceof MoveRequest) {
+                autoRedirect = ((MoveRequest) data).isAutoRedirect();
+            }
+            if (autoRedirect) {
+                DocumentRenamedEvent documentRenamedEvent = (DocumentRenamedEvent) event;
+                this.logger.info(CREATING_AUTOMATIC_REDIRECT_FROM_TO, documentRenamedEvent.getSourceReference(),
+                    documentRenamedEvent.getTargetReference());
+                this.modelBridge.createRedirect(documentRenamedEvent.getSourceReference(),
+                    documentRenamedEvent.getTargetReference());
+            }
+        } else if (event instanceof DocumentDeletedEvent && this.jobContext.getCurrentJob() instanceof DeleteJob) {
+            DeleteJob job = (DeleteJob) this.jobContext.getCurrentJob();
+            DeleteRequest request = (DeleteRequest) job.getRequest();
+            DocumentDeletedEvent documentDeletedEvent = (DocumentDeletedEvent) event;
+
+            // For case when the delete affects also the child pages, only the root document should have a redirect
+            // created.
+            if (request.isAutoRedirect()
+                && isRootDoc(job.getCommonParent(), documentDeletedEvent.getSourceReference())) {
+                this.logger.info(CREATING_AUTOMATIC_REDIRECT_FROM_TO, documentDeletedEvent.getSourceReference(),
+                    request.getNewTarget());
+                this.modelBridge.createRedirect(documentDeletedEvent.getSourceReference(), request.getNewTarget());
+            }
         }
-        if (autoRedirect) {
-            DocumentRenamedEvent documentRenamedEvent = (DocumentRenamedEvent) event;
-            this.logger.info("Creating automatic redirect from [{}] to [{}].",
-                documentRenamedEvent.getSourceReference(), documentRenamedEvent.getTargetReference());
-            this.modelBridge.createRedirect(documentRenamedEvent.getSourceReference(),
-                documentRenamedEvent.getTargetReference());
+    }
+
+    private boolean isRootDoc(EntityReference commonParent, DocumentReference deletedDocReference)
+    {
+        if (commonParent.getType() == EntityType.SPACE) {
+            DocumentReference spaceWebHomeReference =
+                new DocumentReference("WebHome", new SpaceReference(commonParent));
+            return spaceWebHomeReference.equals(deletedDocReference);
         }
+        return true;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/listener/AutomaticRedirectCreatorListener.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/listener/AutomaticRedirectCreatorListener.java
@@ -97,10 +97,11 @@ public class AutomaticRedirectCreatorListener extends AbstractLocalEventListener
             // For case when the delete affects also the child pages, only the root document should have a redirect
             // created.
             if (request.isAutoRedirect()
-                && isRootDoc(job.getCommonParent(), documentDeletedEvent.getSourceReference())) {
-                this.logger.info(CREATING_AUTOMATIC_REDIRECT_FROM_TO, documentDeletedEvent.getSourceReference(),
-                    request.getNewTarget());
-                this.modelBridge.createRedirect(documentDeletedEvent.getSourceReference(), request.getNewTarget());
+                && isRootDoc(job.getCommonParent(), documentDeletedEvent.getDocumentReference())) {
+                this.logger.info(CREATING_AUTOMATIC_REDIRECT_FROM_TO, documentDeletedEvent.getDocumentReference(),
+                    request.getNewBacklinkTarget());
+                this.modelBridge.createRedirect(documentDeletedEvent.getDocumentReference(),
+                    request.getNewBacklinkTarget());
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/listener/BackLinkUpdaterListener.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/listener/BackLinkUpdaterListener.java
@@ -114,8 +114,8 @@ public class BackLinkUpdaterListener extends AbstractLocalEventListener
         DocumentDeletedEvent deletedEvent = (DocumentDeletedEvent) event;
 
         // In case the delete affected the child pages too, only the root document should have the links updated.
-        if (request.isUpdateLinks() && isRootDoc(job.getCommonParent(), deletedEvent.getSourceReference())) {
-            updateBackLinks(deletedEvent.getSourceReference(), request.getNewTarget(), canEdit,
+        if (request.isUpdateLinks() && isRootDoc(job.getCommonParent(), deletedEvent.getDocumentReference())) {
+            updateBackLinks(deletedEvent.getDocumentReference(), request.getNewBacklinkTarget(), canEdit,
                 request.isUpdateLinksOnFarm());
         }
     }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/listener/BackLinkUpdaterListener.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/listener/BackLinkUpdaterListener.java
@@ -33,11 +33,9 @@ import org.xwiki.bridge.event.DocumentDeletedEvent;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.job.JobContext;
 import org.xwiki.job.event.status.JobProgressManager;
-import org.xwiki.model.EntityType;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
-import org.xwiki.model.reference.SpaceReference;
-import org.xwiki.observation.event.AbstractEventListener;
+import org.xwiki.observation.event.AbstractLocalEventListener;
 import org.xwiki.observation.event.Event;
 import org.xwiki.refactoring.event.DocumentRenamedEvent;
 import org.xwiki.refactoring.internal.LinkRefactoring;
@@ -113,21 +111,10 @@ public class BackLinkUpdaterListener extends AbstractLocalEventListener
         Predicate<EntityReference> canEdit = entityReference -> (job.hasAccess(Right.EDIT, entityReference));
         DocumentDeletedEvent deletedEvent = (DocumentDeletedEvent) event;
 
-        // In case the delete affected the child pages too, only the root document should have the links updated.
-        if (request.isUpdateLinks() && isRootDoc(job.getCommonParent(), deletedEvent.getDocumentReference())) {
-            updateBackLinks(deletedEvent.getDocumentReference(), request.getNewBacklinkTarget(), canEdit,
-                request.isUpdateLinksOnFarm());
+        DocumentReference newTarget = request.getNewBacklinkTargets().get(deletedEvent.getDocumentReference());
+        if (request.isUpdateLinks() && newTarget != null) {
+            updateBackLinks(deletedEvent.getDocumentReference(), newTarget, canEdit, request.isUpdateLinksOnFarm());
         }
-    }
-
-    private boolean isRootDoc(EntityReference commonParent, DocumentReference deletedDocReference)
-    {
-        if (commonParent.getType() == EntityType.SPACE) {
-            DocumentReference spaceWebHomeReference =
-                new DocumentReference("WebHome", new SpaceReference(commonParent));
-            return spaceWebHomeReference.equals(deletedDocReference);
-        }
-        return true;
     }
 
     private void maybeUpdateLinksAfterRename(Event event, Object source, Object data)

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/listener/BackLinkUpdaterListener.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/listener/BackLinkUpdaterListener.java
@@ -29,16 +29,22 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.slf4j.Logger;
+import org.xwiki.bridge.event.DocumentDeletedEvent;
 import org.xwiki.component.annotation.Component;
+import org.xwiki.job.JobContext;
 import org.xwiki.job.event.status.JobProgressManager;
+import org.xwiki.model.EntityType;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
-import org.xwiki.observation.event.AbstractLocalEventListener;
+import org.xwiki.model.reference.SpaceReference;
+import org.xwiki.observation.event.AbstractEventListener;
 import org.xwiki.observation.event.Event;
 import org.xwiki.refactoring.event.DocumentRenamedEvent;
 import org.xwiki.refactoring.internal.LinkRefactoring;
 import org.xwiki.refactoring.internal.ModelBridge;
+import org.xwiki.refactoring.internal.job.DeleteJob;
 import org.xwiki.refactoring.internal.job.MoveJob;
+import org.xwiki.refactoring.job.DeleteRequest;
 import org.xwiki.refactoring.job.MoveRequest;
 import org.xwiki.security.authorization.ContextualAuthorizationManager;
 import org.xwiki.security.authorization.Right;
@@ -46,7 +52,7 @@ import org.xwiki.wiki.descriptor.WikiDescriptorManager;
 import org.xwiki.wiki.manager.WikiManagerException;
 
 /**
- * Updates the back-links after a document has been renamed.
+ * Updates the back-links after a document has been renamed or deleted.
  * 
  * @version $Id$
  * @since 11.1RC1
@@ -79,16 +85,52 @@ public class BackLinkUpdaterListener extends AbstractLocalEventListener
     @Inject
     private JobProgressManager progressManager;
 
+    @Inject
+    private JobContext jobContext;
+
     /**
      * Default constructor.
      */
     public BackLinkUpdaterListener()
     {
-        super(NAME, new DocumentRenamedEvent());
+        super(NAME, new DocumentRenamedEvent(), new DocumentDeletedEvent());
     }
 
     @Override
     public void processLocalEvent(Event event, Object source, Object data)
+    {
+        if (event instanceof DocumentRenamedEvent) {
+            maybeUpdateLinksAfterRename(event, source, data);
+        } else if (event instanceof DocumentDeletedEvent && this.jobContext.getCurrentJob() instanceof DeleteJob) {
+            maybeUpdateLinksAfterDelete(event);
+        }
+    }
+
+    private void maybeUpdateLinksAfterDelete(Event event)
+    {
+        DeleteJob job = (DeleteJob) this.jobContext.getCurrentJob();
+        DeleteRequest request = (DeleteRequest) job.getRequest();
+        Predicate<EntityReference> canEdit = entityReference -> (job.hasAccess(Right.EDIT, entityReference));
+        DocumentDeletedEvent deletedEvent = (DocumentDeletedEvent) event;
+
+        // In case the delete affected the child pages too, only the root document should have the links updated.
+        if (request.isUpdateLinks() && isRootDoc(job.getCommonParent(), deletedEvent.getSourceReference())) {
+            updateBackLinks(deletedEvent.getSourceReference(), request.getNewTarget(), canEdit,
+                request.isUpdateLinksOnFarm());
+        }
+    }
+
+    private boolean isRootDoc(EntityReference commonParent, DocumentReference deletedDocReference)
+    {
+        if (commonParent.getType() == EntityType.SPACE) {
+            DocumentReference spaceWebHomeReference =
+                new DocumentReference("WebHome", new SpaceReference(commonParent));
+            return spaceWebHomeReference.equals(deletedDocReference);
+        }
+        return true;
+    }
+
+    private void maybeUpdateLinksAfterRename(Event event, Object source, Object data)
     {
         boolean updateLinks = true;
         boolean updateLinksOnFarm = true;
@@ -104,14 +146,16 @@ public class BackLinkUpdaterListener extends AbstractLocalEventListener
         }
 
         if (updateLinks) {
-            updateBackLinks((DocumentRenamedEvent) event, canEdit, updateLinksOnFarm);
+            DocumentRenamedEvent renameEvent = (DocumentRenamedEvent) event;
+            updateBackLinks(renameEvent.getSourceReference(), renameEvent.getTargetReference(), canEdit,
+                updateLinksOnFarm);
         }
     }
 
-    private void updateBackLinks(DocumentRenamedEvent event, Predicate<EntityReference> canEdit,
+    private void updateBackLinks(DocumentReference source, DocumentReference target, Predicate<EntityReference> canEdit,
         boolean updateLinksOnFarm)
     {
-        Collection<String> wikiIds = Collections.singleton(event.getSourceReference().getWikiReference().getName());
+        Collection<String> wikiIds = Collections.singleton(source.getWikiReference().getName());
         if (updateLinksOnFarm) {
             try {
                 wikiIds = this.wikiDescriptorManager.getAllIds();
@@ -126,7 +170,7 @@ public class BackLinkUpdaterListener extends AbstractLocalEventListener
             try {
                 for (String wikiId : wikiIds) {
                     this.progressManager.startStep(this);
-                    updateBackLinks(event, canEdit, wikiId);
+                    updateBackLinks(source, target, canEdit, wikiId);
                     this.progressManager.endStep(this);
                 }
             } finally {
@@ -135,11 +179,11 @@ public class BackLinkUpdaterListener extends AbstractLocalEventListener
         }
     }
 
-    private void updateBackLinks(DocumentRenamedEvent event, Predicate<EntityReference> canEdit, String wikiId)
+    private void updateBackLinks(DocumentReference source, DocumentReference target, Predicate<EntityReference> canEdit,
+        String wikiId)
     {
-        this.logger.info("Updating the back-links for document [{}] in wiki [{}].", event.getSourceReference(), wikiId);
-        List<DocumentReference> backlinkDocumentReferences =
-            this.modelBridge.getBackLinkedReferences(event.getSourceReference(), wikiId);
+        this.logger.info("Updating the back-links for document [{}] in wiki [{}].", source, wikiId);
+        List<DocumentReference> backlinkDocumentReferences = this.modelBridge.getBackLinkedReferences(source, wikiId);
 
         this.progressManager.pushLevelProgress(backlinkDocumentReferences.size(), this);
 
@@ -147,8 +191,7 @@ public class BackLinkUpdaterListener extends AbstractLocalEventListener
             for (DocumentReference backlinkDocumentReference : backlinkDocumentReferences) {
                 this.progressManager.startStep(this);
                 if (canEdit.test(backlinkDocumentReference)) {
-                    this.linkRefactoring.renameLinks(backlinkDocumentReference, event.getSourceReference(),
-                        event.getTargetReference());
+                    this.linkRefactoring.renameLinks(backlinkDocumentReference, source, target);
                 }
                 this.progressManager.endStep(this);
             }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/script/DefaultRequestFactory.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/script/DefaultRequestFactory.java
@@ -42,6 +42,7 @@ import org.xwiki.model.reference.EntityReference;
 import org.xwiki.model.reference.WikiReference;
 import org.xwiki.refactoring.job.CopyRequest;
 import org.xwiki.refactoring.job.CreateRequest;
+import org.xwiki.refactoring.job.DeleteRequest;
 import org.xwiki.refactoring.job.EntityRequest;
 import org.xwiki.refactoring.job.MoveRequest;
 import org.xwiki.refactoring.job.PermanentlyDeleteRequest;
@@ -170,7 +171,7 @@ public class DefaultRequestFactory implements RequestFactory
     @Override
     public EntityRequest createDeleteRequest(Collection<EntityReference> entityReferences)
     {
-        EntityRequest request = new EntityRequest();
+        DeleteRequest request = new DeleteRequest();
         initEntityRequest(request, RefactoringJobs.DELETE, entityReferences);
         return request;
     }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/job/DeleteRequest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/job/DeleteRequest.java
@@ -1,0 +1,162 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.refactoring.job;
+
+import org.xwiki.model.reference.DocumentReference;
+
+/**
+ * Job request for deleting a page.
+ * 
+ * @version $Id$
+ * @since 14.4RC1
+ */
+public class DeleteRequest extends EntityRequest
+{
+    /**
+     * Key of the optional property that indicates whether the document should be send to the recycle bin or removed
+     * permanently.
+     */
+    public static final String SHOULD_SKIP_RECYCLE_BIN = "shouldSkipRecycleBin";
+
+    /**
+     * @see #getNewTarget()
+     */
+    public static final String NEW_TARGET = "newTarget";
+
+    /**
+     * @see #isUpdateLinks()
+     */
+    public static final String UPDATE_LINKS = "updateLinks";
+
+    /**
+     * @see #isUpdateLinksOnFarm()
+     */
+    public static final String UPDATE_LINKS_ON_FARM = "updateLinksOnFarm";
+
+    /**
+     * @see #isAutoRedirect()
+     */
+    public static final String AUTO_REDIRECT = "autoRedirect";
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * @return {@code true} if the document will be removed permanently, {@code false} if it will be moved to recycle
+     *         bin
+     */
+    public boolean shouldSkipRecycleBin()
+    {
+        return getProperty(SHOULD_SKIP_RECYCLE_BIN, true);
+    }
+
+    /**
+     * Sets whether the document should be send to the recycle bin or removed permanently.
+     * 
+     * @param shouldSkipRecycleBin {@code true} if the document should be removed permanently, {@code false} if it
+     *            should be send to recycle bin
+     */
+    public void setShouldSkipRecycleBin(boolean shouldSkipRecycleBin)
+    {
+        setProperty(SHOULD_SKIP_RECYCLE_BIN, shouldSkipRecycleBin);
+    }
+
+    /**
+     * @return the document to be used as the new target after the delete
+     */
+    public DocumentReference getNewTarget()
+    {
+        return getProperty(NEW_TARGET);
+    }
+
+    /**
+     * Sets a document to be used as the new target after the delete.
+     *
+     * @param newTarget reference to the new target document
+     */
+    public void setNewTarget(DocumentReference newTarget)
+    {
+        setProperty(NEW_TARGET, newTarget);
+    }
+
+    /**
+     * @return {@code true} if the links that target the old entity reference (before the delete) should be updated to
+     *         point to the new specified target, {@code false} to preserve the old link target
+     */
+    public boolean isUpdateLinks()
+    {
+        return getProperty(UPDATE_LINKS, false);
+    }
+
+    /**
+     * Sets whether the links that target the old entity reference (before the delete) should be updated to point to the
+     * new specified target or not.
+     *
+     * @param updateLinks {@code true} to update the links, {@code false} to preserve the old link target
+     */
+    public void setUpdateLinks(boolean updateLinks)
+    {
+        setProperty(UPDATE_LINKS, updateLinks);
+    }
+
+    /**
+     * @return {@code true} if the job should update the links that target the old entity reference (before the delete)
+     *         from anywhere on the farm, {@code false} if the job should update only the links from the wiki where the
+     *         entity was located before the delete
+     */
+    public boolean isUpdateLinksOnFarm()
+    {
+        return getProperty(UPDATE_LINKS_ON_FARM, false);
+    }
+
+    /**
+     * Sets whether the job should update the links that target the old entity reference (before the delete) from
+     * anywhere on the farm, or only from the wiki where the entity was located before the delete.
+     * <p>
+     * Note that this parameter has no effect if {@link #isUpdateLinks()} is {@code false}.
+     *
+     * @param updateLinksOnFarm {@code true} to update the links from anywhere on the farm, {@code false} to update only
+     *            the links from the wiki where the entity is located
+     */
+    public void setUpdateLinksOnFarm(boolean updateLinksOnFarm)
+    {
+        setProperty(UPDATE_LINKS_ON_FARM, updateLinksOnFarm);
+    }
+
+    /**
+     * @return {@code true} if the original pages should be redirected automatically to the new specified location when
+     *         accessed by the user, in order to preserve external links, {@code false} otherwise
+     */
+    public boolean isAutoRedirect()
+    {
+        return getProperty(AUTO_REDIRECT, false);
+    }
+
+    /**
+     * Sets whether the original pages should be redirected automatically to the new specified location when accessed by
+     * the user, in order to preserve external links.
+     * 
+     * @param autoRedirect {@code true} to automatically redirect the old pages to the new target, {@code false}
+     *            otherwise
+     */
+    public void setAutoRedirect(boolean autoRedirect)
+    {
+        setProperty(AUTO_REDIRECT, autoRedirect);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/job/DeleteRequest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/job/DeleteRequest.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.refactoring.job;
 
+import java.util.Map;
+
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.stability.Unstable;
 
@@ -32,15 +34,15 @@ import org.xwiki.stability.Unstable;
 public class DeleteRequest extends EntityRequest
 {
     /**
-     * Key of the optional property that indicates whether the document should be send to the recycle bin or removed
+     * Key of the optional property that indicates whether the document should be sent to the recycle bin or removed
      * permanently.
      */
     public static final String SHOULD_SKIP_RECYCLE_BIN = "shouldSkipRecycleBin";
 
     /**
-     * @see #getNewBacklinkTarget()
+     * @see #getNewBacklinkTargets()
      */
-    public static final String NEW_BACKLINK_TARGET = "newBacklinkTarget";
+    public static final String NEW_BACKLINK_TARGETS = "newBacklinkTargets";
 
     /**
      * @see #isUpdateLinks()
@@ -72,7 +74,7 @@ public class DeleteRequest extends EntityRequest
      * Sets whether the document should be send to the recycle bin or removed permanently.
      *
      * @param shouldSkipRecycleBin {@code true} if the document should be removed permanently, {@code false} if it
-     *            should be send to recycle bin
+     *            should be sent to recycle bin
      */
     public void setShouldSkipRecycleBin(boolean shouldSkipRecycleBin)
     {
@@ -80,21 +82,22 @@ public class DeleteRequest extends EntityRequest
     }
 
     /**
-     * @return the document to be used as the new backlink target after delete
+     * @return a Map where the keys are the deleted documents and the values are the new target documents to be used
+     *         after delete
      */
-    public DocumentReference getNewBacklinkTarget()
+    public Map<DocumentReference, DocumentReference> getNewBacklinkTargets()
     {
-        return getProperty(NEW_BACKLINK_TARGET);
+        return getProperty(NEW_BACKLINK_TARGETS);
     }
 
     /**
-     * Sets a document to be used as the new backlink target after delete.
+     * Sets the new backlink target for documents after delete.
      *
-     * @param newBacklinkTarget reference to the new target document
+     * @param newBacklinkTargets a Map where the keys are the deleted documents and the values are new target documents
      */
-    public void setNewBacklinkTarget(DocumentReference newBacklinkTarget)
+    public void setNewBacklinkTargets(Map<DocumentReference, DocumentReference> newBacklinkTargets)
     {
-        setProperty(NEW_BACKLINK_TARGET, newBacklinkTarget);
+        setProperty(NEW_BACKLINK_TARGETS, newBacklinkTargets);
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/job/DeleteRequest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/job/DeleteRequest.java
@@ -24,9 +24,8 @@ import org.xwiki.stability.Unstable;
 
 /**
  * Job request for deleting a page.
- * 
- * @version $Id$
- * @since 14.4.1
+ *
+ * @since 14.4.2
  * @since 14.5RC1
  */
 @Unstable
@@ -71,7 +70,7 @@ public class DeleteRequest extends EntityRequest
 
     /**
      * Sets whether the document should be send to the recycle bin or removed permanently.
-     * 
+     *
      * @param shouldSkipRecycleBin {@code true} if the document should be removed permanently, {@code false} if it
      *            should be send to recycle bin
      */
@@ -154,7 +153,7 @@ public class DeleteRequest extends EntityRequest
     /**
      * Sets whether the original pages should be redirected automatically to the new specified location when accessed by
      * the user, in order to preserve external links.
-     * 
+     *
      * @param autoRedirect {@code true} to automatically redirect the old pages to the new target, {@code false}
      *            otherwise
      */

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/job/DeleteRequest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/job/DeleteRequest.java
@@ -20,13 +20,16 @@
 package org.xwiki.refactoring.job;
 
 import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.stability.Unstable;
 
 /**
  * Job request for deleting a page.
  * 
  * @version $Id$
- * @since 14.4RC1
+ * @since 14.4.1
+ * @since 14.5RC1
  */
+@Unstable
 public class DeleteRequest extends EntityRequest
 {
     /**
@@ -36,9 +39,9 @@ public class DeleteRequest extends EntityRequest
     public static final String SHOULD_SKIP_RECYCLE_BIN = "shouldSkipRecycleBin";
 
     /**
-     * @see #getNewTarget()
+     * @see #getNewBacklinkTarget()
      */
-    public static final String NEW_TARGET = "newTarget";
+    public static final String NEW_BACKLINK_TARGET = "newBacklinkTarget";
 
     /**
      * @see #isUpdateLinks()
@@ -78,21 +81,21 @@ public class DeleteRequest extends EntityRequest
     }
 
     /**
-     * @return the document to be used as the new target after the delete
+     * @return the document to be used as the new backlink target after delete
      */
-    public DocumentReference getNewTarget()
+    public DocumentReference getNewBacklinkTarget()
     {
-        return getProperty(NEW_TARGET);
+        return getProperty(NEW_BACKLINK_TARGET);
     }
 
     /**
-     * Sets a document to be used as the new target after the delete.
+     * Sets a document to be used as the new backlink target after delete.
      *
-     * @param newTarget reference to the new target document
+     * @param newBacklinkTarget reference to the new target document
      */
-    public void setNewTarget(DocumentReference newTarget)
+    public void setNewBacklinkTarget(DocumentReference newBacklinkTarget)
     {
-        setProperty(NEW_TARGET, newTarget);
+        setProperty(NEW_BACKLINK_TARGET, newBacklinkTarget);
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/job/DeleteRequest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/job/DeleteRequest.java
@@ -27,6 +27,7 @@ import org.xwiki.stability.Unstable;
 /**
  * Job request for deleting a page.
  *
+ * @version $Id$
  * @since 14.4.2
  * @since 14.5RC1
  */

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/listener/AutomaticRedirectCreatorListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/listener/AutomaticRedirectCreatorListenerTest.java
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link AutomaticRedirectCreatorListener}.
- * 
+ *
  * @version $Id$
  */
 @ComponentTest

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/listener/AutomaticRedirectCreatorListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/listener/AutomaticRedirectCreatorListenerTest.java
@@ -19,6 +19,9 @@
  */
 package org.xwiki.refactoring.internal.listener;
 
+import java.util.Arrays;
+import java.util.Collections;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -26,7 +29,6 @@ import org.mockito.Mock;
 import org.xwiki.bridge.event.DocumentDeletedEvent;
 import org.xwiki.job.JobContext;
 import org.xwiki.model.reference.DocumentReference;
-import org.xwiki.model.reference.SpaceReference;
 import org.xwiki.refactoring.event.DocumentRenamedEvent;
 import org.xwiki.refactoring.internal.ModelBridge;
 import org.xwiki.refactoring.internal.job.DeleteJob;
@@ -40,6 +42,7 @@ import org.xwiki.test.junit5.mockito.MockComponent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -84,8 +87,7 @@ class AutomaticRedirectCreatorListenerTest
     {
         when(this.jobContext.getCurrentJob()).thenReturn(deleteJob);
         when(this.deleteJob.getRequest()).thenReturn(deleteRequest);
-        deleteRequest.setNewBacklinkTarget(newReference);
-        when(this.deleteJob.getCommonParent()).thenReturn(oldReference);
+        deleteRequest.setNewBacklinkTargets(Collections.singletonMap(oldReference, newReference));
     }
 
     @Test
@@ -136,16 +138,14 @@ class AutomaticRedirectCreatorListenerTest
     }
 
     @Test
-    void onDocumentDeletedWithAutomaticRedirectOnChildDoc()
+    void onDocumentDeletedWithAutomaticRedirectOnDocWithoutNewTarget()
     {
+        DocumentReference docReference = new DocumentReference("wiki", "Users", "Carol");
         deleteRequest.setAutoRedirect(true);
 
-        SpaceReference parentReference = new SpaceReference("wiki", "Users");
-        when(this.deleteJob.getCommonParent()).thenReturn(parentReference);
+        this.listener.onEvent(new DocumentDeletedEvent(docReference), null, null);
 
-        this.listener.onEvent(documentDeletedEvent, null, null);
-
-        verify(this.modelBridge, never()).createRedirect(any(), any());
+        verify(this.modelBridge, never()).createRedirect(eq(docReference), any(DocumentReference.class));
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/listener/AutomaticRedirectCreatorListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/listener/AutomaticRedirectCreatorListenerTest.java
@@ -19,12 +19,6 @@
  */
 package org.xwiki.refactoring.internal.listener;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -43,6 +37,12 @@ import org.xwiki.test.junit5.LogCaptureExtension;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link AutomaticRedirectCreatorListener}.
@@ -84,7 +84,7 @@ class AutomaticRedirectCreatorListenerTest
     {
         when(this.jobContext.getCurrentJob()).thenReturn(deleteJob);
         when(this.deleteJob.getRequest()).thenReturn(deleteRequest);
-        deleteRequest.setNewTarget(newReference);
+        deleteRequest.setNewBacklinkTarget(newReference);
         when(this.deleteJob.getCommonParent()).thenReturn(oldReference);
     }
 

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/listener/BackLinkUpdaterListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/listener/BackLinkUpdaterListenerTest.java
@@ -19,13 +19,6 @@
  */
 package org.xwiki.refactoring.internal.listener;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
 import java.util.Arrays;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -51,6 +44,13 @@ import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
 import org.xwiki.wiki.descriptor.WikiDescriptorManager;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link BackLinkUpdaterListener}.
@@ -112,7 +112,7 @@ class BackLinkUpdaterListenerTest
 
         when(this.jobContext.getCurrentJob()).thenReturn(deleteJob);
         when(this.deleteJob.getRequest()).thenReturn(deleteRequest);
-        deleteRequest.setNewTarget(bobReference);
+        deleteRequest.setNewBacklinkTarget(bobReference);
         when(this.deleteJob.getCommonParent()).thenReturn(aliceReference);
     }
 
@@ -226,7 +226,7 @@ class BackLinkUpdaterListenerTest
         assertEquals("Updating the back-links for document [foo:Users.Alice] in wiki [foo].", logCapture.getMessage(0));
         assertEquals("Updating the back-links for document [foo:Users.Alice] in wiki [bar].", logCapture.getMessage(1));
     }
-    
+
     @Test
     void onDocumentDeletedWithUpdateLinksOnFarmOnChildDoc()
     {

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/listener/BackLinkUpdaterListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/listener/BackLinkUpdaterListenerTest.java
@@ -19,17 +19,29 @@
  */
 package org.xwiki.refactoring.internal.listener;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import java.util.Arrays;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.Mock;
+import org.xwiki.bridge.event.DocumentDeletedEvent;
+import org.xwiki.job.JobContext;
 import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.SpaceReference;
 import org.xwiki.refactoring.event.DocumentRenamedEvent;
 import org.xwiki.refactoring.internal.LinkRefactoring;
 import org.xwiki.refactoring.internal.ModelBridge;
+import org.xwiki.refactoring.internal.job.DeleteJob;
 import org.xwiki.refactoring.internal.job.RenameJob;
+import org.xwiki.refactoring.job.DeleteRequest;
 import org.xwiki.refactoring.job.MoveRequest;
 import org.xwiki.security.authorization.ContextualAuthorizationManager;
 import org.xwiki.security.authorization.Right;
@@ -39,13 +51,6 @@ import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
 import org.xwiki.wiki.descriptor.WikiDescriptorManager;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for {@link BackLinkUpdaterListener}.
@@ -70,8 +75,14 @@ class BackLinkUpdaterListenerTest
     @MockComponent
     private ContextualAuthorizationManager authorization;
 
+    @MockComponent
+    private JobContext jobContext;
+
     @Mock
     private RenameJob renameJob;
+
+    @Mock
+    private DeleteJob deleteJob;
 
     @RegisterExtension
     LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.INFO);
@@ -86,7 +97,11 @@ class BackLinkUpdaterListenerTest
 
     private DocumentRenamedEvent documentRenamedEvent = new DocumentRenamedEvent(aliceReference, bobReference);
 
+    private DocumentDeletedEvent documentDeletedEvent = new DocumentDeletedEvent(aliceReference);
+
     private MoveRequest renameRequest = new MoveRequest();
+
+    private DeleteRequest deleteRequest = new DeleteRequest();
 
     @BeforeEach
     public void configure() throws Exception
@@ -94,6 +109,11 @@ class BackLinkUpdaterListenerTest
         when(wikiDescriptorManager.getAllIds()).thenReturn(Arrays.asList("foo", "bar"));
         when(this.modelBridge.getBackLinkedReferences(aliceReference, "foo")).thenReturn(Arrays.asList(carolReference));
         when(this.modelBridge.getBackLinkedReferences(aliceReference, "bar")).thenReturn(Arrays.asList(denisReference));
+
+        when(this.jobContext.getCurrentJob()).thenReturn(deleteJob);
+        when(this.deleteJob.getRequest()).thenReturn(deleteRequest);
+        deleteRequest.setNewTarget(bobReference);
+        when(this.deleteJob.getCommonParent()).thenReturn(aliceReference);
     }
 
     @Test
@@ -187,5 +207,96 @@ class BackLinkUpdaterListenerTest
 
         assertEquals("Updating the back-links for document [foo:Users.Alice] in wiki [foo].", logCapture.getMessage(0));
         assertEquals("Updating the back-links for document [foo:Users.Alice] in wiki [bar].", logCapture.getMessage(1));
+    }
+
+    @Test
+    void onDocumentDeletedWithUpdateLinksOnFarm()
+    {
+        deleteRequest.setUpdateLinks(true);
+        deleteRequest.setUpdateLinksOnFarm(true);
+
+        when(this.deleteJob.hasAccess(Right.EDIT, carolReference)).thenReturn(true);
+        when(this.deleteJob.hasAccess(Right.EDIT, denisReference)).thenReturn(true);
+
+        this.listener.onEvent(documentDeletedEvent, null, null);
+
+        verify(this.linkRefactoring).renameLinks(carolReference, aliceReference, bobReference);
+        verify(this.linkRefactoring).renameLinks(denisReference, aliceReference, bobReference);
+
+        assertEquals("Updating the back-links for document [foo:Users.Alice] in wiki [foo].", logCapture.getMessage(0));
+        assertEquals("Updating the back-links for document [foo:Users.Alice] in wiki [bar].", logCapture.getMessage(1));
+    }
+    
+    @Test
+    void onDocumentDeletedWithUpdateLinksOnFarmOnChildDoc()
+    {
+        deleteRequest.setUpdateLinks(true);
+        deleteRequest.setUpdateLinksOnFarm(true);
+
+        SpaceReference parentReference = new SpaceReference("foo", "Users");
+        when(this.deleteJob.getCommonParent()).thenReturn(parentReference);
+        when(this.deleteJob.hasAccess(Right.EDIT, carolReference)).thenReturn(true);
+        when(this.deleteJob.hasAccess(Right.EDIT, denisReference)).thenReturn(true);
+
+        this.listener.onEvent(documentDeletedEvent, null, null);
+
+        verify(this.linkRefactoring, never()).renameLinks(any(), any(DocumentReference.class), any());
+    }
+
+    @Test
+    void onDocumentDeleteWithUpdateLinksOnFarmAndNoEditRight()
+    {
+        deleteRequest.setUpdateLinks(true);
+        deleteRequest.setUpdateLinksOnFarm(true);
+
+        when(this.deleteJob.hasAccess(Right.EDIT, carolReference)).thenReturn(true);
+        when(this.deleteJob.hasAccess(Right.EDIT, denisReference)).thenReturn(false);
+
+        this.listener.onEvent(documentDeletedEvent, null, null);
+
+        verify(this.linkRefactoring).renameLinks(carolReference, aliceReference, bobReference);
+        verify(this.linkRefactoring, never()).renameLinks(eq(denisReference), any(DocumentReference.class), any());
+
+        assertEquals("Updating the back-links for document [foo:Users.Alice] in wiki [foo].", logCapture.getMessage(0));
+        assertEquals("Updating the back-links for document [foo:Users.Alice] in wiki [bar].", logCapture.getMessage(1));
+    }
+
+    @Test
+    void onDocumentDeleteWithUpdateLinksOnWiki()
+    {
+        deleteRequest.setUpdateLinks(true);
+        deleteRequest.setUpdateLinksOnFarm(false);
+
+        when(this.deleteJob.hasAccess(Right.EDIT, carolReference)).thenReturn(true);
+
+        this.listener.onEvent(documentDeletedEvent, null, null);
+
+        verify(this.linkRefactoring).renameLinks(carolReference, aliceReference, bobReference);
+        verify(this.linkRefactoring, never()).renameLinks(eq(denisReference), any(DocumentReference.class), any());
+
+        assertEquals("Updating the back-links for document [foo:Users.Alice] in wiki [foo].", logCapture.getMessage(0));
+    }
+
+    @Test
+    void onDocumentDeletedWithoutUpdateLinks()
+    {
+        deleteRequest.setUpdateLinks(false);
+        deleteRequest.setUpdateLinksOnFarm(true);
+
+        this.listener.onEvent(documentDeletedEvent, null, null);
+
+        verify(this.linkRefactoring, never()).renameLinks(any(), any(DocumentReference.class), any());
+    }
+
+    @Test
+    void onDocumentDeletedWithoutDeleteJob()
+    {
+        when(this.jobContext.getCurrentJob()).thenReturn(null);
+        when(this.authorization.hasAccess(Right.EDIT, carolReference)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.EDIT, denisReference)).thenReturn(true);
+
+        this.listener.onEvent(documentDeletedEvent, null, null);
+
+        verify(this.linkRefactoring, never()).renameLinks(any(), any(DocumentReference.class), any());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/script/RefactoringScriptServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/script/RefactoringScriptServiceTest.java
@@ -40,6 +40,7 @@ import org.xwiki.refactoring.RefactoringConfiguration;
 import org.xwiki.refactoring.job.AbstractCopyOrMoveRequest;
 import org.xwiki.refactoring.job.CopyRequest;
 import org.xwiki.refactoring.job.CreateRequest;
+import org.xwiki.refactoring.job.DeleteRequest;
 import org.xwiki.refactoring.job.EntityRequest;
 import org.xwiki.refactoring.job.MoveRequest;
 import org.xwiki.refactoring.job.PermanentlyDeleteRequest;
@@ -224,7 +225,7 @@ class RefactoringScriptServiceTest
     {
         WikiReference source = new WikiReference("math");
 
-        EntityRequest deleteRequest = new EntityRequest();
+        DeleteRequest deleteRequest = new DeleteRequest();
         this.fillEntityRequest(deleteRequest);
         when(this.requestFactory.createDeleteRequest(Arrays.asList(source))).thenReturn(deleteRequest);
 

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/DeletePageConfirmationPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/DeletePageConfirmationPage.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.test.ui.po;
 
+import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
@@ -68,7 +69,79 @@ public class DeletePageConfirmationPage extends ConfirmationPage
     }
 
     /**
+     * @return the arrow element used for opening or closing the backlinks panel
+     * @since 14.4RC1
+     */
+    public WebElement getBacklinkPanelExpandButton()
+    {
+        return getDriver().findElement(By.cssSelector("#delete .pull-right a[href='#panel-backlinks']"));
+    }
+
+    /**
+     * @return {@code true} if a new target document was selected, {@code false} if the field is empty
+     * @since 14.4RC1
+     */
+    public boolean hasNewTargetAdded()
+    {
+        return getDriver().hasElementWithoutWaiting(By.id("newTarget"));
+    }
+
+    /**
+     * @param target the new target document
+     * @since 14.4RC1
+     */
+    public void setNewTarget(String target)
+    {
+        WebElement element = getDriver().findElement(By.id("newTarget"));
+        SuggestInputElement suggestInputElement = new SuggestInputElement(element);
+        suggestInputElement.clearSelectedSuggestions().sendKeys(target).selectTypedText();
+    }
+
+    /**
+     * @return {@code true} if the backlinks to this document will be updated after delete, {@code false} otherwise
+     * @since 14.4RC1
+     */
+    public boolean isUpdateLinks()
+    {
+        return getDriver().findElement(By.name("updateLinks")).isSelected();
+    }
+
+    /**
+     * @param updateLinks {@code true} if the backlinks to this document should be updated after delete, {@code false}
+     *            otherwise
+     * @since 14.4RC1
+     */
+    public void setUpdateLinks(boolean updateLinks)
+    {
+        if (this.isUpdateLinks() != updateLinks) {
+            getDriver().findElement(By.name("updateLinks")).click();
+        }
+    }
+
+    /**
+     * @return {@code true} if a redirect will be added for this document after delete, {@code false} otherwise
+     * @since 14.4RC1
+     */
+    public boolean isAutoRedirect()
+    {
+        return getDriver().findElement(By.name("autoRedirect")).isSelected();
+    }
+
+    /**
+     * @param autoRedirect {@code true} if a redirect should be added for this document after delete, {@code false}
+     *            otherwise
+     * @since 14.4RC1
+     */
+    public void setAutoRedirect(boolean autoRedirect)
+    {
+        if (this.isAutoRedirect() != autoRedirect) {
+            getDriver().findElement(By.name("autoRedirect")).click();
+        }
+    }
+
+    /**
      * Confirm the deletion of the page.
+     * 
      * @return an object representing the UI displayed when a page is deleted
      */
     public DeletingPage confirmDeletePage()

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/DeletePageConfirmationPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/DeletePageConfirmationPage.java
@@ -71,17 +71,17 @@ public class DeletePageConfirmationPage extends ConfirmationPage
     /**
      * Toggle the backlinks panel
      *
-     * @since 14.4.1
+     * @since 14.4.2
      * @since 14.5RC1
      */
-    public void toggleBacklinksPanel()
+    public void toggleBacklinksPane()
     {
         getDriver().findElement(By.cssSelector("#delete .pull-right a[href='#panel-backlinks']")).click();
     }
 
     /**
      * @return {@code true} if a new target document was selected, {@code false} if the field is empty
-     * @since 14.4.1
+     * @since 14.4.2
      * @since 14.5RC1
      */
     public boolean hasNewBacklinkTargetAdded()
@@ -91,7 +91,7 @@ public class DeletePageConfirmationPage extends ConfirmationPage
 
     /**
      * @param target the new target document
-     * @since 14.4.1
+     * @since 14.4.2
      * @since 14.5RC1
      */
     public void setNewBacklinkTarget(String target)
@@ -103,7 +103,7 @@ public class DeletePageConfirmationPage extends ConfirmationPage
 
     /**
      * @return {@code true} if the backlinks to this document will be updated after delete, {@code false} otherwise
-     * @since 14.4.1
+     * @since 14.4.2
      * @since 14.5RC1
      */
     public boolean isUpdateLinks()
@@ -114,7 +114,7 @@ public class DeletePageConfirmationPage extends ConfirmationPage
     /**
      * @param updateLinks {@code true} if the backlinks to this document should be updated after delete, {@code false}
      *            otherwise
-     * @since 14.4.1
+     * @since 14.4.2
      * @since 14.5RC1
      */
     public void setUpdateLinks(boolean updateLinks)
@@ -126,7 +126,7 @@ public class DeletePageConfirmationPage extends ConfirmationPage
 
     /**
      * @return {@code true} if a redirect will be added for this document after delete, {@code false} otherwise
-     * @since 14.4.1
+     * @since 14.4.2
      * @since 14.5RC1
      */
     public boolean isAutoRedirect()
@@ -137,7 +137,7 @@ public class DeletePageConfirmationPage extends ConfirmationPage
     /**
      * @param autoRedirect {@code true} if a redirect should be added for this document after delete, {@code false}
      *            otherwise
-     * @since 14.4.1
+     * @since 14.4.2
      * @since 14.5RC1
      */
     public void setAutoRedirect(boolean autoRedirect)

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/DeletePageConfirmationPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/DeletePageConfirmationPage.java
@@ -69,37 +69,42 @@ public class DeletePageConfirmationPage extends ConfirmationPage
     }
 
     /**
-     * @return the arrow element used for opening or closing the backlinks panel
-     * @since 14.4RC1
+     * Toggle the backlinks panel
+     *
+     * @since 14.4.1
+     * @since 14.5RC1
      */
-    public WebElement getBacklinkPanelExpandButton()
+    public void toggleBacklinksPanel()
     {
-        return getDriver().findElement(By.cssSelector("#delete .pull-right a[href='#panel-backlinks']"));
+        getDriver().findElement(By.cssSelector("#delete .pull-right a[href='#panel-backlinks']")).click();
     }
 
     /**
      * @return {@code true} if a new target document was selected, {@code false} if the field is empty
-     * @since 14.4RC1
+     * @since 14.4.1
+     * @since 14.5RC1
      */
-    public boolean hasNewTargetAdded()
+    public boolean hasNewBacklinkTargetAdded()
     {
-        return getDriver().hasElementWithoutWaiting(By.id("newTarget"));
+        return getDriver().hasElementWithoutWaiting(By.id("newBacklinkTarget"));
     }
 
     /**
      * @param target the new target document
-     * @since 14.4RC1
+     * @since 14.4.1
+     * @since 14.5RC1
      */
-    public void setNewTarget(String target)
+    public void setNewBacklinkTarget(String target)
     {
-        WebElement element = getDriver().findElement(By.id("newTarget"));
+        WebElement element = getDriver().findElement(By.id("newBacklinkTarget"));
         SuggestInputElement suggestInputElement = new SuggestInputElement(element);
         suggestInputElement.clearSelectedSuggestions().sendKeys(target).selectTypedText();
     }
 
     /**
      * @return {@code true} if the backlinks to this document will be updated after delete, {@code false} otherwise
-     * @since 14.4RC1
+     * @since 14.4.1
+     * @since 14.5RC1
      */
     public boolean isUpdateLinks()
     {
@@ -109,7 +114,8 @@ public class DeletePageConfirmationPage extends ConfirmationPage
     /**
      * @param updateLinks {@code true} if the backlinks to this document should be updated after delete, {@code false}
      *            otherwise
-     * @since 14.4RC1
+     * @since 14.4.1
+     * @since 14.5RC1
      */
     public void setUpdateLinks(boolean updateLinks)
     {
@@ -120,7 +126,8 @@ public class DeletePageConfirmationPage extends ConfirmationPage
 
     /**
      * @return {@code true} if a redirect will be added for this document after delete, {@code false} otherwise
-     * @since 14.4RC1
+     * @since 14.4.1
+     * @since 14.5RC1
      */
     public boolean isAutoRedirect()
     {
@@ -130,7 +137,8 @@ public class DeletePageConfirmationPage extends ConfirmationPage
     /**
      * @param autoRedirect {@code true} if a redirect should be added for this document after delete, {@code false}
      *            otherwise
-     * @since 14.4RC1
+     * @since 14.4.1
+     * @since 14.5RC1
      */
     public void setAutoRedirect(boolean autoRedirect)
     {

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/LiveTableElement.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/LiveTableElement.java
@@ -219,7 +219,8 @@ public class LiveTableElement extends BaseElement
      *
      * @param by the selector of the searched element
      * @return the row index where the element was found
-     * @since 14.4RC1
+     * @since 14.4.1
+     * @since 14.5RC1
      */
     public int getRowNumberForElement(By by)
     {

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/LiveTableElement.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/LiveTableElement.java
@@ -215,6 +215,21 @@ public class LiveTableElement extends BaseElement
     }
 
     /**
+     * Get the row index of an element.
+     *
+     * @param by the selector of the searched element
+     * @return the row index where the element was found
+     * @since 14.4RC1
+     */
+    public int getRowNumberForElement(By by)
+    {
+        WebElement livetableRowElement =
+            getDriver().findElement(By.xpath("//tbody[@id='" + this.livetableId + "-display']/tr/td")).findElement(by);
+        return Integer
+            .parseInt(livetableRowElement.findElement(By.xpath("./ancestor::tr[1]")).getAttribute("data-index"));
+    }
+
+    /**
      * @since 5.3RC1
      */
     public WebElement getCell(WebElement rowElement, int columnNumber)

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/LiveTableElement.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/LiveTableElement.java
@@ -219,7 +219,7 @@ public class LiveTableElement extends BaseElement
      *
      * @param by the selector of the searched element
      * @return the row index where the element was found
-     * @since 14.4.1
+     * @since 14.4.2
      * @since 14.5RC1
      */
     public int getRowNumberForElement(By by)

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/delete.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/delete.js
@@ -18,16 +18,12 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 require(['jquery'], function($) {
-    $('#delete #newTarget').on('keyup change', function() {
-        let updateLinksContainer = $("#delete input[name=updateLinks]").closest('dt');
-        let autoRedirectContainer = $("#delete input[name=autoRedirect]").closest('dt');
-        let elements= updateLinksContainer.add(updateLinksContainer.next('dd'))
-            .add(autoRedirectContainer).add(autoRedirectContainer.next('dd'));
+  $('#delete #newBacklinkTarget').on('keyup change', function() {
+    let updateLinksContainer = $("#delete input[name=updateLinks]").closest('dt');
+    let autoRedirectContainer = $("#delete input[name=autoRedirect]").closest('dt');
+    let elements = updateLinksContainer.add(updateLinksContainer.next('dd'))
+      .add(autoRedirectContainer).add(autoRedirectContainer.next('dd'));
 
-        if ($(this).val() != '') {
-            elements.removeClass('hidden');
-        } else {
-            elements.addClass('hidden');
-        }
-    });
+    elements.toggleClass('hidden', $(this).val() === '');
+  });
 });

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/delete.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/delete.js
@@ -1,0 +1,33 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+require(['jquery'], function($) {
+    $('#delete #newTarget').on('keyup change', function() {
+        let updateLinksContainer = $("#delete input[name=updateLinks]").closest('dt');
+        let autoRedirectContainer = $("#delete input[name=autoRedirect]").closest('dt');
+        let elements= updateLinksContainer.add(updateLinksContainer.next('dd'))
+            .add(autoRedirectContainer).add(autoRedirectContainer.next('dd'));
+
+        if ($(this).val() != '') {
+            elements.removeClass('hidden');
+        } else {
+            elements.addClass('hidden');
+        }
+    });
+});

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/delete.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/delete.js
@@ -18,7 +18,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 require(['jquery'], function($) {
-  $('#delete #newBacklinkTarget').on('keyup change', function() {
+  $(document).on('keyup change', '#delete #newBacklinkTarget', function() {
     let updateLinksContainer = $("#delete input[name=updateLinks]").closest('dt');
     let autoRedirectContainer = $("#delete input[name=autoRedirect]").closest('dt');
     let elements = updateLinksContainer.add(updateLinksContainer.next('dd'))


### PR DESCRIPTION
Cherry-pick of commits from https://github.com/xwiki/xwiki-platform/pull/1843

* added option in the UI to select a new target document and to enable for it the update backlinks and/or the create of an automatic redirect
* set the selected options on the delete request and update AutomaticRedirectCreatorListener and BackLinkUpdaterListener to consider also the DocumentDeletedEvent
* add the possibility to restore a document which was recreated at the original location to include the usecase when a user wants to restore a document after a redirect was added (delete the recreated document and restore the original version)
* add unit tests and functional tests

