### PR TITLE
XWIKI-19653: Ability to redirect deleted page link to a new page

### DIFF
--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/job/DeleteRequest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/job/DeleteRequest.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.refactoring.job;
 
+import java.util.Collections;
 import java.util.Map;
 
 import org.xwiki.model.reference.DocumentReference;
@@ -88,7 +89,7 @@ public class DeleteRequest extends EntityRequest
      */
     public Map<DocumentReference, DocumentReference> getNewBacklinkTargets()
     {
-        return getProperty(NEW_BACKLINK_TARGETS);
+        return getProperty(NEW_BACKLINK_TARGETS, Collections.emptyMap());
     }
 
     /**


### PR DESCRIPTION
Cherry-pick from https://github.com/xwiki/xwiki-platform/pull/1861

* add a default value for DeleteRequest#getNewBacklinkTargets(); this was causing test failures because of a NPE here https://github.com/xwiki/xwiki-platform/blob/master/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/listener/AutomaticRedirectCreatorListener.java#L93