### PR TITLE
XWIKI-19855: SQL errors when upgrading XWiki from pre 14.x to 14.4.1

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/migration/R140401000XWIKI15460DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/migration/R140401000XWIKI15460DataMigration.java
@@ -111,10 +111,6 @@ public class R140401000XWIKI15460DataMigration extends AbstractHibernateDataMigr
     {
         boolean shouldExecute = super.shouldExecute(startupVersion);
 
-        if (shouldExecute && this.filterPreferenceConfiguration.useMainStore() && !isMainWiki()) {
-            shouldExecute = false;
-        }
-
         if (shouldExecute) {
             int version = startupVersion.getVersion();
             shouldExecute = !(version >= 131007000 && version < 140000000);
@@ -125,9 +121,21 @@ public class R140401000XWIKI15460DataMigration extends AbstractHibernateDataMigr
     @Override
     protected void hibernateMigrate() throws DataMigrationException
     {
-        try {
-            boolean isMainWiki = isMainWiki();
+        boolean isMainWiki = isMainWiki();
 
+        // Stop the execution early if the configuration uses the main store and we are not upgrading the main wiki.
+        // This check cannot be done in #shouldExecute because possibly missing columns are not yet added to the 
+        // database.
+        if (this.filterPreferenceConfiguration.useMainStore() && !isMainWiki) {
+            return;
+        }
+
+        internalHibernateMigrate(isMainWiki);
+    }
+
+    private void internalHibernateMigrate(boolean isMainWiki) throws DataMigrationException
+    {
+        try {
             Collection<String> knownWikiIds;
             if (isMainWiki) {
                 // The know wikis are only initialized for the main wiki, as they are not needed for the sub-wikis.


### PR DESCRIPTION
Move the check of whether the execution should be continued based on the configuration and if it is the main wiki that is updated in hibernateMigrate because the missing columns are not yet updated in shouldExecute.