### PR TITLE
XRENDERING-664: Allow macros to have several categories

### DIFF
--- a/xwiki-platform-distribution/xwiki-platform-distribution-war-legacydependencies/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-war-legacydependencies/pom.xml
@@ -72,6 +72,10 @@
           <groupId>org.xwiki.platform</groupId>
           <artifactId>xwiki-platform-refactoring-api</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.xwiki.rendering</groupId>
+          <artifactId>xwiki-rendering-transformation-macro</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -122,6 +126,10 @@
         <exclusion>
           <groupId>org.xwiki.platform</groupId>
           <artifactId>xwiki-platform-office-importer</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.xwiki.rendering</groupId>
+          <artifactId>xwiki-rendering-transformation-macro</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -176,6 +184,10 @@
           <groupId>org.xwiki.platform</groupId>
           <artifactId>xwiki-platform-refactoring-api</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.xwiki.rendering</groupId>
+          <artifactId>xwiki-rendering-transformation-macro</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -210,6 +222,10 @@
           <groupId>org.xwiki.rendering</groupId>
           <artifactId>xwiki-rendering-api</artifactId>
         </exclusion>
+         <exclusion>
+           <groupId>org.xwiki.rendering</groupId>
+           <artifactId>xwiki-rendering-transformation-macro</artifactId>
+         </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -238,6 +254,11 @@
           <artifactId>xwiki-platform-oldcore</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.rendering</groupId>
+      <artifactId>xwiki-rendering-legacy-transformation-macro</artifactId>
+      <version>${rendering.version}</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Replace xwiki-rendering-transformation-macro with xwiki-rendering-legacy-transformation-macro in xwiki-platform-distribution-war-legacydependencies.

See https://github.com/xwiki/xwiki-rendering/pull/216 for the xwiki-rendering part of this work.