### PR TITLE
XWIKI-19818: ODT export doesn't produce 'real' odt documents but 'office html' (?) documents

### DIFF
--- a/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/resources/document-formats.js
+++ b/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/resources/document-formats.js
@@ -59,7 +59,7 @@
     "extensions": ["odt"],
     "mediaType": "application/vnd.oasis.opendocument.text",
     "inputFamily": "TEXT",
-    "storeProperties": {"TEXT": {"FilterName": "writer8"}}
+    "storeProperties": {"TEXT": {"FilterName": "writerweb8_writer"}}
   },
   {
     "name": "OpenOffice.org 1.0 Text Document",


### PR DESCRIPTION
## JIRA

https://jira.xwiki.org/browse/XWIKI-19818

  * Use the appropriate filter for odt documents