### PR TITLE
XWIKI-19902: Potential error log caused by not existing user during R140401000XWIKI15460 migration

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/migration/R140401000XWIKI15460DataMigrationTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/migration/R140401000XWIKI15460DataMigrationTest.java
@@ -20,6 +20,7 @@
 package org.xwiki.notifications.filters.migration;
 
 import java.util.HashSet;
+import java.util.List;
 
 import javax.inject.Named;
 
@@ -168,6 +169,7 @@ class R140401000XWIKI15460DataMigrationTest
             .thenReturn(deletedUserReference);
         when(this.userManager.exists(existingUserReference)).thenReturn(true);
         when(this.userManager.exists(deletedUserReference)).thenReturn(false);
+        when(this.store.getPreferencesOfUser(deletedUserDocumentReference)).thenReturn(List.of(nfp3));
 
         this.dataMigration.hibernateMigrate();
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/pom.xml
@@ -31,7 +31,7 @@
   <name>XWiki Platform - Notifications - Notifiers - Default bridge</name>
   <description>Default bridge to oldcore for the notifications notifiers API module.</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.35</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.38</xwiki.jacoco.instructionRatio>
     <xwiki.extension.namespaces>{root}</xwiki.extension.namespaces>
     <checkstyle.suppressions.location>${basedir}/src/checkstyle/checkstyle-suppressions.xml</checkstyle.suppressions.location>
   </properties>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/UserEventDispatcher.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/UserEventDispatcher.java
@@ -52,6 +52,7 @@ import org.xwiki.model.reference.EntityReferenceSerializer;
 import org.xwiki.model.reference.WikiReference;
 import org.xwiki.notifications.NotificationConfiguration;
 import org.xwiki.notifications.NotificationFormat;
+import org.xwiki.user.UserException;
 import org.xwiki.user.UserManager;
 import org.xwiki.user.UserReference;
 import org.xwiki.user.UserReferenceResolver;
@@ -280,7 +281,7 @@ public class UserEventDispatcher implements Runnable, Disposable, Initializable
         }
     }
 
-    private void dispatchInContext(Event event)
+    private void dispatchInContext(Event event) throws UserException
     {
         WikiReference eventWiki = event.getWiki();
 
@@ -288,7 +289,7 @@ public class UserEventDispatcher implements Runnable, Disposable, Initializable
             // The event explicitly indicate with which entities to associated it
 
             boolean mailEnabled = this.notificationConfiguration.areEmailsEnabled();
-            event.getTarget().forEach(entity -> {
+            for (String entity : event.getTarget()) {
                 DocumentReference entityReference = this.resolver.resolve(entity, event.getWiki());
                 UserReference userReference = this.documentReferenceUserReferenceResolver.resolve(entityReference);
 
@@ -306,7 +307,7 @@ public class UserEventDispatcher implements Runnable, Disposable, Initializable
                 }
                 // Remember we are done pre filtering this event
                 this.events.prefilterEvent(event);
-            });
+            }
         } else {
             // Try to find users listening to this event
 

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/main/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManager.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/main/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManager.java
@@ -48,6 +48,7 @@ import org.xwiki.security.authentication.ResetPasswordManager;
 import org.xwiki.security.authentication.ResetPasswordRequestResponse;
 import org.xwiki.url.ExtendedURL;
 import org.xwiki.url.URLNormalizer;
+import org.xwiki.user.UserException;
 import org.xwiki.user.UserManager;
 import org.xwiki.user.UserProperties;
 import org.xwiki.user.UserPropertiesResolver;
@@ -130,7 +131,11 @@ public class DefaultResetPasswordManager implements ResetPasswordManager
             throw new ResetPasswordException("Only user having a page on the wiki can reset their password.");
         }
 
-        return this.userManager.exists(userReference);
+        try {
+            return this.userManager.exists(userReference);
+        } catch (UserException e) {
+            throw new ResetPasswordException(String.format("Failed to check if user [%s] exists.", userReference), e);
+        }
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManagerTest.java
@@ -170,7 +170,7 @@ class DefaultResetPasswordManagerTest
     }
 
     @Test
-    void requestResetPasswordUnexistingUser() throws ResetPasswordException
+    void requestResetPasswordUnexistingUser() throws Exception
     {
         when(this.userReference.toString()).thenReturn("user:Foobar");
         when(this.userManager.exists(this.userReference)).thenReturn(false);
@@ -179,7 +179,7 @@ class DefaultResetPasswordManagerTest
     }
 
     @Test
-    void requestResetPasswordNotDocumentReferenceUser()
+    void requestResetPasswordNotDocumentReferenceUser() throws Exception
     {
         UserReference otherUserReference = mock(UserReference.class);
         when(this.userManager.exists(otherUserReference)).thenReturn(true);
@@ -317,7 +317,7 @@ class DefaultResetPasswordManagerTest
     }
 
     @Test
-    void checkVerificationCodeUnexistingUser() throws ResetPasswordException
+    void checkVerificationCodeUnexistingUser() throws Exception
     {
         when(this.userReference.toString()).thenReturn("user:Foobar");
         when(this.userManager.exists(this.userReference)).thenReturn(false);

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-api/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-api/pom.xml
@@ -32,7 +32,7 @@
   <packaging>jar</packaging>
   <description>APIs to manipulate users and groups</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.77</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.75</xwiki.jacoco.instructionRatio>
     <xwiki.extension.name>User API</xwiki.extension.name>
     <xwiki.extension.features>
       <!-- Contrib extension to provide groups tab feature to pre 10.8 wikis -->

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-api/src/main/java/org/xwiki/user/UserException.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-api/src/main/java/org/xwiki/user/UserException.java
@@ -19,23 +19,30 @@
  */
 package org.xwiki.user;
 
-import org.xwiki.component.annotation.Role;
+import org.xwiki.stability.Unstable;
 
 /**
- * CRUD operations on users. Note that for retrieving a user's properties you should use a
- * {@link UserPropertiesResolver}.
+ * Generic exception for the user api module.
  *
  * @version $Id$
- * @since 12.2
+ * @since 14.6RC1
+ * @since 14.4.3
+ * @since 13.10.8
  */
-@Role
-public interface UserManager
+@Unstable
+public class UserException extends Exception
 {
+    private static final long serialVersionUID = 3091220482950706563L;
+
     /**
-     * @param userReference the reference to the user to check for existence
-     * @return true if the user pointed to by the reference exists, false otherwise
-     * @throws UserException (since 14.6RC1, 14.4.3, 13.10.8) in case of error while checking for the existence of
-     *     the user
+     * Constructs a new user exception with the specified detail message and cause.
+     *
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method)
+     * @param cause the cause (which is saved for later retrieval by the {@link #getCause()} method). (A
+     *     {@code null} value is permitted, and indicates that the cause is nonexistent or unknown.)
      */
-    boolean exists(UserReference userReference) throws UserException;
+    public UserException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-api/src/main/java/org/xwiki/user/UserException.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-api/src/main/java/org/xwiki/user/UserException.java
@@ -32,7 +32,7 @@ import org.xwiki.stability.Unstable;
 @Unstable
 public class UserException extends Exception
 {
-    private static final long serialVersionUID = 3091220482950706563L;
+    private static final long serialVersionUID = 1L;
 
     /**
      * Constructs a new user exception with the specified detail message and cause.

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/pom.xml
@@ -32,7 +32,7 @@
   <packaging>jar</packaging>
   <description>XWiki Platform - Default</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.75</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.76</xwiki.jacoco.instructionRatio>
     <xwiki.extension.features>
       <!-- Contrib extension to provide groups tab feature to pre 10.8 wikis -->
       org.xwiki.contrib.membership:application-membership-default

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/DefaultUserManager.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/DefaultUserManager.java
@@ -29,6 +29,7 @@ import org.xwiki.component.manager.ComponentManager;
 import org.xwiki.user.CurrentUserReference;
 import org.xwiki.user.GuestUserReference;
 import org.xwiki.user.SuperAdminUserReference;
+import org.xwiki.user.UserException;
 import org.xwiki.user.UserManager;
 import org.xwiki.user.UserReference;
 
@@ -48,7 +49,7 @@ public class DefaultUserManager implements UserManager
     private ComponentManager componentManager;
 
     @Override
-    public boolean exists(UserReference userReference)
+    public boolean exists(UserReference userReference) throws UserException
     {
         boolean exists;
 

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/document/CurrentUserManager.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/document/CurrentUserManager.java
@@ -28,6 +28,7 @@ import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.user.GuestUserReference;
 import org.xwiki.user.SuperAdminUserReference;
+import org.xwiki.user.UserException;
 import org.xwiki.user.UserManager;
 import org.xwiki.user.UserReference;
 import org.xwiki.user.UserReferenceResolver;
@@ -57,7 +58,7 @@ public class CurrentUserManager implements UserManager
     private Provider<XWikiContext> contextProvider;
 
     @Override
-    public boolean exists(UserReference userReference)
+    public boolean exists(UserReference userReference) throws UserException
     {
         boolean exists;
 

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/DefaultUserManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/DefaultUserManagerTest.java
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class DefaultUserManagerTest
+class DefaultUserManagerTest
 {
     @InjectMockComponents
     private DefaultUserManager userManager;
@@ -80,13 +80,13 @@ public class DefaultUserManagerTest
     }
 
     @Test
-    void existsWhenSuperAdmin()
+    void existsWhenSuperAdmin() throws Exception
     {
         assertFalse(this.userManager.exists(SuperAdminUserReference.INSTANCE));
     }
 
     @Test
-    void existsWhenGuest()
+    void existsWhenGuest() throws Exception
     {
         assertFalse(this.userManager.exists(GuestUserReference.INSTANCE));
     }
@@ -121,9 +121,8 @@ public class DefaultUserManagerTest
         when(this.contextComponentManager.getInstance(UserManager.class, TestUserReference.class.getName()))
             .thenThrow(new ComponentLookupException("error"));
 
-        Throwable exception = assertThrows(RuntimeException.class, () -> {
-            this.userManager.exists(new TestUserReference());
-        });
+        TestUserReference userReference = new TestUserReference();
+        Throwable exception = assertThrows(RuntimeException.class, () -> this.userManager.exists(userReference));
         assertEquals("Failed to find user manager for role [org.xwiki.user.UserManager] and hint "
             + "[org.xwiki.user.internal.DefaultUserManagerTest$TestUserReference]", exception.getMessage());
         assertEquals("ComponentLookupException: error", ExceptionUtils.getRootCauseMessage(exception));

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/CurrentUserManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/CurrentUserManagerTest.java
@@ -63,7 +63,7 @@ class CurrentUserManagerTest
     private UserManager documentUserManager;
 
     @Test
-    void existsWhenNoCurrentUser()
+    void existsWhenNoCurrentUser() throws Exception
     {
         // No current user in the context
         XWikiContext xcontext = mock(XWikiContext.class);
@@ -76,7 +76,7 @@ class CurrentUserManagerTest
     }
 
     @Test
-    void existsWhenCurrentUser()
+    void existsWhenCurrentUser() throws Exception
     {
         XWikiContext xcontext = mock(XWikiContext.class);
         DocumentReference documentReference = new DocumentReference("wiki", "XWiki", "User");
@@ -92,7 +92,7 @@ class CurrentUserManagerTest
     }
 
     @Test
-    void existsWhenCurrentUserIsSuperAdmin()
+    void existsWhenCurrentUserIsSuperAdmin() throws Exception
     {
         XWikiContext xcontext = mock(XWikiContext.class);
         DocumentReference documentReference = new DocumentReference("wiki", "XWiki", "superadmin");
@@ -105,7 +105,7 @@ class CurrentUserManagerTest
     }
 
     @Test
-    void existsWhenCurrentUserIsGuest()
+    void existsWhenCurrentUserIsGuest() throws Exception
     {
         XWikiContext xcontext = mock(XWikiContext.class);
         DocumentReference documentReference = new DocumentReference("wiki", "XWiki", "xwikiguest");

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/DocumentUserManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/DocumentUserManagerTest.java
@@ -31,12 +31,16 @@ import org.xwiki.test.junit5.LogCaptureExtension;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
+import org.xwiki.wiki.descriptor.WikiDescriptorManager;
+import org.xwiki.wiki.manager.WikiManagerException;
 
 import com.xpn.xwiki.XWiki;
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.objects.BaseObject;
+
+import ch.qos.logback.classic.Level;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -50,13 +54,16 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class DocumentUserManagerTest
+class DocumentUserManagerTest
 {
     @InjectMockComponents
     private DocumentUserManager userManager;
 
     @MockComponent
     private Provider<XWikiContext> contextProvider;
+
+    @MockComponent
+    private WikiDescriptorManager wikiDescriptorManager;
 
     @RegisterExtension
     LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.WARN);
@@ -69,6 +76,7 @@ public class DocumentUserManagerTest
         XWikiContext xcontext = mock(XWikiContext.class);
         when(xcontext.getWiki()).thenReturn(xwiki);
         when(this.contextProvider.get()).thenReturn(xcontext);
+        when(this.wikiDescriptorManager.exists("wiki")).thenReturn(true);
         XWikiDocument document = mock(XWikiDocument.class);
         when(xwiki.getDocument(reference, xcontext)).thenReturn(document);
         when(document.isNew()).thenReturn(false);
@@ -119,10 +127,38 @@ public class DocumentUserManagerTest
         when(xcontext.getWiki()).thenReturn(xwiki);
         when(this.contextProvider.get()).thenReturn(xcontext);
         when(xwiki.getDocument(reference, xcontext)).thenThrow(new XWikiException(0, 0, "error"));
+        when(this.wikiDescriptorManager.exists("wiki")).thenReturn(true);
 
         assertFalse(this.userManager.exists(new DocumentUserReference(reference, true)));
 
         assertEquals("Failed to check if document [wiki:space.user] holds an XWiki user or not. Considering it's not "
-            + "the case. Root error: [XWikiException: Error number 0 in 0: error]", logCapture.getMessage(0));
+            + "the case. Root error: [XWikiException: Error number 0 in 0: error]", this.logCapture.getMessage(0));
+    }
+
+    @Test
+    void existsWhenUnknownWiki() throws Exception
+    {
+        XWiki xwiki = mock(XWiki.class);
+        XWikiContext xcontext = mock(XWikiContext.class);
+        when(xcontext.getWiki()).thenReturn(xwiki);
+        when(this.contextProvider.get()).thenReturn(xcontext);
+        when(this.wikiDescriptorManager.exists("wiki")).thenReturn(false);
+        DocumentReference reference = new DocumentReference("wiki", "space", "user");
+        assertFalse(this.userManager.exists(new DocumentUserReference(reference, true)));
+    }
+
+    @Test
+    void existsWhenWikiDescriptorManagerError() throws Exception
+    {
+        XWiki xwiki = mock(XWiki.class);
+        XWikiContext xcontext = mock(XWikiContext.class);
+        when(xcontext.getWiki()).thenReturn(xwiki);
+        when(this.contextProvider.get()).thenReturn(xcontext);
+        when(this.wikiDescriptorManager.exists("wiki")).thenThrow(WikiManagerException.class);
+        DocumentReference reference = new DocumentReference("wiki", "space", "user");
+        assertFalse(this.userManager.exists(new DocumentUserReference(reference, true)));
+        assertEquals("Failed to determine if wiki [wiki] exists. Considering it's not the case. " 
+                + "Cause: [WikiManagerException: ]", this.logCapture.getMessage(0));
+        assertEquals(Level.WARN, this.logCapture.getLogEvent(0).getLevel());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-script/src/main/java/org/xwiki/user/script/UserScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-script/src/main/java/org/xwiki/user/script/UserScriptService.java
@@ -30,6 +30,7 @@ import org.xwiki.stability.Unstable;
 import org.xwiki.user.CurrentUserReference;
 import org.xwiki.user.GuestUserReference;
 import org.xwiki.user.SuperAdminUserReference;
+import org.xwiki.user.UserException;
 import org.xwiki.user.UserManager;
 import org.xwiki.user.UserProperties;
 import org.xwiki.user.UserPropertiesResolver;
@@ -192,9 +193,10 @@ public class UserScriptService implements ScriptService
      *                      reference exists or not - for example the superadmin users or the guest users don't exist,
      *                      and a "document"-based User can be constructed and have no profile page and thus not exist)
      * @return true if the user exists in the store or false otherwise
+     * @throws UserException (since 14.6RC1, 14.4.3, 13.10.8) in case of error while checking if the user exists
      * @since 12.2
      */
-    public boolean exists(UserReference userReference)
+    public boolean exists(UserReference userReference) throws UserException
     {
         return this.userManager.exists(userReference);
     }


### PR DESCRIPTION
- Add a control for the existence of the user's wiki on org.xwiki.user.internal.document.DocumentUserManager.exists(org.xwiki.user.UserReference)
- When removing user's notifications in R140401000XWIKI15460DataMigration, verify if their is still notifications to remove before removing unknown user's notifications

Jira: https://jira.xwiki.org/browse/XWIKI-19902