### PR TITLE
XWIKI-13454: Add pagination for Attachments

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/AttachmentsPane.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/AttachmentsPane.java
@@ -190,8 +190,8 @@ public class AttachmentsPane extends BaseElement
         WebElement deleteButton = this.attachmentsLivetable.getCell(getRowIndexByAttachmentName(attachmentName), 6)
             .findElement(By.className("actiondelete"));
         // This is needed since Selenium deleteButton.click() fails on smaller windows, even if the element is
-        // clickable (visible and enabled). The failure was reproduced on {@code org.xwiki.test.ui.CompareVersionsTest}
-        // and might be resolved after moving the test to docker.
+        // clickable (visible and enabled). The failure was reproduced on org.xwiki.test.ui.CompareVersionsTest and
+        // might be resolved after moving the test to docker.
         ((JavascriptExecutor) getDriver()).executeScript("arguments[0].click();", deleteButton);
         this.confirmDelete.clickOk();
 

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/AttachmentsPane.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/AttachmentsPane.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
@@ -188,7 +189,10 @@ public class AttachmentsPane extends BaseElement
             + "']/parent::div/following-sibling::div[contains(@class, 'deleteAttachment')]"));
         WebElement deleteButton = this.attachmentsLivetable.getCell(getRowIndexByAttachmentName(attachmentName), 6)
             .findElement(By.className("actiondelete"));
-        deleteButton.click();
+        // This is needed since Selenium deleteButton.click() fails on smaller windows, even if the element is
+        // clickable (visible and enabled). The failure was reproduced on {@code org.xwiki.test.ui.CompareVersionsTest}
+        // and might be resolved after moving the test to docker.
+        ((JavascriptExecutor) getDriver()).executeScript("arguments[0].click();", deleteButton);
         this.confirmDelete.clickOk();
 
         getDriver().waitUntilCondition(new ExpectedCondition<Boolean>()


### PR DESCRIPTION
* add fix for [org.xwiki.test.ui.CompareVersionsTest](https://github.com/xwiki/xwiki-platform/blob/master/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/src/test/it/org/xwiki/test/ui/CompareVersionsTest.java#L160), since the test was failing with ElementNotInteractableException even if the element was clickable (visible and enabled)

The failure is not reproducible on docker tests that use the `AttachmentsPane#deleteAttachmentByFileByName` so moving this test to docker should remove the need of `JavascriptExecutor` in the future