### PR TITLE
XWIKI-19591: Local users of subwikis can't recover password or username

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/ForgotUsernamePage.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/ForgotUsernamePage.java
@@ -39,7 +39,7 @@ public class ForgotUsernamePage extends ViewPage
 
     public static ForgotUsernamePage gotoPage()
     {
-        getUtil().gotoPage(getUtil().getBaseURL() + "authenticate/forgot");
+        getUtil().gotoPage(getUtil().getBaseURL() + "authenticate/retrieveusername");
         return new ForgotUsernamePage();
     }
 

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/ResetPasswordPage.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/ResetPasswordPage.java
@@ -47,7 +47,7 @@ public class ResetPasswordPage extends ViewPage
     public static ResetPasswordPage gotoPage()
     {
 
-        getUtil().gotoPage(getUtil().getBaseURL() + "authenticate/reset");
+        getUtil().gotoPage(getUtil().getBaseURL() + "authenticate/resetpassword");
         return new ResetPasswordPage();
     }
 

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/ForgotUsername.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/ForgotUsername.xml
@@ -37,8 +37,8 @@
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
   <content>{{velocity}}
-#set ($newUrl = $services.security.authentication.getAuthenticationURL('forgot', $request.parameterMap))
-#set ($discard = $services.logging.deprecate("ForgotUsername", "The page [XWiki.ForgotUsername] should not be used anymore in favor of the new 'authenticate/forgot' URL."));
+#set ($newUrl = $services.security.authentication.getAuthenticationURL('retrieveusername', $request.parameterMap))
+#set ($discard = $services.logging.deprecate("ForgotUsername", "The page [XWiki.ForgotUsername] should not be used anymore in favor of the new 'authenticate/retrieveusername' URL."));
 #set ($discard = $response.sendRedirect($newUrl))
 {{/velocity}}</content>
   <object>

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/ResetPassword.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/ResetPassword.xml
@@ -37,8 +37,8 @@
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
   <content>{{velocity}}
-#set ($newUrl = $services.security.authentication.getAuthenticationURL('reset', $request.parameterMap))
-#set ($discard = $services.logging.deprecate("ResetPassword", "The page [XWiki.ResetPassword] should not be used anymore in favor of the new 'authenticate/reset' URL."));
+#set ($newUrl = $services.security.authentication.getAuthenticationURL('resetpassword', $request.parameterMap))
+#set ($discard = $services.logging.deprecate("ResetPassword", "The page [XWiki.ResetPassword] should not be used anymore in favor of the new 'authenticate/resetpassword' URL."));
 #set ($discard = $response.sendRedirect($newUrl))
 {{/velocity}}</content>
   <object>

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/ResetPasswordComplete.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/ResetPasswordComplete.xml
@@ -37,8 +37,8 @@
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
   <content>{{velocity}}
-#set ($newUrl = $services.security.authentication.getAuthenticationURL('reset', $request.parameterMap))
-#set ($discard = $services.logging.deprecate("The page [XWiki.ResetPasswordComplete] should not be used anymore in favor of the new 'authenticate/reset' URL."));
+#set ($newUrl = $services.security.authentication.getAuthenticationURL('resetpassword', $request.parameterMap))
+#set ($discard = $services.logging.deprecate("The page [XWiki.ResetPasswordComplete] should not be used anymore in favor of the new 'authenticate/resetpassword' URL."));
 #set ($discard = $response.sendRedirect($newUrl))
 {{/velocity}}</content>
   <object>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/login.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/login.vm
@@ -58,7 +58,7 @@
 <dl>
   <dt>
     <label for="j_username">$services.localization.render('username')</label>
-    #set ($forgotUsernameURL = $services.security.authentication.getAuthenticationURL('forgot', $NULL))
+    #set ($forgotUsernameURL = $services.security.authentication.getAuthenticationURL('retrieveusername', $NULL))
     #if("$!forgotUsernameURL" != "")
       <span class="xAdditional"><a href="$forgotUsernameURL" tabindex="500">$services.localization.render('xe.admin.forgotUsername.loginMessage')</a></span>
     #end
@@ -69,7 +69,7 @@
   </dd>
   <dt>
     <label for="j_password">$services.localization.render('password')</label>
-    #set ($resetPasswordUrl = $services.security.authentication.getAuthenticationURL('reset', $NULL))
+    #set ($resetPasswordUrl = $services.security.authentication.getAuthenticationURL('resetpassword', $NULL))
     #if("$!resetPasswordUrl" != '')
       <span class="xAdditional"><a href="$resetPasswordUrl" tabindex="600">$services.localization.render('xe.admin.passwordReset.loginMessage')</a></span>
     #end

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-api/src/main/java/org/xwiki/security/authentication/AuthenticationAction.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-api/src/main/java/org/xwiki/security/authentication/AuthenticationAction.java
@@ -34,14 +34,14 @@ public enum AuthenticationAction
     /**
      * Action used to reset the password of a user.
      */
-    RESET_PASSWORD("reset"),
+    RESET_PASSWORD("resetpassword"),
 
     /**
      * Action used to retrieve the username of a user.
      */
-    FORGOT_USERNAME("forgot");
+    RETRIEVE_USERNAME("retrieveusername");
 
-    private String requestParameter;
+    private final String requestParameter;
 
     AuthenticationAction(String requestParameter)
     {

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-api/src/main/java/org/xwiki/security/authentication/AuthenticationResourceReference.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-api/src/main/java/org/xwiki/security/authentication/AuthenticationResourceReference.java
@@ -21,6 +21,8 @@ package org.xwiki.security.authentication;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.xwiki.model.reference.WikiReference;
 import org.xwiki.resource.AbstractResourceReference;
 import org.xwiki.resource.ResourceType;
 import org.xwiki.stability.Unstable;
@@ -45,15 +47,20 @@ public class AuthenticationResourceReference extends AbstractResourceReference
      */
     public static final ResourceType TYPE = new ResourceType(RESOURCE_TYPE_ID);
 
-    private AuthenticationAction action;
+    private final WikiReference wikiReference;
+
+    private final AuthenticationAction action;
 
     /**
      * Default constructor.
-     * @param action the action of the reference.
+     *
+     * @param wikiReference the reference of the wiki where the action should be performed.
+     * @param action the action to perform.
      */
-    public AuthenticationResourceReference(AuthenticationAction action)
+    public AuthenticationResourceReference(WikiReference wikiReference, AuthenticationAction action)
     {
         setType(TYPE);
+        this.wikiReference = wikiReference;
         this.action = action;
     }
 
@@ -63,6 +70,17 @@ public class AuthenticationResourceReference extends AbstractResourceReference
     public AuthenticationAction getAction()
     {
         return action;
+    }
+
+    /**
+     * @return the reference of the wiki where the action should be performed.
+     * @since 14.6RC1
+     * @since 14.4.3
+     * @since 13.10.8
+     */
+    public WikiReference getWikiReference()
+    {
+        return wikiReference;
     }
 
     @Override
@@ -78,13 +96,30 @@ public class AuthenticationResourceReference extends AbstractResourceReference
 
         AuthenticationResourceReference that = (AuthenticationResourceReference) o;
 
-        return new EqualsBuilder().appendSuper(super.equals(o)).append(action, that.action)
+        return new EqualsBuilder()
+            .appendSuper(super.equals(o))
+            .append(action, that.action)
+            .append(wikiReference, that.wikiReference)
             .isEquals();
     }
 
     @Override
     public int hashCode()
     {
-        return new HashCodeBuilder(17, 37).appendSuper(super.hashCode()).append(action).toHashCode();
+        return new HashCodeBuilder(17, 37)
+            .appendSuper(super.hashCode())
+            .append(action)
+            .append(wikiReference)
+            .toHashCode();
+    }
+
+    @Override
+    public String toString()
+    {
+        return new ToStringBuilder(this)
+            .appendSuper(super.toString())
+            .append("wikiReference", wikiReference)
+            .append("action", action)
+            .toString();
     }
 }

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/main/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManager.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/main/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManager.java
@@ -188,8 +188,9 @@ public class DefaultResetPasswordManager implements ResetPasswordManager
         throws ResetPasswordException
     {
         if (this.checkUserReference(requestResponse.getUserReference())) {
-            AuthenticationResourceReference resourceReference =
-                new AuthenticationResourceReference(AuthenticationAction.RESET_PASSWORD);
+            AuthenticationResourceReference resourceReference = new AuthenticationResourceReference(
+                this.contextProvider.get().getWikiReference(),
+                AuthenticationAction.RESET_PASSWORD);
 
             UserReference userReference = requestResponse.getUserReference();
             UserProperties userProperties = this.userPropertiesResolver.resolve(userReference);

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/main/java/org/xwiki/security/authentication/internal/resource/AuthenticationResourceReferenceSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/main/java/org/xwiki/security/authentication/internal/resource/AuthenticationResourceReferenceSerializer.java
@@ -47,6 +47,8 @@ public class AuthenticationResourceReferenceSerializer implements
     {
         return new ExtendedURL(Arrays.asList(
             AuthenticationResourceReference.TYPE.getId(),
+            "wiki",
+            resource.getWikiReference().getName(),
             resource.getAction().getRequestParameter()),
             resource.getParameters());
     }

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManagerTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.xwiki.configuration.ConfigurationSource;
 import org.xwiki.localization.ContextualLocalizationManager;
 import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.WikiReference;
 import org.xwiki.resource.ResourceReference;
 import org.xwiki.resource.ResourceReferenceSerializer;
 import org.xwiki.security.authentication.AuthenticationAction;
@@ -226,9 +227,10 @@ class DefaultResetPasswordManagerTest
         when(this.referenceSerializer.serialize(this.userReference)).thenReturn("user:Foobar");
         when(this.userProperties.getFirstName()).thenReturn("Foo");
         when(this.userProperties.getLastName()).thenReturn("Bar");
-
+        WikiReference wikiReference = new WikiReference("foo");
+        when(this.context.getWikiReference()).thenReturn(wikiReference);
         AuthenticationResourceReference resourceReference =
-            new AuthenticationResourceReference(AuthenticationAction.RESET_PASSWORD);
+            new AuthenticationResourceReference(wikiReference, AuthenticationAction.RESET_PASSWORD);
 
         String verificationCode = "foobar4242";
         resourceReference.addParameter("u", "user:Foobar");

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/resource/AuthenticationResourceReferenceHandlerTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/resource/AuthenticationResourceReferenceHandlerTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.xwiki.context.Execution;
 import org.xwiki.context.ExecutionContext;
+import org.xwiki.model.reference.WikiReference;
 import org.xwiki.resource.ResourceReferenceHandlerChain;
 import org.xwiki.security.authentication.AuthenticationAction;
 import org.xwiki.security.authentication.AuthenticationResourceReference;
@@ -72,28 +73,32 @@ class AuthenticationResourceReferenceHandlerTest
 
     private XWiki xwiki;
 
-    private XWikiContext xWikiContext;
+    private XWikiContext context;
 
     private ServletOutputStream servletOutputStream;
+
+    private WikiReference currentWiki;
 
     @BeforeEach
     void setup() throws XWikiException, IOException
     {
         ExecutionContext executionContext = mock(ExecutionContext.class);
         when(this.execution.getContext()).thenReturn(executionContext);
-        this.xWikiContext = mock(XWikiContext.class);
-        when(this.xWikiContextInitializer.initialize(executionContext)).thenReturn(xWikiContext);
+        this.context = mock(XWikiContext.class);
+        when(this.xWikiContextInitializer.initialize(executionContext)).thenReturn(context);
         this.response = mock(XWikiResponse.class);
-        when(xWikiContext.getResponse()).thenReturn(response);
+        when(context.getResponse()).thenReturn(response);
         this.xwiki = mock(XWiki.class);
-        when(xWikiContext.getWiki()).thenReturn(xwiki);
+        when(context.getWiki()).thenReturn(xwiki);
         when(this.xwiki.getEncoding()).thenReturn("UTF-8");
         XWikiPluginManager pluginManager = mock(XWikiPluginManager.class);
         when(this.xwiki.getPluginManager()).thenReturn(pluginManager);
-        when(pluginManager.endParsing(any(), eq(xWikiContext)))
+        when(pluginManager.endParsing(any(), eq(context)))
             .then(invocationOnMock -> invocationOnMock.getArgument(0));
         this.servletOutputStream = mock(ServletOutputStream.class);
         when(this.response.getOutputStream()).thenReturn(servletOutputStream);
+        currentWiki = new WikiReference("currentWiki");
+        when(context.getWikiReference()).thenReturn(currentWiki);
     }
 
     @Test
@@ -106,10 +111,12 @@ class AuthenticationResourceReferenceHandlerTest
     @Test
     void handleResetPassword() throws Exception
     {
+        WikiReference wikiReference = new WikiReference("foo");
         AuthenticationResourceReference resourceReference = new AuthenticationResourceReference(
+            wikiReference,
             AuthenticationAction.RESET_PASSWORD);
 
-        when(this.xwiki.evaluateTemplate("resetpassword.vm", xWikiContext)).thenReturn("Reset password content");
+        when(this.xwiki.evaluateTemplate("resetpassword.vm", context)).thenReturn("Reset password content");
 
         ResourceReferenceHandlerChain chain = mock(ResourceReferenceHandlerChain.class);
         this.resourceReferenceHandler.handle(resourceReference, chain);
@@ -118,15 +125,19 @@ class AuthenticationResourceReferenceHandlerTest
         verify(this.xWikiContextInitializer).initialize(any(ExecutionContext.class));
         verify(servletOutputStream).write("Reset password content".getBytes(StandardCharsets.UTF_8));
         verify(chain).handleNext(resourceReference);
+        verify(context).setWikiReference(wikiReference);
+        verify(context).setWikiReference(currentWiki);
     }
 
     @Test
     void handleForgotUsername() throws Exception
     {
+        WikiReference wikiReference = new WikiReference("bar");
         AuthenticationResourceReference resourceReference = new AuthenticationResourceReference(
-            AuthenticationAction.FORGOT_USERNAME);
+            wikiReference,
+            AuthenticationAction.RETRIEVE_USERNAME);
 
-        when(this.xwiki.evaluateTemplate("forgotusername.vm", xWikiContext)).thenReturn("Forgot user name content");
+        when(this.xwiki.evaluateTemplate("forgotusername.vm", context)).thenReturn("Forgot user name content");
 
         ResourceReferenceHandlerChain chain = mock(ResourceReferenceHandlerChain.class);
         this.resourceReferenceHandler.handle(resourceReference, chain);
@@ -135,5 +146,7 @@ class AuthenticationResourceReferenceHandlerTest
         verify(this.xWikiContextInitializer).initialize(any(ExecutionContext.class));
         verify(servletOutputStream).write("Forgot user name content".getBytes(StandardCharsets.UTF_8));
         verify(chain).handleNext(resourceReference);
+        verify(context).setWikiReference(wikiReference);
+        verify(context).setWikiReference(currentWiki);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/resource/AuthenticationResourceReferenceResolverTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/resource/AuthenticationResourceReferenceResolverTest.java
@@ -24,17 +24,26 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.inject.Provider;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.xwiki.model.reference.WikiReference;
 import org.xwiki.resource.CreateResourceReferenceException;
 import org.xwiki.resource.UnsupportedResourceReferenceException;
 import org.xwiki.security.authentication.AuthenticationAction;
 import org.xwiki.security.authentication.AuthenticationResourceReference;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
 import org.xwiki.url.ExtendedURL;
+
+import com.xpn.xwiki.XWikiContext;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for {@link AuthenticationResourceReferenceResolver}.
@@ -47,19 +56,46 @@ class AuthenticationResourceReferenceResolverTest
     @InjectMockComponents
     private AuthenticationResourceReferenceResolver resolver;
 
+    @MockComponent
+    private Provider<XWikiContext> contextProvider;
+
+    private XWikiContext context;
+
+    @BeforeEach
+    void setup()
+    {
+        this.context = mock(XWikiContext.class);
+        when(contextProvider.get()).thenReturn(this.context);
+    }
+
     @Test
     void resolve() throws CreateResourceReferenceException, UnsupportedResourceReferenceException
     {
+        WikiReference currentWiki = new WikiReference("current");
+        when(this.context.getMainXWiki()).thenReturn("current");
         Map parameters = new HashMap<>();
         parameters.put("key1", Collections.singletonList("value1"));
         parameters.put("key2", Arrays.asList("value2_a", "value2_b"));
 
-        ExtendedURL extendedURL = new ExtendedURL(Collections.singletonList("reset"), parameters);
+        ExtendedURL extendedURL = new ExtendedURL(Collections.singletonList("resetpassword"), parameters);
         AuthenticationResourceReference resourceReference =
             this.resolver.resolve(extendedURL, AuthenticationResourceReference.TYPE, parameters);
 
         AuthenticationResourceReference expectedReference = new AuthenticationResourceReference(
+            currentWiki,
             AuthenticationAction.RESET_PASSWORD);
+        expectedReference.addParameter("key1", Collections.singletonList("value1"));
+        expectedReference.addParameter("key2", Arrays.asList("value2_a", "value2_b"));
+
+        assertEquals(expectedReference, resourceReference);
+
+        extendedURL = new ExtendedURL(Arrays.asList("wiki", "foo", "retrieveusername"), parameters);
+        resourceReference =
+            this.resolver.resolve(extendedURL, AuthenticationResourceReference.TYPE, parameters);
+
+        expectedReference = new AuthenticationResourceReference(
+            new WikiReference("foo"),
+            AuthenticationAction.RETRIEVE_USERNAME);
         expectedReference.addParameter("key1", Collections.singletonList("value1"));
         expectedReference.addParameter("key2", Arrays.asList("value2_a", "value2_b"));
 
@@ -69,10 +105,20 @@ class AuthenticationResourceReferenceResolverTest
     @Test
     void resolveBadAction()
     {
+        when(this.context.getMainXWiki()).thenReturn("current");
         ExtendedURL extendedURL = new ExtendedURL(Collections.singletonList("foobar"), Collections.emptyMap());
         CreateResourceReferenceException createResourceReferenceException =
             assertThrows(CreateResourceReferenceException.class,
                 () -> this.resolver.resolve(extendedURL, AuthenticationResourceReference.TYPE, Collections.emptyMap()));
+
+        assertEquals("Cannot find an authentication action for name [foobar]",
+            createResourceReferenceException.getMessage());
+
+        ExtendedURL extendedURL2 = new ExtendedURL(Arrays.asList("wiki", "foo", "foobar"), Collections.emptyMap());
+        createResourceReferenceException =
+            assertThrows(CreateResourceReferenceException.class,
+                () -> this.resolver.resolve(extendedURL2,
+                    AuthenticationResourceReference.TYPE, Collections.emptyMap()));
 
         assertEquals("Cannot find an authentication action for name [foobar]",
             createResourceReferenceException.getMessage());
@@ -81,6 +127,7 @@ class AuthenticationResourceReferenceResolverTest
     @Test
     void resolveBadURL()
     {
+        when(this.context.getMainXWiki()).thenReturn("current");
         ExtendedURL extendedURL = new ExtendedURL(Arrays.asList("authenticate", "foobar"));
         CreateResourceReferenceException createResourceReferenceException =
             assertThrows(CreateResourceReferenceException.class,

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/resource/AuthenticationResourceReferenceSerializerTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/resource/AuthenticationResourceReferenceSerializerTest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import org.apache.commons.collections.map.HashedMap;
 import org.junit.jupiter.api.Test;
+import org.xwiki.model.reference.WikiReference;
 import org.xwiki.resource.SerializeResourceReferenceException;
 import org.xwiki.resource.UnsupportedResourceReferenceException;
 import org.xwiki.security.authentication.AuthenticationAction;
@@ -50,8 +51,10 @@ class AuthenticationResourceReferenceSerializerTest
     @Test
     void serialize() throws UnsupportedResourceReferenceException, SerializeResourceReferenceException
     {
+        WikiReference currentWiki = new WikiReference("current");
         AuthenticationResourceReference resourceReference = new AuthenticationResourceReference(
-            AuthenticationAction.FORGOT_USERNAME);
+            currentWiki,
+            AuthenticationAction.RETRIEVE_USERNAME);
         resourceReference.addParameter("key1", "value1");
         resourceReference.addParameter("key2", Arrays.asList("value2_a", "value2_b"));
 
@@ -60,7 +63,8 @@ class AuthenticationResourceReferenceSerializerTest
         Map<String, List<String>> parameters = new HashedMap();
         parameters.put("key1", Collections.singletonList("value1"));
         parameters.put("key2", Arrays.asList("value2_a", "value2_b"));
-        ExtendedURL expectedURL = new ExtendedURL(Arrays.asList("authenticate", "forgot"), parameters);
+        ExtendedURL expectedURL = new ExtendedURL(
+            Arrays.asList("authenticate", "wiki", "current", "retrieveusername"), parameters);
 
         assertEquals(expectedURL, serialized);
     }

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-script/src/main/java/org/xwiki/security/authentication/script/AuthenticationScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-script/src/main/java/org/xwiki/security/authentication/script/AuthenticationScriptService.java
@@ -166,8 +166,9 @@ public class AuthenticationScriptService implements ScriptService
         try {
             AuthenticationAction authenticationAction = AuthenticationAction.getFromRequestParameter(action);
 
-            AuthenticationResourceReference resourceReference =
-                new AuthenticationResourceReference(authenticationAction);
+            AuthenticationResourceReference resourceReference = new AuthenticationResourceReference(
+                this.contextProvider.get().getWikiReference(),
+                authenticationAction);
             if (params != null) {
                 for (Map.Entry<String, Object> entry : params.entrySet()) {
                     resourceReference.addParameter(entry.getKey(), entry.getValue());

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-script/src/test/java/org/xwiki/security/authentication/script/AuthenticationScriptServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-script/src/test/java/org/xwiki/security/authentication/script/AuthenticationScriptServiceTest.java
@@ -32,6 +32,7 @@ import javax.mail.internet.InternetAddress;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.xwiki.model.reference.WikiReference;
 import org.xwiki.resource.ResourceReference;
 import org.xwiki.resource.ResourceReferenceSerializer;
 import org.xwiki.security.authentication.AuthenticationAction;
@@ -166,13 +167,16 @@ class AuthenticationScriptServiceTest
     @Test
     void getAuthenticationURL() throws Exception
     {
-        String action = AuthenticationAction.FORGOT_USERNAME.getRequestParameter();
+        String action = AuthenticationAction.RETRIEVE_USERNAME.getRequestParameter();
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("u", "foo");
         parameters.put("v", "bar");
 
+        WikiReference wikiReference = new WikiReference("current");
+        when(this.xWikiContext.getWikiReference()).thenReturn(wikiReference);
+
         AuthenticationResourceReference resourceReference =
-            new AuthenticationResourceReference(AuthenticationAction.FORGOT_USERNAME);
+            new AuthenticationResourceReference(wikiReference, AuthenticationAction.RETRIEVE_USERNAME);
         resourceReference.addParameter("u", "foo");
         resourceReference.addParameter("v", "bar");
 

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/forgotusername.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/forgotusername.vm
@@ -41,7 +41,7 @@
       #if($email == '' || !$services.csrf.isTokenValid($request.form_token))
         #forgotUsernameBoxStart("default")
         $services.localization.render('xe.admin.forgotUsername.instructions')
-        <form method="post" action="$services.security.authentication.getAuthenticationURL('forgot', $NULL)" id="forgotUsernameForm" class="xform">
+        <form method="post" action="$services.security.authentication.getAuthenticationURL('retrieveusername', $NULL)" id="forgotUsernameForm" class="xform">
             <dl>
                 <dt>
                     <label for="e">$services.localization.render('xe.admin.forgotUsername.email.label')</label>

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/resetpasswordinline.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/resetpasswordinline.vm
@@ -61,7 +61,7 @@
 #resetPasswordBoxStart("default")
 $services.localization.render('xe.admin.passwordReset.instructions')
 
-  <form method="post" action="$services.security.authentication.getAuthenticationURL('reset', $NULL)" class="xform" id="resetPasswordForm">
+  <form method="post" action="$services.security.authentication.getAuthenticationURL('resetpassword', $NULL)" class="xform" id="resetPasswordForm">
     <input type="hidden" name="form_token" value="$!{services.csrf.getToken()}" />
     <dl>
       <dt>
@@ -93,8 +93,8 @@ $services.localization.render('xe.admin.passwordReset.instructions')
         #end
     #end
   <div class="resetpasswordlinks">
-    <a href="$services.security.authentication.getAuthenticationURL('reset', $NULL)">$services.localization.render('xe.admin.passwordReset.error.retry')</a> |
-    <a href="$services.security.authentication.getAuthenticationURL('forgot', $NULL)">$services.localization.render('xe.admin.passwordReset.error.recoverUsername')</a> |
+    <a href="$services.security.authentication.getAuthenticationURL('resetpassword', $NULL)">$services.localization.render('xe.admin.passwordReset.error.retry')</a> |
+    <a href="$services.security.authentication.getAuthenticationURL('retrieveusername', $NULL)">$services.localization.render('xe.admin.passwordReset.error.recoverUsername')</a> |
     <a href="$xwiki.getURL('XWiki.XWikiLogin', 'login')">$services.localization.render('xe.admin.passwordReset.login')</a>
   </div>
 #else
@@ -118,7 +118,7 @@ $services.localization.render('xe.admin.passwordReset.instructions')
         #set ($passwordFields = [])
         #definePasswordFields($passwordFields, 'p', 'p2', $passwordOptions)
 
-        <form action="$services.security.authentication.getAuthenticationURL('reset', $NULL)" method="post" id="resetPasswordStep2Form" class="xform">
+        <form action="$services.security.authentication.getAuthenticationURL('resetpassword', $NULL)" method="post" id="resetPasswordStep2Form" class="xform">
             <div class="hidden">
                 <input type="hidden" name="form_token" value="$!{services.csrf.getToken()}" />
                 <input type="hidden" name="u" value="$!escapetool.xml($userName)"/>
@@ -140,7 +140,7 @@ $services.localization.render('xe.admin.passwordReset.instructions')
         #if ("$!exception" != '')
             #resetPasswordBoxStart("danger")
             #displayResetPasswordException()
-            <a href="$services.security.authentication.getAuthenticationURL('reset', $NULL)">$services.localization.render('xe.admin.passwordReset.step2.backToStep1')</a>
+            <a href="$services.security.authentication.getAuthenticationURL('resetpassword', $NULL)">$services.localization.render('xe.admin.passwordReset.step2.backToStep1')</a>
         #else
             #displayForm('' $newValidationString)
         #end
@@ -159,7 +159,7 @@ $services.localization.render('xe.admin.passwordReset.instructions')
                 #resetPasswordBoxStart("danger")
                 #displayResetPasswordException()
                 <div class="resetpasswordlinks">
-                    <a href="$services.security.authentication.getAuthenticationURL('reset', $NULL)">$services.localization.render('xe.admin.passwordReset.step2.backToStep1')</a>
+                    <a href="$services.security.authentication.getAuthenticationURL('resetpassword', $NULL)">$services.localization.render('xe.admin.passwordReset.step2.backToStep1')</a>
                 </div>
             #else
                 #resetPasswordBoxStart("success")

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards/src/test/it/org/xwiki/test/webstandards/framework/DefaultValidationTest.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards/src/test/it/org/xwiki/test/webstandards/framework/DefaultValidationTest.java
@@ -106,21 +106,21 @@ public class DefaultValidationTest extends AbstractValidationTest
             Locale.ROOT));
         if (this.target.equals(resetPassword)) {
             this.logCaptureConfiguration.registerExpected("[DEPRECATED] The page [XWiki.ResetPassword] "
-                + "should not be used anymore in favor of the new 'authenticate/reset' URL.");
+                + "should not be used anymore in favor of the new 'authenticate/resetpassword' URL.");
         }
 
         Target resetPasswordComplete = new DocumentReferenceTarget(
             new DocumentReference("xwiki", "XWiki", "ResetPasswordComplete", Locale.ROOT));
         if (this.target.equals(resetPasswordComplete)) {
             this.logCaptureConfiguration.registerExpected("[DEPRECATED] The page [XWiki.ResetPasswordComplete] "
-                + "should not be used anymore in favor of the new 'authenticate/reset' URL.");
+                + "should not be used anymore in favor of the new 'authenticate/resetpassword' URL.");
         }
 
         Target forgotUsername = new DocumentReferenceTarget(
             new DocumentReference("xwiki", "XWiki", "ForgotUsername", Locale.ROOT));
         if (this.target.equals(forgotUsername)) {
             this.logCaptureConfiguration.registerExpected("[DEPRECATED] The page [XWiki.ForgotUsername] "
-                + "should not be used anymore in favor of the new 'authenticate/forgot' URL.");
+                + "should not be used anymore in favor of the new 'authenticate/retrieveusername' URL.");
         }
     }
 


### PR DESCRIPTION
This provides two things: the fix of the bug by handling a wiki part in
the URLs for authentication resource, and a rename of the authentication
resource action (forgot becomes retrieveusername and reset becomes
resetpassword).
Note that the latter changes are not backward compatible, but they were
still unstable (since 13.1RC1).