### PR TITLE
XWIKI-20007: When sharing a page from a subwiki, even non viewable users get suggested

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/uorgsuggest.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/uorgsuggest.vm
@@ -48,7 +48,7 @@
     #if($results.size() >= 10)
       #break
     #end
-    #if ($services.security.authorization.hasAccess('view', $rawResult))
+    #if ($services.security.authorization.hasAccess('view', $services.model.resolveDocument($rawResult, $wikiReference)))
       #set ($discard = $results.add($rawResult))
     #end
   #end


### PR DESCRIPTION
- When controlling access, resolve the user page reference relatively to the wiki reference it belongs to instead of the current wiki reference