### PR TITLE
XWIKI-19832: Take into account the request parameters when caching a LESS SSX

### DIFF
--- a/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/cache/CacheKeyFactory.java
+++ b/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/cache/CacheKeyFactory.java
@@ -24,17 +24,18 @@ import java.util.List;
 import java.util.Map;
 
 import javax.inject.Inject;
-import javax.inject.Provider;
 import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
+import org.xwiki.container.Container;
+import org.xwiki.container.Request;
+import org.xwiki.container.servlet.ServletRequest;
 import org.xwiki.lesscss.internal.colortheme.ColorThemeReference;
 import org.xwiki.lesscss.internal.skin.SkinReference;
 import org.xwiki.lesscss.resources.LESSResourceReference;
 import org.xwiki.text.StringUtils;
 
 import com.xpn.xwiki.XWiki;
-import com.xpn.xwiki.XWikiContext;
 
 /**
  * Factory to create a cache key.
@@ -52,7 +53,7 @@ public class CacheKeyFactory
     private XWikiContextCacheKeyFactory xcontextCacheKeyFactory;
 
     @Inject
-    private Provider<XWikiContext> xcontextProvider;
+    private Container container;
 
     /**
      * Get the cache key corresponding to the given LESS resource and context.
@@ -81,11 +82,11 @@ public class CacheKeyFactory
 
             /** Also take into account the request parameters, if any, except parameters which are already
              * taken into account or that are irrelevant. */
-            XWikiContext context = xcontextProvider.get();
+            Request request = container.getRequest();
             List<String> excludes = Arrays.asList("skin", "colorTheme", "colorThemeVersion", "language", "docVersion",
                 XWiki.CACHE_VERSION);
-            if (context != null && context.getRequest() != null) {
-                Map<String, String[]> parameters = context.getRequest().getParameterMap();
+            if (request instanceof ServletRequest) {
+                Map<String, String[]> parameters = ((ServletRequest) request).getHttpServletRequest().getParameterMap();
                 for (Map.Entry<String, String[]> entry : parameters.entrySet()) {
                     if (!excludes.contains(entry.getKey())) {
                         String[] values = entry.getValue();

--- a/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/cache/CacheKeyFactory.java
+++ b/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/cache/CacheKeyFactory.java
@@ -75,24 +75,24 @@ public class CacheKeyFactory
                      +  skin.length()          + CACHE_KEY_SEPARATOR + skin         + CACHE_KEY_SEPARATOR
                      +  colorTheme.length()    + CACHE_KEY_SEPARATOR + colorTheme;
 
-        /** Also take into account the request parameters, if any, except parameters which are already
-         * taken into account or that are irrelevant. */
-        XWikiContext context = xcontextProvider.get();
-        List<String> excludes = Arrays.asList("skin", "colorTheme", "colorThemeVersion", "language", "docVersion",
-            XWiki.CACHE_VERSION);
-        if (context != null && context.getRequest() != null) {
-            Map<String, String[]> parameters = context.getRequest().getParameterMap();
-            for (Map.Entry<String, String[]> entry : parameters.entrySet()) {
-                if (!excludes.contains(entry.getKey())) {
-                    String[] values = entry.getValue();
-                    result += CACHE_KEY_SEPARATOR + entry.getKey() + ":" + StringUtils.join(values, "|");
-                }
-            }
-        }
-
         if (withContext) {
             String xcontext = xcontextCacheKeyFactory.getCacheKey();
-            result += CACHE_KEY_SEPARATOR + xcontext.length() + CACHE_KEY_SEPARATOR + xcontext; 
+            result += CACHE_KEY_SEPARATOR + xcontext.length() + CACHE_KEY_SEPARATOR + xcontext;
+
+            /** Also take into account the request parameters, if any, except parameters which are already
+             * taken into account or that are irrelevant. */
+            XWikiContext context = xcontextProvider.get();
+            List<String> excludes = Arrays.asList("skin", "colorTheme", "colorThemeVersion", "language", "docVersion",
+                XWiki.CACHE_VERSION);
+            if (context != null && context.getRequest() != null) {
+                Map<String, String[]> parameters = context.getRequest().getParameterMap();
+                for (Map.Entry<String, String[]> entry : parameters.entrySet()) {
+                    if (!excludes.contains(entry.getKey())) {
+                        String[] values = entry.getValue();
+                        result += CACHE_KEY_SEPARATOR + entry.getKey() + ":" + StringUtils.join(values, "|");
+                    }
+                }
+            }
         }
 
         return result;


### PR DESCRIPTION
This is an attempt to implement XWIKI-19832. Not sure this is the right approach nor if the list of excluded parameters is correct but a review and a recommendation on how to implement the feature is welcome.

Remarks:
* The list of excluded parameters was obtained empirically by observing the existing request parameters when computing the cache key of a LESS resource, there might be other parameters to exclude from the list but I don't know how to get the exhaustive list.
* A possible downside of this approach is that the request parameters are in this case always taken into account when `withContext` is `true`. However a LESS resource is not meant to receive request parameters others than the ones already used for computing the cache key and the excluded ones, is it? 