### PR TITLE
XWIKI-20060: Database Tree property changes are not saved anymore in object mode

### DIFF
--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-war/src/main/webapp/resources/uicomponents/widgets/tree.js
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-war/src/main/webapp/resources/uicomponents/widgets/tree.js
@@ -38,16 +38,6 @@ require([paths.treeRequireConfig], function() {
         // Open the tree to the specified node and select it.
         openToNodeId && data.instance.openTo(openToNodeId);
       });
-
-      $('.xtree.dbTreeList').on('changed.jstree', function(event, data) {
-        if (typeof data.instance.settings.xwiki.fieldName !== 'undefined') {
-          var fieldName = data.instance.settings.xwiki.fieldName;
-          var fieldValue = data.selected.join('|');
-          $('input[type="hidden"]').filter(function() {
-            return $(this).attr('name') === fieldName;
-          }).val(fieldValue);
-        }
-      });
     };
 
     $(init).on('xwiki:dom:updated', init);

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-war/src/main/webapp/resources/uicomponents/widgets/tree.js
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-war/src/main/webapp/resources/uicomponents/widgets/tree.js
@@ -38,6 +38,16 @@ require([paths.treeRequireConfig], function() {
         // Open the tree to the specified node and select it.
         openToNodeId && data.instance.openTo(openToNodeId);
       });
+
+      $('.xtree.dbTreeList').on('changed.jstree', function(event, data) {
+        if (typeof data.instance.settings.xwiki.fieldName !== 'undefined') {
+          var fieldName = data.instance.settings.xwiki.fieldName;
+          var fieldValue = data.selected.join('|');
+          $('input[type="hidden"]').filter(function() {
+            return $(this).attr('name') === fieldName;
+          }).val(fieldValue);
+        }
+      });
     };
 
     $(init).on('xwiki:dom:updated', init);

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/tree.js
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/tree.js
@@ -698,6 +698,15 @@ define(['jquery', 'xwiki-page-ready', 'xwiki-job-runner', 'jsTree', 'tree-finder
         data.menu.remove._disabled = !canRemoveNodes(selectedNodes);
       }
 
+    }).on('changed.jstree', function(event, data) {
+      if (typeof data.instance.settings.xwiki.fieldName !== 'undefined') {
+        var fieldName = data.instance.settings.xwiki.fieldName;
+        var fieldValue = data.selected.join('|');
+        $('input[type="hidden"]').filter(function() {
+          return $(this).attr('name') === fieldName;
+        }).val(fieldValue);
+      }
+
     //
     // Un-wrap the links generated from wiki syntax so that they are taken into account by jsTree.
     //

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/treeview.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/treeview.vm
@@ -49,4 +49,3 @@
   }))
 #end
 #tree($dbTreeListSettings)
-$xwiki.jsfx.use('resources/uicomponents/widgets/tree.js', true)

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/treeview.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/treeview.vm
@@ -49,14 +49,4 @@
   }))
 #end
 #tree($dbTreeListSettings)
-<script>
-require(['jquery'], function($) {
-  $('.xtree.dbTreeList').on('changed.jstree', function(event, data) {
-    var fieldName = data.instance.settings.xwiki.fieldName;
-    var fieldValue = data.selected.join('|');
-    $('input[type="hidden"]').filter(function() {
-      return $(this).attr('name') === fieldName;
-    }).val(fieldValue);
-  });
-});
-</script>
+$xwiki.jsfx.use('resources/uicomponents/widgets/tree.js', true)


### PR DESCRIPTION
* move the inline js code to and external file so the dataeditors.js will append it in HTML head
* make sure the moved code is active only when it necessary (when data.instance.settings.xwiki.fieldName is defined)