### PR TITLE
XWIKI-19993: Allow admins to configure the macros

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/MacroService.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/MacroService.xml
@@ -115,7 +115,7 @@
   ## categories.
   ## TODO: Make the list of hidden by default categories configurable from the administration (XWIKI-19993).
   #if(!$services.user.getProperties().displayHiddenDocuments())
-    #set ($hiddenCategories = ['Internal', 'Deprecated'])
+    #set ($hiddenCategories = $services.rendering.getHiddenMacroCategories())
   #else
     #set ($hiddenCategories = [])
   #end

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-transformations/xwiki-platform-rendering-transformation-macro/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-transformations/xwiki-platform-rendering-transformation-macro/pom.xml
@@ -44,6 +44,11 @@
       <artifactId>xwiki-platform-model-api</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-configuration-default</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <!-- Test Dependencies -->
     <dependency>

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-transformations/xwiki-platform-rendering-transformation-macro/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-transformations/xwiki-platform-rendering-transformation-macro/pom.xml
@@ -44,11 +44,6 @@
       <artifactId>xwiki-platform-model-api</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.xwiki.platform</groupId>
-      <artifactId>xwiki-platform-configuration-default</artifactId>
-      <version>${project.version}</version>
-    </dependency>
 
     <!-- Test Dependencies -->
     <dependency>

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-transformations/xwiki-platform-rendering-transformation-macro/src/main/java/org/xwiki/rendering/internal/transformation/macro/XWikiMacroTransformationConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-transformations/xwiki-platform-rendering-transformation-macro/src/main/java/org/xwiki/rendering/internal/transformation/macro/XWikiMacroTransformationConfiguration.java
@@ -19,7 +19,10 @@
  */
 package org.xwiki.rendering.internal.transformation.macro;
 
+import java.util.List;
 import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -27,6 +30,9 @@ import javax.inject.Singleton;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.configuration.ConfigurationSource;
 import org.xwiki.rendering.transformation.macro.MacroTransformationConfiguration;
+
+import static org.xwiki.rendering.macro.AbstractMacro.DEFAULT_CATEGORY_DEPRECATED;
+import static org.xwiki.rendering.macro.AbstractMacro.DEFAULT_CATEGORY_INTERNAL;
 
 /**
  * All configuration options for the Macro Transformation subsystem.
@@ -53,5 +59,13 @@ public class XWikiMacroTransformationConfiguration implements MacroTransformatio
     public Properties getCategories()
     {
         return this.configuration.getProperty(PREFIX + "categories", Properties.class);
+    }
+
+    @Override
+    public Set<String> getHiddenCategories()
+    {
+        List<?> hiddenCategories = this.configuration.getProperty(PREFIX + "hiddenCategories", List.class,
+            List.of(DEFAULT_CATEGORY_INTERNAL, DEFAULT_CATEGORY_DEPRECATED));
+        return hiddenCategories.stream().map(String::valueOf).collect(Collectors.toSet());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-transformations/xwiki-platform-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/transformation/macro/XWikiMacroTransformationConfigurationTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-transformations/xwiki-platform-rendering-transformation-macro/src/test/java/org/xwiki/rendering/internal/transformation/macro/XWikiMacroTransformationConfigurationTest.java
@@ -19,15 +19,21 @@
  */
 package org.xwiki.rendering.internal.transformation.macro;
 
+import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.xwiki.configuration.ConfigurationSource;
-import org.xwiki.test.mockito.MockitoComponentMockingRule;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+import static org.xwiki.rendering.macro.AbstractMacro.DEFAULT_CATEGORY_DEPRECATED;
+import static org.xwiki.rendering.macro.AbstractMacro.DEFAULT_CATEGORY_INTERNAL;
 
 /**
  * Unit tests for {@link XWikiMacroTransformationConfiguration}.
@@ -35,21 +41,33 @@ import static org.mockito.Mockito.*;
  * @version $Id$
  * @since 2.6RC1
  */
-public class XWikiMacroTransformationConfigurationTest
+@ComponentTest
+class XWikiMacroTransformationConfigurationTest
 {
-    @Rule
-    public MockitoComponentMockingRule<XWikiMacroTransformationConfiguration> mocker =
-        new MockitoComponentMockingRule<>(XWikiMacroTransformationConfiguration.class);
+    @InjectMockComponents
+    private XWikiMacroTransformationConfiguration configuration;
+
+    @MockComponent
+    private ConfigurationSource source;
 
     @Test
-    public void getCategories() throws Exception
+    void getCategories()
     {
-        ConfigurationSource source = this.mocker.getInstance(ConfigurationSource.class);
-        when(source.getProperty("rendering.transformation.macro.categories", Properties.class)).thenReturn(
-            new Properties());
+        when(this.source.getProperty("rendering.transformation.macro.categories", Properties.class))
+            .thenReturn(new Properties());
 
-        Properties categories = this.mocker.getComponentUnderTest().getCategories();
+        Properties categories = this.configuration.getCategories();
         assertNotNull(categories);
         assertEquals(0, categories.size());
+    }
+
+    @Test
+    void getHiddenCategories()
+    {
+        when(this.source.getProperty("rendering.transformation.macro." + "hiddenCategories", List.class,
+            List.of(DEFAULT_CATEGORY_INTERNAL, DEFAULT_CATEGORY_DEPRECATED)))
+            .thenReturn(List.of("C1", "C2", "C1", "C3"));
+        Set<String> hiddenCategories = this.configuration.getHiddenCategories();
+        assertEquals(Set.of("C1", "C2", "C3"), hiddenCategories);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/java/org/xwiki/rendering/script/RenderingScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/java/org/xwiki/rendering/script/RenderingScriptService.java
@@ -321,6 +321,16 @@ public class RenderingScriptService implements ScriptService
         return this.macroCategoryManager.getMacroCategories(macroId);
     }
 
+    /**
+     * @return the set of hidden macro categories
+     * @since 14.8RC1
+     */
+    @Unstable
+    public Set<String> getHiddenMacroCategories()
+    {
+        return this.macroCategoryManager.getHiddenCategories();
+    }
+
     private char getEscapeCharacter(Syntax syntax) throws IllegalArgumentException
     {
         if (Syntax.XWIKI_1_0.equals(syntax)) {

--- a/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.properties.vm
+++ b/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.properties.vm
@@ -127,6 +127,13 @@ environment.permanentDirectory = $xwikiPropertiesEnvironmentPermanentDirectory
 # rendering.transformation.macro.categories = toc = My Category\,Deprecated
 # rendering.transformation.macro.categories = script = My Other Category
 
+#-# [Since 14.8RC1]
+#-# Override the default hidden macro categories.
+#-#
+#-# For instance, to make the "Development" category hidden by default, in addition to the default "Internal" and 
+#-# "Deprecated" categories, you'd use:
+# rendering.transformation.macro.hiddenCategories = Development,Internal,Deprecated
+
 #-# [Since 2.5M2]
 #-# Specify whether the image dimensions should be extracted from the image parameters and included in the image URL
 #-# or not. When image dimensions are included in the image URL the image can be resized on the server side before being

--- a/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.properties.vm
+++ b/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.properties.vm
@@ -121,6 +121,7 @@ environment.permanentDirectory = $xwikiPropertiesEnvironmentPermanentDirectory
 #-# [Since 2.0M3]
 #-# Overrides default macro categories (Each macro has default categories already defined, for example
 #-# "Navigation" for the Table of Contents Macro).
+#-# Note: the categories are case sensitive.
 #-#
 #-# Ex: To redefine the macro categories for the TOC macro so that it'd be in the "My Category" and "Deprecated" 
 #-# categories + redefine the category for the Script Macro to be "My Other Category", you'd use:
@@ -129,6 +130,7 @@ environment.permanentDirectory = $xwikiPropertiesEnvironmentPermanentDirectory
 
 #-# [Since 14.8RC1]
 #-# Override the default hidden macro categories.
+#-# Note: the categories are case sensitive.
 #-#
 #-# For instance, to make the "Development" category hidden by default, in addition to the default "Internal" and 
 #-# "Deprecated" categories, you'd use:


### PR DESCRIPTION
- Introduce getHiddenMacroCategories in RenderingScriptService
- Use getHiddenMacroCategories in the CKEditor macro dialog implementation
- Document rendering.transformation.macro.hiddenCategories in xwiki.properties.vm

Jira: https://jira.xwiki.org/browse/XWIKI-19993