### PR TITLE
XWIKI-20078: Wrong panels preferences displayed and edited in the administration of a page when it's not a top level page

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/layoutvars.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/layoutvars.vm
@@ -22,15 +22,15 @@
 ##
 ## In admin mode, Panels.PanelWizard must display the layout for the requested space
 ##
-#set($spaceprefs = "")
+#set($spacePrefsRef = "")
 #set($globalprefs = false)
 
 #if($doc.documentReference.name == "WebPreferences" && "$!{request.space}" != "") ## space administration
-  #set($spaceprefs = $request.space)
-  #set($showLeftPanels =  $xwiki.getSpacePreferenceFor("showLeftPanels", $request.space))
-  #set($showRightPanels = $xwiki.getSpacePreferenceFor("showRightPanels", $request.space))
-  #set($leftPanelsWidth =  $xwiki.getSpacePreferenceFor("leftPanelsWidth", $request.space))
-  #set($rightPanelsWidth =  $xwiki.getSpacePreferenceFor("rightPanelsWidth", $request.space))
+  #set($spacePrefsRef = $services.model.resolveSpace($request.space))
+  #set($showLeftPanels =  $xwiki.getSpacePreferenceFor("showLeftPanels", $spacePrefsRef))
+  #set($showRightPanels = $xwiki.getSpacePreferenceFor("showRightPanels", $spacePrefsRef))
+  #set($leftPanelsWidth =  $xwiki.getSpacePreferenceFor("leftPanelsWidth", $spacePrefsRef))
+  #set($rightPanelsWidth =  $xwiki.getSpacePreferenceFor("rightPanelsWidth", $spacePrefsRef))
 #elseif($doc.fullName == "XWiki.XWikiPreferences" || "$!request.editor" == "globaladmin")
   #set($globalprefs = true)
   #set($showLeftPanels = $xwiki.getXWikiPreference("showLeftPanels"))
@@ -76,8 +76,8 @@
 #if($showLeftPanels)
   #if($globalprefs == true)
      #set($leftPanels = $xwiki.getXWikiPreference("leftPanels"))
-  #elseif($spaceprefs != "")
-     #set($leftPanels = $xwiki.getSpacePreferenceFor("leftPanels", $spaceprefs))
+  #elseif($spacePrefsRef != "")
+     #set($leftPanels = $xwiki.getSpacePreferenceFor("leftPanels", $spacePrefsRef))
   #else
     #set($leftPanels = $xwiki.getUserPreference("leftPanels"))
     #if($leftPanels == "")
@@ -92,8 +92,8 @@
 #if($showRightPanels)
   #if($globalprefs == true)
     #set($rightPanels = $xwiki.getXWikiPreference("rightPanels"))
-  #elseif($spaceprefs != "")
-    #set($rightPanels = $xwiki.getSpacePreferenceFor("rightPanels", $spaceprefs))
+  #elseif($spacePrefsRef != "")
+    #set($rightPanels = $xwiki.getSpacePreferenceFor("rightPanels", $spacePrefsRef))
   #else
     #set($rightPanels = $xwiki.getUserPreference("rightPanels"))
     #if($rightPanels == "")

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/XWiki.java
@@ -1159,9 +1159,7 @@ public class XWiki extends Api
      * @param preference Preference name
      * @param space The space for which this preference is requested
      * @return The preference for this wiki and the current locale
-     * @deprecated use {@link #getSpacePreferenceFor(String, SpaceReference)} instead
      */
-    @Deprecated(since = "14.7")
     public String getSpacePreferenceFor(String preference, String space)
     {
         return getSpacePreferenceFor(preference, space, "");
@@ -1176,9 +1174,7 @@ public class XWiki extends Api
      * @param space The space for which this preference is requested
      * @param defaultValue default value to return if the preference does not exist or is empty
      * @return The preference for this wiki and the current locale in long format
-     * @deprecated use {@link #getSpacePreferenceFor(String, SpaceReference, String)} instead
      */
-    @Deprecated(since = "14.7")
     public String getSpacePreferenceFor(String preference, String space, String defaultValue)
     {
         return this.xwiki.getSpacePreference(preference, space, defaultValue, getXWikiContext());

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/XWiki.java
@@ -1159,7 +1159,9 @@ public class XWiki extends Api
      * @param preference Preference name
      * @param space The space for which this preference is requested
      * @return The preference for this wiki and the current locale
+     * @deprecated use {@link #getSpacePreferenceFor(String, SpaceReference)} instead
      */
+    @Deprecated(since = "14.7")
     public String getSpacePreferenceFor(String preference, String space)
     {
         return getSpacePreferenceFor(preference, space, "");
@@ -1174,7 +1176,9 @@ public class XWiki extends Api
      * @param space The space for which this preference is requested
      * @param defaultValue default value to return if the preference does not exist or is empty
      * @return The preference for this wiki and the current locale in long format
+     * @deprecated use {@link #getSpacePreferenceFor(String, SpaceReference, String)} instead
      */
+    @Deprecated(since = "14.7")
     public String getSpacePreferenceFor(String preference, String space, String defaultValue)
     {
         return this.xwiki.getSpacePreference(preference, space, defaultValue, getXWikiContext());


### PR DESCRIPTION
* use the getSpacePreferenceFor API that takes a spaceReference as a parameter to correctly read preferences for a space of any level