### PR TITLE
[XWIKI-20109] Notification headers for autoreplies

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/AbstractMimeMessageIterator.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/AbstractMimeMessageIterator.java
@@ -364,6 +364,8 @@ public abstract class AbstractMimeMessageIterator implements Iterator<MimeMessag
 
             updateFactoryParameters(templateDocumentReference);
             message = this.factory.createMessage(templateDocumentReference, this.factoryParameters);
+            message.setHeader("Auto-Submitted", "auto-generated");
+            message.setHeader("X-Auto-Response-Suppress", "All");
 
             List<EntityEvent> events = new ArrayList<>();
             this.currentEvents.forEach(


### PR DESCRIPTION
Hello,

We do have an issue with people in vacations and their autoreply email responding to xwiki automatic notifications.

This PR fixes that by adding common email headers ( RFC 5436, 2.7.1 for 'Auto-Submitted', 'X-Auto-Response-Suppress' used by Exchange servers ) to prevent automatic replies.

It's only set in the notification system. It may be set by default in xwiki since everything is probably generated emails - but I'm not sure to I did it only there :)