### PR TITLE
XWIKI-20112: Custom headers are not registered when loaded to soon

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/xwiki.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/xwiki.js
@@ -1821,15 +1821,17 @@ document.observe("xwiki:dom:loaded", function() {
  * Intercept asynchronous HTTP requests and look for the custom X-XWIKI-HTML-HEAD and X-XWIKI-HTML-SCRIPTS response
  * headers that are used by the server to extend the page HTML head asynchronously.
  */
-require(['jquery'], function($) {
+ (function() {
   /**
    * Collect the URLs of all the external stylesheets an JavaScript files that are already loaded (or in the process of
    * being loaded) because their associated tag is in the DOM.
    */
   var getLoadedResources = function() {
-    return $('link[href], script[src]').map(function() {
-      return $(this).attr('href') || $(this).attr('src');
-    }).get();
+    var resources = [];
+    [...document.querySelectorAll('link[href], script[src]')].forEach(function(resource) {
+      resources.push(resource.getAttribute('href') || resource.getAttribute('src'))
+    });
+    return resources;
   };
 
   /**
@@ -1840,17 +1842,21 @@ require(['jquery'], function($) {
    */
   var extendPageHead = function(html) {
     var loadedResources;
-    var contentToInject = $('<div></div>').html(html);
-    // Remove resources that are already loaded.
-    contentToInject.find('link[href], script[src]').filter(function() {
+    // Force the execution of script tags when adding them dynamically, since inserting via innerHTML will not trigger
+    // it.
+    var range = document.createRange();
+    range.setStart(document.head, 0);
+    var contentToInject = range.createContextualFragment(html);
+    // Inject only the resources that are not already loaded.
+    [...contentToInject.querySelectorAll('link[href], script[src]')].forEach(function(resource) {
       if (!loadedResources) {
         loadedResources = getLoadedResources();
       }
-      var url = $(this).attr('href') || $(this).attr('src');
-      return loadedResources.indexOf(url) >= 0;
-    }).remove();
-    // Inject the remaining part into the page head.
-    contentToInject.contents().appendTo('head');
+      var url = resource.getAttribute('href') || resource.getAttribute('src');
+      if(loadedResources.indexOf(url) < 0) {
+        document.head.appendChild(resource);
+      }
+    });
   };
 
   /**
@@ -1900,4 +1906,4 @@ require(['jquery'], function($) {
   // Intercept right away, as early as possible, in order to be sure we catch all requests.
   interceptXMLHttpRequest();
   interceptFetch();
-});
+})();


### PR DESCRIPTION
* move code to plain js, since jquery blocks are executed too late
* use createContextualFragment to preserve the script tag attributes