### PR TITLE
XWIKI-19480: Disable Lightbox for profile, activity stream and livetable

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/macros.vm
@@ -193,7 +193,7 @@
   </div>
   #end
   <table id="${htmlLiveTableId}" class="xwiki-livetable"
-      data-settings="$escapetool.xml($jsontool.serialize($macro.settings))">
+      data-settings="$escapetool.xml($jsontool.serialize($macro.settings))" data-xwiki-lightbox="false">
     #if("$!options.description" != '')
       <caption class="sr-only">$options.description</caption>
     #end

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
@@ -666,7 +666,7 @@ $services.localization.render('platform.core.profile.category.profile.disabled')
 
       &lt;/div&gt;
       #end
-      &lt;div class='userRecentChanges'&gt;
+      &lt;div class='userRecentChanges' data-xwiki-lightbox="false"&gt;
       #if ($xcontext.user == $doc.fullName)
         &lt;h2&gt;$escapetool.xml($services.localization.render('platform.core.profile.section.activity'))&lt;/h2&gt;
       #else

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -1434,7 +1434,7 @@ $Msz MB##
   #end
   <table id="${htmlLiveTableId}" class="xwiki-livetable"
       #if("$!options.description" != '') summary="$escapetool.xml($options.description)"#end
-      data-settings="$escapetool.xml($jsontool.serialize($macro.settings))">
+      data-settings="$escapetool.xml($jsontool.serialize($macro.settings))" data-xwiki-lightbox="false">
     <tr>
       <td class="xwiki-livetable-pagination">
         <span id="${htmlLiveTableId}-limits" class="xwiki-livetable-limits"></span>


### PR DESCRIPTION
* disable lightbox for the activity stream column, since it would display the profile picture for each activity done
* disable lightbox for the livetable, since it might contain images not intended as content