### PR TITLE
[Misc] Trigger an event when an entry is updated on LD

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/webjar/Logic.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/webjar/Logic.js
@@ -583,10 +583,7 @@ define('xwiki-livedata', [
       return this.fetchEntries()
         .then(data => {
           this.data.data = Object.freeze(data);
-          let self = this;
-          Vue.nextTick(function () {
-            self.triggerEvent('entriesUpdated', {});
-          });
+          Vue.nextTick(() => this.triggerEvent('entriesUpdated', {}));
           // Remove the outdated footnotes, they will be recomputed by the new entries.
           this.footnotes.reset()
         })

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/webjar/Logic.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/webjar/Logic.js
@@ -583,6 +583,10 @@ define('xwiki-livedata', [
       return this.fetchEntries()
         .then(data => {
           this.data.data = Object.freeze(data);
+          let self = this;
+          Vue.nextTick(function () {
+            self.triggerEvent('entriesUpdated', {});
+          });
           // Remove the outdated footnotes, they will be recomputed by the new entries.
           this.footnotes.reset()
         })


### PR DESCRIPTION
Trigger an event whenever entries are displayed in a live data. 
This code needs to be better tested, right now I only tested on attachments live data with a JSX containing:
```
require(['jquery'], function ($) {
  var initialize = function () {
    console.log('initialize called');
    $('#docAttachments').find('a.move-attachment').on('click', function (event) {
      event.preventDefault();
      console.log("Property attached!");
    });
  }
  $(document).on('xwiki:livedata:entriesUpdated', initialize);
});
```