### PR TITLE
XWIKI-20112: Custom headers are not registered when loaded to soon

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/xwiki.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/xwiki.js
@@ -1854,9 +1854,10 @@ document.observe("xwiki:dom:loaded", function() {
       }
       var url = resource.getAttribute('href') || resource.getAttribute('src');
       if(loadedResources.indexOf(url) < 0) {
-        if (resource.getAttribute('src')) {
+        if (resource.getAttribute('src') && !resource.getAttribute('async')) {
           // Scripts that are dynamically created and added to the document are async by default, which means there are
           // no guarantees they will execute in the same order they were added.
+          // See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#compatibility_notes
           resource.async = false;
         }
         document.head.appendChild(resource);

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/xwiki.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/xwiki.js
@@ -1854,6 +1854,11 @@ document.observe("xwiki:dom:loaded", function() {
       }
       var url = resource.getAttribute('href') || resource.getAttribute('src');
       if(loadedResources.indexOf(url) < 0) {
+        if (resource.getAttribute('src')) {
+          // Scripts that are dynamically created and added to the document are async by default, which means there are
+          // no guarantees they will execute in the same order they were added.
+          resource.async = false;
+        }
         document.head.appendChild(resource);
       }
     });

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/xwiki.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/xwiki.js
@@ -1854,7 +1854,7 @@ document.observe("xwiki:dom:loaded", function() {
       }
       var url = resource.getAttribute('href') || resource.getAttribute('src');
       if(loadedResources.indexOf(url) < 0) {
-        if (resource.getAttribute('src') && !resource.getAttribute('async')) {
+        if (resource.getAttribute('src') && !resource.hasAttribute('async')) {
           // Scripts that are dynamically created and added to the document are async by default, which means there are
           // no guarantees they will execute in the same order they were added.
           // See: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#compatibility_notes


### PR DESCRIPTION
* make sure that scripts are executed in the order they are added