### PR TITLE
Fix typo in a comment in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@
 # ---------------------------------------------------------------------------
 version: 2
 registries:
-  # Hep find updates for non Maven Central dependencies
+  # Helps find updates for non Maven Central dependencies
   maven-xwiki-public:
     type: maven-repository
     url: https://nexus.xwiki.org/nexus/content/groups/public/


### PR DESCRIPTION
Fixed a typing error by changing `hep` to `helps` in dependabot.yml