### PR TITLE
XWIKI-20167: The cursor is not visible after a macro that supports inline is added standalone on chrome

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/resources/xwiki-macro/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/resources/xwiki-macro/plugin.js
@@ -447,15 +447,16 @@
           // Remove the element we added after the macro to force the inline rendering.
           var inlineEnforcer = editor.editable().findOne('span#xwiki-macro-inline-enforcer');
           if (inlineEnforcer) {
-            // Place the caret after the inserted inline macro in order to allow the user to continue typing.
-            // We proceed by inserting and non-breakable space after the inline enforcer, before selecting its content.
-            // It is required to be cross-browser compatible. Without these operations, the caret was not visible in
-            // Chrome after the inline macro insertion.
+            // Place the caret after the inserted inline macro in order to allow the user to continue typing. We proceed
+            // by inserting and non-breakable space after the inline enforcer. It is required to be cross-browser
+            // compatible. Without these operations, the caret is not visible in Chrome after the inline macro
+            // insertion.
             var space = new CKEDITOR.dom.text('\u00A0');
             space.insertAfter(inlineEnforcer);
             var range = editor.createRange();
             range.selectNodeContents(space);
-            // TEST with not selected space.
+            // Make the range of length zero (from endOffset to endOffset) so that a caret is displayed after the
+            // space, instead of a selection of the space.
             range.setStartAfter(space, range.endOffset);
             editor.getSelection().selectRanges([range]);
             // Clean up the inline enforcer to avoid duplicates for the next inline macro insertion.

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/resources/xwiki-macro/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/resources/xwiki-macro/plugin.js
@@ -447,13 +447,18 @@
           // Remove the element we added after the macro to force the inline rendering.
           var inlineEnforcer = editor.editable().findOne('span#xwiki-macro-inline-enforcer');
           if (inlineEnforcer) {
-            // Adding a zero width space between the widget and inlineEnforcer help webkit based browsers place the
-            // caret once inlineEnforcer is removed (without this, the caret is present but not visible). See
-            // https://github.com/ckeditor/ckeditor5/issues/1724 (mentioning CKEditor 5, but also working with CKEditor
-            // 4). 
-            inlineEnforcer.$.insertAdjacentText('beforebegin', '\u200b');
             // Place the caret after the inserted inline macro in order to allow the user to continue typing.
-            editor.getSelection().selectElement(inlineEnforcer);
+            // We proceed by inserting and non-breakable space after the inline enforcer, before selecting its content.
+            // It is required to be cross-browser compatible. Without these operations, the caret was not visible in
+            // Chrome after the inline macro insertion.
+            var space = new CKEDITOR.dom.text('\u00A0');
+            space.insertAfter(inlineEnforcer);
+            var range = editor.createRange();
+            range.selectNodeContents(space);
+            // TEST with not selected space.
+            range.setStartAfter(space, range.endOffset);
+            editor.getSelection().selectRanges([range]);
+            // Clean up the inline enforcer to avoid duplicates for the next inline macro insertion.
             inlineEnforcer.remove();
           }
           editor.fire('unlockSnapshot');

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/resources/xwiki-macro/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/resources/xwiki-macro/plugin.js
@@ -447,6 +447,11 @@
           // Remove the element we added after the macro to force the inline rendering.
           var inlineEnforcer = editor.editable().findOne('span#xwiki-macro-inline-enforcer');
           if (inlineEnforcer) {
+            // Adding a zero width space between the widget and inlineEnforcer help webkit based browsers place the
+            // caret once inlineEnforcer is removed (without this, the caret is present but not visible). See
+            // https://github.com/ckeditor/ckeditor5/issues/1724 (mentioning CKEditor 5, but also working with CKEditor
+            // 4). 
+            inlineEnforcer.$.insertAdjacentText('beforebegin', '\u200b');
             // Place the caret after the inserted inline macro in order to allow the user to continue typing.
             editor.getSelection().selectElement(inlineEnforcer);
             inlineEnforcer.remove();


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-20167

Result on Chrome:
![Peek 2022-09-29 16-19](https://user-images.githubusercontent.com/327856/193056912-0dd0b02d-eb7e-437d-86f3-8d68bfaf35eb.gif)

PS: Working as well on Firefox and Edge.