### PR TITLE
XWIKI-19702: Attachment selector upload should not save immediately the page

### DIFF
--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -136,6 +136,13 @@
                   <justification>Unstable API change: Script services are not supposed to expose classes from com.xpn.xwiki.doc.*</justification>
                   <criticality>documented</criticality>
                 </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.addedToInterface</code>
+                  <new>method com.xpn.xwiki.doc.XWikiAttachment org.xwiki.store.TemporaryAttachmentSessionsManager::uploadAttachment(org.xwiki.model.reference.DocumentReference, javax.servlet.http.Part, java.lang.String) throws org.xwiki.store.TemporaryAttachmentException</new>
+                  <justification>We can't provide a default implementation for this new method, it needs to be implemented on upgrade</justification>
+                  <criticality>documented</criticality>
+                </item>
               </differences>
             </revapi.differences>
           </analysisConfiguration>

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/pom.xml
@@ -51,9 +51,9 @@
     </dependency>
     <dependency>
       <groupId>org.xwiki.platform</groupId>
-      <artifactId>xwiki-platform-ckeditor-ui</artifactId>
+      <artifactId>xwiki-platform-store-filesystem-oldcore</artifactId>
       <version>${project.version}</version>
-      <type>xar</type>
+      <scope>runtime</scope>
       <optional>true</optional>
     </dependency>
     <!-- Test dependencies. -->

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/pom.xml
@@ -85,5 +85,19 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <!-- Icon manager dependencies for Page Tests. -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-icon-default</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-icon-default</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+      <type>test-jar</type>
+    </dependency>
   </dependencies>
 </project>

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/pom.xml
@@ -56,6 +56,15 @@
       <scope>runtime</scope>
       <optional>true</optional>
     </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-icon-script</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+      <!-- Optional because it is currently only required if xwiki-platform-store-filesystem-oldcore is also 
+           installed. -->
+      <optional>true</optional>
+    </dependency>
     <!-- Test dependencies. -->
     <dependency>
       <groupId>org.xwiki.platform</groupId>

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/pom.xml
@@ -49,6 +49,13 @@
       <version>${project.version}</version>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-ckeditor-ui</artifactId>
+      <version>${project.version}</version>
+      <type>xar</type>
+      <optional>true</optional>
+    </dependency>
     <!-- Test dependencies. -->
     <dependency>
       <groupId>org.xwiki.platform</groupId>

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
@@ -83,11 +83,9 @@ $xwiki.jsx.use($attachmentPickerDocName)
   #end
   (% class="gallery" %)(((
   ## Only display the upload form if they have edit permission on targetAttachDocument
-  #if ($xwiki.hasAccessLevel('edit',$xcontext.user,${targetAttachDocument.fullName}))
-    #attachmentPicker_displayUploadForm($targetDocument, $targetAttachDocument, $options)
-  #end
+  #attachmentPicker_displayUploadForm($targetDocument, $targetAttachDocument, $options)
   #attachmentPicker_displayAttachmentGalleryEmptyValue($targetDocument, $targetAttachDocument, $options, $currentValue)
-  #set ($sortedAttachments = $collectiontool.sort($targetAttachDocument.getAttachmentList(), "${options.sortAttachmentsBy}") )
+  #set ($sortedAttachments = $services.temporaryAttachments.listAllAttachments($targetAttachDocument))
   #foreach ($attachment in $sortedAttachments)
     #set ($extension = $attachment.getFilename())
     #set ($extension = $extension.substring($mathtool.add($extension.lastIndexOf('.'), 1)).toLowerCase())
@@ -149,8 +147,7 @@ $xwiki.jsx.use($attachmentPickerDocName)
 #macro (attachmentPicker_displayAttachmentDetails $attachment $options)
   #if ($attachment)
     ## Compute the attachment reference because there's no getter.
-    #set ($attachmentReference = $services.model.createAttachmentReference($attachment.document.documentReference,
-      $attachment.filename))
+    #set ($attachmentReference = $services.model.createAttachmentReference($attachment.doc.documentReference, $attachment.filename))
     #set ($attachmentStringReference = $services.rendering.escape($services.model.serialize($attachmentReference, 'default'), 'xwiki/2.1'))
     #if ($attachment.isImage() &amp;&amp; $options.displayImage)
       ## We add the version to the query string in order to invalidate the cache when an image attachment is replaced.
@@ -496,20 +493,59 @@ $xwiki.jsx.use($attachmentPickerDocName)
             hasErrors = true;
           }
         }.bind(this));
-        // No form submission by AJAX right now, because file uploads can't be done this way without HTML5, this is future work
-        // Save the document before submitting, since the current form data will be lost otherwise
         if (!hasErrors) {
           if (this.directSave) {
             uploadForm.submit();
           } else {
-            // FIXME This fails in HTML5, will deal with it later:
-            // this.property.down('input').value = uploadForm.down('input[type="file"]').value;
-            // uploadForm.xredirect.value = window.location.pathname;
-            document.observe('xwiki:document:saved', function() {
-              new XWiki.widgets.Notification("$services.localization.render('xe.attachmentSelector.upload.inProgress')", 'inprogress');
-              uploadForm.submit();
-            })
-            document.fire('xwiki:actions:save', {'continue': true, form: this.property.up('form')});
+            // Require jquery locally until we are able to fully migrate this code away from prototype.
+            const form = this.property.up('form');
+            console.log('&gt;&gt;&gt; property', this.property);
+            require(['jquery'], function($){
+              const data = new FormData();
+              const uploadedFile = $('#attachfile')[0].files[0];
+              const filenameCheckbox = $("#uploadAttachment input[name='filename']");
+
+              data.append('upload', uploadedFile);
+              // TODO: Use CKEditor.FileUploader to avoid code duplication, but this document should be move to legacy and replaced by a reusable document located in a common place
+              const notification = new XWiki.widgets.Notification("$services.localization.render('xe.attachmentSelector.upload.inProgress')", 'inprogress');
+              const params = {
+                'form_token': $(form).find('[name="form_token"]').val(),
+                'sheet': 'CKEditor.FileUploader', // TODO: runtime dependency on CKEditor!!
+                'outputSyntax': 'plain'
+              };
+
+              // Update the name of the file with the name of the currently selected attachment if required.
+              if(filenameCheckbox.prop('checked')) {
+                params['filename'] = filenameCheckbox.val()
+              }
+
+              $.ajax({
+                'url': XWiki.currentDocument.getURL('get', new URLSearchParams(params).toString()),
+                method: 'POST',
+                data: data,
+                processData: false,
+                contentType: false, // Sets the 'multipart/form-data' automatically
+                headers: {
+                  // TODO: make this configurable
+                  // TODO: this might also impact if we allow the current user to upload an image!
+                  'X-XWiki-Temporary-Attachment-Support': true // TODO: get the flag from CKEditor?
+                }
+              }).done(function() {
+                // TODO: localization
+                notification.replace(new XWiki.widgets.Notification('Attachment upload succeeded.', 'done'));
+                // Add a field with the name of the uploaded file so that it is moved from the temporary
+                // attachments to the persisded ones on save.
+                $(form).append($('&lt;input/&gt;')
+                               .prop('type', 'hidden')
+                               .prop('name', 'uploadedFiles')
+                               .prop('value', uploadedFile.name))
+                $(form).find('input[type="hidden"].property-reference').prop('value', uploadedFile.name);
+                
+              }).fail(function() {
+                // TODO: localization
+                notification.replace(new XWiki.widgets.Notification('Attachment upload failed.', 'error'));
+              });
+            });
           }
         }
       }.bindAsEventListener(this));
@@ -1197,102 +1233,74 @@ XWiki.widgets.ModalPopup.prototype.closeDialog = function(event) {
       <nameField/>
       <validationScript/>
       <async_cached>
-        <customDisplay/>
         <defaultValue>0</defaultValue>
         <disabled>0</disabled>
         <displayFormType>select</displayFormType>
         <displayType/>
-        <hint/>
         <name>async_cached</name>
         <number>13</number>
         <prettyName>Cached</prettyName>
         <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
       </async_cached>
       <async_context>
         <cache>0</cache>
-        <customDisplay/>
-        <defaultValue/>
         <disabled>0</disabled>
         <displayType>select</displayType>
         <freeText>forbidden</freeText>
-        <hint/>
         <largeStorage>0</largeStorage>
         <multiSelect>1</multiSelect>
         <name>async_context</name>
         <number>14</number>
-        <picker>1</picker>
         <prettyName>Context elements</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator>, </separator>
         <separators>|, </separators>
         <size>5</size>
-        <sort/>
         <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
         <values>action=Action|doc.reference=Document|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.parameters=Request parameters|request.url=Request URL|request.wiki=Request wiki|user=User|wiki=Wiki</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </async_context>
       <async_enabled>
-        <customDisplay/>
         <defaultValue>0</defaultValue>
         <disabled>0</disabled>
         <displayFormType>select</displayFormType>
         <displayType/>
-        <hint/>
         <name>async_enabled</name>
         <number>12</number>
         <prettyName>Asynchronous rendering</prettyName>
         <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
       </async_enabled>
       <code>
-        <contenttype>---</contenttype>
-        <customDisplay/>
         <disabled>0</disabled>
         <editor>Text</editor>
-        <hint/>
         <name>code</name>
         <number>10</number>
-        <picker>1</picker>
         <prettyName>Macro code</prettyName>
         <rows>20</rows>
         <size>40</size>
         <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
       </code>
       <contentDescription>
         <contenttype>PureText</contenttype>
-        <customDisplay/>
         <disabled>0</disabled>
         <editor>PureText</editor>
-        <hint/>
         <name>contentDescription</name>
         <number>9</number>
-        <picker>1</picker>
         <prettyName>Content description (Not applicable for "No content" type)</prettyName>
         <rows>5</rows>
         <size>40</size>
         <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
       </contentDescription>
       <contentJavaType>
         <cache>0</cache>
-        <customDisplay/>
         <defaultValue>Unknown</defaultValue>
         <disabled>0</disabled>
         <displayType>input</displayType>
         <freeText>allowed</freeText>
-        <hint/>
         <largeStorage>1</largeStorage>
         <multiSelect>0</multiSelect>
         <name>contentJavaType</name>
@@ -1303,159 +1311,111 @@ XWiki.widgets.ModalPopup.prototype.closeDialog = function(event) {
         <separator>|</separator>
         <separators>|</separators>
         <size>1</size>
-        <sort/>
         <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
         <values>Unknown|Wiki</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </contentJavaType>
       <contentType>
         <cache>0</cache>
-        <customDisplay/>
-        <defaultValue/>
         <disabled>0</disabled>
         <displayType>select</displayType>
         <freeText>forbidden</freeText>
-        <hint/>
         <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>contentType</name>
         <number>7</number>
-        <picker>1</picker>
         <prettyName>Macro content availability</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator>|</separator>
         <separators>|</separators>
         <size>1</size>
-        <sort/>
         <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
         <values>Optional|Mandatory|No content</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </contentType>
       <defaultCategories>
         <cache>0</cache>
-        <customDisplay/>
-        <defaultValue/>
         <disabled>0</disabled>
         <displayType>input</displayType>
         <freeText>forbidden</freeText>
-        <hint/>
         <largeStorage>0</largeStorage>
         <multiSelect>1</multiSelect>
         <name>defaultCategories</name>
         <number>4</number>
-        <picker>0</picker>
         <prettyName>Default categories</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator> </separator>
         <separators>|, </separators>
         <size>1</size>
-        <sort/>
         <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
         <values/>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </defaultCategories>
       <description>
         <contenttype>PureText</contenttype>
-        <customDisplay/>
         <disabled>0</disabled>
         <editor>PureText</editor>
-        <hint/>
         <name>description</name>
         <number>3</number>
-        <picker>1</picker>
         <prettyName>Macro description</prettyName>
         <rows>5</rows>
         <size>40</size>
         <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
       </description>
       <id>
-        <customDisplay/>
         <disabled>0</disabled>
-        <hint/>
         <name>id</name>
         <number>1</number>
-        <picker>1</picker>
         <prettyName>Macro id</prettyName>
         <size>30</size>
         <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </id>
       <name>
-        <customDisplay/>
         <disabled>0</disabled>
-        <hint/>
         <name>name</name>
         <number>2</number>
-        <picker>1</picker>
         <prettyName>Macro name</prettyName>
         <size>30</size>
         <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </name>
       <priority>
-        <customDisplay/>
         <disabled>0</disabled>
-        <hint/>
         <name>priority</name>
         <number>11</number>
         <numberType>integer</numberType>
         <prettyName>Priority</prettyName>
         <size>10</size>
         <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.NumberClass</classType>
       </priority>
       <supportsInlineMode>
-        <customDisplay/>
-        <defaultValue/>
         <disabled>0</disabled>
         <displayFormType>select</displayFormType>
         <displayType>yesno</displayType>
-        <hint/>
         <name>supportsInlineMode</name>
         <number>5</number>
         <prettyName>Supports inline mode</prettyName>
         <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
       </supportsInlineMode>
       <visibility>
         <cache>0</cache>
-        <customDisplay/>
-        <defaultValue/>
         <disabled>0</disabled>
         <displayType>select</displayType>
         <freeText>forbidden</freeText>
-        <hint/>
         <largeStorage>0</largeStorage>
         <multiSelect>0</multiSelect>
         <name>visibility</name>
         <number>6</number>
-        <picker>1</picker>
         <prettyName>Macro visibility</prettyName>
         <relationalStorage>0</relationalStorage>
         <separator>|</separator>
         <separators>|</separators>
         <size>1</size>
-        <sort/>
         <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
         <values>Current User|Current Wiki|Global</values>
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </visibility>
@@ -1603,25 +1563,23 @@ $xwiki.ssx.use($xcontext.macro.doc.fullName)##
 ##  1. Edit the current page
 ##  2. View the target attachment page. (can be the same page)
 #macro (attachmentPicker_displayButton)
-  #if ($hasEdit &amp;&amp; $targetPermView)
-    #set ($queryString = {
-      'docname': $doc.fullName,
-      'classname': $classname,
-      'property': $property,
-      'object': $object,
-      'savemode': $savemode,
-      'defaultValue': $defaultValue,
-      'filter': $filter,
-      'displayImage': $displayImage,
-      'versionSummary': $xcontext.macro.params.versionSummary.equals('true')
-    })
-    #if ($hasTargetDoc)
-      #set ($queryString.targetdocname = $targetdoc.fullName)
-    #end
-    #set ($linkLabel = $services.rendering.escape($services.rendering.escape($buttontext, 'xwiki/2.1'), 'xwiki/2.1'))
-    (% class="buttonwrapper" %)[[$linkLabel&gt;&gt;${xcontext.macro.doc.fullName}||queryString="$escapetool.url($queryString)"
-      class="attachment-picker-start button" title="$services.rendering.escape($buttontext, 'xwiki/2.1')"]](%%)##
+  #set ($queryString = {
+    'docname': $doc.fullName,
+    'classname': $classname,
+    'property': $property,
+    'object': $object,
+    'savemode': $savemode,
+    'defaultValue': $defaultValue,
+    'filter': $filter,
+    'displayImage': $displayImage,
+    'versionSummary': $xcontext.macro.params.versionSummary.equals('true')
+  })
+  #if ($hasTargetDoc)
+    #set ($queryString.targetdocname = $targetdoc.fullName)
   #end
+  #set ($linkLabel = $services.rendering.escape($services.rendering.escape($buttontext, 'xwiki/2.1'), 'xwiki/2.1'))
+  (% class="buttonwrapper" %)[[$linkLabel&gt;&gt;${xcontext.macro.doc.fullName}||queryString="$escapetool.url($queryString)"
+    class="attachment-picker-start button" title="$services.rendering.escape($buttontext, 'xwiki/2.1')"]](%%)##
 #end
 {{/velocity}}
 
@@ -1631,7 +1589,7 @@ $xwiki.ssx.use($xcontext.macro.doc.fullName)##
 #elseif ($xcontext.action == 'inline' || $xcontext.action == 'edit')
   (% class="attachment-picker" %)(((##
     #attachmentPicker_displayAttachment($propValue $displayImage false true) #attachmentPicker_displayButton()##
-    {{html}}&lt;input type="hidden" name="${classname}_${object}_${property}" value="${propValue}"/&gt;{{/html}}##
+    {{html}}&lt;input type="hidden" name="${classname}_${object}_${property}" value="${propValue}" class="property-reference"/&gt;{{/html}}##
   )))
 #else
   #attachmentPicker_displayAttachment($propValue $displayImage $link false)

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
@@ -90,7 +90,7 @@ $xwiki.jsx.use($attachmentPickerDocName)
     #set ($extension = $attachment.getFilename())
     #set ($extension = $extension.substring($mathtool.add($extension.lastIndexOf('.'), 1)).toLowerCase())
     #if ($options.filter.size() == 0 || $options.filter.contains($extension))
-      #attachmentPicker_displayAttachmentBox($attachment $targetDocument $targetAttachDocument, $options $currentValue)
+    #attachmentPicker_displayAttachmentBox($attachment $targetDocument $targetAttachDocument, $options $currentValue)
     #end
   #end
   )))
@@ -147,7 +147,8 @@ $xwiki.jsx.use($attachmentPickerDocName)
 #macro (attachmentPicker_displayAttachmentDetails $attachment $options)
   #if ($attachment)
     ## Compute the attachment reference because there's no getter.
-    #set ($attachmentReference = $services.model.createAttachmentReference($attachment.doc.documentReference, $attachment.filename))
+    #set ($attachmentReference = $services.model.createAttachmentReference($attachment.document.documentReference,
+      $attachment.filename))
     #set ($attachmentStringReference = $services.rendering.escape($services.model.serialize($attachmentReference, 'default'), 'xwiki/2.1'))
     #if ($attachment.isImage() &amp;&amp; $options.displayImage)
       ## We add the version to the query string in order to invalidate the cache when an image attachment is replaced.
@@ -505,6 +506,7 @@ $xwiki.jsx.use($attachmentPickerDocName)
               const uploadedFile = $('#attachfile')[0].files[0];
               const filenameCheckbox = $("#uploadAttachment input[name='filename']");
 
+              // TODO: deal with replace currently selected checkbox.
               data.append('upload', uploadedFile);
               // TODO: Use CKEditor.FileUploader to avoid code duplication, but this document should be move to legacy and replaced by a reusable document located in a common place
               const notification = new XWiki.widgets.Notification("$services.localization.render('xe.attachmentSelector.upload.inProgress')", 'inprogress');

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
@@ -204,6 +204,7 @@ $xwiki.jsx.use($attachmentPickerDocName)
  *          &lt;dt&gt;rel&lt;/dt&gt;
  *          &lt;dd&gt;an optional parameter to be used in the "rel" HTML attribute; for example "__blank" can be used to open the link in a new tab/window&lt;/dd&gt;
  *        &lt;/dl&gt;
+ * @param $additionalContent optional additional content that does not follow the structure of the actions 
  *#
 #macro (attachmentPicker_displayEndFrame $actions $additionalContent)
     )))## attachmentframe
@@ -1612,23 +1613,25 @@ $xwiki.ssx.use($xcontext.macro.doc.fullName)##
 ##  1. Edit the current page
 ##  2. View the target attachment page. (can be the same page)
 #macro (attachmentPicker_displayButton)
-  #set ($queryString = {
-    'docname': $doc.fullName,
-    'classname': $classname,
-    'property': $property,
-    'object': $object,
-    'savemode': $savemode,
-    'defaultValue': $defaultValue,
-    'filter': $filter,
-    'displayImage': $displayImage,
-    'versionSummary': $xcontext.macro.params.versionSummary.equals('true')
-  })
-  #if ($hasTargetDoc)
-    #set ($queryString.targetdocname = $targetdoc.fullName)
+  #if ($targetPermView)
+    #set ($queryString = {
+      'docname': $doc.fullName,
+      'classname': $classname,
+      'property': $property,
+      'object': $object,
+      'savemode': $savemode,
+      'defaultValue': $defaultValue,
+      'filter': $filter,
+      'displayImage': $displayImage,
+      'versionSummary': $xcontext.macro.params.versionSummary.equals('true')
+    })
+    #if ($hasTargetDoc)
+      #set ($queryString.targetdocname = $targetdoc.fullName)
+    #end
+    #set ($linkLabel = $services.rendering.escape($services.rendering.escape($buttontext, 'xwiki/2.1'), 'xwiki/2.1'))
+    (% class="buttonwrapper" %)[[$linkLabel&gt;&gt;${xcontext.macro.doc.fullName}||queryString="$escapetool.url($queryString)"
+      class="attachment-picker-start button" title="$services.rendering.escape($buttontext, 'xwiki/2.1')"]](%%)##
   #end
-  #set ($linkLabel = $services.rendering.escape($services.rendering.escape($buttontext, 'xwiki/2.1'), 'xwiki/2.1'))
-  (% class="buttonwrapper" %)[[$linkLabel&gt;&gt;${xcontext.macro.doc.fullName}||queryString="$escapetool.url($queryString)"
-    class="attachment-picker-start button" title="$services.rendering.escape($buttontext, 'xwiki/2.1')"]](%%)##
 #end
 {{/velocity}}
 

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
@@ -90,7 +90,7 @@ $xwiki.jsx.use($attachmentPickerDocName)
     #set ($extension = $attachment.getFilename())
     #set ($extension = $extension.substring($mathtool.add($extension.lastIndexOf('.'), 1)).toLowerCase())
     #if ($options.filter.size() == 0 || $options.filter.contains($extension))
-    #attachmentPicker_displayAttachmentBox($attachment $targetDocument $targetAttachDocument, $options $currentValue)
+      #attachmentPicker_displayAttachmentBox($attachment $targetDocument $targetAttachDocument, $options $currentValue)
     #end
   #end
   )))
@@ -500,7 +500,6 @@ $xwiki.jsx.use($attachmentPickerDocName)
           } else {
             // Require jquery locally until we are able to fully migrate this code away from prototype.
             const form = this.property.up('form');
-            console.log('&gt;&gt;&gt; property', this.property);
             require(['jquery'], function($){
               const data = new FormData();
               const uploadedFile = $('#attachfile')[0].files[0];
@@ -508,11 +507,10 @@ $xwiki.jsx.use($attachmentPickerDocName)
 
               // TODO: deal with replace currently selected checkbox.
               data.append('upload', uploadedFile);
-              // TODO: Use CKEditor.FileUploader to avoid code duplication, but this document should be move to legacy and replaced by a reusable document located in a common place
               const notification = new XWiki.widgets.Notification("$services.localization.render('xe.attachmentSelector.upload.inProgress')", 'inprogress');
               const params = {
                 'form_token': $(form).find('[name="form_token"]').val(),
-                'sheet': 'CKEditor.FileUploader', // TODO: runtime dependency on CKEditor!!
+                'sheet': 'CKEditor.FileUploader',
                 'outputSyntax': 'plain'
               };
 
@@ -528,9 +526,7 @@ $xwiki.jsx.use($attachmentPickerDocName)
                 processData: false,
                 contentType: false, // Sets the 'multipart/form-data' automatically
                 headers: {
-                  // TODO: make this configurable
-                  // TODO: this might also impact if we allow the current user to upload an image!
-                  'X-XWiki-Temporary-Attachment-Support': true // TODO: get the flag from CKEditor?
+                  'X-XWiki-Temporary-Attachment-Support': true // TODO: check if services.temporaryAttachments exists
                 }
               }).done(function() {
                 // TODO: localization
@@ -542,7 +538,6 @@ $xwiki.jsx.use($attachmentPickerDocName)
                                .prop('name', 'uploadedFiles')
                                .prop('value', uploadedFile.name))
                 $(form).find('input[type="hidden"].property-reference').prop('value', uploadedFile.name);
-                
               }).fail(function() {
                 // TODO: localization
                 notification.replace(new XWiki.widgets.Notification('Attachment upload failed.', 'error'));

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
@@ -109,12 +109,23 @@ $xwiki.jsx.use($attachmentPickerDocName)
  * @param $currentValue the currently selected file, used for determining if the box should be highlighted as the current value
  *#
 #macro (attachmentPicker_displayAttachmentBox $attachment $targetDocument $targetAttachDocument, $options $currentValue)
-  #if ($options.displayImage &amp;&amp; $attachment.isImage())
-    #set ($cssClass = 'gallery_image')
+  #set ($hasTemporaryAttachment = "$!services.temporaryAttachments" != '')
+  #set ($canEdit = $xwiki.hasAccessLevel('edit', $xcontext.user, ${targetAttachDocument.fullName}))
+  #set ($isTemporaryAttachment = false)
+  #if(!$hasTemporaryAttachment)
+    #set ($canDeleteAttachment = $canEdit)
   #else
-    #set ($cssClass = '')
+    #set ($isTemporaryAttachment = $services.temporaryAttachments.temporaryAttachmentExists($attachment))
+    #set ($canDeleteAttachment = !$isTemporaryAttachment &amp;&amp; $canEdit)
   #end
-  #attachmentPicker_displayStartFrame({'value' : $attachment.filename, 'text' : $attachment.filename, 'cssClass' : "$!{cssClass}"} $currentValue)
+  #set ($cssClasses = [])
+  #if ($options.displayImage &amp;&amp; $attachment.isImage())
+    #set ($discard = $cssClasses.add('gallery_image'))
+  #end
+  #if ($isTemporaryAttachment)
+    #set ($discard = $cssClasses.add('temporary_attachment'))
+  #end
+  #attachmentPicker_displayStartFrame({'value' : $attachment.filename, 'text' : $attachment.filename, 'cssClass' : "${stringtool.join($cssClasses, ' ')}"} $currentValue)
   #attachmentPicker_displayAttachmentDetails($attachment $options)
   #set ($returnURL = $escapetool.url($doc.getURL('view', $request.queryString)))
   #set ($deleteURL = $targetAttachDocument.getAttachmentURL($attachment.filename, 'delattachment', "xredirect=${returnURL}&amp;form_token=$!{services.csrf.getToken()}") )
@@ -126,17 +137,17 @@ $xwiki.jsx.use($attachmentPickerDocName)
   ## Delete action is only proposed for users with the edit right on the document.
   ## If the temporary attachment is available, the delete action is only allowed for non-temporary attachments.  
   #set ($attachmentActions = [{'name' : 'select', 'url' : $selectURL}])
-  #set ($hasTemporaryAttachment = "$!services.temporaryAttachments" != '')
-  #set ($canEdit = $xwiki.hasAccessLevel('edit', $xcontext.user, ${targetAttachDocument.fullName}))
-  #if(!$hasTemporaryAttachment)
-    #set ($canDeleteAttachment = $canEdit)
-  #else
-    #set ($canDeleteAttachment = !$services.temporaryAttachments.temporaryAttachmentExists($attachment) &amp;&amp; $canEdit)
-  #end
   #if($canDeleteAttachment)
     #set ($discard = $attachmentActions.add({'name' : 'delete', 'url' : $deleteURL}))
   #end
-  #attachmentPicker_displayEndFrame ($attachmentActions)
+  #define($additionalContent)
+    #if ($isTemporaryAttachment)
+      #set ($titleMessage = $services.localization.render('attachment.attachmentSelector.attachmentBox.temporaryAttachmentTitle'))
+      #set ($titleMessage = $services.rendering.escape($titleMessage, 'xwiki/2.1'))
+      (% title="$titleMessage" %)$services.icon.render('clock')(%%)
+    #end
+  #end
+  #attachmentPicker_displayEndFrame ($attachmentActions $additionalContent)
 #end
 
 #**
@@ -193,13 +204,14 @@ $xwiki.jsx.use($attachmentPickerDocName)
  *          &lt;dd&gt;an optional parameter to be used in the "rel" HTML attribute; for example "__blank" can be used to open the link in a new tab/window&lt;/dd&gt;
  *        &lt;/dl&gt;
  *#
-#macro (attachmentPicker_displayEndFrame $actions)
+#macro (attachmentPicker_displayEndFrame $actions $additionalContent)
     )))## attachmentframe
     (% class="gallery_actions" %)(((
       #foreach ($action in $actions)
         #set( $actionname = $services.localization.render("${translationPrefix}.actions.${action.name}") )
         [[${actionname}&gt;&gt;path:${action.url}||class="tool ${action.name}" title="${actionname}" #if($action.rel) rel="${action.rel}"#end]]##
       #end
+      $!additionalContent
     )))## actions
   )))## attachmentbox
 #end

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
@@ -117,6 +117,7 @@ $xwiki.jsx.use($attachmentPickerDocName)
     #set ($canDeleteAttachment = $canEdit)
   #else
     #set ($isTemporaryAttachment = $services.temporaryAttachments.temporaryAttachmentExists($attachment))
+    ## TODO: Update once it is made possible to delete temporary attachments (see XWIKI-20225).
     #set ($canDeleteAttachment = !$isTemporaryAttachment &amp;&amp; $canEdit)
   #end
   #set ($cssClasses = [])

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
@@ -85,7 +85,11 @@ $xwiki.jsx.use($attachmentPickerDocName)
   ## Only display the upload form if they have edit permission on targetAttachDocument
   #attachmentPicker_displayUploadForm($targetDocument, $targetAttachDocument, $options)
   #attachmentPicker_displayAttachmentGalleryEmptyValue($targetDocument, $targetAttachDocument, $options, $currentValue)
-  #set ($sortedAttachments = $services.temporaryAttachments.listAllAttachments($targetAttachDocument))
+  #if ("$!services.temporaryAttachments" != '')
+    #set ($sortedAttachments = $services.temporaryAttachments.listAllAttachments($targetAttachDocument))
+  #else
+    #set ($sortedAttachments = $collectiontool.sort($targetAttachDocument.getAttachmentList(), "${options.sortAttachmentsBy}") )
+  #end
   #foreach ($attachment in $sortedAttachments)
     #set ($extension = $attachment.getFilename())
     #set ($extension = $extension.substring($mathtool.add($extension.lastIndexOf('.'), 1)).toLowerCase())
@@ -119,7 +123,18 @@ $xwiki.jsx.use($attachmentPickerDocName)
     "${options.get('classname')}_${options.get('object')}_${options.get('property')}": ${attachment.filename},
     'form_token': $!{services.csrf.getToken()}
   })))
-  #attachmentPicker_displayEndFrame ([{'name' : 'select', 'url' : $selectURL}, {'name' : 'delete', 'url' : $deleteURL}])
+  #set ($attachmentActions = [{'name' : 'select', 'url' : $selectURL}])
+  #set ($hasTemporaryAttachment = "$!services.temporaryAttachments" != '')
+  #set ($canEdit = $xwiki.hasAccessLevel('edit',$xcontext.user,${targetAttachDocument.fullName}))
+  #if(!$hasTemporaryAttachment)
+    #set ($canDeleteAttachment = $canEdit)
+  #else
+    #set ($canDeleteAttachment = !$services.temporaryAttachments.temporaryAttachmentExists($attachment) &amp;&amp; $canEdit)
+  #end
+  #if($canDeleteAttachment)
+    #set ($discard = $attachmentActions.add({'name' : 'delete', 'url' : $deleteURL}))
+  #end
+  #attachmentPicker_displayEndFrame ($attachmentActions)
 #end
 
 #**
@@ -432,6 +447,68 @@ $xwiki.jsx.use($attachmentPickerDocName)
     </property>
     <property>
       <code>var XWiki = (function(XWiki) {
+function uploadTemporaryAttachment() {
+  // Require jquery locally until we are able to fully migrate this code away from prototype.
+  const form = this.property.up('form');
+  require(['jquery'], function ($) {
+    const data = new FormData();
+    const uploadedFile = $('#attachfile')[0].files[0];
+    const filenameCheckbox = $("#uploadAttachment input[name='filename']");
+
+    // TODO: deal with replace currently selected checkbox.
+    data.append('upload', uploadedFile);
+    const notification = new XWiki.widgets.Notification(
+      "$services.localization.render('xe.attachmentSelector.upload.inProgress')", 'inprogress');
+    const params = {
+      'form_token': $(form).find('[name="form_token"]').val(),
+      'sheet': 'CKEditor.FileUploader',
+      'outputSyntax': 'plain'
+    };
+
+    // Update the name of the file with the name of the currently selected attachment if required.
+    if (filenameCheckbox.prop('checked')) {
+      params['filename'] = filenameCheckbox.val()
+    }
+
+    $.ajax({
+      'url': XWiki.currentDocument.getURL('get', new URLSearchParams(params).toString()),
+      method: 'POST',
+      data: data,
+      processData: false,
+      contentType: false, // Sets the 'multipart/form-data' automatically
+      headers: {
+        'X-XWiki-Temporary-Attachment-Support': true
+      }
+    }).done(function (response) {
+      #set ($successMessage = $escapetool.javascript($services.localization.render('attachment.attachmentSelector.temporaryUpload.success')))
+      notification.replace(new XWiki.widgets.Notification("$successMessage", 'done'));
+      // Add a field with the name of the uploaded file so that it is moved from the temporary
+      // attachments to the persisded ones on save.
+      $(form).append($('&lt;input/&gt;')
+        .prop('type', 'hidden')
+        .prop('name', 'uploadedFiles')
+        .prop('value', response.fileName))
+      $(form).find('input[type="hidden"].property-reference').prop('value', response.fileName);
+      this.updateAttachment(response.fileName, response.url);
+      this.dialog.closeDialog();
+    }.bind(this)).fail(function  () {
+      #set ($errorMessage = $escapetool.javascript($services.localization.render('attachment.attachmentSelector.temporaryUpload.failure')))notification.replace(new XWiki.widgets.Notification("$errorMessage", 'error'));
+    });
+  }.bind(this));
+}
+
+function directUploadAttachment(uploadForm) {
+  // FIXME This fails in HTML5, will deal with it later:
+  // this.property.down('input').value = uploadForm.down('input[type="file"]').value;
+  // uploadForm.xredirect.value = window.location.pathname;
+  document.observe('xwiki:document:saved', function () {
+    new XWiki.widgets.Notification("$services.localization.render('xe.attachmentSelector.upload.inProgress')",
+      'inprogress');
+    uploadForm.submit();
+  })
+  document.fire('xwiki:actions:save', {'continue': true, form: this.property.up('form')});
+}
+
   /** Handles the gallery buttons directly in the current page without reloading the window. */
   XWiki.AttachmentPicker = Class.create({
     /**
@@ -498,51 +575,11 @@ $xwiki.jsx.use($attachmentPickerDocName)
           if (this.directSave) {
             uploadForm.submit();
           } else {
-            // Require jquery locally until we are able to fully migrate this code away from prototype.
-            const form = this.property.up('form');
-            require(['jquery'], function($){
-              const data = new FormData();
-              const uploadedFile = $('#attachfile')[0].files[0];
-              const filenameCheckbox = $("#uploadAttachment input[name='filename']");
-
-              // TODO: deal with replace currently selected checkbox.
-              data.append('upload', uploadedFile);
-              const notification = new XWiki.widgets.Notification("$services.localization.render('xe.attachmentSelector.upload.inProgress')", 'inprogress');
-              const params = {
-                'form_token': $(form).find('[name="form_token"]').val(),
-                'sheet': 'CKEditor.FileUploader',
-                'outputSyntax': 'plain'
-              };
-
-              // Update the name of the file with the name of the currently selected attachment if required.
-              if(filenameCheckbox.prop('checked')) {
-                params['filename'] = filenameCheckbox.val()
-              }
-
-              $.ajax({
-                'url': XWiki.currentDocument.getURL('get', new URLSearchParams(params).toString()),
-                method: 'POST',
-                data: data,
-                processData: false,
-                contentType: false, // Sets the 'multipart/form-data' automatically
-                headers: {
-                  'X-XWiki-Temporary-Attachment-Support': true // TODO: check if services.temporaryAttachments exists
-                }
-              }).done(function() {
-                // TODO: localization
-                notification.replace(new XWiki.widgets.Notification('Attachment upload succeeded.', 'done'));
-                // Add a field with the name of the uploaded file so that it is moved from the temporary
-                // attachments to the persisded ones on save.
-                $(form).append($('&lt;input/&gt;')
-                               .prop('type', 'hidden')
-                               .prop('name', 'uploadedFiles')
-                               .prop('value', uploadedFile.name))
-                $(form).find('input[type="hidden"].property-reference').prop('value', uploadedFile.name);
-              }).fail(function() {
-                // TODO: localization
-                notification.replace(new XWiki.widgets.Notification('Attachment upload failed.', 'error'));
-              });
-            });
+            if ("$!services.temporaryAttachments" != '') {
+              uploadTemporaryAttachment.call(this);
+            } else {
+              directUploadAttachment.call(this, uploadForm);
+            }
           }
         }
       }.bindAsEventListener(this));

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
@@ -123,9 +123,11 @@ $xwiki.jsx.use($attachmentPickerDocName)
     "${options.get('classname')}_${options.get('object')}_${options.get('property')}": ${attachment.filename},
     'form_token': $!{services.csrf.getToken()}
   })))
+  ## Delete action is only proposed for users with the edit right on the document.
+  ## If the temporary attachment is available, the delete action is only allowed for non-temporary attachments.  
   #set ($attachmentActions = [{'name' : 'select', 'url' : $selectURL}])
   #set ($hasTemporaryAttachment = "$!services.temporaryAttachments" != '')
-  #set ($canEdit = $xwiki.hasAccessLevel('edit',$xcontext.user,${targetAttachDocument.fullName}))
+  #set ($canEdit = $xwiki.hasAccessLevel('edit', $xcontext.user, ${targetAttachDocument.fullName}))
   #if(!$hasTemporaryAttachment)
     #set ($canDeleteAttachment = $canEdit)
   #else
@@ -447,67 +449,67 @@ $xwiki.jsx.use($attachmentPickerDocName)
     </property>
     <property>
       <code>var XWiki = (function(XWiki) {
-function uploadTemporaryAttachment() {
-  // Require jquery locally until we are able to fully migrate this code away from prototype.
-  const form = this.property.up('form');
-  require(['jquery'], function ($) {
-    const data = new FormData();
-    const uploadedFile = $('#attachfile')[0].files[0];
-    const filenameCheckbox = $("#uploadAttachment input[name='filename']");
-
-    // TODO: deal with replace currently selected checkbox.
-    data.append('upload', uploadedFile);
-    const notification = new XWiki.widgets.Notification(
-      "$services.localization.render('xe.attachmentSelector.upload.inProgress')", 'inprogress');
-    const params = {
-      'form_token': $(form).find('[name="form_token"]').val(),
-      'sheet': 'CKEditor.FileUploader',
-      'outputSyntax': 'plain'
-    };
-
-    // Update the name of the file with the name of the currently selected attachment if required.
-    if (filenameCheckbox.prop('checked')) {
-      params['filename'] = filenameCheckbox.val()
-    }
-
-    $.ajax({
-      'url': XWiki.currentDocument.getURL('get', new URLSearchParams(params).toString()),
-      method: 'POST',
-      data: data,
-      processData: false,
-      contentType: false, // Sets the 'multipart/form-data' automatically
-      headers: {
-        'X-XWiki-Temporary-Attachment-Support': true
+  function uploadTemporaryAttachment() {
+    // Require jquery locally until we are able to fully migrate this code away from prototype.
+    const form = this.property.up('form');
+    require(['jquery'], function ($) {
+      const data = new FormData();
+      const uploadedFile = $('#attachfile')[0].files[0];
+      const filenameCheckbox = $("#uploadAttachment input[name='filename']");
+  
+      // TODO: Fix replace currently selected checkbox (see XWIKI-20181).
+      data.append('upload', uploadedFile);
+      const notification = new XWiki.widgets.Notification(
+        "$services.localization.render('xe.attachmentSelector.upload.inProgress')", 'inprogress');
+      const params = {
+        'form_token': $(form).find('[name="form_token"]').val(),
+        'sheet': 'CKEditor.FileUploader',
+        'outputSyntax': 'plain'
+      };
+  
+      // Update the name of the file with the name of the currently selected attachment if required.
+      if (filenameCheckbox.prop('checked')) {
+        params['filename'] = filenameCheckbox.val()
       }
-    }).done(function (response) {
-      #set ($successMessage = $escapetool.javascript($services.localization.render('attachment.attachmentSelector.temporaryUpload.success')))
-      notification.replace(new XWiki.widgets.Notification("$successMessage", 'done'));
-      // Add a field with the name of the uploaded file so that it is moved from the temporary
-      // attachments to the persisded ones on save.
-      $(form).append($('&lt;input/&gt;')
-        .prop('type', 'hidden')
-        .prop('name', 'uploadedFiles')
-        .prop('value', response.fileName))
-      $(form).find('input[type="hidden"].property-reference').prop('value', response.fileName);
-      this.updateAttachment(response.fileName, response.url);
-      this.dialog.closeDialog();
-    }.bind(this)).fail(function  () {
-      #set ($errorMessage = $escapetool.javascript($services.localization.render('attachment.attachmentSelector.temporaryUpload.failure')))notification.replace(new XWiki.widgets.Notification("$errorMessage", 'error'));
-    });
-  }.bind(this));
-}
-
-function directUploadAttachment(uploadForm) {
-  // FIXME This fails in HTML5, will deal with it later:
-  // this.property.down('input').value = uploadForm.down('input[type="file"]').value;
-  // uploadForm.xredirect.value = window.location.pathname;
-  document.observe('xwiki:document:saved', function () {
-    new XWiki.widgets.Notification("$services.localization.render('xe.attachmentSelector.upload.inProgress')",
-      'inprogress');
-    uploadForm.submit();
-  })
-  document.fire('xwiki:actions:save', {'continue': true, form: this.property.up('form')});
-}
+  
+      $.ajax({
+        'url': XWiki.currentDocument.getURL('get', new URLSearchParams(params).toString()),
+        method: 'POST',
+        data: data,
+        processData: false,
+        contentType: false, // Sets the 'multipart/form-data' automatically
+        headers: {
+          'X-XWiki-Temporary-Attachment-Support': true
+        }
+      }).done(function (response) {
+        #set ($successMessage = $escapetool.javascript($services.localization.render('attachment.attachmentSelector.temporaryUpload.success')))
+        notification.replace(new XWiki.widgets.Notification("$successMessage", 'done'));
+        // Add a field with the name of the uploaded file so that it is moved from the temporary
+        // attachments to the persisded ones on save.
+        $(form).append($('&lt;input/&gt;')
+          .prop('type', 'hidden')
+          .prop('name', 'uploadedFiles')
+          .prop('value', response.fileName))
+        $(form).find('input[type="hidden"].property-reference').prop('value', response.fileName);
+        this.updateAttachment(response.fileName, response.url);
+        this.dialog.closeDialog();
+      }.bind(this)).fail(function  () {
+        #set ($errorMessage = $escapetool.javascript($services.localization.render('attachment.attachmentSelector.temporaryUpload.failure')))notification.replace(new XWiki.widgets.Notification("$errorMessage", 'error'));
+      });
+    }.bind(this));
+  }
+  
+  function directUploadAttachment(uploadForm) {
+    // FIXME This fails in HTML5, will deal with it later:
+    // this.property.down('input').value = uploadForm.down('input[type="file"]').value;
+    // uploadForm.xredirect.value = window.location.pathname;
+    document.observe('xwiki:document:saved', function () {
+      new XWiki.widgets.Notification("$services.localization.render('xe.attachmentSelector.upload.inProgress')",
+        'inprogress');
+      uploadForm.submit();
+    })
+    document.fire('xwiki:actions:save', {'continue': true, form: this.property.up('form')});
+  }
 
   /** Handles the gallery buttons directly in the current page without reloading the window. */
   XWiki.AttachmentPicker = Class.create({

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
@@ -86,7 +86,8 @@ $xwiki.jsx.use($attachmentPickerDocName)
   #attachmentPicker_displayUploadForm($targetDocument, $targetAttachDocument, $options)
   #attachmentPicker_displayAttachmentGalleryEmptyValue($targetDocument, $targetAttachDocument, $options, $currentValue)
   #if ("$!services.temporaryAttachments" != '')
-    #set ($sortedAttachments = $services.temporaryAttachments.listAllAttachments($targetAttachDocument))
+    #set ($unsortedAttachments = $services.temporaryAttachments.listAllAttachments($targetAttachDocument))
+    #set ($sortedAttachments = $collectiontool.sort($unsortedAttachments, "${options.sortAttachmentsBy}"))
   #else
     #set ($sortedAttachments = $collectiontool.sort($targetAttachDocument.getAttachmentList(), "${options.sortAttachmentsBy}") )
   #end

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelectorTranslations.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelectorTranslations.xml
@@ -43,7 +43,8 @@ rendering.macro.attachmentSelector.parameter.versionSummary.name=Version Summary
 rendering.macro.attachmentSelector.parameter.versionSummary.description=Whether to allow the user to enter a version summary that will be recorded in the history. An automatic message is used when no version summary is provided or if the version summary input is not displayed.
   
 attachment.attachmentSelector.temporaryUpload.success=Attachment upload succeeded.
-attachment.attachmentSelector.temporaryUpload.failure=Attachment upload failed.</content>
+attachment.attachmentSelector.temporaryUpload.failure=Attachment upload failed.
+attachment.attachmentSelector.attachmentBox.temporaryAttachmentTitle=Temporary attachment</content>
   <object>
     <name>XWiki.AttachmentSelectorTranslations</name>
     <number>0</number>

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelectorTranslations.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelectorTranslations.xml
@@ -40,7 +40,10 @@
 attachmentSelector.replace.hint=The effect may not be visible immediately due to browser caching.
 
 rendering.macro.attachmentSelector.parameter.versionSummary.name=Version Summary
-rendering.macro.attachmentSelector.parameter.versionSummary.description=Whether to allow the user to enter a version summary that will be recorded in the history. An automatic message is used when no version summary is provided or if the version summary input is not displayed.</content>
+rendering.macro.attachmentSelector.parameter.versionSummary.description=Whether to allow the user to enter a version summary that will be recorded in the history. An automatic message is used when no version summary is provided or if the version summary input is not displayed.
+  
+attachment.attachmentSelector.temporaryUpload.success=Attachment upload succeeded.
+attachment.attachmentSelector.temporaryUpload.failure=Attachment upload failed.</content>
   <object>
     <name>XWiki.AttachmentSelectorTranslations</name>
     <number>0</number>

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/test/java/org/xwiki/attachment/AttachmentSelectorPageTest.java
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/test/java/org/xwiki/attachment/AttachmentSelectorPageTest.java
@@ -21,12 +21,16 @@ package org.xwiki.attachment;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.IOUtils;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -34,6 +38,9 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.xwiki.bridge.event.DocumentCreatedEvent;
 import org.xwiki.component.manager.ComponentManager;
 import org.xwiki.component.wiki.internal.bridge.DefaultContentParser;
+import org.xwiki.icon.IconManagerScriptService;
+import org.xwiki.icon.internal.DefaultIconManagerComponentList;
+import org.xwiki.model.reference.AttachmentReference;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.script.ModelScriptService;
 import org.xwiki.observation.EventListener;
@@ -47,20 +54,29 @@ import org.xwiki.rendering.wikimacro.internal.DefaultWikiMacroFactory;
 import org.xwiki.rendering.wikimacro.internal.DefaultWikiMacroRenderer;
 import org.xwiki.security.authorization.AuthorizationManager;
 import org.xwiki.security.authorization.Right;
+import org.xwiki.store.TemporaryAttachmentSessionsManager;
+import org.xwiki.store.script.TemporaryAttachmentsScriptService;
 import org.xwiki.test.annotation.ComponentList;
+import org.xwiki.test.junit5.mockito.MockComponent;
 import org.xwiki.test.page.HTML50ComponentList;
+import org.xwiki.test.page.IconSetup;
 import org.xwiki.test.page.PageTest;
 import org.xwiki.test.page.XWikiSyntax21ComponentList;
 import org.xwiki.xml.internal.html.filter.ControlCharactersFilter;
 
 import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiAttachment;
 import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.internal.model.reference.DocumentReferenceConverter;
 import com.xpn.xwiki.objects.BaseObject;
 import com.xpn.xwiki.objects.classes.BaseClass;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
@@ -74,6 +90,7 @@ import static org.mockito.Mockito.when;
 @HTML50ComponentList
 @XWikiSyntax21ComponentList
 @RenderingScriptServiceComponentList
+@DefaultIconManagerComponentList
 @ComponentList({
     // Start -  Required in addition of RenderingScriptServiceComponentList
     DefaultExtendedRenderingConfiguration.class,
@@ -88,11 +105,30 @@ import static org.mockito.Mockito.when;
     DefaultWikiMacroManager.class,
     DefaultContentParser.class,
     org.xwiki.rendering.internal.parser.DefaultContentParser.class,
-    DefaultWikiMacroRenderer.class
+    DefaultWikiMacroRenderer.class,
     // End WikiMacroEventListener
+    TemporaryAttachmentsScriptService.class,
+    IconManagerScriptService.class,
+    DocumentReferenceConverter.class
 })
 class AttachmentSelectorPageTest extends PageTest
 {
+    /**
+     * Mocked because we don't want to deal with actual sessions for this test.
+     */
+    @MockComponent
+    private TemporaryAttachmentSessionsManager temporaryAttachmentSessionsManager;
+
+    @BeforeEach
+    void setUp() throws Exception
+    {
+        when(this.temporaryAttachmentSessionsManager.getUploadedAttachments(any(DocumentReference.class)))
+            .thenReturn(List.of());
+
+        // Initializes then environment for the icon extension.
+        IconSetup.setUp(this, "/icons.properties");
+    }
+
     @ParameterizedTest
     @ValueSource(strings = {
         "{{noscript}}println(\"Hello from noscript!\"){{/noscript}}.png",
@@ -113,7 +149,7 @@ class AttachmentSelectorPageTest extends PageTest
         Document document = renderHTMLPage(new DocumentReference("xwiki", "XWiki", "AttachmentSelector"));
 
         assertNotNull(document);
-        Element galleryAttachmentTitle = document.select(".gallery_attachmenttitle").get(1);
+        Element galleryAttachmentTitle = document.select(".current .gallery_attachmenttitle").get(0);
         assertEquals(fileName, galleryAttachmentTitle.attr("title"));
         assertEquals(fileName, galleryAttachmentTitle.text());
         assertEquals(fileName, document.select(".gallery_attachmentframe .filename").text());
@@ -140,7 +176,7 @@ class AttachmentSelectorPageTest extends PageTest
 
         Document document = renderHTMLPage(new DocumentReference("xwiki", "XWiki", "AttachmentSelector"));
         assertNotNull(document);
-        Element galleryAttachmentTitle = document.select(".gallery_attachmenttitle").get(1);
+        Element galleryAttachmentTitle = document.select(".current .gallery_attachmenttitle").get(0);
         assertEquals(fileName, galleryAttachmentTitle.attr("title"));
         assertEquals(fileName, galleryAttachmentTitle.text());
         assertEquals(String.format("attach:xwiki:Space.Test@%s", fileName),
@@ -264,6 +300,39 @@ class AttachmentSelectorPageTest extends PageTest
         xwikiDocument.setSyntax(Syntax.XWIKI_2_1);
         Document document = renderHTMLPage(xwikiDocument);
         assertEquals(expectedWidth, document.select(".displayed img").attr("alt"));
+    }
+
+    @Test
+    void withTemporaryAttachment() throws Exception
+    {
+        String fileName = "test.png";
+
+        XWikiDocument xWikiDocument = commonFixup(fileName);
+
+        XWikiAttachment xWikiAttachment = mock(XWikiAttachment.class);
+        when(xWikiAttachment.getFilename()).thenReturn(fileName);
+        AttachmentReference attachmentReference =
+            new AttachmentReference(fileName, xWikiDocument.getDocumentReference());
+        when(xWikiAttachment.getReference()).thenReturn(attachmentReference);
+        when(this.temporaryAttachmentSessionsManager.getUploadedAttachments(xWikiDocument.getDocumentReference()))
+            .thenReturn(List.of(xWikiAttachment));
+        when(this.temporaryAttachmentSessionsManager.getUploadedAttachment(attachmentReference))
+            .thenReturn(Optional.of(xWikiAttachment));
+
+        this.request.put("docname", "xwiki:Space.Test");
+        this.request.put("classname", "xwiki:Space.Test");
+        this.request.put("property", "avatar");
+        this.request.put("object", "0");
+        this.request.put("filter", "png");
+        this.request.put("displayImage", "true");
+        this.request.put("xpage", "plain");
+
+        Document document = renderHTMLPage(new DocumentReference("xwiki", "XWiki", "AttachmentSelector"));
+        Element element = document.selectFirst(".gallery_attachmentbox.current");
+        assertTrue(element.classNames().contains("temporary_attachment"),
+            String.format("temporary_attachment class not found in %s", element.classNames()));
+        assertNotNull(element.selectFirst(".fake-attach"), "An icon with class fake-attach is expected to "
+            + "be found");
     }
 
     private void attachmentSelectorMacroFixup() throws Exception

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/test/resources/icons.properties
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/test/resources/icons.properties
@@ -1,0 +1,6 @@
+xwiki.iconset.type = image
+xwiki.iconset.render.html = <span class="${icon}"></span>
+
+clock = fake-clock
+attach = fake-attach
+image = fake-image

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/FileUploader.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/FileUploader.xml
@@ -103,7 +103,8 @@
       #set ($document = $xwiki.getDocument($request.document))
     #end
     #set ($reference = $document.documentReference)
-    #set ($attachment = $services.temporaryAttachments.uploadTemporaryAttachment($reference, 'upload'))
+    #set ($attachment = $services.temporaryAttachments.uploadTemporaryAttachment($reference, 'upload', 
+        $request.filename))
     #if ($attachment)
       #sendSuccess($document, $attachment.filename)
     #else

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/TemporaryAttachmentSessionsManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/TemporaryAttachmentSessionsManager.java
@@ -68,7 +68,7 @@ public interface TemporaryAttachmentSessionsManager
      * @return an attachment that is not saved yet but cached and contains the data of the given part.
      * @throws TemporaryAttachmentException if the part size exceeds the maximum upload size, or in case of problem
      *     when reading the part.
-     * @since 13.8
+     * @since 14.9RC1
      */
     @Unstable
     default XWikiAttachment uploadAttachment(DocumentReference documentReference, Part part, String filename)

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/TemporaryAttachmentSessionsManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/TemporaryAttachmentSessionsManager.java
@@ -61,7 +61,7 @@ public interface TemporaryAttachmentSessionsManager
      * Temporary store the given {@link Part} to a cached {@link XWikiAttachment} attached to the given
      * {@link DocumentReference}.
      *
-     * @param documentReference the reference of the document that the attachment should be attached to.
+     * @param documentReference the reference of the document that the attachment should be attached to
      * @param part the actual data that is uploaded
      * @param filename an optional filename used instead of using {@link Part#getSubmittedFileName()}, ignored when
      *     {@code null}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/TemporaryAttachmentSessionsManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/TemporaryAttachmentSessionsManager.java
@@ -71,11 +71,8 @@ public interface TemporaryAttachmentSessionsManager
      * @since 14.9RC1
      */
     @Unstable
-    default XWikiAttachment uploadAttachment(DocumentReference documentReference, Part part, String filename)
-        throws TemporaryAttachmentException
-    {
-        throw new UnsupportedOperationException();
-    }
+    XWikiAttachment uploadAttachment(DocumentReference documentReference, Part part, String filename)
+        throws TemporaryAttachmentException;
 
     /**
      * Retrieve all temporary attachments related to the given document reference in the current user session.

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/TemporaryAttachmentSessionsManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/TemporaryAttachmentSessionsManager.java
@@ -64,7 +64,7 @@ public interface TemporaryAttachmentSessionsManager
      * @param documentReference the reference of the document that the attachment should be attached to
      * @param part the actual data that is uploaded
      * @param filename an optional filename used instead of using {@link Part#getSubmittedFileName()}, ignored when
-     *     {@code null}
+     *     {@code null} or blank
      * @return an attachment that is not saved yet but cached and contains the data of the given part
      * @throws TemporaryAttachmentException if the part size exceeds the maximum upload size, or in case of problem
      *     when reading the part

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/TemporaryAttachmentSessionsManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/TemporaryAttachmentSessionsManager.java
@@ -62,12 +62,12 @@ public interface TemporaryAttachmentSessionsManager
      * {@link DocumentReference}.
      *
      * @param documentReference the reference of the document that the attachment should be attached to.
-     * @param part the actual data that is uploaded.
+     * @param part the actual data that is uploaded
      * @param filename an optional filename used instead of using {@link Part#getSubmittedFileName()}, ignored when
      *     {@code null}
-     * @return an attachment that is not saved yet but cached and contains the data of the given part.
+     * @return an attachment that is not saved yet but cached and contains the data of the given part
      * @throws TemporaryAttachmentException if the part size exceeds the maximum upload size, or in case of problem
-     *     when reading the part.
+     *     when reading the part
      * @since 14.9RC1
      */
     @Unstable

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/TemporaryAttachmentSessionsManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/TemporaryAttachmentSessionsManager.java
@@ -58,6 +58,26 @@ public interface TemporaryAttachmentSessionsManager
         throws TemporaryAttachmentException;
 
     /**
+     * Temporary store the given {@link Part} to a cached {@link XWikiAttachment} attached to the given
+     * {@link DocumentReference}.
+     *
+     * @param documentReference the reference of the document that the attachment should be attached to.
+     * @param part the actual data that is uploaded.
+     * @param filename an optional filename used instead of using {@link Part#getSubmittedFileName()}, ignored when
+     *     {@code null}
+     * @return an attachment that is not saved yet but cached and contains the data of the given part.
+     * @throws TemporaryAttachmentException if the part size exceeds the maximum upload size, or in case of problem
+     *     when reading the part.
+     * @since 13.8
+     */
+    @Unstable
+    default XWikiAttachment uploadAttachment(DocumentReference documentReference, Part part, String filename)
+        throws TemporaryAttachmentException
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
      * Retrieve all temporary attachments related to the given document reference in the current user session.
      *
      * @param documentReference the reference for which to retrieve temporary attachments.

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/pom.xml
@@ -31,7 +31,7 @@
   <name>XWiki Platform - Store - Filesystem - Old Core</name>
   <description>Implement various oldcore store APIs based on filesystem.</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.41</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.40</xwiki.jacoco.instructionRatio>
     <!-- Old names of this module used for retro compatibility when resolving dependencies of old extensions -->
     <xwiki.extension.features>org.xwiki.platform:xwiki-platform-store-filesystem-attachments</xwiki.extension.features>
   </properties>

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/pom.xml
@@ -31,7 +31,7 @@
   <name>XWiki Platform - Store - Filesystem - Old Core</name>
   <description>Implement various oldcore store APIs based on filesystem.</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.38</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>1.00</xwiki.jacoco.instructionRatio>
     <!-- Old names of this module used for retro compatibility when resolving dependencies of old extensions -->
     <xwiki.extension.features>org.xwiki.platform:xwiki-platform-store-filesystem-attachments</xwiki.extension.features>
   </properties>

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/pom.xml
@@ -31,7 +31,7 @@
   <name>XWiki Platform - Store - Filesystem - Old Core</name>
   <description>Implement various oldcore store APIs based on filesystem.</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>1.00</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.41</xwiki.jacoco.instructionRatio>
     <!-- Old names of this module used for retro compatibility when resolving dependencies of old extensions -->
     <xwiki.extension.features>org.xwiki.platform:xwiki-platform-store-filesystem-attachments</xwiki.extension.features>
   </properties>

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/StoreFilesystemOldcoreException.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/StoreFilesystemOldcoreException.java
@@ -17,7 +17,9 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.xwiki.store.filesystem.internal;
+package org.xwiki.store.filesystem;
+
+import org.xwiki.stability.Unstable;
 
 /**
  * Exception for the Store - Filesystem - Old Core module.
@@ -25,16 +27,18 @@ package org.xwiki.store.filesystem.internal;
  * @version $Id$
  * @since 14.9RC1
  */
+@Unstable
 public class StoreFilesystemOldcoreException extends Exception
 {
     /**
-     * Constructor with the cause of this exception.
+     * Constructs a new filesystem oldcore exception with the specified detail message and cause.
      *
+     * @param message the detail message (which is saved for later retrieval by the {@link #getMessage()} method).
      * @param cause the cause (which is saved for later retrieval by the {@link #getCause()} method).  (A
      *     {@code null} value is permitted, and indicates that the cause is nonexistent or unknown.)
      */
-    public StoreFilesystemOldcoreException(Throwable cause)
+    public StoreFilesystemOldcoreException(String message, Throwable cause)
     {
-        super(cause);
+        super(message, cause);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/DefaultTemporaryAttachmentSessionsManager.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/DefaultTemporaryAttachmentSessionsManager.java
@@ -87,6 +87,13 @@ public class DefaultTemporaryAttachmentSessionsManager implements TemporaryAttac
     public XWikiAttachment uploadAttachment(DocumentReference documentReference, Part part)
         throws TemporaryAttachmentException
     {
+        return uploadAttachment(documentReference, part, null);
+    }
+
+    @Override
+    public XWikiAttachment uploadAttachment(DocumentReference documentReference, Part part, String filename)
+        throws TemporaryAttachmentException
+    {
         XWikiAttachment xWikiAttachment;
         long uploadMaxSize = getUploadMaxSize(documentReference);
         if (part.getSize() > uploadMaxSize) {
@@ -97,7 +104,13 @@ public class DefaultTemporaryAttachmentSessionsManager implements TemporaryAttac
         XWikiContext context = this.contextProvider.get();
         try {
             xWikiAttachment = new XWikiAttachment();
-            xWikiAttachment.setFilename(part.getSubmittedFileName());
+            String actualFilename;
+            if (filename != null) {
+                actualFilename = filename;
+            } else {
+                actualFilename = part.getSubmittedFileName();
+            }
+            xWikiAttachment.setFilename(actualFilename);
             xWikiAttachment.setContent(part.getInputStream());
             xWikiAttachment.setAuthorReference(context.getUserReference());
             // Initialize an empty document with the right document reference and locale. We don't set the actual 

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/DefaultTemporaryAttachmentSessionsManager.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/DefaultTemporaryAttachmentSessionsManager.java
@@ -29,6 +29,7 @@ import javax.inject.Singleton;
 import javax.servlet.http.HttpSession;
 import javax.servlet.http.Part;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.DocumentReference;
@@ -105,7 +106,7 @@ public class DefaultTemporaryAttachmentSessionsManager implements TemporaryAttac
         try {
             xWikiAttachment = new XWikiAttachment();
             String actualFilename;
-            if (filename != null) {
+            if (StringUtils.isNotBlank(filename)) {
                 actualFilename = filename;
             } else {
                 actualFilename = part.getSubmittedFileName();

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/StoreFilesystemOldcoreException.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/StoreFilesystemOldcoreException.java
@@ -1,0 +1,40 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.store.filesystem.internal;
+
+/**
+ * Exception for the Store - Filesystem - Old Core module.
+ *
+ * @version $Id$
+ * @since 14.8RC1
+ */
+public class StoreFilesystemOldcoreException extends Exception
+{
+    /**
+     * Constructor with the cause of this exception.
+     *
+     * @param cause the cause (which is saved for later retrieval by the {@link #getCause()} method).  (A
+     *     {@code null} value is permitted, and indicates that the cause is nonexistent or unknown.)
+     */
+    public StoreFilesystemOldcoreException(Throwable cause)
+    {
+        super(cause);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/StoreFilesystemOldcoreException.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/StoreFilesystemOldcoreException.java
@@ -23,7 +23,7 @@ package org.xwiki.store.filesystem.internal;
  * Exception for the Store - Filesystem - Old Core module.
  *
  * @version $Id$
- * @since 14.8RC1
+ * @since 14.9RC1
  */
 public class StoreFilesystemOldcoreException extends Exception
 {

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/script/TemporaryAttachmentsScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/script/TemporaryAttachmentsScriptService.java
@@ -44,7 +44,7 @@ import org.xwiki.script.service.ScriptService;
 import org.xwiki.stability.Unstable;
 import org.xwiki.store.TemporaryAttachmentException;
 import org.xwiki.store.TemporaryAttachmentSessionsManager;
-import org.xwiki.store.filesystem.internal.StoreFilesystemOldcoreException;
+import org.xwiki.store.filesystem.StoreFilesystemOldcoreException;
 
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
@@ -83,7 +83,7 @@ public class TemporaryAttachmentsScriptService implements ScriptService
      *
      * @param documentReference the target document reference the attachment should be later attached to
      * @param fieldName the name of the field of the uploaded data
-     * @return a temporary {@link Attachment} not yet persisted attachment
+     * @return a temporary {@link Attachment} not yet persisted attachment, or {@code null} in case of error
      */
     public Attachment uploadTemporaryAttachment(DocumentReference documentReference, String fieldName)
     {
@@ -238,7 +238,8 @@ public class TemporaryAttachmentsScriptService implements ScriptService
             XWikiContext context = this.contextProvider.get();
             return context.getWiki().getDocument(documentReference, context);
         } catch (XWikiException e) {
-            throw new StoreFilesystemOldcoreException(e);
+            throw new StoreFilesystemOldcoreException(String.format("Failed to load document [%s]", documentReference),
+                e);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/script/TemporaryAttachmentsScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/script/TemporaryAttachmentsScriptService.java
@@ -81,7 +81,7 @@ public class TemporaryAttachmentsScriptService implements ScriptService
      * Temporary upload the attachment identified by the given field name: the request should be of type
      * {@code multipart/form-data}.
      *
-     * @param documentReference the target document reference the attachment should be later attached to.
+     * @param documentReference the target document reference the attachment should be later attached to
      * @param fieldName the name of the field of the uploaded data
      * @return a temporary {@link Attachment} not yet persisted attachment
      */
@@ -127,6 +127,8 @@ public class TemporaryAttachmentsScriptService implements ScriptService
     }
 
     /**
+     * Return a list of the temporary attachments, sorted by filenames (ignoring the case).
+     *
      * @param documentReference the target document reference the attachments should be later attached to
      * @return the list of temporary attachments linked to the given document reference. The list is sorted by the
      *     attachments filenames ({@link XWikiAttachment#getFilename()})
@@ -145,9 +147,9 @@ public class TemporaryAttachmentsScriptService implements ScriptService
     }
 
     /**
-     * Build a list of all the attachments of a given document. The list contains the persisted attachments of the
-     * document, merged with the temporary attachments. The persisted attachments are replaced by the temporary one if
-     * their names match.
+     * Build a list of all the attachments of a given document, sorted by filenames (ignoring the case). The list
+     * contains the persisted attachments of the document, merged with the temporary attachments. The persisted
+     * attachments are replaced by the temporary one if their names match.
      *
      * @param documentReference the target document reference the temporary attachments should be later attached to
      * @return the list of all attachments linked to the given document reference. Persisted attachments are overridden
@@ -191,15 +193,9 @@ public class TemporaryAttachmentsScriptService implements ScriptService
      * @since 14.9RC1
      */
     @Unstable
-    public boolean temporaryAttachmentExists(Attachment attachment) throws StoreFilesystemOldcoreException
+    public boolean temporaryAttachmentExists(Attachment attachment)
     {
-        DocumentReference documentReference = attachment.getReference().getDocumentReference();
-        XWikiDocument document = getDocument(documentReference);
-        return this.temporaryAttachmentSessionsManager
-            .getUploadedAttachments(documentReference)
-            .stream()
-            .map(xWikiAttachment -> convertToAttachment(document, xWikiAttachment))
-            .anyMatch(attachmentEqualityPredicate(attachment));
+        return this.temporaryAttachmentSessionsManager.getUploadedAttachment(attachment.getReference()).isPresent();
     }
 
     /**
@@ -220,11 +216,7 @@ public class TemporaryAttachmentsScriptService implements ScriptService
         throws StoreFilesystemOldcoreException
     {
         XWikiDocument document = getDocument(attachment.getReference().getDocumentReference());
-        return document
-            .getAttachmentList()
-            .stream()
-            .map(xWikiAttachment -> convertToAttachment(document, xWikiAttachment))
-            .anyMatch(attachmentEqualityPredicate(attachment));
+        return document.getAttachment(attachment.getFilename()) != null;
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/script/TemporaryAttachmentsScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/script/TemporaryAttachmentsScriptService.java
@@ -60,6 +60,7 @@ import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCauseMess
 /**
  * Script service dedicated to the handling of temporary attachments.
  *
+ * @version $Id$
  * @see TemporaryAttachmentSessionsManager
  * @since 14.3RC1
  */
@@ -132,7 +133,7 @@ public class TemporaryAttachmentsScriptService implements ScriptService
      * @param documentReference the target document reference the attachments should be later attached to
      * @return the list of temporary attachments linked to the given document reference. The list is sorted by the
      *     attachments filenames ({@link XWikiAttachment#getFilename()})
-     * @since 14.8
+     * @since 14.9RC1
      */
     @Unstable
     public List<Attachment> listTemporaryAttachments(DocumentReference documentReference)
@@ -155,7 +156,7 @@ public class TemporaryAttachmentsScriptService implements ScriptService
      * @return the list of all attachments linked to the given document reference. Persisted attachments are overridden
      *     by temporary one if names match. The list is sorted by the attachments filenames
      *     ({@link XWikiAttachment#getFilename()})
-     * @since 14.8
+     * @since 14.9RC1
      */
     @Unstable
     public List<Attachment> listAllAttachments(DocumentReference documentReference)
@@ -190,7 +191,7 @@ public class TemporaryAttachmentsScriptService implements ScriptService
      * @return {@code true} if a matching attachment exists in the temporary attachment session (i.e., same filename and
      *     document reference), {@code false} otherwise
      * @see #persistentAttachmentExists(Attachment)
-     * @since 14.8
+     * @since 14.9RC1
      */
     @Unstable
     public boolean temporaryAttachmentExists(Attachment attachment) throws StoreFilesystemOldcoreException
@@ -215,7 +216,7 @@ public class TemporaryAttachmentsScriptService implements ScriptService
      *     {@code false} otherwise
      * @throws StoreFilesystemOldcoreException in case of error when accessing the attachment's document
      * @see #temporaryAttachmentExists(Attachment)
-     * @since 14.8
+     * @since 14.9RC1
      */
     @Unstable
     public boolean persistentAttachmentExists(Attachment attachment)

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/script/TemporaryAttachmentsScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/script/TemporaryAttachmentsScriptService.java
@@ -165,7 +165,6 @@ public class TemporaryAttachmentsScriptService implements ScriptService
             new ArrayList<>(this.temporaryAttachmentSessionsManager.getUploadedAttachments(documentReference));
         XWikiDocument document = getDocument(documentReference);
         List<Attachment> fullList = temporaryAttachments.stream()
-            .peek(temporaryAttachment -> temporaryAttachment.setDoc(document))
             .map(attachment -> convertToAttachment(document, attachment))
             .collect(Collectors.toList());
         Stream<Attachment> nonOverriddenAttachments =

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/script/TemporaryAttachmentsScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/script/TemporaryAttachmentsScriptService.java
@@ -25,10 +25,10 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.Optional;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -47,8 +47,6 @@ import org.xwiki.store.TemporaryAttachmentSessionsManager;
 import org.xwiki.store.filesystem.internal.StoreFilesystemOldcoreException;
 
 import com.xpn.xwiki.XWikiContext;
-import com.xpn.xwiki.api.Attachment;
-import com.xpn.xwiki.api.Document;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.api.Attachment;
 import com.xpn.xwiki.api.Document;
@@ -85,8 +83,7 @@ public class TemporaryAttachmentsScriptService implements ScriptService
      *
      * @param documentReference the target document reference the attachment should be later attached to.
      * @param fieldName the name of the field of the uploaded data
-     * @return a temporary {@link Attachment} not yet persisted
-     *          attachment
+     * @return a temporary {@link Attachment} not yet persisted attachment
      */
     public Attachment uploadTemporaryAttachment(DocumentReference documentReference, String fieldName)
     {
@@ -100,7 +97,7 @@ public class TemporaryAttachmentsScriptService implements ScriptService
      * @param documentReference the target document reference the attachment should be later attached to
      * @param fieldName the name of the field of the uploaded data
      * @param filename an optional filename used instead of using the filename of the file passing in
-     *           {@code fieldName}, ignored when {@code null}
+     *     {@code fieldName}, ignored when {@code null}
      * @return a temporary {@link Attachment} not yet persisted attachment, or {@code null} in case of error
      * @since 14.9RC1
      */
@@ -112,8 +109,8 @@ public class TemporaryAttachmentsScriptService implements ScriptService
         try {
             Part part = context.getRequest().getPart(fieldName);
             if (part != null) {
-                result = Optional.of(this.temporaryAttachmentSessionsManager.uploadAttachment(documentReference, part
-                    , filename));
+                result = Optional.of(
+                    this.temporaryAttachmentSessionsManager.uploadAttachment(documentReference, part, filename));
             }
         } catch (IOException | ServletException e) {
             this.logger.warn("Error while reading the request content part: [{}]", getRootCauseMessage(e));

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/test/java/org/xwiki/store/script/TemporaryAttachmentsScriptServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/test/java/org/xwiki/store/script/TemporaryAttachmentsScriptServiceTest.java
@@ -51,12 +51,6 @@ import com.xpn.xwiki.api.Document;
 import com.xpn.xwiki.doc.XWikiAttachment;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.user.api.XWikiRightService;
-import com.xpn.xwiki.XWiki;
-import com.xpn.xwiki.XWikiContext;
-import com.xpn.xwiki.api.Attachment;
-import com.xpn.xwiki.doc.XWikiAttachment;
-import com.xpn.xwiki.doc.XWikiDocument;
-import com.xpn.xwiki.user.api.XWikiRightService;
 import com.xpn.xwiki.web.XWikiRequest;
 
 import ch.qos.logback.classic.Level;
@@ -128,7 +122,7 @@ class TemporaryAttachmentsScriptServiceTest
         XWikiAttachment xWikiAttachment = mock(XWikiAttachment.class);
 
         when(this.request.getPart("upload")).thenReturn(this.part);
-        when(this.temporaryAttachmentSessionsManager.uploadAttachment(DOCUMENT_REFERENCE, this.part))
+        when(this.temporaryAttachmentSessionsManager.uploadAttachment(DOCUMENT_REFERENCE, this.part, null))
             .thenReturn(xWikiAttachment);
 
         Attachment temporaryAttachment =
@@ -136,7 +130,7 @@ class TemporaryAttachmentsScriptServiceTest
 
         assertSame(xWikiAttachment, temporaryAttachment.getAttachment());
 
-        verify(this.temporaryAttachmentSessionsManager).uploadAttachment(DOCUMENT_REFERENCE, this.part);
+        verify(this.temporaryAttachmentSessionsManager).uploadAttachment(DOCUMENT_REFERENCE, this.part, null);
     }
 
     @ParameterizedTest
@@ -167,7 +161,7 @@ class TemporaryAttachmentsScriptServiceTest
         throws Exception
     {
         when(this.request.getPart("upload")).thenReturn(this.part);
-        when(this.temporaryAttachmentSessionsManager.uploadAttachment(DOCUMENT_REFERENCE, this.part))
+        when(this.temporaryAttachmentSessionsManager.uploadAttachment(DOCUMENT_REFERENCE, this.part, null))
             .thenThrow(TemporaryAttachmentException.class);
 
         assertNull(this.temporaryAttachmentsScriptService.uploadTemporaryAttachment(DOCUMENT_REFERENCE,
@@ -190,7 +184,7 @@ class TemporaryAttachmentsScriptServiceTest
         Attachment temporaryAttachment =
             this.temporaryAttachmentsScriptService.uploadTemporaryAttachment(DOCUMENT_REFERENCE, "upload", "filename");
 
-        assertSame(xWikiAttachment, temporaryAttachment);
+        assertSame(xWikiAttachment, temporaryAttachment.getAttachment());
 
         verify(this.temporaryAttachmentSessionsManager).uploadAttachment(DOCUMENT_REFERENCE, this.part, "filename");
     }

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/test/java/org/xwiki/store/script/TemporaryAttachmentsScriptServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/test/java/org/xwiki/store/script/TemporaryAttachmentsScriptServiceTest.java
@@ -42,6 +42,8 @@ import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
 
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.doc.XWikiAttachment;
 import com.xpn.xwiki.XWiki;
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.api.Attachment;
@@ -165,5 +167,22 @@ class TemporaryAttachmentsScriptServiceTest
             this.logCapture.getMessage(0));
         assertEquals(Level.WARN, this.logCapture.getLogEvent(0).getLevel());
     }
-}
 
+    @Test
+    void uploadTemporaryAttachmentWithFilename() throws Exception
+    {
+        DocumentReference documentReference = new DocumentReference("xwiki", "XWiki", "Doc");
+        XWikiAttachment xWikiAttachment = mock(XWikiAttachment.class);
+
+        when(this.request.getPart("upload")).thenReturn(this.part);
+        when(this.temporaryAttachmentSessionsManager.uploadAttachment(documentReference, this.part, "filename"))
+            .thenReturn(xWikiAttachment);
+
+        Attachment temporaryAttachment =
+            this.temporaryAttachmentsScriptService.uploadTemporaryAttachment(documentReference, "upload", "filename");
+
+        assertSame(xWikiAttachment, temporaryAttachment);
+
+        verify(this.temporaryAttachmentSessionsManager).uploadAttachment(documentReference, this.part, "filename");
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/test/java/org/xwiki/store/script/TemporaryAttachmentsScriptServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/test/java/org/xwiki/store/script/TemporaryAttachmentsScriptServiceTest.java
@@ -21,6 +21,7 @@ package org.xwiki.store.script;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import javax.inject.Provider;
@@ -76,6 +77,9 @@ import static org.mockito.Mockito.when;
 class TemporaryAttachmentsScriptServiceTest
 {
     private static final DocumentReference DOCUMENT_REFERENCE = new DocumentReference("xwiki", "XWiki", "Doc");
+
+    private static final AttachmentReference ATTACHMENT_REFERENCE =
+        new AttachmentReference("filename", DOCUMENT_REFERENCE);
 
     @InjectMockComponents
     private TemporaryAttachmentsScriptService temporaryAttachmentsScriptService;
@@ -275,7 +279,7 @@ class TemporaryAttachmentsScriptServiceTest
     }
 
     @Test
-    void temporaryAttachmentExistsNoTemporaryAttachment() throws Exception
+    void temporaryAttachmentExistsNoTemporaryAttachment()
     {
         Document document = new Document(this.xWikiDocument, this.context);
         XWikiAttachment xWikiAttachment = mock(XWikiAttachment.class);
@@ -288,7 +292,7 @@ class TemporaryAttachmentsScriptServiceTest
     }
 
     @Test
-    void temporaryAttachmentExistsNotSameFilename() throws Exception
+    void temporaryAttachmentExistsNotSameFilename()
     {
         Document document = new Document(this.xWikiDocument, this.context);
         XWikiAttachment xWikiAttachment = mock(XWikiAttachment.class);
@@ -308,21 +312,14 @@ class TemporaryAttachmentsScriptServiceTest
     }
 
     @Test
-    void temporaryAttachmentExistsSameFilename() throws Exception
+    void temporaryAttachmentExistsSameFilename()
     {
         Document document = new Document(this.xWikiDocument, this.context);
         XWikiAttachment xWikiAttachment = mock(XWikiAttachment.class);
+        when(xWikiAttachment.getReference()).thenReturn(ATTACHMENT_REFERENCE);
         Attachment attachment = new Attachment(document, xWikiAttachment, this.context);
-        String fileName = "picture.png";
-        when(xWikiAttachment.getReference()).thenReturn(new AttachmentReference(fileName, DOCUMENT_REFERENCE));
-        when(xWikiAttachment.getFilename()).thenReturn(fileName);
-
-        XWikiAttachment xWikiAttachment1 = mock(XWikiAttachment.class);
-        when(this.temporaryAttachmentSessionsManager.getUploadedAttachments(DOCUMENT_REFERENCE)).thenReturn(List.of(
-            xWikiAttachment1
-        ));
-
-        when(xWikiAttachment1.getFilename()).thenReturn(fileName);
+        when(this.temporaryAttachmentSessionsManager.getUploadedAttachment(ATTACHMENT_REFERENCE))
+            .thenReturn(Optional.of(xWikiAttachment));
 
         assertTrue(this.temporaryAttachmentsScriptService.temporaryAttachmentExists(attachment));
     }
@@ -363,15 +360,10 @@ class TemporaryAttachmentsScriptServiceTest
     {
         Document document = new Document(this.xWikiDocument, this.context);
         XWikiAttachment xWikiAttachment = mock(XWikiAttachment.class);
+        when(xWikiAttachment.getFilename()).thenReturn("file.png");
+        when(xWikiAttachment.getReference()).thenReturn(ATTACHMENT_REFERENCE);
         Attachment attachment = new Attachment(document, xWikiAttachment, this.context);
-        String fileName = "picture.png";
-        when(xWikiAttachment.getReference()).thenReturn(new AttachmentReference(fileName, DOCUMENT_REFERENCE));
-        when(xWikiAttachment.getFilename()).thenReturn(fileName);
-
-        XWikiAttachment xWikiAttachment1 = mock(XWikiAttachment.class);
-        when(this.xWikiDocument.getAttachmentList()).thenReturn(List.of(xWikiAttachment1));
-
-        when(xWikiAttachment1.getFilename()).thenReturn(fileName);
+        when(this.xWikiDocument.getAttachment("file.png")).thenReturn(xWikiAttachment);
 
         assertTrue(this.temporaryAttachmentsScriptService.persistentAttachmentExists(attachment));
     }

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/test/java/org/xwiki/store/script/TemporaryAttachmentsScriptServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/test/java/org/xwiki/store/script/TemporaryAttachmentsScriptServiceTest.java
@@ -235,8 +235,6 @@ class TemporaryAttachmentsScriptServiceTest
         assertEquals(List.of(xWikiAttachment1, xWikiAttachment0),
             this.temporaryAttachmentsScriptService.listAllAttachments(DOCUMENT_REFERENCE).stream()
                 .map(Attachment::getAttachment).collect(toList()));
-        verify(xWikiAttachment0).setDoc(this.xWikiDocument);
-        verify(xWikiAttachment1).setDoc(this.xWikiDocument);
     }
 
     @Test


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-19702

- Use the temporary attachment store to save newly uploaded attachments
- Allow users with view right to access the upload button
- List temporary attachments from the current document in the attachment selection modal

TODO:
- [x] Visually distinguish temporary attachment from the others in the selection modal
- [x] Allow temporary attachments to be removed or remove the "delete" button from temporary attachment
- [x] Maybe add a fallback to the legacy behavior when `$services.temporaryAttachments` is missing
- [x] Add missing translations
- [x] take into account `sortAttachmentsBy`
- [x] Add a page test for `AttachmentSelector.xml` (and maybe also a docker test).

Related bug:
- https://jira.xwiki.org/browse/XWIKI-20181