### PR TITLE
XWIKI-20183: Prototype.js breaks the standard Array.from method

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/javascript.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/javascript.vm
@@ -29,6 +29,8 @@
 <script src="$escapetool.xml($services.webjars.url('requirejs', "require$jsExtension"))" data-wysiwyg="true"></script>
 ## Load the JavaScript module used to determine when the page is ready (no pending HTTP requests or promises).
 <script src="$escapetool.xml($xwiki.getSkinFile('uicomponents/tools/pageReady.js'))" data-wysiwyg="true"></script>
+## Fix some Prototype.js breaking changes. 
+<script src="$escapetool.xml($xwiki.getSkinFile('js/xwiki/prototypeJSPatches.js'))"></script>
 ## FIXME: We still have code depending on Prototype.js without declaring it (i.e. without using RequireJS). Short term
 ## goal is to stop loading Prototype.js by default and change the existing code to load it when needed. Long term goal is
 ## to stop relying on Prototype.js . Note that we load Prototype.js before the following inline script because we have to

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/prototypeJSPatches.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/prototypeJSPatches.js
@@ -1,3 +1,22 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
 (function () {
   // Code executed before Prototype.js is loaded.
   const originalArrayFrom = Array.from;

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/prototypeJSPatches.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/prototypeJSPatches.js
@@ -1,0 +1,8 @@
+(function () {
+  // Code executed before Prototype.js is loaded.
+  const originalArrayFrom = Array.from;
+  setTimeout(() => {
+    // Code executed after Prototype.js is loaded.
+    Array.from = originalArrayFrom;
+  }, 0);
+})();

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/prototypeJSPatches.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/prototypeJSPatches.js
@@ -19,6 +19,8 @@
  */
 (function () {
   // Code executed before Prototype.js is loaded.
+  // Restore the original code, since Prototype.js is overriding the Array.from method. See
+  // https://github.com/prototypejs/prototype/issues/338.
   const originalArrayFrom = Array.from;
   setTimeout(() => {
     // Code executed after Prototype.js is loaded.


### PR DESCRIPTION
* save and restore the native Array.from implementation