### PR TITLE
XWIKI-20208: XWikiDocument#getDocumentArchive(context) always return an empty archive

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -2536,6 +2536,9 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
         if (this.archive != null) {
             return this.archive.get();
         }
+        // Some APIs are expecting the archive to be null for loading it
+        // (e.g. VersioningStore#loadXWikiDocumentArchive), so it's better to keep it null than to return an
+        // empty archive which would never be populated.
         return null;
     }
 
@@ -2583,6 +2586,10 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
         // request)
         if (arch != null) {
             this.archive = new SoftReference<XWikiDocumentArchive>(arch);
+        } else {
+            // Some APIs are expecting the archive to be null for loading it
+            // (e.g. VersioningStore#loadXWikiDocumentArchive), so we allow setting it back to null.
+            this.archive = null;
         }
     }
 
@@ -4534,10 +4541,10 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
             if (cloneArchive) {
                 doc.cloneDocumentArchive(this);
             } else {
-                // Initialize the document archive with empty archive, using the new document reference and id.
                 // Without this explicit initialization, it is possible for the archive to be incorrectly initialized.
                 // For instance, with the archive of the cloned document.
-                doc.setDocumentArchive(new XWikiDocumentArchive(newDocumentReference.getWikiReference(), getId()));
+                // Here we guarantee that further calls of APIs to get the archive will properly populate the data.
+                doc.setDocumentArchive((XWikiDocumentArchive) null);
             }
             doc.getAuthors().copyAuthors(getAuthors());
             doc.setContent(getContent());

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentTest.java
@@ -54,6 +54,7 @@ import org.xwiki.velocity.VelocityEngine;
 import org.xwiki.velocity.VelocityManager;
 
 import com.xpn.xwiki.XWiki;
+import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.api.DocumentSection;
 import com.xpn.xwiki.objects.BaseObject;
@@ -77,8 +78,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -848,5 +852,39 @@ public class XWikiDocumentTest
         assertEquals(2, attachmentList.size());
         assertEquals("file.txt", attachmentList.get(1).getFilename());
         assertEquals("file", attachmentList.get(0).getFilename());
+    }
+
+    /*
+     * Test for checking that cloneInternal doesn't replace the XWikiDocumentArchive by an empty document archive,
+     * and to ensure that the versioningStore is properly called when using
+     * XWikiDocument#getDocumentArchive(XWikiContext).
+     */
+    @Test
+    void getDocumentArchiveAfterClone() throws XWikiException
+    {
+        XWikiContext context = this.oldcore.getXWikiContext();
+        XWikiVersioningStoreInterface versioningStore =
+            this.document.getVersioningStore(context);
+        when(versioningStore.getXWikiDocumentArchive(any(), any())).then(invocationOnMock -> {
+            XWikiDocument doc = invocationOnMock.getArgument(0);
+            if (doc.getDocumentArchive() != null) {
+                return doc.getDocumentArchive();
+            } else {
+                return mock(XWikiDocumentArchive.class);
+            }
+        });
+        assertSame(versioningStore, document.getVersioningStore(context));
+        assertNull(this.document.getDocumentArchive());
+        XWikiDocumentArchive documentArchive = this.document.getDocumentArchive(context);
+        assertNotNull(documentArchive);
+        assertNotNull(this.document.getDocumentArchive());
+
+        XWikiDocument cloneDoc = document.clone();
+        assertNull(cloneDoc.getDocumentArchive());
+        XWikiDocumentArchive cloneArchive = cloneDoc.getDocumentArchive(context);
+        verify(versioningStore).getXWikiDocumentArchive(
+            argThat(givenDoc -> givenDoc != XWikiDocumentTest.this.document), eq(context));
+        assertNotNull(cloneArchive);
+        assertNotSame(cloneArchive, documentArchive);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/test/MockitoOldcore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/test/MockitoOldcore.java
@@ -751,9 +751,6 @@ public class MockitoOldcore
                     }
 
                     XWikiDocument savedDocument = document.clone();
-                    // Retrieve the document's history aggregated in the versioning store. 
-                    savedDocument.setDocumentArchive(getMockVersioningStore().getXWikiDocumentArchive(savedDocument,
-                        context));
                     documents.put(document.getDocumentReferenceWithLocale(), savedDocument);
 
                     if (isNew) {


### PR DESCRIPTION
  * Set the archive to null value instead of setting it to an empty archive in case of clone
  * Add some more comment to explain why
  * Add a unit test to ensure that getXWikiDocumentArchive(context) behave as expected even after a clone