### PR TITLE
XWIKI-20138: On private wikis, users cannot recover their username

### DIFF
--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-api/src/main/java/org/xwiki/security/authentication/RetrieveUsernameException.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-api/src/main/java/org/xwiki/security/authentication/RetrieveUsernameException.java
@@ -1,0 +1,55 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.security.authentication;
+
+import org.xwiki.stability.Unstable;
+
+/**
+ * Exception thrown when using {@link RetrieveUsernameManager}.
+ *
+ * @version $Id$
+ * @since 14.9
+ * @since 14.4.6
+ * @since 13.10.10
+ */
+@Unstable
+public class RetrieveUsernameException extends Exception
+{
+    /**
+     * Default constructor.
+     *
+     * @param message end-user message about the problem.
+     */
+    public RetrieveUsernameException(String message)
+    {
+        super(message);
+    }
+
+    /**
+     * Constructor in case of parent exception.
+     *
+     * @param message end-user message about the problem.
+     * @param throwable parent exception.
+     */
+    public RetrieveUsernameException(String message, Throwable throwable)
+    {
+        super(message, throwable);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-api/src/main/java/org/xwiki/security/authentication/RetrieveUsernameManager.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-api/src/main/java/org/xwiki/security/authentication/RetrieveUsernameManager.java
@@ -1,0 +1,60 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.security.authentication;
+
+import java.util.Set;
+
+import org.xwiki.component.annotation.Role;
+import org.xwiki.stability.Unstable;
+import org.xwiki.user.UserReference;
+
+/**
+ * Default manager for handling requests of user who lost their usernames.
+ *
+ * @version $Id$
+ * @since 14.9
+ * @since 14.4.6
+ * @since 13.10.10
+ */
+@Unstable
+@Role
+public interface RetrieveUsernameManager
+{
+    /**
+     * Look for the users registered with the given email address in current wiki and main wiki if none can be found in
+     * current one.
+     *
+     * @param requestEmail the email to use to find users.
+     * @return a set of user references that have been found matching the mail.
+     * @throws RetrieveUsernameException in case of problem to execute the query for finding users.
+     */
+    Set<UserReference> findUsers(String requestEmail) throws RetrieveUsernameException;
+
+    /**
+     * Send an email to the given username with the username information of the given user references.
+     *
+     * @param requestEmail the email address to use for sending the information
+     * @param userReferences the actual user references that can be used by this user
+     * @throws RetrieveUsernameException in case of problem when sending the email, or if the email address is wrong, or
+     *         if the set of user references is empty.
+     */
+    void sendRetrieveUsernameEmail(String requestEmail, Set<UserReference> userReferences)
+        throws RetrieveUsernameException;
+}

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/checkstyle/checkstyle-suppressions.xml
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/checkstyle/checkstyle-suppressions.xml
@@ -27,4 +27,6 @@
 <suppressions>
   <suppress checks="FanOutComplexity" files="DefaultAuthenticationFailureManager.java"/>
   <suppress checks="FanOutComplexity" files="DefaultResetPasswordManager.java"/>
+  <suppress checks="FanOutComplexity" files="DefaultRetrieveUsernameManager.java"/>
+  <suppress checks="FanOutComplexity" files="AuthenticationMailSender.java"/>
 </suppressions>

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/main/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManager.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/main/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManager.java
@@ -114,7 +114,7 @@ public class DefaultResetPasswordManager implements ResetPasswordManager
     private UserReferenceSerializer<String> referenceSerializer;
 
     @Inject
-    private Provider<ResetPasswordMailSender> resetPasswordMailSenderProvider;
+    private Provider<AuthenticationMailSender> resetPasswordMailSenderProvider;
 
     @Inject
     @Named("xwikiproperties")

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/main/java/org/xwiki/security/authentication/internal/DefaultRetrieveUsernameManager.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/main/java/org/xwiki/security/authentication/internal/DefaultRetrieveUsernameManager.java
@@ -1,0 +1,115 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.security.authentication.internal;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
+
+import org.apache.commons.lang3.StringUtils;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.query.Query;
+import org.xwiki.query.QueryException;
+import org.xwiki.query.QueryManager;
+import org.xwiki.security.authentication.RetrieveUsernameException;
+import org.xwiki.security.authentication.RetrieveUsernameManager;
+import org.xwiki.user.UserReference;
+import org.xwiki.user.UserReferenceResolver;
+import org.xwiki.wiki.descriptor.WikiDescriptorManager;
+
+/**
+ * Default implementation of {@link RetrieveUsernameManager}.
+ *
+ * @version $Id$
+ * @since 14.9
+ * @since 14.4.6
+ * @since 13.10.10
+ */
+@Component
+@Singleton
+public class DefaultRetrieveUsernameManager implements RetrieveUsernameManager
+{
+    private static final String HQL_QUERY = ", BaseObject obj, StringProperty prop where obj.name = doc.fullName and "
+        + "obj.className = 'XWiki.XWikiUsers' and prop.id.id = obj.id and prop.id.name = 'email' "
+        + "and LOWER(prop.value) = :email";
+
+    @Inject
+    private QueryManager queryManager;
+
+    @Inject
+    private WikiDescriptorManager wikiDescriptorManager;
+
+    @Inject
+    private UserReferenceResolver<String> userReferenceResolver;
+
+    @Inject
+    private AuthenticationMailSender authenticationMailSender;
+
+    @Override
+    public Set<UserReference> findUsers(String requestEmail) throws RetrieveUsernameException
+    {
+        Set<UserReference> result = this.findUsers(requestEmail, false);
+        if (result.isEmpty()) {
+            result = this.findUsers(requestEmail, true);
+        }
+        return result;
+    }
+
+    private Set<UserReference> findUsers(String requestEmail, boolean mainWiki) throws RetrieveUsernameException
+    {
+        try {
+            Query query = this.queryManager.createQuery(HQL_QUERY, Query.HQL)
+                .bindValue("email", StringUtils.toRootLowerCase(requestEmail));
+
+            if (mainWiki) {
+                query = query.setWiki(this.wikiDescriptorManager.getMainWikiId());
+            }
+
+            List<String> userSerializedReferences = query.execute();
+            return userSerializedReferences.stream()
+                .map(this.userReferenceResolver::resolve)
+                .collect(Collectors.toSet());
+        } catch (QueryException e) {
+            throw new RetrieveUsernameException(
+                String.format("Error when performing the query to retrieve user from email [%s]", requestEmail), e);
+        }
+    }
+
+    @Override
+    public void sendRetrieveUsernameEmail(String requestEmail, Set<UserReference> userReferences)
+        throws RetrieveUsernameException
+    {
+        if (userReferences.isEmpty()) {
+            throw new RetrieveUsernameException("The list of user is empty.");
+        }
+        try {
+            InternetAddress email = new InternetAddress(requestEmail);
+            this.authenticationMailSender.sendRetrieveUsernameEmail(email, userReferences);
+        } catch (AddressException e) {
+            throw new RetrieveUsernameException(
+                String.format("Error with the given email adresse: [%s]", requestEmail), e);
+        }
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/main/java/org/xwiki/security/authentication/internal/R140600000XWIKI19869DataMigrationListener.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/main/java/org/xwiki/security/authentication/internal/R140600000XWIKI19869DataMigrationListener.java
@@ -75,7 +75,7 @@ public class R140600000XWIKI19869DataMigrationListener extends AbstractEventList
     private Provider<ResetPasswordManager> resetPasswordManagerProvider;
 
     @Inject
-    private Provider<ResetPasswordMailSender> resetPasswordMailSenderProvider;
+    private Provider<AuthenticationMailSender> resetPasswordMailSenderProvider;
 
     @Inject
     private Provider<UserReferenceResolver<String>> userReferenceResolverProvider;

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/main/resources/META-INF/components.txt
@@ -8,5 +8,6 @@ org.xwiki.security.authentication.internal.resource.AuthenticationResourceRefere
 org.xwiki.security.authentication.internal.resource.AuthenticationResourceReferenceResolver
 org.xwiki.security.authentication.internal.resource.AuthenticationResourceReferenceSerializer
 org.xwiki.security.authentication.internal.DefaultResetPasswordManager
-org.xwiki.security.authentication.internal.ResetPasswordMailSender
+org.xwiki.security.authentication.internal.AuthenticationMailSender
 org.xwiki.security.authentication.internal.R140600000XWIKI19869DataMigrationListener
+org.xwiki.security.authentication.internal.DefaultRetrieveUsernameManager

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/AuthenticationMailSenderTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/AuthenticationMailSenderTest.java
@@ -73,15 +73,15 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * Tests for {@link ResetPasswordMailSender}.
+ * Tests for {@link AuthenticationMailSender}.
  *
  * @version $Id$
  */
 @ComponentTest
-class ResetPasswordMailSenderTest
+class AuthenticationMailSenderTest
 {
     @InjectMockComponents
-    private ResetPasswordMailSender resetPasswordMailSender;
+    private AuthenticationMailSender resetPasswordMailSender;
 
     private static final LocalDocumentReference RESET_PASSWORD_MAIL_TEMPLATE_REFERENCE =
         new LocalDocumentReference("XWiki", "ResetPasswordMailContent");
@@ -256,7 +256,8 @@ class ResetPasswordMailSenderTest
             () -> this.resetPasswordMailSender.sendResetPasswordEmail(username, email, resetPasswordUrl));
         verify(this.mailSender).sendAsynchronously(Collections.singleton(message), session, this.mailListener);
         verify(mailStatusResult).waitTillProcessed(1000L);
-        assertEquals("Cannot send this email - Some sending error", resetPasswordException.getMessage());
+        assertEquals("Cannot send this email", resetPasswordException.getMessage());
+        assertEquals("Some sending error", resetPasswordException.getCause().getMessage());
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManagerTest.java
@@ -109,7 +109,7 @@ class DefaultResetPasswordManagerTest
     private UserReferenceSerializer<String> referenceSerializer;
 
     @MockComponent
-    private Provider<ResetPasswordMailSender> resetPasswordMailSenderProvider;
+    private Provider<AuthenticationMailSender> resetPasswordMailSenderProvider;
 
     @MockComponent
     @Named("xwikiproperties")
@@ -118,7 +118,7 @@ class DefaultResetPasswordManagerTest
     @RegisterExtension
     LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.INFO);
 
-    private ResetPasswordMailSender resetPasswordMailSender;
+    private AuthenticationMailSender authenticationMailSender;
 
     private DocumentUserReference userReference;
     private DocumentReference userDocumentReference;
@@ -143,8 +143,8 @@ class DefaultResetPasswordManagerTest
         when(this.context.getWiki()).thenReturn(this.xWiki);
         this.userDocument = mock(XWikiDocument.class);
         when(this.xWiki.getDocument(this.userDocumentReference, this.context)).thenReturn(this.userDocument);
-        this.resetPasswordMailSender = mock(ResetPasswordMailSender.class);
-        when(this.resetPasswordMailSenderProvider.get()).thenReturn(this.resetPasswordMailSender);
+        this.authenticationMailSender = mock(AuthenticationMailSender.class);
+        when(this.resetPasswordMailSenderProvider.get()).thenReturn(this.authenticationMailSender);
         when(this.configurationSource.getProperty(DefaultResetPasswordManager.TOKEN_LIFETIME, 0)).thenReturn(0);
     }
 
@@ -251,7 +251,7 @@ class DefaultResetPasswordManagerTest
         DefaultResetPasswordRequestResponse requestResponse =
             new DefaultResetPasswordRequestResponse(this.userReference, verificationCode);
         this.resetPasswordManager.sendResetPasswordEmailRequest(requestResponse);
-        verify(this.resetPasswordMailSender).sendResetPasswordEmail("Foo Bar", email,
+        verify(this.authenticationMailSender).sendResetPasswordEmail("Foo Bar", email,
             new URL("http://xwiki.org/xwiki/authenticate/reset?u=user%3AFoobar&v=foobar4242"));
     }
 

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultRetrieveUsernameManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultRetrieveUsernameManagerTest.java
@@ -1,0 +1,137 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.security.authentication.internal;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.mail.internet.AddressException;
+import javax.mail.internet.InternetAddress;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.query.Query;
+import org.xwiki.query.QueryException;
+import org.xwiki.query.QueryManager;
+import org.xwiki.security.authentication.RetrieveUsernameException;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+import org.xwiki.user.UserReference;
+import org.xwiki.user.UserReferenceResolver;
+import org.xwiki.wiki.descriptor.WikiDescriptorManager;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link DefaultRetrieveUsernameManager}.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+class DefaultRetrieveUsernameManagerTest
+{
+    private static final String HQL_QUERY = ", BaseObject obj, StringProperty prop where obj.name = doc.fullName and "
+        + "obj.className = 'XWiki.XWikiUsers' and prop.id.id = obj.id and prop.id.name = 'email' "
+        + "and LOWER(prop.value) = :email";
+
+    @InjectMockComponents
+    private DefaultRetrieveUsernameManager retrieveUsernameManager;
+
+    @MockComponent
+    private QueryManager queryManager;
+
+    @MockComponent
+    private WikiDescriptorManager wikiDescriptorManager;
+
+    @MockComponent
+    private UserReferenceResolver<String> userReferenceResolver;
+
+    @MockComponent
+    private AuthenticationMailSender authenticationMailSender;
+
+    @Test
+    void findUsers() throws QueryException, RetrieveUsernameException
+    {
+        String email = "foo@bar.com";
+
+        Query query = mock(Query.class);
+        when(this.queryManager.createQuery(HQL_QUERY, Query.HQL)).thenReturn(query);
+        when(query.bindValue("email", email)).thenReturn(query);
+
+        when(query.execute()).thenReturn(Arrays.asList("User1", "User2"));
+        UserReference userReference1 = mock(UserReference.class, "user1");
+        UserReference userReference2 = mock(UserReference.class, "user2");
+        UserReference userReference3 = mock(UserReference.class, "user3");
+
+        when(this.userReferenceResolver.resolve("User1")).thenReturn(userReference1);
+        when(this.userReferenceResolver.resolve("User2")).thenReturn(userReference2);
+        when(this.userReferenceResolver.resolve("User3")).thenReturn(userReference3);
+
+        Set<UserReference> expectedSet = new HashSet<>(Arrays.asList(userReference1, userReference2));
+        assertEquals(expectedSet, this.retrieveUsernameManager.findUsers(email));
+        verify(this.queryManager).createQuery(HQL_QUERY, Query.HQL);
+
+        when(query.execute()).thenReturn(Collections.emptyList());
+        Query globalQuery = mock(Query.class, "globalQuery");
+        when(this.wikiDescriptorManager.getMainWikiId()).thenReturn("mainWiki");
+        when(query.setWiki("mainWiki")).thenReturn(globalQuery);
+
+        when(globalQuery.execute()).thenReturn(Collections.singletonList("User3"));
+        assertEquals(Collections.singleton(userReference3), this.retrieveUsernameManager.findUsers(email));
+
+        // 1 time for previous check
+        // 1 time for checking on current wiki
+        // 1 time for checking on main wiki
+        verify(this.queryManager, times(3)).createQuery(HQL_QUERY, Query.HQL);
+    }
+
+    @Test
+    void sendRetrieveUsernameEmail() throws RetrieveUsernameException, AddressException
+    {
+        RetrieveUsernameException exception = assertThrows(RetrieveUsernameException.class, () ->
+            this.retrieveUsernameManager.sendRetrieveUsernameEmail("",
+                Collections.singleton(mock(UserReference.class))));
+
+        assertTrue(exception.getCause() instanceof AddressException);
+
+        exception = assertThrows(RetrieveUsernameException.class, () ->
+            this.retrieveUsernameManager.sendRetrieveUsernameEmail("foo@bar.com", Collections.emptySet()));
+
+        assertNull(exception.getCause());
+        assertEquals("The list of user is empty.", exception.getMessage());
+
+        Set<UserReference> userReferences = new HashSet<>(Arrays.asList(
+            mock(UserReference.class),
+            mock(UserReference.class)
+        ));
+        this.retrieveUsernameManager.sendRetrieveUsernameEmail("foo@bar.com", userReferences);
+        verify(this.authenticationMailSender)
+            .sendRetrieveUsernameEmail(new InternetAddress("foo@bar.com"), userReferences);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/R140600000XWIKI19869DataMigrationListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/R140600000XWIKI19869DataMigrationListenerTest.java
@@ -73,7 +73,7 @@ class R140600000XWIKI19869DataMigrationListenerTest
     private ResetPasswordManager resetPasswordManager;
 
     @MockComponent
-    private ResetPasswordMailSender resetPasswordMailSender;
+    private AuthenticationMailSender resetPasswordMailSender;
 
     @MockComponent
     private UserReferenceResolver<String> userReferenceResolver;

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-script/src/main/java/org/xwiki/security/authentication/script/AuthenticationScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-script/src/main/java/org/xwiki/security/authentication/script/AuthenticationScriptService.java
@@ -255,6 +255,7 @@ public class AuthenticationScriptService implements ScriptService
      * @since 13.10.10
      * @since 14.4.6
      */
+    @Unstable
     public void retrieveUsernameAndSendEmail(String userEmail) throws RetrieveUsernameException
     {
         Set<UserReference> users = this.retrieveUsernameManager.findUsers(userEmail);

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-script/src/main/java/org/xwiki/security/authentication/script/AuthenticationScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-script/src/main/java/org/xwiki/security/authentication/script/AuthenticationScriptService.java
@@ -45,6 +45,8 @@ import org.xwiki.security.authentication.AuthenticationFailureStrategy;
 import org.xwiki.security.authentication.AuthenticationResourceReference;
 import org.xwiki.security.authentication.ResetPasswordException;
 import org.xwiki.security.authentication.ResetPasswordManager;
+import org.xwiki.security.authentication.RetrieveUsernameException;
+import org.xwiki.security.authentication.RetrieveUsernameManager;
 import org.xwiki.security.authorization.ContextualAuthorizationManager;
 import org.xwiki.security.authorization.Right;
 import org.xwiki.security.script.SecurityScriptService;
@@ -91,6 +93,9 @@ public class AuthenticationScriptService implements ScriptService
 
     @Inject
     private ResetPasswordManager resetPasswordManager;
+
+    @Inject
+    private RetrieveUsernameManager retrieveUsernameManager;
 
     @Inject
     @Named("contextpath")
@@ -239,5 +244,22 @@ public class AuthenticationScriptService implements ScriptService
     {
         this.resetPasswordManager.checkVerificationCode(user, verificationCode);
         this.resetPasswordManager.resetPassword(user, newPassword);
+    }
+
+    /**
+     * Retrieve users information associated to the given email address and send them by email.
+     *
+     * @param userEmail the email address for which to find associated accounts
+     * @throws RetrieveUsernameException in case of problem for finding the information or for sending the email
+     * @since 14.9
+     * @since 13.10.10
+     * @since 14.4.6
+     */
+    public void retrieveUsernameAndSendEmail(String userEmail) throws RetrieveUsernameException
+    {
+        Set<UserReference> users = this.retrieveUsernameManager.findUsers(userEmail);
+        if (!users.isEmpty()) {
+            this.retrieveUsernameManager.sendRetrieveUsernameEmail(userEmail, users);
+        }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/forgotusername.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/forgotusername.vm
@@ -58,57 +58,21 @@
         </form>
         #forgotUsernameBoxEnd()
       #else
-          #set($query = $services.query.hql(", BaseObject obj, StringProperty prop where obj.name = doc.fullName and obj.className = 'XWiki.XWikiUsers' and prop.id.id = obj.id and prop.id.name = 'email' and LOWER(prop.value) = :email").bindValue('email', $email.toLowerCase()))
-          #set($results = $query.execute())
-          ## If local user does not exist check global user
-          #if($results.size() == 0 && ${xcontext.database} != ${xcontext.mainWikiName})
-              #set($results = $query.setWiki("${xcontext.mainWikiName}").execute())
+          #try()
+            #set ($discard = $services.security.authentication.retrieveUsernameAndSendEmail($email))
           #end
-          #set ($emailError = false)
-          #if($results.size() != 0)
-              ## Send the email
-              #set ($from = $services.mail.sender.configuration.fromAddress)
-              #if ("$!from" == '')
-                  #set ($from = "no-reply@${request.serverName}")
-              #end
-              ## The mail temlate use $usernames to display the results.
-              #set ($usernames = $results)
-              #set ($mailTemplateReference = $services.model.createDocumentReference('', 'XWiki', 'ForgotUsernameMailContent'))
-              #set ($mailParameters = {'from' : $from, 'to' : $email, 'language' : $xcontext.locale})
-              #set ($message = $services.mail.sender.createMessage('template', $mailTemplateReference, $mailParameters))
-              #set ($discard = $message.setType('Forgot Username'))
-              #macro (displayError $text)
-                #forgotUsernameBoxStart("error")
-                <div class="xwikirenderingerror" title="Click to get more details about the error" style="cursor: pointer;">
-                  $services.localization.render('xe.admin.forgotUsername.error.emailFailed')
-                </div>
-                <div class="xwikirenderingerrordescription hidden">
-                <pre>${text}</pre>
-                </div>
-                #forgotUsernameBoxEnd()
-                #set ($emailError = true)
-              #end
-              ## Check for an error constructing the message!
-              #if ($services.mail.sender.lastError)
-                  #displayError($exceptiontool.getStackTrace($services.mail.sender.lastError))
-              #else
-                  ## Send the message and wait for it to be sent or for any error to be raised.
-                  #set ($mailResult = $services.mail.sender.send([$message], 'database'))
-                  ## Check for errors during the send
-                  #if ($services.mail.sender.lastError)
-                      #displayError($exceptiontool.getStackTrace($services.mail.sender.lastError))
-                  #else
-                      #set ($failedMailStatuses = $mailResult.statusResult.getAllErrors())
-                      #if ($failedMailStatuses.hasNext())
-                          #set ($mailStatus = $failedMailStatuses.next())
-                          #displayError($mailStatus.errorDescription)
-                      #end
-                  #end
-              #end
-          #end
+          #if ("$!exception" != '')
+            #forgotUsernameBoxStart("error")
+            <div class="xwikirenderingerror" title="Click to get more details about the error" style="cursor: pointer;">
+                $services.localization.render('xe.admin.forgotUsername.error.emailFailed')
+            </div>
+            <div class="xwikirenderingerrordescription hidden">
+              <pre>$escapetool.xml($exceptiontool.getStackTrace($exception))</pre>
+            </div>
+            #forgotUsernameBoxEnd()
+          #else
           ## We always display a success message even if there's no user found to avoid disclosing information
           ## about the users registered on the wiki.
-          #if (!$emailError)
             #forgotUsernameBoxStart("success")
             $services.localization.render('xe.admin.forgotUsername.emailSent', ["$escapetool.xml($email)"])
             <div class="forgotusernamelinks">


### PR DESCRIPTION
Note this is the same PR as #1939 but for branch 14.4.x. 
Creating it since it could be merged before #1939 as we're about to release 14.9RC1 and we shouldn't commit unstable things on master. 