### PR TITLE
[misc] Simplify token generation in DefaultCSRFToken

### DIFF
--- a/xwiki-platform-core/xwiki-platform-csrf/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-csrf/pom.xml
@@ -32,7 +32,7 @@
   <packaging>jar</packaging>
   <description>XWiki CSRF Protection Module</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.79</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.78</xwiki.jacoco.instructionRatio>
     </properties>
   <dependencies>
     <dependency>

--- a/xwiki-platform-core/xwiki-platform-csrf/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-csrf/pom.xml
@@ -32,7 +32,7 @@
   <packaging>jar</packaging>
   <description>XWiki CSRF Protection Module</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.80</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.79</xwiki.jacoco.instructionRatio>
     </properties>
   <dependencies>
     <dependency>

--- a/xwiki-platform-core/xwiki-platform-csrf/src/main/java/org/xwiki/csrf/internal/DefaultCSRFToken.java
+++ b/xwiki-platform-core/xwiki-platform-csrf/src/main/java/org/xwiki/csrf/internal/DefaultCSRFToken.java
@@ -145,13 +145,8 @@ public class DefaultCSRFToken implements CSRFToken, Initializable
             return token;
         }
 
-        // create fresh token if needed
-        synchronized (this.tokens) {
-            if (!this.tokens.containsKey(key)) {
-                this.tokens.put(key, newToken());
-            }
-            return this.tokens.get(key);
-        }
+        // Return the current token if it exists, or generate a new one and return it.
+        return this.tokens.computeIfAbsent(key, documentReference -> newToken());
     }
 
     private String newToken()

--- a/xwiki-platform-core/xwiki-platform-csrf/src/main/java/org/xwiki/csrf/internal/DefaultCSRFToken.java
+++ b/xwiki-platform-core/xwiki-platform-csrf/src/main/java/org/xwiki/csrf/internal/DefaultCSRFToken.java
@@ -139,12 +139,6 @@ public class DefaultCSRFToken implements CSRFToken, Initializable
             return guestToken;
         }
 
-        // Get the token if it has already been created
-        String token = this.tokens.get(key);
-        if (token != null) {
-            return token;
-        }
-
         // Return the current token if it exists, or generate a new one and return it.
         return this.tokens.computeIfAbsent(key, documentReference -> newToken());
     }


### PR DESCRIPTION
- Replace several lines of synchronized code by a call to computeIfAbsent on a ConcurrentHashMap
- Code coverage ratio lowered because we do as much with less code

Note: applicable on master/14.4.x/13.10.x