### PR TITLE
XWIKI-13399 delete UI does not have breadcrumbs, so going back to top level is not intuitive

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/copy.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/copy.vm
@@ -310,6 +310,7 @@
   #template('refactoring_macros.vm')
   <div class="main layoutsubsection">
   <div id="mainContentArea">
+    #template("hierarchy.vm")
     #if ("$!request.copyId" != '')
       ## Display the copy status
       #handleCopyStatusRequest

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/delete.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/delete.vm
@@ -42,6 +42,7 @@
 #template("startpage.vm")
 <div class="main">
   <div id="mainContentArea">
+    #template("hierarchy.vm")
     #define($title)<a href="$doc.getURL('view')">$!escapetool.xml($doc.plainTitle)</a>#end
     #set($titleToDisplay = $services.localization.render('core.delete.title', [$title]))
     <div class="xcontent">

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/rename.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/rename.vm
@@ -35,6 +35,7 @@
   #end
   <div class="main layoutsubsection">
   <div id="mainContentArea">
+    #template("hierarchy.vm")
     #if ("$!request.renameId" != '')
       ## Display the rename status
       #template("renameStatus.vm")


### PR DESCRIPTION
Added breadcrumbs to `copy.vm`, `delete.vm` and `rename.vm` templates.

For now, the page location displayed in the breadcrumbs is always the original page. This makes sense, because the url always stays to the original page too, as the action is bound to this page.
However, this can be a bit misleading in some situations, like after a rename / move operation, where the breadcrumb is now associated with the old path of the page. Maybe in that case it would be better to modify the breadcrumbs path to the renamed / moved page (even if the template is still bound to the original page location). wdyt?
