### PR TITLE
XWIKI-20282: Provide an API allowing to attach an XWikiAttachment as temporary attachment

### DIFF
--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -125,8 +125,18 @@
 
                  Single justification example:
             -->
-
-            
+            <revapi.differences>
+              <justification>Unstable API</justification>
+              <criticality>documented</criticality>
+              <differences>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.addedToInterface</code>
+                  <new>method void org.xwiki.store.TemporaryAttachmentSessionsManager::temporarilyAttach(com.xpn.xwiki.doc.XWikiAttachment, org.xwiki.model.reference.DocumentReference) throws org.xwiki.store.TemporaryAttachmentException</new>
+                  <justification>New method needed in the unstable interface for temporary attachments.</justification>
+                </item>
+              </differences>
+            </revapi.differences>
           </analysisConfiguration>
         </configuration>
       </plugin>

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/TemporaryAttachmentSessionsManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/TemporaryAttachmentSessionsManager.java
@@ -75,6 +75,22 @@ public interface TemporaryAttachmentSessionsManager
         throws TemporaryAttachmentException;
 
     /**
+     * Allow to temporarily attach the given instance of {@link XWikiAttachment} to the given document reference.
+     * This can be useful if an API manipulates an {@link XWikiAttachment} without saving it, and want it to be
+     * discoverable when parsing a document through the download action for example.
+     * Note that consumer of this API needs to be aware that the file attached to the {@link XWikiAttachment} might be
+     * deleted at the end of the session, as any temporary attachment.
+     *
+     * @param attachment the attachment to be temporarily attached to the document
+     * @param documentReference the reference of the document to link this attachment to
+     * @throws TemporaryAttachmentException in case of problem when performing the link
+     * @since 14.10RC1
+     */
+    @Unstable
+    void temporarilyAttach(XWikiAttachment attachment, DocumentReference documentReference)
+        throws TemporaryAttachmentException;
+
+    /**
      * Retrieve all temporary attachments related to the given document reference in the current user session.
      *
      * @param documentReference the reference for which to retrieve temporary attachments.

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/DefaultTemporaryAttachmentSessionsManager.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/DefaultTemporaryAttachmentSessionsManager.java
@@ -126,6 +126,14 @@ public class DefaultTemporaryAttachmentSessionsManager implements TemporaryAttac
     }
 
     @Override
+    public void temporarilyAttach(XWikiAttachment attachment, DocumentReference documentReference)
+        throws TemporaryAttachmentException
+    {
+        TemporaryAttachmentSession temporaryAttachmentSession = getOrCreateSession();
+        temporaryAttachmentSession.addAttachment(documentReference, attachment);
+    }
+
+    @Override
     public Collection<XWikiAttachment> getUploadedAttachments(DocumentReference documentReference)
     {
         TemporaryAttachmentSession temporaryAttachmentSession = getOrCreateSession();

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/test/java/org/xwiki/store/filesystem/internal/DefaultTemporaryAttachmentSessionsManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/test/java/org/xwiki/store/filesystem/internal/DefaultTemporaryAttachmentSessionsManagerTest.java
@@ -39,6 +39,7 @@ import org.mockito.Mock;
 import org.xwiki.environment.Environment;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.SpaceReference;
+import org.xwiki.store.TemporaryAttachmentException;
 import org.xwiki.test.junit5.XWikiTempDir;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
@@ -62,6 +63,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 /**
@@ -253,5 +255,21 @@ class DefaultTemporaryAttachmentSessionsManagerTest
         DocumentReference documentReference = mock(DocumentReference.class);
         when(temporaryAttachmentSession.removeAttachments(documentReference)).thenReturn(true);
         assertTrue(this.attachmentManager.removeUploadedAttachments(documentReference));
+    }
+
+    @Test
+    void temporarilyAttach() throws TemporaryAttachmentException
+    {
+        DocumentReference documentReference = mock(DocumentReference.class);
+        XWikiAttachment attachment = mock(XWikiAttachment.class);
+        String sessionId = "removeUploadedAttachmentsPlural";
+        when(httpSession.getId()).thenReturn(sessionId);
+        TemporaryAttachmentSession temporaryAttachmentSession = mock(TemporaryAttachmentSession.class);
+        when(httpSession.getAttribute(ATTRIBUTE_KEY)).thenReturn(temporaryAttachmentSession);
+
+        this.attachmentManager.temporarilyAttach(attachment, documentReference);
+        verify(temporaryAttachmentSession).addAttachment(documentReference, attachment);
+
+        verifyNoInteractions(attachment);
     }
 }


### PR DESCRIPTION
Example usage of this new API: https://github.com/xwiki-contrib/application-changerequest/pull/74/commits/0a116bc826dd61649d0a429a0816672466b0f15f