### PR TITLE
XWIKI-20302: No error message in case of file uploads in comment without proper rights

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/resources/xwiki-upload/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/resources/xwiki-upload/plugin.js
@@ -153,6 +153,9 @@
         var xhr = event.data.fileLoader.xhr;
         xhr.setRequestHeader( 'X-XWiki-Temporary-Attachment-Support',
           editor.config['xwiki-upload'].isTemporaryAttachmentSupported);
+        console.log(editor);
+        // FIXME: Read this from an attribute.
+        xhr.setRequestHeader( 'X-XWiki-Temporary-Attachment-Skip-Right-Check', 'false');
       }
     });
     // Inject a new input field when an attachment is added so that the save request knows

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/FileUploader.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/FileUploader.xml
@@ -71,7 +71,7 @@
     #sendSuccess($document $fileName)
   #else
     ## Forbidden
-    #sendError(403 'You are not allowed to perform this action.')
+    #sendError(403 "$services.localization.render('ckeditor.upload.error.forbidden')")
   #end
 #end
 
@@ -103,12 +103,17 @@
       #set ($document = $xwiki.getDocument($request.document))
     #end
     #set ($reference = $document.documentReference)
-    #set ($attachment = $services.temporaryAttachments.uploadTemporaryAttachment($reference, 'upload', 
-        $request.filename))
-    #if ($attachment)
-      #sendSuccess($document, $attachment.filename)
+    #set ($skipRightCheck = ($request.getHeader('X-XWiki-Temporary-Attachment-Skip-Right-Check') == 'true'))
+    #if ($skipRightCheck || $document.hasAccessLevel('edit'))
+      #set ($attachment = $services.temporaryAttachments.uploadTemporaryAttachment($reference, 'upload',
+          $request.filename))
+      #if ($attachment)
+        #sendSuccess($document, $attachment.filename)
+      #else
+        #sendError(400 "$services.localization.render('ckeditor.upload.error.emptyreturn')")
+      #end
     #else
-      #sendError(400 "$services.localization.render('ckeditor.upload.error.emptyreturn')")
+    #sendError(403 "$services.localization.render('ckeditor.upload.error.forbidden')")
     #end
   #else
     #sendError(403 "$services.localization.render('ckeditor.upload.error.csrf')")

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/Translations.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/Translations.xml
@@ -153,7 +153,8 @@ ckeditor.plugin.image.imageSelector.urlTab.url.placeholder=https://...
 ckeditor.inline.failedToInit=Failed to initialize CKEditor.
 
 ckeditor.upload.error.csrf=The CSRF token is missing.
-ckeditor.upload.error.emptyReturn=Error when uploading the file: it might exceed the configured maximum upload size.
+ckeditor.upload.error.emptyReturn=Error when uploading the file: it might exceed the configured maximum upload size..
+ckeditor.upload.error.forbidden=You are not allowed to perform this action.
 
 modal.ok=OK
 modal.cancel=Cancel


### PR DESCRIPTION
  * Check rights when performing file upload unless a specific attribute asks to skip this check