### PR TITLE
XWIKI-18989: Cannot upload attachments in annotation

### DIFF
--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/main/java/org/xwiki/annotation/rights/AnnotationRightService.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/main/java/org/xwiki/annotation/rights/AnnotationRightService.java
@@ -20,6 +20,7 @@
 package org.xwiki.annotation.rights;
 
 import org.xwiki.component.annotation.Role;
+import org.xwiki.stability.Unstable;
 
 /**
  * Service to provide functions to check access rights to annotations actions (viewing, adding annotations, editing).
@@ -67,4 +68,17 @@ public interface AnnotationRightService
      * @return {@code true} if the user can edit the annotation, {@code false} otherwise
      */
     boolean canEditAnnotation(String annotationId, String target, String userName);
+
+    /**
+     * Checks if the user can upload attachment to the page as part of adding or editing an annotation.
+     * @param target the target of the page where to upload the attachment
+     * @param userName the name of the user performing the upload
+     * @return {@code true} if the user can upload the attachment, {@code false} otherwise
+     * @since 14.10RC1
+     */
+    @Unstable
+    default boolean canUploadAttachment(String target, String userName)
+    {
+        return false;
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-io/src/main/java/org/xwiki/annotation/rights/internal/XWikiAnnotationRightService.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-io/src/main/java/org/xwiki/annotation/rights/internal/XWikiAnnotationRightService.java
@@ -114,6 +114,12 @@ public class XWikiAnnotationRightService implements AnnotationRightService
         return this.authorization.hasAccess(Right.VIEW, getUserReference(userName), getDocumentReference(target));
     }
 
+    @Override
+    public boolean canUploadAttachment(String target, String userName)
+    {
+        return this.authorization.hasAccess(Right.EDIT, getUserReference(userName), getDocumentReference(target));
+    }
+
     /**
      * Helper method to parse the target as a reference and extract a serialized document reference from it: the
      * document reference serialized if the target can be parsed as a typed reference, or the initial string itself

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/AbstractAnnotationRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/AbstractAnnotationRESTResource.java
@@ -427,4 +427,9 @@ public abstract class AbstractAnnotationRESTResource extends XWikiResource
                 .attachTemporaryAttachmentsInDocument(document, Arrays.asList(uploadedFiles));
         }
     }
+
+    protected void cleanTemporaryUploadedFiles(DocumentReference documentReference)
+    {
+        this.temporaryAttachmentSessionsManager.removeUploadedAttachments(documentReference);
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/AbstractAnnotationRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/AbstractAnnotationRESTResource.java
@@ -23,6 +23,7 @@ package org.xwiki.annotation.rest.internal;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -32,6 +33,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.StringUtils;
 import org.xwiki.annotation.Annotation;
 import org.xwiki.annotation.AnnotationService;
 import org.xwiki.annotation.AnnotationServiceException;
@@ -47,6 +49,7 @@ import org.xwiki.context.Execution;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReferenceSerializer;
 import org.xwiki.rest.XWikiResource;
+import org.xwiki.store.TemporaryAttachmentSessionsManager;
 import org.xwiki.wysiwyg.converter.HTMLConverter;
 
 import com.xpn.xwiki.XWiki;
@@ -109,6 +112,9 @@ public abstract class AbstractAnnotationRESTResource extends XWikiResource
 
     @Inject
     private HTMLConverter htmlConverter;
+
+    @Inject
+    private TemporaryAttachmentSessionsManager temporaryAttachmentSessionsManager;
 
     /**
      * Builds an annotation response containing the annotated content along with the annotation stubs, according to the
@@ -406,5 +412,17 @@ public abstract class AbstractAnnotationRESTResource extends XWikiResource
             metadataMap.remove(REQUIRES_HTML_CONVERSION);
         }
         return metadataMap;
+    }
+
+    protected void handleTemporaryUploadedFiles(DocumentReference documentReference, Map<String, Object> metadataMap)
+        throws XWikiException
+    {
+        if (metadataMap.containsKey("uploadedFiles")) {
+            XWikiContext context = this.xcontextProvider.get();
+            XWikiDocument document = context.getWiki().getDocument(documentReference, context);
+            String[] uploadedFiles = StringUtils.split(String.valueOf(metadataMap.get("uploadedFiles")), ",");
+            this.temporaryAttachmentSessionsManager
+                .attachTemporaryAttachmentsInDocument(document, Arrays.asList(uploadedFiles));
+        }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/AbstractAnnotationRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/AbstractAnnotationRESTResource.java
@@ -417,7 +417,9 @@ public abstract class AbstractAnnotationRESTResource extends XWikiResource
     protected void handleTemporaryUploadedFiles(DocumentReference documentReference, Map<String, Object> metadataMap)
         throws XWikiException
     {
-        if (metadataMap.containsKey("uploadedFiles")) {
+        String documentName = this.referenceSerializer.serialize(documentReference);
+        boolean canUploadAttachment = this.annotationRightService.canUploadAttachment(documentName, getXWikiUser());
+        if (canUploadAttachment && metadataMap.containsKey("uploadedFiles")) {
             XWikiContext context = this.xcontextProvider.get();
             XWikiDocument document = context.getWiki().getDocument(documentReference, context);
             String[] uploadedFiles = StringUtils.split(String.valueOf(metadataMap.get("uploadedFiles")), ",");

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/AnnotationsRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/AnnotationsRESTResource.java
@@ -173,6 +173,7 @@ public class AnnotationsRESTResource extends AbstractAnnotationRESTResource
             this.handleTemporaryUploadedFiles(documentReference, annotationMetadata);
             this.annotationService.addAnnotation(documentName, request.getSelection(), request.getSelectionContext(),
                 request.getSelectionOffset(), getXWikiUser(), annotationMetadata);
+            this.cleanTemporaryUploadedFiles(documentReference);
 
             // and then return the annotated content, as specified by the annotation request
             return getSuccessResponseWithAnnotatedContent(documentName, request);

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/AnnotationsRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/AnnotationsRESTResource.java
@@ -169,6 +169,8 @@ public class AnnotationsRESTResource extends AbstractAnnotationRESTResource
 
             // add the annotation
             Map<String, Object> annotationMetadata = getMap(request.getAnnotation());
+
+            this.handleTemporaryUploadedFiles(documentReference, annotationMetadata);
             this.annotationService.addAnnotation(documentName, request.getSelection(), request.getSelectionContext(),
                 request.getSelectionOffset(), getXWikiUser(), annotationMetadata);
 

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/SingleAnnotationRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/SingleAnnotationRESTResource.java
@@ -137,6 +137,7 @@ public class SingleAnnotationRESTResource extends AbstractAnnotationRESTResource
             }
             Map<String, Object> annotationMetaData = getMap(updateRequest.getAnnotation());
 
+            this.handleTemporaryUploadedFiles(documentReference, annotationMetaData);
             // skip these fields as we don't want to overwrite them with whatever is in this map. Setters should be used
             // for these values or constructor
             Collection<String> skippedFields =

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/SingleAnnotationRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/SingleAnnotationRESTResource.java
@@ -155,6 +155,7 @@ public class SingleAnnotationRESTResource extends AbstractAnnotationRESTResource
             newAnnotation.setAuthor(getXWikiUser());
             // and update
             annotationService.updateAnnotation(documentName, newAnnotation);
+            this.cleanTemporaryUploadedFiles(documentReference);
             // and then return the annotated content, as specified by the annotation request
             AnnotationResponse response = getSuccessResponseWithAnnotatedContent(documentName, updateRequest);
             return response;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -45,7 +45,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -4332,20 +4331,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
     @Unstable
     public void readTemporaryUploadedFiles(EditForm editForm)
     {
-        List<String> temporaryUploadedFiles = editForm.getTemporaryUploadedFiles();
-        if (!temporaryUploadedFiles.isEmpty()) {
-            TemporaryAttachmentSessionsManager attachmentManager = getTemporaryAttachmentManager();
-            for (String temporaryUploadedFile : temporaryUploadedFiles) {
-                Optional<XWikiAttachment> uploadedAttachmentOpt =
-                    attachmentManager.getUploadedAttachment(getDocumentReference(), temporaryUploadedFile);
-                uploadedAttachmentOpt.ifPresent(uploadedAttachment -> {
-                    XWikiAttachment previousAttachment = this.setAttachment(uploadedAttachment);
-                    if (previousAttachment != null) {
-                        uploadedAttachment.setVersion(previousAttachment.getNextVersion());
-                    }
-                });
-            }
-        }
+        getTemporaryAttachmentManager().attachTemporaryAttachmentsInDocument(this, editForm.getTemporaryUploadedFiles());
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/TemporaryAttachmentSessionsManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/TemporaryAttachmentSessionsManager.java
@@ -20,6 +20,7 @@
 package org.xwiki.store;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 import javax.servlet.http.Part;
@@ -30,6 +31,7 @@ import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.stability.Unstable;
 
 import com.xpn.xwiki.doc.XWikiAttachment;
+import com.xpn.xwiki.doc.XWikiDocument;
 
 /**
  * Interface for operations related to temporary upload of attachments.
@@ -141,4 +143,18 @@ public interface TemporaryAttachmentSessionsManager
      *          current user session, {@code false} if there was no matching temporary attachment in cache.
      */
     boolean removeUploadedAttachments(DocumentReference documentReference);
+
+    /**
+     * This method aims at attaching the {@link XWikiAttachment} that might have been previously temporary upload to the
+     * {@link XWikiDocument} they are targeting.
+     * This method should only be called before performing a save of the document to actually persist them.
+     *
+     * @param document the actual document instance that should receive the attachments
+     * @param fileNames the names of the uploaded files to attach
+     * @since 14.10RC1
+     */
+    @Unstable
+    default void attachTemporaryAttachmentsInDocument(XWikiDocument document, List<String> fileNames)
+    {
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/TemporaryAttachmentSessionsManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/TemporaryAttachmentSessionsManager.java
@@ -147,7 +147,10 @@ public interface TemporaryAttachmentSessionsManager
     /**
      * This method aims at attaching the {@link XWikiAttachment} that might have been previously temporary upload to the
      * {@link XWikiDocument} they are targeting.
-     * This method should only be called before performing a save of the document to actually persist them.
+     * This method should only be called before performing a save of the document to actually persist them. Also note
+     * that this method cannot call {@link #removeUploadedAttachment(DocumentReference, String)} as removing the
+     * attachment would delete the data before they can be properly saved in the persistent storage. So the consumer of
+     * the API should take care of properly calling this API when needed.
      *
      * @param document the actual document instance that should receive the attachments
      * @param fileNames the names of the uploaded files to attach

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/DefaultTemporaryAttachmentSessionsManager.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/DefaultTemporaryAttachmentSessionsManager.java
@@ -21,6 +21,7 @@ package org.xwiki.store.filesystem.internal;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 import javax.inject.Inject;
@@ -159,5 +160,22 @@ public class DefaultTemporaryAttachmentSessionsManager implements TemporaryAttac
     {
         TemporaryAttachmentSession temporaryAttachmentSession = getOrCreateSession();
         return temporaryAttachmentSession.removeAttachments(documentReference);
+    }
+
+    @Override
+    public void attachTemporaryAttachmentsInDocument(XWikiDocument document, List<String> fileNames)
+    {
+        if (!fileNames.isEmpty()) {
+            for (String temporaryUploadedFile : fileNames) {
+                Optional<XWikiAttachment> uploadedAttachmentOpt =
+                    getUploadedAttachment(document.getDocumentReference(), temporaryUploadedFile);
+                uploadedAttachmentOpt.ifPresent(uploadedAttachment -> {
+                    XWikiAttachment previousAttachment = document.setAttachment(uploadedAttachment);
+                    if (previousAttachment != null) {
+                        uploadedAttachment.setVersion(previousAttachment.getNextVersion());
+                    }
+                });
+            }
+        }
     }
 }


### PR DESCRIPTION
  * Implement attaching the temporary attachments to document in TemporaryAttachmentSessionManager
  * Use the new method in AnnotationRestResource after parsing the parameter