### PR TITLE
XWIKI-20399: RequestParameterConverter should not always handle errors with ServletResponse

### DIFF
--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -152,6 +152,12 @@
                   <newValue>{org.xwiki.rest.model.jaxb.HistorySummary.class, org.xwiki.rest.model.jaxb.Attribute.class, org.xwiki.rest.model.jaxb.Translation.class, org.xwiki.rest.model.jaxb.Client.class, org.xwiki.rest.model.jaxb.JobLog.class, org.xwiki.rest.model.jaxb.JobStatus.class, org.xwiki.rest.model.jaxb.Syntaxes.class, org.xwiki.rest.model.jaxb.SearchResults.class, org.xwiki.rest.model.jaxb.SearchResult.class, org.xwiki.rest.model.jaxb.Tags.class, org.xwiki.rest.model.jaxb.Tag.class, org.xwiki.rest.model.jaxb.Properties.class, org.xwiki.rest.model.jaxb.Translations.class, org.xwiki.rest.model.jaxb.ObjectSummary.class, org.xwiki.rest.model.jaxb.Objects.class, org.xwiki.rest.model.jaxb.Classes.class, org.xwiki.rest.model.jaxb.Class.class, org.xwiki.rest.model.jaxb.PropertyValues.class, org.xwiki.rest.model.jaxb.Property.class, org.xwiki.rest.model.jaxb.Attachment.class, org.xwiki.rest.model.jaxb.Comment.class, org.xwiki.rest.model.jaxb.Comments.class, org.xwiki.rest.model.jaxb.Attachments.class, org.xwiki.rest.model.jaxb.History.class, org.xwiki.rest.model.jaxb.PageSummary.class, org.xwiki.rest.model.jaxb.Space.class, org.xwiki.rest.model.jaxb.Wiki.class, org.xwiki.rest.model.jaxb.Pages.class, org.xwiki.rest.model.jaxb.Spaces.class, org.xwiki.rest.model.jaxb.Wikis.class, org.xwiki.rest.model.jaxb.Xwiki.class}</newValue>
                   <justification>New REST resource added.</justification>
                 </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.addedToInterface</code>
+                  <new>method org.xwiki.wysiwyg.converter.RequestParameterConversionResult org.xwiki.wysiwyg.converter.RequestParameterConverter::convert(javax.servlet.ServletRequest)</new>
+                  <justification>New method needed for better error handling by consumers of the API.</justification>
+                </item>
               </differences>
             </revapi.differences>
             <revapi.differences>

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/converter/RequestParameterConversionResult.java
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/converter/RequestParameterConversionResult.java
@@ -1,0 +1,78 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.wysiwyg.converter;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.xwiki.stability.Unstable;
+import org.xwiki.wysiwyg.filter.MutableServletRequest;
+
+/**
+ * Simple POJO holding the result of a conversion performed with {@link RequestParameterConverter}.
+ * More specifically this class contains a mutable request, resulting of the conversion, a map of errors that might have
+ * occurred during the conversion for each parameter, and a map of the output of the conversion for each parameter.
+ *
+ * @version $Id$
+ * @since 14.10
+ */
+@Unstable
+public class RequestParameterConversionResult
+{
+    private MutableServletRequest request;
+    private Map<String, Throwable> errors;
+    private Map<String, String> output;
+
+    /**
+     * Default constructor.
+     *
+     * @param request a mutable copy of the original request used for the conversion
+     */
+    public RequestParameterConversionResult(MutableServletRequest request)
+    {
+        this.request = request;
+        this.errors = new LinkedHashMap<>();
+        this.output = new LinkedHashMap<>();
+    }
+
+    /**
+     * @return the mutable request
+     */
+    public MutableServletRequest getRequest()
+    {
+        return request;
+    }
+
+    /**
+     * @return the map of errors indexed by parameters
+     */
+    public Map<String, Throwable> getErrors()
+    {
+        return errors;
+    }
+
+    /**
+     * @return the map of conversion output indexed by parameters
+     */
+    public Map<String, String> getOutput()
+    {
+        return output;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/converter/RequestParameterConverter.java
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/converter/RequestParameterConverter.java
@@ -40,13 +40,34 @@ public interface RequestParameterConverter
 {
     /**
      * Check if the given request needs conversion and perform those conversions.
-     * This method is supposed to create a mutable request and to modify and returns that one. However in case of
-     * error it won't return the modified request, but it will handle directly the errors in the response.
+     * This method creates a mutable request, modifies and returns it. However in case of
+     * error it will return an empty optional, and it will handle directly the errors in the response.
+     * See {@link #convert(ServletRequest)} for using an exception for handling the errors.
      *
-     * @param request the request that might contain parameter needing conversion
+     * @param request the request that might contain parameter needing conversion or an {@link Optional#empty()} in case
+     *        of error
      * @param response the response used to redirect or do changes in case of conversion error
      * @return a mutable request with the converted parameters, or an empty optional in case of error
      * @throws IOException in case of problem to write an answer in the response
      */
     Optional<ServletRequest> convert(ServletRequest request, ServletResponse response) throws IOException;
+
+    /**
+     * Check if the given request needs conversion and perform those conversions.
+     * This method creates a mutable request, modifies it and returns it along with the errors and output that have
+     * occurred as part of the conversion, all that holds in the returned {@link RequestParameterConversionResult}.
+     * Consumer of this API should always check if the obtained result contains errors or not to know if the conversion
+     * properly succeeded.
+     *
+     * @param request the request that might contain parameter needing conversion
+     * @return an instance of {@link RequestParameterConversionResult} containing the modified request and the output
+     *         and errors that might have occurred
+     * @throws IOException in case of problem to write an answer in the response
+     * @since 14.10
+     */
+    @Unstable
+    default RequestParameterConversionResult convert(ServletRequest request) throws IOException
+    {
+        return null;
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/converter/RequestParameterConverter.java
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/converter/RequestParameterConverter.java
@@ -65,8 +65,5 @@ public interface RequestParameterConverter
      * @since 14.10
      */
     @Unstable
-    default RequestParameterConversionResult convert(ServletRequest request)
-    {
-        throw new RuntimeException("Not implemented.");
-    }
+    RequestParameterConversionResult convert(ServletRequest request);
 }

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/converter/RequestParameterConverter.java
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/converter/RequestParameterConverter.java
@@ -67,6 +67,6 @@ public interface RequestParameterConverter
     @Unstable
     default RequestParameterConversionResult convert(ServletRequest request)
     {
-        return null;
+        throw new RuntimeException("Not implemented.");
     }
 }

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/converter/RequestParameterConverter.java
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/converter/RequestParameterConverter.java
@@ -62,11 +62,10 @@ public interface RequestParameterConverter
      * @param request the request that might contain parameter needing conversion
      * @return an instance of {@link RequestParameterConversionResult} containing the modified request and the output
      *         and errors that might have occurred
-     * @throws IOException in case of problem to write an answer in the response
      * @since 14.10
      */
     @Unstable
-    default RequestParameterConversionResult convert(ServletRequest request) throws IOException
+    default RequestParameterConversionResult convert(ServletRequest request)
     {
         return null;
     }

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/internal/converter/DefaultRequestParameterConverter.java
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/main/java/org/xwiki/wysiwyg/internal/converter/DefaultRequestParameterConverter.java
@@ -36,6 +36,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.wysiwyg.converter.HTMLConverter;
+import org.xwiki.wysiwyg.converter.RequestParameterConversionResult;
 import org.xwiki.wysiwyg.converter.RequestParameterConverter;
 import org.xwiki.wysiwyg.filter.MutableServletRequest;
 import org.xwiki.wysiwyg.filter.MutableServletRequestFactory;
@@ -86,32 +87,36 @@ public class DefaultRequestParameterConverter implements RequestParameterConvert
     @Override
     public Optional<ServletRequest> convert(ServletRequest request, ServletResponse response) throws IOException
     {
-        Optional<ServletRequest> result = Optional.of(request);
-        // Take the list of request parameters that require HTML conversion.
-        String[] parametersRequiringHTMLConversion = request.getParameterValues(REQUIRES_HTML_CONVERSION);
-        if (parametersRequiringHTMLConversion != null) {
-            // Wrap the current request in order to be able to change request parameters.
-            MutableServletRequest mreq = this.mutableServletRequestFactory.newInstance(request);
-            // Remove the list of request parameters that require HTML conversion to avoid recurrency.
-            mreq.removeParameter(REQUIRES_HTML_CONVERSION);
-            // Try to convert each parameter from the list and save caught exceptions.
-            Map<String, Throwable> errors = new HashMap<>();
-            // Save also the output to prevent loosing data in case of conversion exceptions.
-            Map<String, String> output = new HashMap<>();
-            convertHTML(parametersRequiringHTMLConversion, mreq, output, errors);
-            if (!errors.isEmpty()) {
-                handleConversionErrors(errors, output, mreq, response);
-                result = Optional.empty();
-            } else {
-                result = Optional.of(mreq);
-            }
+        RequestParameterConversionResult conversionResult = this.convert(request);
+        Optional<ServletRequest> result;
+        if (conversionResult.getErrors().isEmpty()) {
+            result = Optional.of(conversionResult.getRequest());
+        } else {
+            result = Optional.empty();
+            this.handleConversionErrors(conversionResult, response);
         }
         return result;
     }
 
-    private void convertHTML(String[] parametersRequiringHTMLConversion, MutableServletRequest request,
-        Map<String, String> output, Map<String, Throwable> errors)
+    @Override
+    public RequestParameterConversionResult convert(ServletRequest request) throws IOException
     {
+        MutableServletRequest mutableServletRequest = this.mutableServletRequestFactory.newInstance(request);
+        RequestParameterConversionResult result = new RequestParameterConversionResult(mutableServletRequest);
+        // Take the list of request parameters that require HTML conversion.
+        String[] parametersRequiringHTMLConversion = request.getParameterValues(REQUIRES_HTML_CONVERSION);
+        if (parametersRequiringHTMLConversion != null) {
+            // Remove the list of request parameters that require HTML conversion to avoid recurrency.
+            result.getRequest().removeParameter(REQUIRES_HTML_CONVERSION);
+            convertHTML(parametersRequiringHTMLConversion, result);
+        }
+        return result;
+    }
+
+    private void convertHTML(String[] parametersRequiringHTMLConversion,
+        RequestParameterConversionResult conversionResult)
+    {
+        MutableServletRequest request = conversionResult.getRequest();
         for (String parameterName : parametersRequiringHTMLConversion) {
             String html = request.getParameter(parameterName);
             // Remove the syntax parameter from the request to avoid interference with further request processing.
@@ -123,23 +128,23 @@ public class DefaultRequestParameterConverter implements RequestParameterConvert
                 request.setParameter(parameterName, this.htmlConverter.fromHTML(html, syntax));
             } catch (Exception e) {
                 this.logger.error(e.getLocalizedMessage(), e);
-                errors.put(parameterName, e);
+                conversionResult.getErrors().put(parameterName, e);
             }
             // If the conversion fails the output contains the value before the conversion.
-            output.put(parameterName, request.getParameter(parameterName));
+            conversionResult.getOutput().put(parameterName, request.getParameter(parameterName));
         }
     }
 
-    private void handleConversionErrors(Map<String, Throwable> errors, Map<String, String> output,
-        MutableServletRequest mreq, ServletResponse res) throws IOException
+    private void handleConversionErrors(RequestParameterConversionResult conversionResult, ServletResponse res)
+        throws IOException
     {
-        ServletRequest req = mreq.getRequest();
+        ServletRequest req = conversionResult.getRequest().getRequest();
         if (req instanceof HttpServletRequest
             && "XMLHttpRequest".equals(((HttpServletRequest) req).getHeader("X-Requested-With"))) {
             // If this is an AJAX request then we should simply send back the error.
             StringBuilder errorMessage = new StringBuilder();
             // Aggregate all error messages (for all fields that have conversion errors).
-            for (Map.Entry<String, Throwable> entry : errors.entrySet()) {
+            for (Map.Entry<String, Throwable> entry : conversionResult.getErrors().entrySet()) {
                 errorMessage.append(entry.getKey()).append(": ");
                 errorMessage.append(entry.getValue().getLocalizedMessage()).append('\n');
             }
@@ -149,10 +154,10 @@ public class DefaultRequestParameterConverter implements RequestParameterConvert
         // Otherwise, if this is a normal request, we have to redirect the request back and provide a key to
         // access the exception and the value before the conversion from the session.
         // Redirect to the error page specified on the request.
-        String redirectURL = mreq.getParameter("xerror");
+        String redirectURL = conversionResult.getRequest().getParameter("xerror");
         if (redirectURL == null) {
             // Redirect to the referrer page.
-            redirectURL = mreq.getReferer();
+            redirectURL = conversionResult.getRequest().getReferer();
         }
         // Extract the query string.
         String queryString = StringUtils.substringAfterLast(redirectURL, String.valueOf('?'));
@@ -165,43 +170,42 @@ public class DefaultRequestParameterConverter implements RequestParameterConvert
             queryString += '&';
         }
         // Save the output and the caught exceptions on the session.
-        queryString += "key=" + save(mreq, output, errors);
-        mreq.sendRedirect(res, redirectURL + '?' + queryString);
+        queryString += "key=" + save(conversionResult);
+        conversionResult.getRequest().sendRedirect(res, redirectURL + '?' + queryString);
     }
 
     /**
      * Saves on the session the conversion output and the caught conversion exceptions, after a conversion failure.
      *
-     * @param mreq the request used to access the session
-     * @param output the conversion output for the given request
-     * @param errors the conversion exceptions for the given request
+     * @param conversionResult the result of the conversion
      * @return a key that can be used along with the name of the request parameters that required HTML conversion to
      *         extract the conversion output and the conversion exceptions from the {@link #CONVERSION_OUTPUT} and
      *         {@value #CONVERSION_ERRORS} session attributes
      */
     @SuppressWarnings("unchecked")
-    private String save(MutableServletRequest mreq, Map<String, String> output, Map<String, Throwable> errors)
+    private String save(RequestParameterConversionResult conversionResult)
     {
         // Generate a random key to identify the request.
         String key = RandomStringUtils.randomAlphanumeric(4);
+        MutableServletRequest request = conversionResult.getRequest();
 
         // Save the output on the session.
         Map<String, Map<String, String>> conversionOutput =
-            (Map<String, Map<String, String>>) mreq.getSessionAttribute(CONVERSION_OUTPUT);
+            (Map<String, Map<String, String>>) request.getSessionAttribute(CONVERSION_OUTPUT);
         if (conversionOutput == null) {
             conversionOutput = new HashMap<>();
-            mreq.setSessionAttribute(CONVERSION_OUTPUT, conversionOutput);
+            request.setSessionAttribute(CONVERSION_OUTPUT, conversionOutput);
         }
-        conversionOutput.put(key, output);
+        conversionOutput.put(key, conversionResult.getOutput());
 
         // Save the errors on the session.
         Map<String, Map<String, Throwable>> conversionErrors =
-            (Map<String, Map<String, Throwable>>) mreq.getSessionAttribute(CONVERSION_ERRORS);
+            (Map<String, Map<String, Throwable>>) request.getSessionAttribute(CONVERSION_ERRORS);
         if (conversionErrors == null) {
             conversionErrors = new HashMap<>();
-            mreq.setSessionAttribute(CONVERSION_ERRORS, conversionErrors);
+            request.setSessionAttribute(CONVERSION_ERRORS, conversionErrors);
         }
-        conversionErrors.put(key, errors);
+        conversionErrors.put(key, conversionResult.getErrors());
 
         return key;
     }


### PR DESCRIPTION

  * Provide an API to allow use RequestParameterConverter and let consumer of the API decides how to handle errors