### PR TITLE
XWIKI-20426: The backlinks section of the delete UI no longer displayed backlink documents

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/delete.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/delete.vm
@@ -229,15 +229,6 @@
      <strong>$services.localization.render('core.delete.backlinks')</strong> ($links.size())
     #end
     #define($body)
-      <p class="noitems">
-        #set ($backLinksURL = $escapetool.xml($doc.getURL('view', 'viewer=backlinks')))
-        #set ($backlinksMessage = $escapetool.xml($services.localization.render('core.delete.backlinksMessage', [
-          '__STARTLINK__',
-          $doc.backlinks.size(),
-          '__ENDLINK__'
-        ])).replace('__STARTLINK__', "<a href='$backLinksURL'>").replace('__ENDLINK__', '</a>'))
-        $backlinksMessage
-      </p>
       <dl>
         <dt>
           <label for="newBacklinkTarget">
@@ -258,17 +249,16 @@
         #displayLinksCheckbox({
           'label': 'core.delete.updateLinks.label',
           'hint': 'core.delete.updateLinks.hint',
-          'addBacklinksURL': false,
-          'hidden': true
+          'disabled': true
         })
         #displayAutoRedirectCheckbox({
           'label': 'core.delete.autoRedirect.label',
           'hint': 'core.delete.autoRedirect.hint',
-          'hidden': true
+          'disabled': true
         })
       </dl>
     #end
-    #displayPanel('panel-backlinks', 'panel-default', $heading, $body)
+    $body
     #set($hasInlinks = true)
   #end
 #end

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/delete.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/delete.vm
@@ -231,8 +231,12 @@
     #define($body)
       <p class="noitems">
         #set ($backLinksURL = $escapetool.xml($doc.getURL('view', 'viewer=backlinks')))
-        $services.localization.render('core.delete.backlinksMessage',
-          ["<a href='$backLinksURL'>", $doc.backlinks.size(), '</a>'])
+        #set ($backlinksMessage = $escapetool.xml($services.localization.render('core.delete.backlinksMessage', [
+          '__STARTLINK__',
+          $doc.backlinks.size(),
+          '__ENDLINK__'
+        ])).replace('__STARTLINK__', "<a href='$backLinksURL'>").replace('__ENDLINK__', '</a>'))
+        $backlinksMessage
       </p>
       <dl>
         <dt>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/delete.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/delete.vm
@@ -228,17 +228,11 @@
     #define($heading)
      <strong>$services.localization.render('core.delete.backlinks')</strong> ($links.size())
     #end
-    #define($message)
-      <ul>
-      #foreach($docname in $links)
-        #set($rdoc = $xwiki.getDocument($docname).getTranslatedDocument())
-        <li><a href="$rdoc.getURL('view')">$escapetool.xml($rdoc.getPlainTitle())</a></li>
-      #end
-      </ul>
-    #end
     #define($body)
       <p class="noitems">
-        $escapetool.xml($services.localization.render('core.delete.backlinksInfo', [$doc.backlinks.size()]))
+        #set ($backLinksURL = $escapetool.xml($doc.getURL('view', 'viewer=backlinks')))
+        $services.localization.render('core.delete.backlinksMessage',
+          ["<a href='$backLinksURL'>", $doc.backlinks.size(), '</a>'])
       </p>
       <dl>
         <dt>
@@ -260,6 +254,7 @@
         #displayLinksCheckbox({
           'label': 'core.delete.updateLinks.label',
           'hint': 'core.delete.updateLinks.hint',
+          'addBacklinksURL': false,
           'hidden': true
         })
         #displayAutoRedirectCheckbox({

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/delete.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/delete.vm
@@ -224,11 +224,9 @@
 #######################################################
 #macro(displayNewTargetOption)
   #set($links = $doc.getBacklinks())
-  #if($links && $links.size() > 0)
-    #set($hasInlinks = true)
-  #end
+  #set ($hasInlinks = $links && $links.size() > 0)
   #define($heading)
-    <strong>$services.localization.render('core.delete.backlinks')</strong> ($links.size())
+    <strong>$escapetool.xml($services.localization.render('core.delete.backlinks'))</strong> ($links.size())
   #end
   #define($body)
     <dl>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/delete.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/delete.vm
@@ -123,7 +123,7 @@
 #macro(displayConfirmationPage)
   <form id="delete" class="xform" action="$doc.getURL('delete', "$!{languageparams}")" method="post">
     #getChildren()
-    #getBacklinks()
+    #displayNewTargetOption()
     #getChildren_legacy()
     #displayConfirmMessage()
   </form>
@@ -217,50 +217,50 @@
   #end
 #end
 #######################################################
-##                 GET BACKLINKS
+##                 DISPLAY NEW TARGET OPTION
 ##
-## Get the documents having some links to the current 
-## one.
+## Display the possibility to select a new target for existing backlinks and / or to create an automatic redirect to a
+## different page.
 #######################################################
-#macro(getBacklinks)
+#macro(displayNewTargetOption)
   #set($links = $doc.getBacklinks())
   #if($links && $links.size() > 0)
-    #define($heading)
-     <strong>$services.localization.render('core.delete.backlinks')</strong> ($links.size())
-    #end
-    #define($body)
-      <dl>
-        <dt>
-          <label for="newBacklinkTarget">
-            $escapetool.xml($services.localization.render('core.delete.backlinkTarget.label'))
-          </label>
-          <span class="xHint">$escapetool.xml($services.localization.render('core.delete.backlinkTarget.hint'))</span>
-        </dt>
-        <dd>
-          #set ($pagePickerParams = {
-            'id': 'newBacklinkTarget',
-            'name': 'newBacklinkTarget'
-          })
-          #pagePicker($pagePickerParams)
-        </dd>
-        ##------------
-        ## Links field
-        ##------------
-        #displayLinksCheckbox({
-          'label': 'core.delete.updateLinks.label',
-          'hint': 'core.delete.updateLinks.hint',
-          'disabled': true
-        })
-        #displayAutoRedirectCheckbox({
-          'label': 'core.delete.autoRedirect.label',
-          'hint': 'core.delete.autoRedirect.hint',
-          'disabled': true
-        })
-      </dl>
-    #end
-    $body
     #set($hasInlinks = true)
   #end
+  #define($heading)
+    <strong>$services.localization.render('core.delete.backlinks')</strong> ($links.size())
+  #end
+  #define($body)
+    <dl>
+      <dt>
+        <label for="newBacklinkTarget">
+          $escapetool.xml($services.localization.render('core.delete.backlinkTarget.label'))
+        </label>
+        <span class="xHint">$escapetool.xml($services.localization.render('core.delete.backlinkTarget.hint'))</span>
+      </dt>
+      <dd>
+        #set ($pagePickerParams = {
+          'id': 'newBacklinkTarget',
+          'name': 'newBacklinkTarget'
+        })
+        #pagePicker($pagePickerParams)
+      </dd>
+      ##------------
+      ## Links field
+      ##------------
+      #displayLinksCheckbox({
+        'label': 'core.delete.updateLinks.label',
+        'hint': 'core.delete.updateLinks.hint',
+        'disabled': true
+      })
+      #displayAutoRedirectCheckbox({
+        'label': 'core.delete.autoRedirect.label',
+        'hint': 'core.delete.autoRedirect.hint',
+        'disabled': true
+      })
+    </dl>
+  #end
+  $body
 #end
 #######################################################
 ##              DISPLAY CONFIRM MESSAGE

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/refactoring_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/refactoring_macros.vm
@@ -85,7 +85,7 @@
 #end
 
 #macro (displayLinksCheckbox $options)
-  #set ($hidden = !$isAdvancedUser && !$isSuperAdmin)
+  #set ($hidden = (!$isAdvancedUser && !$isSuperAdmin) || $options.hidden)
   ## We hide this option for simple users (instead of simply removing it) because we want to submit the default value
   ## (i.e. we want to make sure the links are updated for simple users).
   <dt#if ($hidden) class="hidden"#end>
@@ -128,7 +128,8 @@
   ## In the future we'll offer a config option to define the default behavior, see
   ## http://jira.xwiki.org/browse/XWIKI-13384
   #set ($checked = $request.autoRedirect == 'true')
-  <dt>
+  #set ($hidden = $options.hidden)
+  <dt #if ($hidden) class="hidden"#end>
     <label>
       <input type="checkbox" name="autoRedirect" value="true" #if ($checked)checked="checked"#end
         #if ($options.disabled)disabled#end/>
@@ -137,7 +138,7 @@
     ## The value submitted when the checkbox is not checked, used to preserve the form state.
     <input type="hidden" name="autoRedirect" value="false" />
   </dt>
-  <dd>
+  <dd #if ($hidden) class="hidden"#end>
     <span class="xHint">$escapetool.xml($services.localization.render($options.hint))</span>
   </dd>
 #end

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/refactoring_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/refactoring_macros.vm
@@ -103,9 +103,14 @@
     <span class="xHint">
       ## The backlinks URL could already be displayed above in some cases, so the link should not be duplicated.
       #if ($options.addBacklinksURL)
-        $services.localization.render($options.hint, ["<a href='$backLinksURL'>", $backLinksCount, '</a>'])
+        #set ($backlinksMessage = $escapetool.xml($services.localization.render($options.hint, [
+          '__STARTLINK__',
+          $backLinksCount,
+          '__ENDLINK__'
+        ])).replace('__STARTLINK__', "<a href='$backLinksURL'>").replace('__ENDLINK__', '</a>'))
+        $backlinksMessage
       #else
-        $services.localization.render($options.hint, ['', $backLinksCount, ''])
+        $escapetool.xml($services.localization.render($options.hint, ['', $backLinksCount, '']))
       #end
     </span>
   </dd>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/refactoring_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/refactoring_macros.vm
@@ -101,7 +101,12 @@
     #set ($backLinksCount = $doc.backlinks.size())
     #set ($backLinksURL = $escapetool.xml($doc.getURL('view', 'viewer=backlinks')))
     <span class="xHint">
-      $services.localization.render($options.hint, ["<a href='$backLinksURL'>", $backLinksCount, '</a>'])
+      ## The backlinks URL could already be displayed above in some cases, so the link should not be duplicated.
+      #if ($options.addBacklinksURL)
+        $services.localization.render($options.hint, ["<a href='$backLinksURL'>", $backLinksCount, '</a>'])
+      #else
+        $services.localization.render($options.hint, ['', $backLinksCount, ''])
+      #end
     </span>
   </dd>
 #end

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/refactoring_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/refactoring_macros.vm
@@ -85,13 +85,14 @@
 #end
 
 #macro (displayLinksCheckbox $options)
-  #set ($hidden = (!$isAdvancedUser && !$isSuperAdmin) || $options.hidden)
+  #set ($hidden = !$isAdvancedUser && !$isSuperAdmin)
   ## We hide this option for simple users (instead of simply removing it) because we want to submit the default value
   ## (i.e. we want to make sure the links are updated for simple users).
   <dt#if ($hidden) class="hidden"#end>
     <label>
       #set ($checked = !$request.updateLinks || $request.updateLinks == 'true')
-      <input type="checkbox" name="updateLinks" value="true" #if ($checked)checked="checked"#end />
+      <input type="checkbox" name="updateLinks" value="true" #if ($checked)checked="checked"#end
+        #if ($options.disabled)disabled#end />
       $services.localization.render($options.label)
     </label>
     ## The value submitted when the checkbox is not checked, used to preserve the form state.
@@ -101,17 +102,12 @@
     #set ($backLinksCount = $doc.backlinks.size())
     #set ($backLinksURL = $escapetool.xml($doc.getURL('view', 'viewer=backlinks')))
     <span class="xHint">
-      ## The backlinks URL could already be displayed above in some cases, so the link should not be duplicated.
-      #if ($options.addBacklinksURL)
-        #set ($backlinksMessage = $escapetool.xml($services.localization.render($options.hint, [
-          '__STARTLINK__',
-          $backLinksCount,
-          '__ENDLINK__'
-        ])).replace('__STARTLINK__', "<a href='$backLinksURL'>").replace('__ENDLINK__', '</a>'))
-        $backlinksMessage
-      #else
-        $escapetool.xml($services.localization.render($options.hint, ['', $backLinksCount, '']))
-      #end
+      #set ($backlinksMessage = $escapetool.xml($services.localization.render($options.hint, [
+        '__STARTLINK__',
+        $backLinksCount,
+        '__ENDLINK__'
+      ])).replace('__STARTLINK__', "<a href='$backLinksURL'>").replace('__ENDLINK__', '</a>'))
+      $backlinksMessage
     </span>
   </dd>
 #end
@@ -132,16 +128,16 @@
   ## In the future we'll offer a config option to define the default behavior, see
   ## http://jira.xwiki.org/browse/XWIKI-13384
   #set ($checked = $request.autoRedirect == 'true')
-  #set ($hidden = $options.hidden)
-  <dt #if ($hidden) class="hidden"#end>
+  <dt>
     <label>
-      <input type="checkbox" name="autoRedirect" value="true" #if ($checked)checked="checked"#end />
+      <input type="checkbox" name="autoRedirect" value="true" #if ($checked)checked="checked"#end
+        #if ($options.disabled)disabled#end/>
       $escapetool.xml($services.localization.render($options.label))
     </label>
     ## The value submitted when the checkbox is not checked, used to preserve the form state.
     <input type="hidden" name="autoRedirect" value="false" />
   </dt>
-  <dd #if ($hidden) class="hidden"#end>
+  <dd>
     <span class="xHint">$escapetool.xml($services.localization.render($options.hint))</span>
   </dd>
 #end

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/renameStep1.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/renameStep1.vm
@@ -64,7 +64,8 @@
         ##------------
         #displayLinksCheckbox({
           'label': 'core.rename.links.label',
-          'hint': 'core.rename.links.hint'
+          'hint': 'core.rename.links.hint',
+          'addBacklinksURL': true
         })
         #displayAutoRedirectCheckbox({
           'label': 'core.rename.autoRedirect.label',

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/renameStep1.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/renameStep1.vm
@@ -64,8 +64,7 @@
         ##------------
         #displayLinksCheckbox({
           'label': 'core.rename.links.label',
-          'hint': 'core.rename.links.hint',
-          'addBacklinksURL': true
+          'hint': 'core.rename.links.hint'
         })
         #displayAutoRedirectCheckbox({
           'label': 'core.rename.autoRedirect.label',

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/DeletePageIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/DeletePageIT.java
@@ -686,7 +686,6 @@ class DeletePageIT
         // Delete page and provide a new target, with updateLinks and autoRedirect enabled.
         ViewPage viewPage = testUtils.gotoPage(reference);
         DeletePageConfirmationPage confirmationPage = viewPage.deletePage();
-        confirmationPage.toggleBacklinksPane();
         confirmationPage.setNewBacklinkTarget(testUtils.serializeReference(newTargetReference));
         confirmationPage.setUpdateLinks(true);
         confirmationPage.setAutoRedirect(true);
@@ -731,8 +730,7 @@ class DeletePageIT
         DeletePageOutcomePage deleteOutcome = deletingPage.getDeletePageOutcomePage();
         assertEquals(LOGGED_USERNAME, deleteOutcome.getPageDeleter());
         assertEquals(DOCUMENT_NOT_FOUND, deleteOutcome.getMessage());
-        assertEquals(String.format("[[Link>>doc:%s]]", testUtils.serializeReference(reference).split(":")[1]),
-            testUtils.rest().<Page>get(backlinkDocReference).getContent());
+        assertEquals(backlinkDocContent, testUtils.rest().<Page>get(backlinkDocReference).getContent());
     }
 
     /**
@@ -763,7 +761,6 @@ class DeletePageIT
         ViewPage parentPage = testUtils.gotoPage(parentReference);
         DeletePageConfirmationPage confirmationPage = parentPage.deletePage();
         confirmationPage.setAffectChildren(true);
-        confirmationPage.toggleBacklinksPane();
         confirmationPage.setNewBacklinkTarget(testUtils.serializeReference(newTargetReference));
         confirmationPage.setUpdateLinks(true);
         confirmationPage.setAutoRedirect(true);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -1483,7 +1483,7 @@ activitystream.event.deleteComment.rss.body=A comment has been deleted from the 
 ### Deleting a page
 core.delete=Delete
 core.delete.title=Delete {0}
-core.delete.backlinksMessage=After deleting this page, the {0} {1,choice,0#incoming links|1#incoming link|1<incoming links}{2} will point to an empty page. To avoid this, you can select a new target.
+core.delete.backlinksMessage=After deleting this page, the {0}{1,choice,0#incoming links|1#incoming link|1<incoming links}{2} will point to an empty page. To avoid this, you can select a new target.
 core.delete.orphansWarning=The following pages have this page specified as a parent:{0}After deleting this page, they will become orphaned.
 core.delete.confirm=The deletion of a page is not reversible. Are you sure you wish to continue?
 core.delete.confirmWithInlinks=In addition, the deletion of a page is not reversible. Are you sure you wish to continue?

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -1483,7 +1483,7 @@ activitystream.event.deleteComment.rss.body=A comment has been deleted from the 
 ### Deleting a page
 core.delete=Delete
 core.delete.title=Delete {0}
-core.delete.backlinksInfo=After deleting this page, the {0,choice,0#incoming links|1#incoming link|1<incoming links} will point to an empty page. To avoid this, you can select a new target.
+core.delete.backlinksMessage=After deleting this page, the {0} {1,choice,0#incoming links|1#incoming link|1<incoming links}{2} will point to an empty page. To avoid this, you can select a new target.
 core.delete.orphansWarning=The following pages have this page specified as a parent:{0}After deleting this page, they will become orphaned.
 core.delete.confirm=The deletion of a page is not reversible. Are you sure you wish to continue?
 core.delete.confirmWithInlinks=In addition, the deletion of a page is not reversible. Are you sure you wish to continue?
@@ -5562,6 +5562,11 @@ core.menu.export.odt=Export as ODT
 core.menu.export.rtf=Export as RTF
 core.menu.export.html=Export as HTML
 core.menu.export.xar=Export as XAR
+
+#######################################
+## until 14.4.8, 14.10.1, 15.0RC1
+#######################################
+core.delete.backlinksInfo=After deleting this page, the {0,choice,0#incoming links|1#incoming link|1<incoming links} will point to an empty page. To avoid this, you can select a new target.
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -1483,7 +1483,6 @@ activitystream.event.deleteComment.rss.body=A comment has been deleted from the 
 ### Deleting a page
 core.delete=Delete
 core.delete.title=Delete {0}
-core.delete.backlinksMessage=After deleting this page, the {0}{1,choice,0#incoming links|1#incoming link|1<incoming links}{2} will point to an empty page. To avoid this, you can select a new target.
 core.delete.orphansWarning=The following pages have this page specified as a parent:{0}After deleting this page, they will become orphaned.
 core.delete.confirm=The deletion of a page is not reversible. Are you sure you wish to continue?
 core.delete.confirmWithInlinks=In addition, the deletion of a page is not reversible. Are you sure you wish to continue?
@@ -1508,7 +1507,7 @@ core.delete.autoRedirect.label=Create an automatic redirect
 core.delete.backlinks=Backlinks
 core.delete.updateLinks.hint=Update the target of {0}{1} {1,choice,0#incoming links|1#incoming link|1<incoming links}{2} to this page.
 core.delete.updateLinks.label=Update links
-core.delete.backlinkTarget.hint=Select an existing page as the new target. Leave empty for no action.
+core.delete.backlinkTarget.hint=After deleting this page, the incoming links (internal and external) will point to an empty page. To avoid this, you can select an existing page as the new target. Leave empty for no action.
 core.delete.backlinkTarget.label=New target
 
 ### Restoring a page

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/DeletePageConfirmationPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/DeletePageConfirmationPage.java
@@ -69,17 +69,6 @@ public class DeletePageConfirmationPage extends ConfirmationPage
     }
 
     /**
-     * Toggle the backlinks panel
-     *
-     * @since 14.4.2
-     * @since 14.5
-     */
-    public void toggleBacklinksPane()
-    {
-        getDriver().findElement(By.cssSelector("#delete .pull-right a[href='#panel-backlinks']")).click();
-    }
-
-    /**
      * @return {@code true} if a new target document was selected, {@code false} if the field is empty
      * @since 14.4.2
      * @since 14.5

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/delete.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/delete.js
@@ -19,11 +19,8 @@
  */
 require(['jquery'], function($) {
   $(document).on('keyup change', '#delete #newBacklinkTarget', function() {
-    let updateLinksContainer = $("#delete input[name=updateLinks]").closest('dt');
-    let autoRedirectContainer = $("#delete input[name=autoRedirect]").closest('dt');
-    let elements = updateLinksContainer.add(updateLinksContainer.next('dd'))
-      .add(autoRedirectContainer).add(autoRedirectContainer.next('dd'));
-
-    elements.toggleClass('hidden', $(this).val() === '');
+    let updateLinksContainer = $("#delete input[name=updateLinks]");
+    let autoRedirectContainer = $("#delete input[name=autoRedirect]");
+    updateLinksContainer.add(autoRedirectContainer).prop('disabled', $(this).val() === '');
   });
 });

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/delete.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/delete.js
@@ -19,8 +19,6 @@
  */
 require(['jquery'], function($) {
   $(document).on('keyup change', '#delete #newBacklinkTarget', function() {
-    let updateLinksContainer = $("#delete input[name=updateLinks]");
-    let autoRedirectContainer = $("#delete input[name=autoRedirect]");
-    updateLinksContainer.add(autoRedirectContainer).prop('disabled', $(this).val() === '');
+    $("#delete input[name=updateLinks], #delete input[name=autoRedirect]").prop('disabled', $(this).val() === '');
   });
 });


### PR DESCRIPTION
* display the backlinks URL at the beginning of the panel, not after the new target is selected
* deprecate translation key
* delete declaration of $message since it wasn't used anymore

Note that I kept that idea of having a link that redirects the user to a backlinks page rather than displaying the full list on the current panel, which is also consistent with the rename operation https://www.xwiki.org/xwiki/bin/download/Documentation/UserGuide/Features/DocumentLifecycle/WebHome/RenameConfirmFlamingoAdvanced.png?rev=1.2

The backlinks panel when no target is selected:
![backlinksPanelWithoutTarget](https://user-images.githubusercontent.com/22794181/205940416-7b6b47da-0939-4b53-b676-23fe12399518.png)

The backlinks panel with a selected target:
![backlinksPanelWithTarget](https://user-images.githubusercontent.com/22794181/205940412-f12db5a7-acd9-4c17-9b48-0864e80e7dd4.png)

