### PR TITLE
XWIKI-20452: Silk icons shouldn't be displayed in lightbox

### DIFF
--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-ui/src/main/resources/IconThemes/Silk.xml
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-ui/src/main/resources/IconThemes/Silk.xml
@@ -39,7 +39,7 @@
   <content>## General settings
 xwiki.iconset.type = image
 xwiki.iconset.render.wiki = [[image:path:$xwiki.getSkinFile("icons/silk/${icon}.png")]]
-xwiki.iconset.render.html = &lt;img src="$xwiki.getSkinFile("icons/silk/${icon}.png")" alt="Icon" /&gt;
+xwiki.iconset.render.html = &lt;img src="$xwiki.getSkinFile("icons/silk/${icon}.png")" alt="Icon" data-xwiki-lightbox="false" /&gt;
 xwiki.iconset.icon.url = $xwiki.getSkinFile("icons/silk/${icon}.png")
 
 ## XWiki Icon Set (see: http://design.xwiki.org/xwiki/bin/view/Proposal/XWiki+Icon+Set).


### PR DESCRIPTION
  * Ensure to ignore the images created for silk icons in lightbox