### PR TITLE
XWIKI-20472: Results drop-down box is not properly displayed in document Delete view

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/misc.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/misc.less
@@ -125,6 +125,7 @@
 .xwiki-livetable {
   .pagesizeselect { // PROBLEM: General styling reset
     height: auto;
+    width: auto;
   }
 }
 


### PR DESCRIPTION
* make sure that livetable pagesize has the right width value, since in this case the xform class was altering the desired value