### PR TITLE
XWIKI-20426: The backlinks section of the delete UI no longer displayed backlink documents

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -5554,7 +5554,7 @@ core.menu.export.html=Export as HTML
 core.menu.export.xar=Export as XAR
 
 #######################################
-## until 14.4.8, 14.10.1, 15.0RC1
+## until 14.4.8, 14.10.2, 15.0RC1
 #######################################
 core.delete.backlinksInfo=After deleting this page, the {0,choice,0#incoming links|1#incoming link|1<incoming links} will point to an empty page. To avoid this, you can select a new target.
 


### PR DESCRIPTION
* cherry-pick from https://github.com/xwiki/xwiki-platform/pull/2023