### PR TITLE
XWIKI-20500: Whitespace to the right of a mention is not properly displayed when the mention is inside a text, in view mode: appears stuck to the text

### DIFF
--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-ui/src/main/resources/XWiki/Mentions/MentionsMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-ui/src/main/resources/XWiki/Mentions/MentionsMacro.xml
@@ -613,7 +613,7 @@ blockquote.mention-quote {
 #set ($link = $xwiki.getURL($reference.reference, 'view'))
 {{html}}
 &lt;a id="$escapetool.xml($anchor)" class="$stringtool.join($cssClasses, ' ')" data-reference="$escapetool.xml($services.model.serialize($reference.reference, 'default'))" href="$escapetool.xml($link)"&gt;
-  $escapetool.xml($content)
+  $escapetool.xml($content)## Do not remove this comment as it ensures that the spacing after mention is not broken.
 &lt;/a&gt;
 {{/html}}
 {{/velocity}}</code>


### PR DESCRIPTION
* using `##` is a common practice to handle possible spacing breakage in Velocity code