### PR TITLE
XWIKI-20137: Upgrade to jodconverter 4.4.5

### DIFF
--- a/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/pom.xml
@@ -34,7 +34,7 @@
     <!-- Skipping revapi since xwiki-platform-legacy-office-importer wraps this module and runs checks on it -->
     <xwiki.revapi.skip>true</xwiki.revapi.skip>
     <xwiki.jacoco.instructionRatio>0.67</xwiki.jacoco.instructionRatio>
-    <jodconverter.version>4.4.2</jodconverter.version>
+    <jodconverter.version>4.4.5</jodconverter.version>
   </properties>
   <dependencies>
     <dependency>

--- a/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/internal/converter/DefaultOfficeConverter.java
+++ b/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/internal/converter/DefaultOfficeConverter.java
@@ -25,9 +25,9 @@ import java.io.InputStream;
 import java.util.Map;
 
 import org.apache.commons.io.IOUtils;
+import org.jodconverter.core.DocumentConverter;
 import org.jodconverter.core.document.DocumentFamily;
 import org.jodconverter.core.document.DocumentFormat;
-import org.jodconverter.local.LocalConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xwiki.officeimporter.converter.OfficeConverter;
@@ -52,7 +52,7 @@ public class DefaultOfficeConverter implements OfficeConverter
     /**
      * Converter provided by JODConverter library.
      */
-    private LocalConverter converter;
+    private DocumentConverter converter;
 
     /**
      * Working directory to be used when working with files.
@@ -65,7 +65,7 @@ public class DefaultOfficeConverter implements OfficeConverter
      * @param converter provided by JODConverter library.
      * @param workDir space for holding temporary file.
      */
-    public DefaultOfficeConverter(LocalConverter converter, File workDir)
+    public DefaultOfficeConverter(DocumentConverter converter, File workDir)
     {
         this.converter = converter;
         this.workDir = workDir;

--- a/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/resources/document-formats.js
+++ b/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/resources/document-formats.js
@@ -19,196 +19,666 @@
  */
 [
   {
-    "name": "Portable Document Format",
-    "extensions": ["pdf"],
-    "mediaType": "application/pdf",
-    "inputFamily": "DRAWING",
+    "name": "OpenDocument Text",
+    "extensions": [
+      "odt"
+    ],
+    "mediaType": "application/vnd.oasis.opendocument.text",
+    "inputFamily": "TEXT",
     "storeProperties": {
-      "DRAWING": {"FilterName": "draw_pdf_Export"},
-      "SPREADSHEET": {"FilterName": "calc_pdf_Export"},
-      "PRESENTATION": {"FilterName": "impress_pdf_Export"},
-      "TEXT": {"FilterName": "writer_pdf_Export"}
+      "TEXT": {
+        "FilterName": "writer8"
+      },
+      "WEB": {
+        "FilterName": "writerweb8_writer"
+      }
+    }
+  },
+  // New one
+  {
+    "name": "OpenDocument Text Template",
+    "extensions": [
+      "ott"
+    ],
+    "mediaType": "application/vnd.oasis.opendocument.text-template",
+    "inputFamily": "TEXT",
+    "storeProperties": {
+      "TEXT": {
+        "FilterName": "writer8_template"
+      },
+      "WEB": {
+        "FilterName": "writerweb8_writer_template"
+      }
+    }
+  },
+  // New one
+  {
+    "name": "OpenDocument Text Flat XML",
+    "extensions": [
+      "fodt"
+    ],
+    "mediaType": "application/vnd.oasis.opendocument.text-flat-xml",
+    "inputFamily": "TEXT",
+    "storeProperties": {
+      "TEXT": {
+        "FilterName": "OpenDocument Text Flat XML"
+      }
     }
   },
   {
-    "name": "Macromedia Flash",
-    "extensions": ["swf"],
-    "mediaType": "application/x-shockwave-flash",
-    "inputFamily": "DRAWING",
+    "name": "Microsoft Word 2007-2013 XML",
+    "extensions": [
+      "docx"
+    ],
+    "mediaType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "inputFamily": "TEXT",
     "storeProperties": {
-      "DRAWING": {"FilterName": "draw_flash_Export"},
-      "PRESENTATION": {"FilterName": "impress_flash_Export"}
+      "TEXT": {
+        "FilterName": "MS Word 2007 XML"
+      }
+    }
+  },
+  // New one
+  {
+    "name": "Word Open XML Document Template",
+    "extensions": [
+      "dotx"
+    ],
+    "mediaType": "application/vnd.openxmlformats-officedocument.wordprocessingml.template",
+    "inputFamily": "TEXT",
+    "storeProperties": {
+      "TEXT": {
+        "FilterName": "MS Word 2007 XML"
+      }
+    }
+  },
+  {
+    "name": "Microsoft Word 97-2003",
+    "extensions": [
+      "doc"
+    ],
+    "mediaType": "application/msword",
+    "inputFamily": "TEXT",
+    "storeProperties": {
+      "TEXT": {
+        "FilterName": "MS Word 97"
+      }
     }
   },
   {
     "name": "HTML",
-    "extensions": ["html"],
+    "extensions": [
+      "html"
+    ],
     "mediaType": "text/html",
-    "inputFamily": "TEXT",
+    "inputFamily": "TEXT", // Standard file is using "WEB"
     "storeProperties": {
-      "SPREADSHEET": {"FilterName": "HTML (StarCalc)"},
+      "SPREADSHEET": {
+        "FilterName": "HTML (StarCalc)"
+      },
       "PRESENTATION": {
         "FilterName": "impress_html_Export",
-        "FilterData": {"PublishMode": 0}
+        // Not among standard file
+        "FilterData": {
+          "PublishMode": 0
+        }
       },
-      "TEXT": {"FilterName": "HTML (StarWriter)"}
+      "TEXT": {
+        "FilterName": "HTML (StarWriter)"
+      }
+    }
+  },
+  // New one
+  {
+    "name": "XHTML",
+    "extensions": [
+      "xhtml"
+    ],
+    "mediaType": "application/xhtml+xml",
+    "inputFamily": "TEXT",
+    "storeProperties": {
+      "SPREADSHEET": {
+        "FilterName": "XHTML Calc File"
+      },
+      "PRESENTATION": {
+        "FilterName": "XHTML Impress File"
+      },
+      "TEXT": {
+        "FilterName": "XHTML Writer File"
+      }
     }
   },
   {
-    "name": "OpenDocument Text",
-    "extensions": ["odt"],
-    "mediaType": "application/vnd.oasis.opendocument.text",
-    "inputFamily": "TEXT",
-    "storeProperties": {"TEXT": {"FilterName": "writerweb8_writer"}}
-  },
-  {
-    "name": "OpenOffice.org 1.0 Text Document",
-    "extensions": ["sxw"],
-    "mediaType": "application/vnd.sun.xml.writer",
-    "inputFamily": "TEXT",
-    "storeProperties": {"TEXT": {"FilterName": "StarOffice XML (Writer)"}}
-  },
-  {
-    "name": "Microsoft Word",
-    "extensions": ["doc"],
-    "mediaType": "application/msword",
-    "inputFamily": "TEXT",
-    "storeProperties": {"TEXT": {"FilterName": "MS Word 97"}}
-  },
-  {
-    "name": "Microsoft Word 2007 XML",
-    "extensions": ["docx"],
-    "mediaType": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-    "inputFamily": "TEXT"
-  },
-  {
     "name": "Rich Text Format",
-    "extensions": ["rtf"],
+    "extensions": [
+      "rtf"
+    ],
     "mediaType": "text/rtf",
     "inputFamily": "TEXT",
-    "storeProperties": {"TEXT": {"FilterName": "Rich Text Format"}}
-  },
-  {
-    "name": "WordPerfect",
-    "extensions": ["wpd"],
-    "mediaType": "application/wordperfect",
-    "inputFamily": "TEXT"
+    "storeProperties": {
+      "TEXT": {
+        "FilterName": "Rich Text Format"
+      }
+    }
   },
   {
     "name": "Plain Text",
-    "extensions": ["txt"],
+    "extensions": [
+      "txt"
+    ],
     "mediaType": "text/plain",
     "inputFamily": "TEXT",
     "loadProperties": {
       "FilterName": "Text (encoded)",
       "FilterOptions": "utf8"
     },
-    "storeProperties": {"TEXT": {
+    "storeProperties": {
+      "TEXT": {
         "FilterName": "Text (encoded)",
         "FilterOptions": "utf8"
-      }}
+      }
+    }
   },
   {
-    "name": "MediaWiki wikitext",
-    "extensions": ["wiki"],
-    "mediaType": "text/x-wiki",
+    "name": "OpenOffice.org 1.0 Text Document",
+    "extensions": [
+      "sxw"
+    ],
+    "mediaType": "application/vnd.sun.xml.writer",
     "inputFamily": "TEXT",
-    "storeProperties": {"TEXT": {"FilterName": "MediaWiki"}}
+    "storeProperties": {
+      "TEXT": {
+        "FilterName": "StarOffice XML (Writer)"
+      }
+    }
+  },
+  {
+    "name": "WordPerfect",
+    "extensions": [
+      "wpd"
+    ],
+    "mediaType": "application/wordperfect",
+    "inputFamily": "TEXT"
   },
   {
     "name": "OpenDocument Spreadsheet",
-    "extensions": ["ods"],
+    "extensions": [
+      "ods"
+    ],
     "mediaType": "application/vnd.oasis.opendocument.spreadsheet",
     "inputFamily": "SPREADSHEET",
-    "storeProperties": {"SPREADSHEET": {"FilterName": "calc8"}}
+    "storeProperties": {
+      "SPREADSHEET": {
+        "FilterName": "calc8"
+      }
+    }
   },
+  // New one
   {
-    "name": "OpenOffice.org 1.0 Spreadsheet",
-    "extensions": ["sxc"],
-    "mediaType": "application/vnd.sun.xml.calc",
+    "name": "OpenDocument Spreadsheet Template",
+    "extensions": [
+      "ots"
+    ],
+    "mediaType": "application/vnd.oasis.opendocument.spreadsheet-template",
     "inputFamily": "SPREADSHEET",
-    "storeProperties": {"SPREADSHEET": {"FilterName": "StarOffice XML (Calc)"}}
+    "storeProperties": {
+      "SPREADSHEET": {
+        "FilterName": "calc8_template"
+      }
+    }
+  },
+  // New one
+  {
+    "name": "OpenDocument Spreadsheet Flat XML",
+    "extensions": [
+      "fods"
+    ],
+    "mediaType": "application/vnd.oasis.opendocument.spreadsheet-flat-xml",
+    "inputFamily": "SPREADSHEET",
+    "storeProperties": {
+      "SPREADSHEET": {
+        "FilterName": "OpenDocument Spreadsheet Flat XML"
+      }
+    }
   },
   {
-    "name": "Microsoft Excel",
-    "extensions": ["xls"],
+    "name": "Microsoft Excel 2007-2013 XML",
+    "extensions": [
+      "xlsx"
+    ],
+    "mediaType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "inputFamily": "SPREADSHEET",
+    // Previously missing: keep it?
+    "storeProperties": {
+      "SPREADSHEET": {
+        "FilterName": "Calc MS Excel 2007 XML"
+      }
+    }
+  },
+  {
+    "name": "Microsoft Excel 2007-2013 XML Template",
+    "extensions": [
+      "xltx"
+    ],
+    "mediaType": "application/vnd.openxmlformats-officedocument.spreadsheetml.template",
+    "inputFamily": "SPREADSHEET",
+    "storeProperties": {
+      "SPREADSHEET": {
+        "FilterName": "Calc MS Excel 2007 XML"
+      }
+    }
+  },
+  {
+    "name": "Microsoft Excel 97-2003",
+    "extensions": [
+      "xls"
+    ],
     "mediaType": "application/vnd.ms-excel",
     "inputFamily": "SPREADSHEET",
-    "storeProperties": {"SPREADSHEET": {"FilterName": "MS Excel 97"}}
-  },
-  {
-    "name": "Microsoft Excel 2007 XML",
-    "extensions": ["xlsx"],
-    "mediaType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-    "inputFamily": "SPREADSHEET"
+    "storeProperties": {
+      "SPREADSHEET": {
+        "FilterName": "MS Excel 97"
+      }
+    }
   },
   {
     "name": "Comma Separated Values",
-    "extensions": ["csv"],
+    "extensions": [
+      "csv"
+    ],
     "mediaType": "text/csv",
     "inputFamily": "SPREADSHEET",
     "loadProperties": {
       "FilterName": "Text - txt - csv (StarCalc)",
       "FilterOptions": "44,34,0"
     },
-    "storeProperties": {"SPREADSHEET": {
+    "storeProperties": {
+      "SPREADSHEET": {
         "FilterName": "Text - txt - csv (StarCalc)",
         "FilterOptions": "44,34,0"
-      }}
+      }
+    }
   },
   {
     "name": "Tab Separated Values",
-    "extensions": ["tsv"],
+    "extensions": [
+      "tsv"
+    ],
     "mediaType": "text/tab-separated-values",
     "inputFamily": "SPREADSHEET",
     "loadProperties": {
       "FilterName": "Text - txt - csv (StarCalc)",
       "FilterOptions": "9,34,0"
     },
-    "storeProperties": {"SPREADSHEET": {
+    "storeProperties": {
+      "SPREADSHEET": {
         "FilterName": "Text - txt - csv (StarCalc)",
         "FilterOptions": "9,34,0"
-      }}
+      }
+    }
+  },
+  {
+    "name": "OpenOffice.org 1.0 Spreadsheet",
+    "extensions": [
+      "sxc"
+    ],
+    "mediaType": "application/vnd.sun.xml.calc",
+    "inputFamily": "SPREADSHEET",
+    "storeProperties": {
+      "SPREADSHEET": {
+        "FilterName": "StarOffice XML (Calc)"
+      }
+    }
   },
   {
     "name": "OpenDocument Presentation",
-    "extensions": ["odp"],
+    "extensions": [
+      "odp"
+    ],
     "mediaType": "application/vnd.oasis.opendocument.presentation",
     "inputFamily": "PRESENTATION",
-    "storeProperties": {"PRESENTATION": {"FilterName": "impress8"}}
+    "storeProperties": {
+      "PRESENTATION": {
+        "FilterName": "impress8"
+      }
+    }
+  },
+  // New one
+  {
+    "name": "OpenDocument Presentation Template",
+    "extensions": [
+      "otp"
+    ],
+    "mediaType": "application/vnd.oasis.opendocument.presentation-template",
+    "inputFamily": "PRESENTATION",
+    "storeProperties": {
+      "PRESENTATION": {
+        "FilterName": "impress8_template"
+      }
+    }
+  },
+  // New one
+  {
+    "name": "OpenDocument Presentation Flat XML",
+    "extensions": [
+      "fodp"
+    ],
+    "mediaType": "application/vnd.oasis.opendocument.presentation-flat-xml",
+    "inputFamily": "PRESENTATION",
+    "storeProperties": {
+      "PRESENTATION": {
+        "FilterName": "OpenDocument Presentation Flat XML"
+      }
+    }
+  },
+  {
+    "name": "Microsoft PowerPoint 2007-2013 XML",
+    "extensions": [
+      "pptx"
+    ],
+    "mediaType": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "inputFamily": "PRESENTATION",
+    // Filter previously missing: keep it?
+    "storeProperties": {
+      "PRESENTATION": {
+        "FilterName": "Impress MS PowerPoint 2007 XML"
+      }
+    }
+  },
+  // New one
+  {
+    "name": "Microsoft PowerPoint 2007-2013 XML Template",
+    "extensions": [
+      "potx"
+    ],
+    "mediaType": "application/vnd.openxmlformats-officedocument.presentationml.template",
+    "inputFamily": "PRESENTATION",
+    "storeProperties": {
+      "PRESENTATION": {
+        "FilterName": "Impress MS PowerPoint 2007 XML"
+      }
+    }
+  },
+  {
+    "name": "Microsoft PowerPoint 97-2003",
+    "extensions": [
+      "ppt"
+    ],
+    "mediaType": "application/vnd.ms-powerpoint",
+    "inputFamily": "PRESENTATION",
+    "storeProperties": {
+      "PRESENTATION": {
+        "FilterName": "MS PowerPoint 97"
+      }
+    }
   },
   {
     "name": "OpenOffice.org 1.0 Presentation",
-    "extensions": ["sxi"],
+    "extensions": [
+      "sxi"
+    ],
     "mediaType": "application/vnd.sun.xml.impress",
     "inputFamily": "PRESENTATION",
-    "storeProperties": {"PRESENTATION": {"FilterName": "StarOffice XML (Impress)"}}
-  },
-  {
-    "name": "Microsoft PowerPoint",
-    "extensions": ["ppt"],
-    "mediaType": "application/vnd.ms-powerpoint",
-    "inputFamily": "PRESENTATION",
-    "storeProperties": {"PRESENTATION": {"FilterName": "MS PowerPoint 97"}}
-  },
-  {
-    "name": "Microsoft PowerPoint 2007 XML",
-    "extensions": ["pptx"],
-    "mediaType": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-    "inputFamily": "PRESENTATION"
+    "storeProperties": {
+      "PRESENTATION": {
+        "FilterName": "StarOffice XML (Impress)"
+      }
+    }
   },
   {
     "name": "OpenDocument Drawing",
-    "extensions": ["odg"],
+    "extensions": [
+      "odg"
+    ],
     "mediaType": "application/vnd.oasis.opendocument.graphics",
     "inputFamily": "DRAWING",
-    "storeProperties": {"DRAWING": {"FilterName": "draw8"}}
+    "storeProperties": {
+      "DRAWING": {
+        "FilterName": "draw8"
+      }
+    }
+  },
+  // New one
+  {
+    "name": "OpenDocument Drawing Template",
+    "extensions": [
+      "otg"
+    ],
+    "mediaType": "application/vnd.oasis.opendocument.graphics-template",
+    "inputFamily": "DRAWING",
+    "storeProperties": {
+      "DRAWING": {
+        "FilterName": "draw8_template"
+      }
+    }
+  },
+  // New one
+  {
+    "name": "OpenDocument Drawing Flat XML",
+    "extensions": [
+      "fodg"
+    ],
+    "mediaType": "application/vnd.oasis.opendocument.graphics-flat-xml",
+    "inputFamily": "DRAWING",
+    "storeProperties": {
+      "DRAWING": {
+        "FilterName": "OpenDocument Drawing Flat XML"
+      }
+    }
+  },
+  {
+    "name": "Portable Document Format",
+    "extensions": [
+      "pdf"
+    ],
+    "mediaType": "application/pdf",
+    "inputFamily": "DRAWING",
+    "storeProperties": {
+      "DRAWING": {
+        "FilterName": "draw_pdf_Export"
+      },
+      "SPREADSHEET": {
+        "FilterName": "calc_pdf_Export"
+      },
+      "PRESENTATION": {
+        "FilterName": "impress_pdf_Export"
+      },
+      "TEXT": {
+        "FilterName": "writer_pdf_Export"
+      },
+      // New property
+      "WEB": {
+        "FilterName": "writer_web_pdf_Export"
+      }
+    }
+  },
+  {
+    "name": "Macromedia Flash",
+    "extensions": [
+      "swf"
+    ],
+    "mediaType": "application/x-shockwave-flash",
+    "inputFamily": "DRAWING",
+    "storeProperties": {
+      "DRAWING": {
+        "FilterName": "draw_flash_Export"
+      },
+      "PRESENTATION": {
+        "FilterName": "impress_flash_Export"
+      }
+    }
+  },
+  // New one
+  {
+    "name": "Visio XML",
+    "extensions": [
+      "vsdx"
+    ],
+    "mediaType": "application/vnd-ms-visio.drawing",
+    "inputFamily": "DRAWING",
+    "storeProperties": {
+      "DRAWING": {
+        "FilterName": "draw_pdf_Export"
+      }
+    }
+  },
+  // New one
+  {
+    "name": "Visio",
+    "extensions": [
+      "vsd"
+    ],
+    "mediaType": "application/vnd-visio",
+    "inputFamily": "DRAWING",
+    "storeProperties": {
+      "DRAWING": {
+        "FilterName": "draw_pdf_Export"
+      }
+    }
+  },
+  // New one
+  {
+    "name": "Windows Bitmap",
+    "extensions": [
+      "bmp"
+    ],
+    "mediaType": "image/bmp",
+    "inputFamily": "DRAWING",
+    "storeProperties": {
+      "DRAWING": {
+        "FilterName": "draw_bmp_Export"
+      },
+      "PRESENTATION": {
+        "FilterName": "impress_bmp_Export"
+      }
+    }
+  },
+  // New one
+  {
+    "name": "Graphics Interchange Format",
+    "extensions": [
+      "gif"
+    ],
+    "mediaType": "image/gif",
+    "inputFamily": "DRAWING",
+    "storeProperties": {
+      "DRAWING": {
+        "FilterName": "draw_gif_Export"
+      },
+      "PRESENTATION": {
+        "FilterName": "impress_gif_Export"
+      }
+    }
+  },
+  // New one
+  {
+    "name": "Joint Photographic Experts Group",
+    "extensions": [
+      "jpg",
+      "jpeg"
+    ],
+    "mediaType": "image/jpeg",
+    "inputFamily": "DRAWING",
+    "storeProperties": {
+      "DRAWING": {
+        "FilterName": "draw_jpg_Export"
+      },
+      "SPREADSHEET": {
+        "FilterName": "calc_jpg_Export"
+      },
+      "PRESENTATION": {
+        "FilterName": "impress_jpg_Export"
+      },
+      "TEXT": {
+        "FilterName": "writer_jpg_Export"
+      },
+      "WEB": {
+        "FilterName": "writer_web_jpg_Export"
+      }
+    }
+  },
+  // New one
+  {
+    "name": "Portable Network Graphics",
+    "extensions": [
+      "png"
+    ],
+    "mediaType": "image/png",
+    "inputFamily": "DRAWING",
+    "storeProperties": {
+      "DRAWING": {
+        "FilterName": "draw_png_Export"
+      },
+      "SPREADSHEET": {
+        "FilterName": "calc_png_Export"
+      },
+      "PRESENTATION": {
+        "FilterName": "impress_png_Export"
+      },
+      "TEXT": {
+        "FilterName": "writer_png_Export"
+      },
+      "WEB": {
+        "FilterName": "writer_web_png_Export"
+      }
+    }
   },
   {
     "name": "Scalable Vector Graphics",
-    "extensions": ["svg"],
+    "extensions": [
+      "svg"
+    ],
     "mediaType": "image/svg+xml",
     "inputFamily": "DRAWING",
-    "storeProperties": {"DRAWING": {"FilterName": "draw_svg_Export"}}
+    "storeProperties": {
+      "DRAWING": {
+        "FilterName": "draw_svg_Export"
+      },
+      // New properties
+      "SPREADSHEET": {
+        "FilterName": "calc_svg_Export"
+      },
+      "PRESENTATION": {
+        "FilterName": "impress_svg_Export"
+      },
+      "TEXT": {
+        "FilterName": "writer_svg_Export"
+      },
+      "WEB": {
+        "FilterName": "writer_svg_Export"
+      }
+    }
+  },
+  // New one
+  {
+    "name": "Tagged Image File Format",
+    "extensions": [
+      "tif",
+      "tiff"
+    ],
+    "mediaType": "image/tiff",
+    "inputFamily": "DRAWING",
+    "storeProperties": {
+      "DRAWING": {
+        "FilterName": "draw_tif_Export"
+      },
+      "PRESENTATION": {
+        "FilterName": "impress_tif_Export"
+      }
+    }
+  },
+  // Missing from the default file
+  {
+    "name": "MediaWiki wikitext",
+    "extensions": [
+      "wiki"
+    ],
+    "mediaType": "text/x-wiki",
+    "inputFamily": "TEXT",
+    "storeProperties": {
+      "TEXT": {
+        "FilterName": "MediaWiki"
+      }
+    }
   }
 ]

--- a/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/resources/document-formats.js
+++ b/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/resources/document-formats.js
@@ -348,7 +348,6 @@
       }
     }
   },
-  // New one
   {
     "name": "OpenDocument Presentation Flat XML",
     "extensions": [
@@ -369,7 +368,6 @@
     ],
     "mediaType": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
     "inputFamily": "PRESENTATION",
-    // Filter previously missing: keep it?
     "storeProperties": {
       "PRESENTATION": {
         "FilterName": "Impress MS PowerPoint 2007 XML"

--- a/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/resources/document-formats.js
+++ b/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/resources/document-formats.js
@@ -34,7 +34,6 @@
       }
     }
   },
-  // New one
   {
     "name": "OpenDocument Text Template",
     "extensions": [
@@ -51,7 +50,6 @@
       }
     }
   },
-  // New one
   {
     "name": "OpenDocument Text Flat XML",
     "extensions": [
@@ -78,7 +76,6 @@
       }
     }
   },
-  // New one
   {
     "name": "Word Open XML Document Template",
     "extensions": [
@@ -111,14 +108,13 @@
       "html"
     ],
     "mediaType": "text/html",
-    "inputFamily": "TEXT", // Standard file is using "WEB"
+    "inputFamily": "WEB",
     "storeProperties": {
       "SPREADSHEET": {
         "FilterName": "HTML (StarCalc)"
       },
       "PRESENTATION": {
         "FilterName": "impress_html_Export",
-        // Not among standard file
         "FilterData": {
           "PublishMode": 0
         }
@@ -128,7 +124,6 @@
       }
     }
   },
-  // New one
   {
     "name": "XHTML",
     "extensions": [
@@ -213,7 +208,6 @@
       }
     }
   },
-  // New one
   {
     "name": "OpenDocument Spreadsheet Template",
     "extensions": [
@@ -227,7 +221,6 @@
       }
     }
   },
-  // New one
   {
     "name": "OpenDocument Spreadsheet Flat XML",
     "extensions": [
@@ -248,7 +241,6 @@
     ],
     "mediaType": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     "inputFamily": "SPREADSHEET",
-    // Previously missing: keep it?
     "storeProperties": {
       "SPREADSHEET": {
         "FilterName": "Calc MS Excel 2007 XML"
@@ -343,7 +335,6 @@
       }
     }
   },
-  // New one
   {
     "name": "OpenDocument Presentation Template",
     "extensions": [
@@ -385,7 +376,6 @@
       }
     }
   },
-  // New one
   {
     "name": "Microsoft PowerPoint 2007-2013 XML Template",
     "extensions": [
@@ -438,7 +428,6 @@
       }
     }
   },
-  // New one
   {
     "name": "OpenDocument Drawing Template",
     "extensions": [
@@ -452,7 +441,6 @@
       }
     }
   },
-  // New one
   {
     "name": "OpenDocument Drawing Flat XML",
     "extensions": [
@@ -486,7 +474,6 @@
       "TEXT": {
         "FilterName": "writer_pdf_Export"
       },
-      // New property
       "WEB": {
         "FilterName": "writer_web_pdf_Export"
       }
@@ -508,7 +495,6 @@
       }
     }
   },
-  // New one
   {
     "name": "Visio XML",
     "extensions": [
@@ -522,7 +508,6 @@
       }
     }
   },
-  // New one
   {
     "name": "Visio",
     "extensions": [
@@ -536,7 +521,6 @@
       }
     }
   },
-  // New one
   {
     "name": "Windows Bitmap",
     "extensions": [
@@ -553,7 +537,6 @@
       }
     }
   },
-  // New one
   {
     "name": "Graphics Interchange Format",
     "extensions": [
@@ -570,7 +553,6 @@
       }
     }
   },
-  // New one
   {
     "name": "Joint Photographic Experts Group",
     "extensions": [
@@ -597,7 +579,6 @@
       }
     }
   },
-  // New one
   {
     "name": "Portable Network Graphics",
     "extensions": [
@@ -634,7 +615,6 @@
       "DRAWING": {
         "FilterName": "draw_svg_Export"
       },
-      // New properties
       "SPREADSHEET": {
         "FilterName": "calc_svg_Export"
       },
@@ -649,7 +629,6 @@
       }
     }
   },
-  // New one
   {
     "name": "Tagged Image File Format",
     "extensions": [
@@ -664,20 +643,6 @@
       },
       "PRESENTATION": {
         "FilterName": "impress_tif_Export"
-      }
-    }
-  },
-  // Missing from the default file
-  {
-    "name": "MediaWiki wikitext",
-    "extensions": [
-      "wiki"
-    ],
-    "mediaType": "text/x-wiki",
-    "inputFamily": "TEXT",
-    "storeProperties": {
-      "TEXT": {
-        "FilterName": "MediaWiki"
       }
     }
   }

--- a/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/test/java/org/xwiki/officeimporter/internal/converter/DefaultOfficeConverterTest.java
+++ b/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/test/java/org/xwiki/officeimporter/internal/converter/DefaultOfficeConverterTest.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
+import org.jodconverter.core.DocumentConverter;
 import org.jodconverter.core.document.DefaultDocumentFormatRegistry;
 import org.jodconverter.core.job.ConversionJobWithOptionalSourceFormatUnspecified;
 import org.jodconverter.core.job.ConversionJobWithOptionalTargetFormatUnspecified;
@@ -61,7 +62,7 @@ import static org.mockito.Mockito.when;
 @ExtendWith(XWikiTempDirExtension.class)
 class DefaultOfficeConverterTest
 {
-    private LocalConverter localConverter;
+    private DocumentConverter localConverter;
 
     @XWikiTempDir
     private File tmpDir;
@@ -71,7 +72,7 @@ class DefaultOfficeConverterTest
     @BeforeEach
     void setup()
     {
-        this.localConverter = mock(LocalConverter.class);
+        this.localConverter = mock(DocumentConverter.class);
         this.defaultOfficeConverter = new DefaultOfficeConverter(localConverter, tmpDir);
     }
 


### PR DESCRIPTION
  * Upgrade dependency
  * Use interface DocumentConverter instead of now final class LocalConverter in DefaultOfficeConverter to allow mocking
  * Refactoring of document-formats.js based on official file to ease future upgrades and integrate changes