### PR TITLE
XWIKI-20532: Server-side image resizing always preserves the aspect ratio

### DIFF
--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-api/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-api/pom.xml
@@ -31,7 +31,7 @@
   <name>XWiki Platform - Image - Processing - API</name>
   <properties>
     <thumbnailator.version>0.4.8</thumbnailator.version>
-    <xwiki.jacoco.instructionRatio>0.00</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.22</xwiki.jacoco.instructionRatio>
     <!-- Old names of this module used for retro compatibility when resolving dependencies of old extensions -->
     <xwiki.extension.features>org.xwiki.platform:xwiki-platform-image-api</xwiki.extension.features>
   </properties>
@@ -47,6 +47,13 @@
       <groupId>net.coobird</groupId>
       <artifactId>thumbnailator</artifactId>
       <version>${thumbnailator.version}</version>
+    </dependency>
+    <!-- Test Dependencies -->
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-tool-test-component</artifactId>
+      <version>${commons.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-api/src/main/java/com/xpn/xwiki/internal/plugin/image/ThumbnailatorImageProcessor.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-api/src/main/java/com/xpn/xwiki/internal/plugin/image/ThumbnailatorImageProcessor.java
@@ -63,8 +63,8 @@ public class ThumbnailatorImageProcessor extends DefaultImageProcessor
     {
         if (image instanceof BufferedImage) {
             try {
-                return Thumbnails.of((BufferedImage) image).size(width, height).imageType(getBestImageTypeFor(image))
-                    .asBufferedImage();
+                return Thumbnails.of((BufferedImage) image).forceSize(width, height)
+                    .imageType(getBestImageTypeFor(image)).asBufferedImage();
             } catch (IOException e) {
             }
         }

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-api/src/test/java/com/xpn/xwiki/internal/plugin/image/ThumbnailatorImageProcessorTest.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-api/src/test/java/com/xpn/xwiki/internal/plugin/image/ThumbnailatorImageProcessorTest.java
@@ -1,0 +1,63 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xpn.xwiki.internal.plugin.image;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.image.BufferedImage;
+import java.awt.image.RenderedImage;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Unit test for {@link ThumbnailatorImageProcessor}.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+class ThumbnailatorImageProcessorTest
+{
+    @InjectMockComponents
+    private ThumbnailatorImageProcessor imageProcessor;
+
+    @Test
+    void changeAspectRatio()
+    {
+        Image image = createImage(20, 20, new Color(37, 220, 182));
+        RenderedImage scaledImage = this.imageProcessor.scaleImage(image, 2, 10);
+        assertEquals(2, scaledImage.getWidth());
+        assertEquals(10, scaledImage.getHeight());
+    }
+
+    private static BufferedImage createImage(int width, int height, Color color)
+    {
+        BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_4BYTE_ABGR);
+        Graphics2D g = image.createGraphics();
+        g.setColor(color);
+        g.fillRect(0, 0, width, height);
+        g.dispose();
+        return image;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-plugin/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-plugin/pom.xml
@@ -32,7 +32,7 @@
   <description>Deprecated Image plugin</description>
   <properties>
     <checkstyle.suppressions.location>${basedir}/src/main/checkstyle/checkstyle-suppressions.xml</checkstyle.suppressions.location>
-    <xwiki.jacoco.instructionRatio>0.54</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.64</xwiki.jacoco.instructionRatio>
     <!-- Old names of this module used for retro compatibility when resolving dependencies of old extensions -->
     <xwiki.extension.features>org.xwiki.platform:xwiki-platform-image-plugin</xwiki.extension.features>
   </properties>

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-plugin/src/main/java/com/xpn/xwiki/plugin/image/ImagePlugin.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-plugin/src/main/java/com/xpn/xwiki/plugin/image/ImagePlugin.java
@@ -372,30 +372,28 @@ public class ImagePlugin extends XWikiDefaultPlugin
         int width = currentWidth;
         int height = currentHeight;
 
-        if (requestedWidth <= 0 || requestedWidth >= currentWidth) {
-            // Ignore the requested width. Check the requested height.
-            if (requestedHeight > 0 && requestedHeight < currentHeight) {
-                // Reduce the height, keeping aspect ratio.
-                width = (int) (requestedHeight * aspectRatio);
-                height = requestedHeight;
-            }
-        } else if (requestedHeight <= 0 || requestedHeight >= currentHeight) {
-            // Ignore the requested height. Reduce the width, keeping aspect ratio.
-            width = requestedWidth;
-            height = (int) (requestedWidth / aspectRatio);
-        } else if (keepAspectRatio) {
-            // Reduce the width and check if the corresponding height is less than the requested height.
-            width = requestedWidth;
-            height = (int) (requestedWidth / aspectRatio);
-            if (height > requestedHeight) {
-                // We have to reduce the height instead and compute the width based on it.
-                width = (int) (requestedHeight * aspectRatio);
-                height = requestedHeight;
+        // Keep the aspect ratio when requested or width or height are missing.
+        if (keepAspectRatio || requestedWidth <= 0 || requestedHeight <= 0) {
+            // Ignore the width if it is not given or too large, i.e., larger than the current width or larger than the
+            // width derived from the requested height.
+            if (requestedWidth <= 0 || requestedWidth >= currentWidth
+                || (requestedHeight > 0 && requestedWidth > (int) (requestedHeight * aspectRatio)))
+            {
+                // Ignore the requested width. Check the requested height.
+                if (requestedHeight > 0 && requestedHeight < currentHeight) {
+                    // Reduce the height, keeping aspect ratio.
+                    width = (int) (requestedHeight * aspectRatio);
+                    height = requestedHeight;
+                }
+            } else {
+                // Ignore the requested height. Reduce the width, keeping aspect ratio.
+                width = requestedWidth;
+                height = (int) (requestedWidth / aspectRatio);
             }
         } else {
             // Reduce both width and height, possibly loosing aspect ratio.
-            width = requestedWidth;
-            height = requestedHeight;
+            width = Math.min(requestedWidth, currentWidth);
+            height = Math.min(requestedHeight, currentHeight);
         }
 
         return new int[] { width, height };


### PR DESCRIPTION
* Force the image size in ThumbnailatorImageProcessor
* Only preserve the aspect ratio when one of the sizes is missing, or it is requested, not also when one of the sizes is larger than the original.
* Add tests.

Jira issue: https://jira.xwiki.org/browse/XWIKI-20532