### PR TITLE
XWIKI-19140: Fix order location actions and breadcrumbs while creating new page

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/breadcrumbs.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/breadcrumbs.less
@@ -53,7 +53,9 @@
   }
 }
 
-dd .location-actions {
+/* TODO: Update the JS code to use a more specific CSS selector when updating the content of the actual breadcrumb,
+  in order to eventually remove this rule and add the 'breadcrumb' class to the 'location-actions' node. */
+dd > .location-actions {
   /* Retrieve style from the breadcrumb block. Needed for keyboard accessibility reorganization of the
   location-picker component. */
   .breadcrumb;

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/breadcrumbs.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/breadcrumbs.less
@@ -53,8 +53,8 @@
   }
 }
 
-dd.location-picker-preview{
-  /*Make the location picker display the breadcrumb "block".
-  Useful to separate behaviour from presentation for the breadcrumb class.*/
+dd .location-actions {
+  /* Retrieve style from the breadcrumb block. Needed for keyboard accessibility reorganization of the
+  location-picker component. */
   .breadcrumb;
 }

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/breadcrumbs.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/breadcrumbs.less
@@ -52,3 +52,9 @@
     }
   }
 }
+
+dd.location-picker-preview{
+  /*Make the location picker display the breadcrumb bg color.
+  Useful to separate behaviour from presentation of the breadcrumb class.*/
+  background-color: @breadcrumb-bg;
+}

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/breadcrumbs.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/breadcrumbs.less
@@ -54,7 +54,7 @@
 }
 
 dd.location-picker-preview{
-  /*Make the location picker display the breadcrumb bg color.
-  Useful to separate behaviour from presentation of the breadcrumb class.*/
-  background-color: @breadcrumb-bg;
+  /*Make the location picker display the breadcrumb "block".
+  Useful to separate behaviour from presentation for the breadcrumb class.*/
+  .breadcrumb;
 }

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/locationPicker_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/locationPicker_macros.vm
@@ -65,20 +65,18 @@
       <label>$escapetool.xml($services.localization.render($options.preview.label))</label>
       <span class="xHint">$escapetool.xml($services.localization.render($options.preview.hint))</span>
     </dt>
-    <dd class="location-picker-preview">
+    <dd>
       ## The breadcrumb is updated whenever the user changes the parent page. This causes the breadcrumb element to be
       ## constantly replaced, preventing us from displaying the live validation message after it. In order to overcome
       ## this, we wrap the breadcrumb element in a DIV that remains the same.
       <div class="breadcrumb-container">
         ## Note: We display only the parent reference here. The new document part will be added from JavaScript.
         #hierarchy($options.parent.reference $options)
+        #if ($isDocumentTreeAvailable)
+          #documentPickerModal($options)
+          #locationPickerActions()
+        #end
       </div>
-      #if ($isDocumentTreeAvailable)
-        #documentPickerModal($options)
-        #locationPickerActions()
-      #end
-    </dd>
-    <dd>
       ##
       ## ---------------------------------------------------------------------------------------------------------
       ## Location advanced edit

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/locationPicker_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/locationPicker_macros.vm
@@ -66,10 +66,6 @@
       <span class="xHint">$escapetool.xml($services.localization.render($options.preview.hint))</span>
     </dt>
     <dd>
-      #if ($isDocumentTreeAvailable)
-        #documentPickerModal($options)
-        #locationPickerActions()
-      #end
       ## The breadcrumb is updated whenever the user changes the parent page. This causes the breadcrumb element to be
       ## constantly replaced, preventing us from displaying the live validation message after it. In order to overcome
       ## this, we wrap the breadcrumb element in a DIV that remains the same.
@@ -77,6 +73,10 @@
         ## Note: We display only the parent reference here. The new document part will be added from JavaScript.
         #hierarchy($options.parent.reference $options)
       </div>
+      #if ($isDocumentTreeAvailable)
+        #documentPickerModal($options)
+        #locationPickerActions()
+      #end
       ##
       ## ---------------------------------------------------------------------------------------------------------
       ## Location advanced edit

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/locationPicker_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/locationPicker_macros.vm
@@ -65,7 +65,7 @@
       <label>$escapetool.xml($services.localization.render($options.preview.label))</label>
       <span class="xHint">$escapetool.xml($services.localization.render($options.preview.hint))</span>
     </dt>
-    <dd>
+    <dd class="location-picker-preview">
       ## The breadcrumb is updated whenever the user changes the parent page. This causes the breadcrumb element to be
       ## constantly replaced, preventing us from displaying the live validation message after it. In order to overcome
       ## this, we wrap the breadcrumb element in a DIV that remains the same.

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/locationPicker_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/locationPicker_macros.vm
@@ -77,6 +77,8 @@
         #documentPickerModal($options)
         #locationPickerActions()
       #end
+    </dd>
+    <dd>
       ##
       ## ---------------------------------------------------------------------------------------------------------
       ## Location advanced edit

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/locationPicker.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/locationPicker.css
@@ -7,20 +7,31 @@
   /* Remove the margin so that the validation message is displayed right below the breadcrumb, for simple users.
      For advanced users the .location-edit element that follows the breadcrumb has a top margin. */
   margin-bottom: 0;
+  /*Overwrite style properties*/
+  background-color: transparent;
+  border-radius: 0px;
+  padding: 0;
+  /*Remove the ol left padding*/
+  padding-left: 0;
 }
 
 dd.location-picker-preview{
-  position: relative;
+  /*Make the location picker display the bg color*/
+  background-color: #f8f8f8;
+  border-radius: 4px;
+  /*Moved padding from both of the visible elements to the location picker*/
+  padding: 8px 15px 8px 15px;
+  /*Set up a flex display for breadcrumbs and location actions*/
+  display: flex;
+  
 }
-
+.breadcrumb-container{
+  /*Keep the same size whatever the content.*/
+  flex-grow: 1;
+}
 .location-actions {
-  /* Use the same padding as the breadcrumb. */
-  padding: 8px 15px 0 15px;
-  /*Allows overlapping with the breadcrumb-container.*/
-  position:absolute;
-  right:0;
-  top:0;
-}
+  /*Keeps all actions on one line.*/
+  white-space:nowrap;
 
 .location-action {
   /* Leave some space between the actions. */
@@ -33,6 +44,3 @@ dd.location-picker-preview{
 .location-edit {
   /* Indent the advanced location edit fields under the breadcrumb. */
   padding: 0 2em;
-  /* Leave some space after the breadcrumb and before the submit button. */
-  margin: 20px 0 2.5em 0;
-}

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/locationPicker.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/locationPicker.css
@@ -17,13 +17,12 @@
 
 dd.location-picker-preview{
   /*Make the location picker display the bg color*/
-  background-color: #f8f8f8;
   border-radius: 4px;
   /*Moved padding from both of the visible elements to the location picker*/
   padding: 8px 15px 8px 15px;
   /*Set up a flex display for breadcrumbs, location actions and edit location.*/
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   
 }
 .breadcrumb-container{

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/locationPicker.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/locationPicker.css
@@ -9,18 +9,17 @@
   margin-bottom: 0;
 }
 
-.location-picker .breadcrumb-container {
-  /*Allows overlapping with the location-action element with visual ordering in HTML.*/
-  float: left;
-  width: 100%;
+dd.location-picker-preview{
+  position: relative;
 }
 
 .location-actions {
-  float: right;
   /* Use the same padding as the breadcrumb. */
   padding: 8px 15px 0 15px;
   /*Allows overlapping with the breadcrumb-container.*/
-  margin-left:-70px;
+  position:absolute;
+  right:0;
+  top:0;
 }
 
 .location-action {

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/locationPicker.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/locationPicker.css
@@ -21,17 +21,20 @@ dd.location-picker-preview{
   border-radius: 4px;
   /*Moved padding from both of the visible elements to the location picker*/
   padding: 8px 15px 8px 15px;
-  /*Set up a flex display for breadcrumbs and location actions*/
+  /*Set up a flex display for breadcrumbs, location actions and edit location.*/
   display: flex;
+  flex-wrap: wrap;
   
 }
 .breadcrumb-container{
   /*Keep the same size whatever the content.*/
   flex-grow: 1;
 }
+
 .location-actions {
   /*Keeps all actions on one line.*/
   white-space:nowrap;
+}
 
 .location-action {
   /* Leave some space between the actions. */
@@ -43,6 +46,10 @@ dd.location-picker-preview{
 }
 
 .location-edit {
+  /*Start on a new line of the flexbox*/
+  flex-basis: 100%;
   /* Indent the advanced location edit fields under the breadcrumb. */
   padding: 0 2em;
+  /* Leave some space after the breadcrumb and before the submit button. */
+  margin: 20px 0 2.5em 0;
 }

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/locationPicker.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/locationPicker.css
@@ -37,6 +37,7 @@ dd.location-picker-preview{
   /* Leave some space between the actions. */
   margin-left: 3px;
 }
+
 .location-action:first-of-type {
   margin-left: 0;
 }
@@ -44,3 +45,4 @@ dd.location-picker-preview{
 .location-edit {
   /* Indent the advanced location edit fields under the breadcrumb. */
   padding: 0 2em;
+}

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/locationPicker.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/locationPicker.css
@@ -9,10 +9,18 @@
   margin-bottom: 0;
 }
 
+.location-picker .breadcrumb-container {
+  /*Allows overlapping with the location-action element with visual ordering in HTML.*/
+  float: left;
+  width: 100%;
+}
+
 .location-actions {
   float: right;
   /* Use the same padding as the breadcrumb. */
   padding: 8px 15px 0 15px;
+  /*Allows overlapping with the breadcrumb-container.*/
+  margin-left:-70px;
 }
 
 .location-action {

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/locationPicker.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/locationPicker.css
@@ -25,6 +25,7 @@ dd.location-picker-preview{
   flex-wrap: nowrap;
   
 }
+
 .breadcrumb-container{
   /*Keep the same size whatever the content.*/
   flex-grow: 1;
@@ -45,8 +46,6 @@ dd.location-picker-preview{
 }
 
 .location-edit {
-  /*Start on a new line of the flexbox*/
-  flex-basis: 100%;
   /* Indent the advanced location edit fields under the breadcrumb. */
   padding: 0 2em;
   /* Leave some space after the breadcrumb and before the submit button. */

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/locationPicker.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/locationPicker.css
@@ -10,27 +10,29 @@
   /* Keep the same size whatever the content. */
   flex-grow: 1;
   /* Remove rounded corners on the right so that the transition is seamless. */
-  border-radius: 4px 0px 0px 4px;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
   /* Combine with .location-actions. */
   border-right: none;
-  padding: 8px 0 8px 15px;
+  padding-right: 0;
 }
 
-.breadcrumb-container{
-  /* Set up a flex display for breadcrumbs and location actions. */
+.breadcrumb-container {
+  /* Sets up a flex display for breadcrumbs and location actions. */
   display: flex;
   flex-wrap: nowrap;
 }
 
-.location-actions {
+.location-picker > dd > .location-actions {
   margin-bottom: 0;
   /* Keeps all actions on one line. */
   white-space: nowrap;
   /* Remove rounded corners on the left so that the transition is seamless. */
-  border-radius: 0px 4px 4px 0px;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
   /* Combine with .breadcrumb. */
   border-left: none;
-  padding: 8px 15px 8px 3px;
+  padding-left: 3px;
 }
 
 .location-action {

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/locationPicker.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/locationPicker.css
@@ -11,8 +11,10 @@
   background-color: transparent;
   border-radius: 0px;
   padding: 0;
-  /*Remove the ol left padding*/
-  padding-left: 0;
+  /*Overwrite extra style properties (such as those changed in the Lumen color theme*/
+  border-color: transparent;
+  border-style: none;
+  border-width: 0;
 }
 
 dd.location-picker-preview{

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/locationPicker.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/locationPicker.css
@@ -7,35 +7,30 @@
   /* Remove the margin so that the validation message is displayed right below the breadcrumb, for simple users.
      For advanced users the .location-edit element that follows the breadcrumb has a top margin. */
   margin-bottom: 0;
-  /*Overwrite style properties*/
-  background-color: transparent;
-  border-radius: 0px;
-  padding: 0;
-  /*Overwrite extra style properties (such as those changed in the Lumen color theme*/
-  border-color: transparent;
-  border-style: none;
-  border-width: 0;
-}
-
-dd.location-picker-preview{
-  /*Make the location picker display the bg color*/
-  border-radius: 4px;
-  /*Moved padding from both of the visible elements to the location picker*/
-  padding: 8px 15px 8px 15px;
-  /*Set up a flex display for breadcrumbs, location actions and edit location.*/
-  display: flex;
-  flex-wrap: nowrap;
-  
+  /* Keep the same size whatever the content. */
+  flex-grow: 1;
+  /* Remove rounded corners on the right so that the transition is seamless. */
+  border-radius: 4px 0px 0px 4px;
+  /* Combine with .location-actions. */
+  border-right: none;
+  padding: 8px 0 8px 15px;
 }
 
 .breadcrumb-container{
-  /*Keep the same size whatever the content.*/
-  flex-grow: 1;
+  /* Set up a flex display for breadcrumbs and location actions. */
+  display: flex;
+  flex-wrap: nowrap;
 }
 
 .location-actions {
-  /*Keeps all actions on one line.*/
-  white-space:nowrap;
+  margin-bottom: 0;
+  /* Keeps all actions on one line. */
+  white-space: nowrap;
+  /* Remove rounded corners on the left so that the transition is seamless. */
+  border-radius: 0px 4px 4px 0px;
+  /* Combine with .breadcrumb. */
+  border-left: none;
+  padding: 8px 15px 8px 3px;
 }
 
 .location-action {


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-19140

- Changes to the locationpicker template: moving the block for the location actions after the breadcrumbs (same as visual) , which allows for the focus to go in the expected order when tabbing.
- The style changes in the .css are there to put the objects back at their original position. 


![Screenshot from 2023-01-17 15-38-47](https://user-images.githubusercontent.com/28761965/212927495-8c3e1105-7634-4f3c-998b-23b2d585ab2c.png)

