### PR TITLE
XCOMMONS-2610: Upgrade to Mockito 5

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-page/src/main/java/org/xwiki/test/page/LocalizationSetup.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-page/src/main/java/org/xwiki/test/page/LocalizationSetup.java
@@ -92,11 +92,11 @@ public final class LocalizationSetup
                 when(translation.getLocale()).thenReturn(Locale.ENGLISH);
                 String translationKey = invocationOnMockTranslation.getArgument(0);
                 when(translation.getKey()).thenReturn(translationKey);
-                when(translation.render(any())).thenAnswer(invocationOnMockRender -> {
+                when(translation.render(any(Object[].class))).thenAnswer(invocationOnMockRender -> {
                     Object[] parameters = getVarArgs(invocationOnMockRender, 0);
                     return renderBlock(translationKey, parameters);
                 });
-                when(translation.render(any(), any())).thenAnswer(invocationOnMockRender -> {
+                when(translation.render(any(), any(Object[].class))).thenAnswer(invocationOnMockRender -> {
                     Object[] parameters = getVarArgs(invocationOnMockRender, 1);
                     return renderBlock(translationKey, parameters);
                 });


### PR DESCRIPTION
  * Fix LocalizationSetup to properly match method with varargs following changes in Mockito 5

Note: to be merged once the upgrade of Mockito 5 is performed on xwiki-commons