### PR TITLE
[Misc] Add missing dependency in tool packager plugin

### DIFF
--- a/xwiki-platform-tools/xwiki-platform-tool-packager-plugin/pom.xml
+++ b/xwiki-platform-tools/xwiki-platform-tool-packager-plugin/pom.xml
@@ -142,6 +142,11 @@
     </dependency>
     <dependency>
       <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-url-default</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
       <artifactId>xwiki-platform-rendering-configuration-default</artifactId>
       <version>${project.version}</version>
     </dependency>


### PR DESCRIPTION
  * Tool packager plugin seemed to miss a dependency to xwiki-platform-url-default which is needed