### PR TITLE
XWIKI-20549: Provide a new script service API to check trustfulness of an URI

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiServletResponse.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiServletResponse.java
@@ -25,6 +25,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.Locale;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.servlet.ServletOutputStream;
@@ -40,7 +41,15 @@ import org.xwiki.url.URLSecurityManager;
 public class XWikiServletResponse implements XWikiResponse
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(XWikiServletResponse.class);
-    private static final Pattern ABSOLUTE_URL_PATTERN = Pattern.compile("[a-z0-9]+:/[/]?.*");
+
+    // Regular expression taken from https://www.rfc-editor.org/rfc/rfc3986#appendix-B.
+    private static final Pattern URI_PATTERN =
+        Pattern.compile("^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?");
+
+    private static final String ERROR_TRANSFORMING_URI_LOG =
+        "Error while transforming redirect to [{}] to proper URI: [{}]";
+
+    private static final String FULL_STACK_TRACE = "Full stack trace:";
 
     private HttpServletResponse response;
 
@@ -65,8 +74,8 @@ public class XWikiServletResponse implements XWikiResponse
     public void sendRedirect(String redirect) throws IOException
     {
         if (!StringUtils.isBlank(redirect)) {
-            try {
-                URI uri = new URI(redirect);
+            URI uri = parseURI(redirect);
+            if (uri != null) {
                 if (!getURLSecurityManager().isURITrusted(uri)) {
                     LOGGER.warn(
                         "Possible phishing attack, attempting to redirect to [{}], this request has been blocked. "
@@ -75,14 +84,42 @@ public class XWikiServletResponse implements XWikiResponse
                             + "the configuration: it can be configured in xwiki.properties in url.trustedDomains.",
                         redirect);
                 } else {
-                    this.response.sendRedirect(redirect);
+                    this.response.sendRedirect(uri.toString());
                 }
-            } catch (URISyntaxException e) {
-                LOGGER.error("Error while transforming redirect to [{}] to proper URI: [{}]", redirect,
-                    ExceptionUtils.getRootCauseMessage(e));
-                LOGGER.debug("Full stack trace:", e);
             }
         }
+    }
+
+    private URI parseURI(String location)
+    {
+        URI uri = null;
+        try {
+            uri = new URI(location);
+        } catch (URISyntaxException e) {
+            // Attempt repairing the invalid URI similar to org.eclipse.jetty.client.HttpRedirector#sanitize by
+            // extracting the different parts and then passing them to the multi-argument constructor that quotes
+            // illegal characters.
+            Matcher matcher = URI_PATTERN.matcher(location);
+            if (matcher.matches()) {
+                String scheme = matcher.group(2);
+                String authority = matcher.group(4);
+                String path = matcher.group(5);
+                String query = matcher.group(7);
+                String fragment = matcher.group(9);
+                try {
+                    uri = new URI(scheme, authority, path, query, fragment);
+                } catch (URISyntaxException ex) {
+                    LOGGER.error(ERROR_TRANSFORMING_URI_LOG, location,
+                        ExceptionUtils.getRootCauseMessage(e));
+                    LOGGER.debug(FULL_STACK_TRACE, e);
+                }
+            } else {
+                LOGGER.error(ERROR_TRANSFORMING_URI_LOG, location,
+                    ExceptionUtils.getRootCauseMessage(e));
+                LOGGER.debug(FULL_STACK_TRACE, e);
+            }
+        }
+        return uri;
     }
 
     private URLSecurityManager getURLSecurityManager()


### PR DESCRIPTION
* Add missing quoting during URI parsing to avoid parse errors.

This fixes support for redirects to URLs that contain illegal characters like spaces in query strings.  However, this also changes how newlines are handled and requires for security that the parsed URI is used for redirect which could lead to unexpected results.

Jira issue: https://jira.xwiki.org/browse/XWIKI-20549