### PR TITLE
XWIKI-20538: attachments are not returned by solr when the locale does not match the default locale

### DIFF
--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-picker/xwiki-platform-attachment-picker-webjar/src/main/webjar/attachmentGalleryPicker.js
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-picker/xwiki-platform-attachment-picker-webjar/src/main/webjar/attachmentGalleryPicker.js
@@ -127,7 +127,7 @@ define('xwiki-attachment-picker',
         } else {
           typesFqs = [];
         }
-        const computedFqs = ['type:ATTACHMENT'].concat(optionsFqs).concat(typesFqs);
+        const computedFqs = ['type:ATTACHMENT', 'locale:*'].concat(optionsFqs).concat(typesFqs);
         const query = computedFqs.map((fq) => 'fq=' + fq).join('\n');
 
         return new Promise((resolve, reject) => {

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/resources/xwiki-resource/entityResourceSuggester.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/resources/xwiki-resource/entityResourceSuggester.js
@@ -113,7 +113,8 @@ define('entityResourceSuggester', [
       var deferred = $.Deferred();
       var query = [
         'q=__INPUT__',
-        'fq=type:ATTACHMENT'
+        'fq=type:ATTACHMENT',
+        'fq=locale:*'
       ];
       var input = resourceReference.reference.trim();
       if (input) {

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/LinkSuggestions.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/LinkSuggestions.xml
@@ -154,6 +154,7 @@
 #macro (searchAttachmentsSolr $input $limit $results)
   #set ($params = [
     'fq=type:ATTACHMENT',
+    'fq=locale:*',
     'qf=filename^4 attcontent',
     'fl=type wiki spaces name filename score',
     "bq=attauthor:""$services.model.serialize($xcontext.userReference, 'default')""",

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-macro/src/main/resources/XWiki/DocumentTreeMacros.xml
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-macro/src/main/resources/XWiki/DocumentTreeMacros.xml
@@ -1164,6 +1164,7 @@
 #macro (searchAttachmentsSolr $text $limit $return)
   #set ($params = [
     'fq=type:ATTACHMENT',
+    'fq=locale:*',
     'qf=filename^4 attcontent',
     'fl=type wiki spaces name filename'
   ])

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/SearchSuggestConfig.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/SearchSuggestConfig.xml
@@ -905,6 +905,7 @@ qf=doccontent^2 doccontentraw</query>
     </property>
     <property>
       <query>fq=type:ATTACHMENT
+fq=locale:*
 qf=filename</query>
     </property>
     <property>
@@ -1066,6 +1067,7 @@ qf=filename</query>
     </property>
     <property>
       <query>fq=type:ATTACHMENT
+fq=locale:*
 qf=attcontent</query>
     </property>
     <property>


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-20538

Attachments are linked with one of the locale of a page. But in the search, we restrict the locale to the current one.
Consequently, in mulilingual wikis, chances are the attachment search is partial.

The current solution is to include `fq=locale:*` to return the attachments regardless of their locale.