### PR TITLE
XWIKI-20578: tool packager plugin ouputs lots of errors related to missing URLConfiguration component

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/skin/InternalSkinManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/skin/InternalSkinManager.java
@@ -95,7 +95,7 @@ public class InternalSkinManager implements Initializable
     private Logger logger;
 
     @Inject
-    private URLConfiguration urlConfiguration;
+    private Provider<URLConfiguration> urlConfigurationProvider;
 
     @Inject
     private WikiDescriptorManager wikiDescriptorManager;
@@ -160,7 +160,7 @@ public class InternalSkinManager implements Initializable
         } else {
             EnvironmentSkin environmentSkin =
                 new EnvironmentSkin(id, this, this.skinConfiguration, this.logger, this.environment,
-                    this.xcontextProvider, this.urlConfiguration);
+                    this.xcontextProvider, this.urlConfigurationProvider.get());
             // Check if the environment skin actually exists on the environment before returning it.
             // Other fallbacks to a classloader skin.
             if (environmentSkin.exists()) {
@@ -171,7 +171,7 @@ public class InternalSkinManager implements Initializable
                 NamespaceURLClassLoader wikiClassLoader =
                     this.classLoaderManager.getURLClassLoader(wikiNamespace.serialize(), false);
                 skin = new ClassLoaderSkin(id, this, this.skinConfiguration, this.logger, this.xcontextProvider,
-                    this.urlConfiguration, wikiClassLoader);
+                    this.urlConfigurationProvider.get(), wikiClassLoader);
             }
         }
 

--- a/xwiki-platform-tools/xwiki-platform-tool-packager-plugin/src/main/java/org/xwiki/tool/packager/internal/PackagerComponentManagerInitializer.java
+++ b/xwiki-platform-tools/xwiki-platform-tool-packager-plugin/src/main/java/org/xwiki/tool/packager/internal/PackagerComponentManagerInitializer.java
@@ -23,24 +23,30 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
-import org.xwiki.context.ExecutionContext;
-import org.xwiki.context.ExecutionContextException;
+import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.component.manager.ComponentManagerInitializer;
 import org.xwiki.context.ExecutionContextInitializer;
+import org.xwiki.observation.EventListener;
 
 /**
- * Cancel ThreadClassloaderExecutionContextInitializer to not mess with the Maven classloader.
- * 
+ * Dedicated component manager initializer for the packager plugin.
+ * Main role of this initializer is to unregister the components we don't want to have when the importer is used.
+ *
  * @version $Id$
- * @since 9.7RC1
+ * @since 15.0
  */
 @Component
 @Singleton
-@Named("threadclassloader")
-public class MavenBuildThreadClassloaderExecutionContextInitializer implements ExecutionContextInitializer
+@Named("packager")
+public class PackagerComponentManagerInitializer implements ComponentManagerInitializer
 {
     @Override
-    public void initialize(ExecutionContext context) throws ExecutionContextException
+    public void initialize(ComponentManager componentManager)
     {
-        // Cancel
+        // We don't want the solr indexer to be triggered whenever a document is imported.
+        componentManager.unregisterComponent(EventListener.class, "solr.update");
+        // We don't need the untyped event listener and it requires specific dependencies.
+        componentManager.unregisterComponent(EventListener.class, "Untyped Event Listener");
+        componentManager.unregisterComponent(ExecutionContextInitializer.class, "threadclassloader");
     }
 }

--- a/xwiki-platform-tools/xwiki-platform-tool-packager-plugin/src/main/java/org/xwiki/tool/packager/internal/PackagerComponentManagerInitializer.java
+++ b/xwiki-platform-tools/xwiki-platform-tool-packager-plugin/src/main/java/org/xwiki/tool/packager/internal/PackagerComponentManagerInitializer.java
@@ -47,6 +47,7 @@ public class PackagerComponentManagerInitializer implements ComponentManagerInit
         componentManager.unregisterComponent(EventListener.class, "solr.update");
         // We don't need the untyped event listener and it requires specific dependencies.
         componentManager.unregisterComponent(EventListener.class, "Untyped Event Listener");
+        //  Cancel ThreadClassloaderExecutionContextInitializer to not mess with the Maven classloader.
         componentManager.unregisterComponent(ExecutionContextInitializer.class, "threadclassloader");
     }
 }

--- a/xwiki-platform-tools/xwiki-platform-tool-packager-plugin/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-tools/xwiki-platform-tool-packager-plugin/src/main/resources/META-INF/components.txt
@@ -1,3 +1,3 @@
 500:org.xwiki.tool.packager.internal.MavenBuildJarExtensionHandler
-500:org.xwiki.tool.packager.internal.MavenBuildThreadClassloaderExecutionContextInitializer
+org.xwiki.tool.packager.internal.PackagerComponentManagerInitializer
 org.xwiki.tool.utils.OldCoreHelper


### PR DESCRIPTION
  * Use a Provider<URLConfiguration> in InternalSkinManager to avoid dependency issues with tool packager plugin
  * Add a new ComponentManagerInitializer in the tool packager plugin to handle unregistering the stuff we don't need for packaging

Note that I only tested this by building  `xwiki-platform-distribution-flavor-data-hsqldb` so I might miss impacts on the other mojo than packager. 