### PR TITLE
XWIKI-17588: Display some text when there's no tag for a page

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/documentTags.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/documentTags.vm
@@ -138,7 +138,8 @@
     #end
     #if($hasedit || !$tags.isEmpty())
         $services.localization.render('core.tags.list.label')
-        #foreach($tag in $tags)
+    #end
+    #foreach($tag in $tags)
         #displayTag($tag)
     #end
     #if($hasedit && $xwiki.tag)

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/documentTags.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/documentTags.vm
@@ -152,7 +152,7 @@
             #else
                 #displayAddForm()
             #end
-        </div>##
+        </div>
     #end
 </div>
     #if($tagErrorMessage != '')

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/documentTags.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/documentTags.vm
@@ -136,20 +136,13 @@
         #set($hasTagsPlugin = false)
         #set($tags = $doc.getTagList())
     #end
-    ##   #if($!tags.size() == 0)
-    ##     No tags
-    ##   #else
-    $services.localization.render('core.tags.list.label')
-    #foreach($tag in $tags)
+    #if($hasedit || !$tags.isEmpty())
+        $services.localization.render('core.tags.list.label')
+        #foreach($tag in $tags)
         #displayTag($tag)
     #end
-    ##   #end
-    #if($hasedit)
-        #if($xwiki.tag)
-          <div class="tag-tool tag-add">#if("$!{request.showTagAddForm}" == '')<a href="$doc.getURL('view', "showTagAddForm=true&amp;$!{escapetool.url(${request.queryString})}#${tagsId}")" title="$services.localization.render('core.tags.add.tooltip')" rel="nofollow">[+]</a>#else #displayAddForm()#end</div>
-        #else
-            ## TODO
-        #end
+    #if($hasedit && $xwiki.tag)
+        <div class="tag-tool tag-add">#if("$!{request.showTagAddForm}" == '')<a href="$doc.getURL('view', "showTagAddForm=true&amp;$!{escapetool.url(${request.queryString})}#${tagsId}")" title="$services.localization.render('core.tags.add.tooltip')" rel="nofollow">[+]</a>#else #displayAddForm()#end</div>
     #end
 </div>
     #if($tagErrorMessage != '')

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/documentTags.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/documentTags.vm
@@ -143,7 +143,16 @@
         #displayTag($tag)
     #end
     #if($hasedit && $xwiki.tag)
-        <div class="tag-tool tag-add">#if("$!{request.showTagAddForm}" == '')<a href="$doc.getURL('view', "showTagAddForm=true&amp;$!{escapetool.url(${request.queryString})}#${tagsId}")" title="$services.localization.render('core.tags.add.tooltip')" rel="nofollow">[+]</a>#else #displayAddForm()#end</div>
+        <div class="tag-tool tag-add">##
+            #if("$!{request.showTagAddForm}" == '')
+                <a href="$doc.getURL('view', 
+                    "showTagAddForm=true&amp;$!{escapetool.url(${request.queryString})}#${tagsId}")" 
+                    title="$services.localization.render('core.tags.add.tooltip')" 
+                    rel="nofollow">[+]</a>##
+            #else
+                #displayAddForm()
+            #end
+        </div>##
     #end
 </div>
     #if($tagErrorMessage != '')

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/DocumentTagsTest.java
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/DocumentTagsTest.java
@@ -87,7 +87,7 @@ class DocumentTagsTest extends PageTest
         // Remove extra spaces to make it easy to assert the result below.
         String result = templateManager.render("documentTags.vm").trim().replaceAll("\\s+", " ");
 
-        // Verify that the generated HTML matches the expectation:
+        // Verify that the generated HTML matches the expectations:
         // - The tag label is not displayed since there is/are no tag(s)
         // - No tag is listed after the tag label
         // - No "+" link is displayed since the user doesn't have edit rights
@@ -104,7 +104,7 @@ class DocumentTagsTest extends PageTest
         // Remove extra spaces to make it easy to assert the result below.
         String result = templateManager.render("documentTags.vm").trim().replaceAll("\\s+", " ");
 
-        // Verify that the generated HTML matches the expectation:
+        // Verify that the generated HTML matches the expectations:
         // - The tag label is displayed
         // - No tag is listed after the tag label
         // - The "+" link is displayed since the user has edit rights
@@ -128,7 +128,7 @@ class DocumentTagsTest extends PageTest
         // Remove extra spaces to make it easy to assert the result below.
         String result = templateManager.render("documentTags.vm").trim().replaceAll("\\s+", " ");
 
-        // Verify that the generated HTML matches the expectation:
+        // Verify that the generated HTML matches the expectations:
         // - The tag label is displayed
         // - The tags after the tag label
         // - No "+" link is displayed since the user doesn't have edit rights

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/DocumentTagsTest.java
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/DocumentTagsTest.java
@@ -109,8 +109,8 @@ class DocumentTagsTest extends PageTest
         // - No tag is listed after the tag label
         // - The "+" link is displayed since the user has edit rights
         assertThat(result, matchesPattern("\\Q<div class=\"doc-tags\" id=\"xdocTags\"> core.tags.list.label "
-            + "<div class=\"tag-tool tag-add\"><a href=\"\\E.*\"\\Q title=\"core.tags.add.tooltip\" "
-            + "rel=\"nofollow\">[+]</a></div> </div>\\E"));
+            + "<div class=\"tag-tool tag-add\"> <a href=\"/xwiki/bin/view/space/page?showTagAddForm=true#xdocTags\" title=\"core.tags.add.tooltip\" "
+            + "rel=\"nofollow\">[+]</a> </div> </div>"));
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/DocumentTagsTest.java
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/DocumentTagsTest.java
@@ -144,4 +144,41 @@ class DocumentTagsTest extends PageTest
             + "</span> "
             + "</div>"));
     }
+
+    @Test
+    void displayTagsWhenEditRightsAndTagPluginAvailableAndTags() throws Exception
+    {
+        // Give edit rights ($hasEdit = true)
+        when(this.oldcore.getMockContextualAuthorizationManager().hasAccess(Right.EDIT)).thenReturn(true);
+
+        // Add tags to the current document
+        XWikiDocument currentDocument = this.context.getDoc();
+        BaseObject bo = new BaseObject();
+        bo.setXClassReference(new DocumentReference("xwiki", "XWiki", "TagClass"));
+        bo.setStringListValue("tags", Arrays.asList("tag1", "tag2"));
+        currentDocument.addXObject(bo);
+        this.xwiki.saveDocument(currentDocument, this.context);
+
+        TemplateManager templateManager = this.oldcore.getMocker().getInstance(TemplateManager.class);
+        // Remove extra spaces to make it easy to assert the result below.
+        String result = templateManager.render("documentTags.vm").trim().replaceAll("\\s+", " ");
+
+        // Verify that the generated HTML matches the expectations:
+        // - The tag label is displayed
+        // - The tags after the tag label
+        // - The "+" link is displayed since the user has edit rights
+        assertThat(result, matchesPattern("\\Q<div class=\"doc-tags\" id=\"xdocTags\"> core.tags.list.label "
+        + "<span class=\"tag-wrapper\"> <span class=\"tag\">"
+        + "<a href=\"/xwiki/bin/view/Main/Tags?do=viewTag&amp;tag=tag1\">tag1</a></span> "
+        + "<span class=\"separator\">[</span>"
+        + "<a href=\"/xwiki/bin/view/space/page?xpage=documentTags&amp;xaction=delete&amp;tag=tag1&amp;form_token=&amp;xredirect=%2Fxwiki%2Fbin%2Fview%2Fspace%2Fpage%23xdocTags\" "
+        + "class=\"tag-tool tag-delete\" title=\"core.tags.remove.tooltip\">X</a><span class=\"separator\">]</span></span> "
+        + "<span class=\"tag-wrapper\"> <span class=\"tag\">"
+        + "<a href=\"/xwiki/bin/view/Main/Tags?do=viewTag&amp;tag=tag2\">tag2</a></span> "
+        + "<span class=\"separator\">[</span>"
+        + "<a href=\"/xwiki/bin/view/space/page?xpage=documentTags&amp;xaction=delete&amp;tag=tag2&amp;form_token=&amp;xredirect=%2Fxwiki%2Fbin%2Fview%2Fspace%2Fpage%23xdocTags\" "
+        + "class=\"tag-tool tag-delete\" title=\"core.tags.remove.tooltip\">X</a><span class=\"separator\">]</span></span> "
+        + "<div class=\"tag-tool tag-add\"> <a href=\"/xwiki/bin/view/space/page?showTagAddForm=true#xdocTags\" "
+        + "title=\"core.tags.add.tooltip\" rel=\"nofollow\">[+]</a> </div> </div>"));
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/DocumentTagsTest.java
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/DocumentTagsTest.java
@@ -42,8 +42,8 @@ import com.xpn.xwiki.plugin.tag.TagPlugin;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.matchesPattern;
-import static org.mockito.Mockito.when;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests the {@code documentTags.vm} template.

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/DocumentTagsTest.java
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/DocumentTagsTest.java
@@ -118,10 +118,10 @@ class DocumentTagsTest extends PageTest
     {
         // Add tags to the current document
         XWikiDocument currentDocument = this.context.getDoc();
-        BaseObject bo = new BaseObject();
-        bo.setXClassReference(new DocumentReference("xwiki", "XWiki", "TagClass"));
-        bo.setStringListValue("tags", Arrays.asList("tag1", "tag2"));
-        currentDocument.addXObject(bo);
+        BaseObject baseObject = new BaseObject();
+        baseObject.setXClassReference(new DocumentReference("xwiki", "XWiki", "TagClass"));
+        baseObject.setStringListValue("tags", Arrays.asList("tag1", "tag2"));
+        currentDocument.addXObject(baseObject);
         this.xwiki.saveDocument(currentDocument, this.context);
 
         TemplateManager templateManager = this.oldcore.getMocker().getInstance(TemplateManager.class);
@@ -153,10 +153,10 @@ class DocumentTagsTest extends PageTest
 
         // Add tags to the current document
         XWikiDocument currentDocument = this.context.getDoc();
-        BaseObject bo = new BaseObject();
-        bo.setXClassReference(new DocumentReference("xwiki", "XWiki", "TagClass"));
-        bo.setStringListValue("tags", Arrays.asList("tag1", "tag2"));
-        currentDocument.addXObject(bo);
+        BaseObject baseObject = new BaseObject();
+        baseObject.setXClassReference(new DocumentReference("xwiki", "XWiki", "TagClass"));
+        baseObject.setStringListValue("tags", Arrays.asList("tag1", "tag2"));
+        currentDocument.addXObject(baseObject);
         this.xwiki.saveDocument(currentDocument, this.context);
 
         TemplateManager templateManager = this.oldcore.getMocker().getInstance(TemplateManager.class);

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/DocumentTagsTest.java
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/DocumentTagsTest.java
@@ -90,7 +90,7 @@ class DocumentTagsTest extends PageTest
         // - The tag label is displayed
         // - No tag is listed after the tag label
         // - No "+" link is displayed since the user doesn't have edit rights
-        assertThat(result, matchesPattern("\\Q<div class=\"doc-tags\" id=\"xdocTags\"> core.tags.list.label </div>"));
+        assertThat(result, matchesPattern("<div class=\"doc-tags\" id=\"xdocTags\"> </div>"));
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/DocumentTagsTest.java
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/DocumentTagsTest.java
@@ -43,6 +43,7 @@ import com.xpn.xwiki.plugin.tag.TagPlugin;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests the {@code documentTags.vm} template.
@@ -90,7 +91,7 @@ class DocumentTagsTest extends PageTest
         // - The tag label is not displayed since there is/are no tag(s)
         // - No tag is listed after the tag label
         // - No "+" link is displayed since the user doesn't have edit rights
-        assertThat(result, matchesPattern("<div class=\"doc-tags\" id=\"xdocTags\"> </div>"));
+        assertEquals("<div class=\"doc-tags\" id=\"xdocTags\"> </div>", result);
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/DocumentTagsTest.java
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/DocumentTagsTest.java
@@ -87,7 +87,7 @@ class DocumentTagsTest extends PageTest
         String result = templateManager.render("documentTags.vm").trim().replaceAll("\\s+", " ");
 
         // Verify that the generated HTML matches the expectation:
-        // - The tag label is displayed
+        // - The tag label is not displayed since there is/are no tag(s)
         // - No tag is listed after the tag label
         // - No "+" link is displayed since the user doesn't have edit rights
         assertThat(result, matchesPattern("<div class=\"doc-tags\" id=\"xdocTags\"> </div>"));


### PR DESCRIPTION
Summary:
When there are no tags:

When user **has edit rights**, ```Tags [+]``` is displayed.
When user **does NOT have edit rights**, nothing is displayed at all.

When there are tags, it is displayed to all type of users irrespective of their edit rights.
(But user with edit rights can see the ```+``` sign as well :)