### PR TITLE
XWIKI-20615: $response.sendRedirect repair too much

### DIFF
--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-api/src/main/java/org/xwiki/url/URLSecurityManager.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-api/src/main/java/org/xwiki/url/URLSecurityManager.java
@@ -37,6 +37,15 @@ import org.xwiki.stability.Unstable;
 public interface URLSecurityManager
 {
     /**
+     * Dedicated string used to escape {@code %} character.
+     * @see #parseToSafeURI(String)
+     * @since 15.1RC1
+     * @since 14.10.5
+     */
+    @Unstable
+    String PERCENT_ESCAPE = "__XWIKI_URL_SECURITY_PERCENT__";
+
+    /**
      * Constant to be used in {@link org.xwiki.context.ExecutionContext} with the value {@code "true"} to bypass a
      * check of {@link #isDomainTrusted(URL)}.
      */
@@ -82,6 +91,10 @@ public interface URLSecurityManager
      * This method throws a {@link SecurityException} if the parsed URI is not safe to use according to
      * {@link #isURITrusted(URI)}. It might also throw a {@link URISyntaxException} if the parameter cannot be properly
      * parsed.
+     * Note that this method might try to "repair" URI that are not parsed correctly by {@link URI#URI(String)}
+     * (e.g. serialized uri containing spaces). As part of that repair we need to perform escaping of the {@code %}
+     * character and we use {@link #PERCENT_ESCAPE} value as replacement string: the chain contained in
+     * {@link #PERCENT_ESCAPE} is then a protected token that should never be present in your serialized URI.
      *
      * @param serializedURI a string representing a URI that needs to be parsed.
      * @return a URI safe to use

--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-api/src/main/java/org/xwiki/url/URLSecurityManager.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-api/src/main/java/org/xwiki/url/URLSecurityManager.java
@@ -37,15 +37,6 @@ import org.xwiki.stability.Unstable;
 public interface URLSecurityManager
 {
     /**
-     * Dedicated string used to escape {@code %} character.
-     * @see #parseToSafeURI(String)
-     * @since 15.1RC1
-     * @since 14.10.5
-     */
-    @Unstable
-    String PERCENT_ESCAPE = "__XWIKI_URL_SECURITY_PERCENT__";
-
-    /**
      * Constant to be used in {@link org.xwiki.context.ExecutionContext} with the value {@code "true"} to bypass a
      * check of {@link #isDomainTrusted(URL)}.
      */
@@ -92,9 +83,7 @@ public interface URLSecurityManager
      * {@link #isURITrusted(URI)}. It might also throw a {@link URISyntaxException} if the parameter cannot be properly
      * parsed.
      * Note that this method might try to "repair" URI that are not parsed correctly by {@link URI#URI(String)}
-     * (e.g. serialized uri containing spaces). As part of that repair we need to perform escaping of the {@code %}
-     * character and we use {@link #PERCENT_ESCAPE} value as replacement string: the chain contained in
-     * {@link #PERCENT_ESCAPE} is then a protected token that should never be present in your serialized URI.
+     * (e.g. serialized uri containing spaces).
      *
      * @param serializedURI a string representing a URI that needs to be parsed.
      * @return a URI safe to use

--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-default/src/main/java/org/xwiki/url/internal/DefaultURLSecurityManager.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-default/src/main/java/org/xwiki/url/internal/DefaultURLSecurityManager.java
@@ -61,6 +61,12 @@ public class DefaultURLSecurityManager implements URLSecurityManager
     private static final char DOT = '.';
     private static final char PERCENT = '%';
 
+    /**
+     * Dedicated string used to escape {@code %} character.
+     * @see #parseToSafeURI(String)
+     */
+    private static final String PERCENT_ESCAPE = "__XWIKI_URL_SECURITY_PERCENT__";
+
     // Regular expression taken from https://www.rfc-editor.org/rfc/rfc3986#appendix-B.
     private static final Pattern URI_PATTERN =
         Pattern.compile("^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?");
@@ -214,6 +220,11 @@ public class DefaultURLSecurityManager implements URLSecurityManager
     public URI parseToSafeURI(String serializedURI) throws URISyntaxException, SecurityException
     {
         URI uri;
+        if (serializedURI.contains(PERCENT_ESCAPE)) {
+            throw new IllegalArgumentException(
+                String.format("The given uri [%s] contains the string [%s] which is used internally "
+                + "for performing escaping operations. Please use another marker.", serializedURI, PERCENT_ESCAPE));
+        }
         try {
             uri = new URI(serializedURI);
         } catch (URISyntaxException e) {

--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-default/src/main/java/org/xwiki/url/internal/DefaultURLSecurityManager.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-default/src/main/java/org/xwiki/url/internal/DefaultURLSecurityManager.java
@@ -60,7 +60,6 @@ public class DefaultURLSecurityManager implements URLSecurityManager
 {
     private static final char DOT = '.';
     private static final char PERCENT = '%';
-    private static final String PERCENT_ESCAPE = "__XWIKI_PERCENT__";
 
     // Regular expression taken from https://www.rfc-editor.org/rfc/rfc3986#appendix-B.
     private static final Pattern URI_PATTERN =
@@ -224,7 +223,7 @@ public class DefaultURLSecurityManager implements URLSecurityManager
             Matcher matcher = URI_PATTERN.matcher(serializedURI);
             if (matcher.matches()) {
                 String scheme = matcher.group(2);
-                String authority = matcher.group(4);
+                String authority = replaceUnquotedPercent(matcher.group(4));
                 String path = replaceUnquotedPercent(matcher.group(5));
                 String query = replaceUnquotedPercent(matcher.group(7));
                 String fragment = replaceUnquotedPercent(matcher.group(9));
@@ -234,7 +233,7 @@ public class DefaultURLSecurityManager implements URLSecurityManager
                 uri = new URI(scheme, authority, path, query, fragment);
                 // the URI should be parsed again after properly replacing the escape chain by the % character since
                 // it won't be encoded anymore with the single argument constructor.
-                uri = new URI(uri.toString().replaceAll(PERCENT_ESCAPE, "%"));
+                uri = new URI(uri.toString().replace(PERCENT_ESCAPE, "%"));
             } else {
                 throw e;
             }

--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-default/src/test/java/org/xwiki/url/internal/DefaultURLSecurityManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-default/src/test/java/org/xwiki/url/internal/DefaultURLSecurityManagerTest.java
@@ -464,5 +464,31 @@ class DefaultURLSecurityManagerTest
 
         location = "foo://www.x wiki.org/";
         assertParseToSafeThrowSecurity(location, "foo://www.x%20wiki.org/");
+
+        location = "/xwiki/bin/edit/GroupeInformatique/Comptes%20Rendus/03%20f%C3%A9vrier%202023";
+        uri = this.urlSecurityManager.parseToSafeURI(location);
+        assertEquals(location, uri.toString());
+
+        location = "/xwiki/bin/edit/GroupeInformatique/Comptes Rendus/03%20f%C3%A9vrier%202023";
+        uri = this.urlSecurityManager.parseToSafeURI(location);
+        assertEquals("/xwiki/bin/edit/GroupeInformatique/Comptes%20Rendus/03%20f%C3%A9vrier%202023", uri.toString());
+
+        location = "/xwiki/bin/edit/GroupeInformatique/Comptes Rendus/%%%%";
+        uri = this.urlSecurityManager.parseToSafeURI(location);
+        assertEquals("/xwiki/bin/edit/GroupeInformatique/Comptes%20Rendus/%25%25%25%25", uri.toString());
+
+        location = "/xwiki/bin/edit/GroupeInformatique/Comptes Rendus/%C3";
+        uri = this.urlSecurityManager.parseToSafeURI(location);
+        assertEquals("/xwiki/bin/edit/GroupeInformatique/Comptes%20Rendus/%C3", uri.toString());
+
+        location = "/xwiki/bin/edit/GroupeInformatique/Comptes Rendus/%C";
+        uri = this.urlSecurityManager.parseToSafeURI(location);
+        assertEquals("/xwiki/bin/edit/GroupeInformatique/Comptes%20Rendus/%25C", uri.toString());
+
+        location = "/xwiki/bin/edit/GroupeInformatique/Comptes "
+            + "Rendus/%?query=03%20f%C3%A9vrier%202023%C#anchor%25C%A9%e";
+        uri = this.urlSecurityManager.parseToSafeURI(location);
+        assertEquals("/xwiki/bin/edit/GroupeInformatique/Comptes%20Rendus/%25"
+            + "?query=03%20f%C3%A9vrier%202023%25C#anchor%25C%A9%25e", uri.toString());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-default/src/test/java/org/xwiki/url/internal/DefaultURLSecurityManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-default/src/test/java/org/xwiki/url/internal/DefaultURLSecurityManagerTest.java
@@ -489,5 +489,19 @@ class DefaultURLSecurityManagerTest
         uri = this.urlSecurityManager.parseToSafeURI(location);
         assertEquals("/xwiki/bin/edit/Some%20Space/%25"
             + "?query=03%20f%C3%A9vrier%202023%25C#anchor%25C%A9%25e", uri.toString());
+
+        // invalidate cache so that we can call inject other trustedDomains
+        this.urlSecurityManager.invalidateCache();
+        when(urlConfiguration.getTrustedDomains()).thenReturn(List.of(
+            "faß.example",
+            "fa%C3%9F%25.example"
+        ));
+        location = "http://faß.example/Some%20Space/%C";
+        uri = this.urlSecurityManager.parseToSafeURI(location);
+        assertEquals("http://faß.example/Some%20Space/%25C", uri.toString());
+
+        location = "http://fa%C3%9F%.example/Some Space/Test#anchor%202";
+        uri = this.urlSecurityManager.parseToSafeURI(location);
+        assertEquals("http://fa%C3%9F%25.example/Some%20Space/Test#anchor%202", uri.toString());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-default/src/test/java/org/xwiki/url/internal/DefaultURLSecurityManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-default/src/test/java/org/xwiki/url/internal/DefaultURLSecurityManagerTest.java
@@ -503,5 +503,12 @@ class DefaultURLSecurityManagerTest
         location = "http://fa%C3%9F%.example/Some Space/Test#anchor%202";
         uri = this.urlSecurityManager.parseToSafeURI(location);
         assertEquals("http://fa%C3%9F%25.example/Some%20Space/Test#anchor%202", uri.toString());
+
+        String locationWithForbiddenToken = "//xwiki.org/xwiki/__XWIKI_URL_SECURITY_PERCENT__/something/";
+        IllegalArgumentException illegalArgumentException = assertThrows(IllegalArgumentException.class,
+            () -> this.urlSecurityManager.parseToSafeURI(locationWithForbiddenToken));
+        assertEquals("The given uri [//xwiki.org/xwiki/__XWIKI_URL_SECURITY_PERCENT__/something/] contains the string "
+            + "[__XWIKI_URL_SECURITY_PERCENT__] which is used internally for performing escaping operations. "
+            + "Please use another marker.", illegalArgumentException.getMessage());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-default/src/test/java/org/xwiki/url/internal/DefaultURLSecurityManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-default/src/test/java/org/xwiki/url/internal/DefaultURLSecurityManagerTest.java
@@ -465,30 +465,29 @@ class DefaultURLSecurityManagerTest
         location = "foo://www.x wiki.org/";
         assertParseToSafeThrowSecurity(location, "foo://www.x%20wiki.org/");
 
-        location = "/xwiki/bin/edit/GroupeInformatique/Comptes%20Rendus/03%20f%C3%A9vrier%202023";
+        location = "/xwiki/bin/edit/Some%20Space/03%20f%C3%A9vrier%202023";
         uri = this.urlSecurityManager.parseToSafeURI(location);
         assertEquals(location, uri.toString());
 
-        location = "/xwiki/bin/edit/GroupeInformatique/Comptes Rendus/03%20f%C3%A9vrier%202023";
+        location = "/xwiki/bin/edit/Some Space/03%20f%C3%A9vrier%202023";
         uri = this.urlSecurityManager.parseToSafeURI(location);
-        assertEquals("/xwiki/bin/edit/GroupeInformatique/Comptes%20Rendus/03%20f%C3%A9vrier%202023", uri.toString());
+        assertEquals("/xwiki/bin/edit/Some%20Space/03%20f%C3%A9vrier%202023", uri.toString());
 
-        location = "/xwiki/bin/edit/GroupeInformatique/Comptes Rendus/%%%%";
+        location = "/xwiki/bin/edit/Some Space/%%%%";
         uri = this.urlSecurityManager.parseToSafeURI(location);
-        assertEquals("/xwiki/bin/edit/GroupeInformatique/Comptes%20Rendus/%25%25%25%25", uri.toString());
+        assertEquals("/xwiki/bin/edit/Some%20Space/%25%25%25%25", uri.toString());
 
-        location = "/xwiki/bin/edit/GroupeInformatique/Comptes Rendus/%C3";
+        location = "/xwiki/bin/edit/Some Space/%C3";
         uri = this.urlSecurityManager.parseToSafeURI(location);
-        assertEquals("/xwiki/bin/edit/GroupeInformatique/Comptes%20Rendus/%C3", uri.toString());
+        assertEquals("/xwiki/bin/edit/Some%20Space/%C3", uri.toString());
 
-        location = "/xwiki/bin/edit/GroupeInformatique/Comptes Rendus/%C";
+        location = "/xwiki/bin/edit/Some Space/%C";
         uri = this.urlSecurityManager.parseToSafeURI(location);
-        assertEquals("/xwiki/bin/edit/GroupeInformatique/Comptes%20Rendus/%25C", uri.toString());
+        assertEquals("/xwiki/bin/edit/Some%20Space/%25C", uri.toString());
 
-        location = "/xwiki/bin/edit/GroupeInformatique/Comptes "
-            + "Rendus/%?query=03%20f%C3%A9vrier%202023%C#anchor%25C%A9%e";
+        location = "/xwiki/bin/edit/Some Space/%?query=03%20f%C3%A9vrier%202023%C#anchor%25C%A9%e";
         uri = this.urlSecurityManager.parseToSafeURI(location);
-        assertEquals("/xwiki/bin/edit/GroupeInformatique/Comptes%20Rendus/%25"
+        assertEquals("/xwiki/bin/edit/Some%20Space/%25"
             + "?query=03%20f%C3%A9vrier%202023%25C#anchor%25C%A9%25e", uri.toString());
     }
 }


### PR DESCRIPTION
  * Avoid double-encoding when trying to repair a URI by escaping % that belongs to percent encoded byte and replacing them afterwards
  * Add new various test cases related to reparation of URI with %