### PR TITLE
XWIKI-19725: Menu are not accessible using a screen reader

### DIFF
--- a/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
@@ -167,22 +167,20 @@ require(['jquery'], function($) {
   $('.menu-horizontal li ul,.menu-vertical li ul').parent().addClass('xDropdown');
 
   // Make sure the menu separators are really empty.
-  $('.menu-horizontal, .menu-vertical').find('li > br:first-child').remove();
+  $('.menu-horizontal, .menu-vertical').find('li &gt; br:first-child').remove();
 
-  //add aria attributes to the different elements
+  // Add aria attributes to the different elements.
   $('.menu-horizontal').attr('role', 'menubar');
   $('.menu-vertical').attr('role', 'menu');
-  $('.xDropdown').each(function(){
+  $('.xDropdown').each(function() {
     $(this).attr('role', 'menuitem');
     $(this).attr('aria-haspopup', 'menu');
   });
   $('.menu-horizontal, .menu-vertical').find('li')
-    .filter(function(index){return this.textContent.trim() === ""})
+    .filter(function(index) {return this.textContent.trim() === ""; })
     .attr("role","separator");
 
-
-
-  $('.menu-vertical.collapsible').each(function(){
+  $('.menu-vertical.collapsible').each(function() {
     var open = $(this).hasClass('open');
     $(this).find('li ul').each(function() {
       $(this).addClass('xDropdown-menu').parent().addClass('xDropdown' + (open ? ' open' : ''));
@@ -202,13 +200,13 @@ require(['jquery'], function($) {
     });
   }
 
-  $('.menu-horizontal .xDropdown,.menu-vertical .xDropdown').each(function(){
+  $('.menu-horizontal .xDropdown,.menu-vertical .xDropdown').each(function() {
     var dropDownHeader = this.ownerDocument.createElement("div");
     $(dropDownHeader).addClass("xDropdown-header");
     var dropDownButton = this.ownerDocument.createElement("button");
     $(dropDownButton).addClass("xDropdown-header-toggle");
     setDropdownButtonTitle(dropDownButton);
-    dropDownButton.addEventListener('click',function(){
+    dropDownButton.addEventListener('click',function() {
       //Swaps the state of the submenu.
       var xDropdown = $(this).parent().parent();
       xDropdown.toggleClass('open');
@@ -220,13 +218,13 @@ require(['jquery'], function($) {
     $(dropDownHeader).next().addClass('xDropdown-menu');
   });
 
-  $('.menu-horizontal .xDropdown').each(function(){
+  $('.menu-horizontal .xDropdown').each(function() {
     // In case of horizontal menus, make it so that a class is added on hover, instead of using the :hover pseudo-class
-    this.addEventListener("mouseover", function(){
+    this.addEventListener("mouseover", function() {
       $(this).addClass('open');
       setDropdownButtonTitle(this.firstChild.lastChild);
     });
-    this.addEventListener("mouseout", function(){
+    this.addEventListener("mouseout", function() {
       $(this).removeClass('open');
       setDropdownButtonTitle(this.firstChild.lastChild);
     });
@@ -651,24 +649,25 @@ require(['jquery'], function($) {
   }
 }
 .menu {
+  /* Rotate the carets when the menu is opened. */
   .xDropdown{
-    &gt; .xDropdown-header &gt; .xDropdown-header-toggle:before{
+    &gt; .xDropdown-header &gt; .xDropdown-header-toggle:before {
         transform: rotate(90deg);
       }
-    &amp;.open &gt; .xDropdown-header &gt; .xDropdown-header-toggle:before{
+    &amp;.open &gt; .xDropdown-header &gt; .xDropdown-header-toggle:before {
       transform: rotate(0);
     }
   }
-  .xDropdown-header-toggle{
+  .xDropdown-header-toggle {
     background: transparent;
     border:none;
     border-radius: @border-radius-base;
     margin: (@line-height-computed / 8) .3em;
-    line-height: (@line-height-computed / 2) ;
+    line-height: (@line-height-computed / 2);
     &amp;:hover, &amp;:focus-within {
       background-color: @dropdown-bg;
     }
-    &amp;:before{
+    &amp;:before {
       .caret;
       margin-left: 0px;
       content: '';
@@ -711,10 +710,10 @@ require(['jquery'], function($) {
     min-height: @navbar-height;
     padding-left: 25px;
     .xDropdown.open {
-      &gt; .xDropdown-header &gt; .xDropdown-header-toggle:before{
+      &gt; .xDropdown-header &gt; .xDropdown-header-toggle:before {
         transform: rotate(0);
       }
-      > ul {
+      &gt; ul {
         display: block;
       }
     }
@@ -757,14 +756,13 @@ require(['jquery'], function($) {
           max-height: @navbar-height - (2 * @navbar-padding-vertical) - 2px;
           overflow: hidden;
           &amp;.xDropdown-header{
-            /* No border on the dropdown header */
             max-height: unset;
           }
         }
-        /*Navbar headers.*/
-        &amp; &gt; .xDropdown-header &gt; .xDropdown-header-toggle{
-          &amp;:hover, &amp;:focus-within{
-            /* Change background color of the caret when hovering on the navbar.*/
+        /* Horizontal menu top-level headers. */
+        &amp; &gt; .xDropdown-header &gt; .xDropdown-header-toggle {
+          &amp;:hover, &amp;:focus-within {
+            /* Change background color of the caret when hovering on the navbar. */
             background-color: @navbar-default-bg;
           }
         }
@@ -844,7 +842,7 @@ require(['jquery'], function($) {
               display: inherit;
             }
             /* Place the arrow on the right */
-            &amp;:after  {
+            &amp;:after {
               position: absolute;
               margin-top: @line-height-computed / 2;
               right: 8px;

--- a/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
@@ -164,7 +164,7 @@ $menuTemplateDoc.content.replace('{', '')
 require(['jquery'], function($) {
   // It's not possible to write a CSS selector that targets list items containing lists so we rely on JavaScript.
   // The 'dropdown' CSS class is used only to display the down/left arrow.
-  $('.menu-horizontal li ul,.menu-vertical li ul').parent().addClass('xDropdown');
+  $('.menu-horizontal li ul, .menu-vertical li ul').parent().addClass('xDropdown');
 
   // Make sure the menu separators are really empty.
   $('.menu-horizontal, .menu-vertical').find('li &gt; br:first-child').remove();
@@ -200,7 +200,7 @@ require(['jquery'], function($) {
     });
   }
 
-  $('.menu-horizontal .xDropdown,.menu-vertical .xDropdown').each(function() {
+  $('.menu-horizontal .xDropdown, .menu-vertical .xDropdown').each(function() {
     var dropDownHeader = this.ownerDocument.createElement("div");
     $(dropDownHeader).addClass("xDropdown-header");
     var dropDownButton = this.ownerDocument.createElement("button");

--- a/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
@@ -167,7 +167,20 @@ require(['jquery'], function($) {
   $('.menu-horizontal li ul,.menu-vertical li ul').parent().addClass('xDropdown');
 
   // Make sure the menu separators are really empty.
-  $('.menu-horizontal, .menu-vertical').find('li &gt; br:first-child').remove();
+  $('.menu-horizontal, .menu-vertical').find('li > br:first-child').remove();
+
+  //add aria attributes to the different elements
+  $('.menu-horizontal').attr('role', 'menubar');
+  $('.menu-vertical').attr('role', 'menu');
+  $('.xDropdown').each(function(){
+    $(this).attr('role', 'menuitem');
+    $(this).attr('aria-haspopup', 'menu');
+  });
+  $('.menu-horizontal, .menu-vertical').find('li')
+    .filter(function(index){return this.textContent.trim() === ""})
+    .attr("role","separator");
+
+
 
   $('.menu-vertical.collapsible').each(function(){
     var open = $(this).hasClass('open');
@@ -176,38 +189,47 @@ require(['jquery'], function($) {
     });
   });
 
+  function setDropdownButtonTitle(dropDownButton) {
+    var xDropdown = $(dropDownButton).parent().parent();
+    require(['xwiki-l10n!menu-ui-translation-keys'], function(l10n) {
+      if($(dropDownButton).parent().parent().hasClass('open')){
+        $(dropDownButton).attr('title',l10n['closeSubMenu']);
+        $(xDropdown).attr('aria-expanded', "true");
+      }else{
+        $(dropDownButton).attr('title',l10n['openSubMenu']);
+        $(xDropdown).attr('aria-expanded', "false");
+      }
+    });
+  }
+
   $('.menu-horizontal .xDropdown,.menu-vertical .xDropdown').each(function(){
-    console.log("FoundElement.");
     var dropDownHeader = this.ownerDocument.createElement("div");
     $(dropDownHeader).addClass("xDropdown-header");
     var dropDownButton = this.ownerDocument.createElement("button");
     $(dropDownButton).addClass("xDropdown-header-toggle");
-    require(['xwiki-l10n!menu-ui-translation-keys'], function(l10n) {
-      if($(dropDownButton).parent().parent().hasClass('open')){
-        $(dropDownButton).attr('title',l10n['closeSubMenu']);
-      }else{
-        $(dropDownButton).attr('title',l10n['openSubMenu']);
-      }
-    });
-
+    setDropdownButtonTitle(dropDownButton);
     dropDownButton.addEventListener('click',function(){
-      console.log("Clicked toggle button.");
       //Swaps the state of the submenu.
-      var toggable = $(this).parent().parent();
-      toggable.toggleClass('open');
-      $(dropDownButton).attr('title',"Open menu");
-      require(['xwiki-l10n!menu-ui-translation-keys'], function(l10n) {
-        if(toggable.hasClass('open')){
-          $(dropDownButton).attr('title',l10n['closeSubMenu']);
-        }else{
-          $(dropDownButton).attr('title',l10n['openSubMenu']);
-        }
-      });
+      var xDropdown = $(this).parent().parent();
+      xDropdown.toggleClass('open');
+      setDropdownButtonTitle(dropDownButton);
     });
     dropDownHeader.append($(this).contents()[0]);
     dropDownHeader.append(dropDownButton);
     $(this).prepend(dropDownHeader);
     $(dropDownHeader).next().addClass('xDropdown-menu');
+  });
+
+  $('.menu-horizontal .xDropdown').each(function(){
+    // In case of horizontal menus, make it so that a class is added on hover, instead of using the :hover pseudo-class
+    this.addEventListener("mouseover", function(){
+      $(this).addClass('open');
+      setDropdownButtonTitle(this.firstChild.lastChild);
+    });
+    this.addEventListener("mouseout", function(){
+      $(this).removeClass('open');
+      setDropdownButtonTitle(this.firstChild.lastChild);
+    });
   });
 
   // In case of horizontal responsive menus, make sub-submenus in the navbar work on mobile devices
@@ -641,9 +663,9 @@ require(['jquery'], function($) {
     background: transparent;
     border:none;
     border-radius: @border-radius-base;
-    margin: (@line-height-computed / 4);
-    line-height: (@line-height-computed / 2) + 2;
-    &amp;:hover, :focus{
+    margin: (@line-height-computed / 8) .3em;
+    line-height: (@line-height-computed / 2) ;
+    &amp;:hover, &amp;:focus-within {
       background-color: @dropdown-bg;
     }
     &amp;:before{
@@ -689,12 +711,12 @@ require(['jquery'], function($) {
     min-height: @navbar-height;
     padding-left: 25px;
     .xDropdown.open {
-      &gt; ul {
+      &gt; .xDropdown-header &gt; .xDropdown-header-toggle:before{
+        transform: rotate(0);
+      }
+      > ul {
         display: block;
       }
-    }
-    .xDropdown:hover &gt; .xDropdown-header &gt; .xDropdown-header-toggle:before{
-      transform: rotate(0);
     }
     &amp; &gt; ul {
       padding-left: 0;
@@ -711,7 +733,7 @@ require(['jquery'], function($) {
         }
         line-height: @line-height-computed;
         color: @navbar-default-link-color;
-        &amp;:hover {
+        &amp;:hover, &amp;:focus-within {
           color: @navbar-default-link-hover-color;
           background-color: @navbar-default-link-hover-bg;
           background-color: @navbar-default-link-active-bg;
@@ -725,7 +747,7 @@ require(['jquery'], function($) {
         /* Links inside menu */
         a {
           color: @navbar-default-link-color;
-          &amp;:hover{
+          &amp;:hover, &amp;:focus-within {
             text-decoration: none;
           }
         }
@@ -736,12 +758,12 @@ require(['jquery'], function($) {
           overflow: hidden;
           &amp;.xDropdown-header{
             /* No border on the dropdown header */
-            max-height: @navbar-height - (2 * @navbar-padding-vertical);
+            max-height: unset;
           }
         }
         /*Navbar headers.*/
         &amp; &gt; .xDropdown-header &gt; .xDropdown-header-toggle{
-          &amp;:hover, &amp;:focus{
+          &amp;:hover, &amp;:focus-within{
             /* Change background color of the caret when hovering on the navbar.*/
             background-color: @navbar-default-bg;
           }
@@ -789,7 +811,7 @@ require(['jquery'], function($) {
             color: @dropdown-link-color;
             overflow: hidden;
             text-overflow: ellipsis; // Displaying ... if the text is too long
-            &amp;:hover {
+            &amp;:hover, &amp;:focus-within {
               /* &amp;:extend(.dropdown-menu&gt;li&gt;a:hover); */
               text-decoration: none;
               color: @dropdown-link-hover-color;
@@ -807,7 +829,7 @@ require(['jquery'], function($) {
             color: @dropdown-link-color;
             /* Empty dropdowns should have height in order to display the arrow */
             min-height: 2 * @font-size-base;
-            &amp;:hover{
+            &amp;:hover, &amp;:focus-within {
               text-decoration: none;
               color: @dropdown-link-hover-color;
               background-color: @dropdown-link-hover-bg;
@@ -839,7 +861,7 @@ require(['jquery'], function($) {
     /* Stylization: Generic */
     li {
       /* Display submenus on hover */
-      &amp;:hover &gt; ul {
+      &amp;.open &gt; ul {
         display: block;
       }
     }
@@ -885,14 +907,11 @@ require(['jquery'], function($) {
             /* Links inside menu */
             a {
               color: @navbar-default-link-color;
-              &amp;:hover {
-                /* Preserve the styling from dropdown */
-              }
             }
             /* Submenus inside menu */
             &amp;.xDropdown {
               color: @navbar-default-link-color;
-              &amp;:hover {
+              &amp;.open {
                 background-color: transparent;
                 color: inherit;
               }

--- a/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
@@ -162,7 +162,20 @@ $menuTemplateDoc.content.replace('{', '')
   // Make sure the menu separators are really empty.
   $('.menu-horizontal, .menu-vertical').find('li &gt; br:first-child').remove();
 
-  // Collapsible menu bahavior.
+  //Make sure there is no simple text content. There needs to be an indexable object instead inside of each menu
+  $('.menu-horizontal .xDropdown').each(function(){
+    console.log("FoundElement.");
+    var dropDownHeader = this.ownerDocument.createElement("div");
+    $(dropDownHeader).addClass("xDropdown-header");
+    var dropDownButton = this.ownerDocument.createElement("button");
+    $(dropDownButton).addClass("xDropdown-header-toggle");
+    $(dropDownButton).setAttribute('title',"Open menu");
+    dropDownHeader.append($(this).contents()[0]);
+    dropDownHeader.append(dropDownButton);
+    $(this).prepend(dropDownHeader);
+  });
+
+  // Collapsible menu behavior.
   $('.menu-vertical.collapsible').each(function(){
     var open = $(this).hasClass('open');
     $(this).find('li ul').each(function() {
@@ -408,7 +421,7 @@ $menuTemplateDoc.content.replace('{', '')
   z-index: 1000;
 }
 
-.skin-colibri .menu-horizontal li:hover &gt; ul {
+.skin-colibri .menu-horizontal li:hover &gt; ul, li:focus-within &gt; ul {
   display: block;
 }
 
@@ -453,7 +466,7 @@ $menuTemplateDoc.content.replace('{', '')
   cursor: pointer;
 }
 
-.skin-colibri .menu-vertical .xDropdown-toggle:hover {
+.skin-colibri .menu-vertical .xDropdown-toggle:hover, .xDropdown-toggle:focus-within {
   background-color: $theme.highlightColor;
 }
 
@@ -622,7 +635,7 @@ $menuTemplateDoc.content.replace('{', '')
     .xDropdown-toggle {
       cursor: pointer;
       position: relative;
-      &amp;:hover {
+      &amp;:hover, &amp;:focus-within {
         background-color: @nav-link-hover-bg;
       }
       &amp;:after {
@@ -673,7 +686,7 @@ $menuTemplateDoc.content.replace('{', '')
         }
         line-height: @line-height-computed;
         color: @navbar-default-link-color;
-        &amp;:hover {
+        &amp;:hover, &amp;:focus-within {
           color: @navbar-default-link-hover-color;
           background-color: @navbar-default-link-hover-bg;
           background-color: @navbar-default-link-active-bg;
@@ -687,7 +700,7 @@ $menuTemplateDoc.content.replace('{', '')
         /* Links inside menu */
         a {
           color: @navbar-default-link-color;
-          &amp;:hover {
+          &amp;:hover, &amp;:focus-within {
             text-decoration: none;
           }
         }
@@ -740,7 +753,7 @@ $menuTemplateDoc.content.replace('{', '')
             color: @dropdown-link-color;
             overflow: hidden;
             text-overflow: ellipsis; // Displaying ... if the text is too long
-            &amp;:hover {
+            &amp;:hover, &amp;:focus-within {
               /* &amp;:extend(.dropdown-menu&gt;li&gt;a:hover); */
               text-decoration: none;
               color: @dropdown-link-hover-color;
@@ -758,7 +771,7 @@ $menuTemplateDoc.content.replace('{', '')
             color: @dropdown-link-color;
             /* Empty dropdowns should have height in order to display the arrow */
             min-height: 2 * @font-size-base;
-            &amp;:hover {
+            &amp;:hover, &amp;:focus-within {
               text-decoration: none;
               color: @dropdown-link-hover-color;
               background-color: @dropdown-link-hover-bg;
@@ -773,7 +786,7 @@ $menuTemplateDoc.content.replace('{', '')
               display: inherit;
             }
             /* Place the arrow on the right */
-            &amp;:after {
+            &amp;:after  {
               position: absolute;
               margin-top: @line-height-computed / 2;
               right: 8px;
@@ -790,15 +803,22 @@ $menuTemplateDoc.content.replace('{', '')
     /* Stylization: Generic */
     li {
       /* Display submenus on hover */
-      &amp;:hover &gt; ul {
+      &amp;:hover &gt; ul, &amp;:focus-within &gt; ul {
         display: block;
       }
       /* Display an arrow for expandable items */
       &amp;.xDropdown {
-        &amp;:after {
-          .caret;
-          content: '';
-          margin-left: .5em;
+        &amp; .xDropdown-header {
+          display: inline-block;
+          &amp; .xDropdown-header-toggle{
+            all: inherit;
+            .caret;
+            content: '';
+            margin-left: .5em;
+            &amp;:focus{
+              outline:unset;
+            }
+          }
         }
       }
     }
@@ -822,7 +842,7 @@ $menuTemplateDoc.content.replace('{', '')
     }
     /* Resetting rules for mobile view */
     @media (max-width: @screen-xs-max) {
-      &gt; ul { 
+      &gt; ul {
         margin: 0 0 0 -25px; /* Remove padding added in normal view */
         &gt; li {
           &amp;:empty {
@@ -844,19 +864,19 @@ $menuTemplateDoc.content.replace('{', '')
             /* Links inside menu */
             a {
               color: @navbar-default-link-color;
-              &amp;:hover {
+              &amp;:hover, &amp;:focus-within {
                 /* Preserve the styling from dropdown */
               }
             }
             /* Submenus inside menu */
             &amp;.xDropdown {
               color: @navbar-default-link-color;
-              &amp;:hover {
+              &amp;:hover, &amp;:focus-within {
                 background-color: transparent;
                 color: inherit;
               }
               /* When in dropdown we also have a link */
-              &gt; span &gt; a { 
+              &gt; span &gt; a {
                 color: @navbar-default-link-color;
               }
             }

--- a/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
@@ -154,42 +154,60 @@ $menuTemplateDoc.content.replace('{', '')
       <cache>long</cache>
     </property>
     <property>
-      <code>require(['jquery'], function($) {
+      <code>define('menu-ui-translation-keys', {
+  prefix: 'menu.ui.',
+  keys: [
+    "openSubMenu",
+    "closeSubMenu"
+  ]
+});
+require(['jquery'], function($) {
   // It's not possible to write a CSS selector that targets list items containing lists so we rely on JavaScript.
   // The 'dropdown' CSS class is used only to display the down/left arrow.
-  $('.menu-horizontal li ul').parent().addClass('xDropdown');
+  $('.menu-horizontal li ul,.menu-vertical li ul').parent().addClass('xDropdown');
 
   // Make sure the menu separators are really empty.
   $('.menu-horizontal, .menu-vertical').find('li &gt; br:first-child').remove();
 
-  //Make sure there is no simple text content. There needs to be an indexable object instead inside of each menu
-  $('.menu-horizontal .xDropdown').each(function(){
+  $('.menu-vertical.collapsible').each(function(){
+    var open = $(this).hasClass('open');
+    $(this).find('li ul').each(function() {
+      $(this).addClass('xDropdown-menu').parent().addClass('xDropdown' + (open ? ' open' : ''));
+    });
+  });
+
+  $('.menu-horizontal .xDropdown,.menu-vertical .xDropdown').each(function(){
     console.log("FoundElement.");
     var dropDownHeader = this.ownerDocument.createElement("div");
     $(dropDownHeader).addClass("xDropdown-header");
     var dropDownButton = this.ownerDocument.createElement("button");
     $(dropDownButton).addClass("xDropdown-header-toggle");
-    $(dropDownButton).setAttribute('title',"Open menu");
+    require(['xwiki-l10n!menu-ui-translation-keys'], function(l10n) {
+      if($(dropDownButton).parent().parent().hasClass('open')){
+        $(dropDownButton).attr('title',l10n['closeSubMenu']);
+      }else{
+        $(dropDownButton).attr('title',l10n['openSubMenu']);
+      }
+    });
+
+    dropDownButton.addEventListener('click',function(){
+      console.log("Clicked toggle button.");
+      //Swaps the state of the submenu.
+      var toggable = $(this).parent().parent();
+      toggable.toggleClass('open');
+      $(dropDownButton).attr('title',"Open menu");
+      require(['xwiki-l10n!menu-ui-translation-keys'], function(l10n) {
+        if(toggable.hasClass('open')){
+          $(dropDownButton).attr('title',l10n['closeSubMenu']);
+        }else{
+          $(dropDownButton).attr('title',l10n['openSubMenu']);
+        }
+      });
+    });
     dropDownHeader.append($(this).contents()[0]);
     dropDownHeader.append(dropDownButton);
     $(this).prepend(dropDownHeader);
-  });
-
-  // Collapsible menu behavior.
-  $('.menu-vertical.collapsible').each(function(){
-    var open = $(this).hasClass('open');
-    $(this).find('li ul').each(function() {
-      $(this).addClass('xDropdown-menu').parent().addClass('xDropdown' + (open ? ' open' : ''));
-      // Wrap everything (including text nodes) before the sub-menu in a DIV that will toggle its state.
-      var toggle = this.ownerDocument.createElement('div');
-      $(this).parent().prepend(toggle);
-      for(var next = toggle.nextSibling; next != this; next = toggle.nextSibling) {
-        toggle.appendChild(next);
-      }
-      $(toggle).addClass('xDropdown-toggle').on('click', function() {
-        $(this).parent().toggleClass('open');
-      });
-    });
+    $(dropDownHeader).next().addClass('xDropdown-menu');
   });
 
   // In case of horizontal responsive menus, make sub-submenus in the navbar work on mobile devices
@@ -421,7 +439,7 @@ $menuTemplateDoc.content.replace('{', '')
   z-index: 1000;
 }
 
-.skin-colibri .menu-horizontal li:hover &gt; ul, li:focus-within &gt; ul {
+.skin-colibri .menu-horizontal li:hover &gt; ul {
   display: block;
 }
 
@@ -466,7 +484,7 @@ $menuTemplateDoc.content.replace('{', '')
   cursor: pointer;
 }
 
-.skin-colibri .menu-vertical .xDropdown-toggle:hover, .xDropdown-toggle:focus-within {
+.skin-colibri .menu-vertical .xDropdown-toggle:hover {
   background-color: $theme.highlightColor;
 }
 
@@ -611,6 +629,29 @@ $menuTemplateDoc.content.replace('{', '')
   }
 }
 .menu {
+  .xDropdown{
+    &gt; .xDropdown-header &gt; .xDropdown-header-toggle:before{
+        transform: rotate(90deg);
+      }
+    &amp;.open &gt; .xDropdown-header &gt; .xDropdown-header-toggle:before{
+      transform: rotate(0);
+    }
+  }
+  .xDropdown-header-toggle{
+    background: transparent;
+    border:none;
+    border-radius: @border-radius-base;
+    margin: (@line-height-computed / 4);
+    line-height: (@line-height-computed / 2) + 2;
+    &amp;:hover, :focus{
+      background-color: @dropdown-bg;
+    }
+    &amp;:before{
+      .caret;
+      margin-left: 0px;
+      content: '';
+    }
+  }
   &amp;.menu-vertical {
     ul {
       list-style-type: none;
@@ -632,32 +673,8 @@ $menuTemplateDoc.content.replace('{', '')
     .xDropdown-menu {
       display: none;
     }
-    .xDropdown-toggle {
-      cursor: pointer;
-      position: relative;
-      &amp;:hover, &amp;:focus-within {
-        background-color: @nav-link-hover-bg;
-      }
-      &amp;:after {
-        .caret;
-        content: '';
-        /* Positioning */
-        position: absolute;
-        margin-top: @line-height-computed / 3;
-        right: 1em;
-        /* Collapsed arrow style */
-        border-bottom: 4px solid transparent;
-        border-right: 4px solid;
-        border-top: 4px solid transparent;
-      }
-    }
     .xDropdown.open {
-      &gt; .xDropdown-toggle:after {
-        /* Expanded arrow style */
-        .caret;
-        margin-top: @line-height-computed / 2;
-      }
-      &gt; .xDropdown-menu {
+      &gt; ul {
         display: block;
       }
     }
@@ -671,6 +688,14 @@ $menuTemplateDoc.content.replace('{', '')
     .box-shadow(0 2px 8px rgba(0,0,0,0.4) inset);
     min-height: @navbar-height;
     padding-left: 25px;
+    .xDropdown.open {
+      &gt; ul {
+        display: block;
+      }
+    }
+    .xDropdown:hover &gt; .xDropdown-header &gt; .xDropdown-header-toggle:before{
+      transform: rotate(0);
+    }
     &amp; &gt; ul {
       padding-left: 0;
       list-style-type: none;
@@ -686,7 +711,7 @@ $menuTemplateDoc.content.replace('{', '')
         }
         line-height: @line-height-computed;
         color: @navbar-default-link-color;
-        &amp;:hover, &amp;:focus-within {
+        &amp;:hover {
           color: @navbar-default-link-hover-color;
           background-color: @navbar-default-link-hover-bg;
           background-color: @navbar-default-link-active-bg;
@@ -700,7 +725,7 @@ $menuTemplateDoc.content.replace('{', '')
         /* Links inside menu */
         a {
           color: @navbar-default-link-color;
-          &amp;:hover, &amp;:focus-within {
+          &amp;:hover{
             text-decoration: none;
           }
         }
@@ -709,6 +734,17 @@ $menuTemplateDoc.content.replace('{', '')
           /* Limit the height to the nav height minus the padding and minus border */
           max-height: @navbar-height - (2 * @navbar-padding-vertical) - 2px;
           overflow: hidden;
+          &amp;.xDropdown-header{
+            /* No border on the dropdown header */
+            max-height: @navbar-height - (2 * @navbar-padding-vertical);
+          }
+        }
+        /*Navbar headers.*/
+        &amp; &gt; .xDropdown-header &gt; .xDropdown-header-toggle{
+          &amp;:hover, &amp;:focus{
+            /* Change background color of the caret when hovering on the navbar.*/
+            background-color: @navbar-default-bg;
+          }
         }
         /* Separator vertical inside menu */
         &amp;:empty {
@@ -753,7 +789,7 @@ $menuTemplateDoc.content.replace('{', '')
             color: @dropdown-link-color;
             overflow: hidden;
             text-overflow: ellipsis; // Displaying ... if the text is too long
-            &amp;:hover, &amp;:focus-within {
+            &amp;:hover {
               /* &amp;:extend(.dropdown-menu&gt;li&gt;a:hover); */
               text-decoration: none;
               color: @dropdown-link-hover-color;
@@ -771,7 +807,7 @@ $menuTemplateDoc.content.replace('{', '')
             color: @dropdown-link-color;
             /* Empty dropdowns should have height in order to display the arrow */
             min-height: 2 * @font-size-base;
-            &amp;:hover, &amp;:focus-within {
+            &amp;:hover{
               text-decoration: none;
               color: @dropdown-link-hover-color;
               background-color: @dropdown-link-hover-bg;
@@ -803,23 +839,8 @@ $menuTemplateDoc.content.replace('{', '')
     /* Stylization: Generic */
     li {
       /* Display submenus on hover */
-      &amp;:hover &gt; ul, &amp;:focus-within &gt; ul {
+      &amp;:hover &gt; ul {
         display: block;
-      }
-      /* Display an arrow for expandable items */
-      &amp;.xDropdown {
-        &amp; .xDropdown-header {
-          display: inline-block;
-          &amp; .xDropdown-header-toggle{
-            all: inherit;
-            .caret;
-            content: '';
-            margin-left: .5em;
-            &amp;:focus{
-              outline:unset;
-            }
-          }
-        }
       }
     }
     /* The only way to have a menu with more than 2 levels without JavaScript is to use a fixed width. */
@@ -864,14 +885,14 @@ $menuTemplateDoc.content.replace('{', '')
             /* Links inside menu */
             a {
               color: @navbar-default-link-color;
-              &amp;:hover, &amp;:focus-within {
+              &amp;:hover {
                 /* Preserve the styling from dropdown */
               }
             }
             /* Submenus inside menu */
             &amp;.xDropdown {
               color: @navbar-default-link-color;
-              &amp;:hover, &amp;:focus-within {
+              &amp;:hover {
                 background-color: transparent;
                 color: inherit;
               }

--- a/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuTranslations.xml
+++ b/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuTranslations.xml
@@ -84,6 +84,10 @@ rendering.macro.menu.parameter.type.name=Type
 rendering.macro.menu.parameter.type.description=The optional menu type determines the menu appearance and behaviour. The supported values are: horizontal (default value) and vertical.
 rendering.macro.menu.content.description=Define the menu structure using wiki syntax. Each menu item should be a list item and should contain the menu item label or link. You can use nested lists for sub-menu items.
 
+# Menu Extension
+menu.ui.openSubMenu=Open the submenu.
+menu.ui.closeSubMenu=Close the submenu.
+
 # Menu WebHome
 menu.description=This is a simple application that helps you create navigation menus to be displayed either horizontally as a top bar after the page header or vertically in a side panel.</content>
   <object>


### PR DESCRIPTION
**Jira:**
https://jira.xwiki.org/browse/XWIKI-19725

**PR Changes:**

- Two new translation values for the state of the dropdowns.
- Buttons for navigation in the menus in place of the carets.
- Aria attributes on menus
- Rotating carets for horizontal menus (already on vertical menus)
- Instead of being exclusively on the pseudo-class :hover , horizontal dropdown menus, like vertical ones, are now using an additional "open" class on the container (see https://www.w3.org/WAI/tutorials/menus/flyout/#use-button-as-toggle )

For a keyboard user, navigation is now possible. Moreover, this implementation respects the [standards](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html) and allows to expand/minimize parts of the menu.


**View:**
Example of tabbing order through the menu (displayed with Firefox Inspector accessibility tool):
![19725TabbingOrderExample](https://user-images.githubusercontent.com/28761965/217265433-a8422b2e-8d06-4477-a3f3-6a829f97c7cc.png)

Visual Accessibility report made with the WAVE Firefox extension:
![19725WaveReport](https://user-images.githubusercontent.com/28761965/217266391-45516deb-443f-40d3-a80e-68dbe2dbc52b.png)

Usage Demo:

https://user-images.githubusercontent.com/28761965/217278716-addc6abc-d2be-4015-982b-633923c37794.mp4

