### PR TITLE
XWIKI-17325  The page title field cannot be made mandatory at space level

### DIFF
--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/Title.xml
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/Title.xml
@@ -53,7 +53,7 @@
   #end
   {{html clean="false"}}
   &lt;input type="text" name="$name" value="$!escapetool.xml($value)"
-    #if ($xwiki.getXWikiPreference('xwiki.title.mandatory') == 1)class="required"#end/&gt;
+    #if ($xwiki.getSpacePreference('xwiki.title.mandatory') == 1)class="required"#end/&gt;
   {{/html}}
 #elseif ("$!type" != '')
   ## Render the title of the current document.

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editmeta.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editmeta.vm
@@ -41,7 +41,7 @@
   </dt>
   <dd>
     <input type="text" id="xwikidoctitleinput" name="title" value="$escapetool.xml("$!docTitle")" 
-      class="#if($xwiki.getXWikiPreference('xwiki.title.mandatory') == 1)required#end"/>
+      class="#if($xwiki.getSpacePreference('xwiki.title.mandatory') == 1)required#end"/>
   </dd>
 </dl>
 #end


### PR DESCRIPTION
* we should check first if the current space is expecting the title to be mandatory
* using #getSpacePreference(String) will eventually fallback on a #getXWikiPreference() method