### PR TITLE
XWIKI-13786-3: Accessibility problem with rights management's checkboxes states

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/EditRightsPane.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/EditRightsPane.java
@@ -72,7 +72,7 @@ public class EditRightsPane extends BaseElement
             return values()[(ordinal() + 1) % values().length];
         }
 
-        static State getButtonState(WebElement button)
+        static State getButtonImageState(WebElement button)
         {
             for (State s : values()) {
                 //  The URL may contain query string parameters (e.g. starting with 11.1RC1 the resource URLs can now
@@ -119,9 +119,9 @@ public class EditRightsPane extends BaseElement
      */
     public State getGuestRight(String rightName)
     {
-        final By iconLocator = By.xpath(String.format("//tr[@id='unregistered']/td[@data-title='%s']/img", rightName));
+        final By iconLocator = By.xpath(String.format("//tr[@id='unregistered']/td[@data-title='%s']/button/img", rightName));
         final WebElement icon = getDriver().findElement(iconLocator);
-        return State.getButtonState(icon);
+        return State.getButtonImageState(icon);
     }
 
     public State getRight(String entityName, Right right)
@@ -142,10 +142,10 @@ public class EditRightsPane extends BaseElement
         final By iconLocator =
             By.xpath(String.format(
                 "//*[@id='usersandgroupstable-display']//td[@class='username']/a[contains(@href, '%s')]"
-                    + "/../../td[@data-title='%s']/img",
+                    + "/../../td[@data-title='%s']/button/img",
                 entityName, rightName));
         final WebElement icon = getDriver().findElement(iconLocator);
-        return State.getButtonState(icon);
+        return State.getButtonImageState(icon);
     }
 
     public boolean hasEntity(String entityName)
@@ -172,9 +172,9 @@ public class EditRightsPane extends BaseElement
             getDriver().executeJavascript(
                 "window.__oldConfirm = window.confirm; window.confirm = function() { return true; };");
             final By buttonLocator = By.xpath(
-                String.format("*//tr[@id='unregistered']/td[@data-title='%s']/img", rightName));
+                String.format("*//tr[@id='unregistered']/td[@data-title='%s']/button/img", rightName));
             final WebElement button = getDriver().findElement(buttonLocator);
-            State currentState = State.getButtonState(button);
+            State currentState = State.getButtonImageState(button);
             button.click();
             // Note: Selenium 2.0a4 returns a relative URL when calling getAttribute("src") but since we moved to
             // Selenium 2.0a7 it returns a *full* URL even though the DOM has a relative URL as in:
@@ -212,9 +212,9 @@ public class EditRightsPane extends BaseElement
             final By buttonLocator =
                 By.xpath(
                     String.format("//*[@id='usersandgroupstable-display']//td[@class='username']"
-                        + "/a[contains(@href, '%s')]/../../td[@data-title='%s']/img", entityName, rightName));
+                        + "/a[contains(@href, '%s')]/../../td[@data-title='%s']/button/img", entityName, rightName));
             final WebElement button = getDriver().findElement(buttonLocator);
-            State currentState = State.getButtonState(button).getNextState();
+            State currentState = State.getButtonImageState(button).getNextState();
             button.click();
             // Note: Selenium 2.0a4 returns a relative URL when calling getAttribute("src") but since we moved to
             // Selenium 2.0a7 it returns a *full* URL even though the DOM has a relative URL as in:


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-13786

Continuation of https://github.com/xwiki/xwiki-platform/pull/2051

Fixed the `EditRightsPane` BaseElement to take into account the image wrapping.

CI Fails:
* https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/master/6524/testReport/org.xwiki.administration.test.ui/AllITs$NestedUsersGroupsRightsManagementIT/Platform_Builds___main___integration_tests___IT_for_xwiki_platform_core_xwiki_platform_administration_xwiki_platform_administration_test_xwiki_platform_administration_test_docker___Build_for_IT_for_xwiki_platform_core_xwiki_platform_administration_xwiki_platform_administration_test_xwiki_platform_administration_test_docker___createAndDeleteGroup_TestUtils__TestReference_/
* https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/master/lastCompletedBuild/testReport/org.xwiki.index.test.ui.docker/AllITs$NestedAllDocsIT/Platform_Builds___main___integration_tests___IT_for_xwiki_platform_core_xwiki_platform_index_xwiki_platform_index_test_xwiki_platform_index_test_docker___Build_for_IT_for_xwiki_platform_core_xwiki_platform_index_xwiki_platform_index_test_xwiki_platform_index_test_docker___verifyAllDocs_TestUtils__TestInfo__TestReference_/