### PR TITLE
minor: make private class final with default constructor

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/EditGroupModal.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/EditGroupModal.java
@@ -31,7 +31,7 @@ import org.xwiki.test.ui.po.LiveTableElement;
  */
 public class EditGroupModal extends BaseModal
 {
-    private static class ModalContent extends GroupEditPage
+    private static final class ModalContent extends GroupEditPage
     {
         @Override
         public void waitUntilPageIsReady()

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-io/src/main/java/org/xwiki/annotation/io/internal/migration/hibernate/R40001XWIKI7540DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-io/src/main/java/org/xwiki/annotation/io/internal/migration/hibernate/R40001XWIKI7540DataMigration.java
@@ -189,7 +189,7 @@ public class R40001XWIKI7540DataMigration extends AbstractHibernateDataMigration
      *
      * @version $Id$
      */
-    private class GetWorkToBeDoneHibernateCallback implements HibernateCallback<Object>
+    private final class GetWorkToBeDoneHibernateCallback implements HibernateCallback<Object>
     {
         @Override
         public Object doInHibernate(Session session) throws HibernateException, XWikiException
@@ -254,7 +254,7 @@ public class R40001XWIKI7540DataMigration extends AbstractHibernateDataMigration
      *
      * @version $Id$
      */
-    private class DoWorkOnDocumentHibernateCallback implements HibernateCallback<Object>
+    private final class DoWorkOnDocumentHibernateCallback implements HibernateCallback<Object>
     {
         /** @see #setDocumentReference(DocumentReference) */
         private DocumentReference documentReference;

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/DefaultUntypedRecordableEventTest.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/DefaultUntypedRecordableEventTest.java
@@ -40,7 +40,7 @@ public class DefaultUntypedRecordableEventTest
 {
     private DefaultUntypedRecordableEvent defaultUntypedRecordableEvent;
 
-    private class RandomRecordableEvent implements RecordableEvent
+    private final class RandomRecordableEvent implements RecordableEvent
     {
         @Override
         public boolean matches(Object o)

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-default/src/test/java/org/xwiki/eventstream/internal/DefaultRecordableEventConverterTest.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-default/src/test/java/org/xwiki/eventstream/internal/DefaultRecordableEventConverterTest.java
@@ -94,7 +94,7 @@ class DefaultRecordableEventConverterTest
         when(this.eventFactory.createRawEvent()).thenReturn(new DefaultEvent());
     }
 
-    private class MockedRecordableEvent implements RecordableEvent, TargetableEvent
+    private final class MockedRecordableEvent implements RecordableEvent, TargetableEvent
     {
         @Override
         public boolean matches(Object otherEvent) {

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/doc/InstalledExtensionDocumentTree.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/doc/InstalledExtensionDocumentTree.java
@@ -50,7 +50,7 @@ import org.xwiki.model.reference.SpaceReference;
 @Singleton
 public class InstalledExtensionDocumentTree
 {
-    private static class InstalledExtensionDocumentTreeNode
+    private static final class InstalledExtensionDocumentTreeNode
     {
         public Set<Locale> customizedLocales;
 

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-tests/src/test/it/org/xwiki/flamingo/test/ui/HTMLExportIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-tests/src/test/it/org/xwiki/flamingo/test/ui/HTMLExportIT.java
@@ -62,7 +62,7 @@ public class HTMLExportIT extends AbstractTest
         void assertResult();
     }
 
-    private class TopPageValidator implements PageValidator
+    private final class TopPageValidator implements PageValidator
     {
         private boolean result;
 
@@ -87,7 +87,7 @@ public class HTMLExportIT extends AbstractTest
         }
     }
 
-    private class NestedPageValidator implements PageValidator
+    private final class NestedPageValidator implements PageValidator
     {
         private boolean result;
 

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-pageobjects/src/main/java/org/xwiki/livedata/test/po/TableLayoutElement.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-pageobjects/src/main/java/org/xwiki/livedata/test/po/TableLayoutElement.java
@@ -175,7 +175,7 @@ public class TableLayoutElement extends BaseElement
         }
     }
 
-    private static class DatePatternMatcher extends TypeSafeMatcher<WebElement>
+    private static final class DatePatternMatcher extends TypeSafeMatcher<WebElement>
     {
         private static final String REGEX = "\\d{4}/\\d{2}/\\d{2} \\d{2}:\\d{2}";
 

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/DefaultQuoteService.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/DefaultQuoteService.java
@@ -101,7 +101,7 @@ public class DefaultQuoteService implements QuoteService
         }
     }
 
-    private class RenderFunction implements Function<Block, String>
+    private final class RenderFunction implements Function<Block, String>
     {
         @Override
         public String apply(Block mentionBlock)

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/reference/EntityReferenceSet.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/reference/EntityReferenceSet.java
@@ -40,7 +40,7 @@ import org.xwiki.model.EntityType;
  */
 public class EntityReferenceSet
 {
-    private static class EntityReferenceEntryChildren
+    private static final class EntityReferenceEntryChildren
     {
         public EntityType childrenType;
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/IntervalUsersManager.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/IntervalUsersManager.java
@@ -54,7 +54,7 @@ public class IntervalUsersManager
 {
     private static final int BATCH_SIZE = 100;
 
-    private static class WikiEntry
+    private static final class WikiEntry
     {
         private final Map<NotificationEmailInterval, List<DocumentReference>> usersPerInterval =
             new ConcurrentHashMap<>();

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/live/LiveNotificationEmailListener.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/live/LiveNotificationEmailListener.java
@@ -80,7 +80,7 @@ public class LiveNotificationEmailListener extends AbstractEventListener
      * Thread used for triggering {@link LiveNotificationEmailManager#run()} when needed (ie : when an event grace time
      * has ended).
      */
-    private class NotificationGraceTimeRunnable implements Runnable
+    private final class NotificationGraceTimeRunnable implements Runnable
     {
         @Override
         public void run()

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/src/main/java/org/xwiki/notifications/preferences/internal/DefaultTargetableNotificationPreferenceBuilder.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/src/main/java/org/xwiki/notifications/preferences/internal/DefaultTargetableNotificationPreferenceBuilder.java
@@ -45,7 +45,7 @@ public class DefaultTargetableNotificationPreferenceBuilder implements Targetabl
 {
     private TargetablePreference preference;
 
-    private class TargetablePreference extends AbstractNotificationPreference
+    private final class TargetablePreference extends AbstractNotificationPreference
             implements TargetableNotificationPreference
     {
         /*

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/DefaultParametrizedNotificationManager.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/DefaultParametrizedNotificationManager.java
@@ -259,7 +259,7 @@ public class DefaultParametrizedNotificationManager implements ParametrizedNotif
         return events.stream().map(Event::getId).collect(Collectors.toList());
     }
 
-    private class BestSimilarity
+    private final class BestSimilarity
     {
         public int value;
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/doc/ListAttachmentArchive.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/doc/ListAttachmentArchive.java
@@ -379,7 +379,7 @@ public class ListAttachmentArchive extends XWikiAttachmentArchive
     /**
      * A comparator which compares attachments by version number.
      */
-    private static class XWikiAttachmentVersionComparator implements Comparator<XWikiAttachment>
+    private static final class XWikiAttachmentVersionComparator implements Comparator<XWikiAttachment>
     {
         /**
          * A single instance to use instead of constructing one each time.

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/ImplicitlyAllowedValuesDBListQueryBuilder.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/ImplicitlyAllowedValuesDBListQueryBuilder.java
@@ -50,7 +50,7 @@ import com.xpn.xwiki.objects.classes.DBTreeListClass;
 @Singleton
 public class ImplicitlyAllowedValuesDBListQueryBuilder implements QueryBuilder<DBListClass>
 {
-    private static class DBListQuerySpec
+    private static final class DBListQuerySpec
     {
         public String wiki;
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/AbstractDataMigrationManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/AbstractDataMigrationManager.java
@@ -124,7 +124,7 @@ public abstract class AbstractDataMigrationManager implements DataMigrationManag
     /**
      * Internal class used to prevent double checking of the database during migration operation.
      */
-    private static class ThreadLock extends ThreadLocal<Integer>
+    private static final class ThreadLock extends ThreadLocal<Integer>
     {
         @Override
         protected Integer initialValue()
@@ -256,7 +256,7 @@ public abstract class AbstractDataMigrationManager implements DataMigrationManag
     /**
      * Internal class used to clean the database version cache on wiki deletion.
      */
-    private class WikiDeletedEventListener implements EventListener
+    private final class WikiDeletedEventListener implements EventListener
     {
         @Override
         public String getName()

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R35100XWIKI7564DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R35100XWIKI7564DataMigration.java
@@ -105,7 +105,7 @@ public class R35100XWIKI7564DataMigration extends AbstractHibernateDataMigration
      *
      * @version $Id$
      */
-    private static class R35100Work implements Work
+    private static final class R35100Work implements Work
     {
         @Override
         public void execute(Connection connection) throws SQLException

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R35101XWIKI7645DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R35101XWIKI7645DataMigration.java
@@ -107,7 +107,7 @@ public class R35101XWIKI7645DataMigration extends AbstractHibernateDataMigration
      *
      * @version $Id$
      */
-    private static class R35101Work implements Work
+    private static final class R35101Work implements Work
     {
         @Override
         public void execute(Connection connection) throws SQLException

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R40000XWIKI6990DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R40000XWIKI6990DataMigration.java
@@ -117,7 +117,7 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
     private static final String INTERNAL = "internal";
 
     /** Stub statistic class used to compute new ids from existing objects. */
-    private static class StatsIdComputer extends XWikiStats
+    private static final class StatsIdComputer extends XWikiStats
     {
         private static final long serialVersionUID = 1L;
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R42000XWIKI7726DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R42000XWIKI7726DataMigration.java
@@ -94,7 +94,7 @@ public class R42000XWIKI7726DataMigration extends AbstractHibernateDataMigration
      *
      * @version $Id$
      */
-    private static class R42000Work implements Work
+    private static final class R42000Work implements Work
     {
         @Override
         public void execute(Connection connection) throws SQLException

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R54600TranslationDataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R54600TranslationDataMigration.java
@@ -76,7 +76,7 @@ public class R54600TranslationDataMigration extends AbstractHibernateDataMigrati
         });
     }
 
-    private static class R54600Work implements Work
+    private static final class R54600Work implements Work
     {
         @Override
         public void execute(Connection connection) throws SQLException

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R72000XWIKI12153DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R72000XWIKI12153DataMigration.java
@@ -85,7 +85,7 @@ public class R72000XWIKI12153DataMigration extends AbstractHibernateDataMigratio
         });
     }
 
-    private class R72000Work implements Work
+    private final class R72000Work implements Work
     {
         @Override
         public void execute(Connection connection) throws SQLException

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/doc/BaseObjectsTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/doc/BaseObjectsTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 public class BaseObjectsTest
 {
-    private static class TestBaseObject extends BaseObject
+    private static final class TestBaseObject extends BaseObject
     {
         @Override
         public String toString()

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/DownloadActionTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/DownloadActionTest.java
@@ -775,7 +775,7 @@ class DownloadActionTest
         verifyResponseExpectations(d.getTime(), this.fileContent.length);
     }
 
-    private static class StubServletOutputStream extends ServletOutputStream
+    private static final class StubServletOutputStream extends ServletOutputStream
     {
         public ByteArrayOutputStream baos = new ByteArrayOutputStream();
 

--- a/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/EscapeLikeParametersQuery.java
+++ b/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/EscapeLikeParametersQuery.java
@@ -154,7 +154,7 @@ public class EscapeLikeParametersQuery extends WrappingQuery
         return statement.toString();
     }
 
-    private class XWikiExpressionVisitor extends ExpressionVisitorAdapter
+    private final class XWikiExpressionVisitor extends ExpressionVisitorAdapter
     {
         @Override
         public void visit(LikeExpression expr)
@@ -166,7 +166,7 @@ public class EscapeLikeParametersQuery extends WrappingQuery
         }
     }
 
-    private class XWikiLikeExpressionVisitor extends ExpressionVisitorAdapter
+    private final class XWikiLikeExpressionVisitor extends ExpressionVisitorAdapter
     {
         @Override
         public void visit(JdbcParameter parameter)

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/DefaultSolrIndexer.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/DefaultSolrIndexer.java
@@ -182,7 +182,7 @@ public class DefaultSolrIndexer implements SolrIndexer, Initializable, Disposabl
      * 
      * @version $Id$
      */
-    private class Resolver extends AbstractXWikiRunnable
+    private final class Resolver extends AbstractXWikiRunnable
     {
         @Override
         public void runInternal()

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/RightMap.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/RightMap.java
@@ -269,7 +269,7 @@ public class RightMap<V> extends AbstractMap<Right, V> implements Serializable, 
     /**
      * Private right set for representing keys of this map.
      */
-    private class RightSet extends AbstractSet<Right>
+    private final class RightSet extends AbstractSet<Right>
     {
         @Override
         public Iterator<Right> iterator()
@@ -316,7 +316,7 @@ public class RightMap<V> extends AbstractMap<Right, V> implements Serializable, 
     /**
      * Private value collection for representing value of this map.
      */
-    private class Values extends AbstractCollection<V>
+    private final class Values extends AbstractCollection<V>
     {
         @Override
         public Iterator<V> iterator()
@@ -361,7 +361,7 @@ public class RightMap<V> extends AbstractMap<Right, V> implements Serializable, 
     /**
      * Private EntrySet for representing this map.
      */
-    private class EntrySet extends AbstractSet<Entry<Right, V>>
+    private final class EntrySet extends AbstractSet<Entry<Right, V>>
     {
         @Override
         public Iterator<Entry<Right, V>> iterator()
@@ -482,7 +482,7 @@ public class RightMap<V> extends AbstractMap<Right, V> implements Serializable, 
     /**
      * Private iterator for keys.
      */
-    private class RightIterator extends AbstractRightMapIterator<Right>
+    private final class RightIterator extends AbstractRightMapIterator<Right>
     {
         @Override
         public Right next()
@@ -498,7 +498,7 @@ public class RightMap<V> extends AbstractMap<Right, V> implements Serializable, 
     /**
      * Private iterator for values.
      */
-    private class ValueIterator extends AbstractRightMapIterator<V>
+    private final class ValueIterator extends AbstractRightMapIterator<V>
     {
         @Override
         public V next()
@@ -514,7 +514,7 @@ public class RightMap<V> extends AbstractMap<Right, V> implements Serializable, 
     /**
      * Private iterator for entries.
      */
-    private class EntryIterator extends AbstractRightMapIterator<Entry<Right, V>> implements Map.Entry<Right, V>
+    private final class EntryIterator extends AbstractRightMapIterator<Entry<Right, V>> implements Map.Entry<Right, V>
     {
         @Override
         public Map.Entry<Right, V> next()

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/DefaultAuthorizationManagerIntegrationTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/DefaultAuthorizationManagerIntegrationTest.java
@@ -816,7 +816,7 @@ class DefaultAuthorizationManagerIntegrationTest extends AbstractAuthorizationTe
             nullValue());
     }
 
-    private class CustomRightDescription implements RightDescription
+    private final class CustomRightDescription implements RightDescription
     {
         @Override
         public String getName()

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-bridge/src/main/java/org/xwiki/security/authorization/internal/XWikiCachingRightService.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-bridge/src/main/java/org/xwiki/security/authorization/internal/XWikiCachingRightService.java
@@ -150,7 +150,7 @@ public class XWikiCachingRightService implements XWikiRightService
     /**
      * Specialized map with a chainable put action to avoid exceeding code complexity during initialization.
      */
-    private static class ActionMap extends HashMap<String, Right>
+    private static final class ActionMap extends HashMap<String, Right>
     {
         /** Serialization identifier for conformance to Serializable. */
         private static final long serialVersionUID = 1;

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-bridge/src/test/java/org/xwiki/security/authorization/testwikibuilding/AbstractTestWiki.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-bridge/src/test/java/org/xwiki/security/authorization/testwikibuilding/AbstractTestWiki.java
@@ -106,7 +106,7 @@ public abstract class AbstractTestWiki
     /**
      * A SAX handler for building a test wiki.
      */
-    private class WikiBuilder extends DefaultHandler
+    private final class WikiBuilder extends DefaultHandler
     {
 
         /**
@@ -157,7 +157,7 @@ public abstract class AbstractTestWiki
         /**
          * Convenience class for declaring element builders.
          */
-        private class DeclareElementBuilders {
+        private final class DeclareElementBuilders {
 
             /**
              * @param name The XML element name.

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-transaction/src/test/java/org/xwiki/store/TransactionRunnableTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-transaction/src/test/java/org/xwiki/store/TransactionRunnableTest.java
@@ -502,7 +502,7 @@ public class TransactionRunnableTest
         this.hasRun = true;
     }
 
-    private class CustomException extends Exception
+    private final class CustomException extends Exception
     {
         // Does nothing different.
     }

--- a/xwiki-platform-core/xwiki-platform-svg/xwiki-platform-svg-rasterizer/src/test/java/org/xwiki/platform/svg/internal/BatikSVGRasterizerTest.java
+++ b/xwiki-platform-core/xwiki-platform-svg/xwiki-platform-svg-rasterizer/src/test/java/org/xwiki/platform/svg/internal/BatikSVGRasterizerTest.java
@@ -301,7 +301,7 @@ public class BatikSVGRasterizerTest
         }
     }
 
-    private class CapturingOutputStream extends ServletOutputStream
+    private final class CapturingOutputStream extends ServletOutputStream
     {
         private ByteArrayOutputStream out = new ByteArrayOutputStream();
 

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-integration/src/test/java/org/xwiki/test/integration/junit5/ValidateConsoleExtensionTest.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-integration/src/test/java/org/xwiki/test/integration/junit5/ValidateConsoleExtensionTest.java
@@ -59,7 +59,7 @@ import static org.xwiki.test.integration.junit5.ValidateConsoleExtension.SKIP_PR
  */
 public class ValidateConsoleExtensionTest
 {
-    private static class ValidateConsoleExtensionTestSetup implements BeforeAllCallback, AfterAllCallback
+    private static final class ValidateConsoleExtensionTestSetup implements BeforeAllCallback, AfterAllCallback
     {
         private static String skipValue;
 

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/DefaultUserManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/DefaultUserManagerTest.java
@@ -58,7 +58,7 @@ class DefaultUserManagerTest
     @Named("context")
     private ComponentManager contextComponentManager;
 
-    private class TestUserReference implements UserReference
+    private final class TestUserReference implements UserReference
     {
         @Override
         public boolean isGlobal()

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/DefaultUserPropertiesResolverTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/DefaultUserPropertiesResolverTest.java
@@ -72,7 +72,7 @@ public class DefaultUserPropertiesResolverTest
     @MockComponent
     private UserReferenceResolver<CurrentUserReference> currentUserReferenceUserReferenceResolver;
 
-    private class TestUserReference implements UserReference
+    private final class TestUserReference implements UserReference
     {
         @Override
         public boolean isGlobal()

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-storage/src/test/it/org/xwiki/test/storage/profiles/ForEachProfileSuite.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-storage/src/test/it/org/xwiki/test/storage/profiles/ForEachProfileSuite.java
@@ -143,7 +143,7 @@ public class ForEachProfileSuite extends ClasspathSuite
     /**
      * Tester which will help ClassPathSuite find all Profiles.
      */
-    private static class IsProfileTester implements ClassTester
+    private static final class IsProfileTester implements ClassTester
     {
         public static IsProfileTester INSTANCE = new IsProfileTester();
 


### PR DESCRIPTION
minor: make private class final with default constructor

This is part of https://github.com/checkstyle/checkstyle/pull/12737

According to the https://docs.oracle.com/javase/specs/jls/se17/html/jls-8.html#jls-8.8.9 The default constructor has the same access modifier as the class.
and according to the check https://checkstyle.org/config_design.html#FinalClass a class that has only private constructors and has no descendant classes is declared as final.