### PR TITLE
XWIKI-20670: Location icons are displayed smaller and without grey background in Create Page view

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/breadcrumbs.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/breadcrumbs.less
@@ -55,7 +55,7 @@
 
 /* TODO: Update the JS code to use a more specific CSS selector when updating the content of the actual breadcrumb,
   in order to eventually remove this rule and add the 'breadcrumb' class to the 'location-actions' node. */
-dd > .location-actions {
+dd > .breadcrumb-container > .location-actions {
   /* Retrieve style from the breadcrumb block. Needed for keyboard accessibility reorganization of the
   location-picker component. */
   .breadcrumb;

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/locationPicker.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/locationPicker.css
@@ -23,7 +23,7 @@
   flex-wrap: nowrap;
 }
 
-.location-picker > dd > .location-actions {
+.location-picker > dd > .breadcrumb-container > .location-actions {
   margin-bottom: 0;
   /* Keeps all actions on one line. */
   white-space: nowrap;


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-20670

Fixed a regression introduced in 
https://github.com/xwiki/xwiki-platform/pull/2049/commits/3580ea9292c002b5166a07212b7d102efb8bfc8a

The css selectors were not valid.
