### PR TITLE
XWIKI-19450: Several nav tags are used without aria-label

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/drawer.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/drawer.vm
@@ -21,7 +21,8 @@
 ##
 ## Display the drawer
 ##
-<nav class="drawer-nav" id="tmDrawer">
+<nav class="drawer-nav" id="tmDrawer"
+aria-label="$escapetool.xml($services.localization.render('core.menu.drawer.label'))">
   <ul class="drawer-menu">
     ##
     ## Drawer header (with elements concerning the current user: profile, login, logout, register, etc...)

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_macros.vm
@@ -31,7 +31,8 @@
 ###    Toplevel Menu
 ###
 #macro(xwikitopmenustart)
-  <nav class="navbar navbar-default actionmenu">
+  <nav class="navbar navbar-default actionmenu"
+  aria-label="$services.localization.render('core.menu.navbar.label')">
     <div class="container-fluid">
       ## Brand and toggle get grouped for better mobile display
       <div class="navbar-header">
@@ -163,14 +164,14 @@
 ###    Toplevel Menu entry separator
 ###
 #macro(xwikitopmenuseparator)
-  <li class="divider" role="separator"></li>
+  <li class="divider" role="separator" aria-hidden="true"></li>
 #end
 
 ###
 ###    Menu submenu separator
 ###
 #macro(submenuseparator)
-  <li class="divider" role="separator"></li>
+  <li class="divider" role="separator" aria-hidden="true"></li>
 #end
 
 ###

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-macro/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-macro/src/main/resources/ApplicationResources.properties
@@ -77,6 +77,8 @@ livedata.selection.infoBar.selectedCount={0} entries selected
 livedata.selection.infoBar.allSelected=All entries selected
 livedata.selection.infoBar.allSelectedBut=All entries selected but {0}
 
+livedata.pagination.label=Data page details
+livedata.pagination.index.label=Data page selection
 livedata.pagination.currentEntries=Entries {0} - {1} out of {2}
 livedata.pagination.pageSize=per page of
 livedata.pagination.page=page

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/LivedataPagination.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/LivedataPagination.vue
@@ -72,12 +72,13 @@
 
     <!--
       The actual pagination widget
-      It dislays the the available pages numbers, and change to them on click.
+      It displays the the available pages numbers, and change to them on click.
       Not all page numbers are show depending of the `pagination.maxShownPages`
       property in the Livedata meta config.
       Arrows can be shown to go to first, last, previous, next page.
     -->
-    <nav class="pagination-indexes">
+    <nav class="pagination-indexes"
+      :aria-label="$t('livedata.pagination.index.label')">
       {{ $t('livedata.pagination.page') }}
       <!--
         Go to First Page button

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/LivedataPagination.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/LivedataPagination.vue
@@ -28,11 +28,12 @@
 -->
 <template>
   <!-- Pagination -->
-  <nav class="livedata-pagination">
+  <nav class="livedata-pagination"
+    :aria-label="$t('livedata.pagination.label')">
 
     <!--
       Display the pagination current entry range
-      Can be shown / hiden by the `pagination.showEntryRange` property
+      Can be shown / hidden by the `pagination.showEntryRange` property
       in the Livedata meta config
     -->
     <span

--- a/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
@@ -1171,7 +1171,7 @@ $menuTemplateDoc.content.replace('{', '')
   #if ($stringtool.isBlank("$!id"))
     #set ($id = $wikimacro.context.getXDOM().getIdGenerator().generateUniqueId("M", "GeneratedMenuId"))
   #end
-  (% role="navigation" class="menu-horizontal-toggle" %)(((
+  (% role="navigation" class="menu-horizontal-toggle" aria-label="$services.localization.render('rendering.macro.menu.horizontal.label')" %)(((
     (% class="navbar-header" %)(((
       {{html}}
         &lt;button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#$!{escapetool.xml($id)}" aria-expanded="false"&gt;

--- a/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
@@ -1187,7 +1187,7 @@ $menuTemplateDoc.content.replace('{', '')
     )))
   )))
 #else
-  (% #if ("$!id" != '') id="${services.rendering.escape($id, 'xwiki/2.1')}"#end class="menu menu-${services.rendering.escape($!type, 'xwiki/2.1')}" %)(((
+  (% role="navigation" #if ("$!id" != '') id="${services.rendering.escape($id, 'xwiki/2.1')}"#end class="menu menu-${services.rendering.escape($!type, 'xwiki/2.1')}" aria-label="$services.localization.render('rendering.macro.menu.vertical.label')" %)(((
     {{wikimacrocontent/}}
   )))
 #end

--- a/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuTranslations.xml
+++ b/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuTranslations.xml
@@ -84,6 +84,9 @@ rendering.macro.menu.parameter.type.name=Type
 rendering.macro.menu.parameter.type.description=The optional menu type determines the menu appearance and behaviour. The supported values are: horizontal (default value) and vertical.
 rendering.macro.menu.content.description=Define the menu structure using wiki syntax. Each menu item should be a list item and should contain the menu item label or link. You can use nested lists for sub-menu items.
 
+# Accessibility labels
+rendering.macro.menu.horizontal.label=Horizontal custom menu
+
 # Menu WebHome
 menu.description=This is a simple application that helps you create navigation menus to be displayed either horizontally as a top bar after the page header or vertically in a side panel.</content>
   <object>

--- a/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuTranslations.xml
+++ b/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuTranslations.xml
@@ -86,6 +86,7 @@ rendering.macro.menu.content.description=Define the menu structure using wiki sy
 
 # Accessibility labels
 rendering.macro.menu.horizontal.label=Horizontal custom menu
+rendering.macro.menu.horizontal.label=Vertical custom menu
 
 # Menu WebHome
 menu.description=This is a simple application that helps you create navigation menus to be displayed either horizontally as a top bar after the page header or vertically in a side panel.</content>

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -954,6 +954,7 @@ core.minoredit.hide=Hide minor edits
 ### top menu
 core.menu.main.title=General Actions:
 core.menu.content.title=Page Actions:
+core.menu.navbar.label=Top level bar
 core.menu.goto.wiki=Go to Wiki
 core.menu.goto.space=Go to Space
 core.menu.goto.page=Go to Page
@@ -977,6 +978,7 @@ core.menu.edit.class=Class
 core.menu.edit.rights=Access Rights
 core.menu.edit.currentEditor=Edit{0}
 core.menu.drawer=Drawer
+core.menu.drawer.label=Top drawer menu
 core.menu.view.source=Source
 core.menu.view.comments=Comments
 core.menu.view.attachments=Attachments


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-19450
**PR Changes:**
* Added labels to the <nav> elements in the XWiki interface
* Added labels to the role="navigation" elements in the XWiki interface
(*Added role="navigation" to the vertical custom menus)
* Added translation entries for these labels