### PR TITLE
XWIKI-20637: Image overlaps lists when using start alignment and a mix with text wrap and the start alignment

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
@@ -260,6 +260,10 @@
 
 #xwikicontent {
   overflow: auto;
+  
+  ol, ul {
+    overflow: auto;
+  }
 }
 
 .document-header {


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-20637