### PR TITLE
XWIKI-20680: Contrast issues on the default theme

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemes/Iceberg.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemes/Iceberg.xml
@@ -896,10 +896,10 @@
       <btn-success-color/>
     </property>
     <property>
-      <btn-warning-bg>#000000</btn-warning-bg>
+      <btn-warning-bg>#ffd483</btn-warning-bg>
     </property>
     <property>
-      <btn-warning-bg>#ffd483</btn-warning-bg>
+      <btn-warning-color>#000000</btn-warning-color>
     </property>
     <property>
       <component-active-bg>@list-group-hover-bg</component-active-bg>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemes/Iceberg.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemes/Iceberg.xml
@@ -896,10 +896,10 @@
       <btn-success-color/>
     </property>
     <property>
-      <btn-warning-bg/>
+      <btn-warning-bg>#000000</btn-warning-bg>
     </property>
     <property>
-      <btn-warning-color/>
+      <btn-warning-bg>#ffd483</btn-warning-bg>
     </property>
     <property>
       <component-active-bg>@list-group-hover-bg</component-active-bg>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemes/Iceberg.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemes/Iceberg.xml
@@ -836,7 +836,7 @@
       <body-bg>#fafafa</body-bg>
     </property>
     <property>
-      <brand-danger/>
+      <brand-danger>#ca302c</brand-danger>
     </property>
     <property>
       <brand-info>#3bb2d0</brand-info>
@@ -854,7 +854,7 @@
       <breadcrumb-bg>#f8f8f8</breadcrumb-bg>
     </property>
     <property>
-      <breadcrumb-color/>
+      <breadcrumb-color>#727272</breadcrumb-color>
     </property>
     <property>
       <breadcrumb-separator/>
@@ -884,13 +884,13 @@
       <btn-info-color/>
     </property>
     <property>
-      <btn-primary-bg>#3E7CBC</btn-primary-bg>
+      <btn-primary-bg>#386da7</btn-primary-bg>
     </property>
     <property>
       <btn-primary-color>#fff</btn-primary-color>
     </property>
     <property>
-      <btn-success-bg/>
+      <btn-success-bg>#31754f</btn-success-bg>
     </property>
     <property>
       <btn-success-color/>
@@ -968,6 +968,10 @@
       <lessCode>/* Administration: Vertical Menus */
 @list-group-active-border: @list-group-border;
 
+/* Accessibility */
+@gray-light: #727272;
+@text-muted: @gray;
+
 /* Drawer */
 @xwiki-drawer-menu-item-hover-bg: @list-group-hover-bg;
 @xwiki-drawer-menu-item-hover-color: @list-group-link-hover-color;
@@ -979,13 +983,13 @@
 </lessCode>
     </property>
     <property>
-      <link-color>#3173b5</link-color>
+      <link-color>#2f6faf</link-color>
     </property>
     <property>
       <logo>logo.svg</logo>
     </property>
     <property>
-      <navbar-default-bg>#3E7CBC</navbar-default-bg>
+      <navbar-default-bg>#3E79BC</navbar-default-bg>
     </property>
     <property>
       <navbar-default-color>#fff</navbar-default-color>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemes/Iceberg.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemes/Iceberg.xml
@@ -968,8 +968,10 @@
       <lessCode>/* Administration: Vertical Menus */
 @list-group-active-border: @list-group-border;
 
-/* Accessibility */
+/* Increasing default contrast for accessibility. */
+/* Slight change on @gray-light to make it pass the 4.5 contrast threshold on a white background. */
 @gray-light: #727272;
+/* Gray-light is too light on a light backgrounds. @gray for muted text is easier to read. */
 @text-muted: @gray;
 
 /* Drawer */


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-20680

**PR changes:**
Colors on the flamingo colorTheme `Iceberg`:
*  \@navbar-default-bg : #3E7CBC → #3E79BC  (slightly darker blue)
*  \@link-color : #3173B5 → #2F6FAF (slightly darker blue)
* \@gray-light:#777777 → #727272 (slightly darker gray)
* \@breadcrumb-color:#777777 → #727272 (slightly darker gray)
* \@btn-primary-bg: #3e7cbc→ #386da7 (darker blue)
* \@text-muted: \@light-gray → \@gray
*  \@btn-success-bg: \@brand-success (#56b881) → #31754f (much darker green)
*  \@brand-danger: #d9534f  → #ca302c (darker red)


See https://forum.xwiki.org/t/fixing-a11y-contrast-issues-on-the-main-view/11917 for more details.