### PR TITLE
XRENDERING-708: Table of content does not support level skipping

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-toc/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-toc/pom.xml
@@ -46,5 +46,10 @@
       <artifactId>xwiki-platform-model-api</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-skin-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 </project>

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-toc/src/main/java/org/xwiki/rendering/internal/macro/toc/XWikiTocMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-toc/src/main/java/org/xwiki/rendering/internal/macro/toc/XWikiTocMacro.java
@@ -19,18 +19,25 @@
  */
 package org.xwiki.rendering.internal.macro.toc;
 
+import java.util.List;
+
+import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
+import org.xwiki.rendering.block.Block;
+import org.xwiki.rendering.macro.MacroExecutionException;
 import org.xwiki.rendering.macro.toc.XWikiTocMacroParameters;
+import org.xwiki.rendering.transformation.MacroTransformationContext;
+import org.xwiki.skinx.SkinExtension;
 
 /**
  * Generate a Table Of Contents based on the document sections.
  * <p>
  * We override the default Table of Contents macro because we want to associate a {@code DocumentReference} picker to
  * the {@code reference} parameter (using the {@code PropertyDisplayType} annotation).
- * 
+ *
  * @version $Id$
  * @since 11.5RC1
  */
@@ -39,11 +46,23 @@ import org.xwiki.rendering.macro.toc.XWikiTocMacroParameters;
 @Singleton
 public class XWikiTocMacro extends AbstractTocMacro<XWikiTocMacroParameters>
 {
+    @Inject
+    @Named("ssfx")
+    private SkinExtension ssfx;
+
     /**
      * Create and initialize the descriptor of the macro.
      */
     public XWikiTocMacro()
     {
         super(XWikiTocMacroParameters.class);
+    }
+
+    @Override
+    public List<Block> execute(XWikiTocMacroParameters parameters, String content, MacroTransformationContext context)
+        throws MacroExecutionException
+    {
+        this.ssfx.use("toc.css");
+        return super.execute(parameters, content, context);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-toc/src/main/java/org/xwiki/rendering/internal/macro/toc/XWikiTocMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-toc/src/main/java/org/xwiki/rendering/internal/macro/toc/XWikiTocMacro.java
@@ -37,7 +37,7 @@ import org.xwiki.skinx.SkinExtension;
  * <p>
  * We override the default Table of Contents macro because we want to associate a {@code DocumentReference} picker to
  * the {@code reference} parameter (using the {@code PropertyDisplayType} annotation).
- *
+ * 
  * @version $Id$
  * @since 11.5RC1
  */
@@ -47,7 +47,7 @@ import org.xwiki.skinx.SkinExtension;
 public class XWikiTocMacro extends AbstractTocMacro<XWikiTocMacroParameters>
 {
     @Inject
-    @Named("ssfx")
+    @Named("ssrx")
     private SkinExtension ssfx;
 
     /**

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-toc/src/main/resources/toc.css
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-toc/src/main/resources/toc.css
@@ -1,0 +1,3 @@
+.wikitoc li.nodirectchild {
+    list-style-type: none;
+}

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-toc/src/main/resources/toc.css
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-toc/src/main/resources/toc.css
@@ -1,3 +1,3 @@
 .wikitoc li.nodirectchild {
-    list-style-type: none;
+  list-style-type: none;
 }


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XRENDERING-708

Depends on https://github.com/xwiki/xwiki-rendering/pull/254

Apply a css style on toc item with no direct children of the level right below (e.g., an h3 following an h1), based on the `nodirectchild` css class.

Related forum post: https://forum.xwiki.org/t/annotating-table-of-content-entries-skipped-level/12070