### PR TITLE
XWIKI-20702: Allow to chose the fallback version in case of conflict when performing merge

### DIFF
--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -133,7 +133,7 @@
                   <ignore>true</ignore>
                   <code>java.method.addedToInterface</code>
                   <new>method org.xwiki.store.merge.MergeManagerResult&lt;com.xpn.xwiki.objects.ElementInterface, java.lang.Object&gt; com.xpn.xwiki.objects.ElementInterface::merge(com.xpn.xwiki.objects.ElementInterface, com.xpn.xwiki.objects.ElementInterface, com.xpn.xwiki.doc.merge.MergeConfiguration, com.xpn.xwiki.XWikiContext)</new>
-                  <justification>This method replaces the now deprecated old ElementInterface#merge method.</justification>
+                  <justification>Change needed to provide a merge operation taking into account the configuration: we cannot provide a default method as it would wrongly give the feeling that the operation succeeded.</justification>
                 </item>
               </differences>
             </revapi.differences>

--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -126,8 +126,30 @@
                  Single justification example:
             -->
             
-            
-            
+            <revapi.differences>
+              <justification>The MergeConfiguration should always have been specified for calling this
+                method, it became obvious when adding configurations we need to reuse.</justification>
+              <criticality>highlight</criticality>
+              <differences>
+                <item>
+                  <code>java.method.numberOfParametersChanged</code>
+                  <old>method void com.xpn.xwiki.objects.BaseProperty&lt;R extends org.xwiki.model.reference.EntityReference&gt;::mergeValue(java.lang.Object, java.lang.Object, com.xpn.xwiki.doc.merge.MergeResult)</old>
+                  <new>method void com.xpn.xwiki.objects.BaseProperty&lt;R extends org.xwiki.model.reference.EntityReference&gt;::mergeValue(java.lang.Object, java.lang.Object, com.xpn.xwiki.doc.merge.MergeConfiguration, com.xpn.xwiki.doc.merge.MergeResult)</new>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.numberOfParametersChanged</code>
+                  <old>method void com.xpn.xwiki.objects.LargeStringProperty::mergeValue(java.lang.Object, java.lang.Object, com.xpn.xwiki.doc.merge.MergeResult)</old>
+                  <new>method void com.xpn.xwiki.objects.LargeStringProperty::mergeValue(java.lang.Object, java.lang.Object, com.xpn.xwiki.doc.merge.MergeConfiguration, com.xpn.xwiki.doc.merge.MergeResult)</new>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.numberOfParametersChanged</code>
+                  <old>method void com.xpn.xwiki.objects.ListProperty::mergeValue(java.lang.Object, java.lang.Object, com.xpn.xwiki.doc.merge.MergeResult)</old>
+                  <new>method void com.xpn.xwiki.objects.ListProperty::mergeValue(java.lang.Object, java.lang.Object, com.xpn.xwiki.doc.merge.MergeConfiguration, com.xpn.xwiki.doc.merge.MergeResult)</new>
+                </item>
+              </differences>
+            </revapi.differences>
           </analysisConfiguration>
         </configuration>
       </plugin>

--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -126,14 +126,13 @@
                  Single justification example:
             -->
             <revapi.differences>
-              <justification>Needed changes for properly handling merge with fallback version.</justification>
+              <justification>Change needed to provide a merge operation taking into account the configuration: we cannot provide a default method as it would wrongly give the feeling that the operation succeeded. We consider this breaking change acceptable since it's unlikely anyone directly implements this interface.</justification>
               <criticality>highlight</criticality>
               <differences>
                 <item>
                   <ignore>true</ignore>
                   <code>java.method.addedToInterface</code>
                   <new>method org.xwiki.store.merge.MergeManagerResult&lt;com.xpn.xwiki.objects.ElementInterface, java.lang.Object&gt; com.xpn.xwiki.objects.ElementInterface::merge(com.xpn.xwiki.objects.ElementInterface, com.xpn.xwiki.objects.ElementInterface, com.xpn.xwiki.doc.merge.MergeConfiguration, com.xpn.xwiki.XWikiContext)</new>
-                  <justification>Change needed to provide a merge operation taking into account the configuration: we cannot provide a default method as it would wrongly give the feeling that the operation succeeded.</justification>
                 </item>
               </differences>
             </revapi.differences>

--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -125,28 +125,15 @@
 
                  Single justification example:
             -->
-            
             <revapi.differences>
-              <justification>The MergeConfiguration should always have been specified for calling this
-                method, it became obvious when adding configurations we need to reuse.</justification>
+              <justification>Needed changes for properly handling merge with fallback version.</justification>
               <criticality>highlight</criticality>
               <differences>
                 <item>
-                  <code>java.method.numberOfParametersChanged</code>
-                  <old>method void com.xpn.xwiki.objects.BaseProperty&lt;R extends org.xwiki.model.reference.EntityReference&gt;::mergeValue(java.lang.Object, java.lang.Object, com.xpn.xwiki.doc.merge.MergeResult)</old>
-                  <new>method void com.xpn.xwiki.objects.BaseProperty&lt;R extends org.xwiki.model.reference.EntityReference&gt;::mergeValue(java.lang.Object, java.lang.Object, com.xpn.xwiki.doc.merge.MergeConfiguration, com.xpn.xwiki.doc.merge.MergeResult)</new>
-                </item>
-                <item>
                   <ignore>true</ignore>
-                  <code>java.method.numberOfParametersChanged</code>
-                  <old>method void com.xpn.xwiki.objects.LargeStringProperty::mergeValue(java.lang.Object, java.lang.Object, com.xpn.xwiki.doc.merge.MergeResult)</old>
-                  <new>method void com.xpn.xwiki.objects.LargeStringProperty::mergeValue(java.lang.Object, java.lang.Object, com.xpn.xwiki.doc.merge.MergeConfiguration, com.xpn.xwiki.doc.merge.MergeResult)</new>
-                </item>
-                <item>
-                  <ignore>true</ignore>
-                  <code>java.method.numberOfParametersChanged</code>
-                  <old>method void com.xpn.xwiki.objects.ListProperty::mergeValue(java.lang.Object, java.lang.Object, com.xpn.xwiki.doc.merge.MergeResult)</old>
-                  <new>method void com.xpn.xwiki.objects.ListProperty::mergeValue(java.lang.Object, java.lang.Object, com.xpn.xwiki.doc.merge.MergeConfiguration, com.xpn.xwiki.doc.merge.MergeResult)</new>
+                  <code>java.method.addedToInterface</code>
+                  <new>method org.xwiki.store.merge.MergeManagerResult&lt;com.xpn.xwiki.objects.ElementInterface, java.lang.Object&gt; com.xpn.xwiki.objects.ElementInterface::merge(com.xpn.xwiki.objects.ElementInterface, com.xpn.xwiki.objects.ElementInterface, com.xpn.xwiki.doc.merge.MergeConfiguration, com.xpn.xwiki.XWikiContext)</new>
+                  <justification>This method replaces the now deprecated old ElementInterface#merge method.</justification>
                 </item>
               </differences>
             </revapi.differences>

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseCollection.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseCollection.java
@@ -837,7 +837,7 @@ public abstract class BaseCollection<R extends EntityReference> extends BaseElem
             PropertyInterface previousProperty = previousCollection.getField(diff.getPropName());
             PropertyInterface newProperty = newCollection.getField(diff.getPropName());
 
-            if (diff.getAction().equals(ObjectDiff.ACTION_PROPERTYADDED)) {
+            if (ObjectDiff.ACTION_PROPERTYADDED.equals(diff.getAction())) {
                 if (propertyResult == null) {
                     // Add if none has been added by user already
                     modifiableResult.safeput(diff.getPropName(),
@@ -853,7 +853,7 @@ public abstract class BaseCollection<R extends EntityReference> extends BaseElem
                     }
                     mergeResult.getLog().error("Collision found on property [{}]", newProperty.getReference());
                 }
-            } else if (diff.getAction().equals(ObjectDiff.ACTION_PROPERTYREMOVED)) {
+            } else if (ObjectDiff.ACTION_PROPERTYREMOVED.equals(diff.getAction())) {
                 if (propertyResult != null) {
                     if (propertyResult.equals(previousProperty)) {
                         // Delete if it's the same as previous one
@@ -869,7 +869,7 @@ public abstract class BaseCollection<R extends EntityReference> extends BaseElem
                     // Already removed from DB, lets assume the user is prescient
                     mergeResult.getLog().warn("Property [{}] already removed", previousProperty.getReference());
                 }
-            } else if (diff.getAction().equals(ObjectDiff.ACTION_PROPERTYCHANGED)) {
+            } else if (ObjectDiff.ACTION_PROPERTYCHANGED.equals(diff.getAction())) {
                 if (propertyResult != null) {
                     if (propertyResult.equals(previousProperty)) {
                         // Let some automatic migration take care of that modification between DB and new
@@ -878,7 +878,7 @@ public abstract class BaseCollection<R extends EntityReference> extends BaseElem
                         mergeResult.setModified(true);
                     } else if (!propertyResult.equals(newProperty)) {
                         // Try to apply 3 ways merge on the property
-                        // FIXME: we should deprecate mergeField and rewrite it properly, but it's lot of work
+                        // FIXME: we should deprecate mergeField and rewrite it properly, but it's a lot of work
                         // as it involves to also rewrite PropertyClass#mergeProperty
                         // right now we still use it, but we ensure that the configuration is used to modify the
                         // actual values, and not clones as it was the behaviour

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseProperty.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseProperty.java
@@ -228,6 +228,9 @@ public class BaseProperty<R extends EntityReference> extends BaseElement<R>
                     setValue(newValue);
                 } else {
                     // collision between current and new
+                    if (configuration.getConflictFallbackVersion() == MergeConfiguration.ConflictFallbackVersion.NEXT) {
+                        setValue(newValue);
+                    }
                     mergeResult.getLog().error("Collision found on property [{}] between from value [{}] and to [{}]",
                         getName(), getValue(), newValue);
                 }
@@ -237,6 +240,7 @@ public class BaseProperty<R extends EntityReference> extends BaseElement<R>
                 setValue(null);
             } else {
                 // collision between current and new
+                // We don't remove the value in fallback
                 mergeResult.getLog().error("Collision found on property [{}] between from value [{}] and to [{}]",
                     getName(), getValue(), newValue);
             }
@@ -248,7 +252,7 @@ public class BaseProperty<R extends EntityReference> extends BaseElement<R>
                 mergeResult.getLog().error("Collision found on property [{}] between from value [] and to []",
                     getName(), getValue(), newValue);
             } else if (!Objects.equals(newValue, getValue())) {
-                mergeValue(previousValue, newValue, mergeResult);
+                mergeValue(previousValue, newValue, configuration, mergeResult);
             }
         }
     }
@@ -261,7 +265,8 @@ public class BaseProperty<R extends EntityReference> extends BaseElement<R>
      * @param mergeResult merge report
      * @since 3.2M1
      */
-    protected void mergeValue(Object previousValue, Object newValue, MergeResult mergeResult)
+    protected void mergeValue(Object previousValue, Object newValue, MergeConfiguration mergeConfiguration,
+        MergeResult mergeResult)
     {
         // collision between current and new: don't know how to apply 3 way merge on unknown type
         mergeResult.getLog().error("Collision found on property [{}] between from value [{}] and to [{}]", getName(),

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseProperty.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseProperty.java
@@ -224,7 +224,7 @@ public class BaseProperty<R extends EntityReference> extends BaseElement<R>
     {
         MergeManagerResult<ElementInterface, Object> mergeManagerResult =
             this.merge(previousElement, newElement, configuration, context);
-        mergeResult.setModified(mergeManagerResult.isModified());
+        mergeResult.setModified(mergeResult.isModified() || mergeManagerResult.isModified());
         mergeResult.getLog().addAll(mergeManagerResult.getLog());
         // this method used to always set the value, no matter the result of
         // MergeConfiguration#isProvidedVersionsModifiables.
@@ -296,13 +296,13 @@ public class BaseProperty<R extends EntityReference> extends BaseElement<R>
      * @param newValue the new version of the value
      * @param mergeResult merge report
      * @since 3.2M1
-     * @deprecated Since 15.2RC1,14.10.7 use {@link #mergeValue(Object, Object, MergeConfiguration)}
+     * @deprecated now use {@link #mergeValue(Object, Object, MergeConfiguration)}
      */
     @Deprecated(since = "14.10.7,15.2RC1")
     protected void mergeValue(Object previousValue, Object newValue, MergeResult mergeResult)
     {
         MergeManagerResult<Object, Object> result = this.mergeValue(previousValue, newValue, new MergeConfiguration());
-        mergeResult.setModified(result.isModified());
+        mergeResult.setModified(mergeResult.isModified() || result.isModified());
         mergeResult.getLog().addAll(result.getLog());
         if (result.isModified()) {
             setValue(result.getMergeResult());

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseProperty.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseProperty.java
@@ -27,6 +27,8 @@ import org.dom4j.Element;
 import org.xwiki.model.reference.EntityReference;
 import org.xwiki.model.reference.ObjectPropertyReference;
 import org.xwiki.model.reference.ObjectReference;
+import org.xwiki.stability.Unstable;
+import org.xwiki.store.merge.MergeManagerResult;
 import org.xwiki.xml.XMLUtils;
 
 import com.xpn.xwiki.XWikiContext;
@@ -45,6 +47,9 @@ public class BaseProperty<R extends EntityReference> extends BaseElement<R>
     implements PropertyInterface, Serializable, Cloneable
 {
     private static final long serialVersionUID = 1L;
+
+    private static final String MERGE_CONFLICT_LOG = "Collision found on property [{}] between from value [{}] and to"
+        + " [{}]";
 
     private BaseCollection object;
 
@@ -217,60 +222,112 @@ public class BaseProperty<R extends EntityReference> extends BaseElement<R>
     public void merge(ElementInterface previousElement, ElementInterface newElement, MergeConfiguration configuration,
         XWikiContext context, MergeResult mergeResult)
     {
-        super.merge(previousElement, newElement, configuration, context, mergeResult);
+        MergeManagerResult<ElementInterface, Object> mergeManagerResult =
+            this.merge(previousElement, newElement, configuration, context);
+        mergeResult.setModified(mergeManagerResult.isModified());
+        mergeResult.getLog().addAll(mergeManagerResult.getLog());
+        // this method used to always set the value, no matter the result of
+        // MergeConfiguration#isProvidedVersionsModifiables.
+        setValue(((BaseProperty<R>)mergeManagerResult.getMergeResult()).getValue());
+    }
 
+    @Override
+    public MergeManagerResult<ElementInterface, Object> merge(ElementInterface previousElement,
+        ElementInterface newElement, MergeConfiguration configuration, XWikiContext context)
+    {
+        MergeManagerResult<ElementInterface, Object> mergeResult =
+            super.merge(previousElement, newElement, configuration, context);
+
+        // We don't change current result, but the one in the mergeResult so that we modify either current instance
+        // or a clone depending on the given configuration.
+        BaseProperty<R> modifiableResult = (BaseProperty<R>) mergeResult.getMergeResult();
         // Value
         Object previousValue = ((BaseProperty<R>) previousElement).getValue();
         Object newValue = ((BaseProperty<R>) newElement).getValue();
         if (previousValue == null) {
             if (newValue != null) {
                 if (getValue() == null) {
-                    setValue(newValue);
+                    modifiableResult.setValue(newValue);
+                    mergeResult.setModified(true);
                 } else {
                     // collision between current and new
                     if (configuration.getConflictFallbackVersion() == MergeConfiguration.ConflictFallbackVersion.NEXT) {
-                        setValue(newValue);
+                        modifiableResult.setValue(newValue);
+                        mergeResult.setModified(true);
                     }
-                    mergeResult.getLog().error("Collision found on property [{}] between from value [{}] and to [{}]",
-                        getName(), getValue(), newValue);
+                    mergeResult.getLog().error(MERGE_CONFLICT_LOG, getName(), getValue(), newValue);
                 }
             }
         } else if (newValue == null) {
             if (Objects.equals(previousValue, getValue())) {
-                setValue(null);
+                modifiableResult.setValue(null);
+                mergeResult.setModified(true);
             } else {
                 // collision between current and new
                 // We don't remove the value in fallback
-                mergeResult.getLog().error("Collision found on property [{}] between from value [{}] and to [{}]",
-                    getName(), getValue(), newValue);
+                mergeResult.getLog().error(MERGE_CONFLICT_LOG, getName(), getValue(), newValue);
             }
         } else {
             if (Objects.equals(previousValue, getValue())) {
-                setValue(newValue);
+                modifiableResult.setValue(newValue);
+                mergeResult.setModified(true);
             } else if (previousValue.getClass() != newValue.getClass()) {
                 // collision between current and new
-                mergeResult.getLog().error("Collision found on property [{}] between from value [] and to []",
-                    getName(), getValue(), newValue);
+                mergeResult.getLog().error(MERGE_CONFLICT_LOG, getName(), getValue(), newValue);
             } else if (!Objects.equals(newValue, getValue())) {
-                mergeValue(previousValue, newValue, configuration, mergeResult);
+                MergeManagerResult<Object, Object> mergeValueResult =
+                    mergeValue(previousValue, newValue, configuration);
+                mergeResult.getLog().addAll(mergeValueResult.getLog());
+                if (mergeValueResult.isModified()) {
+                    modifiableResult.setValue(mergeValueResult.getMergeResult());
+                    mergeResult.setModified(true);
+                    mergeResult.addConflicts(mergeValueResult.getConflicts());
+                }
             }
         }
+        return mergeResult;
     }
 
     /**
      * Try to apply 3 ways merge on property value.
+     * Note that this method modifies the internal value of the property.
      *
      * @param previousValue the previous version of the value
      * @param newValue the new version of the value
      * @param mergeResult merge report
      * @since 3.2M1
+     * @deprecated Since 15.2RC1,14.10.7 use {@link #mergeValue(Object, Object, MergeConfiguration)}
      */
-    protected void mergeValue(Object previousValue, Object newValue, MergeConfiguration mergeConfiguration,
-        MergeResult mergeResult)
+    @Deprecated(since = "14.10.7,15.2RC1")
+    protected void mergeValue(Object previousValue, Object newValue, MergeResult mergeResult)
     {
+        MergeManagerResult<Object, Object> result = this.mergeValue(previousValue, newValue, new MergeConfiguration());
+        mergeResult.setModified(result.isModified());
+        mergeResult.getLog().addAll(result.getLog());
+        if (result.isModified()) {
+            setValue(result.getMergeResult());
+        }
+    }
+
+    /**
+     * Try to apply 3 ways merge on property value.
+     * Note that this method does not modify the internal value of the property.
+     *
+     * @param previousValue the previous version of the value
+     * @param newValue the new version of the value
+     * @param mergeConfiguration the merge configuration to use
+     * @since 15.2RC1
+     * @since 14.10.7
+     */
+    @Unstable
+    protected MergeManagerResult<Object, Object> mergeValue(Object previousValue, Object newValue,
+        MergeConfiguration mergeConfiguration)
+    {
+        MergeManagerResult<Object, Object> result = new MergeManagerResult<>();
+        result.setMergeResult(getValue());
         // collision between current and new: don't know how to apply 3 way merge on unknown type
-        mergeResult.getLog().error("Collision found on property [{}] between from value [{}] and to [{}]", getName(),
-            getValue(), newValue);
+        result.getLog().error(MERGE_CONFLICT_LOG, getName(), getValue(), newValue);
+        return result;
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/ElementInterface.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/ElementInterface.java
@@ -70,8 +70,7 @@ public interface ElementInterface
      * @param context the XWiki context
      * @param mergeResult the merge report
      * @since 3.2M1
-     * @deprecated Since 14.10.7,15.2RC1 use
-     *              {@link #merge(ElementInterface, ElementInterface, MergeConfiguration, XWikiContext)}.
+     * @deprecated now use {@link #merge(ElementInterface, ElementInterface, MergeConfiguration, XWikiContext)}.
      */
     @Deprecated(since = "14.10.7,15.2RC1")
     void merge(ElementInterface previousElement, ElementInterface newElement, MergeConfiguration configuration,

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/ElementInterface.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/ElementInterface.java
@@ -21,6 +21,8 @@ package com.xpn.xwiki.objects;
 
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
+import org.xwiki.stability.Unstable;
+import org.xwiki.store.merge.MergeManagerResult;
 
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.doc.merge.MergeConfiguration;
@@ -68,9 +70,31 @@ public interface ElementInterface
      * @param context the XWiki context
      * @param mergeResult the merge report
      * @since 3.2M1
+     * @deprecated Since 14.10.7,15.2RC1 use
+     *              {@link #merge(ElementInterface, ElementInterface, MergeConfiguration, XWikiContext)}.
      */
+    @Deprecated(since = "14.10.7,15.2RC1")
     void merge(ElementInterface previousElement, ElementInterface newElement, MergeConfiguration configuration,
         XWikiContext context, MergeResult mergeResult);
+
+    /**
+     * Apply a 3 ways merge on the current element based on provided previous and new version of the element.
+     * <p>
+     * All 3 elements are supposed to have the same class and reference.
+     * <p>
+     * Note that the current element is modified only if {@link MergeConfiguration#isProvidedVersionsModifiables()}
+     * returns {@code true}.
+     *
+     * @param previousElement the previous version of the element
+     * @param newElement the next version of the element
+     * @param configuration the configuration of the merge Indicate how to deal with some conflicts use cases, etc.
+     * @param context the XWiki context
+     * @since 14.10.7
+     * @since 15.2RC1
+     */
+    @Unstable
+    MergeManagerResult<ElementInterface, Object> merge(ElementInterface previousElement, ElementInterface newElement,
+        MergeConfiguration configuration, XWikiContext context);
 
     /**
      * Apply the provided element so that the current one contains the same informations and indicate if it was

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/LargeStringProperty.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/LargeStringProperty.java
@@ -19,29 +19,26 @@
  */
 package com.xpn.xwiki.objects;
 
-import org.xwiki.logging.event.LogEvent;
 import org.xwiki.store.merge.MergeManagerResult;
 
 import com.xpn.xwiki.doc.merge.MergeConfiguration;
-import com.xpn.xwiki.doc.merge.MergeResult;
 
 public class LargeStringProperty extends BaseStringProperty
 {
     private static final long serialVersionUID = 1L;
 
     @Override
-    protected void mergeValue(Object previousValue, Object newValue, MergeConfiguration configuration,
-        MergeResult mergeResult)
+    protected MergeManagerResult<Object, Object> mergeValue(Object previousValue, Object newValue,
+        MergeConfiguration configuration)
     {
         MergeManagerResult<String, String> valueMergeManagerResult = getMergeManager()
             .mergeLines((String) previousValue, (String) newValue, getValue(), configuration);
-        for (LogEvent logEvent : valueMergeManagerResult.getLog()) {
-            String newMessage = String.format("%s [Location: %s]", logEvent.getMessage(), getObject().getReference());
-            LogEvent copyLog =
-                new LogEvent(logEvent.getLevel(), newMessage, logEvent.getArgumentArray(), logEvent.getThrowable());
-            mergeResult.getLog().add(copyLog);
-        }
-        mergeResult.setModified(mergeResult.isModified() || valueMergeManagerResult.isModified());
-        setValue(valueMergeManagerResult.getMergeResult());
+
+        MergeManagerResult<Object, Object> result = new MergeManagerResult<>();
+        result.setLog(valueMergeManagerResult.getLog());
+        result.setMergeResult(valueMergeManagerResult.getMergeResult());
+        // We cannot convert a Conflict<String> to Conflict<Object> right now, so we're loosing conflicts info here...
+        result.setModified(valueMergeManagerResult.isModified());
+        return result;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/ListProperty.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/ListProperty.java
@@ -259,23 +259,18 @@ public class ListProperty extends BaseProperty implements Cloneable
     }
 
     @Override
-    protected void mergeValue(Object previousValue, Object newValue, MergeConfiguration configuration,
-        MergeResult mergeResult)
+    protected MergeManagerResult<Object, Object> mergeValue(Object previousValue, Object newValue,
+        MergeConfiguration configuration)
     {
         MergeManagerResult<List<String>, String> listStringMergeManagerResult = getMergeManager()
             .mergeList((List<String>) previousValue, (List<String>) newValue, this.list, configuration);
-        for (LogEvent logEvent : listStringMergeManagerResult.getLog()) {
-            String newMessage = String.format("%s [Location: %s]", logEvent.getMessage(), getObject().getReference());
-            LogEvent copyLog =
-                new LogEvent(logEvent.getLevel(), newMessage, logEvent.getArgumentArray(), logEvent.getThrowable());
-            mergeResult.getLog().add(copyLog);
-        }
-        mergeResult.setModified(mergeResult.isModified() || listStringMergeManagerResult.isModified());
 
-        if (listStringMergeManagerResult.isModified()) {
-            this.list.clear();
-            this.list.addAll(listStringMergeManagerResult.getMergeResult());
-        }
+        MergeManagerResult<Object, Object> result = new MergeManagerResult<>();
+        result.setLog(listStringMergeManagerResult.getLog());
+        result.setMergeResult(listStringMergeManagerResult.getMergeResult());
+        // We cannot convert a Conflict<String> to Conflict<Object> right now, so we're loosing conflicts info here...
+        result.setModified(listStringMergeManagerResult.isModified());
+        return result;
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BaseClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BaseClass.java
@@ -46,7 +46,6 @@ import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.doc.merge.MergeConfiguration;
-import com.xpn.xwiki.doc.merge.MergeResult;
 import com.xpn.xwiki.objects.BaseCollection;
 import com.xpn.xwiki.objects.BaseObject;
 import com.xpn.xwiki.objects.BaseProperty;
@@ -1521,62 +1520,67 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
     }
 
     @Override
-    public void merge(ElementInterface previousElement, ElementInterface newElement, MergeConfiguration configuration,
-        XWikiContext context, MergeResult mergeResult)
+    public MergeManagerResult<ElementInterface, Object> merge(ElementInterface previousElement,
+        ElementInterface newElement, MergeConfiguration configuration, XWikiContext context)
     {
+        MergeManagerResult<ElementInterface, Object> mergeResult =
+            super.merge(previousElement, newElement, configuration, context);
+
         BaseClass previousClass = (BaseClass) previousElement;
         BaseClass newClass = (BaseClass) newElement;
+
+        BaseClass modifiableResult = (BaseClass) mergeResult.getMergeResult();
 
         MergeManagerResult<String, String> customClassMergeResult =
             getMergeManager().mergeObject(previousClass.getCustomClass(),
                 newClass.getCustomClass(), getCustomClass(), configuration);
         mergeResult.getLog().addAll(customClassMergeResult.getLog());
         mergeResult.setModified(mergeResult.isModified() || customClassMergeResult.isModified());
-        setCustomClass(customClassMergeResult.getMergeResult());
+        modifiableResult.setCustomClass(customClassMergeResult.getMergeResult());
 
-        MergeManagerResult<String, String> customMappingMergeResult = getMergeManager().mergeObject(previousClass.getCustomMapping(),
+        MergeManagerResult<String, String> customMappingMergeResult = getMergeManager().mergeObject(
+            previousClass.getCustomMapping(),
             newClass.getCustomMapping(), getCustomMapping(), configuration);
         mergeResult.getLog().addAll(customMappingMergeResult.getLog());
         mergeResult.setModified(mergeResult.isModified() || customMappingMergeResult.isModified());
-        setCustomMapping(customMappingMergeResult.getMergeResult());
+        modifiableResult.setCustomMapping(customMappingMergeResult.getMergeResult());
 
-        MergeManagerResult<String, String> defaultWebMergeResult = getMergeManager().mergeObject(previousClass.getDefaultWeb(),
+        MergeManagerResult<String, String> defaultWebMergeResult = getMergeManager().mergeObject(
+            previousClass.getDefaultWeb(),
             newClass.getDefaultWeb(), getDefaultWeb(), configuration);
         mergeResult.getLog().addAll(defaultWebMergeResult.getLog());
         mergeResult.setModified(mergeResult.isModified() || defaultWebMergeResult.isModified());
-        setDefaultWeb(defaultWebMergeResult.getMergeResult());
+        modifiableResult.setDefaultWeb(defaultWebMergeResult.getMergeResult());
 
         MergeManagerResult<String, String> defaultViewSheetMergeResult =
             getMergeManager().mergeObject(previousClass.getDefaultViewSheet(), newClass.getDefaultViewSheet(),
                 getDefaultViewSheet(), configuration);
         mergeResult.getLog().addAll(defaultViewSheetMergeResult.getLog());
         mergeResult.setModified(mergeResult.isModified() || defaultViewSheetMergeResult.isModified());
-        setDefaultViewSheet(defaultViewSheetMergeResult.getMergeResult());
+        modifiableResult.setDefaultViewSheet(defaultViewSheetMergeResult.getMergeResult());
 
         MergeManagerResult<String, String> defaultEditSheetMergeResult =
             getMergeManager().mergeObject(previousClass.getDefaultEditSheet(), newClass.getDefaultEditSheet(),
                 getDefaultEditSheet(), configuration);
         mergeResult.getLog().addAll(defaultEditSheetMergeResult.getLog());
         mergeResult.setModified(mergeResult.isModified() || defaultEditSheetMergeResult.isModified());
-        setDefaultEditSheet(defaultEditSheetMergeResult.getMergeResult());
+        modifiableResult.setDefaultEditSheet(defaultEditSheetMergeResult.getMergeResult());
 
         MergeManagerResult<String, String> validationScriptMergeResult =
             getMergeManager().mergeObject(previousClass.getValidationScript(), newClass.getValidationScript(),
                 getValidationScript(), configuration);
         mergeResult.getLog().addAll(validationScriptMergeResult.getLog());
         mergeResult.setModified(mergeResult.isModified() || validationScriptMergeResult.isModified());
-        setValidationScript(validationScriptMergeResult.getMergeResult());
+        modifiableResult.setValidationScript(validationScriptMergeResult.getMergeResult());
 
         MergeManagerResult<String, String> nameFieldMergeResult =
             getMergeManager().mergeObject(previousClass.getNameField(), newClass.getNameField(), getNameField(),
                 configuration);
         mergeResult.getLog().addAll(nameFieldMergeResult.getLog());
         mergeResult.setModified(mergeResult.isModified() || nameFieldMergeResult.isModified());
-        setNameField(nameFieldMergeResult.getMergeResult());
+        modifiableResult.setNameField(nameFieldMergeResult.getMergeResult());
 
-        // Properties
-
-        super.merge(previousElement, newElement, configuration, context, mergeResult);
+        return mergeResult;
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/BaseObjectTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/BaseObjectTest.java
@@ -165,7 +165,7 @@ public class BaseObjectTest
         BaseObject currentObject = new BaseObject();
         currentObject.setStringValue("str", "value");
 
-        when(mergeManager.mergeObject(any(), any(), any(), any())).thenReturn(new MergeManagerResult<>());
+        when(mergeManager.mergeCharacters(any(), any(), any(), any())).thenReturn(new MergeManagerResult<>());
         MergeManagerResult<String, String> mergeManagerResult = new MergeManagerResult<>();
         mergeManagerResult.setMergeResult("newvalue");
         mergeManagerResult.setModified(true);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/BaseClassTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/BaseClassTest.java
@@ -175,16 +175,17 @@ class BaseClassTest
         newClass.setPrettyName("new");
         newClass.setValidationScript("my new validation script");
         newClass.setDefaultEditSheet("A previous edit sheet");
-
         when(mergeManager.mergeObject(any(), any(), any(), any())).thenReturn(new MergeManagerResult<>());
 
-        MergeManagerResult<String, String> mergeManagerResult = new MergeManagerResult<>();
-        mergeManagerResult.setMergeResult("current");
-        mergeManagerResult.setModified(false);
-        mergeManagerResult.getLog().error("Failed to merge objects: previous=[previous] new=[new] current=[current]");
-        when(mergeManager.mergeObject(eq("previous"), eq("new"), eq("current"), any())).thenReturn(mergeManagerResult);
+        MergeManagerResult<String, Character> prettyNameManagerResult = new MergeManagerResult<>();
+        prettyNameManagerResult.setMergeResult("current");
+        prettyNameManagerResult.setModified(false);
+        prettyNameManagerResult.getLog()
+            .error("Failed to merge objects: previous=[previous] new=[new] current=[current]");
+        when(mergeManager.mergeCharacters(eq("previous"), eq("new"), eq("current"), any()))
+            .thenReturn(prettyNameManagerResult);
 
-        mergeManagerResult = new MergeManagerResult<>();
+        MergeManagerResult<String,  String> mergeManagerResult = new MergeManagerResult<>();
         mergeManagerResult.setMergeResult("my new validation script");
         mergeManagerResult.setModified(true);
         when(mergeManager

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-api/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-api/pom.xml
@@ -35,7 +35,7 @@
     XWiki module API dedicated to perform document merge operations and manage related conflicts resolution.
   </description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.63</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.62</xwiki.jacoco.instructionRatio>
     </properties>
 
   <dependencies>

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-api/src/main/java/com/xpn/xwiki/doc/merge/MergeConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-api/src/main/java/com/xpn/xwiki/doc/merge/MergeConfiguration.java
@@ -21,6 +21,8 @@ package com.xpn.xwiki.doc.merge;
 
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
+import org.xwiki.stability.Unstable;
+import org.xwiki.store.merge.MergeManagerResult;
 
 /**
  * Allow to define some behaviors of the merge.
@@ -31,6 +33,27 @@ import org.xwiki.model.reference.EntityReference;
 public class MergeConfiguration
 {
     /**
+     * Versions to use as fallback in case of conflicts.
+     *
+     * @version $Id$
+     * @since 15.2RC1
+     * @since 14.10.7
+     */
+    @Unstable
+    public enum ConflictFallbackVersion
+    {
+        /**
+         * Current version. Default value.
+         */
+        CURRENT,
+
+        /**
+         * Next version.
+         */
+        NEXT
+    };
+
+    /**
      * @see #isProvidedVersionsModifiables()
      */
     private boolean providedVersionsModifiables = true;
@@ -38,6 +61,8 @@ public class MergeConfiguration
     private DocumentReference concernedDocument;
 
     private EntityReference userReference;
+
+    private ConflictFallbackVersion conflictFallbackVersion = ConflictFallbackVersion.CURRENT;
 
     /**
      * @param providedVersionsModifiables true if the merge is allowed to modify input elements
@@ -95,5 +120,34 @@ public class MergeConfiguration
     public void setUserReference(EntityReference userReference)
     {
         this.userReference = userReference;
+    }
+
+    /**
+     * Get the version to use as fallback in case of conflict: this is the version that is used in
+     * {@link MergeManagerResult#getMergeResult()} whenever a conflict is found.
+     * When not set the default value is {@link ConflictFallbackVersion#CURRENT}.
+     *
+     * @return the version to use as fallback
+     * @since 15.2RC1
+     * @since 14.10.7
+     */
+    @Unstable
+    public ConflictFallbackVersion getConflictFallbackVersion()
+    {
+        return conflictFallbackVersion;
+    }
+
+    /**
+     * Specify the version to use as fallback in case of conflict.
+     *
+     * @param conflictFallbackVersion the fallback version to use
+     * @see #getConflictFallbackVersion()
+     * @since 15.2RC1
+     * @since 14.10.7
+     */
+    @Unstable
+    public void setConflictFallbackVersion(ConflictFallbackVersion conflictFallbackVersion)
+    {
+        this.conflictFallbackVersion = conflictFallbackVersion;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-api/src/main/java/org/xwiki/store/merge/MergeManagerResult.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-api/src/main/java/org/xwiki/store/merge/MergeManagerResult.java
@@ -28,6 +28,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.xwiki.diff.Conflict;
 import org.xwiki.logging.LogLevel;
 import org.xwiki.logging.LogQueue;
+import org.xwiki.stability.Unstable;
 
 /**
  * This represents the result of a merge operation: it contains both the result of the merge, the possible conflicts
@@ -48,7 +49,7 @@ public class MergeManagerResult<R, C>
 
     private R mergeResult;
 
-    private final LogQueue log;
+    private LogQueue log;
 
     private boolean modified;
 
@@ -110,6 +111,18 @@ public class MergeManagerResult<R, C>
     public R getMergeResult()
     {
         return this.mergeResult;
+    }
+
+    /**
+     * Specify the log queue to be used: this method should mainly be used when wrapping a result.
+     * @param logQueue the log queue to be used.
+     * @since 14.10.7
+     * @since 15.2RC1
+     */
+    @Unstable
+    public void setLog(LogQueue logQueue)
+    {
+        this.log = logQueue;
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-default/src/main/java/org/xwiki/store/merge/internal/DefaultMergeManager.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-default/src/main/java/org/xwiki/store/merge/internal/DefaultMergeManager.java
@@ -56,6 +56,7 @@ import com.xpn.xwiki.doc.merge.MergeConfiguration.ConflictFallbackVersion;
 import org.xwiki.store.merge.MergeManagerResult;
 import com.xpn.xwiki.doc.merge.MergeResult;
 import com.xpn.xwiki.objects.BaseObject;
+import com.xpn.xwiki.objects.ElementInterface;
 import com.xpn.xwiki.objects.ObjectDiff;
 import com.xpn.xwiki.objects.PropertyInterface;
 import com.xpn.xwiki.objects.classes.BaseClass;
@@ -190,20 +191,23 @@ public class DefaultMergeManager implements MergeManager
         MergeConfiguration configuration)
     {
         MergeManagerResult<String, Character> mergeResult = new MergeManagerResult<>();
-        try {
-            org.xwiki.diff.MergeResult<Character> result =
-                this.diffManager.merge(toCharacters(previousStr), toCharacters(newStr), toCharacters(currentStr),
-                    getDefaultConfiguration(configuration));
+        if (currentStr == null && newStr == null) {
+            mergeResult.setMergeResult(null);
+        } else {
+            try {
+                org.xwiki.diff.MergeResult<Character> result =
+                    this.diffManager.merge(toCharacters(previousStr), toCharacters(newStr), toCharacters(currentStr),
+                        getDefaultConfiguration(configuration));
 
-            mergeResult.getLog().addAll(result.getLog());
-            mergeResult.addConflicts(result.getConflicts());
-            String resultStr = fromCharacters(result.getMerged());
-            mergeResult.setMergeResult(resultStr);
-            mergeResult.setModified(!resultStr.equals(currentStr));
-        } catch (MergeException e) {
-            mergeResult.getLog().error("Failed to execute merge characters", e);
+                mergeResult.getLog().addAll(result.getLog());
+                mergeResult.addConflicts(result.getConflicts());
+                String resultStr = fromCharacters(result.getMerged());
+                mergeResult.setMergeResult(resultStr);
+                mergeResult.setModified(!resultStr.equals(currentStr));
+            } catch (MergeException e) {
+                mergeResult.getLog().error("Failed to execute merge characters", e);
+            }
         }
-
         return mergeResult;
     }
 
@@ -320,7 +324,7 @@ public class DefaultMergeManager implements MergeManager
             mergeResult.putMergeResult(MergeDocumentResult.DocumentPart.XOBJECTS, objectMergeManagerResult);
 
             // Class
-            MergeManagerResult<BaseClass, BaseClass> classMergeManagerResult =
+            MergeManagerResult<ElementInterface, Object> classMergeManagerResult =
                 mergeXClass(previousDoc, mergedDocument, newDoc, configuration);
             mergeResult.putMergeResult(MergeDocumentResult.DocumentPart.XCLASS, classMergeManagerResult);
 
@@ -338,20 +342,14 @@ public class DefaultMergeManager implements MergeManager
         return mergeResult;
     }
 
-    private MergeManagerResult<BaseClass, BaseClass> mergeXClass(XWikiDocument previousDoc,
+    private MergeManagerResult<ElementInterface, Object> mergeXClass(XWikiDocument previousDoc,
         XWikiDocument mergedDocument, XWikiDocument newDoc, MergeConfiguration configuration)
     {
         XWikiContext context = this.contextProvider.get();
-        MergeResult classMergeResult = new MergeResult();
         BaseClass classResult = mergedDocument.getXClass();
         BaseClass previousClass = previousDoc.getXClass();
         BaseClass newClass = newDoc.getXClass();
-        classResult.merge(previousClass, newClass, configuration, context, classMergeResult);
-        MergeManagerResult<BaseClass, BaseClass> classMergeManagerResult = new MergeManagerResult<>();
-        classMergeManagerResult.setMergeResult(mergedDocument.getXClass());
-        classMergeManagerResult.getLog().addAll(classMergeResult.getLog());
-        classMergeManagerResult.setModified(classMergeResult.isModified());
-        return classMergeManagerResult;
+        return classResult.merge(previousClass, newClass, configuration, context);
     }
 
     private MergeManagerResult<Map<DocumentReference, List<BaseObject>>, BaseObject> mergeXObjects(
@@ -359,7 +357,10 @@ public class DefaultMergeManager implements MergeManager
     {
         XWikiContext context = this.contextProvider.get();
 
-        MergeResult objectMergeResult = new MergeResult();
+        MergeManagerResult<Map<DocumentReference, List<BaseObject>>, BaseObject> objectMergeResult =
+            new MergeManagerResult<>();
+        objectMergeResult.setMergeResult(mergedDocument.getXObjects());
+
         List<List<ObjectDiff>> objectsDiff = mergedDocument.getObjectDiff(previousDoc, newDoc, context);
         if (!objectsDiff.isEmpty()) {
             // Apply diff on result
@@ -464,8 +465,14 @@ public class DefaultMergeManager implements MergeManager
                                         objectMergeResult.setModified(true);
                                     } else {
                                         // Try to apply a 3 ways merge on the property
-                                        propertyResult.merge(previousProperty, newProperty, configuration, context,
-                                            objectMergeResult);
+                                        MergeManagerResult<ElementInterface, Object> propertyManagerResult =
+                                            propertyResult.merge(previousProperty, newProperty, configuration, context);
+                                        objectMergeResult.getLog().addAll(propertyManagerResult.getLog());
+                                        if (propertyManagerResult.isModified()) {
+                                            objectMergeResult.setModified(true);
+                                            objectResult.safeput(diff.getPropName(),
+                                                (PropertyInterface) propertyManagerResult.getMergeResult());
+                                        }
                                     }
                                 } else {
                                     // collision between DB and new: property to modify but does not exists in DB
@@ -485,13 +492,8 @@ public class DefaultMergeManager implements MergeManager
                 }
             }
         }
-        MergeManagerResult<Map<DocumentReference, List<BaseObject>>, BaseObject> objectMergeManagerResult =
-            new MergeManagerResult<>();
-        objectMergeManagerResult.getLog().addAll(objectMergeResult.getLog());
-        objectMergeManagerResult.setMergeResult(mergedDocument.getXObjects());
-        objectMergeManagerResult.setModified(objectMergeResult.isModified());
 
-        return objectMergeManagerResult;
+        return objectMergeResult;
     }
 
     private MergeManagerResult<List<XWikiAttachment>, XWikiAttachment> mergeAttachments(XWikiDocument previousDoc,

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-default/src/test/java/org/xwiki/store/merge/internal/DefaultMergeManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-default/src/test/java/org/xwiki/store/merge/internal/DefaultMergeManagerTest.java
@@ -230,6 +230,26 @@ public class DefaultMergeManagerTest
     }
 
     @Test
+    public void mergeCharactersNull()
+    {
+        MergeManagerResult<String, Character> result =
+            mergeManager.mergeCharacters(null, null, null, new MergeConfiguration());
+        assertNull(result.getMergeResult());
+        assertFalse(result.isModified());
+        assertFalse(result.hasConflicts());
+    }
+
+    @Test
+    public void mergeCharactersEmpty()
+    {
+        MergeManagerResult<String, Character> result =
+            mergeManager.mergeCharacters("", "", "", new MergeConfiguration());
+        assertEquals("", result.getMergeResult());
+        assertFalse(result.isModified());
+        assertFalse(result.hasConflicts());
+    }
+
+    @Test
     public void mergeCharactersWhileModified()
     {
         MergeManagerResult<String, Character> result =


### PR DESCRIPTION
  * Provide a new configuration option for allowing to fallback on another version
  * Use that new configuration in all merge operations
  * Change the signature of the BaseProperty#merge method to be able to reference the configuration instance