### PR TITLE
XWIKI-19139: Like button can't be focused by tabulator

### DIFF
--- a/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-test/xwiki-platform-like-test-pageobjects/src/main/java/org/xwiki/like/test/po/LikeButton.java
+++ b/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-test/xwiki-platform-like-test-pageobjects/src/main/java/org/xwiki/like/test/po/LikeButton.java
@@ -59,7 +59,7 @@ public class LikeButton extends BaseElement
     public boolean canBeClicked()
     {
         WebElement button = getButton();
-        return !button.getAttribute("class").contains("disabled");
+        return button.isEnabled();
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-ui/src/main/resources/XWiki/Like/LikeUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-ui/src/main/resources/XWiki/Like/LikeUIX.xml
@@ -142,7 +142,14 @@
       <cache>long</cache>
     </property>
     <property>
-      <code>require(['jquery', 'xwiki-meta'], function ($, xm) {
+      <code>define('like-button-title-keys', {
+  prefix: 'like.button.title.',
+  keys: [
+    "unlike",
+    "like"
+  ]
+});
+require(['jquery', 'xwiki-meta', 'xwiki-l10n!like-button-title-keys'], function ($, xm, l10n) {
   var likeUIXReference = XWiki.Model.resolve('XWiki.Like.LikeUIX', XWiki.EntityType.DOCUMENT);
   var likeUIXurl = new XWiki.Document(likeUIXReference).getURL('get');
   
@@ -165,6 +172,7 @@
        likeButton.removeClass('btn-primary');
        likeButton.addClass('btn-default');
        likeButton.find('.like-number').text(data.counter);
+       likeButton.attr('title', l10n.get('unlike',data.counter));
        $('#is-liked').val('true');
        new XWiki.widgets.Notification("$escapetool.xml($services.localization.render('like.newlike.success'))", 'done');
      }).catch(() =&gt; {
@@ -182,6 +190,7 @@
       unlikeButton.removeClass('btn-default');
       unlikeButton.addClass('btn-primary');
       unlikeButton.find('.like-number').text(data.counter);
+      unlikeButton.attr('title', l10n.get('like',data.counter));
       $('#is-liked').val('false');
       new XWiki.widgets.Notification("$escapetool.xml($services.localization.render('like.unlike.success'))", 'done');
     }).catch(() =&gt; {
@@ -482,7 +491,7 @@
         #if($disabledButton) disabled #{end}
         title="$escapetool.xml($services.localization.render($titleMessageTranslationKey, [$likeCount]))"&gt;
           $services.icon.renderHTML('heart') &lt;span class="like-number"&gt;$likeCount&lt;/span&gt;
-      &lt;/div&gt;
+      &lt;/button&gt;
     &lt;/div&gt;
   #end
 #end

--- a/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-ui/src/main/resources/XWiki/Like/LikeUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-ui/src/main/resources/XWiki/Like/LikeUIX.xml
@@ -197,7 +197,7 @@ require(['jquery', 'xwiki-meta', 'xwiki-l10n!like-button-title-keys'], function 
       new XWiki.widgets.Notification("$escapetool.xml($services.localization.render('like.unlike.error'))", 'error');
     });
   };
-  $('.like-button:not([disabled])').on('click', likeClick);
+  $('.like-button').on('click', likeClick);
 });</code>
     </property>
     <property>

--- a/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-ui/src/main/resources/XWiki/Like/LikeUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-ui/src/main/resources/XWiki/Like/LikeUIX.xml
@@ -478,7 +478,8 @@
         #set ($disabledButton = "disabled")
         #set ($titleMessageTranslationKey = "like.button.title")
       #end
-      &lt;div class="like-button btn $btnClass $disabledButton badge" title="$escapetool.xml($services.localization.render($titleMessageTranslationKey, [$likeCount]))"&gt;
+      &lt;button class="like-button btn $btnClass $disabledButton badge"
+      title="$escapetool.xml($services.localization.render($titleMessageTranslationKey, [$likeCount]))"&gt;
           $services.icon.renderHTML('heart') &lt;span class="like-number"&gt;$likeCount&lt;/span&gt;
       &lt;/div&gt;
     &lt;/div&gt;

--- a/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-ui/src/main/resources/XWiki/Like/LikeUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-ui/src/main/resources/XWiki/Like/LikeUIX.xml
@@ -188,7 +188,7 @@
       new XWiki.widgets.Notification("$escapetool.xml($services.localization.render('like.unlike.error'))", 'error');
     });
   };
-  $('.like-button:not(.disabled)').on('click', likeClick);
+  $('.like-button:not([disabled])').on('click', likeClick);
 });</code>
     </property>
     <property>
@@ -478,7 +478,7 @@
         #set ($disabledButton = true)
         #set ($titleMessageTranslationKey = "like.button.title")
       #end
-      &lt;button class="like-button btn $btnClass badge #if($disabledButton)disabled#{end}"
+      &lt;button class="like-button btn $btnClass badge"
         #if($disabledButton) disabled #{end}
         title="$escapetool.xml($services.localization.render($titleMessageTranslationKey, [$likeCount]))"&gt;
           $services.icon.renderHTML('heart') &lt;span class="like-number"&gt;$likeCount&lt;/span&gt;

--- a/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-ui/src/main/resources/XWiki/Like/LikeUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-ui/src/main/resources/XWiki/Like/LikeUIX.xml
@@ -473,13 +473,14 @@
         #set ($btnClass = "btn-primary")
         #set ($titleMessageTranslationKey = "like.button.title.like")
       #end
-      #set ($disabledButton = "")
+      #set ($disabledButton = false)
       #if (!$services.like.isAuthorized($doc))
-        #set ($disabledButton = "disabled")
+        #set ($disabledButton = true)
         #set ($titleMessageTranslationKey = "like.button.title")
       #end
-      &lt;button class="like-button btn $btnClass $disabledButton badge"
-      title="$escapetool.xml($services.localization.render($titleMessageTranslationKey, [$likeCount]))"&gt;
+      &lt;button class="like-button btn $btnClass badge #if($disabledButton)disabled#{end}"
+        #if($disabledButton) disabled #{end}
+        title="$escapetool.xml($services.localization.render($titleMessageTranslationKey, [$likeCount]))"&gt;
           $services.icon.renderHTML('heart') &lt;span class="like-number"&gt;$likeCount&lt;/span&gt;
       &lt;/div&gt;
     &lt;/div&gt;

--- a/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-ui/src/main/resources/XWiki/Like/LikeUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-ui/src/main/resources/XWiki/Like/LikeUIX.xml
@@ -142,14 +142,14 @@
       <cache>long</cache>
     </property>
     <property>
-      <code>define('like-button-title-keys', {
+      <code>define('xwiki-like-messages', {
   prefix: 'like.button.title.',
   keys: [
     "unlike",
     "like"
   ]
 });
-require(['jquery', 'xwiki-meta', 'xwiki-l10n!like-button-title-keys'], function ($, xm, l10n) {
+require(['jquery', 'xwiki-meta', 'xwiki-l10n!xwiki-like-messages'], function ($, xm, l10n) {
   var likeUIXReference = XWiki.Model.resolve('XWiki.Like.LikeUIX', XWiki.EntityType.DOCUMENT);
   var likeUIXurl = new XWiki.Document(likeUIXReference).getURL('get');
   

--- a/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-ui/src/main/resources/XWiki/Like/LikeUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-ui/src/main/resources/XWiki/Like/LikeUIX.xml
@@ -172,7 +172,7 @@ require(['jquery', 'xwiki-meta', 'xwiki-l10n!like-button-title-keys'], function 
        likeButton.removeClass('btn-primary');
        likeButton.addClass('btn-default');
        likeButton.find('.like-number').text(data.counter);
-       likeButton.attr('title', l10n.get('unlike',data.counter));
+       likeButton.attr('title', l10n.get('unlike', data.counter));
        $('#is-liked').val('true');
        new XWiki.widgets.Notification("$escapetool.xml($services.localization.render('like.newlike.success'))", 'done');
      }).catch(() =&gt; {

--- a/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-ui/src/main/resources/XWiki/Like/LikeUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-ui/src/main/resources/XWiki/Like/LikeUIX.xml
@@ -190,7 +190,7 @@ require(['jquery', 'xwiki-meta', 'xwiki-l10n!like-button-title-keys'], function 
       unlikeButton.removeClass('btn-default');
       unlikeButton.addClass('btn-primary');
       unlikeButton.find('.like-number').text(data.counter);
-      unlikeButton.attr('title', l10n.get('like',data.counter));
+      unlikeButton.attr('title', l10n.get('like', data.counter));
       $('#is-liked').val('false');
       new XWiki.widgets.Notification("$escapetool.xml($services.localization.render('like.unlike.success'))", 'done');
     }).catch(() =&gt; {


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-19139

**PR Changes:**
* Changed the `like-button`element nature from `div` to `button`.

___

Accessibility works properly now: accessible through keyboard and activable with keyboard using standard button interactions.