### PR TITLE
XWIKI-20724: Allow extensions to add parameters to the html conversion request

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/resources/xwiki-source/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/resources/xwiki-source/plugin.js
@@ -32,7 +32,7 @@
       // The values of this object are then used as parameters on the html convertion request.
       var extendedParams = {};
 
-      $(document).trigger('xwiki:ckeditor:convertHTML', extendedParams);
+      $(document).trigger('xwiki:wysiwyg:convertHTML', extendedParams);
       var localParams = {
         // Make sure we use the syntax specified when the editor was loaded. This is especially important when the
         // edited document is new (unsaved) because we want the converter to use the syntax specified by the template

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/resources/xwiki-source/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/resources/xwiki-source/plugin.js
@@ -28,7 +28,12 @@
 
   CKEDITOR.plugins.xwikiSource = {
     convertHTML: function(editor, params) {
-      return $.post(editor.config['xwiki-source'].htmlConverter, $.extend({
+      // Empty object that can be populated by listener of the 'xwiki:ckeditor:convertHTML' event.
+      // The values of this object are then used as parameters on the html convertion request.
+      var  extendedParams = {}
+
+      $(document).trigger('xwiki:ckeditor:convertHTML', extendedParams);
+      var localParams = {
         // Make sure we use the syntax specified when the editor was loaded. This is especially important when the
         // edited document is new (unsaved) because we want the converter to use the syntax specified by the template
         // rather than the default wiki syntax.
@@ -38,7 +43,9 @@
         // Don't wrap the returned HTML with the BODY tag and don't include the HEAD tag when the editor is used
         // in-line (because the returned HTML will be inserted directly into the main page).
         stripHTMLEnvelope: editor.elementMode === CKEDITOR.ELEMENT_MODE_INLINE
-      }, params));
+      };
+      var postParams = $.extend(extendedParams, $.extend(localParams, params));
+      return $.post(editor.config['xwiki-source'].htmlConverter, postParams);
     },
 
     getFullData: function(editor) {

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/resources/xwiki-source/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/resources/xwiki-source/plugin.js
@@ -28,8 +28,8 @@
 
   CKEDITOR.plugins.xwikiSource = {
     convertHTML: function(editor, params) {
-      // Empty object that can be populated by listener of the 'xwiki:ckeditor:convertHTML' event.
-      // The values of this object are then used as parameters on the html convertion request.
+      // Empty object that can be populated by listener of the 'xwiki:wysiwyg:convertHTML' event.
+      // The values of this object are then used as parameters on the html conversion request.
       var extendedParams = {};
 
       $(document).trigger('xwiki:wysiwyg:convertHTML', extendedParams);

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/resources/xwiki-source/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/resources/xwiki-source/plugin.js
@@ -30,7 +30,7 @@
     convertHTML: function(editor, params) {
       // Empty object that can be populated by listener of the 'xwiki:ckeditor:convertHTML' event.
       // The values of this object are then used as parameters on the html convertion request.
-      var  extendedParams = {}
+      var extendedParams = {};
 
       $(document).trigger('xwiki:ckeditor:convertHTML', extendedParams);
       var localParams = {


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-20724

Required for https://jira.xwiki.org/browse/NCAPP-68

Example of use by an extension:

```javascript
$(document).on('xwiki:ckeditor:convertHTML', function(event, data) {
    data.example = 1;
});
```