### PR TITLE
XWIKI-16144: Add a label to the home link in breadcrumbs for accessibility purpose

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/hierarchy_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/hierarchy_macros.vm
@@ -163,7 +163,10 @@
         #set ($closingTag = '')
       #end
       class="$stringtool.join($classNames, ' ')">#if ($item.url)<a href="$item.url"
-        >#end$item.label#if ($item.url)</a>#end$treeNavigation$closingTag##
+      #if ($foreach.index == 0 && !$options.plain)
+        title="$escapetool.xml($services.localization.render('core.menu.type.home'))"
+      #end
+      >#end$item.label#if ($item.url)</a>#end$treeNavigation$closingTag##
     #end##
   </li></ol>
 #end


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-16144

**PR Changes:**
* Added a title to the home icon at the start of the hierarchy in the breadcrumb.


***Note:*** 
This PR does not cover all the improvements mentioned in the Jira ticket because there's overlapping with https://jira.xwiki.org/browse/XWIKI-20696 . This other ticket is currently getting addressed in an active PR https://github.com/xwiki/xwiki-platform/pull/2106 .