### PR TITLE
XWIKI-20736: Contrast issues on a themeless wiki 

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/variablesInit.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/variablesInit.vm
@@ -251,11 +251,9 @@
   @btn-succes-bg:                       #31754f;
   @btn-danger-bg:                       #ca302c;
   @btn-success-bg:                      #31754f;
-  ## For the warning buttons, since the saturation is very high, we'd need to make the background way darker, going
-  ## from an orangish yellow to complete brown.
-  ## Instead, we change the text color to black and make the background a bit lighter than default.
-  @btn-warning-color:                   #000000;
-  @btn-warning-bg:                      #ffd483;
+  ##For the warning buttons, since the saturation is very high, we'd need to make the background way darker, going
+  ## from an orangish yellow to complete brown. Instead, we change the text color to black.
+  @btn-warning-color:                   #000;
 #end
 
 ##############################################

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/variablesInit.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/variablesInit.vm
@@ -251,9 +251,11 @@
   @btn-succes-bg:                       #31754f;
   @btn-danger-bg:                       #ca302c;
   @btn-success-bg:                      #31754f;
-  ##For the warning buttons, since the saturation is very high, we'd need to make the background way darker, going
-  ## from an orangish yellow to complete brown. Instead, we change the text color to black.
-  @btn-warning-color:                   #000;
+  ## For the warning buttons, since the saturation is very high, we'd need to make the background way darker, going
+  ## from an orangish yellow to complete brown.
+  ## Instead, we change the text color to black and make the background a bit lighter than default.
+  @btn-warning-color:                   #000000;
+  @btn-warning-bg:                      #ffd483;
 #end
 
 ##############################################

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/variablesInit.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/variablesInit.vm
@@ -251,7 +251,7 @@
   @btn-succes-bg:                       #31754f;
   @btn-danger-bg:                       #ca302c;
   @btn-success-bg:                      #31754f;
-  ##For the warning buttons, since the saturation is very high, we'd need to make the background way darker, going
+  ## For the warning buttons, since the saturation is very high, we'd need to make the background way darker, going
   ## from an orangish yellow to complete brown. Instead, we change the text color to black.
   @btn-warning-color:                   #000;
 #end

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/variablesInit.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/variablesInit.vm
@@ -238,6 +238,10 @@
   @navbar-default-link-color:           #727272;
   @navbar-default-color:                #727272;
   ##
+  ## Make sure the breadcrumb links are dark enough
+  @breadcrumb-active-color:             #707070;
+  ## Ensure that all text-muted based components have sufficient contrast on white
+  @gray-light:                          #727272;
 #end
 
 ##############################################

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/variablesInit.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/variablesInit.vm
@@ -237,11 +237,23 @@
   ## Make sure the links are dark enough in the tmDrawer
   @navbar-default-link-color:           #727272;
   @navbar-default-color:                #727272;
-  ##
   ## Make sure the breadcrumb links are dark enough
   @breadcrumb-active-color:             #707070;
-  ## Ensure that all text-muted based components have sufficient contrast on white
-  @gray-light:                          #727272;
+  @breadcrumb-color:                    #707070;
+  ## Make sure that all text-muted based components have sufficient contrast on white
+  @text-muted:                          @gray;
+  ## Make the links a bit darker than the default from bootstrap. Default #337ab7 has sufficient contrast on white
+  ## but this updated value allows light grey background to keep enough contrast.
+  @brand-primary:                       #2f70a7;
+  ## Make sure button white text has enough contrast on the whole gradient
+  @btn-primary-bg:                      #386da7;
+  ## Make sure all kinds of buttons have proper contrast
+  @btn-succes-bg:                       #31754f;
+  @btn-danger-bg:                       #ca302c;
+  @btn-success-bg:                      #31754f;
+  ##For the warning buttons, since the saturation is very high, we'd need to make the background way darker, going
+  ## from an orangish yellow to complete brown. Instead, we change the text color to black.
+  @btn-warning-color:                   #000;
 #end
 
 ##############################################

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/variablesInit.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/variablesInit.vm
@@ -232,6 +232,12 @@
   @xwiki-page-header-bg-color:          $theme.pageHeaderBackgroundColor;
   @xwiki-page-header-bg-image:          $stringtool.defaultString($theme.headerBackgroundImage, '""');
   @xwiki-page-header-bg-position:       $stringtool.defaultString($theme.headerBackgroundPosition, '""');
+
+  ## Some values are changed from the bootstrap default in order to make sure there's no accessibility contrast issue
+  ## Make sure the links are dark enough in the tmDrawer
+  @navbar-default-link-color:           #727272;
+  @navbar-default-color:                #727272;
+  ##
 #end
 
 ##############################################

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsDisplayerUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsDisplayerUIX.xml
@@ -780,7 +780,7 @@ require(['jquery', 'xwiki-meta', 'xwiki-bootstrap-switch'], function ($, xm) {
  * Notifications Header
  ***********************************************/
 .notifications-count {
-  background-color: red;
+  background-color: firebrick;
   opacity: 0.9;
   position: absolute;
   margin-left: 1.6em;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsDisplayerUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsDisplayerUIX.xml
@@ -780,7 +780,7 @@ require(['jquery', 'xwiki-meta', 'xwiki-bootstrap-switch'], function ($, xm) {
  * Notifications Header
  ***********************************************/
 .notifications-count {
-  background-color: firebrick;
+  background-color: red;
   opacity: 0.9;
   position: absolute;
   margin-left: 1.6em;


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-20736
**PR Changes:**
* Added redefinition of some bootstrap variables when initializing a wiki without a theme.


**View:**
![20736-FullScreenAfter](https://user-images.githubusercontent.com/28761965/225078892-ef454ab7-6c4c-4220-815b-60a5b74b0de5.png)
