### PR TITLE
XWIKI-20745: Notification count color lacks contrast

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsDisplayerUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsDisplayerUIX.xml
@@ -780,8 +780,8 @@ require(['jquery', 'xwiki-meta', 'xwiki-bootstrap-switch'], function ($, xm) {
  * Notifications Header
  ***********************************************/
 .notifications-count {
-  background-color: red;
-  opacity: 0.9;
+  color: @btn-danger-color;
+  background-color: @btn-danger-bg;
   position: absolute;
   margin-left: 1.6em;
   top: 0;
@@ -833,10 +833,10 @@ require(['jquery', 'xwiki-meta', 'xwiki-bootstrap-switch'], function ($, xm) {
 }</code>
     </property>
     <property>
-      <contentType>CSS</contentType>
+      <contentType>LESS</contentType>
     </property>
     <property>
-      <name>CSS</name>
+      <name>LESS</name>
     </property>
     <property>
       <parse>1</parse>


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-20745
**PR Changes:**
* Changed the css containing presentation to a less and used a color theme variable
* Removed the .9 opacity that reduced contrast on most themes.

Now this notification count is a `badge` with the color pattern of a `danger button`.

**View: **
*Before*
![RedNotificationsWithoutTheme](https://user-images.githubusercontent.com/28761965/225268651-eb2ab7a9-9a05-4906-bc10-f045ff120c42.png)
*After*
![20745-afterChanges](https://user-images.githubusercontent.com/28761965/225268636-daba620c-f9f0-49df-a4a3-f6e1d72cc4ad.png)

**Note:** The solution chosen depends on the compliance of the active color theme danger buttons to WCAG 2.1 AA contrast minimums. If the buttons pass it, this badge will pass too. This makes this solution dependant of https://github.com/xwiki/xwiki-platform/pull/2101