### PR TITLE
XWIKI-20707: Remove <ul> separator in navbar

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_macros.vm
@@ -56,7 +56,8 @@
 ###    Toplevel Left Menu
 ###
 #macro(xwikitopmenuleftstart)
-  <ul class="nav navbar-nav navbar-left">
+  <ul class="nav navbar-nav navbar-left"
+    aria-label="$escapetool.xml($services.localization.render('core.menu.navbar.left.label'))">
 #end
 
 ###

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_macros.vm
@@ -57,7 +57,6 @@
 ###
 #macro(xwikitopmenuleftstart)
   <ul class="nav navbar-nav navbar-left">
-    #submenuseparator()
 #end
 
 ###

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -1021,6 +1021,7 @@ core.menu.type.profile=Profile
 core.menu.wiki.documentindex=Page Index
 core.menu.space.documentindex=Page Index
 core.menu.space.delete=Delete
+core.menu.navbar.left.label=Left side of the navigation bar
 ### Translations used from web standard templates, not colibri
 core.menu.view=View
 core.menu.print=Print


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-20707
**PR Changes:**
* Removed the separator at the start of the navbar left.


This doesn't change any display, and has little to no sense, since there is no element before (and none after). 
The use of separators should be avoided, since it's in most cases a sign that 2 distinct lists could be created.

This separator was first introduced in https://github.com/xwiki/xwiki-platform/commit/0681b42fd3ac050aebd9777bacbe5c3ffcc17d9b .