### PR TITLE
XWIKI-18004: Alert menu cannot be activated with keyboard + hover message not accessible with keyboard

### DIFF
--- a/xwiki-platform-core/xwiki-platform-alerts/xwiki-platform-alerts-ui/src/main/resources/XWiki/Alerts/Code/AlertsMenuUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-alerts/xwiki-platform-alerts-ui/src/main/resources/XWiki/Alerts/Code/AlertsMenuUIX.xml
@@ -137,13 +137,13 @@
   #set ($cachedMenuContent = $menuContent.toString())
   #if ($stringtool.isNotBlank($cachedMenuContent))
     &lt;li class="dropdown" id="tmNotifications"&gt;
-      &lt;a class="icon-navbar dropdown-toggle" data-toggle="dropdown" role="button"
+      &lt;button class="dropdown-toggle" data-toggle="dropdown"
       title="$services.localization.render('watchlist.notification.tooltip')"&gt;
         &lt;span class="sr-only"&gt;
           $services.localization.render('core.menu.toggleNavigation')
         &lt;/span&gt;
         $services.icon.renderHTML('bell')
-      &lt;/a&gt;
+      &lt;/button&gt;
       &lt;ul class="dropdown-menu"&gt;
         $cachedMenuContent
       &lt;/ul&gt;

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/action-menus.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/action-menus.less
@@ -151,6 +151,19 @@
   }
 }
 
+#tmNotifications {
+  & > button {
+    background-color: @navbar-default-bg;
+    color: @navbar-default-link-color;
+    border: 0;
+    padding: 10px @navbar-padding-horizontal;
+
+    @media (min-width: @grid-float-breakpoint) {
+      padding: @navbar-padding-vertical @navbar-padding-horizontal;
+    }
+  }
+}
+
 @media (min-width: @screen-sm-min) {
   .navbar-nav > li > a {
     /* When the page name is long, add ellipsis. */

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/action-menus.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/action-menus.less
@@ -161,6 +161,15 @@
     @media (min-width: @grid-float-breakpoint) {
       padding: @navbar-padding-vertical @navbar-padding-horizontal;
     }
+    &:hover,
+    &:focus {
+      background-color: @navbar-default-link-hover-bg;
+      color: @navbar-default-link-hover-color;
+    }
+    &:active {
+      background-color: @navbar-default-link-active-bg;
+      color: @navbar-default-link-active-color;
+    }
   }
 }
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsDisplayerUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsDisplayerUIX.xml
@@ -295,7 +295,7 @@ Get the actual notifications.
     // Create the counter if it is not present
     if (counter.length == 0) {
       counter = $('&lt;span&gt;').addClass('notifications-count badge');
-      $('#tmNotifications &gt; a.icon-navbar').after(counter);
+      $('#tmNotifications &gt; button.dropdown-toggle').append(counter);
     }
     // Update the counter
     counter.text(count);
@@ -783,13 +783,13 @@ require(['jquery', 'xwiki-meta', 'xwiki-bootstrap-switch'], function ($, xm) {
   background-color: red;
   opacity: 0.9;
   position: absolute;
-  margin-left: 1.6em;
   top: 0;
 }
 
 @media (min-width: 768px) {
   .notifications-count {
     top: 3px;
+    right: 3px;
   }
 }
 


### PR DESCRIPTION
**PR Changes:**
* Changed the dropdown toggle to a button. 
* Removed superfluous markup from the element.
* Updated css rules on hover and focus

**Notes: **
* The dropdown toggle used to be a link but the correct use of links is for navigation. Here we want to trigger a change of interface (and not move to somewhere else in the interface), so we should use a button. Buttons are properly accessible even without any text content.
* Because of a bootstrap dependency, there is still major accessibility violations inside the popup menu that should be reported one by one and addressed.  

