### PR TITLE
XWIKI-19469: The size of the image download and open Lightbox links is too small

### DIFF
--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/less/lightbox.less
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/less/lightbox.less
@@ -104,7 +104,7 @@
     }
 
     .tooltip-inner {
-      white-space:nowrap;
+      white-space: nowrap;
     }
   }
 }

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/less/lightbox.less
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/less/lightbox.less
@@ -80,21 +80,7 @@
 #imageToolbarTemplate {
   display: none;
 }
-.imageToolbar {
-  display: flex !important;
 
-  & > *, & a {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 44px;
-    min-height: 44px;
-  }
-
-  .tooltip-inner {
-    white-space:nowrap;
-  }
-}
 #imagePopoverContainer {
   position: absolute;
 
@@ -104,5 +90,21 @@
 
   .popover-content {
     padding: 0;
+  }
+
+  .imageToolbar {
+    display: flex;
+
+    & > *, & a {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 44px;
+      min-height: 44px;
+    }
+
+    .tooltip-inner {
+      white-space:nowrap;
+    }
   }
 }

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/less/lightbox.less
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/less/lightbox.less
@@ -81,8 +81,14 @@
   display: none;
 }
 .imageToolbar {
-  > * {
-    margin: .5em;
+  display: flex !important;
+
+  & > *, & a {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 44px;
+    min-height: 44px;
   }
 
   .tooltip-inner {
@@ -94,5 +100,9 @@
 
   .popover {
     white-space: nowrap;
+  }
+
+  .popover-content {
+    padding: 0;
   }
 }

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/less/lightbox.less
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/less/lightbox.less
@@ -99,8 +99,8 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      min-width: 44px;
-      min-height: 44px;
+      min-width: @target-size-recommended;
+      min-height: @target-size-recommended;
     }
 
     .tooltip-inner {


### PR DESCRIPTION


**Jira:** https://jira.xwiki.org/browse/XWIKI-19469
**PR Changes:**
* Reduced margins and increased size of elements up to 44*44

See jira for details about the choice of solution.

**View:**
![19469-WithoutMarginAndTabs](https://user-images.githubusercontent.com/28761965/226929799-b72f392a-bd47-4df0-81fa-435dc87dc1f9.png)
With tabbing order displayed by Firefox accessibility tool, we can see that the interactive elments cover most of the popup:
![19469-WithoutMargin](https://user-images.githubusercontent.com/28761965/226929806-f706b42d-77ff-48ae-a3e4-f30b85520bb7.png)