### PR TITLE
XWIKI-20781: Livedata colors are hard coded

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/LivedataDropdownMenu.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/LivedataDropdownMenu.vue
@@ -129,13 +129,20 @@ export default {
 
 <style>
 
-.livedata-dropdown-menu .btn-default {
-  background-color: #f8f8f8;
-  background-image: none;
-  border-color: #e5e5e5;
-  box-shadow: none;
-  color: #333333;
-  text-shadow: none;
+.livedata-dropdown-menu {
+  // Similar to .flat-buttons(), but there's no access
+  .btn-default {
+    background-color: @breadcrumb-bg;
+    background-image: none;
+    border-color: @dropdown-divider-bg;
+    box-shadow: none;
+    color: @dropdown-link-color;
+    text-shadow: none;
+  }
+
+  .btn-default:hover, .btn-default:active, .btn-default:focus, .open .dropdown-toggle {
+      border-color: darken(@dropdown-divider-bg, 10%);
+  }
 }
 
 .livedata-dropdown-menu .btn-default span {

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/LivedataDropdownMenu.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/LivedataDropdownMenu.vue
@@ -130,7 +130,7 @@ export default {
 <style>
 
 .livedata-dropdown-menu {
-  // Similar to .flat-buttons(), but there's no access
+  // Similar to .flat-buttons()
   .btn-default {
     background-color: @breadcrumb-bg;
     background-image: none;

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/LivedataEntrySelectorInfoBar.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/LivedataEntrySelectorInfoBar.vue
@@ -76,7 +76,7 @@ export default {
   margin-bottom: 1rem;
   padding: 12px;
   border-radius: 5px;
-  background-color: #ddd4;
+  background-color: @panel-default-heading-bg;
 }
 
 </style>

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/LivedataPagination.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/LivedataPagination.vue
@@ -312,7 +312,7 @@ export default {
 <style>
 
 .livedata-pagination {
-  color: #777777;
+  color: @text-muted;
   font-size: 0.9em;
 }
 

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/DisplayerActions.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/DisplayerActions.vue
@@ -101,7 +101,7 @@ export default {
 <style>
 
 .displayer-actions .action {
-  color: #777;
+  color: @text-muted;
   white-space: nowrap;
 }
 

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/LayoutLoader.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/LayoutLoader.vue
@@ -114,7 +114,7 @@ export default {
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: #3e7cbc;
+  background-color: @btn-primary-bg;
 }
 
 .layout-loader.waiting.visible {

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/cards/LayoutCards.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/cards/LayoutCards.vue
@@ -160,7 +160,7 @@ export default {
 
 .noentries-card {
   text-align: center;
-  color: #777777;
+  color: @text-muted;
   width: 100%;
   padding-bottom: 1em;
 }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/table/LayoutTable.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/table/LayoutTable.vue
@@ -188,7 +188,7 @@ export default {
 
 .noentries-table {
   text-align: center;
-  color: #777777;
+  color: @text-muted;
   width: 100%;
   padding-bottom: 1em;
 }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/panels/LivedataAdvancedPanelFilterEntry.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/panels/LivedataAdvancedPanelFilterEntry.vue
@@ -121,7 +121,7 @@ export default {
   visibility: visible;
 }
 .livedata-filter-container .delete-filter:hover {
-  background-color: #ccc4;
+  background-color: @panel-default-heading-bg;
 }
 .livedata-filter-container .delete-filter:active {
   background-color: unset;

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/panels/LivedataAdvancedPanelSort.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/panels/LivedataAdvancedPanelSort.vue
@@ -217,7 +217,7 @@ export default {
   visibility: visible;
 }
 .livedata-advanced-panel-sort .delete-sort:hover {
-  background-color: #ccc4;
+  background-color: @panel-default-heading-bg;
 }
 .livedata-advanced-panel-sort .delete-sort:active {
   background-color: unset;

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/utilities/XWikiLoader.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/utilities/XWikiLoader.vue
@@ -71,7 +71,7 @@ export default {
   height: 100%;
   min-height: 1rem;
   animation: waiting 2s linear infinite;
-  background: linear-gradient(135deg, transparent 25%, #ccc4 50%, transparent 75%);
+  background: linear-gradient(135deg, transparent 25%, @panel-default-heading-bg 50%, transparent 75%);
   background-repeat: repeat;
   background-size: 200% 100%;
 }


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-20781

**PR Changes:**
* Replaced hard coded values with color theme values, trying to match the closest: value-wise (considering the Iceberg color theme) and then semantically-wise.
* Replaced some semi-transparent elements with full colors (from the theme), some uses of transparency seemed superfluous


**View:**
![20781ViewAnnotated](https://user-images.githubusercontent.com/28761965/228188805-35ab82c0-a26b-4401-a85b-69efb1c6307c.png)


**Note:**
 Those changes will only change code quality and not accessibility of the interface as long as https://jira.xwiki.org/browse/XWIKI-20680 is not closed.