### PR TITLE
XWIKI-20548: Allow choosing the authenticator at runtime

### DIFF
--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/test/java/org/xwiki/extension/xar/internal/handler/WikiEventListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/test/java/org/xwiki/extension/xar/internal/handler/WikiEventListenerTest.java
@@ -45,7 +45,7 @@ import org.xwiki.test.annotation.AllComponents;
 import org.xwiki.wiki.descriptor.WikiDescriptorManager;
 
 @AllComponents
-public class WikiCopiedEventListenerTest
+public class WikiEventListenerTest
 {
     @Rule
     public MockitoRepositoryUtilsRule repositoryUtil = new MockitoRepositoryUtilsRule();

--- a/xwiki-platform-core/xwiki-platform-oldcore/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-oldcore/pom.xml
@@ -37,7 +37,11 @@
       com.xpn.xwiki.platform:xwiki-core,
 
       <!-- The old org.xwiki.platform:xwiki-platform-filter-instance-oldcore has been merged with oldcore -->
-      org.xwiki.platform:xwiki-platform-filter-instance-oldcore
+      org.xwiki.platform:xwiki-platform-filter-instance-oldcore,
+
+      <!-- A contrib extension to use with versions of oldcore which does not support authservice API -->
+      org.xwiki.contrib:authservice-backport-api,
+      org.xwiki.contrib:authservice-backport-default
     </xwiki.extension.features>
     <!-- Skipping revapi since xwiki-platform-legacy-oldcore wraps this module and runs checks on it -->
     <xwiki.revapi.skip>true</xwiki.revapi.skip>

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/security/authservice/AbstractXWikiAuthServiceWrapper.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/security/authservice/AbstractXWikiAuthServiceWrapper.java
@@ -1,0 +1,71 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.security.authservice;
+
+import java.security.Principal;
+
+import org.xwiki.stability.Unstable;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.user.api.XWikiAuthService;
+import com.xpn.xwiki.user.api.XWikiUser;
+
+/**
+ * Helper to redirect all {@link XWikiAuthService} calls to another {@link XWikiAuthService}.
+ * 
+ * @version $Id$
+ * @since 15.3RC1
+ */
+@Unstable
+public abstract class AbstractXWikiAuthServiceWrapper implements XWikiAuthService
+{
+    private final XWikiAuthService service;
+
+    protected AbstractXWikiAuthServiceWrapper(XWikiAuthService service)
+    {
+        this.service = service;
+    }
+
+    @Override
+    public XWikiUser checkAuth(XWikiContext context) throws XWikiException
+    {
+        return this.service.checkAuth(context);
+    }
+
+    @Override
+    public XWikiUser checkAuth(String username, String password, String rememberme, XWikiContext context)
+        throws XWikiException
+    {
+        return this.service.checkAuth(username, password, rememberme, context);
+    }
+
+    @Override
+    public void showLogin(XWikiContext context) throws XWikiException
+    {
+        this.service.showLogin(context);
+    }
+
+    @Override
+    public Principal authenticate(String username, String password, XWikiContext context) throws XWikiException
+    {
+        return this.service.authenticate(username, password, context);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/security/authservice/XWikiAuthServiceComponent.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/security/authservice/XWikiAuthServiceComponent.java
@@ -1,0 +1,45 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.security.authservice;
+
+import org.xwiki.component.annotation.Role;
+import org.xwiki.stability.Unstable;
+
+import com.xpn.xwiki.user.api.XWikiAuthService;
+
+/**
+ * Expose {@link XWikiAuthService} instances as components.
+ * 
+ * @version $Id$
+ * @since 15.3RC1
+ */
+@Role
+@Unstable
+public interface XWikiAuthServiceComponent extends XWikiAuthService
+{
+    // Name provided as translation "security.authservice.<id>.name"
+
+    // Description provided as translation "security.authservice.<id>.description"
+
+    /**
+     * @return the identifier of the authenticator, used as component role hint
+     */
+    String getId();
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/security/authservice/XWikiAuthServiceComponent.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/security/authservice/XWikiAuthServiceComponent.java
@@ -26,6 +26,12 @@ import com.xpn.xwiki.user.api.XWikiAuthService;
 
 /**
  * Expose {@link XWikiAuthService} instances as components.
+ * <p>
+ * A name and a description should also be exposed through translations using key of the followin form:
+ * <ul>
+ * <li>security.authservice.<id>.name for the name</li>
+ * <li>security.authservice.<id>.description for the description</li>
+ * </ul>
  * 
  * @version $Id$
  * @since 15.3RC1
@@ -34,10 +40,6 @@ import com.xpn.xwiki.user.api.XWikiAuthService;
 @Unstable
 public interface XWikiAuthServiceComponent extends XWikiAuthService
 {
-    // Name provided as translation "security.authservice.<id>.name"
-
-    // Description provided as translation "security.authservice.<id>.description"
-
     /**
      * @return the identifier of the authenticator, used as component role hint
      */

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/security/authservice/internal/AuthServiceConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/security/authservice/internal/AuthServiceConfiguration.java
@@ -72,6 +72,16 @@ public class AuthServiceConfiguration
     public static final String CONFIGURATION_INSTANCE_PROPERTY =
         "security.authentication." + AuthServiceConfigurationClassInitializer.FIELD_SERVICE;
 
+    /**
+     * Used to store the configured name in the cache. The reason why we don't directly store the name is that we need
+     * to differentiate between two use cases:
+     * <ul>
+     * <li>A given wiki does not have any configured auth service: the cache contains an entry associated with the wiki
+     * identifier with a null name in it</li>
+     * <li>The configuration of a given wiki hasn't been cache yet: the cache does not contain any entry associated with
+     * the wiki identifier</li>
+     * </ul>
+     */
     private class ServiceCacheEntry
     {
         private final String name;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/security/authservice/internal/AuthServiceConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/security/authservice/internal/AuthServiceConfiguration.java
@@ -1,0 +1,183 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.security.authservice.internal;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.apache.commons.lang3.StringUtils;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.configuration.ConfigurationSource;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.LocalDocumentReference;
+import org.xwiki.model.reference.WikiReference;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.objects.BaseObject;
+
+/**
+ * Store and read the configured auth service.
+ * 
+ * @version $Id$
+ * @since 15.3RC1
+ */
+@Component(roles = AuthServiceConfiguration.class)
+@Singleton
+public class AuthServiceConfiguration
+{
+    /**
+     * The spaces in which the authentication configuration is stored.
+     */
+    public static final List<String> SPACES = Arrays.asList("XWiki", "AuthService");
+
+    /**
+     * The spaces in which the authentication configuration is stored.
+     */
+    public static final String SPACES_STRING = "XWiki.AuthService";
+
+    /**
+     * The reference of the document holding the configuration of the authentication.
+     */
+    public static final LocalDocumentReference DOC_REFERENCE = new LocalDocumentReference(SPACES, "Configuration");
+
+    /**
+     * The name of the property containing the identifier of the authenticator in the xwiki.properties file.
+     */
+    public static final String CONFIGURATION_INSTANCE_PROPERTY =
+        "security.authentication." + AuthServiceConfigurationClassInitializer.FIELD_SERVICE;
+
+    private class ServiceCacheEntry
+    {
+        private final String name;
+
+        ServiceCacheEntry(String name)
+        {
+            this.name = name;
+        }
+    }
+
+    private Map<String, ServiceCacheEntry> serviceCache = new ConcurrentHashMap<>();
+
+    @Inject
+    private Provider<XWikiContext> xcontextProvider;
+
+    @Inject
+    @Named("xwikiproperties")
+    private ConfigurationSource configurationSource;
+
+    /**
+     * @return the hint of the configured authentication service
+     * @throws XWikiException when failing to load the configuration
+     */
+    public String getAuthService() throws XWikiException
+    {
+        XWikiContext xcontext = this.xcontextProvider.get();
+
+        // Try at current wiki level
+        String service = getAuthService(xcontext.getWikiReference(), xcontext);
+        if (service != null) {
+            return service;
+        }
+
+        // Try at main wiki level
+        if (!xcontext.isMainWiki()) {
+            service = getAuthService(xcontext.getWikiReference(), xcontext);
+            if (service != null) {
+                return service;
+            }
+        }
+
+        // Try at xwiki.properties level
+        return this.configurationSource.getProperty(CONFIGURATION_INSTANCE_PROPERTY);
+    }
+
+    private String getAuthService(WikiReference wiki, XWikiContext xcontext) throws XWikiException
+    {
+        ServiceCacheEntry service = this.serviceCache.get(wiki.getName());
+
+        if (service == null) {
+            service = new ServiceCacheEntry(loadAuthServiceId(wiki, xcontext));
+
+            this.serviceCache.put(wiki.getName(), service);
+        }
+
+        return service.name;
+    }
+
+    private String loadAuthServiceId(WikiReference wiki, XWikiContext xcontext) throws XWikiException
+    {
+        XWikiDocument configurationDocument =
+            xcontext.getWiki().getDocument(new DocumentReference(DOC_REFERENCE, wiki), xcontext);
+        BaseObject configurationObject =
+            configurationDocument.getXObject(AuthServiceConfigurationClassInitializer.CLASS_REFERENCE);
+
+        if (configurationObject != null) {
+            String serviceId =
+                configurationObject.getStringValue(AuthServiceConfigurationClassInitializer.FIELD_SERVICE);
+
+            if (StringUtils.isNotBlank(serviceId)) {
+                return serviceId;
+            }
+        }
+
+        return null;
+    }
+
+    private void setAuthServiceId(String id, WikiReference wiki, XWikiContext xcontext) throws XWikiException
+    {
+        XWikiDocument configurationDocument =
+            xcontext.getWiki().getDocument(new DocumentReference(DOC_REFERENCE, wiki), xcontext);
+        BaseObject configurationObject =
+            configurationDocument.getXObject(AuthServiceConfigurationClassInitializer.CLASS_REFERENCE, true, xcontext);
+
+        configurationObject.setStringValue(AuthServiceConfigurationClassInitializer.FIELD_SERVICE,
+            StringUtils.defaultString(id));
+
+        xcontext.getWiki().saveDocument(configurationDocument, "Change authenticator service", xcontext);
+    }
+
+    /**
+     * @param id the identifier of the authenticator
+     * @throws XWikiException when failing to update the configuration
+     */
+    public void setAuthServiceId(String id) throws XWikiException
+    {
+        XWikiContext xcontext = this.xcontextProvider.get();
+
+        setAuthServiceId(id, new WikiReference(xcontext.getWikiId()), xcontext);
+    }
+
+    /**
+     * @param wikiId the identifier of the wiki to remove from the cache
+     */
+    public void invalidate(String wikiId)
+    {
+        this.serviceCache.remove(wikiId);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/security/authservice/internal/AuthServiceConfigurationClassInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/security/authservice/internal/AuthServiceConfigurationClassInitializer.java
@@ -1,0 +1,72 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.security.authservice.internal;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.model.reference.LocalDocumentReference;
+
+import com.xpn.xwiki.doc.AbstractMandatoryClassInitializer;
+import com.xpn.xwiki.objects.classes.BaseClass;
+
+/**
+ * Initialize auth service configuration class.
+ * 
+ * @version $Id$
+ * @since 15.3RC1
+ */
+@Component
+@Named(AuthServiceConfigurationClassInitializer.CLASS_REFERENCE_STRING)
+@Singleton
+public class AuthServiceConfigurationClassInitializer extends AbstractMandatoryClassInitializer
+{
+    /**
+     * The reference of the class holding the configuration of the authentication.
+     */
+    public static final LocalDocumentReference CLASS_REFERENCE =
+        new LocalDocumentReference(AuthServiceConfiguration.SPACES, "ConfigurationClass");
+
+    /**
+     * The serialized reference of the class holding the configuration of the authentication.
+     */
+    public static final String CLASS_REFERENCE_STRING =
+        AuthServiceConfiguration.SPACES_STRING + ".ConfigurationClass";
+
+    /**
+     * The name of the property containing the identifier of the authenticator in the wiki.
+     */
+    public static final String FIELD_SERVICE = "authService";
+
+    /**
+     * The default constructor.
+     */
+    public AuthServiceConfigurationClassInitializer()
+    {
+        super(CLASS_REFERENCE, "AuthService Configuration Class");
+    }
+
+    @Override
+    protected void createClass(BaseClass xclass)
+    {
+        xclass.addTextField(FIELD_SERVICE, "Service", 30);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/security/authservice/internal/AuthServiceConfigurationInvalidator.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/security/authservice/internal/AuthServiceConfigurationInvalidator.java
@@ -1,0 +1,82 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.security.authservice.internal;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.bridge.event.WikiDeletedEvent;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.model.EntityType;
+import org.xwiki.model.reference.EntityReference;
+import org.xwiki.observation.AbstractEventListener;
+import org.xwiki.observation.event.Event;
+
+import com.xpn.xwiki.internal.event.EntityEvent;
+import com.xpn.xwiki.internal.event.XObjectPropertyAddedEvent;
+import com.xpn.xwiki.internal.event.XObjectPropertyDeletedEvent;
+import com.xpn.xwiki.internal.event.XObjectPropertyUpdatedEvent;
+import com.xpn.xwiki.objects.BaseObjectReference;
+
+/**
+ * Invalidate the configuration cache when the configuration is modified.
+ * 
+ * @version $Id$
+ * @since 15.3RC1
+ */
+@Component
+@Named(AuthServiceConfigurationInvalidator.NAME)
+@Singleton
+public class AuthServiceConfigurationInvalidator extends AbstractEventListener
+{
+    /**
+     * The name of this event listener (and its component hint at the same time).
+     */
+    public static final String NAME = "AuthenticationServiceConfigurationInvalidator";
+
+    private static final EntityReference PROPERTY_REFERENCE_MATCHER = new EntityReference(
+        AuthServiceConfigurationClassInitializer.FIELD_SERVICE, EntityType.OBJECT_PROPERTY,
+        BaseObjectReference.any(AuthServiceConfigurationClassInitializer.CLASS_REFERENCE_STRING));
+
+    @Inject
+    private AuthServiceConfiguration configuration;
+
+    /**
+     * Default constructor.
+     */
+    public AuthServiceConfigurationInvalidator()
+    {
+        super(NAME, new WikiDeletedEvent(), new XObjectPropertyAddedEvent(PROPERTY_REFERENCE_MATCHER),
+            new XObjectPropertyUpdatedEvent(PROPERTY_REFERENCE_MATCHER),
+            new XObjectPropertyDeletedEvent(PROPERTY_REFERENCE_MATCHER));
+    }
+
+    @Override
+    public void onEvent(Event event, Object source, Object data)
+    {
+        if (event instanceof WikiDeletedEvent) {
+            this.configuration.invalidate(((WikiDeletedEvent) event).getWikiId());
+        } else {
+            this.configuration
+                .invalidate(((EntityEvent) event).getReference().extractReference(EntityType.WIKI).getName());
+        }
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/security/authservice/internal/AuthServiceManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/security/authservice/internal/AuthServiceManager.java
@@ -1,0 +1,96 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.security.authservice.internal;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.slf4j.Logger;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.manager.ComponentLookupException;
+import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.security.authservice.XWikiAuthServiceComponent;
+
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.user.api.XWikiAuthService;
+
+/**
+ * Get the configured authenticator in the current context.
+ * 
+ * @version $Id$
+ * @since 15.3RC1
+ */
+@Component(roles = AuthServiceManager.class)
+@Singleton
+public class AuthServiceManager
+{
+    @Inject
+    private AuthServiceConfiguration configuration;
+
+    @Inject
+    @Named(StandardXWikiAuthServiceComponent.ID)
+    private XWikiAuthServiceComponent standardAuthenticator;
+
+    @Inject
+    @Named("context")
+    private Provider<ComponentManager> componentManagerProvider;
+
+    @Inject
+    private Logger logger;
+
+    /**
+     * @return the XWikiAuthService in the current context
+     * @throws ComponentLookupException when failing to get the current auth service
+     * @throws XWikiException when failing to get the current auth service configuration
+     */
+    public XWikiAuthService getAuthService() throws ComponentLookupException, XWikiException
+    {
+        // Get the configured authenticator
+        String authHint = this.configuration.getAuthService();
+
+        // Resolve the corresponding authenticator
+        if (authHint != null) {
+            ComponentManager componentManager = this.componentManagerProvider.get();
+
+            if (componentManager.hasComponent(XWikiAuthServiceComponent.class, authHint)) {
+                return componentManager.getInstance(XWikiAuthServiceComponent.class, authHint);
+            } else {
+                this.logger.warn("No authentication service could be found for identifier [{}]. "
+                    + "Fallbacking on the standard one.", authHint);
+            }
+        }
+
+        // Fallback on the standard authenticator
+        return this.standardAuthenticator;
+    }
+
+    /**
+     * @return the auth services available in the current context
+     * @throws ComponentLookupException when failing to get the current auth services
+     */
+    public List<XWikiAuthServiceComponent> getAuthServices() throws ComponentLookupException
+    {
+        return this.componentManagerProvider.get().getInstanceList(XWikiAuthServiceComponent.class);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/security/authservice/internal/StandardXWikiAuthServiceComponent.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/security/authservice/internal/StandardXWikiAuthServiceComponent.java
@@ -1,0 +1,91 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.security.authservice.internal;
+
+import java.security.Principal;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.phase.Initializable;
+import org.xwiki.component.phase.InitializationException;
+import org.xwiki.security.authservice.XWikiAuthServiceComponent;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.user.api.XWikiUser;
+import com.xpn.xwiki.user.impl.xwiki.XWikiAuthServiceImpl;
+
+/**
+ * The standard XWiki authenticator, to use by default.
+ * 
+ * @version $Id$
+ * @since 15.3RC1
+ */
+@Component
+@Singleton
+@Named(StandardXWikiAuthServiceComponent.ID)
+public class StandardXWikiAuthServiceComponent implements XWikiAuthServiceComponent, Initializable
+{
+    /**
+     * The identifier of the authentication service.
+     */
+    public static final String ID = "standard";
+
+    private XWikiAuthServiceImpl service;
+
+    @Override
+    public String getId()
+    {
+        return ID;
+    }
+
+    @Override
+    public void initialize() throws InitializationException
+    {
+        this.service = new XWikiAuthServiceImpl();
+    }
+
+    @Override
+    public XWikiUser checkAuth(XWikiContext context) throws XWikiException
+    {
+        return this.service.checkAuth(context);
+    }
+
+    @Override
+    public XWikiUser checkAuth(String username, String password, String rememberme, XWikiContext context)
+        throws XWikiException
+    {
+        return this.service.checkAuth(username, password, rememberme, context);
+    }
+
+    @Override
+    public void showLogin(XWikiContext context) throws XWikiException
+    {
+        this.service.showLogin(context);
+    }
+
+    @Override
+    public Principal authenticate(String username, String password, XWikiContext context) throws XWikiException
+    {
+        return this.service.authenticate(username, password, context);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/security/authservice/internal/StandardXWikiAuthServiceComponent.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/security/authservice/internal/StandardXWikiAuthServiceComponent.java
@@ -25,8 +25,6 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
-import org.xwiki.component.phase.Initializable;
-import org.xwiki.component.phase.InitializationException;
 import org.xwiki.security.authservice.XWikiAuthServiceComponent;
 
 import com.xpn.xwiki.XWikiContext;
@@ -43,25 +41,19 @@ import com.xpn.xwiki.user.impl.xwiki.XWikiAuthServiceImpl;
 @Component
 @Singleton
 @Named(StandardXWikiAuthServiceComponent.ID)
-public class StandardXWikiAuthServiceComponent implements XWikiAuthServiceComponent, Initializable
+public class StandardXWikiAuthServiceComponent implements XWikiAuthServiceComponent
 {
     /**
      * The identifier of the authentication service.
      */
     public static final String ID = "standard";
 
-    private XWikiAuthServiceImpl service;
+    private final XWikiAuthServiceImpl service = new XWikiAuthServiceImpl();
 
     @Override
     public String getId()
     {
         return ID;
-    }
-
-    @Override
-    public void initialize() throws InitializationException
-    {
-        this.service = new XWikiAuthServiceImpl();
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/security/authservice/script/AuthServiceScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/security/authservice/script/AuthServiceScriptService.java
@@ -1,0 +1,155 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.security.authservice.script;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.manager.ComponentLookupException;
+import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.configuration.ConfigurationSource;
+import org.xwiki.script.service.ScriptService;
+import org.xwiki.security.authorization.AccessDeniedException;
+import org.xwiki.security.authorization.AuthorizationManager;
+import org.xwiki.security.authorization.Right;
+import org.xwiki.security.authservice.XWikiAuthServiceComponent;
+import org.xwiki.security.authservice.internal.AuthServiceConfiguration;
+import org.xwiki.security.authservice.internal.AuthServiceManager;
+import org.xwiki.security.script.SecurityScriptService;
+
+import com.xpn.xwiki.XWiki;
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.user.api.XWikiAuthService;
+
+/**
+ * The script service used to manipulate the registered {@link XWikiAuthService} instances.
+ *
+ * @version $Id$
+ * @since 15.3RC1
+ */
+@Component
+@Named(SecurityScriptService.ROLEHINT + '.' + AuthServiceScriptService.ID)
+@Singleton
+public class AuthServiceScriptService implements ScriptService
+{
+    /**
+     * The role hint of this component.
+     */
+    public static final String ID = "authService";
+
+    @Inject
+    @Named("context")
+    private Provider<ComponentManager> componentManagerProvider;
+
+    @Inject
+    @Named("xwikicfg")
+    private ConfigurationSource xwikicfg;
+
+    @Inject
+    private AuthServiceConfiguration configuration;
+
+    @Inject
+    private Provider<XWikiContext> contextProvider;
+
+    @Inject
+    private AuthorizationManager authorization;
+
+    @Inject
+    private AuthServiceManager authServices;
+
+    private void checkWikiAdmin() throws AccessDeniedException
+    {
+        XWikiContext xcontext = this.contextProvider.get();
+
+        // Make sure current author has wiki admin right to use this API
+        this.authorization.checkAccess(Right.ADMIN, xcontext.getAuthorReference(), xcontext.getWikiReference());
+    }
+
+    /**
+     * Get the {@link XWikiAuthService} according to {@link XWiki#getAuthService()}.
+     * 
+     * @return the main {@link XWikiAuthService}
+     * @throws AccessDeniedException when the current author is not authorized to use this API
+     */
+    public XWikiAuthService getAuthService() throws AccessDeniedException
+    {
+        checkWikiAdmin();
+
+        XWikiContext xcontext = this.contextProvider.get();
+
+        return xcontext.getWiki().getAuthService();
+    }
+
+    /**
+     * @return the authentication service class indicated in xwiki.cfg
+     * @throws AccessDeniedException when the current author is not authorized to use this API
+     */
+    public String getConfiguredAuthClass() throws AccessDeniedException
+    {
+        checkWikiAdmin();
+
+        return this.xwikicfg.getProperty("xwiki.authentication.authclass");
+    }
+
+    /**
+     * @return true if the auth service is a component, false when it's based on the old xwiki.cfg authClass property or
+     *         if it's directly injected through {@link XWiki#setAuthService(Class)}
+     */
+    public boolean isAuthServiceComponent()
+    {
+        XWikiContext xcontext = this.contextProvider.get();
+
+        return xcontext.getWiki().isAuthServiceComponent();
+    }
+
+    /**
+     * Get all the available component based authentication services.
+     * 
+     * @return the available authentication services
+     * @throws AccessDeniedException when the current author is not authorized to use this API
+     * @throws ComponentLookupException when failing to looking the authentication services
+     */
+    public List<XWikiAuthServiceComponent> getAuthServices() throws AccessDeniedException, ComponentLookupException
+    {
+        checkWikiAdmin();
+
+        return this.authServices.getAuthServices();
+    }
+
+    /**
+     * Set the authentication service in the wiki configuration.
+     * 
+     * @param id the identifier of the authentication service
+     * @throws AccessDeniedException when the current author is not authorized to use this API
+     * @throws XWikiException when failing to get the authentication service
+     */
+    public void setAuthService(String id) throws AccessDeniedException, XWikiException
+    {
+        checkWikiAdmin();
+
+        this.configuration.setAuthServiceId(id);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -4016,6 +4016,11 @@ notifications.events.delete.description.by.users=deleted by {0} users
 
 template.error.requirement.action=Action [{0}] does not match action requirement [{1}].
 
+## Auth Services
+
+security.authservice.service.standard.name=Standard XWiki Authenticator
+security.authservice.service.standard.description=The default authenticator, based on passwords stored in user profiles
+
 ###############################################################################
 ## Deprecated
 ## Note: each element should be removed when the last branch using it is no longer supported

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/META-INF/components.txt
@@ -270,3 +270,9 @@ org.xwiki.internal.template.ActionTemplateRequirement
 org.xwiki.internal.migration.R150000000XWIKI20285DataMigration
 org.xwiki.internal.migration.InvitationInternalDocumentParameterEscapingFixer
 org.xwiki.internal.migration.InvitationInternalDocumentParameterEscapingTaskConsumer
+org.xwiki.security.authservice.internal.AuthServiceConfiguration
+org.xwiki.security.authservice.internal.AuthServiceConfigurationClassInitializer
+org.xwiki.security.authservice.internal.AuthServiceConfigurationInvalidator
+org.xwiki.security.authservice.internal.AuthServiceManager
+org.xwiki.security.authservice.internal.StandardXWikiAuthServiceComponent
+org.xwiki.security.authservice.script.AuthServiceScriptService

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-ui/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-ui/pom.xml
@@ -32,6 +32,11 @@
   <properties>
     <!-- Name to display by the Extension Manager -->
     <xwiki.extension.name>Authentication Application</xwiki.extension.name>
+
+    <xwiki.extension.features>
+      <!-- A contrib extension to use with versions of the authentication administration which does not support authservice -->
+      org.xwiki.contrib:authservice-backport-ui
+    </xwiki.extension.features>
   </properties>
   <dependencies>
     <dependency>

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-ui/src/main/resources/XWiki/Authentication/Administration.xml
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-ui/src/main/resources/XWiki/Authentication/Administration.xml
@@ -36,7 +36,8 @@
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
-  <content>== {{translation key="security.authservice.admin.title"/}}
+  <content>(% id='HAuthService' %)
+== {{translation key="security.authservice.admin.title"/}}
 
 {{velocity}}
 #if ($request.setauthservice &amp;&amp; $request.authServiceId)
@@ -100,6 +101,7 @@
 #end
 {{/velocity}}
 
+(% id='HAuthenticationSecurity' %)
 == {{translation key="authentication.admin.heading"/}}
 
 {{velocity}}
@@ -404,7 +406,7 @@
       <displayInSection>Authentication</displayInSection>
     </property>
     <property>
-      <heading>$services.localization.render('authentication.admin.heading')</heading>
+      <heading/>
     </property>
     <property>
       <iconAttachment/>

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-ui/src/main/resources/XWiki/Authentication/Administration.xml
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-ui/src/main/resources/XWiki/Authentication/Administration.xml
@@ -77,7 +77,7 @@
   #if ($authServices.size() &gt; 1)
     {{html}}
       &lt;form action="$xwiki.relativeRequestURL" method="post"&gt;
-        &lt;input type="hidden" name="form_token" value="$!{services.csrf.getToken()}" /&gt;;
+        &lt;input type="hidden" name="form_token" value="$!{services.csrf.getToken()}" /&gt;
         $escapetool.xml($services.localization.render("security.authservice.admin.component.label"))
         &lt;select name="authServiceId" id="authServiceId"&gt;
         #foreach ($availableAuthService in $authServices)

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-ui/src/main/resources/XWiki/Authentication/Administration.xml
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-ui/src/main/resources/XWiki/Authentication/Administration.xml
@@ -36,7 +36,73 @@
   <minorEdit>false</minorEdit>
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
-  <content>{{velocity}}
+  <content>== {{translation key="security.authservice.admin.title"/}}
+
+{{velocity}}
+#if ($request.setauthservice &amp;&amp; $request.authServiceId)
+  #if ($services.csrf.isTokenValid($request.getParameter('form_token')))
+    $services.security.authService.setAuthService($request.authServiceId)
+  #end
+#end
+{{/velocity}}
+
+{{velocity}}
+#set ($authService = $services.security.authService.getAuthService())
+#set ($configuredAuthClass = $services.security.authService.getConfiguredAuthClass())
+#if ($services.security.authService.isAuthServiceComponent())
+  #set ($authServiceType = 'component')
+#elseif ($configuredAuthClass &amp;&amp; ($authService.class.name == $configuredAuthClass || $authService.class.name == 'com.xpn.xwiki.user.impl.xwiki.XWikiAuthServiceImpl'))
+  #set ($authServiceType = 'class')
+#else
+  #set ($authServiceType = 'other')
+#end
+
+{{box}}
+  #set ($authService = $services.security.authService.getAuthService())
+  #set ($authServiceName = $services.localization.get("security.authservice.service.${authService.id}.name"))
+  #if ($authServiceName)
+    **{{translation key="security.authservice.service.${authService.id}.name"/}}** (//$authService.class.name//)
+    #set ($authServiceDescription = $services.localization.get("security.authservice.service.${authService.id}.description"))
+    #if ($authServiceDescription)
+      {{translation key="security.authservice.service.${authService.id}.description"/}}
+    #end
+  #else
+    $authService.class.name
+  #end
+{{/box}}
+
+#if ($authServiceType == 'component')
+  #set ($authServices = $services.security.authService.getAuthServices())
+  #if ($authServices.size() &gt; 1)
+    {{html}}
+      &lt;form action="$xwiki.relativeRequestURL" method="post"&gt;
+        &lt;input type="hidden" name="form_token" value="$!{services.csrf.getToken()}" /&gt;;
+        $escapetool.xml($services.localization.render("security.authservice.admin.component.label"))
+        &lt;select name="authServiceId" id="authServiceId"&gt;
+        #foreach ($availableAuthService in $authServices)
+          &lt;option#if ($availableAuthService.id == $authService.id) selected#end value="$escapetool.xml($availableAuthService.id)" title="$escapetool.xml($services.localization.render("security.authservice.service.${availableAuthService.id}.description"))"&gt;
+            $escapetool.xml($services.localization.render("security.authservice.service.${availableAuthService.id}.name"))
+          &lt;/option&gt;
+        #end
+        &lt;/select&gt;
+        &lt;button class="btn btn-danger" name="setauthservice"&gt;$escapetool.xml($services.localization.render("security.authservice.admin.component.save"))&lt;/button&gt;
+      &lt;/form&gt;
+    {{/html}}
+  #else
+    {{info}}{{translation key="security.authservice.admin.component.noService"/}}{{/info}}
+  #end
+#else
+  #if ($authServiceType == 'other')
+    {{warning}}{{translation key="security.authservice.admin.other.warning"/}}{{/warning}}
+  #elseif ($authServiceType == 'class')
+    {{warning}}{{translation key="security.authservice.admin.class.warning"/}}{{/warning}}
+  #end
+#end
+{{/velocity}}
+
+== {{translation key="authentication.admin.heading"/}}
+
+{{velocity}}
 #set ($discard = $xwiki.jsx.use('XWiki.Authentication.Administration'))
 #set ($authConfig = $services.security.authentication.authenticationConfiguration)
 #set ($selectedStrategies = {})


### PR DESCRIPTION
* introduce a role to expose an authenticator as component
* refactor XWiki#getAuthService() to rely on components by default
* add a section in the authentication administration to
  * show information about the current authenticator
  * allow changing it (when it's not an authenticator set through xwiki.cfg or injected dynamically)
* as a bonus of being configured at wiki level: it's possible to use different auth services on different wikis (unconfigured subwiki inherit main wiki configuration which inherit xwiki.properties configuration)

A backport of the API is provided through https://github.com/xwiki-contrib/authservice-backport because existing authenticators needs to implement this new role, and they are obviously not going to upgrade to 15.3 anytime soon.

Before someone ask: the java part is not in xwiki-platform-security-authentication because this is just here to expose the current API as component, and ideally one day we want to design an entirely new authentication API without any dependency on oldcore classes which and, this time, will be located in by xwiki-platform-security-authentication-api.