### PR TITLE
XWIKI-20757: CK Editor loading form element doesn't have a label

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/Translations.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/Translations.xml
@@ -50,6 +50,7 @@ CKEditor.ConfigClass_advanced=Advanced Configuration
 CKEditor.ConfigClass_advanced.hint=You can write a JavaScript snippet to modify directly the configuration object. Check the {0}CKEditor documentation{1} for the list of available configuration properties.
 
 ckeditor.content.placeholder=Start typing here...
+ckeditor.loader.placeholder=Loading the content
 
 ckeditor.admin.saveComment=Updated the CKEditor configuration from the Administration
 ckeditor.admin.reset=Reset

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/VelocityMacros.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/VelocityMacros.xml
@@ -187,9 +187,12 @@
   ## See CKEDITOR-34: Wiki syntax gets escaped when you click "Back" in the browser
   &lt;input value="" name="$!{escapedName}_cache" type="hidden" class="cache"/&gt;
   ##
+  #set ($loaderDescription = $escapetool.xml($services.localization.render("ckeditor.loader.placeholder")))
   #set ($discard = $parameters.attributes.putAll({
     'class': "$!parameters.attributes.get('class') ckeditor-textarea loading",
-    'spellcheck': false
+    'spellcheck': false,
+    'title': "$!loaderDescription",
+    'aria-label': "$!loaderDescription"
   }))
   ##
   #set ($sourceDocumentReference = $parameters.attributes.get('data-sourceDocumentReference'))

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/VelocityMacros.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/VelocityMacros.xml
@@ -187,7 +187,7 @@
   ## See CKEDITOR-34: Wiki syntax gets escaped when you click "Back" in the browser
   &lt;input value="" name="$!{escapedName}_cache" type="hidden" class="cache"/&gt;
   ##
-  #set ($loaderDescription = $escapetool.xml($services.localization.render("ckeditor.loader.placeholder")))
+  #set ($loaderDescription = $services.localization.render("ckeditor.loader.placeholder"))
   #set ($discard = $parameters.attributes.putAll({
     'class': "$!parameters.attributes.get('class') ckeditor-textarea loading",
     'spellcheck': false,


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-20757
**PR Changes:**
* Added the label to the parameters of the loading textarea as a `title` and `aria-label`
* Added a translation for the label

**Note:** 
The translation key name might be not precise enough, I tried to keep consistency with `ckeditor.content.placeholder`