### PR TITLE
[Misc] Fixed formFields structure in functional tests

### DIFF
--- a/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-test/xwiki-platform-export-pdf-test-content/src/main/resources/PDFExportIT/FormFields.xml
+++ b/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-test/xwiki-platform-export-pdf-test-content/src/main/resources/PDFExportIT/FormFields.xml
@@ -38,7 +38,7 @@
   <hidden>false</hidden>
   <content>{{html clean="false"}}
 &lt;form class="xform"&gt;
-  &lt;dd&gt;
+  &lt;dl&gt;
     &lt;dt&gt;
       &lt;label for="testTitle"&gt;Title&lt;/label&gt;
     &lt;/dt&gt;


### PR DESCRIPTION
* The HTML wasn't valid. The region was opened with \<dd> and closed with \<dl>.

**WCAG report that highlights this typo in tests:** 

> WCAG warnings in the test class [org.xwiki.export.pdf.test.ui.AllITs]:
> Validation in the test method [formFields]
> Check for [org.xwiki.test.ui.po.ViewPage] at [http://xwikiweb:8080/xwiki/bin/view/PDFExportIT/FormFields].
> \<dt> and \<dd> elements must be contained by a \<dl>
> Description: Ensures \<dt> and \<dd> elements are contained by a \<dl>
> Help URL: https://dequeuniversity.com/rules/axe/4.6/dlitem?application=axeAPI
> Impact: serious
> Tags: cat.structure, wcag2a, wcag131
> HTML element: 
> 	\<dd>
> 	\</dd>
> Selector: [dd:nth-child(1)]
> Fix any of the following:
>   Description list item does not have a \<dl> parent element
