### PR TITLE
Misc accessibility rules update

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/WCAGContext.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/WCAGContext.java
@@ -66,7 +66,8 @@ public class WCAGContext
 
             // WCAG 2.0 Level A & AA Rules
             entry("area-alt", true),
-            entry("aria-allowed-attr", false), // Set to true once the build doesn't fail this rule anymore
+            // Set to true once the build doesn't fail this rule anymore
+            entry("aria-allowed-attr", false),
             entry("aria-command-name", true),
             entry("aria-hidden-body", true),
             entry("aria-hidden-focus", true),
@@ -74,7 +75,8 @@ public class WCAGContext
             entry("aria-meter-name", true),
             entry("aria-progressbar-name", true),
             entry("aria-required-attr", true),
-            entry("aria-required-children", false), // Set to true once the build doesn't fail this rule anymore
+            // Set to true once the build doesn't fail this rule anymore
+            entry("aria-required-children", false),
             entry("aria-required-parent", true),
             entry("aria-roledescription", true),
             entry("aria-roles", true),
@@ -86,27 +88,38 @@ public class WCAGContext
             entry("blink", true),
             entry("button-name", true),
             entry("bypass", true),
-            entry("color-contrast", false), // Set to true once the build doesn't fail this rule anymore
+            // Set to true once the build doesn't fail this rule anymore
+            entry("color-contrast", false),
             entry("definition-list", true),
-            entry("dlitem", false), // Set to true once the build doesn't fail this rule anymore
+            // Set to true once the build doesn't fail this rule anymore
+            entry("dlitem", false),
             entry("document-title", true),
-            entry("duplicate-id-active", false), // Set to true once the build doesn't fail this rule anymore
-            entry("duplicate-id-aria", false), // Set to true once the build doesn't fail this rule anymore
-            entry("duplicate-id", false), // Set to true once the build doesn't fail this rule anymore
+            // Set to true once the build doesn't fail this rule anymore
+            entry("duplicate-id-active", false),
+            // Set to true once the build doesn't fail this rule anymore
+            entry("duplicate-id-aria", false),
+            // Set to true once the build doesn't fail this rule anymore
+            entry("duplicate-id", false),
             entry("form-field-multiple-labels", true),
             entry("frame-focusable-content", true),
             entry("frame-title-unique", true),
-            entry("frame-title", false), // Set to true once the build doesn't fail this rule anymore
+            // Set to true once the build doesn't fail this rule anymore
+            entry("frame-title", false),
             entry("html-has-lang", true),
             entry("html-lang-valid", true),
             entry("html-xml-lang-mismatch", true),
-            entry("image-alt", false), // Set to true once the build doesn't fail this rule anymore
+            // Set to true once the build doesn't fail this rule anymore
+            entry("image-alt", false),
             entry("input-button-name", true),
             entry("input-image-alt", true),
-            entry("label", false), // Set to true once the build doesn't fail this rule anymore
-            entry("link-in-text-block", false), // Set to true once the build doesn't fail this rule anymore
-            entry("link-name", false), // Set to true once the build doesn't fail this rule anymore
-            entry("list", false), // Set to true once the build doesn't fail this rule anymore
+            // Set to true once the build doesn't fail this rule anymore
+            entry("label", false),
+            // Set to true once the build doesn't fail this rule anymore
+            entry("link-in-text-block", false),
+            // Set to true once the build doesn't fail this rule anymore
+            entry("link-name", false),
+            // Set to true once the build doesn't fail this rule anymore
+            entry("list", false),
             entry("listitem", true),
             entry("marquee", true),
             entry("meta-refresh", true),
@@ -116,7 +129,8 @@ public class WCAGContext
             entry("object-alt", true),
             entry("role-img-alt", true),
             entry("scrollable-region-focusable", true),
-            entry("select-name", false), // Set to true once the build doesn't fail this rule anymore
+            // Set to true once the build doesn't fail this rule anymore
+            entry("select-name", false),
             entry("server-side-image-map", true),
             entry("svg-img-alt", true),
             entry("td-headers-attr", true),

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/WCAGContext.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/WCAGContext.java
@@ -65,71 +65,71 @@ public class WCAGContext
     private static final Map<String, Boolean> FAILS_ON_RULE = Map.ofEntries(
 
             // WCAG 2.0 Level A & AA Rules
-            entry("area-alt", false),
-            entry("aria-allowed-attr", false),
-            entry("aria-command-name", false),
-            entry("aria-hidden-body", false),
-            entry("aria-hidden-focus", false),
-            entry("aria-input-field-name", false),
-            entry("aria-meter-name", false),
-            entry("aria-progressbar-name", false),
-            entry("aria-required-attr", false),
-            entry("aria-required-children", false),
-            entry("aria-required-parent", false),
-            entry("aria-roledescription", false),
-            entry("aria-roles", false),
-            entry("aria-toggle-field-name", false),
-            entry("aria-tooltip-name", false),
-            entry("aria-valid-attr-value", false),
-            entry("aria-valid-attr", false),
-            entry("audio-caption", false),
-            entry("blink", false),
-            entry("button-name", false),
-            entry("bypass", false),
-            entry("color-contrast", false),
-            entry("definition-list", false),
-            entry("dlitem", false),
-            entry("document-title", false),
-            entry("duplicate-id-active", false),
-            entry("duplicate-id-aria", false),
-            entry("duplicate-id", false),
-            entry("form-field-multiple-labels", false),
-            entry("frame-focusable-content", false),
-            entry("frame-title-unique", false),
-            entry("frame-title", false),
-            entry("html-has-lang", false),
-            entry("html-lang-valid", false),
-            entry("html-xml-lang-mismatch", false),
-            entry("image-alt", false),
-            entry("input-button-name", false),
-            entry("input-image-alt", false),
-            entry("label", false),
-            entry("link-in-text-block", false),
-            entry("link-name", false),
-            entry("list", false),
-            entry("listitem", false),
-            entry("marquee", false),
-            entry("meta-refresh", false),
-            entry("meta-viewport", false),
-            entry("nested-interactive", false),
-            entry("no-autoplay-audio", false),
-            entry("object-alt", false),
-            entry("role-img-alt", false),
-            entry("scrollable-region-focusable", false),
-            entry("select-name", false),
-            entry("server-side-image-map", false),
-            entry("svg-img-alt", false),
-            entry("td-headers-attr", false),
-            entry("th-has-data-cells", false),
-            entry("valid-lang", false),
-            entry("video-caption", false),
+            entry("area-alt", true),
+            entry("aria-allowed-attr", false), // Set to true once the build doesn't fail this rule anymore
+            entry("aria-command-name", true),
+            entry("aria-hidden-body", true),
+            entry("aria-hidden-focus", true),
+            entry("aria-input-field-name", true),
+            entry("aria-meter-name", true),
+            entry("aria-progressbar-name", true),
+            entry("aria-required-attr", true),
+            entry("aria-required-children", false), // Set to true once the build doesn't fail this rule anymore
+            entry("aria-required-parent", true),
+            entry("aria-roledescription", true),
+            entry("aria-roles", true),
+            entry("aria-toggle-field-name", true),
+            entry("aria-tooltip-name", true),
+            entry("aria-valid-attr-value", true),
+            entry("aria-valid-attr", true),
+            entry("audio-caption", true),
+            entry("blink", true),
+            entry("button-name", true),
+            entry("bypass", true),
+            entry("color-contrast", false), // Set to true once the build doesn't fail this rule anymore
+            entry("definition-list", true),
+            entry("dlitem", false), // Set to true once the build doesn't fail this rule anymore
+            entry("document-title", true),
+            entry("duplicate-id-active", false), // Set to true once the build doesn't fail this rule anymore
+            entry("duplicate-id-aria", false), // Set to true once the build doesn't fail this rule anymore
+            entry("duplicate-id", false), // Set to true once the build doesn't fail this rule anymore
+            entry("form-field-multiple-labels", true),
+            entry("frame-focusable-content", true),
+            entry("frame-title-unique", true),
+            entry("frame-title", false), // Set to true once the build doesn't fail this rule anymore
+            entry("html-has-lang", true),
+            entry("html-lang-valid", true),
+            entry("html-xml-lang-mismatch", true),
+            entry("image-alt", false), // Set to true once the build doesn't fail this rule anymore
+            entry("input-button-name", true),
+            entry("input-image-alt", true),
+            entry("label", false), // Set to true once the build doesn't fail this rule anymore
+            entry("link-in-text-block", false), // Set to true once the build doesn't fail this rule anymore
+            entry("link-name", false), // Set to true once the build doesn't fail this rule anymore
+            entry("list", false), // Set to true once the build doesn't fail this rule anymore
+            entry("listitem", true),
+            entry("marquee", true),
+            entry("meta-refresh", true),
+            entry("meta-viewport", true),
+            entry("nested-interactive", true),
+            entry("no-autoplay-audio", true),
+            entry("object-alt", true),
+            entry("role-img-alt", true),
+            entry("scrollable-region-focusable", true),
+            entry("select-name", false), // Set to true once the build doesn't fail this rule anymore
+            entry("server-side-image-map", true),
+            entry("svg-img-alt", true),
+            entry("td-headers-attr", true),
+            entry("th-has-data-cells", true),
+            entry("valid-lang", true),
+            entry("video-caption", true),
 
             // WCAG 2.1 Level A & AA Rules
-            entry("autocomplete-valid", false),
-            entry("avoid-inline-spacing", false),
+            entry("autocomplete-valid", true),
+            entry("avoid-inline-spacing", true),
 
             // WCAG 2.2 Level A & AA Rules
-            entry("target-size", false)
+            entry("target-size", true)
     );
 
     /**


### PR DESCRIPTION
Changes to the status of the WCAG rules that are currently not violated. From this point on, all rules set to true will make the build fail when they are violated. The build will only fail on an accessibility regression. See the [XWiki WCAG testing page](https://dev.xwiki.org/xwiki/bin/view/Community/WCAGTesting#HTesting) for more details about the consequences of these changes.


As of https://ci.xwiki.org/job/XWiki%20Environment%20Tests/job/xwiki-platform/job/master/182/, there are only a few rules that fail through tests:
- link-in-text-block 344 violations
- aria-allowed-attr 5 violations
- dlitem 1 violation
- aria-required-children 73 violations
- label 80 violations
- duplicate-id 7 violations
- duplicate-id-active 3 violations
- duplicate-id-aria 9 violations
- frame-title 6 violations
- image-alt 56 violations
- link-name 99 violations
- select-name 71 violations
- list 1146 violations
- color-contrast 207 violations 

Total violations: 2107

There are no additional failing types in [environment test master build #187](https://ci.xwiki.org/job/XWiki%20Environment%20Tests/job/xwiki-platform/job/master/187/)

|  | Count of warning rules | Count of failing rules |
| ------------- | ------------- | ------------- |
| Before this PR | 61 | 0 |
| After this PR | 14 | 47 |