### PR TITLE
XWIKI-20843: Application Panel "More Applications" dropdown is not accessible

### DIFF
--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
@@ -240,11 +240,11 @@
 &lt;/ul&gt;
 &lt;ul class="applicationsPanel applicationsPanelMoreList nav nav-pills nav-stacked"&gt;
   &lt;li&gt;
-    &lt;a href="$xwiki.getURL($services.model.createDocumentReference('', 'XWiki', 'XWikiPreferences'), 'admin',
-        'editor=globaladmin&amp;section=XWiki.AddExtensions')" class="applicationPanelMoreButton" title="$services.localization.render('panels.applications.more')"&gt;
+    &lt;button class="applicationPanelMoreButton btn btn-default"
+      title="$services.localization.render('panels.applications.more')" aria-expanded='false' &gt;
       &lt;span class="application-img"&gt;$services.icon.renderHTML('add')&lt;/span&gt;
       &lt;span class="application-label"&gt;$services.localization.render('panels.applications.more')&lt;/span&gt;
-    &lt;/a&gt;
+    &lt;/button&gt;
     &lt;div class="applicationPanelMoreContainer hidden"&gt;
       &lt;ul class="nav nav-pills nav-stacked"&gt;
         #displayAppPanelEntries('org.xwiki.platform.panels.Applications.more')
@@ -366,6 +366,7 @@ panels.MoreApplicationsButtonListener = Class.create({
     var moreAppsCount = this.container.select('.application-label').length;
     if (moreAppsCount &gt; 0) {
       this.container.id = 'applicationPanelMoreContainer' + Math.floor(Math.random()*101);
+      this.button.setAttribute('aria-controls',this.container.id);
       this.isToggling = false;
       this.button.observe('click', function(e) {
         e.stop();
@@ -389,6 +390,7 @@ panels.MoreApplicationsButtonListener = Class.create({
         duration: 0.1,
         afterFinish: function() {
           this.isToggling = false;
+          this.button.setAttribute('aria-expanded','true');
         }.bind(this)
       });
     } else {
@@ -399,6 +401,7 @@ panels.MoreApplicationsButtonListener = Class.create({
         afterFinish: function() {
           this.container.addClassName('hidden');
           this.isToggling = false;
+          this.button.setAttribute('aria-expanded','false');
         }.bind(this)
       });
     }
@@ -613,20 +616,6 @@ require(['scriptaculous/effects'], function() {
   padding: 0;
 }
 
-.panel-width-Small .applicationPanelMoreContainer ul {
-  padding: 0;
-  margin: 0;
-  background-color: $theme.pageContentBackgroundColor;
-}
-
-.panel-width-Small .applicationPanelMoreContainer ul li:hover {
-  background-color: $theme.highlightColor;
-}
-
-.panel-width-Small .applicationPanelMoreContainer ul li:hover a {
-  color: $theme.textPrimaryColor;
-}
-
 .panel-width-Small .applicationPanelMoreContainer > ul > li > a {
   justify-content: center;
 }
@@ -693,15 +682,6 @@ require(['scriptaculous/effects'], function() {
 }
 
 /* for colibri */
-
-.skin-colibri .applicationPanelMoreContainer ul {
-  margin-left: 0;
-}
-
-.skin-colibri .panel-width-Medium .applicationPanelMoreContainer ul,
-.skin-colibri .panel-width-Large .applicationPanelMoreContainer ul {
-  margin-left: 20px;
-}
 
 .skin-colibri .panel-width-Small .applicationsPanel {
   margin: 0;

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
@@ -562,7 +562,7 @@ require(['scriptaculous/effects'], function() {
 .applicationPanelMoreButton .application-label{
   white-space: normal;
   text-align: left;
-  display: block;
+  display: inline;
   margin-left: 20px;
 }
 
@@ -628,6 +628,11 @@ require(['scriptaculous/effects'], function() {
 
 .panel-width-Small .applicationPanelMoreContainer > ul > li > a {
   justify-content: center;
+}
+
+.panel-width-Small .applicationPanelMoreContainer ul {
+  padding: 0;
+  margin: 0;
 }
 
 .panel-width-Small .application-img {

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
@@ -554,9 +554,13 @@ require(['scriptaculous/effects'], function() {
   margin-left: 0.1em;
 }
 
-.applicationPanelMoreButton {
+.applicationPanelMoreButton, .applicationPanelMoreButton:hover, .applicationPanelMoreButton:focus {
   padding-left: 0px;
   padding-right: 6px;
+  border: 0;
+  color: #2f6faf;
+  box-shadow: none;
+  background: transparent;
 }
 
 .applicationPanelMoreButton .application-label{

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
@@ -241,7 +241,7 @@
 &lt;ul class="applicationsPanel applicationsPanelMoreList nav"&gt;
   &lt;li&gt;
     #set ($panelId = $doc.getXDOM().getIdGenerator().generateUniqueId('applicationPanelMoreContainer',''))
-    &lt;button class='applicationPanelMoreButton btn btn-default' aria-controls="$panelId"
+    &lt;button class='applicationPanelMoreButton' aria-controls="$panelId"
       title="$services.localization.render('panels.applications.more')" aria-expanded='false' &gt;
       &lt;span class="application-img"&gt;$services.icon.renderHTML('add')&lt;/span&gt;
       &lt;span class="application-label"&gt;$services.localization.render('panels.applications.more')&lt;/span&gt;
@@ -533,10 +533,6 @@ require(['scriptaculous/effects'], function() {
     <property>
       <code>#template('colorThemeInit.vm')
 
-.applicationsPanelMoreList {
-  margin-top: 1em;
-}
-
 .applicationsPanel li img {
   float: left;
   width: 16px;
@@ -554,10 +550,8 @@ require(['scriptaculous/effects'], function() {
   margin-left: 0.1em;
 }
 
-.applicationPanelMoreButton, .applicationPanelMoreButton:hover,
-.applicationPanelMoreButton:focus, .applicationPanelMoreButton:active {
-  padding-left: 0px;
-  padding-right: 6px;
+.applicationPanelMoreButton {
+  padding: 10px 15px 10px 0;
   border: 0;
   color: $theme.linkColor;
   box-shadow: none;
@@ -635,7 +629,8 @@ require(['scriptaculous/effects'], function() {
   justify-content: center;
 }
 
-.panel-width-Small .applicationPanelMoreContainer ul {
+.panel-width-Small .applicationPanelMoreContainer ul,
+.panel-width-Medium .applicationPanelMoreContainer ul {
   padding: 0;
   margin: 0;
 }

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
@@ -564,7 +564,7 @@ require(['scriptaculous/effects'], function() {
   background-color: $theme.highlightColor;
 }
 
-.applicationPanelMoreButton .application-label{
+.applicationPanelMoreButton .application-label {
   white-space: normal;
   text-align: left;
   display: inline;
@@ -591,7 +591,7 @@ require(['scriptaculous/effects'], function() {
   padding: 0;
 }
 
-.panel-width-Small .applicationPanelMoreButton .application-label{
+.panel-width-Small .applicationPanelMoreButton .application-label {
   text-align: center;
 }
 

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
@@ -240,7 +240,7 @@
 &lt;/ul&gt;
 &lt;ul class="applicationsPanel applicationsPanelMoreList nav"&gt;
   &lt;li&gt;
-    #set ($panelId = $doc.getXDOM().getIdGenerator().generateUniqueId('applicationPanelMoreContainer',''))
+    #set ($panelId = 'applicationPanelMoreContainer' + $util.generateRandomString(10))
     &lt;button class='applicationPanelMoreButton' aria-controls="$panelId"
       title="$services.localization.render('panels.applications.more')" aria-expanded='false' &gt;
       &lt;span class="application-img"&gt;$services.icon.renderHTML('add')&lt;/span&gt;

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
@@ -232,13 +232,13 @@
 #panelheader($services.localization.render('panels.applications.title'))
 
 {{html}}
-&lt;ul class="applicationsPanel nav nav-pills nav-stacked"&gt;
+&lt;ul class="applicationsPanel nav"&gt;
   ## Get the blacklist configuration
   #set ($configDoc = $xwiki.getDocument($services.model.createDocumentReference('', 'PanelsCode',
     'ApplicationsPanelConfiguration')))
   #displayAppPanelEntries('org.xwiki.platform.panels.Applications' $configDoc)
 &lt;/ul&gt;
-&lt;ul class="applicationsPanel applicationsPanelMoreList nav nav-pills nav-stacked"&gt;
+&lt;ul class="applicationsPanel applicationsPanelMoreList nav"&gt;
   &lt;li&gt;
     #set ($panelId = $doc.getXDOM().getIdGenerator().generateUniqueId('applicationPanelMoreContainer',''))
     &lt;button class='applicationPanelMoreButton btn btn-default' aria-controls="$panelId"
@@ -247,7 +247,7 @@
       &lt;span class="application-label"&gt;$services.localization.render('panels.applications.more')&lt;/span&gt;
     &lt;/button&gt;
     &lt;div id="$panelId" class="applicationPanelMoreContainer hidden"&gt;
-      &lt;ul class="nav nav-pills nav-stacked"&gt;
+      &lt;ul class="nav"&gt;
         #displayAppPanelEntries('org.xwiki.platform.panels.Applications.more')
       &lt;/ul&gt;
     &lt;/div&gt;

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
@@ -560,7 +560,8 @@ require(['scriptaculous/effects'], function() {
   display: flex;
 }
 
-.applicationPanelMoreButton:hover {
+.applicationPanelMoreButton:hover,
+.applicationPanelMoreButton:focus {
   background-color: $theme.highlightColor;
 }
 

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
@@ -383,7 +383,6 @@ panels.MoreApplicationsButtonListener = Class.create({
   toggle: function() {
     this.isToggling = true;
     if (this.container.hasClassName('hidden')) {
-      this.container.style.display = "none";
       this.container.removeClassName('hidden');
       Effect.BlindDown(this.container.id, {
         duration: 0.1,
@@ -553,6 +552,18 @@ require(['scriptaculous/effects'], function() {
 
 .applicationsPanel li .application-label {
   margin-left: 0.1em;
+}
+
+.applicationPanelMoreButton {
+  padding-left: 0px;
+  padding-right: 6px;
+}
+
+.applicationPanelMoreButton .application-label{
+  white-space: normal;
+  text-align: left;
+  display: block;
+  margin-left: 20px;
 }
 
 .applicationPanelMoreContainer ul {

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
@@ -555,7 +555,13 @@ require(['scriptaculous/effects'], function() {
   border: 0;
   color: $theme.linkColor;
   box-shadow: none;
-  background: transparent;
+  background-color: transparent;
+  width: 100%;
+  display: flex;
+}
+
+.applicationPanelMoreButton:hover {
+  background-color: $theme.highlightColor;
 }
 
 .applicationPanelMoreButton .application-label{

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
@@ -240,12 +240,13 @@
 &lt;/ul&gt;
 &lt;ul class="applicationsPanel applicationsPanelMoreList nav nav-pills nav-stacked"&gt;
   &lt;li&gt;
-    &lt;button class="applicationPanelMoreButton btn btn-default"
+    #set ($panelId = $doc.getXDOM().getIdGenerator().generateUniqueId('applicationPanelMoreContainer',''))
+    &lt;button class='applicationPanelMoreButton btn btn-default' aria-controls="$panelId"
       title="$services.localization.render('panels.applications.more')" aria-expanded='false' &gt;
       &lt;span class="application-img"&gt;$services.icon.renderHTML('add')&lt;/span&gt;
       &lt;span class="application-label"&gt;$services.localization.render('panels.applications.more')&lt;/span&gt;
     &lt;/button&gt;
-    &lt;div class="applicationPanelMoreContainer hidden"&gt;
+    &lt;div id="$panelId" class="applicationPanelMoreContainer hidden"&gt;
       &lt;ul class="nav nav-pills nav-stacked"&gt;
         #displayAppPanelEntries('org.xwiki.platform.panels.Applications.more')
       &lt;/ul&gt;
@@ -365,8 +366,6 @@ panels.MoreApplicationsButtonListener = Class.create({
 
     var moreAppsCount = this.container.select('.application-label').length;
     if (moreAppsCount &gt; 0) {
-      this.container.id = 'applicationPanelMoreContainer' + Math.floor(Math.random()*101);
-      this.button.setAttribute('aria-controls',this.container.id);
       this.isToggling = false;
       this.button.observe('click', function(e) {
         e.stop();

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
@@ -554,7 +554,8 @@ require(['scriptaculous/effects'], function() {
   margin-left: 0.1em;
 }
 
-.applicationPanelMoreButton, .applicationPanelMoreButton:hover, .applicationPanelMoreButton:focus {
+.applicationPanelMoreButton, .applicationPanelMoreButton:hover,
+.applicationPanelMoreButton:focus, .applicationPanelMoreButton:active {
   padding-left: 0px;
   padding-right: 6px;
   border: 0;

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
@@ -586,6 +586,15 @@ require(['scriptaculous/effects'], function() {
   gap: 1em;
 }
 
+.panel-width-Small .applicationPanelMoreButton {
+  flex-direction: column;
+  padding: 0;
+}
+
+.panel-width-Small .applicationPanelMoreButton .application-label{
+  text-align: center;
+}
+
 .panel-width-Small .panel.Applications {
   background-color: transparent;
   border: 0;
@@ -635,8 +644,7 @@ require(['scriptaculous/effects'], function() {
   justify-content: center;
 }
 
-.panel-width-Small .applicationPanelMoreContainer ul,
-.panel-width-Medium .applicationPanelMoreContainer ul {
+.panel .applicationPanelMoreContainer ul {
   padding: 0;
   margin: 0;
 }

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
@@ -558,7 +558,7 @@ require(['scriptaculous/effects'], function() {
   padding-left: 0px;
   padding-right: 6px;
   border: 0;
-  color: #2f6faf;
+  color: $theme.linkColor;
   box-shadow: none;
   background: transparent;
 }


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-20843
**PR Changes:**
* Replaced the anchor for _more applications_ in the Applications panel with a button.
* Updated style
* Added semantics to the disclosure

**View:**
Before PR:
![20843-Before](https://user-images.githubusercontent.com/28761965/234214228-08ec2031-0025-4a8d-9652-fdca3fc5cf8a.png)
After PR:
![20843-After](https://user-images.githubusercontent.com/28761965/234234934-790470f1-9dda-4c3f-83ec-85efdb241d73.png)
The button has the same style when the disclosure is closed.

**Demo:** (made before the last changes on style, but still very similar even on style)
https://up1.xwikisas.com/#NdrhBiSPlXXJNnwWHWfPtA

**Notes:**
* This section is visible only by admins and not regular users.
* For regular users, the section appears and then gets hidden. It was not very noticeable but with a blue button it's way easier to notice this behavior. I couldn't find the code responsible for hiding the section so I didn't fix this. 
https://up1.xwikisas.com/#504lX2oFtkkPm8M9w-L7XQ