### PR TITLE
XWIKI 20884: Pass a file in AttachmentSelector instead of a file input to fix file size and mimetype verification

### DIFF
--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
@@ -590,7 +590,7 @@ $xwiki.jsx.use($attachmentPickerDocName)
             hasErrors = true;
           }
           const beforeUploadEvent = Event.fire(document, 'xwiki:actions:beforeUpload', {
-            file: fileInput
+            file: fileInput.files[0]
           });
 
           if (beforeUploadEvent.defaultPrevented) {


### PR DESCRIPTION
https://jira.xwiki.org/browse/XWIKI-20884