### PR TITLE
XWIKI-20824: Administration user images must have an alternate text

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/attachment_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/attachment_macros.vm
@@ -163,7 +163,7 @@
   <div class="user" data-reference="$escapetool.xml($userName)">
     <span class="user-avatar-wrapper">
       #getUserAvatarURL($userName $avatarURL 120)
-      <img class="user-avatar" src="$escapetool.xml($avatarURL.url)" />
+      <img class="user-avatar" src="$escapetool.xml($avatarURL.url)" alt=""/>
     </span>
     $xwiki.getUserName($userName)
   </div>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/attachment_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/attachment_macros.vm
@@ -163,7 +163,7 @@
   <div class="user" data-reference="$escapetool.xml($userName)">
     <span class="user-avatar-wrapper">
       #getUserAvatarURL($userName $avatarURL 120)
-      <img class="user-avatar" src="$escapetool.xml($avatarURL.url)" alt=""/>
+      <img class="user-avatar" src="$escapetool.xml($avatarURL.url)" alt="" />
     </span>
     $xwiki.getUserName($userName)
   </div>

--- a/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-api/src/main/resources/templates/likers.vm
+++ b/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-api/src/main/resources/templates/likers.vm
@@ -22,7 +22,7 @@
     <div class="user#if ($disabled) disabled#end" data-reference="$escapetool.xml($userReference)">
     <span class="user-avatar-wrapper">
       #getUserAvatarURL($userReference $avatarURL 120)
-      <img class="user-avatar" src="$escapetool.xml($avatarURL.url)" alt=""/>
+      <img class="user-avatar" src="$escapetool.xml($avatarURL.url)" alt="" />
     </span>
       <a href="$xwiki.getURL($userReference)">$escapetool.xml($userReference.name)</a>
     </div>

--- a/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-api/src/main/resources/templates/likers.vm
+++ b/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-api/src/main/resources/templates/likers.vm
@@ -22,7 +22,7 @@
     <div class="user#if ($disabled) disabled#end" data-reference="$escapetool.xml($userReference)">
     <span class="user-avatar-wrapper">
       #getUserAvatarURL($userReference $avatarURL 120)
-      <img class="user-avatar" src="$escapetool.xml($avatarURL.url)" />
+      <img class="user-avatar" src="$escapetool.xml($avatarURL.url)" alt=""/>
     </span>
       <a href="$xwiki.getURL($userReference)">$escapetool.xml($userReference.name)</a>
     </div>

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/Main/SolrUserFacet.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/Main/SolrUserFacet.xml
@@ -42,7 +42,7 @@
   #set ($escapedUserName = $escapetool.xml($xwiki.getPlainUserName($userReference)))
   #getUserAvatarURL($userReference $avatarURL 30)
   &lt;span class="user"&gt;##
-    &lt;img class="user-avatar" src="$escapetool.xml($avatarURL.url)" alt="$escapedUserName" /&gt;##
+    &lt;img class="user-avatar" src="$escapetool.xml($avatarURL.url)" alt="" /&gt;##
     &lt;span class="user-name"&gt;$escapedUserName&lt;/span&gt;##
   &lt;/span&gt;##
 #end

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/getusers.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/getusers.vm
@@ -21,7 +21,7 @@
   <div class="user#if ($disabled) disabled#end" data-reference="$escapetool.xml($userReference)">
     <span class="user-avatar-wrapper">
       #getUserAvatarURL($userReference $avatarURL 120)
-      <img class="user-avatar" src="$escapetool.xml($avatarURL.url)" alt=""/>
+      <img class="user-avatar" src="$escapetool.xml($avatarURL.url)" alt="" />
     </span>
     <a href="$xwiki.getURL($userReference)">$escapetool.xml($userReference.name)</a>
   </div>

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/getusers.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/getusers.vm
@@ -21,7 +21,7 @@
   <div class="user#if ($disabled) disabled#end" data-reference="$escapetool.xml($userReference)">
     <span class="user-avatar-wrapper">
       #getUserAvatarURL($userReference $avatarURL 120)
-      <img class="user-avatar" src="$escapetool.xml($avatarURL.url)" />
+      <img class="user-avatar" src="$escapetool.xml($avatarURL.url)" alt=""/>
     </span>
     <a href="$xwiki.getURL($userReference)">$escapetool.xml($userReference.name)</a>
   </div>

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -2934,7 +2934,7 @@ Recursive title display detected!##
   <div class="user" data-reference="$escapetool.xml($docReference)">
     <span class="user-avatar-wrapper">
       #getUserAvatarURL($docReference $avatarURL 120)
-      <img class="user-avatar" src="$escapetool.xml($avatarURL.url)" alt=""/>
+      <img class="user-avatar" src="$escapetool.xml($avatarURL.url)" alt="" />
     </span>
     <a href="$xwiki.getURL($docReference)">$escapetool.xml($docReference.name)</a>
   </div>

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -2934,7 +2934,7 @@ Recursive title display detected!##
   <div class="user" data-reference="$escapetool.xml($docReference)">
     <span class="user-avatar-wrapper">
       #getUserAvatarURL($docReference $avatarURL 120)
-      <img class="user-avatar" src="$escapetool.xml($avatarURL.url)" />
+      <img class="user-avatar" src="$escapetool.xml($avatarURL.url)" alt=""/>
     </span>
     <a href="$xwiki.getURL($docReference)">$escapetool.xml($docReference.name)</a>
   </div>


### PR DESCRIPTION
### Jira: 
https://jira.xwiki.org/browse/XWIKI-20824
### PR Changes:
* Added an alt text to user avatars.

### Notes:
* The change to solve the PR is in **`getusers.vm`**, but other files were changed too to solve the same problem in other parts of the UI. The solution is the same since the structure around those images is the same.
* All values are changed to `""` because this `img` in this context is purely decorative: it only helps the user to understand faster what account the anchor next to the picture is pointing to. For a non sighted user, adding a label would only "repeat" the name twice (once for the image, and another for the anchor content). See the jira ticket comments for more details.

### View
![20824-AltNone](https://user-images.githubusercontent.com/28761965/236170995-660850ce-2558-4e51-bd7d-b75db63eff67.png)
