### PR TITLE
XWIKI-20842: More actions button is an anchor

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_content.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_content.vm
@@ -145,18 +145,18 @@
  *#
 #macro(displayMenu $id $icon $menuContent $titleKey $titleAsLabel $actionUrl $extraAttribute)
   <div class="btn-group" id="$id">
-    <a class="btn btn-default#if ("$!actionUrl" == '') dropdown-toggle#end" title="$services.localization.render($titleKey)"##
+    <#if ("$!actionUrl" == '')button#{else}a#end class="btn btn-default#if ("$!actionUrl" == '') dropdown-toggle#end" title="$services.localization.render($titleKey)"##
     #if ("$!actionUrl" != '')
       href="$actionUrl"
     #else
       data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
     #end
-    role="button"#if ("$!extraAttribute" != '') ${extraAttribute}#end>
+    #if ("$!extraAttribute" != '') ${extraAttribute}#end>
       $services.icon.renderHTML($icon)
       #if ($titleAsLabel)
         <span class="btn-label">$services.localization.render($titleKey)</span>
       #end
-    </a>
+    </#if ("$!actionUrl" == '')button#{else}a#end>
     #if ($stringtool.isNotBlank("$!menuContent"))
       #if ("$!actionUrl" != '')
         <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BasePage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BasePage.java
@@ -70,7 +70,7 @@ public class BasePage extends BaseElement
     @FindBy(xpath = "//div[@id='tmCreate']/a[contains(@role, 'button')]")
     private WebElement tmCreate;
 
-    @FindBy(xpath = "//div[@id='tmMoreActions']/a[contains(@role, 'button')]")
+    @FindBy(xpath = "//div[@id='tmMoreActions']/button")
     private WebElement moreActionsMenu;
 
     @FindBy(xpath = "//input[@id='tmWatchDocument']/../span[contains(@class, 'bootstrap-switch-label')]")
@@ -317,7 +317,7 @@ public class BasePage extends BaseElement
      */
     public void clickMoreActionsSubMenuEntry(String id)
     {
-        clickSubMenuEntryFromMenu(By.xpath("//div[@id='tmMoreActions']/a[contains(@role, 'button')]"), id);
+        clickSubMenuEntryFromMenu(By.xpath("//div[@id='tmMoreActions']/button"), id);
     }
 
     /**


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-20842
**PR Changes:**
* Changed the type of the button-anchor elements depending on their expected behavior: drop-down toggles are buttons and non empty hrefs are anchors.
* Updated selectors in environment tests.

**Notes:** 
* We could also separate the button-anchor templates in two functions and/or use a boolean as a parameter rather than checking the presence of a value for a field. My current implementation of a solution aims at minimal refactoring.
* The buttons are already properly labelled and the style selectors work well with the changes brought in this PR (eg. no UI change in the screenshot below).
**View:**
![20842-ViewChanges](https://github.com/xwiki/xwiki-platform/assets/28761965/2d0bf475-0b40-4e68-9dbe-0938ef719055)
