### PR TITLE
XWIKI-20613: Tags are not spaced well when user does not have edit rights

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
@@ -321,6 +321,14 @@
   padding-top: 0;
 }
 
+.tag-wrapper {
+  padding: 2px;
+  background-color: @breadcrumb-bg;
+  border-radius: 6px;
+  margin-left: 0.2em;
+  margin-right: 0.2em;
+}
+
 // Tabbar =====================================================================
 
 .xwikitabbar { // Used by: AllDocs, DocExtra


### PR DESCRIPTION
- [Jira Link here](https://jira.xwiki.org/browse/XWIKI-20613)

This PR adds a background color (`@breadcrumb-bg`) to the tags present in a wiki page to be able to better differentiate between different tags.

**Screenshots:**

- Before this PR (very difficult to figure out that `abstract theorem` is a single tag and NOT two different tags)
[
![2023-05-12-19 50 49-screenshot](https://github.com/xwiki/xwiki-platform/assets/38693805/c4dfc0da-ac1c-4dc0-b3d0-267a802c9ff0)
](url)

- After this PR (tags are easily differentiable all thanks to the background color) 
![2023-05-12-19 51 59-screenshot](https://github.com/xwiki/xwiki-platform/assets/38693805/a6b510cf-11b9-457d-94b9-622a4869ff67)
![2023-05-12-19 49 56-screenshot](https://github.com/xwiki/xwiki-platform/assets/38693805/78d88ba8-3aa8-44b1-a5bc-2ca93ab1688f)

