### PR TITLE
XWIKI-20903: Add support for configuring an empty line placeholder

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/resources/xwiki-focusedplaceholder/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/resources/xwiki-focusedplaceholder/plugin.js
@@ -24,26 +24,6 @@
 
   CKEDITOR.plugins.add('xwiki-focusedplaceholder', {
 
-    /**
-     * Styles that would be applied to the editor by the placeholder text when visible.
-     *
-     * @property {String}
-     */
-    placeholderStyle: '[' + ATTRIBUTE_NAME + ']::before {' +
-      'position: absolute;' +
-      'opacity: .8;' +
-      'color: #aaa;' +
-      'content: attr( ' + ATTRIBUTE_NAME + ' );' +
-      '}' +
-      '.cke_wysiwyg_div[' + ATTRIBUTE_NAME + ']::before {' +
-      'margin-top: 1em;' +
-      '}',
-
-    onLoad: function () {
-      // Adding the style only when the editor is loaded prevents placeholders to appear in view mode
-      CKEDITOR.addCss(this.placeholderStyle);
-    },
-
     beforeInit: function (editor) {
       // Default plugin configuration, to be overriden by other plugins
       editor.config["xwiki-focusedplaceholder"] = {
@@ -118,6 +98,20 @@
     },
 
     init: function (editor) {
+
+      // Filter out placeholders when saving
+      var filterPlaceholders = {
+        elements: {
+          '^': function (element) {
+            if (element.attributes[ATTRIBUTE_NAME] !== undefined) {
+              delete element.attributes[ATTRIBUTE_NAME];
+            }
+          },
+        }
+      };
+      var htmlFilter = editor.dataProcessor && editor.dataProcessor.htmlFilter;
+      htmlFilter.addRules(filterPlaceholders);
+
 
       // Create a TextWatcher instance to detect changes in the document
       var placeholderTextWatcher = new CKEDITOR.plugins.textWatcher(editor, updatePlaceholder);

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/resources/xwiki-focusedplaceholder/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/resources/xwiki-focusedplaceholder/plugin.js
@@ -17,252 +17,239 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-(function() {
-    'use strict';
+(function () {
+  'use strict';
 
-    var ATTRIBUTE_NAME = 'data-xwiki-focusedplaceholder';
+  var ATTRIBUTE_NAME = 'data-xwiki-focusedplaceholder';
 
-    CKEDITOR.plugins.add('xwiki-focusedplaceholder', {
+  CKEDITOR.plugins.add('xwiki-focusedplaceholder', {
 
-        /**
-         * Styles that would be applied to the editor by the placeholder text when visible.
-         *
-         * @property {String}
-         */
-        placeholderStyle: '[' + ATTRIBUTE_NAME + ']::before {' +
-            'position: absolute;' +
-            'opacity: .8;' +
-            'color: #aaa;' +
-            'content: attr( ' + ATTRIBUTE_NAME + ' );' +
-            '}' +
-            '.cke_wysiwyg_div[' + ATTRIBUTE_NAME + ']::before {' +
-            'margin-top: 1em;' +
-            '}',
-
-        onLoad: function() {
-            // Placeholder style
-            CKEDITOR.addCss(this.placeholderStyle);
+    beforeInit: function (editor) {
+      // Default plugin configuration, to be overriden by other plugins
+      editor.config["xwiki-focusedplaceholder"] = {
+        // Default placeholder for content sectioning, text and table HTML tags
+        placeholder: {
+          body: "xwiki-focusedplaceholder.placeholder.body", // Body
+          address: "xwiki-focusedplaceholder.placeholder.address", // Address
+          aside: "xwiki-focusedplaceholder.placeholder.aside", // Aside
+          footer: "xwiki-focusedplaceholder.placeholder.footer", // Footer
+          header: "xwiki-focusedplaceholder.placeholder.header", // Header
+          h1: "xwiki-focusedplaceholder.placeholder.h1", // Heading 1
+          h2: "xwiki-focusedplaceholder.placeholder.h2", // Heading 2
+          h3: "xwiki-focusedplaceholder.placeholder.h3", // Heading 3
+          h4: "xwiki-focusedplaceholder.placeholder.h4", // Heading 4
+          h5: "xwiki-focusedplaceholder.placeholder.h5", // Heading 5
+          h6: "xwiki-focusedplaceholder.placeholder.h6", // Heading 6
+          main: "xwiki-focusedplaceholder.placeholder.main", // Main content
+          nav: "xwiki-focusedplaceholder.placeholder.nav", // Navigation
+          section: "xwiki-focusedplaceholder.placeholder.section", // Section
+          blockquote: "xwiki-focusedplaceholder.placeholder.blockquote", // Quote
+          dl: "xwiki-focusedplaceholder.placeholder.dl", // Definition list
+          dt: "xwiki-focusedplaceholder.placeholder.dt", // Definition entry
+          dd: "xwiki-focusedplaceholder.placeholder.dd", // Description
+          figcaption: "xwiki-focusedplaceholder.placeholder.figcaption", // Caption
+          figure: "xwiki-focusedplaceholder.placeholder.figure", // Figure
+          ol: "xwiki-focusedplaceholder.placeholder.ol", // Ordered list
+          ul: "xwiki-focusedplaceholder.placeholder.ul", // Unordered list
+          menu: "xwiki-focusedplaceholder.placeholder.menu", // Menu (unordered list)
+          li: "xwiki-focusedplaceholder.placeholder.li", // List item
+          p: "xwiki-focusedplaceholder.placeholder.p", // Paragraph
+          pre: "xwiki-focusedplaceholder.placeholder.pre", // Preformated
+          caption: "xwiki-focusedplaceholder.placeholder.caption", // Title
+          th: "xwiki-focusedplaceholder.placeholder.th", // Header
+          td: "xwiki-focusedplaceholder.placeholder.td", // Cell
         },
+        /* Empty inline tags (or nodeNames) that usually do not appear on screen should be ignored by default
+         * because they might get propagated to new lines by CKEditor*/
+        ignoreIfEmpty: [
+          "#text",
+          "a",
+          "abbr",
+          "b",
+          "bdi",
+          "bdo",
+          "br",
+          "cite",
+          "data",
+          "dfn",
+          "em",
+          "i",
+          "mark",
+          "s",
+          "small",
+          "span",
+          "strong",
+          "time",
+          "u",
+          "var",
+          "wbr",
+          "del",
+          "ins",
+        ],
+      };
+    },
 
-        beforeInit: function(editor) {
-            // Default plugin configuration, to be overriden by other plugins
-            editor.config.focusedplaceholder = {
-                // Default placeholder for content sectioning, text and table HTML tags
-                placeholder: {
-                    _fallback: "",
-                    body: "xwiki-focusedplaceholder.placeholder.body", // Body
-                    address: "xwiki-focusedplaceholder.placeholder.address", // Address
-                    aside: "xwiki-focusedplaceholder.placeholder.aside", // Aside
-                    footer: "xwiki-focusedplaceholder.placeholder.footer", // Footer
-                    header: "xwiki-focusedplaceholder.placeholder.header", // Header
-                    h1: "xwiki-focusedplaceholder.placeholder.h1", // Heading 1
-                    h2: "xwiki-focusedplaceholder.placeholder.h2", // Heading 2
-                    h3: "xwiki-focusedplaceholder.placeholder.h3", // Heading 3
-                    h4: "xwiki-focusedplaceholder.placeholder.h4", // Heading 4
-                    h5: "xwiki-focusedplaceholder.placeholder.h5", // Heading 5
-                    h6: "xwiki-focusedplaceholder.placeholder.h6", // Heading 6
-                    main: "xwiki-focusedplaceholder.placeholder.main", // Main content
-                    nav: "xwiki-focusedplaceholder.placeholder.nav", // Navigation
-                    section: "xwiki-focusedplaceholder.placeholder.section", // Section
-                    blockquote: "xwiki-focusedplaceholder.placeholder.blockquote", // Quote
-                    dl: "xwiki-focusedplaceholder.placeholder.dl", // Definition list
-                    dt: "xwiki-focusedplaceholder.placeholder.dt", // Definition entry
-                    dd: "xwiki-focusedplaceholder.placeholder.dd", // Description
-                    figcaption: "xwiki-focusedplaceholder.placeholder.figcaption", // Caption
-                    figure: "xwiki-focusedplaceholder.placeholder.figure", // Figure
-                    ol: "xwiki-focusedplaceholder.placeholder.ol", // Ordered list
-                    ul: "xwiki-focusedplaceholder.placeholder.ul", // Unordered list
-                    menu: "xwiki-focusedplaceholder.placeholder.menu", // Menu (unordered list)
-                    li: "xwiki-focusedplaceholder.placeholder.li", // List item
-                    p: "xwiki-focusedplaceholder.placeholder.p", // Paragraph
-                    pre: "xwiki-focusedplaceholder.placeholder.pre", // Preformated
-                    caption: "xwiki-focusedplaceholder.placeholder.caption", // Title
-                    th: "xwiki-focusedplaceholder.placeholder.th", // Header
-                    td: "xwiki-focusedplaceholder.placeholder.td", // Cell
-                },
-                /* Empty inline tags (or nodeNames) that usually do not appear on screen should be ignored by default
-                 * because they might get propagated to new lines by CKEditor*/
-                ignoreIfEmpty: [
-                    "#text",
-                    "a",
-                    "abbr",
-                    "b",
-                    "bdi",
-                    "bdo",
-                    "br",
-                    "cite",
-                    "data",
-                    "dfn",
-                    "em",
-                    "i",
-                    "mark",
-                    "s",
-                    "small",
-                    "span",
-                    "strong",
-                    "time",
-                    "u",
-                    "var",
-                    "wbr",
-                    "del",
-                    "ins",
-                ],
-            };
-        },
+    init: function (editor) {
 
-        init: function(editor) {
+      // Create a TextWatcher instance to detect changes in the document
+      var placeholderTextWatcher = new CKEDITOR.plugins.textWatcher(editor,
+        function (range) {
+          updatePlaceholder(range);
+        });
 
-            var focusedplaceholder = editor.plugins["xwiki-focusedplaceholder"];
-            focusedplaceholder.editor = editor;
+      // The placeholder should update at every keystroke
+      placeholderTextWatcher.ignoredKeys = [];
 
-            // Create a TextWatcher instance to detect changes in the document
-            focusedplaceholder.placeholderTextWatcher = new CKEDITOR.plugins.textWatcher(editor,
-                function(range) {
-                    focusedplaceholder.updatePlaceholder(range);
-                });
+      editor.on('instanceReady', function () {
+        // Attach the textWatcher to the editor
+        placeholderTextWatcher.attach();
 
-            // The placeholder should update at every keystroke
-            focusedplaceholder.placeholderTextWatcher.ignoredKeys = [];
-
-            editor.on('instanceReady', function() {
-                // Attach the placeholder to the editor
-                focusedplaceholder.placeholderTextWatcher.attach();
-
-                /* The placeholder should update when the content is changed via menus
-                 * snapshots are created when that occurs*/
-                editor.on("saveSnapshot", function() {
-                    focusedplaceholder.placeholderTextWatcher.check(false);
-                });
-            });
+        /* The placeholder should update when the content is changed via menus.
+         * snapshots are created when that occurs*/
+        editor.on("saveSnapshot", function () {
+          placeholderTextWatcher.check(false);
+        });
+      });
 
 
-            /* The placeholder should update when the user clicks somewhere in the document.
-             * Note: using contentDom event in case the DOM Tree gets recreated by CKEditor (e.g. mode change)*/
-            editor.on("contentDom", function() {
-                editor.document.$.addEventListener("click",
-                    function() {
-                        focusedplaceholder.placeholderTextWatcher.check(false);
-                    });
-            });
-        },
+      /* Using contentDom event in case the DOM Tree gets recreated by CKEditor (e.g. mode change)*/
+      editor.on("contentDom", function () {
 
-        /**
-         * Removes any placeholder present in the document
-         *
-         * @param {Object} document - the DOM Document
-         */
-        removeAllPlaceholders: function(document) {
-            document.querySelectorAll("[" + ATTRIBUTE_NAME + "]").forEach(function(match) {
-                match.removeAttribute(ATTRIBUTE_NAME);
-            });
-        },
+        /* The placeholder should update when the user clicks somewhere in the document. */
+        editor.document.$.addEventListener("click",
+          function () {
+            placeholderTextWatcher.check(false);
+          });
 
-        /**
-         * Checks if an element should be considered empty
-         *
-         * @param {Object} element - the DOM Element
-         * @return {bool}
-         */
-        isEmpty: function(element) {
+        /* The placeholder should update when the editor gains focus. */
+        editor.document.$.addEventListener("focus",
+          function () {
+            placeholderTextWatcher.check(false);
+          });
 
-            // Consider the length of a text node as its number of children
-            if (element.nodeName === "#text") {
-                return !Boolean(element.length);
-            }
-            var i;
-            for (i = 0; i < element.childNodes.length; i++) {
-                var child = element.childNodes[i];
-                // Child is not empty if it doesn't have a nodeName
-                if (child.nodeName === undefined) {
-                    return false;
-                }
+        /* The placeholder should disappear when the editor loses focus.
+         * (The empty document placeholder might appear) */
+        editor.document.$.addEventListener("blur",
+          function () {
+            removeAllPlaceholders(editor.document.$);
+          });
 
-                // Child is not considered empty if it is not ignored if empty
-                if (!this.editor.config.focusedplaceholder.ignoreIfEmpty.includes(child.nodeName.toLowerCase())) {
-                    return false;
-                }
+      });
 
-                // Child is not considered empty if it is not empty
-                if (!this.isEmpty(child)) {
-                    return false;
-                }
-            }
+      /**
+       * Removes any placeholder present in the document
+       *
+       * @param {Object} document - the DOM Document
+       */
+      function removeAllPlaceholders(document) {
+        document.querySelectorAll("[" + ATTRIBUTE_NAME + "]").forEach(function (match) {
+          match.removeAttribute(ATTRIBUTE_NAME);
+        });
+      }
 
-            return true;
-        },
+      /**
+       * Checks if an element should be considered empty
+       *
+       * @param {Object} element - the DOM Element
+       * @return {bool}
+       */
+      function isEmpty(element) {
 
-        /**
-         * Finds the first configured ancestor of a DOM element
-         *
-         * @param {Object} element
-         * @return {Object} - The first configured ancestor
-         */
-        getFirstConfiguredAncestor: function(element) {
-
-            // No parents
-            if (element === null) {
-                return element;
-            }
-            if (element.parentNode === null) {
-                return element.parentNode;
-            }
-
-            // Configured element
-            if (element.tagName !== undefined &&
-                this.editor.config.focusedplaceholder.placeholder[element.tagName.toLowerCase()] !== undefined) {
-                return element;
-            }
-
-            return this.getFirstConfiguredAncestor(element.parentNode);
-
-        },
-
-        /**
-         * Updates the placeholder when the caret moves
-         *
-         * @param {CKEDITOR.dom.range}
-         */
-        updatePlaceholder: function(range) {
-            // Clear previous placeholders
-            this.removeAllPlaceholders(range.document.$);
-
-            // No placeholder when a selection is occuring
-            if (!range.collapsed) {
-                return null;
-            }
-
-            // Find the matching ancestor
-            var ancestor = this.getFirstConfiguredAncestor(range.getCommonAncestor().$);
-            if (ancestor === null) {
-                ancestor = range.getCommonAncestor().$;
-            }
-
-            // Add placeholder when ancestor is considered empty
-            if (this.isEmpty(ancestor)) {
-                ancestor.setAttribute(ATTRIBUTE_NAME, this.getPlaceholderContent(ancestor.tagName.toLowerCase()));
-            }
-        },
-
-        /**
-         * Returns the expected placeholder text for a given element
-         *
-         * @param {string} tag - Lowercase tagName
-         * @return {string}
-         */
-        getPlaceholderContent: function(tag) {
-
-            var translationKey = this.editor.config.focusedplaceholder.placeholder[tag];
-
-            if (translationKey === null) {
-                translationKey = this.editor.config.focusedplaceholder.placeholder._fallback;
-            }
-
-            if (translationKey === undefined) {
-                return "";
-            }
-
-            return this.editor.localization.get(translationKey);
+        // Consider the length of a text node as its number of children
+        if (element.nodeName === "#text") {
+          return !Boolean(element.length);
         }
 
-    });
+        var i;
+        for (i = 0; i < element.childNodes.length; i++) {
+          var child = element.childNodes[i];
+
+          // Child is not considered empty if it is not ignored if empty
+          if (!editor.config["xwiki-focusedplaceholder"].ignoreIfEmpty.includes(child.nodeName.toLowerCase())) {
+            return false;
+          }
+
+          // Child is not considered empty if it is not empty
+          if (!isEmpty(child)) {
+            return false;
+          }
+        }
+
+        return true;
+      }
+
+      /**
+       * Finds the first configured ancestor of a DOM element
+       *
+       * @param {Object} element
+       * @return {Object} - The first configured ancestor
+       */
+      function getFirstConfiguredAncestor(element) {
+
+        // No parents
+        if (element === null) {
+          return element;
+        }
+        if (element.parentNode === null) {
+          return element.parentNode;
+        }
+
+        // Configured element
+        if (element.tagName !== undefined &&
+          editor.config["xwiki-focusedplaceholder"].placeholder[element.tagName.toLowerCase()] !== undefined) {
+          return element;
+        }
+
+        return getFirstConfiguredAncestor(element.parentNode);
+
+      }
+
+      /**
+       * Updates the placeholder when the caret moves
+       *
+       * @param {CKEDITOR.dom.range}
+       */
+      function updatePlaceholder(range) {
+        // Clear previous placeholders
+        removeAllPlaceholders(range.document.$);
+
+        // No placeholder when a selection is occuring
+        if (!range.collapsed) {
+          return null;
+        }
+
+        // Find the matching ancestor
+        var ancestor = getFirstConfiguredAncestor(range.getCommonAncestor().$);
+        if (ancestor === null) {
+          // No placeholder when there is no configured ancestor
+          return;
+        }
+
+        // Add placeholder when ancestor is considered empty
+        if (isEmpty(ancestor)) {
+          ancestor.setAttribute(ATTRIBUTE_NAME, getPlaceholderContent(ancestor.tagName.toLowerCase()));
+        }
+      }
+
+      /**
+       * Returns the expected placeholder text for a given element
+       *
+       * @param {string} tag - Lowercase tagName
+       * @return {string}
+       */
+      function getPlaceholderContent(tag) {
+
+        var translationKey = editor.config["xwiki-focusedplaceholder"].placeholder[tag];
+
+        if (translationKey === undefined) {
+          return "";
+        }
+
+        return editor.localization.get(translationKey);
+      }
+
+    },
+
+
+  });
 })();

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/resources/xwiki-focusedplaceholder/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/resources/xwiki-focusedplaceholder/plugin.js
@@ -1,0 +1,268 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+(function() {
+    'use strict';
+
+    var ATTRIBUTE_NAME = 'data-xwiki-focusedplaceholder';
+
+    CKEDITOR.plugins.add('xwiki-focusedplaceholder', {
+
+        /**
+         * Styles that would be applied to the editor by the placeholder text when visible.
+         *
+         * @property {String}
+         */
+        placeholderStyle: '[' + ATTRIBUTE_NAME + ']::before {' +
+            'position: absolute;' +
+            'opacity: .8;' +
+            'color: #aaa;' +
+            'content: attr( ' + ATTRIBUTE_NAME + ' );' +
+            '}' +
+            '.cke_wysiwyg_div[' + ATTRIBUTE_NAME + ']::before {' +
+            'margin-top: 1em;' +
+            '}',
+
+        onLoad: function() {
+            // Placeholder style
+            CKEDITOR.addCss(this.placeholderStyle);
+        },
+
+        beforeInit: function(editor) {
+            // Default plugin configuration, to be overriden by other plugins
+            editor.config.focusedplaceholder = {
+                // Default placeholder for content sectioning, text and table HTML tags
+                placeholder: {
+                    _fallback: "",
+                    body: "xwiki-focusedplaceholder.placeholder.body", // Body
+                    address: "xwiki-focusedplaceholder.placeholder.address", // Address
+                    aside: "xwiki-focusedplaceholder.placeholder.aside", // Aside
+                    footer: "xwiki-focusedplaceholder.placeholder.footer", // Footer
+                    header: "xwiki-focusedplaceholder.placeholder.header", // Header
+                    h1: "xwiki-focusedplaceholder.placeholder.h1", // Heading 1
+                    h2: "xwiki-focusedplaceholder.placeholder.h2", // Heading 2
+                    h3: "xwiki-focusedplaceholder.placeholder.h3", // Heading 3
+                    h4: "xwiki-focusedplaceholder.placeholder.h4", // Heading 4
+                    h5: "xwiki-focusedplaceholder.placeholder.h5", // Heading 5
+                    h6: "xwiki-focusedplaceholder.placeholder.h6", // Heading 6
+                    main: "xwiki-focusedplaceholder.placeholder.main", // Main content
+                    nav: "xwiki-focusedplaceholder.placeholder.nav", // Navigation
+                    section: "xwiki-focusedplaceholder.placeholder.section", // Section
+                    blockquote: "xwiki-focusedplaceholder.placeholder.blockquote", // Quote
+                    dl: "xwiki-focusedplaceholder.placeholder.dl", // Definition list
+                    dt: "xwiki-focusedplaceholder.placeholder.dt", // Definition entry
+                    dd: "xwiki-focusedplaceholder.placeholder.dd", // Description
+                    figcaption: "xwiki-focusedplaceholder.placeholder.figcaption", // Caption
+                    figure: "xwiki-focusedplaceholder.placeholder.figure", // Figure
+                    ol: "xwiki-focusedplaceholder.placeholder.ol", // Ordered list
+                    ul: "xwiki-focusedplaceholder.placeholder.ul", // Unordered list
+                    menu: "xwiki-focusedplaceholder.placeholder.menu", // Menu (unordered list)
+                    li: "xwiki-focusedplaceholder.placeholder.li", // List item
+                    p: "xwiki-focusedplaceholder.placeholder.p", // Paragraph
+                    pre: "xwiki-focusedplaceholder.placeholder.pre", // Preformated
+                    caption: "xwiki-focusedplaceholder.placeholder.caption", // Title
+                    th: "xwiki-focusedplaceholder.placeholder.th", // Header
+                    td: "xwiki-focusedplaceholder.placeholder.td", // Cell
+                },
+                /* Empty inline tags (or nodeNames) that usually do not appear on screen should be ignored by default
+                 * because they might get propagated to new lines by CKEditor*/
+                ignoreIfEmpty: [
+                    "#text",
+                    "a",
+                    "abbr",
+                    "b",
+                    "bdi",
+                    "bdo",
+                    "br",
+                    "cite",
+                    "data",
+                    "dfn",
+                    "em",
+                    "i",
+                    "mark",
+                    "s",
+                    "small",
+                    "span",
+                    "strong",
+                    "time",
+                    "u",
+                    "var",
+                    "wbr",
+                    "del",
+                    "ins",
+                ],
+            };
+        },
+
+        init: function(editor) {
+
+            var focusedplaceholder = editor.plugins["xwiki-focusedplaceholder"];
+            focusedplaceholder.editor = editor;
+
+            // Create a TextWatcher instance to detect changes in the document
+            focusedplaceholder.placeholderTextWatcher = new CKEDITOR.plugins.textWatcher(editor,
+                function(range) {
+                    focusedplaceholder.updatePlaceholder(range);
+                });
+
+            // The placeholder should update at every keystroke
+            focusedplaceholder.placeholderTextWatcher.ignoredKeys = [];
+
+            editor.on('instanceReady', function() {
+                // Attach the placeholder to the editor
+                focusedplaceholder.placeholderTextWatcher.attach();
+
+                /* The placeholder should update when the content is changed via menus
+                 * snapshots are created when that occurs*/
+                editor.on("saveSnapshot", function() {
+                    focusedplaceholder.placeholderTextWatcher.check(false);
+                });
+            });
+
+
+            /* The placeholder should update when the user clicks somewhere in the document.
+             * Note: using contentDom event in case the DOM Tree gets recreated by CKEditor (e.g. mode change)*/
+            editor.on("contentDom", function() {
+                editor.document.$.addEventListener("click",
+                    function() {
+                        focusedplaceholder.placeholderTextWatcher.check(false);
+                    });
+            });
+        },
+
+        /**
+         * Removes any placeholder present in the document
+         *
+         * @param {Object} document - the DOM Document
+         */
+        removeAllPlaceholders: function(document) {
+            document.querySelectorAll("[" + ATTRIBUTE_NAME + "]").forEach(function(match) {
+                match.removeAttribute(ATTRIBUTE_NAME);
+            });
+        },
+
+        /**
+         * Checks if an element should be considered empty
+         *
+         * @param {Object} element - the DOM Element
+         * @return {bool}
+         */
+        isEmpty: function(element) {
+
+            // Consider the length of a text node as its number of children
+            if (element.nodeName === "#text") {
+                return !Boolean(element.length);
+            }
+            var i;
+            for (i = 0; i < element.childNodes.length; i++) {
+                var child = element.childNodes[i];
+                // Child is not empty if it doesn't have a nodeName
+                if (child.nodeName === undefined) {
+                    return false;
+                }
+
+                // Child is not considered empty if it is not ignored if empty
+                if (!this.editor.config.focusedplaceholder.ignoreIfEmpty.includes(child.nodeName.toLowerCase())) {
+                    return false;
+                }
+
+                // Child is not considered empty if it is not empty
+                if (!this.isEmpty(child)) {
+                    return false;
+                }
+            }
+
+            return true;
+        },
+
+        /**
+         * Finds the first configured ancestor of a DOM element
+         *
+         * @param {Object} element
+         * @return {Object} - The first configured ancestor
+         */
+        getFirstConfiguredAncestor: function(element) {
+
+            // No parents
+            if (element === null) {
+                return element;
+            }
+            if (element.parentNode === null) {
+                return element.parentNode;
+            }
+
+            // Configured element
+            if (element.tagName !== undefined &&
+                this.editor.config.focusedplaceholder.placeholder[element.tagName.toLowerCase()] !== undefined) {
+                return element;
+            }
+
+            return this.getFirstConfiguredAncestor(element.parentNode);
+
+        },
+
+        /**
+         * Updates the placeholder when the caret moves
+         *
+         * @param {CKEDITOR.dom.range}
+         */
+        updatePlaceholder: function(range) {
+            // Clear previous placeholders
+            this.removeAllPlaceholders(range.document.$);
+
+            // No placeholder when a selection is occuring
+            if (!range.collapsed) {
+                return null;
+            }
+
+            // Find the matching ancestor
+            var ancestor = this.getFirstConfiguredAncestor(range.getCommonAncestor().$);
+            if (ancestor === null) {
+                ancestor = range.getCommonAncestor().$;
+            }
+
+            // Add placeholder when ancestor is considered empty
+            if (this.isEmpty(ancestor)) {
+                ancestor.setAttribute(ATTRIBUTE_NAME, this.getPlaceholderContent(ancestor.tagName.toLowerCase()));
+            }
+        },
+
+        /**
+         * Returns the expected placeholder text for a given element
+         *
+         * @param {string} tag - Lowercase tagName
+         * @return {string}
+         */
+        getPlaceholderContent: function(tag) {
+
+            var translationKey = this.editor.config.focusedplaceholder.placeholder[tag];
+
+            if (translationKey === null) {
+                translationKey = this.editor.config.focusedplaceholder.placeholder._fallback;
+            }
+
+            if (translationKey === undefined) {
+                return "";
+            }
+
+            return this.editor.localization.get(translationKey);
+        }
+
+    });
+})();

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/resources/xwiki-focusedplaceholder/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/resources/xwiki-focusedplaceholder/plugin.js
@@ -92,10 +92,7 @@
     init: function (editor) {
 
       // Create a TextWatcher instance to detect changes in the document
-      var placeholderTextWatcher = new CKEDITOR.plugins.textWatcher(editor,
-        function (range) {
-          updatePlaceholder(range);
-        });
+      var placeholderTextWatcher = new CKEDITOR.plugins.textWatcher(editor, updatePlaceholder);
 
       // The placeholder should update at every keystroke
       placeholderTextWatcher.ignoredKeys = [];
@@ -112,16 +109,16 @@
       });
 
 
-      /* Using contentDom event in case the DOM Tree gets recreated by CKEditor (e.g. mode change)*/
+      // Using contentDom event in case the DOM Tree gets recreated by CKEditor (e.g. mode change)
       editor.on("contentDom", function () {
 
-        /* The placeholder should update when the user clicks somewhere in the document. */
+        // The placeholder should update when the user clicks somewhere in the document.
         editor.document.$.addEventListener("click",
           function () {
             placeholderTextWatcher.check(false);
           });
 
-        /* The placeholder should update when the editor gains focus. */
+        // The placeholder should update when the editor gains focus.
         editor.document.$.addEventListener("focus",
           function () {
             placeholderTextWatcher.check(false);
@@ -148,21 +145,21 @@
       }
 
       /**
-       * Checks if an element should be considered empty
+       * Checks if a node should be considered empty
        *
-       * @param {Object} element - the DOM Element
-       * @return {bool}
+       * @param {Object} node - the DOM Node
+       * @return {bool} - True when the node is considered empty, false otherwise
        */
-      function isEmpty(element) {
+      function isEmpty(node) {
 
         // Consider the length of a text node as its number of children
-        if (element.nodeName === "#text") {
-          return !Boolean(element.length);
+        if (node.nodeName === "#text") {
+          return !Boolean(node.length);
         }
 
         var i;
-        for (i = 0; i < element.childNodes.length; i++) {
-          var child = element.childNodes[i];
+        for (i = 0; i < node.childNodes.length; i++) {
+          var child = node.childNodes[i];
 
           // Child is not considered empty if it is not ignored if empty
           if (!editor.config["xwiki-focusedplaceholder"].ignoreIfEmpty.includes(child.nodeName.toLowerCase())) {
@@ -179,28 +176,28 @@
       }
 
       /**
-       * Finds the first configured ancestor of a DOM element
+       * Finds the first configured ancestor of a DOM Node
        *
-       * @param {Object} element
-       * @return {Object} - The first configured ancestor
+       * @param {Object} node
+       * @return {Object} - The first configured ancestor, null if none were found
        */
-      function getFirstConfiguredAncestor(element) {
+      function getFirstConfiguredAncestor(node) {
 
         // No parents
-        if (element === null) {
-          return element;
+        if (node === null) {
+          return node;
         }
-        if (element.parentNode === null) {
-          return element.parentNode;
+        if (node.parentNode === null) {
+          return node.parentNode;
         }
 
         // Configured element
-        if (element.tagName !== undefined &&
-          editor.config["xwiki-focusedplaceholder"].placeholder[element.tagName.toLowerCase()] !== undefined) {
-          return element;
+        if (node.tagName !== undefined &&
+          editor.config["xwiki-focusedplaceholder"].placeholder[node.tagName.toLowerCase()] !== undefined) {
+          return node;
         }
 
-        return getFirstConfiguredAncestor(element.parentNode);
+        return getFirstConfiguredAncestor(node.parentNode);
 
       }
 
@@ -232,10 +229,10 @@
       }
 
       /**
-       * Returns the expected placeholder text for a given element
+       * Returns the expected placeholder text for a given tagName
        *
        * @param {string} tag - Lowercase tagName
-       * @return {string}
+       * @return {string} - Placeholder text
        */
       function getPlaceholderContent(tag) {
 

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
@@ -229,6 +229,14 @@ a[data-linktype="create"]::after {
   text-decoration: none;
 }
 
+[contenteditable="true"] [data-xwiki-focusedplaceholder]::before {
+  /* Show the value of the focused line placeholder attribute */
+  position: absolute;
+  opacity: .8;
+  color: #aaa;
+  content: attr(data-xwiki-focusedplaceholder);
+}
+
 .macro-placeholder {
   /* Hide the placeholder by default and show it only if the macro is editable. */
   display: none;

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
@@ -242,14 +242,6 @@ a[data-linktype="create"]::after {
   display: block;
 }
 
-[data-xwiki-focusedplaceholder]::before {
-  /* Show the value of the focused line placeholder attribute */
-  position: absolute;
-  opacity: .8;
-  color: #aaa;
-  content: attr(data-xwiki-focusedplaceholder);
-}
-
 /* Inline widgets (macros) have display:inline-block and thus don't inherit the text-decoration styles. We fix this by
   applying the styles directly for the text-decoration values that are commonly used.
   See CKEDITOR-282: Strikethrough not displayed for macros */

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
@@ -242,6 +242,14 @@ a[data-linktype="create"]::after {
   display: block;
 }
 
+[data-xwiki-focusedplaceholder]::before {
+  /* Show the value of the focused line placeholder attribute */
+  position: absolute;
+  opacity: .8;
+  color: #aaa;
+  content: attr(data-xwiki-focusedplaceholder);
+}
+
 /* Inline widgets (macros) have display:inline-block and thus don't inherit the text-decoration styles. We fix this by
   applying the styles directly for the text-decoration values that are commonly used.
   See CKEDITOR-282: Strikethrough not displayed for macros */

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/Translations.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/Translations.xml
@@ -150,6 +150,36 @@ ckeditor.plugin.image.imageSelector.urlTab.url.title=Url
 ckeditor.plugin.image.imageSelector.urlTab.url.hint=The url of the image to display.
 ckeditor.plugin.image.imageSelector.urlTab.url.placeholder=https://...
 
+ckeditor.plugin.focusedplaceholder.placeholder.body=Body
+ckeditor.plugin.focusedplaceholder.placeholder.address=Address
+ckeditor.plugin.focusedplaceholder.placeholder.aside=Aside
+ckeditor.plugin.focusedplaceholder.placeholder.footer=Footer
+ckeditor.plugin.focusedplaceholder.placeholder.header=Header
+ckeditor.plugin.focusedplaceholder.placeholder.h1=Heading 1
+ckeditor.plugin.focusedplaceholder.placeholder.h2=Heading 2
+ckeditor.plugin.focusedplaceholder.placeholder.h3=Heading 3
+ckeditor.plugin.focusedplaceholder.placeholder.h4=Heading 4
+ckeditor.plugin.focusedplaceholder.placeholder.h5=Heading 5
+ckeditor.plugin.focusedplaceholder.placeholder.h6=Heading 6
+ckeditor.plugin.focusedplaceholder.placeholder.main=Main content
+ckeditor.plugin.focusedplaceholder.placeholder.nav=Navigation
+ckeditor.plugin.focusedplaceholder.placeholder.section=Section
+ckeditor.plugin.focusedplaceholder.placeholder.blockquote=Quote
+ckeditor.plugin.focusedplaceholder.placeholder.dl=Definition list
+ckeditor.plugin.focusedplaceholder.placeholder.dt=Definition entry
+ckeditor.plugin.focusedplaceholder.placeholder.dd=Description
+ckeditor.plugin.focusedplaceholder.placeholder.figcaption=Caption
+ckeditor.plugin.focusedplaceholder.placeholder.figure=Figure
+ckeditor.plugin.focusedplaceholder.placeholder.ol=Ordered list
+ckeditor.plugin.focusedplaceholder.placeholder.ul=Unordered list
+ckeditor.plugin.focusedplaceholder.placeholder.menu=Menu (unordered list)
+ckeditor.plugin.focusedplaceholder.placeholder.li=List item
+ckeditor.plugin.focusedplaceholder.placeholder.p=Paragraph
+ckeditor.plugin.focusedplaceholder.placeholder.pre=Preformated
+ckeditor.plugin.focusedplaceholder.placeholder.caption=Title
+ckeditor.plugin.focusedplaceholder.placeholder.th=Header
+ckeditor.plugin.focusedplaceholder.placeholder.td=Cell
+
 ckeditor.inline.failedToInit=Failed to initialize CKEditor.
 
 ckeditor.upload.error.csrf=The CSRF token is missing.

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-webjar/src/main/config/build-config.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-webjar/src/main/config/build-config.js
@@ -124,6 +124,7 @@ var CKBUILDER_CONFIG = {
     wysiwygarea: 1,
     'xwiki-config': 1,
     'xwiki-filter': 1,
+    'xwiki-focusedplaceholder': 1,
     'xwiki-image-old': 1,
     'xwiki-image': 1,
     'xwiki-link': 1,


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-20903

This PR adds a placeholder text to new lines in the WYSIWYG editor. 
The plugin comes with a default configuration that can be overridden by other plugins. (e.g. advertising features to the user)