### PR TITLE
[Misc] Remove list label in navbar

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_macros.vm
@@ -57,7 +57,7 @@
 ###    Toplevel Left Menu
 ###
 #macro(xwikitopmenuleftstart)
-  <ul class="nav navbar-nav navbar-left">
+  <ul class='nav navbar-nav navbar-left'>
 #end
 
 ###

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_macros.vm
@@ -57,8 +57,7 @@
 ###    Toplevel Left Menu
 ###
 #macro(xwikitopmenuleftstart)
-  <ul class="nav navbar-nav navbar-left"
-    aria-label="$escapetool.xml($services.localization.render('core.menu.navbar.left.label'))">
+  <ul class="nav navbar-nav navbar-left">
 #end
 
 ###

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -1029,7 +1029,6 @@ core.menu.type.profile=Profile
 core.menu.wiki.documentindex=Page Index
 core.menu.space.documentindex=Page Index
 core.menu.space.delete=Delete
-core.menu.navbar.left.label=Left side of the navigation bar
 ### Translations used from web standard templates, not colibri
 core.menu.view=View
 core.menu.print=Print
@@ -5601,6 +5600,11 @@ xe.officeimporter.import.splitting=Splitting
 xe.officeimporter.import.help.target=Key-in target space and page name. Select "Append result" to append the result to an existing wiki page.
 xe.officeimporter.import.appendresult=Append result
 platform.office.importDocumentOverwriteConfirmation=The target document exists. Are you sure you want to overwrite its content?
+
+#######################################
+## until 15.4RC1
+#######################################
+core.menu.navbar.left.label=Left side of the navigation bar
 
 ## Used to indicate where deprecated keys end
 #@deprecatedend


### PR DESCRIPTION
## Context
The HTML validator returned warnings such as:
```
Validating HTML5 validity for [http://127.0.0.1:8080/xwiki/bin/view/WikiManager/Translations] executed with credentials Admin:admin
Warning at 209:49 Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)
```
[The warning on the CI](https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/master/6680/testReport//org.xwiki.test.webstandards.framework/DefaultValidationTest/Platform_Builds___main___distribution___flavor_test_webstandards___Build_for_Flavor_Test___Webstandards______/)
This was caused by the PR https://github.com/xwiki/xwiki-platform/pull/2120 merged in 15.3.

## Choice of a fix:
I tested out a screen reader to see how it would react in regards to this list. NVDA on Windows does not read the list out, even if it has a label, because there's no element in it. Henceforth this label is for the most part useless. Even if the list is not empty because some extension populate it, the label would not be necessary (see source below). The label only conveyed position information, and not any meaning. This is done at a level above, in the navbar itself -- there is no difference in meaning between the left and right side, except that they are two distinct groups (information already conveyed by the structure -- two distinct lists).
Removing the aria-label does not trigger any accessibility violation.

See https://www.scottohara.me/blog/2020/05/02/labelled-lists.html for more details about the accessibility of labeling lists

## PR Changes:
* Removed the aria-label
* Deprecated the translation key used for this label.

**No visual change (the list itself takes no space on a standard distribution)**