### PR TITLE
XWIKI-19982: Add ability to add a macro by using the keyboard

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/macroEditor.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/macroEditor.js
@@ -29,57 +29,6 @@ define('macroEditorTranslationKeys', [], [
 ]);
 
 /**
- * Macro Service
- */
-define('macroService', ['jquery', 'xwiki-meta'], function($, xcontext) {
-  'use strict';
-
-  var macroDescriptors = {},
-
-  getMacroDescriptor = function(macroId, maybeSourceDocumentReference) {
-    var deferred = $.Deferred();
-    var macroDescriptor = macroDescriptors[macroId];
-    if (macroDescriptor) {
-      deferred.resolve(macroDescriptor);
-    } else {
-      var sourceDocumentReference = maybeSourceDocumentReference || XWiki.currentDocument.documentReference;
-      var url = new XWiki.Document(sourceDocumentReference).getURL('get', $.param({
-        outputSyntax: 'plain',
-        language: $('html').attr('lang'),
-        sheet: 'CKEditor.MacroService'
-      }));
-      $.get(url, {data: 'descriptor', macroId: macroId}).done(function(macroDescriptor) {
-        if (typeof macroDescriptor === 'object' && macroDescriptor !== null) {
-          macroDescriptors[macroId] = macroDescriptor;
-          deferred.resolve(macroDescriptor);
-        } else {
-          deferred.reject.apply(deferred, arguments);
-        }
-      }).fail(function() {
-        deferred.reject.apply(deferred, arguments);
-      });
-    }
-    return deferred.promise();
-  },
-
-  installMacro = function(extensionId, extensionVersion) {
-    var url = new XWiki.Document('MacroService', 'CKEditor').getURL('get', $.param({
-      outputSyntax: 'plain',
-      language: $('html').attr('lang')
-    }));
-
-    return $.post(url, {action: 'install', extensionId: extensionId, extensionVersion: extensionVersion,
-        /*jshint camelcase: false */
-    	'form_token': xcontext.form_token});
-  };
-
-  return {
-    getMacroDescriptor: getMacroDescriptor,
-    installMacro: installMacro
-  };
-});
-
-/**
  * Macro Parameter Tree Builder
  *
  * The result is a JavaScript plain object with a structure similar to this:

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/macroSelector.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/macroSelector.js
@@ -32,41 +32,10 @@ define('macroSelectorTranslationKeys', [], [
   'install.notAllowed'
 ]);
 
-define('macroSelector', ['jquery', 'modal', 'l10n!macroSelector', 'xwiki-selectize'], 
-  function($, $modal, translations) {
+define('macroSelector', ['jquery', 'modal', 'l10n!macroSelector', 'macroService', 'xwiki-selectize'],
+  function($, $modal, translations, macroService) {
   'use strict';
-  var macrosBySyntax = {},
-
-  getMacros = function(syntaxId, force) {
-    var deferred = $.Deferred();
-    var macros = macrosBySyntax[syntaxId || ''];
-    if (macros && !force) {
-      deferred.resolve(macros);
-    } else {
-      var url = new XWiki.Document('MacroService', 'CKEditor').getURL('get', $.param({
-        outputSyntax: 'plain',
-        language: $('html').attr('lang')
-      }));
-      $.get(url, {data: 'list', syntaxId: syntaxId}).done(function(macros) {
-        // Bulletproofing: check if the returned data is json since it could some HTML representing an error
-        if (typeof macros === 'object' && Array.isArray(macros.list)) {
-          var macroList = macros.list;
-          if (Array.isArray(macros.notinstalled)) {
-            macroList = macroList.concat(macros.notinstalled);
-          }
-          macrosBySyntax[syntaxId || ''] = macroList;
-          deferred.resolve(macroList);
-        } else {
-          deferred.reject.apply(deferred, arguments);
-        }
-      }).fail(function() {
-        deferred.reject.apply(deferred, arguments);
-      });
-    }
-    return deferred.promise();
-  },
-
-  macroListTemplate = '<ul class="macro-list form-control" tabindex="0"></ul>',
+  var macroListTemplate = '<ul class="macro-list form-control" tabindex="0"></ul>',
   macroListItemTemplate =
     '<li data-macroCategories="" data-macroId="" ' +
         'data-extensionId="" data-extensionVersion="" data-extensionInstallAllowed="">' +
@@ -332,7 +301,7 @@ define('macroSelector', ['jquery', 'modal', 'l10n!macroSelector', 'xwiki-selecti
         macroSelector.empty().addClass('loading')
           .attr('data-syntaxId', syntaxId)
           .prop('requestNumber', requestNumber);
-        getMacros(syntaxId, force).done(maybeDisplayMacros.bind(macroSelector, requestNumber))
+        macroService.getMacros(syntaxId, force).done(maybeDisplayMacros.bind(macroSelector, requestNumber))
           .fail(maybeShowError.bind(macroSelector, requestNumber));
       }
     };

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/macroSelector.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/macroSelector.js
@@ -322,9 +322,11 @@ define('macroSelector', ['jquery', 'modal', 'l10n!macroSelector', 'macroService'
         if (!macroSelectorAPI) {
           // Create the macro selector.
           macroSelector.on('ready', function() {
+            macroSelectorAPI = macroSelector.data('macroSelectorAPI');
             macroSelectorAPI.select(input.macroId);
             macroSelector.find('.macro-textFilter').focus();
           }).on('change', function() {
+            macroSelectorAPI = macroSelector.data('macroSelectorAPI');
             var buttonText;
             var buttonTitle;
             var buttonDisabled = !macroSelectorAPI.getSelectedMacro();

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/macroService.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/macroService.js
@@ -1,0 +1,112 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+/**
+ * Macro Service
+ */
+define('macroService', ['jquery', 'xwiki-meta'], function ($, xcontext) {
+  'use strict';
+
+  var macroDescriptors = {},
+
+    getMacroDescriptor = function (macroId, maybeSourceDocumentReference) {
+      var deferred = $.Deferred();
+      var macroDescriptor = macroDescriptors[macroId];
+      if (macroDescriptor) {
+        deferred.resolve(macroDescriptor);
+      } else {
+        var sourceDocumentReference = maybeSourceDocumentReference || XWiki.currentDocument.documentReference;
+        var url = new XWiki.Document(sourceDocumentReference).getURL('get', $.param({
+          outputSyntax: 'plain',
+          language: $('html').attr('lang'),
+          sheet: 'CKEditor.MacroService'
+        }));
+        $.get(url, {
+          data: 'descriptor',
+          macroId: macroId
+        }).done(function (macroDescriptor) {
+          if (typeof macroDescriptor === 'object' && macroDescriptor !== null) {
+            macroDescriptors[macroId] = macroDescriptor;
+            deferred.resolve(macroDescriptor);
+          } else {
+            deferred.reject.apply(deferred, arguments);
+          }
+        }).fail(function () {
+          deferred.reject.apply(deferred, arguments);
+        });
+      }
+      return deferred.promise();
+    },
+
+    macrosBySyntax = {},
+
+      getMacros = function (syntaxId, force) {
+        var deferred = $.Deferred();
+        var macros = macrosBySyntax[syntaxId || ''];
+        if (macros && !force) {
+          deferred.resolve(macros);
+        } else {
+          var url = new XWiki.Document('MacroService', 'CKEditor').getURL('get', $.param({
+            outputSyntax: 'plain',
+            language: $('html').attr('lang')
+          }));
+          $.get(url, {
+            data: 'list',
+            syntaxId: syntaxId
+          }).done(function (macros) {
+            // Bulletproofing: check if the returned data is json since it could some HTML representing an error
+            if (typeof macros === 'object' && Array.isArray(macros.list)) {
+              var macroList = macros.list;
+              if (Array.isArray(macros.notinstalled)) {
+                macroList = macroList.concat(macros.notinstalled);
+              }
+              macrosBySyntax[syntaxId || ''] = macroList;
+              deferred.resolve(macroList);
+            } else {
+              deferred.reject.apply(deferred, arguments);
+            }
+          }).fail(function () {
+            deferred.reject.apply(deferred, arguments);
+          });
+        }
+        return deferred.promise();
+      },
+
+  installMacro = function (extensionId, extensionVersion) {
+    var url = new XWiki.Document('MacroService', 'CKEditor').getURL('get', $.param({
+      outputSyntax: 'plain',
+      language: $('html').attr('lang')
+    }));
+
+    return $.post(url, {
+      action: 'install',
+      extensionId: extensionId,
+      extensionVersion: extensionVersion,
+      /*jshint camelcase: false */
+      'form_token': xcontext.form_token
+    });
+  };
+
+  return {
+    getMacroDescriptor: getMacroDescriptor,
+    installMacro: installMacro,
+    getMacros: getMacros
+  };
+});

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/macroService.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/macroService.js
@@ -55,11 +55,10 @@ define('macroService', ['jquery', 'xwiki-meta'], function ($, xcontext) {
     return deferred.promise();
   };
 
-  var macrosCache = {};
+  var macrosBySyntax = {};
 
-  var getMacros = function (syntaxId, force, cacheId) {
+  var getMacros = function (syntaxId, force) {
     var deferred = $.Deferred();
-    var macrosBySyntax = macrosCache[cacheId || ''] || {};
     var macros = macrosBySyntax[syntaxId || ''];
     if (macros && !force) {
       deferred.resolve(macros);

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/macroService.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/macroService.js
@@ -24,72 +24,72 @@
 define('macroService', ['jquery', 'xwiki-meta'], function ($, xcontext) {
   'use strict';
 
-  var macroDescriptors = {},
+  var macroDescriptors = {};
 
-    getMacroDescriptor = function (macroId, maybeSourceDocumentReference) {
-      var deferred = $.Deferred();
-      var macroDescriptor = macroDescriptors[macroId];
-      if (macroDescriptor) {
-        deferred.resolve(macroDescriptor);
-      } else {
-        var sourceDocumentReference = maybeSourceDocumentReference || XWiki.currentDocument.documentReference;
-        var url = new XWiki.Document(sourceDocumentReference).getURL('get', $.param({
-          outputSyntax: 'plain',
-          language: $('html').attr('lang'),
-          sheet: 'CKEditor.MacroService'
-        }));
-        $.get(url, {
-          data: 'descriptor',
-          macroId: macroId
-        }).done(function (macroDescriptor) {
-          if (typeof macroDescriptor === 'object' && macroDescriptor !== null) {
-            macroDescriptors[macroId] = macroDescriptor;
-            deferred.resolve(macroDescriptor);
-          } else {
-            deferred.reject.apply(deferred, arguments);
-          }
-        }).fail(function () {
-          deferred.reject.apply(deferred, arguments);
-        });
-      }
-      return deferred.promise();
-    },
-
-    macrosBySyntax = {},
-
-      getMacros = function (syntaxId, force) {
-        var deferred = $.Deferred();
-        var macros = macrosBySyntax[syntaxId || ''];
-        if (macros && !force) {
-          deferred.resolve(macros);
+  var getMacroDescriptor = function (macroId, maybeSourceDocumentReference) {
+    var deferred = $.Deferred();
+    var macroDescriptor = macroDescriptors[macroId];
+    if (macroDescriptor) {
+      deferred.resolve(macroDescriptor);
+    } else {
+      var sourceDocumentReference = maybeSourceDocumentReference || XWiki.currentDocument.documentReference;
+      var url = new XWiki.Document(sourceDocumentReference).getURL('get', $.param({
+        outputSyntax: 'plain',
+        language: $('html').attr('lang'),
+        sheet: 'CKEditor.MacroService'
+      }));
+      $.get(url, {
+        data: 'descriptor',
+        macroId: macroId
+      }).done(function (macroDescriptor) {
+        if (typeof macroDescriptor === 'object' && macroDescriptor !== null) {
+          macroDescriptors[macroId] = macroDescriptor;
+          deferred.resolve(macroDescriptor);
         } else {
-          var url = new XWiki.Document('MacroService', 'CKEditor').getURL('get', $.param({
-            outputSyntax: 'plain',
-            language: $('html').attr('lang')
-          }));
-          $.get(url, {
-            data: 'list',
-            syntaxId: syntaxId
-          }).done(function (macros) {
-            // Bulletproofing: check if the returned data is json since it could some HTML representing an error
-            if (typeof macros === 'object' && Array.isArray(macros.list)) {
-              var macroList = macros.list;
-              if (Array.isArray(macros.notinstalled)) {
-                macroList = macroList.concat(macros.notinstalled);
-              }
-              macrosBySyntax[syntaxId || ''] = macroList;
-              deferred.resolve(macroList);
-            } else {
-              deferred.reject.apply(deferred, arguments);
-            }
-          }).fail(function () {
-            deferred.reject.apply(deferred, arguments);
-          });
+          deferred.reject.apply(deferred, arguments);
         }
-        return deferred.promise();
-      },
+      }).fail(function () {
+        deferred.reject.apply(deferred, arguments);
+      });
+    }
+    return deferred.promise();
+  };
 
-  installMacro = function (extensionId, extensionVersion) {
+  var macrosBySyntax = {};
+
+  var getMacros = function (syntaxId, force) {
+    var deferred = $.Deferred();
+    var macros = macrosBySyntax[syntaxId || ''];
+    if (macros && !force) {
+      deferred.resolve(macros);
+    } else {
+      var url = new XWiki.Document('MacroService', 'CKEditor').getURL('get', $.param({
+        outputSyntax: 'plain',
+        language: $('html').attr('lang')
+      }));
+      $.get(url, {
+        data: 'list',
+        syntaxId: syntaxId
+      }).done(function (macros) {
+        // Bulletproofing: check if the returned data is json since it could some HTML representing an error
+        if (typeof macros === 'object' && Array.isArray(macros.list)) {
+          var macroList = macros.list;
+          if (Array.isArray(macros.notinstalled)) {
+            macroList = macroList.concat(macros.notinstalled);
+          }
+          macrosBySyntax[syntaxId || ''] = macroList;
+          deferred.resolve(macroList);
+        } else {
+          deferred.reject.apply(deferred, arguments);
+        }
+      }).fail(function () {
+        deferred.reject.apply(deferred, arguments);
+      });
+    }
+    return deferred.promise();
+  };
+
+  var installMacro = function (extensionId, extensionVersion) {
     var url = new XWiki.Document('MacroService', 'CKEditor').getURL('get', $.param({
       outputSyntax: 'plain',
       language: $('html').attr('lang')

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/macroService.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/macroService.js
@@ -55,10 +55,11 @@ define('macroService', ['jquery', 'xwiki-meta'], function ($, xcontext) {
     return deferred.promise();
   };
 
-  var macrosBySyntax = {};
+  var macrosCache = {};
 
-  var getMacros = function (syntaxId, force) {
+  var getMacros = function (syntaxId, force, cacheId) {
     var deferred = $.Deferred();
+    var macrosBySyntax = macrosCache[cacheId || ''] || {};
     var macros = macrosBySyntax[syntaxId || ''];
     if (macros && !force) {
       deferred.resolve(macros);

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/macroWizard.css
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/macroWizard.css
@@ -28,16 +28,16 @@ ul.macro-list > li.selected {
 }
 
 ul.macro-list .macro-name,
-li.auto-macro-list .macro-name,
+li.macro-suggestion .macro-name,
 ul.macro-parameters .macro-parameter-name {
   color: #333;
   color: $theme.textColor;
 }
 
 ul.macro-list .macro-description,
-li.auto-macro-list .macro-description,
+li.macro-suggestion .macro-description,
 ul.macro-list .macro-extension,
-li.auto-macro-list .macro-extension,
+li.macro-suggestion .macro-extension,
 .macro-editor .macro-description,
 ul.macro-parameters .macro-parameter-description,
 ul.macro-parameters > li.more,
@@ -48,13 +48,14 @@ ul.macro-parameter-group-members > li.more {
   font-size: smaller;
 }
 
-li.auto-macro-list .macro-description {
+li.macro-suggestion .macro-description {
+  /* We do not want the description to affect the width of the macro suggestion menu*/
   width: 0;
   min-width: 100%;
 }
 
 ul.macro-list .macro-extension,
-li.auto-macro-list .macro-extension {
+li.macro-suggestion .macro-extension {
   margin-right: 1em;
 }
 

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/macroWizard.css
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/macroWizard.css
@@ -28,16 +28,13 @@ ul.macro-list > li.selected {
 }
 
 ul.macro-list .macro-name,
-li.macro-suggestion .macro-name,
 ul.macro-parameters .macro-parameter-name {
   color: #333;
   color: $theme.textColor;
 }
 
 ul.macro-list .macro-description,
-li.macro-suggestion .macro-description,
 ul.macro-list .macro-extension,
-li.macro-suggestion .macro-extension,
 .macro-editor .macro-description,
 ul.macro-parameters .macro-parameter-description,
 ul.macro-parameters > li.more,
@@ -48,14 +45,7 @@ ul.macro-parameter-group-members > li.more {
   font-size: smaller;
 }
 
-li.macro-suggestion .macro-description {
-  /* We do not want the description to affect the width of the macro suggestion menu*/
-  width: 0;
-  min-width: 100%;
-}
-
-ul.macro-list .macro-extension,
-li.macro-suggestion .macro-extension {
+ul.macro-list .macro-extension {
   margin-right: 1em;
 }
 

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/macroWizard.css
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/macroWizard.css
@@ -28,13 +28,16 @@ ul.macro-list > li.selected {
 }
 
 ul.macro-list .macro-name,
+li.auto-macro-list .macro-name,
 ul.macro-parameters .macro-parameter-name {
   color: #333;
   color: $theme.textColor;
 }
 
 ul.macro-list .macro-description,
+li.auto-macro-list .macro-description,
 ul.macro-list .macro-extension,
+li.auto-macro-list .macro-extension,
 .macro-editor .macro-description,
 ul.macro-parameters .macro-parameter-description,
 ul.macro-parameters > li.more,
@@ -45,8 +48,13 @@ ul.macro-parameter-group-members > li.more {
   font-size: smaller;
 }
 
+li.auto-macro-list .macro-description {
+  width: 0;
+  min-width: 100%;
+}
 
-ul.macro-list .macro-extension {
+ul.macro-list .macro-extension,
+li.auto-macro-list .macro-extension {
   margin-right: 1em;
 }
 

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/plugin.js
@@ -374,7 +374,7 @@
             var command = this;
 
             // Find the macro we are going to insert
-            macroService.getMacros(XWiki.docsyntax, false, 'macro-slash').done(function (macros) {
+            macroService.getMacros(XWiki.docsyntax).done(function (macros) {
               macros.forEach(function (macro) {
                 if (macro.id.id === macroCall.id) {
 
@@ -467,7 +467,7 @@
                                                 'success',
                                                 5000);
                         // Update the cache for future insertions
-                        macroService.getMacros(XWiki.docsyntax, true, 'macro-slash');
+                        macroService.getMacros(XWiki.docsyntax, true);
 
                         // Update the pre-inserted widget
                         insertMacro(evt.data);
@@ -563,7 +563,7 @@
         };
 
         // Register macros in Quick Actions plugin
-        macroService.getMacros(XWiki.docsyntax, false, 'macro-slash').done(function (macros) {
+        macroService.getMacros(XWiki.docsyntax).done(function (macros) {
 
           // Keep track of how many groups we created
           var macroGroupsCount = 0;

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-macro/plugin.js
@@ -374,7 +374,7 @@
             var command = this;
 
             // Find the macro we are going to insert
-            macroService.getMacros(XWiki.docsyntax).done(function (macros) {
+            macroService.getMacros(XWiki.docsyntax, false, 'macro-slash').done(function (macros) {
               macros.forEach(function (macro) {
                 if (macro.id.id === macroCall.id) {
 
@@ -467,7 +467,7 @@
                                                 'success',
                                                 5000);
                         // Update the cache for future insertions
-                        macroService.getMacros(XWiki.docsyntax, true);
+                        macroService.getMacros(XWiki.docsyntax, true, 'macro-slash');
 
                         // Update the pre-inserted widget
                         insertMacro(evt.data);
@@ -563,7 +563,7 @@
         };
 
         // Register macros in Quick Actions plugin
-        macroService.getMacros(XWiki.docsyntax).done(function (macros) {
+        macroService.getMacros(XWiki.docsyntax, false, 'macro-slash').done(function (macros) {
 
           // Keep track of how many groups we created
           var macroGroupsCount = 0;

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-slash/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-slash/plugin.js
@@ -30,7 +30,12 @@
     constructor(config) {
       this.config = Object.assign({
         // Default values for quick action / group fields.
-        defaultAction: {group: '', id: '', name: '', description: '', iconClass: '', iconURL: '', shortcut: ''},
+        defaultAction: {group: '', id: '', name: '', description: '',
+          iconClass: '', iconURL: '', shortcut: '',
+          //Default value for badges
+          ...Array(3).fill().map(function (_, i) {return i;}).reduce(function (acc, element)
+            {return ({...acc, ['badge' + (element+1)]: ''});}, {}),
+        },
         defaultGroup: {id: '', name: '', order: Infinity}
       }, config);
 
@@ -108,6 +113,19 @@
     }
 
     /**
+      * Get an action definition based on its id
+      * @param {String} The action id
+      * @return {Object} The action if it exists
+      */
+    getAction(id) {
+      for (var action of this.actions) {
+        if (action.id === id) {
+          return action;
+        }
+      }
+    }
+
+    /**
      * Defines one or more quick action groups.
      *
      * @param {Object | Array} the groups to add
@@ -132,6 +150,17 @@
       group.nameTokens = (group.name || '').split(/\s+/);
       this.groups[group.id] = group;
       return group;
+    }
+
+
+    /**
+     * Get a group definition based on its id
+     *
+     * @param {String} The group id
+     * @return {Object} The group
+     */
+    getGroup(id) {
+      return this.groups[id];
     }
 
     /**
@@ -387,34 +416,42 @@
     init: function(editor) {
       editor.quickActions.addGroups([
         {
-          id: 'structure',
-          name: editor.localization.get('xwiki-slash.group.structure'),
+          id: 'Layout',
+          name: editor.localization.get('xwiki-slash.group.Layout'),
           order: 100
         }, {
-          id: 'content',
-          name: editor.localization.get('xwiki-slash.group.content'),
+          id: 'Content',
+          name: editor.localization.get('xwiki-slash.group.Content'),
           order: 200
         }, {
-          id: 'macros',
-          name: editor.localization.get('xwiki-slash.group.macros'),
-          order: 400
+          id: 'Formatting',
+          name: editor.localization.get('xwiki-slash.group.Formatting'),
+          order: 300
         }, {
-          id: 'actions',
-          name: editor.localization.get('xwiki-slash.group.actions'),
+          id: 'Navigation',
+          name: editor.localization.get('xwiki-slash.group.Navigation'),
+          order: 500
+        }, {
+          id: 'Actions',
+          name: editor.localization.get('xwiki-slash.group.Actions'),
           order: 600
         }, {
-          id: 'table',
-          name: editor.localization.get('xwiki-slash.group.table'),
+          id: 'Table',
+          name: editor.localization.get('xwiki-slash.group.Table'),
           order: 700
+        }, {
+          id: 'Macro',
+          name: editor.localization.get('xwiki-slash.group.Macro'),
+          order: 800
         }
       ]);
 
       editor.quickActions.addActions([
         //
-        // Structure
+        // Layout
         //
         {
-          group: 'structure',
+          group: 'Layout',
           id: 'h1',
           name: editor.lang.format.tag_h1, // jshint ignore:line
           iconClass: 'fa fa-header',
@@ -426,7 +463,7 @@
             }
           }
         }, {
-          group: 'structure',
+          group: 'Layout',
           id: 'h2',
           name: editor.lang.format.tag_h2, // jshint ignore:line
           iconClass: 'fa fa-header',
@@ -438,7 +475,7 @@
             }
           }
         }, {
-          group: 'structure',
+          group: 'Layout',
           id: 'h3',
           name: editor.lang.format.tag_h3, // jshint ignore:line
           iconClass: 'fa fa-header',
@@ -450,7 +487,7 @@
             }
           }
         }, {
-          group: 'structure',
+          group: 'Layout',
           id: 'p',
           name: editor.localization.get('xwiki-slash.action.p.name'),
           iconClass: 'fa fa-paragraph',
@@ -462,36 +499,36 @@
             }
           }
         }, {
-          group: 'structure',
+          group: 'Layout',
           id: 'ul',
           name: editor.localization.get('xwiki-toolbar.bulletedlist'),
           iconClass: 'fa fa-list-ul',
           description: editor.localization.get('xwiki-slash.action.ul.hint'),
           command: 'bulletedlist'
         }, {
-          group: 'structure',
+          group: 'Layout',
           id: 'ol',
           name: editor.localization.get('xwiki-toolbar.numberedlist'),
           iconClass: 'fa fa-list-ol',
           description: editor.localization.get('xwiki-slash.action.ol.hint'),
           command: 'numberedlist'
         }, {
-          group: 'structure',
+          group: 'Layout',
           id: 'table',
           name: editor.lang.table.toolbar,
           iconClass: 'fa fa-table',
           description: editor.localization.get('xwiki-slash.action.table.hint'),
           command: 'table'
         }, {
-          group: 'structure',
+          group: 'Layout',
           id: 'blockquote',
           name: editor.localization.get('xwiki-slash.action.blockquote.name'),
           iconClass: 'fa fa-quote-left',
           description: editor.localization.get('xwiki-slash.action.blockquote.hint'),
           command: 'blockquote'
         }, {
-          group: 'structure',
-          id: 'info',
+          group: 'Layout',
+          id: 'macro-info',
           name: editor.localization.get('xwiki-toolbar.infoBox'),
           iconClass: 'fa fa-info-circle',
           description: editor.localization.get('xwiki-slash.action.info.hint'),
@@ -503,8 +540,8 @@
             }
           }
         }, {
-          group: 'structure',
-          id: 'success',
+          group: 'Layout',
+          id: 'macro-success',
           name: editor.localization.get('xwiki-toolbar.successBox'),
           iconClass: 'fa fa-check-circle',
           description: editor.localization.get('xwiki-slash.action.success.hint'),
@@ -516,8 +553,8 @@
             }
           }
         }, {
-          group: 'structure',
-          id: 'warning',
+          group: 'Layout',
+          id: 'macro-warning',
           name: editor.localization.get('xwiki-toolbar.warningBox'),
           iconClass: 'fa fa-exclamation-triangle',
           description: editor.localization.get('xwiki-slash.action.warning.hint'),
@@ -529,8 +566,8 @@
             }
           }
         }, {
-          group: 'structure',
-          id: 'error',
+          group: 'Layout',
+          id: 'macro-error',
           name: editor.localization.get('xwiki-toolbar.errorBox'),
           iconClass: 'fa fa-exclamation-circle',
           description: editor.localization.get('xwiki-slash.action.error.hint'),
@@ -542,7 +579,7 @@
             }
           }
         }, {
-          group: 'structure',
+          group: 'Layout',
           id: 'hr',
           name: editor.localization.get('xwiki-toolbar.horizontalrule'),
           iconClass: 'fa fa-minus',
@@ -554,7 +591,7 @@
         // Content
         //
         {
-          group: 'content',
+          group: 'Content',
           id: 'a',
           name: editor.lang.link.toolbar,
           iconClass: 'fa fa-link',
@@ -562,14 +599,14 @@
           description: editor.localization.get('xwiki-slash.action.a.hint'),
           outputHTML: '['
         }, {
-          group: 'content',
+          group: 'Content',
           id: 'img',
           name: editor.lang.common.image,
           iconClass: 'fa fa-image',
           description: editor.localization.get('xwiki-slash.action.img.hint'),
           command: 'image'
         }, {
-          group: 'content',
+          group: 'Content',
           id: 'mention',
           name: editor.localization.get('xwiki-slash.action.mention.name'),
           iconClass: 'fa fa-user-o',
@@ -577,21 +614,33 @@
           description: editor.localization.get('xwiki-slash.action.mention.hint'),
           outputHTML: '@'
         }, {
-          group: 'content',
+          group: 'Content',
           id: 'emoji',
           name: editor.localization.get('xwiki-slash.action.emoji.name'),
           iconClass: 'fa fa-smile-o',
           shortcut: ':',
           description: editor.localization.get('xwiki-slash.action.emoji.hint'),
           outputHTML: ':sm'
+        }, {
+          group: 'Content',
+          id: 'macro-include',
+          name: editor.localization.get('xwiki-toolbar.include'),
+          iconClass: 'fa fa-file-text-o',
+          description: editor.localization.get('xwiki-slash.action.include.hint'),
+          command: {
+            name: 'xwiki-macro',
+            data: {
+              name: 'include'
+            }
+          }
         },
 
         //
-        // Macros
+        // Formatting
         //
         {
-          group: 'macros',
-          id: 'code',
+          group: 'Formatting',
+          id: 'macro-code',
           name: editor.localization.get('xwiki-toolbar.code'),
           iconClass: 'fa fa-code',
           description: editor.localization.get('xwiki-slash.action.code.hint'),
@@ -604,9 +653,14 @@
               },
             }
           }
-        }, {
-          group: 'macros',
-          id: 'toc',
+        },
+
+        //
+        // Navigation
+        //
+        {
+          group: 'Navigation',
+          id: 'macro-toc',
           name: editor.localization.get('xwiki-toolbar.toc'),
           iconClass: 'fa fa-list',
           description: editor.localization.get('xwiki-slash.action.toc.hint'),
@@ -616,33 +670,13 @@
               name: 'toc'
             }
           }
-        }, {
-          group: 'macros',
-          id: 'include',
-          name: editor.localization.get('xwiki-toolbar.include'),
-          iconClass: 'fa fa-file-text-o',
-          description: editor.localization.get('xwiki-slash.action.include.hint'),
-          command: {
-            name: 'xwiki-macro',
-            data: {
-              name: 'include'
-            }
-          }
-        }, {
-          group: 'macros',
-          id: 'macros',
-          name: editor.localization.get('xwiki-slash.action.macros.name'),
-          iconClass: 'fa fa-th-list',
-          description: editor.localization.get('xwiki-slash.action.macros.hint'),
-          shortcut: '{',
-          outputHTML: '{'
         },
 
         //
         // Actions
         //
         {
-          group: 'actions',
+          group: 'Actions',
           id: 'find',
           name: editor.lang.find.title,
           iconClass: 'fa fa-search',
@@ -656,21 +690,21 @@
 
         // Rows
         {
-          group: 'table',
+          group: 'Table',
           id: 'table_row_before',
           name: editor.lang.table.row.insertBefore,
           iconClass: 'fa fa-plus',
           description: editor.localization.get('xwiki-slash.action.table_row_before.hint'),
           command: 'rowInsertBefore'
         }, {
-          group: 'table',
+          group: 'Table',
           id: 'table_row_after',
           name: editor.lang.table.row.insertAfter,
           iconClass: 'fa fa-plus',
           description: editor.localization.get('xwiki-slash.action.table_row_after.hint'),
           command: 'rowInsertAfter'
         }, {
-          group: 'table',
+          group: 'Table',
           id: 'table_row_delete',
           name: editor.localization.get('xwiki-slash.action.table_row_delete.name'),
           iconClass: 'fa fa-trash',
@@ -680,21 +714,21 @@
 
         // Columns
         {
-          group: 'table',
+          group: 'Table',
           id: 'table_col_before',
           name: editor.lang.table.column.insertBefore,
           iconClass: 'fa fa-plus',
           description: editor.localization.get('xwiki-slash.action.table_col_before.hint'),
           command: 'columnInsertBefore'
         }, {
-          group: 'table',
+          group: 'Table',
           id: 'table_col_after',
           name: editor.lang.table.column.insertAfter,
           iconClass: 'fa fa-plus',
           description: editor.localization.get('xwiki-slash.action.table_col_after.hint'),
           command: 'columnInsertAfter'
         }, {
-          group: 'table',
+          group: 'Table',
           id: 'table_col_delete',
           name: editor.localization.get('xwiki-slash.action.table_col_delete.name'),
           iconClass: 'fa fa-trash',
@@ -704,49 +738,49 @@
 
         // Cells
         {
-          group: 'table',
+          group: 'Table',
           id: 'table_cell_split_horizontal',
           name: editor.lang.table.cell.splitHorizontal,
           iconClass: 'fa fa-bars',
           description: editor.localization.get('xwiki-slash.action.table_cell_split_horizontal.hint'),
           command: 'cellHorizontalSplit'
         }, {
-          group: 'table',
+          group: 'Table',
           id: 'table_cell_split_vertical',
           name: editor.lang.table.cell.splitVertical,
           iconClass: 'fa fa-columns',
           description: editor.localization.get('xwiki-slash.action.table_cell_split_vertical.hint'),
           command: 'cellVerticalSplit'
         }, {
-          group: 'table',
+          group: 'Table',
           id: 'table_cell_merge_right',
           name: editor.localization.get('xwiki-slash.action.table_cell_merge_right.name'),
           iconClass: 'fa fa-compress',
           description: editor.localization.get('xwiki-slash.action.table_cell_merge_right.hint'),
           command: 'cellMergeRight'
         }, {
-          group: 'table',
+          group: 'Table',
           id: 'table_cell_merge_down',
           name: editor.localization.get('xwiki-slash.action.table_cell_merge_down.name'),
           iconClass: 'fa fa-compress',
           description: editor.localization.get('xwiki-slash.action.table_cell_merge_down.hint'),
           command: 'cellMergeDown'
         }, {
-          group: 'table',
+          group: 'Table',
           id: 'table_cell_before',
           name: editor.lang.table.cell.insertBefore,
           iconClass: 'fa fa-plus',
           description: editor.localization.get('xwiki-slash.action.table_cell_before.hint'),
           command: 'cellInsertBefore'
         }, {
-          group: 'table',
+          group: 'Table',
           id: 'table_cell_after',
           name: editor.lang.table.cell.insertAfter,
           iconClass: 'fa fa-plus',
           description: editor.localization.get('xwiki-slash.action.table_cell_after.hint'),
           command: 'cellInsertAfter'
         }, {
-          group: 'table',
+          group: 'Table',
           id: 'table_cell_delete',
           name: editor.localization.get('xwiki-slash.action.table_cell_delete.name'),
           iconClass: 'fa fa-trash',
@@ -755,7 +789,7 @@
         },
 
         {
-          group: 'table',
+          group: 'Table',
           id: 'table_delete',
           name: editor.lang.table.deleteTable,
           iconClass: 'fa fa-trash',
@@ -799,6 +833,10 @@
               '</span>',
               '<span class="ckeditor-autocomplete-item-label">{name}</span>',
               '<span class="ckeditor-autocomplete-item-shortcut">{shortcut}</span>',
+            '</div>',
+            '<div class="ckeditor-autocomplete-item-badges">',
+            ...Array(3).fill().map(function (_, i)
+              {return '<span class="badge ckeditor-autocomplete-item-badge">{badge' + (i+1) + '}</span>';}),
             '</div>',
             '<div class="ckeditor-autocomplete-item-hint">{description}</div>',
           '</li>'].join(''),

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-slash/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-slash/plugin.js
@@ -32,11 +32,9 @@
         // Default values for quick action / group fields.
         defaultAction: {group: '', id: '', name: '', description: '',
           iconClass: '', iconURL: '', shortcut: '',
-          //Default value for badges
-          ...Array(3).fill().map(function (_, i) {return i;}).reduce(function (acc, element)
-            {return ({...acc, ['badge' + (element+1)]: ''});}, {}),
         },
-        defaultGroup: {id: '', name: '', order: Infinity}
+        defaultGroup: {id: '', name: '', order: Infinity},
+        maxBadges: 3,
       }, config);
 
       // Configuration for the quick actions search.
@@ -56,6 +54,16 @@
           {name: 'group.nameTokens', weight: 1}
         ]
       }, this.config.search);
+
+      //Default value for badges
+      this.config.defaultAction = Object.assign(
+        Array(this.config.maxBadges)
+        .fill()
+        .map(function (_, i) {return i;})
+        .reduce(function (acc, element)
+            {return ({...acc, ['badge' + (element+1)]: ''});}, {}
+                ),
+        this.config.defaultAction);
 
       // Start with an empty list of quick actions and no groups;
       this.actions = [];
@@ -835,7 +843,7 @@
               '<span class="ckeditor-autocomplete-item-shortcut">{shortcut}</span>',
             '</div>',
             '<div class="ckeditor-autocomplete-item-badges">',
-            ...Array(3).fill().map(function (_, i)
+            ...Array(editor.quickActions.config.maxBadges).fill().map(function (_, i)
               {return '<span class="badge ckeditor-autocomplete-item-badge">{badge' + (i+1) + '}</span>';}),
             '</div>',
             '<div class="ckeditor-autocomplete-item-hint">{description}</div>',

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-slash/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-slash/plugin.js
@@ -634,7 +634,8 @@
           name: editor.localization.get('xwiki-slash.action.macros.name'),
           iconClass: 'fa fa-th-list',
           description: editor.localization.get('xwiki-slash.action.macros.hint'),
-          command: 'xwiki-macro'
+          shortcut: '{',
+          outputHTML: '{'
         },
 
         //

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/EditSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/EditSheet.xml
@@ -887,9 +887,14 @@ ul.cke_autocomplete_panel {
   margin-left: .5em;
 }
 .ckeditor-autocomplete-item-shortcut,
+.ckeditor-autocomplete-item-badge,
 .ckeditor-autocomplete-item-hint {
   color: @text-muted;
   font-size: smaller;
+}
+.ckeditor-autocomplete-item-badge {
+  background-color: @xwiki-border-color;
+  font-weight: normal;
 }
 .ckeditor-autocomplete-item-hint {
   /* Limit to 3 lines of text (based on line height). */

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/Translations.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/Translations.xml
@@ -69,6 +69,9 @@ ckeditor.plugin.macro.buttonHint=XWiki Macro
 ckeditor.plugin.macro.editButtonHint=Edit Macro
 ckeditor.plugin.macro.refreshFailed=Failed to refresh the edited content.
 ckeditor.plugin.macro.dedicatedInsertButtonHint=Insert {0} macro
+ckeditor.plugin.macro.installPending=Installing {0} {1}...
+ckeditor.plugin.macro.installSuccessful=Successfully installed {0} {1}.
+ckeditor.plugin.macro.installFailed=Failed to install {0} {1}.
 
 ckeditor.plugin.office.importer.title=Import Office File
 ckeditor.plugin.office.importer.filePath=File Path
@@ -150,11 +153,13 @@ ckeditor.plugin.image.imageSelector.urlTab.url.title=Url
 ckeditor.plugin.image.imageSelector.urlTab.url.hint=The url of the image to display.
 ckeditor.plugin.image.imageSelector.urlTab.url.placeholder=https://...
 
-ckeditor.plugin.slash.group.structure=Structure
-ckeditor.plugin.slash.group.content=Content
-ckeditor.plugin.slash.group.macros=Macros
-ckeditor.plugin.slash.group.actions=Actions
-ckeditor.plugin.slash.group.table=Table
+ckeditor.plugin.slash.group.Layout=Layout
+ckeditor.plugin.slash.group.Content=Content
+ckeditor.plugin.slash.group.Formatting=Formatting
+ckeditor.plugin.slash.group.Navigation=Navigation
+ckeditor.plugin.slash.group.Actions=Actions
+ckeditor.plugin.slash.group.Table=Table
+ckeditor.plugin.slash.group.Macro=Macro
 
 ckeditor.plugin.slash.action.h1.hint=Big section heading.
 ckeditor.plugin.slash.action.h2.hint=Medium section heading.


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-19982

This PR introduces a "{" shortcut to quickly insert Macros from the WYSIWYG editor.
It also skips the macro parameters dialog when no mandatory fields are present to reduce interactions (The user can still edit them afterwards).

Here's a preview of the feature:
![autoMacro](https://github.com/xwiki/xwiki-platform/assets/132468278/e1aff78e-11f4-4b10-a600-2e3c047e5245)
