### PR TITLE
XWIKI-20932: Images pasted from clipboard are attached with 'grafik.png' name on Firefox with German language

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/FileUploader.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/FileUploader.xml
@@ -80,6 +80,7 @@
   #set ($fileName = $xwiki.fileupload.getFileName('upload'))
   #if ("$!fileName" != '')
     #if ($services.csrf.isTokenValid($request.form_token))
+      ## Note: this is not useful anymore and files are expected to have their definitive name on upload.
       #if ($fileName.startsWith('__fileCreatedFromDataURI__.'))
         ## We need to generate a new name so that we don't overwrite existing attachments.
         #set ($extension = $stringtool.substringAfter($fileName, '.'))
@@ -109,6 +110,7 @@
         #set ($fileName = $request.filename)
       #else
         #set ($fileName = $request.getPart('upload').getSubmittedFileName())
+        ## Note: this is not useful anymore and files are expected to have their definitive name on upload.
         #if ($fileName.startsWith('__fileCreatedFromDataURI__.'))
           ## We need to generate a new name so that we don't overwrite existing attachments.
           #set ($extension = $stringtool.substringAfter($fileName, '.'))

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/FileUploader.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/FileUploader.xml
@@ -80,7 +80,8 @@
   #set ($fileName = $xwiki.fileupload.getFileName('upload'))
   #if ("$!fileName" != '')
     #if ($services.csrf.isTokenValid($request.form_token))
-      ## Note: this is not useful anymore and files are expected to have their definitive name on upload.
+      ## Note: This is not useful anymore and files are expected to have their definitive name on upload.
+      ## Kept for legacy.
       #if ($fileName.startsWith('__fileCreatedFromDataURI__.'))
         ## We need to generate a new name so that we don't overwrite existing attachments.
         #set ($extension = $stringtool.substringAfter($fileName, '.'))
@@ -111,6 +112,7 @@
       #else
         #set ($fileName = $request.getPart('upload').getSubmittedFileName())
         ## Note: this is not useful anymore and files are expected to have their definitive name on upload.
+        ## Kept for legacy.
         #if ($fileName.startsWith('__fileCreatedFromDataURI__.'))
           ## We need to generate a new name so that we don't overwrite existing attachments.
           #set ($extension = $stringtool.substringAfter($fileName, '.'))


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-20932

Currently, we decide if we are in the presence of a pasted image based on its name (i.e., `image.png`) which proved to be inaccurate and locale dependent.

Instead, I propose to toggle a `duringPaste` flag based on two listeners, `beforePaste` and `afterPaste`, respectively turning setting the flag `true` and `false`.
We append a timestamp and a random integer to the filename when  `duringPaste` is `true`.

Note: Not fully cleaned up, I'd like to have some opinion of the approach before.