### PR TITLE
XWIKI-19142: Livetable select options have invalid attribute "text"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/table/livetable.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/table/livetable.js
@@ -1033,7 +1033,7 @@ var LiveTablePagination = Class.create({
       'aria-label': '$escapetool.javascript($services.localization.render("platform.livetable.selectPageSize.label"))'
     });
     for (var i=this.startValue; i<=this.maxValue; i += this.step) {
-      var attrs = {'value':i, 'text':i};
+      var attrs = {'value':i};
       if (i == this.currentValue) {
         attrs.selected = true;
       } else {

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/table/livetable.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/table/livetable.js
@@ -1041,7 +1041,6 @@ var LiveTablePagination = Class.create({
         if (this.currentValue > prevStep && this.currentValue < i) {
           select.appendChild(new Element('option', {
             value: this.currentValue,
-            text: this.currentValue,
             selected: true
           }).update(this.currentValue));
         }


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-19142

## PR Changes

* Removed the `text` attribute generated in the options for the livetable select element.

## View
No changes to UI, only some in the generated HTML.
![19142-viewPatch](https://github.com/xwiki/xwiki-platform/assets/28761965/c5bbdd79-12bf-4d5a-aea7-3314bcd8983c)
