### PR TITLE
XWIKI-20913: More actions dropdown structure is not accessible

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/action-menus.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/action-menus.less
@@ -301,6 +301,7 @@
 
 #contentmenu {
   .text-right();
+  .flat-buttons();
 
   .dropdown {
     display: inline-block;
@@ -313,5 +314,31 @@
     }
   }
 
-  .flat-buttons();
+  #tmMoreActions > dl.dropdown-menu {
+    & > dt.dropdown-header {
+      // Use the bootstrap style for our semantic architecture
+      &:extend(li.dropdown-header);
+      font-weight: initial;
+
+      // Add a css separator above the header
+      &.separator-above {
+        padding-top: 10px;
+        border-top: 1px solid @dropdown-divider-bg ;
+      }
+    }
+
+    & > dd > ul {
+      // Remove default list style
+      list-style: none;
+      padding-left: 0;
+
+      & > li > a {
+        // Use the bootstrap style for our semantic architecture
+        &:extend(.dropdown-menu > li > a);
+        &:hover, &:focus-within {
+          &:extend(.dropdown-menu > li > a:hover);
+        }
+      }
+    }
+  }
 }

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_content.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_content.vm
@@ -164,9 +164,17 @@
           <span class="sr-only">$services.localization.render('core.menu.toggleDropdown')</span>
         </button>
       #end
-      <ul class="dropdown-menu #if ("$!actionUrl" == '')dropdown-menu-right#end">
-        $menuContent
-      </ul>
+      #if ("$!actionUrl" == '')
+        ## We use another component for the more action menu, since it has
+        ## a more complex structure with submenus.
+        <dl class='dropdown-menu dropdown-menu-right'>
+          $menuContent
+        </dl>
+      #else
+        <ul class='dropdown-menu'>
+          $menuContent
+        </ul>
+      #end
     #end
   </div>
 #end
@@ -220,8 +228,8 @@
   #setVariable("$count", $count)
 #end
 
-#macro (submenuheader $titleKey)
-  <li class="dropdown-header">$services.localization.render($titleKey)</li>
+#macro (submenuheader $titleKey, $needsSeparator)
+  <dt class="dropdown-header#if($needsSeparator) separator-above#end">$services.localization.render($titleKey)</dt>
 #end
 
 #**
@@ -402,7 +410,9 @@
       #set ($adminActions = "#displayAdminActions()")
       #if ($stringtool.isNotBlank("$!adminActions"))
         #submenuheader('core.menu.actions.main')
-        $adminActions
+        <dd><ul>
+          $adminActions
+        </ul></dd>
         #set ($needsSeparator = true)
       #end
     #end
@@ -410,11 +420,10 @@
     #if ($displayMoreActionsMenu)
       #set ($moreActions = "#displayMoreActions()")
       #if ($stringtool.isNotBlank("$!moreActions"))
-        #if ($needsSeparator)
-          #submenuseparator()
-        #end
-        #submenuheader('core.menu.actions.others')
-        $moreActions
+        #submenuheader('core.menu.actions.others', $needsSeparator)
+        <dd><ul>
+          $moreActions
+        </ul></dd>
         #set ($needsSeparator = true)
       #end
       ## ----------------------------
@@ -423,20 +432,19 @@
       #if($xwiki.hasAccessLevel('view') && $displayShortcuts)
         #set ($viewersContent = "#template('shortcuts.vm')")
         ## Only display a separator if at least one menu entry has been displayed before
-        #if ($needsSeparator)
-          #submenuseparator()
-        #end
-        #submenuheader('core.menu.actions.viewers')
+        #submenuheader('core.menu.actions.viewers', $needsSeparator)
         ##
         ## VIEW SOURCE
         ##
         #if ("$!request.rev" != '')
           #set ($revisionParameter = "&rev=$request.rev")
         #end
-        #submenuitem($doc.getURL('view', "viewer=code$!{revisionParameter}") $services.localization.render('core.menu.view.source') 'tmViewSource', '', 'search', $extraAttributes)
-        $viewersContent
-        ## Display Viewers menu UIX..
-        #displaySecureUIX('org.xwiki.platform.template.menu.viewers', [])
+        <dd><ul>
+          #submenuitem($doc.getURL('view', "viewer=code$!{revisionParameter}") $services.localization.render('core.menu.view.source') 'tmViewSource', '', 'search', $extraAttributes)
+          $viewersContent
+          ## Display Viewers menu UIX..
+          #displaySecureUIX('org.xwiki.platform.template.menu.viewers', [])
+        </ul></dd>
         #set ($needsSeparator = true)
       #end
     #end

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_macros.vm
@@ -142,7 +142,7 @@
     #set($linkName = $linkWords.get(1))
     #set($linkTitle = "${linkWords.get(0)}: ${linkWords.get(1)}")
   #end
-  <li class="$!class">
+  <li #if("$!class" != '')class="$!class"#end>
     <a href="$actionurl" #if(!$stringtool.isBlank($linkid))id="$linkid"#end title="$escapetool.xml($linkTitle)"
       $!extraAttributes>$services.icon.renderHTML($icon) $escapetool.xml($linkName)</a>
   </li>


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-20913

## PR Changes

* Replaced the <ul> with a more semantically precise structure based on a <dl>
* Updated style

## Notes

* In xwiki-platform, the submenuheader velocity macro is only used for this dropdown. Those changes might create issues for extensions relying on this macro.
* Added a condition on menu items to not add the class atttribute if it's empty (looks less cluttered in the HTML markup).

## View

On the left, the dropdown before the changes (example from xwiki.org), on the right, the dropdown after the changes.
We can see on this screenshot that the HTML structure is radically different, while the visuals are very similar.
![20913-ComparisonStructure](https://github.com/xwiki/xwiki-platform/assets/28761965/03a4afd3-8499-41b0-9f29-e15988c8059b)