### PR TITLE
XRENDERING-670: Image captions cannot be used in combination with links on images

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/ImagePluginIT.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/ImagePluginIT.java
@@ -28,8 +28,10 @@ import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
 import org.xwiki.ckeditor.test.po.CKEditor;
+import org.xwiki.ckeditor.test.po.LinkSelectorModal;
 import org.xwiki.ckeditor.test.po.image.ImageDialogEditModal;
 import org.xwiki.ckeditor.test.po.image.ImageDialogSelectModal;
+import org.xwiki.ckeditor.test.po.image.edit.ImageDialogAdvancedEditForm;
 import org.xwiki.ckeditor.test.po.image.edit.ImageDialogStandardEditForm;
 import org.xwiki.ckeditor.test.po.image.select.ImageDialogIconSelectForm;
 import org.xwiki.ckeditor.test.po.image.select.ImageDialogUrlSelectForm;
@@ -45,6 +47,7 @@ import org.xwiki.test.ui.po.editor.WYSIWYGEditPage;
 import org.xwiki.test.ui.po.editor.WikiEditPage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test of the CKEditor Image Plugin.
@@ -383,6 +386,67 @@ class ImagePluginIT
         ViewPage savedPage = wysiwygEditPage.clickSaveAndView();
 
         assertEquals("[[~[~[image:image.gif~]~]>>doc:]]", savedPage.editWiki().getContent());
+    }
+
+    @Test
+    @Order(9)
+    void imageWithLinkAndCaptionUI(TestUtils setup, TestReference testReference) throws Exception
+    {
+        // Upload an attachment to test with.
+        String attachmentName = "image.gif";
+        AttachmentReference attachmentReference = new AttachmentReference(attachmentName, testReference);
+        ViewPage newPage = uploadAttachment(setup, testReference, attachmentName);
+
+        // Move to the WYSIWYG edition page.
+        WYSIWYGEditPage wysiwygEditPage = newPage.editWYSIWYG();
+        CKEditor editor = new CKEditor("content").waitToLoad();
+
+        // Insert a with caption and alignment to center.
+        ImageDialogSelectModal imageDialogSelectModal = editor.clickImageButton();
+        imageDialogSelectModal.switchToTreeTab().selectAttachment(attachmentReference);
+        ImageDialogEditModal imageDialogEditModal = imageDialogSelectModal.clickSelect();
+        imageDialogEditModal.switchToStandardTab().clickCaptionCheckbox();
+        imageDialogEditModal.switchToAdvancedTab().selectCenterAlignment();
+        imageDialogEditModal.clickInsert();
+
+        editor.executeOnIframe(() -> setup.getDriver().findElement(By.cssSelector("img")).click());
+
+        editor.clickLinkButton().setResourceValue("doc:Main.WebHome", false).clickOK();
+
+        ViewPage savedPage = wysiwygEditPage.clickSaveAndView();
+
+        assertEquals("[[~[~[Caption~>~>image:image.gif~|~|data-xwiki-image-style-alignment=\"center\"~]~]"
+            + ">>doc:Main.WebHome]]", savedPage.editWiki().getContent());
+        // Test that when re-editing the image, the link, caption and alignment are still set.
+        wysiwygEditPage = savedPage.editWYSIWYG();
+        editor = new CKEditor("content").waitToLoad();
+
+        editor.executeOnIframe(() -> setup.getDriver().findElement(By.cssSelector("img")).click());
+
+        imageDialogEditModal = editor.clickImageButtonWhenImageExists();
+        // Verify that the caption and alignment are still set.
+        ImageDialogStandardEditForm standardEditForm = imageDialogEditModal.switchToStandardTab();
+        assertTrue(standardEditForm.isCaptionCheckboxChecked());
+        ImageDialogAdvancedEditForm advancedEditForm = imageDialogEditModal.switchToAdvancedTab();
+        assertEquals("center", advancedEditForm.getAlignment());
+        imageDialogEditModal.clickCancel();
+
+        // Verify that the link is still set.
+        editor.executeOnIframe(() -> setup.getDriver().findElement(By.cssSelector("img")).click());
+        LinkSelectorModal linkSelectorModal = editor.clickLinkButton();
+        assertEquals("doc", linkSelectorModal.getSelectedResourceType());
+        assertEquals("Main.WebHome", linkSelectorModal.getSelectedResourceReference());
+        linkSelectorModal.clickCancel();
+
+        // Change the caption to ensure that saving again works.
+        editor.executeOnIframe(
+            () -> setup.getDriver().findElement(By.cssSelector("figcaption"))
+                // Go to the start of the caption and insert "New ".
+                .sendKeys(Keys.HOME, "New "));
+        savedPage = wysiwygEditPage.clickSaveAndView();
+
+        assertEquals("[[~[~[New Caption~>~>image:image.gif~|~|data-xwiki-image-style-alignment=\"center\"~]~]"
+            + ">>doc:Main.WebHome]]", savedPage.editWiki().getContent());
     }
 
     private static void createAndLoginStandardUser(TestUtils setup)

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/LinkSelectorModal.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/LinkSelectorModal.java
@@ -73,7 +73,7 @@ public class LinkSelectorModal extends BaseElement
 
     /**
      * @return the resource type currently selected in the resource picker (e.g., {@code "doc"})
-     * @since 14.10.12
+     * @since 14.10.13
      * @since 15.5RC1
      */
     public String getSelectedResourceType()
@@ -83,7 +83,7 @@ public class LinkSelectorModal extends BaseElement
 
     /**
      * @return the resource reference currently selected in the resource picker (e.g., {@code "Sandbox.WebHome"})
-     * @since 14.10.12
+     * @since 14.10.13
      * @since 15.5RC1
      */
     public String getSelectedResourceReference()
@@ -127,6 +127,8 @@ public class LinkSelectorModal extends BaseElement
 
     /**
      * Click on the {@code "Cancel"} button of the modal.
+     * @since 14.10.13
+     * @since 15.5RC1
      */
     public void clickCancel()
     {

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/LinkSelectorModal.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/LinkSelectorModal.java
@@ -72,6 +72,31 @@ public class LinkSelectorModal extends BaseElement
     }
 
     /**
+     * @return the resource type currently selected in the resource picker (e.g., {@code "doc"})
+     * @since 14.10.12
+     * @since 15.5RC1
+     */
+    public String getSelectedResourceType()
+    {
+        return getResourceDisplay().getAttribute("data-resourcetype");
+    }
+
+    /**
+     * @return the resource reference currently selected in the resource picker (e.g., {@code "Sandbox.WebHome"})
+     * @since 14.10.12
+     * @since 15.5RC1
+     */
+    public String getSelectedResourceReference()
+    {
+        return getResourceDisplay().getAttribute("data-resourcereference");
+    }
+
+    private WebElement getResourceDisplay()
+    {
+        return getResourcePicker().findElement(cssSelector(".resourceDisplay"));
+    }
+
+    /**
      * Click on one of the choices proposed in the dropdown after using {@link #setResourceValue(String)}, based on its
      * hint and label.
      *
@@ -98,6 +123,14 @@ public class LinkSelectorModal extends BaseElement
     public void clickOK()
     {
         getCKEditorDialog().findElement(By.cssSelector(".cke_dialog_ui_button_ok")).click();
+    }
+
+    /**
+     * Click on the {@code "Cancel"} button of the modal.
+     */
+    public void clickCancel()
+    {
+        getCKEditorDialog().findElement(By.cssSelector(".cke_dialog_ui_button_cancel")).click();
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/image/ImageDialogEditModal.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/image/ImageDialogEditModal.java
@@ -50,9 +50,25 @@ public class ImageDialogEditModal extends BaseElement
      */
     public void clickInsert()
     {
+        By buttonSelector = By.cssSelector(".image-editor-modal .btn-primary");
+        clickCloseButton(buttonSelector);
+    }
+
+    /**
+     * Click on the cancel button to close the modal.
+     * @since 14.10.12
+     * @since 15.5RC1
+     */
+    public void clickCancel()
+    {
+        By buttonSelector = By.cssSelector(".image-editor-modal [data-dismiss='modal']");
+        clickCloseButton(buttonSelector);
+    }
+
+    private void clickCloseButton(By buttonSelector)
+    {
         // Wait for the button to be enabled before clicking.
         // Wait for the button to be hidden before continuing.
-        By buttonSelector = By.cssSelector(".image-editor-modal .btn-primary");
         WebElement buttonElement = getDriver().findElement(buttonSelector);
         getDriver().waitUntilElementIsEnabled(buttonElement);
         buttonElement.click();

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/image/ImageDialogEditModal.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/image/ImageDialogEditModal.java
@@ -56,7 +56,7 @@ public class ImageDialogEditModal extends BaseElement
 
     /**
      * Click on the cancel button to close the modal.
-     * @since 14.10.12
+     * @since 14.10.13
      * @since 15.5RC1
      */
     public void clickCancel()

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/image/edit/ImageDialogAdvancedEditForm.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/image/edit/ImageDialogAdvancedEditForm.java
@@ -41,4 +41,14 @@ public class ImageDialogAdvancedEditForm extends BaseElement
         getDriver().findElement(By.cssSelector("#advanced [name='alignment'][value='center']")).click();
         return this;
     }
+
+    /**
+     * @return the currently selected alignment value
+     * @since 14.10.12
+     * @since 15.5RC1
+     */
+    public String getAlignment()
+    {
+        return getDriver().findElement(By.cssSelector("#advanced [name='alignment']:checked")).getAttribute("value");
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/image/edit/ImageDialogAdvancedEditForm.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/image/edit/ImageDialogAdvancedEditForm.java
@@ -44,7 +44,7 @@ public class ImageDialogAdvancedEditForm extends BaseElement
 
     /**
      * @return the currently selected alignment value
-     * @since 14.10.12
+     * @since 14.10.13
      * @since 15.5RC1
      */
     public String getAlignment()

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/image/edit/ImageDialogStandardEditForm.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/image/edit/ImageDialogStandardEditForm.java
@@ -51,7 +51,7 @@ public class ImageDialogStandardEditForm extends BaseElement
 
     /**
      * @return true if the caption checkbox is checked
-     * @since 14.10.12
+     * @since 14.10.13
      * @since 15.5RC1
      */
     public boolean isCaptionCheckboxChecked()

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/image/edit/ImageDialogStandardEditForm.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/image/edit/ImageDialogStandardEditForm.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
 import org.xwiki.test.ui.po.BaseElement;
 import org.xwiki.test.ui.po.SuggestInputElement;
 
@@ -35,11 +36,27 @@ import org.xwiki.test.ui.po.SuggestInputElement;
 public class ImageDialogStandardEditForm extends BaseElement
 {
     /**
+     * The image caption checkbox.
+     */
+    @FindBy(id = "imageCaptionActivation")
+    private WebElement captionCheckbox;
+
+    /**
      * Click on the caption checkbox field.
      */
     public void clickCaptionCheckbox()
     {
-        getDriver().findElement(By.id("imageCaptionActivation")).click();
+        this.captionCheckbox.click();
+    }
+
+    /**
+     * @return true if the caption checkbox is checked
+     * @since 14.10.12
+     * @since 15.5RC1
+     */
+    public boolean isCaptionCheckboxChecked()
+    {
+        return this.captionCheckbox.isSelected();
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/xwiki-platform-image-style-api/src/main/java/org/xwiki/image/style/internal/rendering/AbstractCaptionedImageChainingListener.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/xwiki-platform-image-style-api/src/main/java/org/xwiki/image/style/internal/rendering/AbstractCaptionedImageChainingListener.java
@@ -1,0 +1,112 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.image.style.internal.rendering;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Map;
+
+import org.xwiki.rendering.listener.QueueListener;
+import org.xwiki.rendering.listener.chaining.EventType;
+import org.xwiki.rendering.listener.chaining.ListenerChain;
+import org.xwiki.rendering.listener.chaining.LookaheadChainingListener;
+import org.xwiki.rendering.listener.reference.ResourceReference;
+
+/**
+ * Base class for chaining listeners that handle captioned images.
+ *
+ * @version $Id$
+ * @since 14.10.12
+ * @since 15.5RC1
+ */
+abstract class AbstractCaptionedImageChainingListener extends LookaheadChainingListener
+{
+    static final String DATA_XWIKI_IMAGE_STYLE_TEXT_WRAP = "data-xwiki-image-style-text-wrap";
+
+    static final String WIDTH_PROPERTY = "width";
+
+    static final String STYLE_PROPERTY = "style";
+
+    static final String STYLE_SEPARATOR = ";";
+
+    static final String DATA_XWIKI_IMAGE_STYLE = "data-xwiki-image-style";
+
+    static final String DATA_XWIKI_IMAGE_STYLE_ALIGNMENT = "data-xwiki-image-style-alignment";
+
+    static final String DATA_XWIKI_IMAGE_STYLE_BORDER = "data-xwiki-image-style-border";
+
+    protected final Deque<Map<String, String>> figureParametersQueue = new ArrayDeque<>();
+
+    protected AbstractCaptionedImageChainingListener(ListenerChain listenerChain)
+    {
+        super(listenerChain, 2);
+    }
+
+    @Override
+    public void beginFigure(Map<String, String> parameters)
+    {
+        this.figureParametersQueue.push(parameters);
+        super.beginFigure(parameters);
+    }
+
+    @Override
+    public void onImage(ResourceReference reference, boolean freestanding, String id, Map<String, String> parameters)
+    {
+        QueueListener.Event figureEvent = getPreviousFigureEvent();
+        if (figureEvent != null) {
+            // Merge the image parameters to the figure parameters when the image is wrapped in a figure.
+            Object[] eventParameters = figureEvent.eventParameters;
+            // Sanity check to make sure that we are handling the expected case.
+            if (eventParameters.length == 1 && eventParameters[0] instanceof Map<?, ?>) {
+                Map<String, String> figureParameters = this.figureParametersQueue.pop();
+                Map<String, String> updatedFigureParameters = updateFigureParameters(figureParameters, parameters);
+                this.figureParametersQueue.push(updatedFigureParameters);
+                eventParameters[0] = updatedFigureParameters;
+            }
+        }
+
+        super.onImage(reference, freestanding, id, parameters);
+    }
+
+    @Override
+    public void endFigure(Map<String, String> parameters)
+    {
+        super.endFigure(this.figureParametersQueue.pop());
+    }
+
+    protected abstract Map<String, String> updateFigureParameters(Map<String, String> figureParameters,
+        Map<String, String> imageParameters);
+
+    private QueueListener.Event getPreviousFigureEvent()
+    {
+        QueueListener.Event result = null;
+
+        QueueListener.Event candidate = getPreviousEvents().peekLast();
+        if (candidate != null && candidate.eventType == EventType.BEGIN_LINK) {
+            result = candidate;
+            candidate = getPreviousEvents().get(getPreviousEvents().size() - 2);
+        }
+        if (candidate != null && candidate.eventType == EventType.BEGIN_FIGURE) {
+            result = candidate;
+        }
+
+        return result;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/xwiki-platform-image-style-api/src/main/java/org/xwiki/image/style/internal/rendering/AbstractCaptionedImageChainingListener.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/xwiki-platform-image-style-api/src/main/java/org/xwiki/image/style/internal/rendering/AbstractCaptionedImageChainingListener.java
@@ -33,7 +33,7 @@ import org.xwiki.rendering.listener.reference.ResourceReference;
  * Base class for chaining listeners that handle captioned images.
  *
  * @version $Id$
- * @since 14.10.12
+ * @since 14.10.13
  * @since 15.5RC1
  */
 abstract class AbstractCaptionedImageChainingListener extends LookaheadChainingListener

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/xwiki-platform-image-style-api/src/main/java/org/xwiki/image/style/internal/rendering/CaptionedImageParseChainingListener.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/xwiki-platform-image-style-api/src/main/java/org/xwiki/image/style/internal/rendering/CaptionedImageParseChainingListener.java
@@ -1,0 +1,97 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.image.style.internal.rendering;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.xwiki.rendering.listener.chaining.ListenerChain;
+
+import static org.apache.commons.lang3.StringUtils.SPACE;
+
+/**
+ * A listener that puts the image parameters in the figure parameters when the image is wrapped in a figure.
+ *
+ * @version $Id$
+ * @since 14.10.12
+ * @since 15.5RC1
+ */
+class CaptionedImageParseChainingListener extends AbstractCaptionedImageChainingListener
+{
+    private static final Set<String> KNOWN_PARAMETERS = Set.of(
+        WIDTH_PROPERTY,
+        DATA_XWIKI_IMAGE_STYLE,
+        DATA_XWIKI_IMAGE_STYLE_ALIGNMENT,
+        DATA_XWIKI_IMAGE_STYLE_BORDER,
+        DATA_XWIKI_IMAGE_STYLE_TEXT_WRAP
+    );
+
+    /**
+     * Default constructor.
+     *
+     * @param listenerChain the listener chainer to set for this listener
+     */
+    protected CaptionedImageParseChainingListener(ListenerChain listenerChain)
+    {
+        super(listenerChain);
+    }
+
+    protected Map<String, String> updateFigureParameters(Map<String, String> figureParameters,
+        Map<String, String> imageParameters)
+    {
+        Map<String, String> mergedMap = new LinkedHashMap<>(figureParameters);
+        KNOWN_PARAMETERS.stream()
+            .filter(imageParameters::containsKey)
+            .forEach(key -> mergeParameter(key, mergedMap, imageParameters, figureParameters));
+        return mergedMap;
+    }
+
+    private void mergeParameter(String key, Map<String, String> mergedMap,
+        Map<String, String> imageParameters, Map<String, String> figureParameters)
+    {
+        String imageParameter = imageParameters.get(key);
+        if (Objects.equals(key, WIDTH_PROPERTY)) {
+            mergeWidthParameter(mergedMap, figureParameters, imageParameters.get(WIDTH_PROPERTY));
+        } else {
+            mergedMap.put(key, imageParameter);
+        }
+    }
+
+    private void mergeWidthParameter(Map<String, String> mergedMap, Map<String, String> figureParameters,
+        String imageWidthParameter)
+    {
+        String styleValue = String.format("width: %spx;", imageWidthParameter);
+        if (figureParameters.containsKey(STYLE_PROPERTY)) {
+            if (figureParameters.get(STYLE_PROPERTY).contains("width:")) {
+                styleValue = figureParameters.get(STYLE_PROPERTY);
+            } else {
+                if (!figureParameters.get(STYLE_PROPERTY).endsWith(STYLE_SEPARATOR)) {
+                    styleValue = STYLE_SEPARATOR + SPACE + styleValue;
+                } else {
+                    styleValue = SPACE + styleValue;
+                }
+                styleValue = figureParameters.get(STYLE_PROPERTY) + styleValue;
+            }
+        }
+        mergedMap.put(STYLE_PROPERTY, styleValue);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/xwiki-platform-image-style-api/src/main/java/org/xwiki/image/style/internal/rendering/CaptionedImageParseChainingListener.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/xwiki-platform-image-style-api/src/main/java/org/xwiki/image/style/internal/rendering/CaptionedImageParseChainingListener.java
@@ -32,7 +32,7 @@ import static org.apache.commons.lang3.StringUtils.SPACE;
  * A listener that puts the image parameters in the figure parameters when the image is wrapped in a figure.
  *
  * @version $Id$
- * @since 14.10.12
+ * @since 14.10.13
  * @since 15.5RC1
  */
 class CaptionedImageParseChainingListener extends AbstractCaptionedImageChainingListener

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/xwiki-platform-image-style-api/src/main/java/org/xwiki/image/style/internal/rendering/CaptionedImageRenderChainingListener.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/xwiki-platform-image-style-api/src/main/java/org/xwiki/image/style/internal/rendering/CaptionedImageRenderChainingListener.java
@@ -30,6 +30,13 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.xwiki.rendering.listener.chaining.ListenerChain;
 
+/**
+ * A listener that cleans the image parameters from the figure when rendering to XWiki syntax.
+ *
+ * @version $Id$
+ * @since 14.10.13
+ * @since 15.5RC1
+ */
 class CaptionedImageRenderChainingListener extends AbstractCaptionedImageChainingListener
 {
     static final Set<String> KNOWN_PARAMETERS = Set.of(

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/xwiki-platform-image-style-api/src/main/java/org/xwiki/image/style/internal/rendering/CaptionedImageRenderChainingListener.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/xwiki-platform-image-style-api/src/main/java/org/xwiki/image/style/internal/rendering/CaptionedImageRenderChainingListener.java
@@ -1,0 +1,89 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.image.style.internal.rendering;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.xwiki.rendering.listener.chaining.ListenerChain;
+
+class CaptionedImageRenderChainingListener extends AbstractCaptionedImageChainingListener
+{
+    static final Set<String> KNOWN_PARAMETERS = Set.of(
+        WIDTH_PROPERTY,
+        STYLE_PROPERTY,
+        DATA_XWIKI_IMAGE_STYLE,
+        DATA_XWIKI_IMAGE_STYLE_ALIGNMENT,
+        DATA_XWIKI_IMAGE_STYLE_BORDER,
+        DATA_XWIKI_IMAGE_STYLE_TEXT_WRAP
+    );
+
+    /**
+     * Default constructor.
+     *
+     * @param listenerChain the listener chainer to set for this listener
+     */
+    protected CaptionedImageRenderChainingListener(ListenerChain listenerChain)
+    {
+        super(listenerChain);
+    }
+
+    @Override
+    protected Map<String, String> updateFigureParameters(Map<String, String> figureParameters,
+        Map<String, String> imageParameters)
+    {
+        Map<String, String> updatedFigureParameters = new LinkedHashMap<>(figureParameters);
+        KNOWN_PARAMETERS.forEach(key -> {
+            if (key.equals(STYLE_PROPERTY) && updatedFigureParameters.containsKey(
+                STYLE_PROPERTY)
+                && imageParameters.containsKey(WIDTH_PROPERTY))
+            {
+                String figureStyle = updatedFigureParameters.get(STYLE_PROPERTY);
+                String cleanupStyle =
+                    Arrays.stream(figureStyle.split(STYLE_SEPARATOR))
+                        .filter(Predicate.not(value -> Objects.equals(value.trim(),
+                            String.format("width: %spx", imageParameters.get(
+                                WIDTH_PROPERTY)))))
+                        .collect(
+                            Collectors.joining(STYLE_SEPARATOR, StringUtils.EMPTY,
+                                STYLE_SEPARATOR));
+
+                if (cleanupStyle.equals(STYLE_SEPARATOR)) {
+                    cleanupStyle = "";
+                }
+                if (cleanupStyle.isEmpty()) {
+                    updatedFigureParameters.remove(key);
+                } else {
+                    updatedFigureParameters.put(key, cleanupStyle);
+                }
+            } else if (!key.equals(STYLE_PROPERTY)) {
+                updatedFigureParameters.remove(key);
+            }
+        });
+
+        return updatedFigureParameters;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/xwiki-platform-image-style-api/src/main/java/org/xwiki/image/style/internal/rendering/CaptionedImageRenderListenerProvider.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/xwiki-platform-image-style-api/src/main/java/org/xwiki/image/style/internal/rendering/CaptionedImageRenderListenerProvider.java
@@ -19,29 +19,16 @@
  */
 package org.xwiki.image.style.internal.rendering;
 
-import java.util.ArrayDeque;
-import java.util.Arrays;
-import java.util.Deque;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.apache.commons.lang3.StringUtils;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.rendering.listener.ListenerProvider;
-import org.xwiki.rendering.listener.QueueListener;
 import org.xwiki.rendering.listener.chaining.ChainingListener;
-import org.xwiki.rendering.listener.chaining.EventType;
 import org.xwiki.rendering.listener.chaining.ListenerChain;
-import org.xwiki.rendering.listener.chaining.LookaheadChainingListener;
-import org.xwiki.rendering.listener.reference.ResourceReference;
 import org.xwiki.rendering.syntax.Syntax;
 
 import static org.xwiki.rendering.syntax.Syntax.HTML_5_0;
@@ -60,110 +47,12 @@ import static org.xwiki.rendering.syntax.Syntax.XWIKI_2_1;
 @Named("captionedImageRender")
 public class CaptionedImageRenderListenerProvider implements ListenerProvider
 {
-    static final String WIDTH_PROPERTY = "width";
-
-    static final String STYLE_PROPERTY = "style";
-
-    static final String STYLE_SEPARATOR = ";";
-
-    static final String DATA_XWIKI_IMAGE_STYLE = "data-xwiki-image-style";
-
-    static final String DATA_XWIKI_IMAGE_STYLE_ALIGNMENT = "data-xwiki-image-style-alignment";
-
-    static final String DATA_XWIKI_IMAGE_STYLE_BORDER = "data-xwiki-image-style-border";
-
-    static final String DATA_XWIKI_IMAGE_STYLE_TEXT_WRAP = "data-xwiki-image-style-text-wrap";
-
     private static final List<Syntax> ACCEPTED_SYNTAX = List.of(HTML_5_0, XWIKI_2_0, XWIKI_2_1);
-
-    static final Set<String> KNOWN_PARAMETERS = Set.of(
-        WIDTH_PROPERTY,
-        STYLE_PROPERTY,
-        DATA_XWIKI_IMAGE_STYLE,
-        DATA_XWIKI_IMAGE_STYLE_ALIGNMENT,
-        DATA_XWIKI_IMAGE_STYLE_BORDER,
-        DATA_XWIKI_IMAGE_STYLE_TEXT_WRAP
-    );
-
-    private static class InternalChainingListener extends LookaheadChainingListener
-    {
-        private final Deque<Map<String, String>> figureParametersQueue = new ArrayDeque<>();
-
-        /**
-         * Default constructor.
-         *
-         * @param listenerChain the listener chainer to set for this listener
-         */
-        protected InternalChainingListener(ListenerChain listenerChain)
-        {
-            super(listenerChain, 1);
-        }
-
-        @Override
-        public void beginFigure(Map<String, String> parameters)
-        {
-            this.figureParametersQueue.push(parameters);
-            super.beginFigure(parameters);
-        }
-
-        @Override
-        public void onImage(ResourceReference reference, boolean freestanding, String id,
-            Map<String, String> parameters)
-        {
-            QueueListener.Event nextEvent = getPreviousEvents().peekLast();
-            if (nextEvent != null && nextEvent.eventType == EventType.BEGIN_FIGURE) {
-                // Merge the image parameters to the figure parameters when the image is wrapped in a figure.
-                Object[] eventParameters = nextEvent.eventParameters;
-                // Sanity check to make sure that we are handling the expected case.
-                if (eventParameters.length == 1 && eventParameters[0] instanceof Map<?, ?>) {
-                    Map<String, String> figureParameters = new LinkedHashMap<>(this.figureParametersQueue.pop());
-                    cleanupFigureParameters(figureParameters, parameters);
-                    this.figureParametersQueue.push(figureParameters);
-                    eventParameters[0] = figureParameters;
-                }
-            }
-
-            super.onImage(reference, freestanding, id, parameters);
-        }
-
-        private void cleanupFigureParameters(Map<String, String> figureParameters, Map<String, String> imageParameters)
-        {
-            KNOWN_PARAMETERS.forEach(key -> {
-                if (key.equals(STYLE_PROPERTY) && figureParameters.containsKey(STYLE_PROPERTY)
-                    && imageParameters.containsKey(WIDTH_PROPERTY))
-                {
-                    String figureStyle = figureParameters.get(STYLE_PROPERTY);
-                    String cleanupStyle =
-                        Arrays.stream(figureStyle.split(STYLE_SEPARATOR))
-                            .filter(Predicate.not(value -> Objects.equals(value.trim(),
-                                String.format("width: %spx", imageParameters.get(WIDTH_PROPERTY)))))
-                            .collect(Collectors.joining(STYLE_SEPARATOR, StringUtils.EMPTY, STYLE_SEPARATOR));
-
-                    if (cleanupStyle.equals(STYLE_SEPARATOR)) {
-                        cleanupStyle = "";
-                    }
-                    if (cleanupStyle.isEmpty()) {
-                        figureParameters.remove(key);
-                    } else {
-                        figureParameters.put(key, cleanupStyle);
-                    }
-                } else if (!key.equals(STYLE_PROPERTY)) {
-                    figureParameters.remove(key);
-                }
-            });
-        }
-
-        @Override
-        public void endFigure(Map<String, String> parameters)
-        {
-            super.endFigure(this.figureParametersQueue.pop());
-        }
-    }
 
     @Override
     public ChainingListener getListener(ListenerChain listenerChain)
     {
-        return new InternalChainingListener(listenerChain);
+        return new CaptionedImageRenderChainingListener(listenerChain);
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/xwiki-platform-image-style-api/src/test/resources/figure/linkedImage.test
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/xwiki-platform-image-style-api/src/test/resources/figure/linkedImage.test
@@ -1,0 +1,41 @@
+.#-----------------------------------------------------
+.inputexpect|xwiki/2.1
+.# Test captioned images wrapped in a link.
+.#-----------------------------------------------------
+(% style="border: 1px;" %)
+[[~[~[Caption1~>~>image:my.png~|~|width="200" height="100"~]~]>>https://www.example.org]]
+
+[[~[~[Caption2~>~>image:my.png~]~]>>https://www.example.org]]
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+beginFigure [[class]=[image][style]=[border: 1px; width: 200px;]]
+beginLink [Typed = [false] Type = [url] Reference = [https://www.example.org]] [false]
+onImage [Typed = [false] Type = [url] Reference = [my.png]] [false] [Imy.png] [[height]=[100][width]=[200]]
+endLink [Typed = [false] Type = [url] Reference = [https://www.example.org]] [false]
+beginFigureCaption
+beginParagraph
+onWord [Caption1]
+endParagraph
+endFigureCaption
+endFigure [[class]=[image][style]=[border: 1px; width: 200px;]]
+beginFigure [[class]=[image]]
+beginLink [Typed = [false] Type = [url] Reference = [https://www.example.org]] [false]
+onImage [Typed = [false] Type = [url] Reference = [my.png]] [false] [Imy.png-1]
+endLink [Typed = [false] Type = [url] Reference = [https://www.example.org]] [false]
+beginFigureCaption
+beginParagraph
+onWord [Caption2]
+endParagraph
+endFigureCaption
+endFigure [[class]=[image]]
+endDocument
+.#-----------------------------------------------------
+.expect|xhtml/1.0
+.#-----------------------------------------------------
+<span class="wikiexternallink"><a href="https://www.example.org"><img src="my.png" width="200" height="100" id="Imy.png" class="wikigeneratedid" alt="my.png"/></a></span><div class="figcaption"><p>Caption1</p></div><span class="wikiexternallink"><a href="https://www.example.org"><img src="my.png" id="Imy.png-1" class="wikigeneratedid" alt="my.png"/></a></span><div class="figcaption"><p>Caption2</p></div>
+.#-----------------------------------------------------
+.expect|html/5.0
+.#-----------------------------------------------------
+<figure style="border: 1px; width: 200px;" class="image"><span class="wikiexternallink"><a href="https://www.example.org"><img src="my.png" width="200" height="100" id="Imy.png" class="wikigeneratedid" alt="my.png"/></a></span><figcaption><p>Caption1</p></figcaption></figure><figure class="image"><span class="wikiexternallink"><a href="https://www.example.org"><img src="my.png" id="Imy.png-1" class="wikigeneratedid" alt="my.png"/></a></span><figcaption><p>Caption2</p></figcaption></figure>


### PR DESCRIPTION
* Handle images that are wrapped inside links for figure styles.
* Refactor the code to move common code inside the chaining listeners to a base class.
* Add a functional test to verify that image captions and links can actually be used together via CKEditor.

Jira issue: https://jira.xwiki.org/browse/XRENDERING-670