### PR TITLE
XWIKI-17034: Allow to define different grouping strategy for notifications

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/src/main/java/org/xwiki/notifications/GroupingEventManager.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/src/main/java/org/xwiki/notifications/GroupingEventManager.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.xwiki.component.annotation.Role;
 import org.xwiki.eventstream.Event;
 import org.xwiki.stability.Unstable;
+import org.xwiki.user.UserReference;
 
 /**
  * Component responsible to perform the grouping based on the available {@link GroupingEventStrategy}, on the targeted
@@ -41,12 +42,12 @@ public interface GroupingEventManager
      * it to group the given events.
      *
      * @param events the list of events to group
-     * @param userId the identifier of the user for whom the grouping is performed
+     * @param userId the user for whom the grouping is performed (or {@code null} if it's not for a specific user)
      * @param target the output target (e.g. email or alert)
      * @return a list of composite events as computed by {@link GroupingEventStrategy#group(List)}
      * @throws NotificationException in case of problem when performing the grouping
      */
-    List<CompositeEvent> getCompositeEvents(List<Event> events, String userId, String target) throws
+    List<CompositeEvent> getCompositeEvents(List<Event> events, UserReference userId, String target) throws
         NotificationException;
 
     /**
@@ -56,10 +57,10 @@ public interface GroupingEventManager
      *
      * @param compositeEvents a list of composite events (might be empty)
      * @param newEvents the new events to group along with the given list of composite events
-     * @param userId the identifier of the user for whom the grouping is performed
+     * @param userId the user for whom the grouping is performed (or {@code null} if it's not for a specific user)
      * @param target the output target (e.g. email or alert)
      * @throws NotificationException in case of problem when performing the grouping
      */
-    void augmentCompositeEvents(List<CompositeEvent> compositeEvents, List<Event> newEvents, String userId,
+    void augmentCompositeEvents(List<CompositeEvent> compositeEvents, List<Event> newEvents, UserReference userId,
         String target) throws NotificationException;
 }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/src/main/java/org/xwiki/notifications/GroupingEventManager.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/src/main/java/org/xwiki/notifications/GroupingEventManager.java
@@ -42,13 +42,14 @@ public interface GroupingEventManager
      * it to group the given events.
      *
      * @param events the list of events to group
-     * @param userId the user for whom the grouping is performed (or {@code null} if it's not for a specific user)
+     * @param userReference the user for whom the grouping is performed (or {@code null} if it's not for a specific
+     *                      user)
      * @param target the output target (e.g. email or alert)
      * @return a list of composite events as computed by {@link GroupingEventStrategy#group(List)}
      * @throws NotificationException in case of problem when performing the grouping
      */
-    List<CompositeEvent> getCompositeEvents(List<Event> events, UserReference userId, String target) throws
-        NotificationException;
+    List<CompositeEvent> getCompositeEvents(List<Event> events, UserReference userReference, String target)
+        throws NotificationException;
 
     /**
      * Add new events to an already existing list of composite events, using the {@link GroupingEventStrategy}
@@ -57,10 +58,11 @@ public interface GroupingEventManager
      *
      * @param compositeEvents a list of composite events (might be empty)
      * @param newEvents the new events to group along with the given list of composite events
-     * @param userId the user for whom the grouping is performed (or {@code null} if it's not for a specific user)
+     * @param userReference the user for whom the grouping is performed (or {@code null} if it's not for a specific
+     *                      user)
      * @param target the output target (e.g. email or alert)
      * @throws NotificationException in case of problem when performing the grouping
      */
-    void augmentCompositeEvents(List<CompositeEvent> compositeEvents, List<Event> newEvents, UserReference userId,
-        String target) throws NotificationException;
+    void augmentCompositeEvents(List<CompositeEvent> compositeEvents, List<Event> newEvents,
+        UserReference userReference, String target) throws NotificationException;
 }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/src/main/java/org/xwiki/notifications/NotificationConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/src/main/java/org/xwiki/notifications/NotificationConfiguration.java
@@ -94,6 +94,6 @@ public interface NotificationConfiguration
     @Unstable
     default String getEmailGroupingStrategyHint()
     {
-        return "";
+        return "default";
     }
 }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/src/main/java/org/xwiki/notifications/NotificationConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/src/main/java/org/xwiki/notifications/NotificationConfiguration.java
@@ -20,6 +20,7 @@
 package org.xwiki.notifications;
 
 import org.xwiki.component.annotation.Role;
+import org.xwiki.stability.Unstable;
 
 /**
  * Get the configuration options concerning the Notification module.
@@ -84,5 +85,15 @@ public interface NotificationConfiguration
     default int getAsyncPoolSize()
     {
         return 2;
+    }
+
+    /**
+     * @return the hint of the component to be used for the email grouping strategy.
+     * @since 15.5RC1
+     */
+    @Unstable
+    default String getEmailGroupingStrategyHint()
+    {
+        return "";
     }
 }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/src/main/java/org/xwiki/notifications/internal/DefaultNotificationConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/src/main/java/org/xwiki/notifications/internal/DefaultNotificationConfiguration.java
@@ -84,4 +84,10 @@ public class DefaultNotificationConfiguration implements NotificationConfigurati
     {
         return configurationSource.getProperty(CONFIGURATION_PREFIX + "async.poolSize", 2);
     }
+
+    @Override
+    public String getEmailGroupingStrategyHint()
+    {
+        return configurationSource.getProperty(CONFIGURATION_PREFIX + "emailGroupingStrategyHint", "default");
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/pom.xml
@@ -31,7 +31,7 @@
   <name>XWiki Platform - Notifications - Notifiers - API</name>
   <description>Handle how notifications are transmitted to a user</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.70</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.75</xwiki.jacoco.instructionRatio>
   </properties>
   <dependencies>
     <dependency>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/email/NotificationEmailGroupingStrategy.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/email/NotificationEmailGroupingStrategy.java
@@ -1,0 +1,54 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.notifications.notifiers.email;
+
+import org.xwiki.component.annotation.Role;
+import org.xwiki.notifications.CompositeEvent;
+import org.xwiki.notifications.NotificationException;
+import org.xwiki.stability.Unstable;
+
+import java.util.List;
+
+/**
+ * Defines how the events should be grouped to be sent in individual emails.
+ * Contrarily to {@link org.xwiki.notifications.GroupingEventStrategy} the goal here is not to group individual
+ * {@link org.xwiki.eventstream.Event} in {@link CompositeEvent} but to group a list of {@link CompositeEvent} that has
+ * been already computed based on the {@link org.xwiki.notifications.GroupingEventStrategy} and decide how many mails
+ * should be sent for those {@link CompositeEvent}.
+ *
+ * @version $Id$
+ * @since 15.5RC1
+ */
+@Unstable
+@Role
+public interface NotificationEmailGroupingStrategy
+{
+    /**
+     * Group the given list of {@link CompositeEvent} in sub-lists, where each list represent an email to be sent.
+     * Hence, if that method returns a single list containing all {@link CompositeEvent} a single email with all the
+     * events will be sent. On the contrary, if it returns as many list as there is events, then there will be as many
+     * emails as there is events.
+     *
+     * @param compositeEvents the list of composite events that should be sent by email
+     * @return a list of list of events where each list of events represents an email
+     * @throws NotificationException in case of problem to compute the sub-lists
+     */
+    List<List<CompositeEvent>> groupEventsPerMail(List<CompositeEvent> compositeEvents) throws NotificationException;
+}

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/grouping/DefaultNotificationEmailGroupingStrategy.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/grouping/DefaultNotificationEmailGroupingStrategy.java
@@ -25,7 +25,6 @@ import org.xwiki.notifications.NotificationException;
 import org.xwiki.notifications.notifiers.email.NotificationEmailGroupingStrategy;
 
 import javax.inject.Singleton;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -44,6 +43,6 @@ public class DefaultNotificationEmailGroupingStrategy implements NotificationEma
             throws NotificationException
     {
         // TODO: Maybe the default component should systematically paginate?
-        return Collections.singletonList(compositeEvents);
+        return List.of(compositeEvents);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/grouping/DefaultNotificationEmailGroupingStrategy.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/grouping/DefaultNotificationEmailGroupingStrategy.java
@@ -1,0 +1,49 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.notifications.notifiers.internal.email.grouping;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.notifications.CompositeEvent;
+import org.xwiki.notifications.NotificationException;
+import org.xwiki.notifications.notifiers.email.NotificationEmailGroupingStrategy;
+
+import javax.inject.Singleton;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Default implementation of {@link NotificationEmailGroupingStrategy}.
+ * This implementation considers that all events should be returned in a single email.
+ *
+ * @version $Id$
+ * @since 15.5RC1
+ */
+@Component
+@Singleton
+public class DefaultNotificationEmailGroupingStrategy implements NotificationEmailGroupingStrategy
+{
+    @Override
+    public List<List<CompositeEvent>> groupEventsPerMail(List<CompositeEvent> compositeEvents)
+            throws NotificationException
+    {
+        // TODO: Maybe the default component should systematically paginate?
+        return Collections.singletonList(compositeEvents);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/grouping/OneMailPerCompositeEmailGroupingStrategy.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/grouping/OneMailPerCompositeEmailGroupingStrategy.java
@@ -1,0 +1,56 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.notifications.notifiers.internal.email.grouping;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.notifications.CompositeEvent;
+import org.xwiki.notifications.NotificationException;
+import org.xwiki.notifications.notifiers.email.NotificationEmailGroupingStrategy;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * This component offers a strategy for sending one email per composite event to notify to the user.
+ * This strategy can be used in combination with
+ * {@link org.xwiki.notifications.internal.ApplicationTypeGroupingStrategy} to send as many emails as there is type of
+ * events to notify the users. It could also be used with the default event grouping strategy so that users received as
+ * many emails as there is group of events.
+ *
+ * @version $Id$
+ * @since 15.5RC1
+ */
+@Component
+@Singleton
+@Named("emailperevent")
+public class OneMailPerCompositeEmailGroupingStrategy implements NotificationEmailGroupingStrategy
+{
+    @Override
+    public List<List<CompositeEvent>> groupEventsPerMail(List<CompositeEvent> compositeEvents)
+            throws NotificationException
+    {
+        List<List<CompositeEvent>> result = new ArrayList<>();
+        compositeEvents.forEach(ce -> result.add(Collections.singletonList(ce)));
+        return result;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/grouping/OneMailPerCompositeEmailGroupingStrategy.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/grouping/OneMailPerCompositeEmailGroupingStrategy.java
@@ -29,6 +29,7 @@ import javax.inject.Singleton;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * This component offers a strategy for sending one email per composite event to notify to the user.
@@ -49,8 +50,6 @@ public class OneMailPerCompositeEmailGroupingStrategy implements NotificationEma
     public List<List<CompositeEvent>> groupEventsPerMail(List<CompositeEvent> compositeEvents)
             throws NotificationException
     {
-        List<List<CompositeEvent>> result = new ArrayList<>();
-        compositeEvents.forEach(ce -> result.add(Collections.singletonList(ce)));
-        return result;
+        return compositeEvents.stream().map(List::of).collect(Collectors.toList());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/grouping/SeparatedMentionEmailGroupingStrategy.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/grouping/SeparatedMentionEmailGroupingStrategy.java
@@ -1,0 +1,70 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.notifications.notifiers.internal.email.grouping;
+
+import org.apache.commons.lang.StringUtils;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.notifications.CompositeEvent;
+import org.xwiki.notifications.NotificationException;
+import org.xwiki.notifications.notifiers.email.NotificationEmailGroupingStrategy;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This component offers a strategy where the notifications related to mentions are sent in a separated email than all
+ * others notifications. So two emails are sent in case of mentions: one for the mentions, and another one for other
+ * events.
+ *
+ * @version $Id$
+ * @since 15.5RC1
+ */
+@Component
+@Singleton
+@Named("separatedmention")
+public class SeparatedMentionEmailGroupingStrategy implements NotificationEmailGroupingStrategy
+{
+    @Override
+    public List<List<CompositeEvent>> groupEventsPerMail(List<CompositeEvent> compositeEvents)
+            throws NotificationException
+    {
+        List<CompositeEvent> otherEvents = new ArrayList<>();
+        List<CompositeEvent> mention = new ArrayList<>();
+        List<List<CompositeEvent>> result = new ArrayList<>();
+
+        for (CompositeEvent compositeEvent : compositeEvents) {
+            if (StringUtils.equals("mention", compositeEvent.getType())) {
+                mention.add(compositeEvent);
+            } else {
+                otherEvents.add(compositeEvent);
+            }
+        }
+
+        if (!otherEvents.isEmpty()) {
+            result.add(otherEvents);
+        }
+        if (!mention.isEmpty()) {
+            result.add(mention);
+        }
+        return result;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/live/LiveNotificationEmailListener.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/live/LiveNotificationEmailListener.java
@@ -44,10 +44,12 @@ import org.xwiki.observation.remote.RemoteObservationManagerContext;
  *
  * @since 9.6-RC1
  * @version $Id$
+ * @deprecated This component is only used in case of post-filtering events. We stopped supporting those.
  */
 @Component
 @Singleton
 @Named(LiveNotificationEmailListener.NAME)
+@Deprecated(since = "15.5RC1")
 public class LiveNotificationEmailListener extends AbstractEventListener
 {
     /**

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/live/LiveNotificationEmailListener.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/live/LiveNotificationEmailListener.java
@@ -42,7 +42,7 @@ import org.xwiki.observation.remote.RemoteObservationManagerContext;
 /**
  * This listener is responsible of starting triggers when specific events occurs in the wiki.
  *
- * @since 9.6-RC1
+ * @since 9.6RC1
  * @version $Id$
  * @deprecated This component is only used in case of post-filtering events. We stopped supporting those.
  */

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/live/LiveNotificationEmailManager.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/live/LiveNotificationEmailManager.java
@@ -42,9 +42,11 @@ import org.xwiki.notifications.internal.SimilarityCalculator;
  *
  * @since 9.6RC1
  * @version $Id$
+ * @deprecated This component is only used in case of post-filtering events. We stopped supporting those.
  */
 @Component(roles = LiveNotificationEmailManager.class)
 @Singleton
+@Deprecated(since = "15.5RC1")
 public class LiveNotificationEmailManager implements Initializable
 {
     @Inject
@@ -91,7 +93,6 @@ public class LiveNotificationEmailManager implements Initializable
         Iterator<QueueElement> it = queue.iterator();
         while (it.hasNext()) {
             QueueElement element = it.next();
-
             // Compute the similarity between the event and the composite event in the map
             int similarity = similarityCalculator.computeSimilarity(event, element.event.getEvents().get(0));
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/live/LiveNotificationEmailSender.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/live/LiveNotificationEmailSender.java
@@ -46,9 +46,11 @@ import org.xwiki.wiki.descriptor.WikiDescriptorManager;
  *
  * @since 9.6RC1
  * @version $Id$
+ * @deprecated This component is only used in case of post-filtering events. We stopped supporting those.
  */
 @Component(roles = LiveNotificationEmailSender.class)
 @InstantiationStrategy(ComponentInstantiationStrategy.PER_LOOKUP)
+@Deprecated(since = "15.5RC1")
 public class LiveNotificationEmailSender
 {
     @Inject

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/live/PrefilteringLiveNotificationEmailDispatcher.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/live/PrefilteringLiveNotificationEmailDispatcher.java
@@ -164,6 +164,7 @@ public class PrefilteringLiveNotificationEmailDispatcher implements Initializabl
         entry.entities.forEach(entity -> {
             CompositeEvent composite = eventsToSend.get(entity);
 
+            // FIXME: This should use the grouping strategy
             if (composite != null) {
                 // Compute the similarity between the event and the composite event in the map
                 int similarity = similarityCalculator.computeSimilarity(composite.getEvents().get(0), entry.event);

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/resources/META-INF/components.txt
@@ -4,6 +4,9 @@ org.xwiki.notifications.notifiers.internal.DefaultNotificationCacheManager
 org.xwiki.notifications.notifiers.internal.DefaultNotificationDisplayer
 org.xwiki.notifications.notifiers.internal.DefaultNotificationRenderer
 org.xwiki.notifications.notifiers.internal.InternalHtmlNotificationRenderer
+org.xwiki.notifications.notifiers.internal.email.grouping.DefaultNotificationEmailGroupingStrategy
+org.xwiki.notifications.notifiers.internal.email.grouping.OneMailPerCompositeEmailGroupingStrategy
+org.xwiki.notifications.notifiers.internal.email.grouping.SeparatedMentionEmailGroupingStrategy
 org.xwiki.notifications.notifiers.internal.email.IntervalUsersManager
 org.xwiki.notifications.notifiers.internal.email.IntervalUsersManagerInvalidator
 org.xwiki.notifications.notifiers.internal.email.live.LiveNotificationEmailListener

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/email/grouping/DefaultNotificationEmailGroupingStrategyTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/email/grouping/DefaultNotificationEmailGroupingStrategyTest.java
@@ -19,35 +19,38 @@
  */
 package org.xwiki.notifications.notifiers.internal.email.grouping;
 
-import org.xwiki.component.annotation.Component;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
 import org.xwiki.notifications.CompositeEvent;
 import org.xwiki.notifications.NotificationException;
-import org.xwiki.notifications.notifiers.email.NotificationEmailGroupingStrategy;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
 
-import javax.inject.Named;
-import javax.inject.Singleton;
-import java.util.List;
-import java.util.stream.Collectors;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
 
 /**
- * This component offers a strategy for sending one email per composite event to notify to the user.
- * This strategy can be used in combination with
- * {@link org.xwiki.notifications.internal.ApplicationTypeGroupingStrategy} to send as many emails as there is type of
- * events to notify the users. It could also be used with the default event grouping strategy so that users received as
- * many emails as there is group of events.
+ * Tests for {@link DefaultNotificationEmailGroupingStrategy}.
  *
  * @version $Id$
  * @since 15.5RC1
  */
-@Component
-@Singleton
-@Named("emailperevent")
-public class OneMailPerCompositeEmailGroupingStrategy implements NotificationEmailGroupingStrategy
+@ComponentTest
+class DefaultNotificationEmailGroupingStrategyTest
 {
-    @Override
-    public List<List<CompositeEvent>> groupEventsPerMail(List<CompositeEvent> compositeEvents)
-            throws NotificationException
+    @InjectMockComponents
+    private DefaultNotificationEmailGroupingStrategy groupingStrategy;
+
+    @Test
+    void groupEventsPerMail() throws NotificationException
     {
-        return compositeEvents.stream().map(List::of).collect(Collectors.toList());
+        CompositeEvent event1 = mock(CompositeEvent.class, "event1");
+        CompositeEvent event2 = mock(CompositeEvent.class, "event2");
+        CompositeEvent event3 = mock(CompositeEvent.class, "event3");
+        CompositeEvent event4 = mock(CompositeEvent.class, "event4");
+
+        List<CompositeEvent> input = List.of(event1, event2, event3, event4);
+        assertEquals(List.of(input), this.groupingStrategy.groupEventsPerMail(input));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/email/grouping/OneMailPerCompositeEmailGroupingStrategyTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/email/grouping/OneMailPerCompositeEmailGroupingStrategyTest.java
@@ -1,0 +1,61 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.notifications.notifiers.internal.email.grouping;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.notifications.CompositeEvent;
+import org.xwiki.notifications.NotificationException;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link OneMailPerCompositeEmailGroupingStrategy}.
+ *
+ * @version $Id$
+ * @since 15.5RC1
+ */
+@ComponentTest
+class OneMailPerCompositeEmailGroupingStrategyTest
+{
+    @InjectMockComponents
+    private OneMailPerCompositeEmailGroupingStrategy groupingStrategy;
+
+    @Test
+    void groupEventsPerMail() throws NotificationException
+    {
+        CompositeEvent event1 = mock(CompositeEvent.class, "event1");
+        CompositeEvent event2 = mock(CompositeEvent.class, "event2");
+        CompositeEvent event3 = mock(CompositeEvent.class, "event3");
+        CompositeEvent event4 = mock(CompositeEvent.class, "event4");
+
+        List<CompositeEvent> input = List.of(event1, event2, event3, event4);
+        assertEquals(List.of(
+            List.of(event1),
+            List.of(event2),
+            List.of(event3),
+            List.of(event4)
+        ), this.groupingStrategy.groupEventsPerMail(input));
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/email/grouping/SeparatedMentionEmailGroupingStrategyTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/email/grouping/SeparatedMentionEmailGroupingStrategyTest.java
@@ -1,0 +1,88 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.notifications.notifiers.internal.email.grouping;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.notifications.CompositeEvent;
+import org.xwiki.notifications.NotificationException;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link SeparatedMentionEmailGroupingStrategy}.
+ *
+ * @version $Id$
+ * @since 15.5RC1
+ */
+@ComponentTest
+class SeparatedMentionEmailGroupingStrategyTest
+{
+    @InjectMockComponents
+    private SeparatedMentionEmailGroupingStrategy groupingStrategy;
+
+    @Test
+    void groupEventsPerMail() throws NotificationException
+    {
+        CompositeEvent event1 = mock(CompositeEvent.class, "event1");
+        CompositeEvent event2 = mock(CompositeEvent.class, "event2");
+        CompositeEvent event3 = mock(CompositeEvent.class, "event3");
+        CompositeEvent event4 = mock(CompositeEvent.class, "event4");
+
+        List<CompositeEvent> input = List.of(event1, event2, event3, event4);
+        assertEquals(List.of(input), this.groupingStrategy.groupEventsPerMail(input));
+
+        when(event1.getType()).thenReturn("update");
+        when(event2.getType()).thenReturn("mention");
+        when(event3.getType()).thenReturn("create");
+        when(event4.getType()).thenReturn("mention");
+
+        assertEquals(List.of(
+            List.of(event1, event3),
+            List.of(event2, event4)
+        ), this.groupingStrategy.groupEventsPerMail(input));
+
+        when(event1.getType()).thenReturn("mention");
+        when(event2.getType()).thenReturn("mention");
+        when(event3.getType()).thenReturn("mention");
+        when(event4.getType()).thenReturn("mention");
+        assertEquals(List.of(input), this.groupingStrategy.groupEventsPerMail(input));
+
+        when(event1.getType()).thenReturn("update");
+        when(event2.getType()).thenReturn("create");
+        when(event3.getType()).thenReturn("delete");
+        when(event4.getType()).thenReturn("other");
+        assertEquals(List.of(input), this.groupingStrategy.groupEventsPerMail(input));
+
+        when(event1.getType()).thenReturn("update");
+        when(event2.getType()).thenReturn("create");
+        when(event3.getType()).thenReturn("delete");
+        when(event4.getType()).thenReturn("mention");
+        assertEquals(List.of(
+            List.of(event1, event2, event3),
+            List.of(event4)
+        ), this.groupingStrategy.groupEventsPerMail(input));
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/pom.xml
@@ -31,7 +31,7 @@
   <name>XWiki Platform - Notifications - Notifiers - Default bridge</name>
   <description>Default bridge to oldcore for the notifications notifiers API module.</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.32</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.33</xwiki.jacoco.instructionRatio>
     <xwiki.extension.namespaces>{root}</xwiki.extension.namespaces>
     <checkstyle.suppressions.location>${basedir}/src/checkstyle/checkstyle-suppressions.xml</checkstyle.suppressions.location>
   </properties>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/AbstractMimeMessageIterator.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/AbstractMimeMessageIterator.java
@@ -224,7 +224,7 @@ public abstract class AbstractMimeMessageIterator implements Iterator<MimeMessag
                 strategy = this.componentManager
                         .getInstance(NotificationEmailGroupingStrategy.class, emailGroupingStrategyHint);
             } catch (ComponentLookupException e) {
-                this.logger.error("Error while loading NotificationEmailGroupingStrategy with hint [{}]. " +
+                this.logger.warn("Error while loading NotificationEmailGroupingStrategy with hint [{}]. " +
                                 "Fallback on default strategy. Root cause: [{}]",
                         emailGroupingStrategyHint, ExceptionUtils.getRootCauseMessage(e));
                 this.logger.debug("Root cause of the error was: ", e);

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/AbstractMimeMessageIterator.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/AbstractMimeMessageIterator.java
@@ -37,8 +37,11 @@ import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.bridge.DocumentAccessBridge;
+import org.xwiki.component.manager.ComponentLookupException;
+import org.xwiki.component.manager.ComponentManager;
 import org.xwiki.eventstream.EntityEvent;
 import org.xwiki.eventstream.EventStore;
 import org.xwiki.eventstream.internal.DefaultEntityEvent;
@@ -53,7 +56,9 @@ import org.xwiki.model.reference.EntityReference;
 import org.xwiki.model.reference.EntityReferenceSerializer;
 import org.xwiki.model.reference.WikiReference;
 import org.xwiki.notifications.CompositeEvent;
+import org.xwiki.notifications.NotificationConfiguration;
 import org.xwiki.notifications.NotificationException;
+import org.xwiki.notifications.notifiers.email.NotificationEmailGroupingStrategy;
 import org.xwiki.notifications.notifiers.email.NotificationEmailRenderer;
 
 import com.xpn.xwiki.XWikiContext;
@@ -126,6 +131,16 @@ public abstract class AbstractMimeMessageIterator implements Iterator<MimeMessag
     @Inject
     private Provider<XWikiContext> xcontextProvider;
 
+    @Inject
+    @Named("context")
+    private ComponentManager componentManager;
+
+    @Inject
+    private NotificationConfiguration notificationConfiguration;
+
+    @Inject
+    private NotificationEmailGroupingStrategy fallbackNotificationEmailGroupingStrategy;
+
     private final MailListener listener = new VoidMailListener()
     {
         @Override
@@ -152,6 +167,8 @@ public abstract class AbstractMimeMessageIterator implements Iterator<MimeMessag
     private Map<MimeMessage, List<EntityEvent>> eventsMappingPerMessage = new ConcurrentHashMap<>();
 
     private EntityReference templateReference;
+
+    private Iterator<List<CompositeEvent>> processingEvents = null;
 
     private List<CompositeEvent> currentEvents = Collections.emptyList();
 
@@ -198,32 +215,59 @@ public abstract class AbstractMimeMessageIterator implements Iterator<MimeMessag
     protected abstract List<CompositeEvent> retrieveCompositeEventList(DocumentReference user)
         throws NotificationException;
 
+    private NotificationEmailGroupingStrategy getEmailGroupingStrategy()
+    {
+        NotificationEmailGroupingStrategy strategy = this.fallbackNotificationEmailGroupingStrategy;
+        String emailGroupingStrategyHint = this.notificationConfiguration.getEmailGroupingStrategyHint();
+        if (this.componentManager.hasComponent(NotificationEmailGroupingStrategy.class, emailGroupingStrategyHint)) {
+            try {
+                strategy = this.componentManager
+                        .getInstance(NotificationEmailGroupingStrategy.class, emailGroupingStrategyHint);
+            } catch (ComponentLookupException e) {
+                this.logger.error("Error while loading NotificationEmailGroupingStrategy with hint [{}]. " +
+                                "Fallback on default strategy. Root cause: [{}]",
+                        emailGroupingStrategyHint, ExceptionUtils.getRootCauseMessage(e));
+                this.logger.debug("Root cause of the error was: ", e);
+            }
+        } else {
+            this.logger.warn("Cannot find a NotificationEmailGroupingStrategy with hint [{}]. " +
+                    "Fallback on default strategy.", emailGroupingStrategyHint);
+        }
+        return strategy;
+    }
+
     /**
      * Compute the message that will be sent to the next user in the iterator.
      */
     protected void computeNext()
     {
-        this.currentEvents = Collections.emptyList();
-        this.currentUserEmail = null;
-        while ((this.currentEvents.isEmpty() || this.currentUserEmail == null) && this.userIterator.hasNext()) {
-            this.currentUser = this.userIterator.next();
-            try {
-                this.currentUserEmail = new InternetAddress(getUserEmail(this.currentUser));
-            } catch (AddressException e) {
-                // The user has not written a valid email
-                continue;
-            }
+        if (this.processingEvents == null || !this.processingEvents.hasNext()) {
+            this.currentEvents = Collections.emptyList();
+            this.currentUserEmail = null;
+            while ((this.currentEvents.isEmpty() || this.currentUserEmail == null) && this.userIterator.hasNext()) {
+                this.currentUser = this.userIterator.next();
+                try {
+                    this.currentUserEmail = new InternetAddress(getUserEmail(this.currentUser));
+                } catch (AddressException e) {
+                    // The user has not written a valid email
+                    continue;
+                }
 
-            try {
-                // TODO: in a next version, it will be important to paginate these results and to send several emails
-                // if there is too much content
-                this.currentEvents = retrieveCompositeEventList(this.currentUser);
-            } catch (NotificationException e) {
-                logger.error(ERROR_MESSAGE, this.currentUser, e);
+                try {
+                    List<CompositeEvent> compositeEvents = retrieveCompositeEventList(this.currentUser);
+                    if (!compositeEvents.isEmpty()) {
+                        this.processingEvents =
+                                getEmailGroupingStrategy().groupEventsPerMail(compositeEvents).iterator();
+                        this.currentEvents = this.processingEvents.next();
+                    }
+                } catch (NotificationException e) {
+                    logger.error(ERROR_MESSAGE, this.currentUser, e);
+                }
             }
+            this.currentUsedId = this.serializer.serialize(this.currentUser);
+        } else {
+            this.currentEvents = this.processingEvents.next();
         }
-        this.currentUsedId = this.serializer.serialize(this.currentUser);
-
         this.hasNext = this.currentUserEmail != null && !this.currentEvents.isEmpty();
     }
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/live/DefaultLiveMimeMessageIterator.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/live/DefaultLiveMimeMessageIterator.java
@@ -44,9 +44,11 @@ import org.xwiki.notifications.notifiers.internal.email.NotificationUserIterator
  *
  * @since 9.10RC1
  * @version $Id$
+ * @deprecated This component is only used in case of post-filtering events. We stopped supporting those.
  */
 @Component
 @InstantiationStrategy(ComponentInstantiationStrategy.PER_LOOKUP)
+@Deprecated(since = "15.5RC1")
 public class DefaultLiveMimeMessageIterator extends AbstractMimeMessageIterator
     implements LiveMimeMessageIterator
 {

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/test/java/org/xwiki/notifications/notifiers/internal/email/DefaultPeriodicMimeMessageIteratorTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/test/java/org/xwiki/notifications/notifiers/internal/email/DefaultPeriodicMimeMessageIteratorTest.java
@@ -50,6 +50,8 @@ import org.xwiki.notifications.sources.ParametrizedNotificationManager;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
+import org.xwiki.user.UserReference;
+import org.xwiki.user.UserReferenceResolver;
 import org.xwiki.wiki.descriptor.WikiDescriptorManager;
 
 import com.xpn.xwiki.api.Attachment;
@@ -111,6 +113,9 @@ class DefaultPeriodicMimeMessageIteratorTest
     @MockComponent
     private UserAvatarAttachmentExtractor userAvatarAttachmentExtractor;
 
+    @Named("document")
+    private UserReferenceResolver<DocumentReference> userReferenceResolver;
+
     @BeforeEach
     void beforeEach()
     {
@@ -165,9 +170,15 @@ class DefaultPeriodicMimeMessageIteratorTest
         when(this.notificationManager.getRawEvents(notificationParameters2))
             .thenReturn(Collections.singletonList(event2));
 
-        when(this.groupingEventManager.getCompositeEvents(Collections.singletonList(event1), "xwiki:XWiki.UserA",
+        UserReference userRefA = mock(UserReference.class, "userA");
+        UserReference userRefC = mock(UserReference.class, "userC");
+
+        when(this.userReferenceResolver.resolve(userA)).thenReturn(userRefA);
+        when(this.userReferenceResolver.resolve(userC)).thenReturn(userRefC);
+
+        when(this.groupingEventManager.getCompositeEvents(Collections.singletonList(event1), userRefA,
             "EMAIL")).thenReturn(Collections.singletonList(compositeEvent1));
-        when(this.groupingEventManager.getCompositeEvents(Collections.singletonList(event2), "xwiki:XWiki.UserC",
+        when(this.groupingEventManager.getCompositeEvents(Collections.singletonList(event2), userRefC,
             "EMAIL")).thenReturn(Collections.singletonList(compositeEvent2));
 
         when(compositeEvent1.getUsers()).thenReturn(Sets.newSet(userB));

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/DefaultGroupingEventManager.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/DefaultGroupingEventManager.java
@@ -25,7 +25,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
@@ -38,7 +37,6 @@ import org.xwiki.notifications.GroupingEventStrategy;
 import org.xwiki.notifications.NotificationException;
 import org.xwiki.notifications.preferences.NotificationPreferenceManager;
 import org.xwiki.user.UserReference;
-import org.xwiki.user.UserReferenceResolver;
 
 /**
  * Default implementation of {@link GroupingEventManager}.
@@ -54,9 +52,6 @@ public class DefaultGroupingEventManager implements GroupingEventManager
     private GroupingEventStrategy defaultGroupingEventStrategy;
 
     @Inject
-    private UserReferenceResolver<String> userReferenceResolver;
-
-    @Inject
     private NotificationPreferenceManager notificationPreferenceManager;
 
     @Inject
@@ -67,26 +62,25 @@ public class DefaultGroupingEventManager implements GroupingEventManager
     private Logger logger;
 
     @Override
-    public List<CompositeEvent> getCompositeEvents(List<Event> events, String userId, String target) throws
-        NotificationException
+    public List<CompositeEvent> getCompositeEvents(List<Event> events, UserReference userReference, String target)
+            throws NotificationException
     {
-        return getStrategy(userId, target).group(events);
+        return getStrategy(userReference, target).group(events);
     }
 
     @Override
-    public void augmentCompositeEvents(List<CompositeEvent> compositeEvents, List<Event> newEvents, String userId,
-        String target) throws NotificationException
+    public void augmentCompositeEvents(List<CompositeEvent> compositeEvents, List<Event> newEvents,
+                                       UserReference userReference, String target) throws NotificationException
     {
-        getStrategy(userId, target).group(compositeEvents, newEvents);
+        getStrategy(userReference, target).group(compositeEvents, newEvents);
     }
 
-    private GroupingEventStrategy getStrategy(String userId, String target) throws NotificationException
+    private GroupingEventStrategy getStrategy(UserReference userReference, String target) throws NotificationException
     {
         GroupingEventStrategy groupingEventStrategy = this.defaultGroupingEventStrategy;
 
         // FIXME: We should have a way to fallback on wiki preference
-        if (!StringUtils.isBlank(userId)) {
-            UserReference userReference = this.userReferenceResolver.resolve(userId);
+        if (userReference != null) {
             String strategyHint =
                 this.notificationPreferenceManager.getNotificationGroupingStrategy(userReference, target);
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/DefaultParametrizedNotificationManager.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/DefaultParametrizedNotificationManager.java
@@ -45,6 +45,8 @@ import org.xwiki.notifications.sources.ParametrizedNotificationManager;
 import org.xwiki.security.authorization.AuthorizationManager;
 import org.xwiki.security.authorization.ContextualAuthorizationManager;
 import org.xwiki.security.authorization.Right;
+import org.xwiki.user.UserReference;
+import org.xwiki.user.UserReferenceResolver;
 import org.xwiki.user.group.GroupException;
 import org.xwiki.user.group.GroupManager;
 
@@ -97,6 +99,10 @@ public class DefaultParametrizedNotificationManager implements ParametrizedNotif
 
     @Inject
     private Logger logger;
+
+    @Inject
+    @Named("document")
+    private UserReferenceResolver<DocumentReference> userReferenceResolver;
 
     @Override
     public List<CompositeEvent> getEvents(NotificationParameters parameters) throws NotificationException
@@ -182,11 +188,11 @@ public class DefaultParametrizedNotificationManager implements ParametrizedNotif
             // if what's requested is the composite events, then we only stop when the number of composite events
             // is reached
             if (compositeEvents != null) {
-                String userId = null;
+                UserReference userReference = null;
                 if (parameters.user != null) {
-                    userId = this.serializer.serialize(parameters.user);
+                    userReference = this.userReferenceResolver.resolve(parameters.user);
                 }
-                this.groupingEventManager.augmentCompositeEvents(compositeEvents, newEvents, userId,
+                this.groupingEventManager.augmentCompositeEvents(compositeEvents, newEvents, userReference,
                     parameters.groupingEventTarget);
                 reachedSize = compositeEvents.size();
             }

--- a/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.properties.vm
+++ b/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.properties.vm
@@ -1275,6 +1275,14 @@ edit.defaultEditor.org.xwiki.rendering.block.XDOM#wysiwyg=$xwikiPropertiesDefaul
 #-# The default is :
 # notifications.async.poolSize = 2
 
+#-# [Since 15.5RC1]
+#-# The hint of the strategy component to use for email grouping notifications. Default strategy is to group all
+#-# notifications in a single email, but other strategies can be provided, e.g. to send as many emails as there was
+#-# type of notifications. Check online documentation related to notification to see the list of available strategies.
+#-#
+#-# The default is :
+# notifications.emailGroupingStrategyHint = "default"
+
 #-------------------------------------------------------------------------------------
 # Mentions
 #-------------------------------------------------------------------------------------


### PR DESCRIPTION
JIRA: https://jira.xwiki.org/browse/XWIKI-17034

Previous work was about introducing strategies to group events for creating composite events. This work is about strategies for chosing how many mails should be sent for each composite event to notify by email. Historically the strategy was hardcoded and consisted in putting all composite events in the same email. Here we provide different strategies: the previous one, but also a strategy allowing to send one email per composite event, and another one allowing to send a separate email specifically for mentions.

That work also improves previous API to use a clear UserReference instead of a String which is vague.