### PR TITLE
[Misc] Accessibility rules update

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/WCAGContext.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/WCAGContext.java
@@ -91,8 +91,7 @@ public class WCAGContext
             // Set to true once the build doesn't fail this rule anymore
             entry("color-contrast", false),
             entry("definition-list", true),
-            // Set to true once the build doesn't fail this rule anymore
-            entry("dlitem", false),
+            entry("dlitem", true),
             entry("document-title", true),
             // Set to true once the build doesn't fail this rule anymore
             entry("duplicate-id-active", false),
@@ -118,8 +117,7 @@ public class WCAGContext
             entry("link-in-text-block", false),
             // Set to true once the build doesn't fail this rule anymore
             entry("link-name", false),
-            // Set to true once the build doesn't fail this rule anymore
-            entry("list", false),
+            entry("list", true),
             entry("listitem", true),
             entry("marquee", true),
             entry("meta-refresh", true),
@@ -128,7 +126,8 @@ public class WCAGContext
             entry("no-autoplay-audio", true),
             entry("object-alt", true),
             entry("role-img-alt", true),
-            entry("scrollable-region-focusable", true),
+            // Set to true once the build doesn't fail this rule anymore
+            entry("scrollable-region-focusable", false),
             // Set to true once the build doesn't fail this rule anymore
             entry("select-name", false),
             entry("server-side-image-map", true),


### PR DESCRIPTION
Changes to the status of the WCAG rules that are currently not violated. From this point on, all rules set to true will make the build fail when they are violated. The build will only fail on an accessibility regression. See the [XWiki WCAG testing page](https://dev.xwiki.org/xwiki/bin/view/Community/WCAGTesting#HTesting) for more details about the consequences of these changes.

Because of https://jira.xwiki.org/browse/XWIKI-20909, in order to pass tests, we temporarily deactivate the `scrollable-region-focusable` fails.

As of https://ci.xwiki.org/job/XWiki%20Environment%20Tests/job/xwiki-platform/job/master/255/, there are only a few rules that fail through tests:
- aria-allowed-attr 5 violations
- aria-required-children 65 violations
- label 79 violations
- duplicate-id 8 violations
- duplicate-id-active 3 violations
- duplicate-id-aria 9 violations
- frame-title 6 violations
- image-alt 52 violations
- link-in-text-block 328 violations
- link-name 3 violations
- select-name 26 violations
- color-contrast 81 violations
- scrollable-region-focusable 1 violation

Total violations: 666

There are no additional failing types in [environment test master build #255](https://ci.xwiki.org/job/XWiki%20Environment%20Tests/job/xwiki-platform/job/master/255/)

|  | Count of warning rules | Count of failing rules |
| ------------- | ------------- | ------------- |
| Before this PR | 14 | 47 |
| After this PR | 13 | 48 |

This is a continuation of the process started in https://github.com/xwiki/xwiki-platform/pull/2152