### PR TITLE
XWIKI-20999: Page history tab radio buttons have no label

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/historyinline.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/historyinline.vm
@@ -108,11 +108,11 @@ $xwiki.ssfx.use('uicomponents/pagination/pagination.css', true)##
       <tr class="extension">
         #if ($displayCompare)
           <td data-title="$escapetool.xml($services.localization.render('core.viewers.history.from'))">
-            <label class="hidden" for="rev1_$version">$escapetool.xml($services.localization.render('core.viewers.history.from'))</label>
+            <label class="sr-only" for="rev1_$version">$escapetool.xml($services.localization.render('core.viewers.history.from'))</label>
             <input type="radio" name="rev1" id="rev1_$version" value="$version" #if ($totalVersions == 1) checked="checked" #end/>
           </td>
           <td data-title="$escapetool.xml($services.localization.render('core.viewers.history.to'))">
-            <label class="hidden" for="rev2_$version">$escapetool.xml($services.localization.render('core.viewers.history.to'))</label>
+            <label class="sr-only" for="rev2_$version">$escapetool.xml($services.localization.render('core.viewers.history.to'))</label>
             <input type="radio" name="rev2" id="rev2_$version" value="$version"/>
           </td>
         #end


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-20999

## PR Changes
* Changed the class of labels from `hidden` to `sr-only`

## Note
The labels were already there, but using `display: none` (style from the class 'hidden') prevented them from being read out by Assistive Technologies (AT). I decided to keep them as is, and change their class so that they would be readable while still not appearing. This way, there is no presentation change, no structure change and minimal attribute changes.

## Tests
Couldn't find a reference to the changed elements in the functional tests. 
Starting an axe-core analysis on a page concerned by the issue did not return any violation there anymore.