### PR TITLE
XWIKI-20972: Delete page children tab dropdown toggler has no accessible name

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/delete.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/delete.vm
@@ -137,7 +137,7 @@
       $heading
       <div class="pull-right"><a class="panel-collapse-carret" role="button" data-toggle="collapse" href="#$panelId" aria-expanded="false" aria-controls="$panelId">
         <span class="caret"></span>
-        <label class='sr-only'>$escapetool.xml($services.localization.render('core.delete.affectChildren.dropDown.label'))</label>
+        <span class='sr-only'>$escapetool.xml($services.localization.render('core.delete.affectChildren.dropDown.label'))</span>
       </a></div>
     </div>
     <div class="panel-body collapse" id="$panelId">

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/delete.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/delete.vm
@@ -164,7 +164,7 @@
         #set ($forceAffectChildren = " checked='checked'")
       #end
       #define($heading)
-        <input name="affectChildren" id="affectChildren" type="checkbox" $!{forceAffectChildren}/><label for="affectChildren">$escapetool.xml($services.localization.render('core.delete.affectChildren'))</label> ($childCount)
+        <input name="affectChildren" id="affectChildren" type="checkbox" $!{forceAffectChildren}/><label for="affectChildren">$escapetool.xml($services.localization.render('core.delete.affectChildren')) ($childCount)</label>
       #end
       #define($body)
         ##

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/delete.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/delete.vm
@@ -135,7 +135,10 @@
   <div class="panel $!panelClass">
     <div class="panel-heading">
       $heading
-      <div class="pull-right"><a class="panel-collapse-carret" role="button" data-toggle="collapse" href="#$panelId" aria-expanded="false" aria-controls="$panelId"><span class="caret"></span></a></div>
+      <div class="pull-right"><a class="panel-collapse-carret" role="button" data-toggle="collapse" href="#$panelId" aria-expanded="false" aria-controls="$panelId">
+        <span class="caret"></span>
+        <label class='sr-only'>$escapetool.xml($services.localization.render('core.delete.affectChildren.dropDown.label'))</label>
+      </a></div>
     </div>
     <div class="panel-body collapse" id="$panelId">
       $body
@@ -161,7 +164,7 @@
         #set ($forceAffectChildren = " checked='checked'")
       #end
       #define($heading)
-        <input name="affectChildren" id="affectChildren" type="checkbox" $!{forceAffectChildren}/><label for="affectChildren">$services.localization.render('core.delete.affectChildren')</label> ($childCount)
+        <input name="affectChildren" id="affectChildren" type="checkbox" $!{forceAffectChildren}/><label for="affectChildren">$escapetool.xml($services.localization.render('core.delete.affectChildren'))</label> ($childCount)
       #end
       #define($body)
         ##

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/restore.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/restore.vm
@@ -112,7 +112,7 @@
       $heading
       <div class="pull-right"><a class="panel-collapse-carret" role="button" data-toggle="collapse" href="#$panelId" aria-expanded="false" aria-controls="$panelId">
         <span class="caret"></span>
-        <label class='sr-only'>$escapetool.xml($services.localization.render('core.delete.affectChildren.dropDown.label'))</label>
+        <span class='sr-only'>$escapetool.xml($services.localization.render('core.delete.affectChildren.dropDown.label'))</span>
       </a></div>
     </div>
     <div class="panel-body collapse" id="$panelId">

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/restore.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/restore.vm
@@ -129,7 +129,7 @@
   ## Only propose to restore the batch if it also contains other documents than the current one.
   #if ($batchDeletedDocuments.size() > 1)
     #define($heading)
-      <input name="includeBatch" id="includeBatch" type="checkbox" value="true"/><label for="includeBatch">$escapetool.xml($services.localization.render('core.restore.includeBatch'))</label> ($batchDeletedDocuments.size())
+      <input name="includeBatch" id="includeBatch" type="checkbox" value="true"/><label for="includeBatch">$escapetool.xml($services.localization.render('core.restore.includeBatch')) ($batchDeletedDocuments.size())</label>
     #end
     #define($body)
       ##

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/restore.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/restore.vm
@@ -110,7 +110,10 @@
   <div class="panel $!panelClass">
     <div class="panel-heading">
       $heading
-      <div class="pull-right"><a class="panel-collapse-carret" role="button" data-toggle="collapse" href="#$panelId" aria-expanded="false" aria-controls="$panelId"><span class="caret"></span></a></div>
+      <div class="pull-right"><a class="panel-collapse-carret" role="button" data-toggle="collapse" href="#$panelId" aria-expanded="false" aria-controls="$panelId">
+        <span class="caret"></span>
+        <label class='sr-only'>$escapetool.xml($services.localization.render('core.delete.affectChildren.dropDown.label'))</label>
+      </a></div>
     </div>
     <div class="panel-body collapse" id="$panelId">
       $body
@@ -126,7 +129,7 @@
   ## Only propose to restore the batch if it also contains other documents than the current one.
   #if ($batchDeletedDocuments.size() > 1)
     #define($heading)
-      <input name="includeBatch" id="includeBatch" type="checkbox" value="true"/><label for="includeBatch">$services.localization.render('core.restore.includeBatch')</label> ($batchDeletedDocuments.size())
+      <input name="includeBatch" id="includeBatch" type="checkbox" value="true"/><label for="includeBatch">$escapetool.xml($services.localization.render('core.restore.includeBatch'))</label> ($batchDeletedDocuments.size())
     #end
     #define($body)
       ##

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -1510,6 +1510,7 @@ core.delete.warningExtensions.canceling=Canceling the delete action
 core.delete.warningExtensions.canceled=Delete action canceled
 core.delete.warningExtensions.timeout=The action has been canceled because we have not received any answer after 5 minutes.
 core.delete.affectChildren=Affect children
+core.delete.affectChildren.dropDown.label=Toggle details about affected children.
 core.delete.autoRedirect.hint=Redirect the user to the new page when accessing the old page. Select this option if you don't want to break external links to the deleted page.
 core.delete.autoRedirect.label=Create an automatic redirect
 core.delete.backlinks=Backlinks


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-20972

EDIT: A commit message https://github.com/xwiki/xwiki-platform/pull/2215/commits/bb81586d9c450d8dae3644557c480331c3370fe5 does not follow best practices, please squash this PR when merging.

## PR Changes
* Added labels for the dropdowns, with an escaped translation.

## Notes
No view changes.
This hsould also fix https://jira.xwiki.org/browse/XWIKI-20991. 
The issues are very similar but were reported differently.
## Tests
Didn't trigger the reported WCAG warnings when running:
* `mvn clean install -f xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/ -Pdocker,integration-tests -Dxwiki.test.ui.wcag=true -Dit.test=DeletePageIT#deletePageWithUsedClass`
* `mvn clean install -f xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/ -Pdocker,integration-tests -Dxwiki.test.ui.wcag=true -Dit.test=NavigationIT#navigateWithKeyboardShortcuts`