### PR TITLE
XWIKI-20973: Color theme edit frame must have an accessible name

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/ThemeSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/ThemeSheet.xml
@@ -409,7 +409,14 @@
       <cache>long</cache>
     </property>
     <property>
-      <code>require(['jquery', 'bootstrap'], function($) {
+      <code>define('xwiki-flamingo-theme-messages', {
+  prefix: 'platform.flamingo.themes.',
+  keys: [
+    'preview.iframe.label'
+  ]
+});
+
+require(['jquery', 'xwiki-l10n!xwiki-flamingo-theme-messages', 'bootstrap'], function($, l10n) {
   'use strict';
 
   var createPreview = function() {
@@ -420,7 +427,9 @@
     var iframe = $('&lt;iframe/&gt;').attr({
       src: new XWiki.Document('WebHome', 'Main').getURL('view', 'colortheme=no'),
       id: 'iframe',
-      'class': 'col-xs-12'
+      class: 'col-xs-12',
+      title: l10n.get('preview.iframe.label'),
+      'aria-label': l10n.get('preview.iframe.label')
     // We need to register the load listener before the iframe is attached to the DOM otherwise we can't catch reliably
     // the load event (because the iframe might load before we register our listener).
     }).on('load', function() {

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/Translations.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/Translations.xml
@@ -91,6 +91,7 @@ platform.flamingo.themes.title.preview=Preview
 platform.flamingo.themes.autorefresh=Auto refresh
 platform.flamingo.themes.refresh=Refresh
 platform.flamingo.themes.refreshwarning=The refresh can take several seconds.
+platform.flamingo.themes.preview.iframe.label=Preview of the color theme.
 platform.flamingo.themes.loading=Loading...
 platform.flamingo.themes.category.logos=Logos
 platform.flamingo.themes.category.base-colors=Base colors


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-20973

## PR Changes
* Added a localized label to the iframe

## View
![20973-viewAfter](https://github.com/xwiki/xwiki-platform/assets/28761965/659da463-4515-44ac-a930-63d23e72c0db)

## Test
In the document shown above, an Axe-core analysis with Axe devtool doesn't report any WCAG violation from the iframe.
I could not find many references to this element in tests. The only one is a pageobject that's generated using the id of the element (`iframe`) that I left unchanged, so no test should be failed because of this PR.
## Note
This label is generated in javascript, so we create a new l10n javascript module. It might have been possible to generate it in velocity and not have one extra HTTP request to avoid loading this very small module.