### PR TITLE
XWIKI-21012: Rights are messed up after unregistering a right/uninstalling the like application

### DIFF
--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/RightSet.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/RightSet.java
@@ -25,6 +25,8 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
+import static org.xwiki.security.authorization.Right.MAX_SIZE;
+
 /**
  * Optimized set of {@link Right}.
  *
@@ -42,9 +44,7 @@ public class RightSet extends AbstractSet<Right> implements Cloneable, java.io.S
     /** Default constructor. */
     public RightSet()
     {
-        if (Right.size() > 64) {
-            throw new IllegalStateException();
-        }
+        maxSizeCheck();
     }
 
     /**
@@ -54,9 +54,7 @@ public class RightSet extends AbstractSet<Right> implements Cloneable, java.io.S
      */
     public RightSet(Collection<? extends Right> rights)
     {
-        if (Right.size() > 64) {
-            throw new IllegalStateException();
-        }
+        maxSizeCheck();
         this.addAll(rights);
     }
 
@@ -66,11 +64,16 @@ public class RightSet extends AbstractSet<Right> implements Cloneable, java.io.S
      */
     public RightSet(Right... rights)
     {
-        if (Right.size() > 64) {
-            throw new IllegalStateException();
-        }
-
+        maxSizeCheck();
         Collections.addAll(this, rights);
+    }
+
+    private void maxSizeCheck()
+    {
+        if (Right.size() > MAX_SIZE) {
+            throw new IllegalStateException(String.format("You cannot register more than [%s] rights.",
+                MAX_SIZE));
+        }
     }
 
     @Override


### PR DESCRIPTION
JIRA: https://jira.xwiki.org/browse/XWIKI-21012

  * Ensure to not mess up the list of rights used for computing ordinals by setting null in it when unregistering
  * Reuse the empty places in the list of rights for preventing reaching the limit of 64 rights
  * Add new unit test for covering previous bug and for emphasizing the 64 rights limitation