### PR TITLE
XWIKI-21008: Livedata table headers buttons should not be read out

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/table/LayoutTableHeaderNames.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/table/LayoutTableHeaderNames.vue
@@ -67,6 +67,7 @@
           to prevent sorting the column unintentionally.
         -->
         <div
+          role="presentation"
           class="handle"
           :title="$t('livedata.action.reorder.hint')"
           @click.stop
@@ -89,7 +90,7 @@
         Use the stop propagation modifier on click event
         to prevent sorting the column unintentionally.
       -->
-      <div class="resize-handle" :title="$t('livedata.action.resizeColumn.hint')"
+      <div role="presentation" class="resize-handle" :title="$t('livedata.action.resizeColumn.hint')"
         v-mousedownmove="resizeColumnInit"
         @mousedownmove="resizeColumn"
         @click.stop


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-21008
## PR Changes
* Added `role=presentation` on both of the buttons that trigger the dragging behaviour.
## Tests
Successfully passed:
* `mvn clean install -f xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/ -Pdocker,integration-tests,quality -Dxwiki.test.ui.wcag=true`
* `mvn clean install -f xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/ -Pdocker,integration-tests,quality -Dxwiki.test.ui.wcag=true`
