### PR TITLE
XWIKI-21003: Wiki delete confirmation form doesn't have a label

### DIFF
--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-mainwiki/src/main/resources/WikiManager/DeleteWiki.xml
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-mainwiki/src/main/resources/WikiManager/DeleteWiki.xml
@@ -106,7 +106,9 @@
             &lt;form action="$doc.getURL()" method="post"&gt;
               &lt;input type="hidden" name="wikiId" value="$!escapetool.xml($wikiId)" /&gt;
               &lt;input type="hidden" name="form_token" value="$!escapetool.xml($services.csrf.getToken())" /&gt;
-              &lt;p&gt;$services.localization.render('platform.wiki.delete.confirmation.retypeWikiId') &lt;input type="text" name="wikiIdConfirm" value="$!{escapetool.xml($wikiIdConfirm)}" id="wikiDeleteConfirmation" class="required" /&gt;
+              &lt;p&gt;
+                &lt;label for='wikiDeleteConfirmation'&gt;$services.localization.render('platform.wiki.delete.confirmation.retypeWikiId')&lt;/label&gt;
+                &lt;input type="text" name="wikiIdConfirm" value="$!{escapetool.xml($wikiIdConfirm)}" id="wikiDeleteConfirmation" class="required" /&gt;
               &lt;/p&gt;
               &lt;button class="btn btn-danger" id="confirmButton"&gt;$services.localization.render('delete')&lt;/button&gt;
               &lt;a class="btn btn-default" href="$backUrl"&gt;$services.localization.render('cancel')&lt;/a&gt;


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-21003

## PR Changes
* Used the text string next to the input as a label
## View
The label is now in bold, as it is the style for all labels. I don't think this change in UI is detrimental to the document.
As a label, clicking on it will now focus its attached input.
![21003-viewAfter](https://github.com/xwiki/xwiki-platform/assets/28761965/bb672ca2-4585-4755-879b-ef25a8c0d477)
## Tests
Successfully passed:
*  `mvn clean install -f xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-mainwiki/ -Pdocker,integration-tests,quality -Dxwiki.test.ui.wcag=true`
* `mvn clean install -f xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/ -Pdocker,integration-tests,quality` (no wcag tests since some were too long locally to pass)