### PR TITLE
XWIKI-21001: Job scheduler creation form name field is not labelled

### DIFF
--- a/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-ui/src/main/resources/Scheduler/WebHome.xml
+++ b/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-ui/src/main/resources/Scheduler/WebHome.xml
@@ -192,9 +192,9 @@ $services.localization.render('xe.scheduler.welcome')
   &lt;input type="hidden" name="template" value="XWiki.SchedulerJobTemplate" /&gt;
   &lt;input type="hidden" name="sheet" value="1" /&gt;
   &lt;input type="hidden" name="space" value="Scheduler"/&gt;
-  &lt;label class="hidden" for="page"&gt;$services.localization.render('xe.scheduler.jobs.create.nameTip')&lt;/label&gt;
+  &lt;label class="sr-only" for="page"&gt;$services.localization.render('xe.scheduler.jobs.create.nameTip')&lt;/label&gt;
   &lt;input id="page" name="page" size="30" type="text"
-      value="$escapetool.xml($services.localization.render('xe.scheduler.jobs.create.nameTip'))" /&gt;
+      placeholder="$escapetool.xml($services.localization.render('xe.scheduler.jobs.create.nameTip'))" /&gt;
   &lt;span class="buttonwrapper"&gt;
     &lt;input type="submit" class="btn btn-success"
         value="$escapetool.xml($services.localization.render('xe.scheduler.jobs.create.submit'))"/&gt;


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-21001

## PR Changes
* Changed the class of the label in order to make it visible to screen readers and not just unusable.
* Replaced the input default value with a placeholder

## Tests
Passed successfully: 
* `mvn clean install -f xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-ui/ -Pdocker,integration-tests,quality -Dxwiki.test.ui.wcag=true`
* `mvn clean install -f xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-test/ -Pdocker,integration-tests,quality -Dxwiki.test.ui.wcag=true`