### PR TITLE
XWIKI-21013: Access rights aren't applied after nested group member changes in subwiki

### DIFF
--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/DefaultAuthorizationManagerIntegrationTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/DefaultAuthorizationManagerIntegrationTest.java
@@ -700,8 +700,11 @@ class DefaultAuthorizationManagerIntegrationTest extends AbstractAuthorizationTe
         assertAccess(new RightSet(List.of(LOGIN, REGISTER, VIEW, DELETE)), getXUser("userA") ,
             getXDoc("docDeleteAllowA", "any space"));
 
-        /* Test XWIKI-21013: ensure that access entries are removed when a local parent group is removed from the
-        cache. */
+        /* In the situation where a global user (userA) is in a global group (groupA) that is in another global group
+         (groupB) that is in a local group (groupC) that is in a subwiki (subwiki), ensure that removing the local
+         group (groupC) from the cache removes the access entries for the global user (userA) in the subwiki as
+         otherwise permissions based on groupC are not recalculated when a member of groupC is removed. This
+         verifies that memberships between groups are correctly mirrored in the shadow entries for the subwiki. */
         SecurityCache securityCache = this.componentManager.getInstance(SecurityCache.class);
         UserSecurityReference subwikiGroupC =
             this.securityReferenceFactory.newUserReference(getUser("groupC", "subwiki"));

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/DefaultAuthorizationManagerIntegrationTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/DefaultAuthorizationManagerIntegrationTest.java
@@ -79,6 +79,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -698,6 +699,21 @@ class DefaultAuthorizationManagerIntegrationTest extends AbstractAuthorizationTe
 
         assertAccess(new RightSet(List.of(LOGIN, REGISTER, VIEW, DELETE)), getXUser("userA") ,
             getXDoc("docDeleteAllowA", "any space"));
+
+        /* Test XWIKI-21013: ensure that access entries are removed when a local parent group is removed from the
+        cache. */
+        SecurityCache securityCache = this.componentManager.getInstance(SecurityCache.class);
+        UserSecurityReference subwikiGroupC =
+            this.securityReferenceFactory.newUserReference(getUser("groupC", "subwiki"));
+        UserSecurityReference userA = this.securityReferenceFactory.newUserReference(getXUser("userA"));
+        SecurityReference docC =
+            this.securityReferenceFactory.newEntityReference(getDoc("docAllowGroupC", "any space", "subwiki"));
+
+        assertNotNull(securityCache.get(subwikiGroupC));
+        assertNotNull(securityCache.get(userA, docC));
+        securityCache.remove(subwikiGroupC);
+        assertNull(securityCache.get(userA, docC));
+        assertNotNull(securityCache.get(userA));
     }
 
     @Test


### PR DESCRIPTION
* Load the full group hierarchy for shadow entries.
* Refactor the group loading code.
* Add a test for this scenario.
* Refactor group listing in the security cache to be safe from concurrent modifications.
