### PR TITLE
XWIKI-18007: Drawer menu improvements for accessibility

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/flamingo.js
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/flamingo.js
@@ -51,3 +51,39 @@ require(['jquery', 'bootstrap'], function($) {
     translateButton.attr('title', translateButton.attr('data-title')).popover();
   });
 });
+
+require(['jquery', 'iscroll', 'drawer'], function($, IScroll) {
+  // Unfortunately drawer doesn't declare the dependency on iscroll and expects it to be defined as a global variable.
+  window.IScroll = IScroll;
+  $(function() {
+    // Note that the 'drawer-open' and 'drawer-close' CSS classes are added before the open and close animations end
+    // which prevents us from using them in automated tests. We need something more reliable so we listen to
+    // 'drawer.opened' and 'drawer.closed' events and add our own markers.
+    var tmDrawer = $('#tmDrawer');
+    $('.drawer-nav').closest('body').drawer().on('drawer.opened', function(event) {
+      $('#tmDrawerActivator').attr('aria-expanded', 'true');
+      //Focus the first focusable element in tmDrawer.
+      tmDrawer.find('button, a, input:not([type="hidden"]), select, textarea, [tabindex]:not([tabindex="-1"])')
+        .first()
+        .focus();
+      let closeDrawer = () => $('.drawer-nav').closest('body').drawer('close');
+      // Drawer can be closed by pressing the ESC key.
+      tmDrawer.on('keydown', function (event) {
+        if (event.key === 'Escape') {
+          closeDrawer();
+        }
+      });
+      // It can also be closed by getting the focus out of it.
+      document.getElementById('tmDrawer').addEventListener('focusout',
+        function (event) {
+        if(!this.contains(event.relatedTarget)) {
+          closeDrawer();
+        }
+      });
+    }).on('drawer.closed', function(event) {
+      $('#tmDrawerActivator').attr('aria-expanded', 'false');
+      // We remove the listeners
+      tmDrawer.off('keydown focusout');
+    });
+  });
+});

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/javascript.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/javascript.vm
@@ -189,20 +189,6 @@ if (window.Prototype && Prototype.BrowserFeatures.ElementExtensions) {
     disablePrototypeJS('hide', pluginsToDisable);
   });
 }
-require(['jquery', 'iscroll', 'drawer'], function($, IScroll) {
-  // Unfortunately drawer doesn't declare the dependency on iscroll and expects it to be defined as a global variable.
-  window.IScroll = IScroll;
-  $(function() {
-    // Note that the 'drawer-open' and 'drawer-close' CSS classes are added before the open and close animations end
-    // which prevents us from using them in automated tests. We need something more reliable so we listen to
-    // 'drawer.opened' and 'drawer.closed' events and add our own markers.
-    $('.drawer-nav').closest('body').drawer().on('drawer.opened', function(event) {
-      $('#tmDrawerActivator').attr('aria-expanded', 'true');
-    }).on('drawer.closed', function(event) {
-      $('#tmDrawerActivator').attr('aria-expanded', 'false');
-    });
-  });
-});
 ##
 ## Pass useful contextual information from the server to the client using the global XWiki object.
 ##

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/drawer.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/drawer.less
@@ -142,6 +142,11 @@
   margin: 12px 0;
 }
 
+//Make the drawer invisible to any reader when it's closed off.
+.drawer-close .drawer-menu {
+  display: none;
+}
+
 // Special styling for login/logout/register =============================
 #tmLogin, #tmLogout, #tmRegister {
   font-style: italic;

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_view.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_view.vm
@@ -39,8 +39,6 @@
 
   ## End of Top Menu
   #xwikitopmenuend()
-
-  #template("drawer.vm")
 #end
 #**
  * Display the drawer activator with an humberger-style icon.
@@ -51,5 +49,6 @@
       aria-expanded="false" title="$escapetool.xml($services.localization.render('core.menu.drawer'))"
       ><span class="sr-only">$escapetool.xml($services.localization.render('core.menu.toggleNavigation'))</span
       >$services.icon.renderHTML('menu')</button>
+    #template("drawer.vm")
   </li>
 #end


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-18007

## PR Changes
* Changed the drawer menu position, so it gets right after its toggler.
* Updated the drawer controls to close when focusing out and pressing escape
* Moved the script from javascript.vm to flamingo.js
* Added one style rule in drawer.less to hide elements from the tab order when the drawer is closed.

## Video demo
https://up1.xwikisas.com/#BrnQdLpraMVHfWyF0be0og
## Notes
This PR takes elements from https://github.com/xwiki/xwiki-platform/pull/2075 and adds upon them more changes to fix the ticket completely.

## Tests
`mvn clean install -f xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/ -Pdocker,integration-tests,quality` failed only on NavigationIT.navigateWithKeyboardShortcuts:142 and NavigationIT.docExtraLoadingFromTabClicks:164, which are build fails as of the 16th of June.
 