### PR TITLE
XWIKI-21000: Administration Import upload input field is not labelled

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/attachmentsinline.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/attachmentsinline.vm
@@ -45,7 +45,7 @@ $xwiki.ssfx.use('js/xwiki/viewers/attachments.css', true)
     ## Temporarily disabled, until we fix attachment name handling
     ## <div><label id="xwikiuploadnamelabel" for="xwikiuploadname">$services.localization.render('core.viewers.attachments.upload.filename')</label></div>
     ## <div><input id="xwikiuploadname" type="hidden" name="filename" value="" size="40"/></div>
-    <div class="fileupload-field"><label class="hidden" for="xwikiuploadfile">$services.localization.render('core.viewers.attachments.upload.file')</label><input id="xwikiuploadfile" type="file" name="filepath" size="40" class="uploadFileInput noitems" data-max-file-size="$!escapetool.xml($xwiki.getSpacePreference('upload_maxsize'))" /></div>
+    <div class="fileupload-field"><label class="sr-only" for="xwikiuploadfile">$services.localization.render('core.viewers.attachments.upload.file')</label><input id="xwikiuploadfile" type="file" name="filepath" size="40" class="uploadFileInput noitems" data-max-file-size="$!escapetool.xml($xwiki.getSpacePreference('upload_maxsize'))" /></div>
     <div>
       <span class="buttonwrapper"><input type="submit" value="$services.localization.render('core.viewers.attachments.upload.submit')" class="button btn btn-primary"/></span>
       <span class="buttonwrapper"><a class="cancel secondary button btn btn-primary" href="$doc.getURL()">$services.localization.render('core.viewers.attachments.upload.cancel')</a></span>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/DefaultParametrizedNotificationManager.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/DefaultParametrizedNotificationManager.java
@@ -165,7 +165,6 @@ public class DefaultParametrizedNotificationManager implements ParametrizedNotif
     {
         boolean done = false;
         // Add to the results the events the user has the right to see
-        List<Event> newEvents = new ArrayList<>();
         for (Event event : batch) {
             DocumentReference document = event.getDocument();
             // 1) Don't include events concerning a doc the passed user cannot see
@@ -181,7 +180,6 @@ public class DefaultParametrizedNotificationManager implements ParametrizedNotif
 
             // Record this event
             results.add(event);
-            newEvents.add(event);
 
             int reachedSize = results.size();
 
@@ -192,7 +190,7 @@ public class DefaultParametrizedNotificationManager implements ParametrizedNotif
                 if (parameters.user != null) {
                     userReference = this.userReferenceResolver.resolve(parameters.user);
                 }
-                this.groupingEventManager.augmentCompositeEvents(compositeEvents, newEvents, userReference,
+                this.groupingEventManager.augmentCompositeEvents(compositeEvents, List.of(event), userReference,
                     parameters.groupingEventTarget);
                 reachedSize = compositeEvents.size();
             }

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/importinline.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/importinline.vm
@@ -71,7 +71,7 @@
             ## <div><label id="xwikiuploadnamelabel" for="xwikiuploadname">$services.localization.render('core.viewers.attachments.upload.filename')</label></div>
             <div><input id="xwikiuploadname" type="hidden" name="filename" value="" /></div>
             <div class="package-upload">
-              <label for="xwikiuploadfile" class="hidden">
+              <label for="xwikiuploadfile" class="sr-only">
                 $escapetool.xml($services.localization.render('core.viewers.attachments.upload.file'))
               </label>
               <input id="xwikiuploadfile" type="file" name="filepath" class="uploadFileInput noitems"


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-21000

## PR Changes
* Updated the class of the labels so they can be seen by screen reader users

## Tests
Passed successfully:
* `mvn clean install -f xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/ -Pdocker,integration-tests,quality`
* `mvn clean install -f xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/ -Pdocker,integration-tests,quality  `
* `mvn clean install -f xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/ -Pdocker,integration-tests`