### PR TITLE
XWIKI-18508: Access (view) denied randomly on pages and solr search

### DIFF
--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/DefaultAuthorizationManagerIntegrationTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/DefaultAuthorizationManagerIntegrationTest.java
@@ -79,6 +79,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -698,6 +699,21 @@ class DefaultAuthorizationManagerIntegrationTest extends AbstractAuthorizationTe
 
         assertAccess(new RightSet(List.of(LOGIN, REGISTER, VIEW, DELETE)), getXUser("userA") ,
             getXDoc("docDeleteAllowA", "any space"));
+
+        /* Test XWIKI-21013: ensure that access entries are removed when a local parent group is removed from the
+        cache. */
+        SecurityCache securityCache = this.componentManager.getInstance(SecurityCache.class);
+        UserSecurityReference subwikiGroupC =
+            this.securityReferenceFactory.newUserReference(getUser("groupC", "subwiki"));
+        UserSecurityReference userA = this.securityReferenceFactory.newUserReference(getXUser("userA"));
+        SecurityReference docC =
+            this.securityReferenceFactory.newEntityReference(getDoc("docAllowGroupC", "any space", "subwiki"));
+
+        assertNotNull(securityCache.get(subwikiGroupC));
+        assertNotNull(securityCache.get(userA, docC));
+        securityCache.remove(subwikiGroupC);
+        assertNull(securityCache.get(userA, docC));
+        assertNotNull(securityCache.get(userA));
     }
 
     @Test


### PR DESCRIPTION
* Don't fail the security cache loading when an entry cannot be inserted into the security cache.
* Bulletproof the security cache against adding non-group/user entries as parents when a group/user is required.
* Mark the main wiki entry as user to respect this model that user parents are actually user entries.

Jira issue: https://jira.xwiki.org/browse/XWIKI-18508

This PR also includes the commits from #2223 as I wouldn't dare applying this without these fixes and the changes have quite some conflicts. If you want to review this in isolation, I would suggest to just look at the most recent commit. I'll rebase this once #2223 has been merged.


