### PR TITLE
XWIKI-16150: Make livetable suggest filters accessible

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/macros.vm
@@ -355,14 +355,17 @@
     #if ("$!dateFormat" == '')
       #set ($dateFormat = $xwiki.getXWikiPreference('dateformat', 'yyyy/MM/dd HH:mm'))
     #end
+    #set($dateRangeFormat = $dateFormat + " - " + $dateFormat)
+    <div id="xwiki-livetable-${htmlLiveTableId}-filter-date-combobox-${foreach.count}-description" class='sr-only'>
+      $!escapetool.xml($services.localization.render('platform.livetable.filter.date.format.description',[$dateRangeFormat]))
+    </div>
     <div role="combobox" id="xwiki-livetable-${htmlLiveTableId}-filter-date-combobox-${foreach.count}"
       class="xwiki-livetable-display-header-filter-date-combobox" aria-expanded="false">
-      #set($dateRangeFormat = $dateFormat + " - " + $dateFormat)
       <input id="xwiki-livetable-${htmlLiveTableId}-filter-${foreach.count}" type="text"
         data-type="date" data-dateformat="$escapetool.xml($dateFormat)"
         #if ("$!columnProperties.size" != '')size="$!escapetool.xml($columnProperties.size)"#end
         title="$!filterTitle"
-        aria-description="$!escapetool.xml($services.localization.render('platform.livetable.filter.date.format.description',[$dateRangeFormat]))"/>
+        aria-describedby="xwiki-livetable-${htmlLiveTableId}-filter-date-combobox-${foreach.count}-description"/>
     </div>
   #elseif ($filterType == 'suggest' && $xproperty)
     #set ($discard = $xwiki.linkx.use($services.webjars.url('selectize.js', 'css/selectize.bootstrap3.css'),

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/macros.vm
@@ -356,7 +356,7 @@
       #set ($dateFormat = $xwiki.getXWikiPreference('dateformat', 'yyyy/MM/dd HH:mm'))
     #end
     #set($dateRangeFormat = $dateFormat + " - " + $dateFormat)
-    <div id="xwiki-livetable-${htmlLiveTableId}-filter-${foreach.count}-description" class='sr-only'>
+    <div id="xwiki-livetable-${htmlLiveTableId}-filter-${foreach.count}-description" hidden>
       $!escapetool.xml($services.localization.render('platform.livetable.filter.date.format.description',[$dateRangeFormat]))
     </div>
     <div role="combobox" id="xwiki-livetable-${htmlLiveTableId}-filter-date-combobox-${foreach.count}"

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/macros.vm
@@ -356,7 +356,7 @@
       #set ($dateFormat = $xwiki.getXWikiPreference('dateformat', 'yyyy/MM/dd HH:mm'))
     #end
     #set($dateRangeFormat = $dateFormat + " - " + $dateFormat)
-    <div id="xwiki-livetable-${htmlLiveTableId}-filter-date-combobox-${foreach.count}-description" class='sr-only'>
+    <div id="xwiki-livetable-${htmlLiveTableId}-filter-${foreach.count}-description" class='sr-only'>
       $!escapetool.xml($services.localization.render('platform.livetable.filter.date.format.description',[$dateRangeFormat]))
     </div>
     <div role="combobox" id="xwiki-livetable-${htmlLiveTableId}-filter-date-combobox-${foreach.count}"
@@ -365,7 +365,7 @@
         data-type="date" data-dateformat="$escapetool.xml($dateFormat)"
         #if ("$!columnProperties.size" != '')size="$!escapetool.xml($columnProperties.size)"#end
         title="$!filterTitle"
-        aria-describedby="xwiki-livetable-${htmlLiveTableId}-filter-date-combobox-${foreach.count}-description"/>
+        aria-describedby="xwiki-livetable-${htmlLiveTableId}-filter-${foreach.count}-description"/>
     </div>
   #elseif ($filterType == 'suggest' && $xproperty)
     #set ($discard = $xwiki.linkx.use($services.webjars.url('selectize.js', 'css/selectize.bootstrap3.css'),


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-16150
## Description
Yesterday, a PR was merged: https://github.com/xwiki/xwiki-platform/pull/2149.
However, it brought in some webstandard fails: https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/master/6746/testReport/org.xwiki.test.webstandards.framework/DefaultValidationTest/Platform_Builds___main___distribution___flavor_test_webstandards___Build_for_Flavor_Test___Webstandards______/
Here is a fix to those fails.

## PR Changes
* Replaced the `aria-description` with `aria-describedby`

## Note: 
* `aria-description` is not yet in the aria standards (in the draft for ARIA 1.3 though), so we fall back onto the very similar solution that is `aria-describedby`.