### PR TITLE
[Misc] Bump axe-core for selenium from 4.6.0 to 4.7.0

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/pom.xml
@@ -75,7 +75,7 @@
     <dependency>
       <groupId>com.deque.html.axe-core</groupId>
       <artifactId>selenium</artifactId>
-      <version>4.6.0</version>
+      <version>4.7.0</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
We currently have [issues with WCAG tests on the CI environment tests](https://ci.xwiki.org/job/XWiki%20Environment%20Tests/job/xwiki-platform/job/master/261/), and I found that it was caused by a dependency not being up-to-date. I noticed there's dependabot on xwiki-platform, but I don't know why it wouldn't bump https://mvnrepository.com/artifact/com.deque.html.axe-core/selenium that we depend on in xwiki-platform-test-ui . 

It would be great if it could start PRs for bumping this dependency's versions, is there something to fix in [the POM](https://github.com/xwiki/xwiki-platform/blob/0414805d43c29a72a31fca1fb075fdafd0c1a133/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/pom.xml#L78) ?