### PR TITLE
XWIKI-21069: Live email notifications are received in a single email at once instead of a separate email for each event

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/AbstractMimeMessageIterator.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/AbstractMimeMessageIterator.java
@@ -215,7 +215,7 @@ public abstract class AbstractMimeMessageIterator implements Iterator<MimeMessag
     protected abstract List<CompositeEvent> retrieveCompositeEventList(DocumentReference user)
         throws NotificationException;
 
-    private NotificationEmailGroupingStrategy getEmailGroupingStrategy()
+    protected NotificationEmailGroupingStrategy getEmailGroupingStrategy()
     {
         NotificationEmailGroupingStrategy strategy = this.fallbackNotificationEmailGroupingStrategy;
         String emailGroupingStrategyHint = this.notificationConfiguration.getEmailGroupingStrategyHint();

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/live/DefaultPrefilteringLiveMimeMessageIterator.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/live/DefaultPrefilteringLiveMimeMessageIterator.java
@@ -35,6 +35,7 @@ import org.xwiki.model.reference.EntityReference;
 import org.xwiki.notifications.CompositeEvent;
 import org.xwiki.notifications.GroupingEventManager;
 import org.xwiki.notifications.NotificationException;
+import org.xwiki.notifications.notifiers.email.NotificationEmailGroupingStrategy;
 import org.xwiki.notifications.notifiers.internal.email.AbstractMimeMessageIterator;
 import org.xwiki.user.UserReference;
 import org.xwiki.user.UserReferenceResolver;
@@ -60,6 +61,11 @@ public class DefaultPrefilteringLiveMimeMessageIterator extends AbstractMimeMess
     @Inject
     private LiveNotificationEmailEventFilter eventFilter;
 
+    // We used to have one email per event in live email, so we keep that strategy
+    @Inject
+    @Named("emailperevent")
+    private NotificationEmailGroupingStrategy liveEmailGroupingStrategy;
+
     private Map<DocumentReference, List<Event>> events;
 
     @Override
@@ -68,6 +74,12 @@ public class DefaultPrefilteringLiveMimeMessageIterator extends AbstractMimeMess
     {
         this.events = events;
         super.initialize(events.keySet().iterator(), factoryParameters, templateReference);
+    }
+
+    @Override
+    protected NotificationEmailGroupingStrategy getEmailGroupingStrategy()
+    {
+        return this.liveEmailGroupingStrategy;
     }
 
     /**

--- a/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.properties.vm
+++ b/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.properties.vm
@@ -1287,6 +1287,7 @@ edit.defaultEditor.org.xwiki.rendering.block.XDOM#wysiwyg=$xwikiPropertiesDefaul
 #-# The hint of the strategy component to use for email grouping notifications. Default strategy is to group all
 #-# notifications in a single email, but other strategies can be provided, e.g. to send as many emails as there was
 #-# type of notifications. Check online documentation related to notification to see the list of available strategies.
+#-# Note that this strategy does not apply to live email notifications.
 #-#
 #-# The default is :
 # notifications.emailGroupingStrategyHint = "default"


### PR DESCRIPTION
JIRA: https://jira.xwiki.org/browse/XWIKI-21069
Related forum proposal: https://forum.xwiki.org/t/change-the-default-behaviour-of-live-email-notification-in-15-5/12735/

This aims at also being merged on 15.5.x branch if it gets merged.
Integration test ok locally and manual test ok.

  * Force using the emailperevent grouping strategy in case of live email notifications