### PR TITLE
XWIKI-21083: Tag suggest feature is broken

### DIFF
--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -125,12 +125,86 @@
 
                  Single justification example:
             -->
-            
-            
-            
-            
-            
-            
+            <revapi.differences>
+              <justification>This is an actual bug from aspectj reported in https://bugs.eclipse.org/bugs/show_bug.cgi?id=582107. The impact is ok as it concerns only Deprecated annotation.</justification>
+              <criticality>allowed</criticality>
+              <differences>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.annotation.attributeRemoved</code>
+                  <old>method void com.xpn.xwiki.doc.XWikiDocument::rename(org.xwiki.model.reference.DocumentReference, com.xpn.xwiki.XWikiContext) throws com.xpn.xwiki.XWikiException @ com.xpn.xwiki.doc.LazyXWikiDocument</old>
+                  <new>method void com.xpn.xwiki.doc.XWikiDocument::rename(org.xwiki.model.reference.DocumentReference, com.xpn.xwiki.XWikiContext) throws com.xpn.xwiki.XWikiException @ com.xpn.xwiki.doc.LazyXWikiDocument</new>
+                  <annotation>@java.lang.Deprecated</annotation>
+                  <attribute>since</attribute>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.annotation.attributeRemoved</code>
+                  <old>method void com.xpn.xwiki.doc.XWikiDocument::rename(org.xwiki.model.reference.DocumentReference, java.util.List&lt;org.xwiki.model.reference.DocumentReference&gt;, com.xpn.xwiki.XWikiContext) throws com.xpn.xwiki.XWikiException @ com.xpn.xwiki.doc.LazyXWikiDocument</old>
+                  <new>method void com.xpn.xwiki.doc.XWikiDocument::rename(org.xwiki.model.reference.DocumentReference, java.util.List&lt;org.xwiki.model.reference.DocumentReference&gt;, com.xpn.xwiki.XWikiContext) throws com.xpn.xwiki.XWikiException @ com.xpn.xwiki.doc.LazyXWikiDocument</new>
+                  <annotation>@java.lang.Deprecated</annotation>
+                  <attribute>since</attribute>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.annotation.attributeRemoved</code>
+                  <old>method void com.xpn.xwiki.doc.XWikiDocument::rename(org.xwiki.model.reference.DocumentReference, java.util.List&lt;org.xwiki.model.reference.DocumentReference&gt;, java.util.List&lt;org.xwiki.model.reference.DocumentReference&gt;, com.xpn.xwiki.XWikiContext) throws com.xpn.xwiki.XWikiException @ com.xpn.xwiki.doc.LazyXWikiDocument</old>
+                  <new>method void com.xpn.xwiki.doc.XWikiDocument::rename(org.xwiki.model.reference.DocumentReference, java.util.List&lt;org.xwiki.model.reference.DocumentReference&gt;, java.util.List&lt;org.xwiki.model.reference.DocumentReference&gt;, com.xpn.xwiki.XWikiContext) throws com.xpn.xwiki.XWikiException @ com.xpn.xwiki.doc.LazyXWikiDocument</new>
+                  <annotation>@java.lang.Deprecated</annotation>
+                  <attribute>since</attribute>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.annotation.attributeRemoved</code>
+                  <old>method void com.xpn.xwiki.doc.XWikiDocument::rename(org.xwiki.model.reference.DocumentReference, com.xpn.xwiki.XWikiContext) throws com.xpn.xwiki.XWikiException</old>
+                  <new>method void com.xpn.xwiki.doc.XWikiDocument::rename(org.xwiki.model.reference.DocumentReference, com.xpn.xwiki.XWikiContext) throws com.xpn.xwiki.XWikiException</new>
+                  <annotation>@java.lang.Deprecated</annotation>
+                  <attribute>since</attribute>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.annotation.attributeRemoved</code>
+                  <old>method void com.xpn.xwiki.doc.XWikiDocument::rename(org.xwiki.model.reference.DocumentReference, java.util.List&lt;org.xwiki.model.reference.DocumentReference&gt;, com.xpn.xwiki.XWikiContext) throws com.xpn.xwiki.XWikiException</old>
+                  <new>method void com.xpn.xwiki.doc.XWikiDocument::rename(org.xwiki.model.reference.DocumentReference, java.util.List&lt;org.xwiki.model.reference.DocumentReference&gt;, com.xpn.xwiki.XWikiContext) throws com.xpn.xwiki.XWikiException</new>
+                  <annotation>@java.lang.Deprecated</annotation>
+                  <attribute>since</attribute>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.annotation.attributeRemoved</code>
+                  <old>method void com.xpn.xwiki.doc.XWikiDocument::rename(org.xwiki.model.reference.DocumentReference, java.util.List&lt;org.xwiki.model.reference.DocumentReference&gt;, java.util.List&lt;org.xwiki.model.reference.DocumentReference&gt;, com.xpn.xwiki.XWikiContext) throws com.xpn.xwiki.XWikiException</old>
+                  <new>method void com.xpn.xwiki.doc.XWikiDocument::rename(org.xwiki.model.reference.DocumentReference, java.util.List&lt;org.xwiki.model.reference.DocumentReference&gt;, java.util.List&lt;org.xwiki.model.reference.DocumentReference&gt;, com.xpn.xwiki.XWikiContext) throws com.xpn.xwiki.XWikiException</new>
+                  <annotation>@java.lang.Deprecated</annotation>
+                  <attribute>since</attribute>
+                </item>
+              </differences>
+            </revapi.differences>
+            <revapi.differences>
+              <justification>APIs moved to legacy but as we're analyzing transitive dependencies some other modules are reporting them.</justification>
+              <criticality>allowed</criticality>
+              <differences>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.removed</code>
+                  <old>method void com.xpn.xwiki.XWiki::renameByCopyAndDelete(com.xpn.xwiki.doc.XWikiDocument, org.xwiki.model.reference.DocumentReference, java.util.List&lt;org.xwiki.model.reference.DocumentReference&gt;, java.util.List&lt;org.xwiki.model.reference.DocumentReference&gt;, com.xpn.xwiki.XWikiContext) throws com.xpn.xwiki.XWikiException</old>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.removed</code>
+                  <old>method void com.xpn.xwiki.doc.XWikiDocument::rename(org.xwiki.model.reference.DocumentReference, com.xpn.xwiki.XWikiContext) throws com.xpn.xwiki.XWikiException</old>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.removed</code>
+                  <old>method void com.xpn.xwiki.doc.XWikiDocument::rename(org.xwiki.model.reference.DocumentReference, java.util.List&lt;org.xwiki.model.reference.DocumentReference&gt;, com.xpn.xwiki.XWikiContext) throws com.xpn.xwiki.XWikiException</old>
+                </item>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.method.removed</code>
+                  <old>method void com.xpn.xwiki.doc.XWikiDocument::rename(org.xwiki.model.reference.DocumentReference, java.util.List&lt;org.xwiki.model.reference.DocumentReference&gt;, java.util.List&lt;org.xwiki.model.reference.DocumentReference&gt;, com.xpn.xwiki.XWikiContext) throws com.xpn.xwiki.XWikiException</old>
+                </item>
+              </differences>
+            </revapi.differences>
           </analysisConfiguration>
         </configuration>
       </plugin>

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/documentTags.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/documentTags.vm
@@ -109,9 +109,11 @@
 ## Note that the form_token parameter needs to be kept before the xredirect parameter since the JS code might replace the latter
 ## All that would need a cleaner fix in the javascript of tags.
 <form action="$doc.getURL('view', "xpage=documentTags&amp;xaction=add&amp;form_token=$!{escapetool.url($services.csrf.token)}&amp;xredirect=${xredirect}")" method="post" class="tag-add-form">
-  <div>
+  <div id="tag-add-form-suggest">
     <label for="tag">$services.localization.render('core.tags.add.label')<br/>
-      <input class="input-tag" type="text" id="tag" name="tag" autocomplete="off"/></label><br/>
+      <input class="input-tag" type="text" id="tag" name="tag" autocomplete="off"/></label>
+  </div>
+  <div>
     <span class="buttonwrapper"><input class="button button-add-tag" type="submit" value="$services.localization.render('core.tags.add.submit')"/></span>
     <span class="buttonwrapper"><a class="button button-add-tag-cancel" href="$doc.getURL('view', "#${tagsId}")">$services.localization.render('core.tags.add.cancel')</a></span>
   </div>

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/documentTags.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/documentTags.vm
@@ -111,7 +111,8 @@
 <form action="$doc.getURL('view', "xpage=documentTags&amp;xaction=add&amp;form_token=$!{escapetool.url($services.csrf.token)}&amp;xredirect=${xredirect}")" method="post" class="tag-add-form">
   <div id="tag-add-form-suggest">
     <label for="tag">$services.localization.render('core.tags.add.label')<br/>
-      <input class="input-tag" type="text" id="tag" name="tag" autocomplete="off"/></label>
+      <input class="input-tag" type="text" id="tag" name="tag" autocomplete="off"/>
+    </label>
   </div>
   <div>
     <span class="buttonwrapper"><input class="button button-add-tag" type="submit" value="$services.localization.render('core.tags.add.submit')"/></span>

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggest.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggest.js
@@ -730,7 +730,9 @@ var XWiki = (function(XWiki){
         noHighlight: true, // we do the highlighting ourselves
         containerTagName: 'a'
       });
-      if (arr[i].url == null)  item.containerElement.setAttribute('href', '#0');
+      if (arr[i].url == null)  {
+        item.containerElement.setAttribute('href', 'javascript:void()');
+      }
       else item.containerElement.setAttribute('href', arr[i].url);
       item.listItemElement.addEventListener('focusin', (event) => pointer.setHighlight(event.currentTarget));
       list.addItem(item);

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggest.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggest.js
@@ -731,7 +731,7 @@ var XWiki = (function(XWiki){
         containerTagName: 'a'
       });
       if (arr[i].url == null)  {
-        item.containerElement.setAttribute('href', 'javascript:void()');
+        item.containerElement.setAttribute('href', 'javascript:void(0)');
       }
       else item.containerElement.setAttribute('href', arr[i].url);
       item.listItemElement.addEventListener('focusin', (event) => pointer.setHighlight(event.currentTarget));

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggest.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggest.js
@@ -244,7 +244,6 @@ var XWiki = (function(XWiki){
     var checkPropagation = true;
 
     switch(key) {
-      case 32: // The space key
       case Event.KEY_RETURN:
         if (!this.iHighlighted && (Object.keys(this.aSuggestions).length == 1 && this.aSuggestions[Object.keys(this.aSuggestions)[0]].length == 1)) {
           this.highlightFirst();

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggest.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggest.js
@@ -730,6 +730,7 @@ var XWiki = (function(XWiki){
         noHighlight: true, // we do the highlighting ourselves
         containerTagName: 'a'
       });
+      // When the url is empty, we need to put a correct default value to avoid unexpected page loads/reloads
       item.containerElement.setAttribute('href', arr[i].url || 'javascript:void(0)');
       item.listItemElement.addEventListener('focusin', (event) => pointer.setHighlight(event.currentTarget));
       list.addItem(item);

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggest.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggest.js
@@ -244,6 +244,7 @@ var XWiki = (function(XWiki){
     var checkPropagation = true;
 
     switch(key) {
+      case 32: // The space key
       case Event.KEY_RETURN:
         if (!this.iHighlighted && (Object.keys(this.aSuggestions).length == 1 && this.aSuggestions[Object.keys(this.aSuggestions)[0]].length == 1)) {
           this.highlightFirst();
@@ -730,7 +731,8 @@ var XWiki = (function(XWiki){
         noHighlight: true, // we do the highlighting ourselves
         containerTagName: 'a'
       });
-      item.containerElement.setAttribute('href', arr[i].url);
+      if (arr[i].url == null)  item.containerElement.setAttribute('href', '#0');
+      else item.containerElement.setAttribute('href', arr[i].url);
       item.listItemElement.addEventListener('focusin', (event) => pointer.setHighlight(event.currentTarget));
       list.addItem(item);
     }

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/viewers/tags.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/viewers/tags.css
@@ -48,7 +48,7 @@ a.tag-delete, a.tag-delete:visited {
   vertical-align: top !important;
   z-index: 1000;
 }
-.tag-add-form div {
+.tag-add-form > div {
   background: $theme.backgroundSecondaryColor;
   overflow: hidden;
   padding: 4px 8px;

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/viewers/tags.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/viewers/tags.js
@@ -169,7 +169,7 @@ viewers.Tags = Class.create({
 
     new XWiki.widgets.Suggest(form.down('input[type=text]'), {
       script: "${xwiki.getURL('Main.WebHome', 'view', 'xpage=suggest&classname=XWiki.TagClass&fieldname=tags&firCol=-&secCol=-')}&",
-      parentContainer:"tag-add-form-suggest",
+      parentContainer: 'tag-add-form-suggest',
       varname: 'input',
       seps: "${xwiki.getDocument('XWiki.TagClass').xWikiClass.tags.getProperty('separators').value}",
       shownoresults : false,

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/viewers/tags.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/viewers/tags.js
@@ -169,7 +169,7 @@ viewers.Tags = Class.create({
 
     new XWiki.widgets.Suggest(form.down('input[type=text]'), {
       script: "${xwiki.getURL('Main.WebHome', 'view', 'xpage=suggest&classname=XWiki.TagClass&fieldname=tags&firCol=-&secCol=-')}&",
-      parentContainer: 'tag-add-form-suggest',
+      parentContainer: 'tag-add-form-suggest', // Generate the suggest drop-down at a correct place in the DOM for easy keyboard access.
       varname: 'input',
       seps: "${xwiki.getDocument('XWiki.TagClass').xWikiClass.tags.getProperty('separators').value}",
       shownoresults : false,

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/viewers/tags.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/viewers/tags.js
@@ -169,6 +169,7 @@ viewers.Tags = Class.create({
 
     new XWiki.widgets.Suggest(form.down('input[type=text]'), {
       script: "${xwiki.getURL('Main.WebHome', 'view', 'xpage=suggest&classname=XWiki.TagClass&fieldname=tags&firCol=-&secCol=-')}&",
+      parentContainer:"tag-add-form-suggest",
       varname: 'input',
       seps: "${xwiki.getDocument('XWiki.TagClass').xWikiClass.tags.getProperty('separators').value}",
       shownoresults : false,


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-21083

## PR Changes
* Now using  `javascript:void(0)` instead of `null` for an empty URL
* (extra Accessibility) Updated the DOM to properly generate the suggest element
* (extra Accessibility) Updated style to avoid visual changes related to the DOM changes

## Video demo
Used keyboard only to choose tags. It'd be similar with a mouse.
https://up1.xwikisas.com/#0ig--RpKFzgBJ3ES2Yd6Ew

## Notes
It's not a good thing to have an anchor with an empty URL, so there is no perfectly clean solution to make those and I chose to go with the `javascript:void(0)` which has some impact on performance, very minimal but still here.
The better technical solution would have been to replace the anchor with a button in the case there's no URL, however it would have brought a lot of changes in the way the suggest currently works and would have probably needed an overhaul of this UI component.
Since this issue is a huge blocker, I decided to go with a correct solution here instead of the technically perfect one.