### PR TITLE
XWIKI-21108: "Border" of the page content area in edit mode is not of…

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
@@ -233,7 +233,7 @@
 
 #xwikieditor .main {
   background-color: @xwiki-page-content-bg;
-  box-shadow: 0 1px 2px @input-border;
+  box-shadow: 0 1px 2px @xwiki-border-color;
 }
 
 #xwikieditcontent .main {


### PR DESCRIPTION
… the same color as in view mode

* Reset the color of the border of the content area in edit mode to xwiki-border-color instead of input-border