### PR TITLE
XWIKI-21154: Lack of space in the bottom of the login form

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/misc.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/misc.less
@@ -218,6 +218,7 @@ div.suggestItems .hide-button {
   .submitSection {
     display: flex;
     flex-flow: row wrap;
+    gap: 1em;
   }
 }
 


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-21154

## PR Change
* Added a gap in between the login form submit button and the recovery anchors

## Note
I made this gap 1em large, but this is completely arbitrary.

## Visuals
![18859-2-After](https://github.com/xwiki/xwiki-platform/assets/28761965/dd35138f-2c6d-488d-98be-ad8b9cc4c96f)
vvv with the box model highlighted vvv
![18859-2-After2](https://github.com/xwiki/xwiki-platform/assets/28761965/23535669-0fc2-41af-92ef-f06ec5e9b6c5)