### PR TITLE
XWIKI-21019: Inplace edit summary form lacks a visible accessible name

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editactions.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editactions.vm
@@ -53,7 +53,7 @@
         #if ($xwiki.isEditCommentFieldHidden())
           <input type="hidden" name="comment" id="comment" value="$!{escapetool.xml($request.comment)}" />
         #else
-          <label class="hidden" for="commentinput">$services.localization.render('core.comment')</label>
+          <label class="sr-only" for="commentinput">$services.localization.render('core.comment')</label>
           <input type="text" name="comment" id="commentinput" value="$!{escapetool.xml($request.comment)}" size="40"
             title="$!escapetool.xml($services.localization.render('core.comment.tooltip'))"
             placeholder="$!escapetool.xml($services.localization.render('core.comment.hint'))"


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-21019
## PR Changes
* Changed the class of the label from `hidden` to `sr-only`

## View
No visual change