### PR TITLE
XWIKI-20997: Invitation displayActionConfirmationForm displays unlabelled form elements

### DIFF
--- a/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/main/resources/Invitation/InvitationCommon.xml
+++ b/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/main/resources/Invitation/InvitationCommon.xml
@@ -361,7 +361,7 @@
     ##
     &lt;dl&gt;
      &lt;dt&gt;&lt;label for="memo"&gt;$memoLabel&lt;/label&gt;&lt;/dt&gt;
-     &lt;dd&gt;&lt;input type="text" size="54" name="memo" /&gt;&lt;/dd&gt;
+     &lt;dd&gt;&lt;input id='memo' type="text" size="54" name="memo" /&gt;&lt;/dd&gt;
     &lt;/dl&gt;
     &lt;div class="bottombuttons"&gt;
      &lt;div class="buttons"&gt;

--- a/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/main/resources/Invitation/InvitationMembersCommon.xml
+++ b/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/main/resources/Invitation/InvitationMembersCommon.xml
@@ -81,6 +81,7 @@
   #else
 
     (%class="message-table"%)(((
+     #set($checkboxCount = 0)
      #foreach($field in $fieldsToDisplay)
        #if($field == '_history')
          |=(%class="history"%)$services.localization.render('xe.invitation.displayMessageTable.history')##
@@ -95,7 +96,6 @@
        #end
      #end
 
-     #set($checkboxCount = 0)
      #foreach($message in $messages)
        #foreach($field in $fieldsToDisplay)
          #if($field == 'sendingUser')
@@ -124,8 +124,8 @@
            |$services.localization.render('xe.invitation.displayMessageTable.multipleRecipients',
                      [$numberOfRecipientsByMessage.get($message.get('recipient'))])
          #elseif($field == '_checkbox')
-           |&lt;label for="messageCheckboxID$checkboxCount"&gt;
-             $escapetool.xml($services.localization.render('xe.invitation.displayMessageTable.checkbox.input.label', [$checkboxCount]))
+           |&lt;label for="messageCheckboxID$checkboxCount" class='sr-only'&gt;
+             $escapetool.xml($services.localization.render('xe.invitation.displayMessageTable.checkbox.input.label'))
            &lt;/label&gt;
            &lt;input type="checkbox" id="messageCheckboxID$checkboxCount" name="messageCheckboxID$checkboxCount"
             value="$message.getProperty('messageID').getValue()" ##

--- a/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/main/resources/Invitation/InvitationMembersCommon.xml
+++ b/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/main/resources/Invitation/InvitationMembersCommon.xml
@@ -95,6 +95,7 @@
        #end
      #end
 
+     #set($checkboxCount = 0)
      #foreach($message in $messages)
        #foreach($field in $fieldsToDisplay)
          #if($field == 'sendingUser')
@@ -123,8 +124,13 @@
            |$services.localization.render('xe.invitation.displayMessageTable.multipleRecipients',
                      [$numberOfRecipientsByMessage.get($message.get('recipient'))])
          #elseif($field == '_checkbox')
-           |&lt;input type="checkbox" name="messageID" value="$message.getProperty('messageID').getValue()" ##
-           ## If there is only one message in the group, add the convienence of checking the box by default.
+           |&lt;label for="messageCheckboxID$checkboxCount"&gt;
+             $escapetool.xml($services.localization.render('xe.invitation.displayMessageTable.checkbox.input.label', [$checkboxCount]))
+           &lt;/label&gt;
+           &lt;input type="checkbox" id="messageCheckboxID$checkboxCount" name="messageCheckboxID$checkboxCount"
+            value="$message.getProperty('messageID').getValue()" ##
+           #set($checkboxCount = $checkboxCount + 1)
+           ## If there is only one message in the group, add the convenience of checking the box by default.
            #if($messages.size() == 1)
              checked="checked" ##
            #end

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -2621,7 +2621,7 @@ xe.invitation.displayMessageTable.recipient=Email
 xe.invitation.displayMessageTable.history=Message History
 xe.invitation.displayMessageTable.showHistory=Show History
 xe.invitation.displayMessageTable.multipleRecipients={0} Recipients
-xe.invitation.displayMessageTable.checkbox.input.label=Checkbox message n.[{0}]
+xe.invitation.displayMessageTable.checkbox.input.label=Select this invitation
 xe.invitation.displayMessageTable.various=<various>
 xe.invitation.displayMessageTable.noMessages=No messages to display
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -2621,6 +2621,7 @@ xe.invitation.displayMessageTable.recipient=Email
 xe.invitation.displayMessageTable.history=Message History
 xe.invitation.displayMessageTable.showHistory=Show History
 xe.invitation.displayMessageTable.multipleRecipients={0} Recipients
+xe.invitation.displayMessageTable.checkbox.input.label=Checkbox message n.[{0}]
 xe.invitation.displayMessageTable.various=<various>
 xe.invitation.displayMessageTable.noMessages=No messages to display
 


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-20997
## PR Changes
* Added a label to the checkbox input field
* Added an id to the memo field, in order for its label to be paired properly

## Tests
Passed the build: 
* `mvn clean install -f xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui -Pdocker,integration-tests,quality -Dxwiki.test.ui.wcag=true`