### PR TITLE
XWIKI-19128: burger menu does not have a description

### DIFF
--- a/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
@@ -1249,7 +1249,9 @@ require(['jquery','xwiki-l10n!menu-ui-translation-keys'], function($, l10n) {
     (% class="navbar-header" %)(((
       {{html}}
         &lt;button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#$!{escapetool.xml($id)}" aria-expanded="false"&gt;
-          &lt;span class="sr-only"&gt;&lt;/span&gt;
+          &lt;span class="sr-only"&gt;
+            $escapetool.xml($services.localization.render('menu.ui.horizontal.toggler.description'))
+          &lt;/span&gt;
           &lt;span class="icon-bar"&gt;&lt;/span&gt;
           &lt;span class="icon-bar"&gt;&lt;/span&gt;
           &lt;span class="icon-bar"&gt;&lt;/span&gt;

--- a/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
@@ -1248,7 +1248,8 @@ require(['jquery','xwiki-l10n!menu-ui-translation-keys'], function($, l10n) {
   aria-label="${services.rendering.escape($label, 'xwiki/2.1')}" %)(((
     (% class="navbar-header" %)(((
       {{html}}
-        &lt;button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#$!{escapetool.xml($id)}" aria-expanded="false"&gt;
+        &lt;button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#$!{escapetool.xml($id)}"
+          aria-expanded="false" aria-controls="$!{escapetool.xml($id)}"&gt;
           &lt;span class="sr-only"&gt;
             $escapetool.xml($services.localization.render('menu.ui.horizontal.toggler.description'))
           &lt;/span&gt;

--- a/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuTranslations.xml
+++ b/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuTranslations.xml
@@ -89,6 +89,7 @@ rendering.macro.menu.content.description=Define the menu structure using wiki sy
 # Menu UI
 menu.ui.openSubMenu=Open the submenu.
 menu.ui.closeSubMenu=Close the submenu.
+menu.ui.horizontal.toggler.description=Toggle the horizontal menu.
 
 # Menu WebHome
 menu.description=This is a simple application that helps you create navigation menus to be displayed either horizontally as a top bar after the page header or vertically in a side panel.</content>


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-19128
## PR Changes
* Added an escaped and translated textual content to the menu.
* Added an aria-controls attribute for improved semantics
## Note
We can just add this content to an already existing element that was empty (for no reason? probably forgot to fill it up after https://github.com/xwiki/xwiki-platform/commit/b22c0a82bf65f9e4d2d84fadad4e7d5bada37b25 ).
## View
No visual change