### PR TITLE
XWIKI-20984: Invitation decline link lacks contrast

### DIFF
--- a/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/main/resources/Invitation/InvitationConfig.xml
+++ b/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/main/resources/Invitation/InvitationConfig.xml
@@ -373,7 +373,7 @@
       <messageBodyTemplate>{{velocity}}
 #set($discard = "#template('colorThemeInit.vm')")
 #if("$!theme" == "")
- #set($theme = {"linkColor":"#4791BC"})
+ #set($theme = {"linkColor":"#4791BC", "notificationErrorColor":"#ca302c"})
 #end
 #set($userName = $xwiki.getUserName($xcontext.getUser(), false))
 #set($wikiName = $xwiki.getRequestURL().replaceAll("http://([^/:]*).*$", "$1"))
@@ -381,7 +381,8 @@
 #set($linkStyle = "color:$theme.get('linkColor');text-decoration:none;")
 #set($bigText = "font-size:130%;")
 #set($joinLink = "float:left;")
-#set($declineLink = "color:#f88;float:right;text-decoration:none;")
+#set($dangerColor = $theme.notificationErrorColor)
+#set($declineLink = "color:$dangerColor;float:right;text-decoration:none;")
 
 $services.localization.render('xe.invitation.emailContent.userHasInvitedYouToJoinWiki', [$userName, $wikiName])
 


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-20984

## PR Changes
* Updated decline message color to follow color theme (danger color)

## Note
It was a hardcoded color, which is against the code style. However we could argue that the color theme should not influence the style of the invitation sent. It's part of the UI here, so it's important to change, and I don't think it'd have nefarious consequences to follow codestyle here.

## View
![20984-ViewAfter](https://github.com/xwiki/xwiki-platform/assets/28761965/145d2d25-6fae-430e-abdb-8f76343a6825)
