### PR TITLE
XWIKI-20987: Admin Navigation Panel excluded page 'None' lacks contrast

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/variablesInit.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/variablesInit.vm
@@ -237,6 +237,8 @@
   ## Make sure the links are dark enough in the tmDrawer
   @navbar-default-link-color:           #727272;
   @navbar-default-color:                #727272;
+  ## Make sure the placeholder are not too light (the default from bootstrap is #999, which does not have enough contrast with a white bg)
+  @input-color-placeholder:             #727272;
   ## Make sure the breadcrumb links are dark enough
   @breadcrumb-active-color:             #707070;
   @breadcrumb-color:                    #707070;

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemes/Iceberg.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemes/Iceberg.xml
@@ -973,6 +973,8 @@
 @gray-light: #727272;
 /* Gray-light is too light on a light backgrounds. @gray for muted text is easier to read. */
 @text-muted: @gray;
+/* Input-color-placeholder is hardcoded in bootstrap, we need to override it. */
+@input-color-placeholder: @gray-light;
 
 /* Drawer */
 @xwiki-drawer-menu-item-hover-bg: @list-group-hover-bg;


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-20987
## PR Changes
* Fixed the 'None' block text color

## Note
Updated on Iceberg color theme, and for the absence of color theme (triggered on accessibility tests) The change in value is from `#999999` to  `#727272`.
## View
![20987-ViewAfter](https://github.com/xwiki/xwiki-platform/assets/28761965/97b3db21-10f3-4f12-b1e6-8b2d2535fa03)
