### PR TITLE
XWIKI-21104: Panel background color from the color theme is not kept for the edit mode panels, which can break contrast

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -823,7 +823,7 @@ $fn
 <h1 class="xwikipaneltitle#if ($isHeaderHidden) hidden#end">$title</h1>
 <div class="xwikipanelcontents">
 #else
-(% class="#if ($isLarge)large#{end}panel expanded $!specialClassAttribute $!deprecatedClassAttribute" %)(((
+(% class="#if ($isLarge)large #{end}panel expanded $!specialClassAttribute $!deprecatedClassAttribute" %)(((
 {{html}}<h1 class="xwikipaneltitle#if ($isHeaderHidden) hidden#end">$title</h1>{{/html}}
 (% class="xwikipanelcontents" %)(((
 #end


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-21104
## PR Changes: 
* Added a space between the classes for large panels
## View
We can see that the edit mode (right) panels now follow the proper style for panels, just like view mode (left).
![21104-ViewAfter2](https://github.com/xwiki/xwiki-platform/assets/28761965/a87bf412-c77e-4d9a-9152-0d75ccf853fb)
The classes are now properly space separated.
![21104-ViewAfter](https://github.com/xwiki/xwiki-platform/assets/28761965/1c0cac99-5751-45aa-ba17-6e2ef096776a)
