### PR TITLE
XWIKI-21039: Don't dispose security cache entries hierarchically when the cache is full

### DIFF
--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/cache/internal/IllegalCacheStateException.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/cache/internal/IllegalCacheStateException.java
@@ -1,0 +1,39 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.security.authorization.cache.internal;
+
+/**
+ * Exception thrown when the cache is in an illegal state.
+ *
+ * @version $Id$
+ * @since 15.6RC1
+ */
+public class IllegalCacheStateException extends RuntimeException
+{
+    /**
+     * Constructor with a message but no cause.
+     *
+     * @param message the message
+     */
+    public IllegalCacheStateException(String message)
+    {
+        super(message);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/cache/internal/DefaultSecurityCacheTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/cache/internal/DefaultSecurityCacheTest.java
@@ -825,7 +825,7 @@ class DefaultSecurityCacheTest extends AbstractSecurityTestCase
             }
         }
 
-        // For a GC to try emptying the reference map as much as possible to purge the docRef/userRef access entry.
+        // Force a GC to try emptying the reference map as much as possible to purge the docRef/userRef access entry.
         // All "internal" entries should be kept as they should be referenced through parents of the access entries
         // still in the cache.
         System.gc();

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/cache/internal/DefaultSecurityCacheTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/cache/internal/DefaultSecurityCacheTest.java
@@ -214,7 +214,9 @@ class DefaultSecurityCacheTest extends AbstractSecurityTestCase
             for (GroupSecurityReference group : groupRefs.keySet()) {
                 if (groupRefs.get(group).contains(user.getReference())) {
                     if (group.getOriginalReference().getWikiReference()
-                        .equals(user.getWikiReference().getOriginalWikiReference())) {
+                        .equals(user.getWikiReference().getOriginalWikiReference())
+                        || group.isGlobal())
+                    {
                         groups.add(group);
                     }
                 }
@@ -813,20 +815,26 @@ class DefaultSecurityCacheTest extends AbstractSecurityTestCase
         entries.putAll(InsertEntities());
         entries.putAll(InsertAccess());
 
-        final Map<SecurityReference, String> keys = new HashMap<SecurityReference, String>();
-
         for (Map.Entry<String, SecurityEntry> entry : entries.entrySet()) {
-            if (entry.getValue() instanceof SecurityRuleEntry) {
-                keys.put(entry.getValue().getReference(), entry.getKey());
+            // Remove all "internal" entries and remove one access entry for the docRef/userRef.
+            if (!(entry.getValue() instanceof SecurityAccessEntry)
+                || (entry.getValue().getReference() == this.docRef
+                && ((SecurityAccessEntry) entry.getValue()).getUserReference() == this.userRef))
+            {
+                this.cache.remove(entry.getKey());
             }
         }
 
-        removerTest(entries, new Remover()
+        // For a GC to try emptying the reference map as much as possible to purge the docRef/userRef access entry.
+        // All "internal" entries should be kept as they should be referenced through parents of the access entries
+        // still in the cache.
+        System.gc();
+
+        checkEntries(entries, new Keeper()
         {
-            @Override
-            public void remove(SecurityReference ref)
+            public boolean keepAccess(SecurityAccessEntry entry)
             {
-                cache.remove(keys.get(ref));
+                return entry.getReference() != docRef || entry.getUserReference() != userRef;
             }
         });
     }


### PR DESCRIPTION
* Add a reference map to store entries that are needed for the hierarchy but that are no longer in the cache.
* Use weak references for children to allow children to just disappear and to allow the GC to remove the parts of the hierarchy that are no longer referenced by the cache.
* Don't trigger hierarchical cache invalidation when an entry is removed from the cache.
* Fix adding shadow parents in the security cache test.
* Modify the tests to expect the new behavior of not triggering hierarchical removal when entries are removed from the cache.

Jira issue: https://jira.xwiki.org/browse/XWIKI-21039