### PR TITLE
XWIKI-20990: User profile select for showing hidden elements lacks an accessible name

### DIFF
--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserPreferencesSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserPreferencesSheet.xml
@@ -254,7 +254,7 @@
   #set ($escapedSelectId = $escapetool.xml("XWiki.XWikiUsers_0_${fieldName}"))
   #set ($escapedHintId = $escapedSelectId + "_hint")
   &lt;dt&gt;
-    &lt;label for="$escapedSelectId"&gt;$!escapetool.xml($services.localization.render($label))&lt;/label&gt;
+    &lt;label #if($isEdit)for="$escapedSelectId"#end&gt;$!escapetool.xml($services.localization.render($label))&lt;/label&gt;
     #if ($services.localization.get($hintKey))
       &lt;span id="$escapedHintId" class='xHint'&gt;$!escapetool.xml($services.localization.render($hintKey))&lt;/span&gt;
     #end


### PR DESCRIPTION
**Jira:** https://jira.xwiki.org/browse/XWIKI-20990

## PR Changes
* Fixed web standard error on view mode

## Note
The 'for' attribute of the label did not point to any id in view mode.

## View
Edit mode (unchanged):
![20990-2-Editmode](https://github.com/xwiki/xwiki-platform/assets/28761965/598c3401-0580-4861-92ff-e1881f87d440)
View mode: no `for` attribute on the label
![20990-2-Viewmode](https://github.com/xwiki/xwiki-platform/assets/28761965/db5f4f9b-1554-477f-a77c-80d9fb6c9d90)
