### PR TITLE
XWIKI-20979: Add a quick action for inserting an icon

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/config/bundleConfiguration.json
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/config/bundleConfiguration.json
@@ -29,6 +29,16 @@
         "**/*.min.*",
         "**/plugin.js"
       ]
+    },
+    {
+      "name": "xwiki-icon/icon.bundle.min.js",
+      "includes": [
+        "xwiki-icon/*.js"
+      ],
+      "excludes": [
+        "**/*.min.*",
+        "**/plugin.js"
+      ]
     }
   ]
 }

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-icon/iconService.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-icon/iconService.js
@@ -1,0 +1,67 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+define('xwiki-iconService', [
+  'jquery',
+], function ($) {
+
+  /**
+   * Generate an URL for getting JSON resources about icons.
+   */
+  const getResourceURL = function (action, parameters) {
+    const params = Object.assign({outputSyntax: "plain", action: action}, parameters);
+    return (new XWiki.Document('IconPicker', 'IconThemesCode')).getURL('get', $.param(params), true);
+  };
+
+  let cachedIconThemes = false;
+  const getIconThemes = function () {
+    return new Promise(function (resolve, reject) {
+
+      if (cachedIconThemes) {
+        return resolve(cachedIconThemes);
+      }
+
+      $.getJSON(getResourceURL('data_iconthemes'), function (data) {
+        cachedIconThemes = data;
+        resolve(data);
+      }).fail(reject);
+    });
+  };
+
+  const cachedIcons = {};
+  const getIcons = function (iconTheme) {
+    return new Promise(function (resolve, reject) {
+
+      if (cachedIcons[iconTheme]) {
+        resolve(cachedIcons[iconTheme]);
+      }
+
+      $.getJSON(getResourceURL('data_icons', {iconTheme}), function (dataIcons) {
+        cachedIcons[iconTheme] = dataIcons;
+        resolve(dataIcons);
+      }).fail(reject);
+    });
+  };
+
+  return {
+    getIconThemes,
+    getIcons,
+  };
+});

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-icon/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-icon/plugin.js
@@ -1,0 +1,79 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+(function () {
+  'use strict';
+
+  CKEDITOR.plugins.add('xwiki-icon', {
+    init: function (editor) {
+      editor.config.mentions = editor.config.mentions || [];
+      // Icon Autocomplete
+      editor.config.mentions.push({
+        marker: `icon::`,
+        pattern: new RegExp('icon::\\S{0,30}$'),
+        minChars: 0,
+        itemsLimit: 0,
+        itemTemplate: `<li data-id="{id}">
+            <div class="ckeditor-autocomplete-item-head">
+              <span class="ckeditor-autocomplete-item-icon-wrapper">` +
+                // We use aria-hidden="true" and role="presentation" for the icon display
+                // because it is redundant with the label that is shown next to it.
+                `<span class="{iconClass}" aria-hidden="true"></span>
+                <img src="{imgSrc}" role="presentation"></img>
+              </span>
+              <span class="ckeditor-autocomplete-item-label">{label}</span>
+            </div>
+          </li>`,
+        feed: function (opts, callback) {
+          require(['xwiki-iconService'], function (iconService) {
+            iconService.getIconThemes().then(function (iconThemes) {
+              // Retreive the list of available icons.
+              iconService.getIcons(iconThemes.currentIconTheme).then(function (icons) {
+                callback(icons
+                  .filter(icon => icon.name.toLowerCase().startsWith(opts.query.toLowerCase()))
+                  .map(icon => ({
+                    id: icon.name,
+                    label: icon.name,
+                    imgSrc: icon.metadata.url,
+                    iconClass: icon.metadata.cssClass
+                  }))
+                );
+              }).catch(function () {
+              editor.showNotification(editor.localization.get('xwiki-icon.iconsFetchFailed'), 'warning', 5000);
+            });
+            }).catch(function () {
+              editor.showNotification(editor.localization.get('xwiki-icon.iconThemesFetchFailed'), 'warning', 5000);
+            });
+          });
+        },
+        outputTemplate: function (item) {
+          editor.execCommand('xwiki-macro-insert', {
+            name: "displayIcon",
+            parameters: {
+              name: item.id,
+            },
+            // Displaying the macro inline allows to write text around the icon after insertion.
+            inline: "enforce",
+          });
+          return "";
+        }
+      });
+    },
+  });
+})();

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-slash/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-slash/plugin.js
@@ -724,6 +724,13 @@
           outputHTML: '/img::'
         }, {
           group: 'Content',
+          id: 'icon',
+          name: editor.localization.get('xwiki-slash.action.icon.name'),
+          iconClass: 'fa fa-image',
+          description: editor.localization.get('xwiki-slash.action.icon.hint'),
+          outputHTML: 'icon::'
+        }, {
+          group: 'Content',
           id: 'mention',
           name: editor.localization.get('xwiki-slash.action.mention.name'),
           iconClass: 'fa fa-user-o',

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/AllIT.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/AllIT.java
@@ -67,4 +67,5 @@ public class AllIT
     class NestedUndoRedoIT extends UndoRedoIT
     {
     }
+    
 }

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/QuickActionsIT.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/QuickActionsIT.java
@@ -520,5 +520,27 @@ public class QuickActionsIT extends AbstractCKEditorIT
         textArea.sendKeys(Keys.ENTER);
 
         assertSourceEquals("🐈");
+
+    @Test
+    @Order(25)
+    void icon() throws Exception
+    {
+        textArea.sendKeys("/icon");
+        AutocompleteDropdown qa = new AutocompleteDropdown();
+        qa.waitForItemSelected("/icon", "Icon");
+        textArea.sendKeys(Keys.ENTER);
+        qa.waitForItemSubmitted();
+
+        // Search and insert the wiki icon.
+        textArea.sendKeys("wiki");
+        AutocompleteDropdown icon = new AutocompleteDropdown().waitForItemSelected("icon::wiki", "wiki");
+        textArea.sendKeys(Keys.ENTER);
+        icon.waitForItemSubmitted();
+
+        // We wait for the editor to update because the icon quick action is using a macro.
+        textArea = editor.getRichTextArea();
+        textArea.waitUntilContentEditable();
+
+        assertSourceEquals("{{displayIcon name=\"wiki\"/}} ");
     }
 }

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/Translations.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/Translations.xml
@@ -114,6 +114,9 @@ ckeditor.plugin.syntax.update.done=WYSIWYG editor updated
 ckeditor.plugin.syntax.update.failed=Failed to update the WYSIWYG editor
 ckeditor.plugin.syntax.wysiwygModeUnsupported=The WYSIWYG edit mode is not supported by the {0} syntax.
 
+ckeditor.plugin.icon.iconsFetchFailed=Failed to retreive the icon list.
+ckeditor.plugin.icon.iconThemesFetchFailed=Failed to retreive the available icon themes.
+
 ckeditor.plugin.image.imageEditor.standardTab.title=Standard
 ckeditor.plugin.image.imageEditor.advancedTab.title=Advanced
 ckeditor.plugin.image.imageEditor.standardTab.imageStyles.label=Image Styles
@@ -193,6 +196,8 @@ ckeditor.plugin.slash.action.error.defaultContent=Type your error message here.
 ckeditor.plugin.slash.action.hr.hint=Mark a thematic break between blocks of content: for example, a change of scene in a story, or a shift of topic within a section.
 ckeditor.plugin.slash.action.a.hint=Create a link to another page.
 ckeditor.plugin.slash.action.img.hint=Embed or upload an image.
+ckeditor.plugin.slash.action.icon.name=Icon
+ckeditor.plugin.slash.action.icon.hint=Embed an icon.
 ckeditor.plugin.slash.action.mention.name=Mention
 ckeditor.plugin.slash.action.mention.hint=Mention someone to send them a notification.
 ckeditor.plugin.slash.action.emoji.name=Emoji

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-webjar/src/main/webjar/config.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-webjar/src/main/webjar/config.js
@@ -153,6 +153,7 @@ CKEDITOR.editorConfig = function(config) {
       'xwiki-config',
       'xwiki-filter',
       'xwiki-focusedplaceholder',
+      'xwiki-icon',
       'xwiki-image-old',
       'xwiki-image',
       'xwiki-link',

--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-ui/src/main/resources/IconThemesCode/IconPicker.xml
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-ui/src/main/resources/IconThemesCode/IconPicker.xml
@@ -59,6 +59,7 @@
     #set($icon = {})
     #set($discard = $icon.put('name', $xwikiIcon))
     #set($discard = $icon.put('render', $services.icon.renderHTML($xwikiIcon, $iconTheme)))
+    #set($discard = $icon.put('metadata', $services.icon.getMetaData($xwikiIcon, $iconTheme)))
     #set($discard = $icons.add($icon))
   #end
   #jsonResponse($icons)


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-20979

This pull request adds a new Quick Action to quickly search for and insert an icon in the WYSIWYG editor.

Here's a preview of the feature:
![preview](https://github.com/xwiki/xwiki-platform/assets/132468278/074edc8e-9edf-4637-b042-b56ec899b026)
