### PR TITLE
Misc: Accessibility rules update

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/WCAGContext.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/WCAGContext.java
@@ -102,8 +102,7 @@ public class WCAGContext
             entry("form-field-multiple-labels", true),
             entry("frame-focusable-content", true),
             entry("frame-title-unique", true),
-            // Set to true once the build doesn't fail this rule anymore
-            entry("frame-title", false),
+            entry("frame-title", true),
             entry("html-has-lang", true),
             entry("html-lang-valid", true),
             entry("html-xml-lang-mismatch", true),
@@ -115,8 +114,7 @@ public class WCAGContext
             entry("label", false),
             // Set to true once the build doesn't fail this rule anymore
             entry("link-in-text-block", false),
-            // Set to true once the build doesn't fail this rule anymore
-            entry("link-name", false),
+            entry("link-name", true),
             entry("list", true),
             entry("listitem", true),
             entry("marquee", true),


### PR DESCRIPTION
EDIT: <s>**Merge after the 15.6 release, this is not an urgent matter and can wait 15.7RC1** :slightly_smiling_face: </s>
**Do not cherrypick for 15.6 or backport. :)**

Changes to the status of the WCAG rules that are currently not violated. From this point on, all rules set to true will make the build fail when they are violated. The build will only fail on an accessibility regression. See the [XWiki WCAG testing page](https://dev.xwiki.org/xwiki/bin/view/Community/Testing/WCAGTesting#HTesting) for more details about the consequences of these changes.

As of https://ci.xwiki.org/job/XWiki%20Environment%20Tests/job/xwiki-platform/job/master/299/, there are only a few rules that fail through tests:
- aria-allowed-attr 5 violations
- aria-required-children 65 violations
- label 63 violations
- duplicate-id 6 violations
- duplicate-id-active 3 violations
- duplicate-id-aria 8 violations
- image-alt 51 violations
- link-in-text-block 328 violations
- select-name 16 violations
- color-contrast 83 violations
- scrollable-region-focusable 1 violation

Total violations: 629


There are no additional failing types in [environment test master build #299](https://ci.xwiki.org/job/XWiki%20Environment%20Tests/job/xwiki-platform/job/master/299/)

* frame-title fixed by https://jira.xwiki.org/browse/XWIKI-20973
* link-name fixed

|  | Count of warning rules | Count of failing rules |
| ------------- | ------------- | ------------- |
| Before this PR | 13 | 48 |
| After this PR | 11 | 50 |

This is a continuation of the process started in https://github.com/xwiki/xwiki-platform/pull/2152, last step before this one was https://github.com/xwiki/xwiki-platform/pull/2211.