### PR TITLE
XWIKI-20988: Livetable edit sheet available column select lacks a name

### DIFF
--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/LiveTableEditSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/LiveTableEditSheet.xml
@@ -42,7 +42,7 @@
 
 {{velocity output="false"}}
 #macro (listAvailableColumns $classReference)
-  &lt;select id="availableColumns"&gt;
+  &lt;select id="availableColumns" aria-describedby='availableColumnsDescription'&gt;
     #set ($classFields = $xwiki.getDocument($classReference).getxWikiClass().properties)
     #if ($classFields.size() &gt; 0)
       &lt;optgroup label="$escapetool.xml($services.localization.render(
@@ -150,8 +150,8 @@
     &lt;/dt&gt;
     &lt;dd&gt;#displayPropertyValue('description')&lt;/dd&gt;
     &lt;dt&gt;
-      &lt;label for="AppWithinMinutes.LiveTableClass_0_columns"&gt;$doc.displayPrettyName('columns', false, false)&lt;/label&gt;
-      &lt;span class="xHint"&gt;$services.localization.render('platform.appwithinminutes.liveTableEditorColumnsHint')&lt;/span&gt;
+      &lt;label for="availableColumns"&gt;$doc.displayPrettyName('columns', false, false)&lt;/label&gt;
+      &lt;span id='availableColumnsDescription' class="xHint"&gt;$services.localization.render('platform.appwithinminutes.liveTableEditorColumnsHint')&lt;/span&gt;
     &lt;/dt&gt;
     &lt;dd&gt;#displayPropertyValue('columns')&lt;/dd&gt;
   &lt;/dl&gt;

--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/LiveTableEditSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/LiveTableEditSheet.xml
@@ -42,7 +42,7 @@
 
 {{velocity output="false"}}
 #macro (listAvailableColumns $classReference)
-  &lt;select id="availableColumns" aria-describedby='availableColumnsDescription'&gt;
+  &lt;select id="addAvailableColumn" aria-describedby='addAvailableColumnHint'&gt;
     #set ($classFields = $xwiki.getDocument($classReference).getxWikiClass().properties)
     #if ($classFields.size() &gt; 0)
       &lt;optgroup label="$escapetool.xml($services.localization.render(
@@ -150,8 +150,8 @@
     &lt;/dt&gt;
     &lt;dd&gt;#displayPropertyValue('description')&lt;/dd&gt;
     &lt;dt&gt;
-      &lt;label for="availableColumns"&gt;$doc.displayPrettyName('columns', false, false)&lt;/label&gt;
-      &lt;span id='availableColumnsDescription' class="xHint"&gt;$services.localization.render('platform.appwithinminutes.liveTableEditorColumnsHint')&lt;/span&gt;
+      &lt;label for="AppWithinMinutes.LiveTableClass_0_description"&gt;$doc.displayPrettyName('columns', false, false)&lt;/label&gt;
+      &lt;span id='addAvailableColumnHint' class="xHint"&gt;$services.localization.render('platform.appwithinminutes.liveTableEditorColumnsHint')&lt;/span&gt;
     &lt;/dt&gt;
     &lt;dd&gt;#displayPropertyValue('columns')&lt;/dd&gt;
   &lt;/dl&gt;

--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/LiveTableEditSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/LiveTableEditSheet.xml
@@ -42,7 +42,7 @@
 
 {{velocity output="false"}}
 #macro (listAvailableColumns $classReference)
-  &lt;select id="addAvailableColumn" aria-describedby='addAvailableColumnHint'&gt;
+  &lt;select id="availableColumns" aria-describedby='availableColumnsHint'&gt;
     #set ($classFields = $xwiki.getDocument($classReference).getxWikiClass().properties)
     #if ($classFields.size() &gt; 0)
       &lt;optgroup label="$escapetool.xml($services.localization.render(
@@ -150,8 +150,8 @@
     &lt;/dt&gt;
     &lt;dd&gt;#displayPropertyValue('description')&lt;/dd&gt;
     &lt;dt&gt;
-      &lt;label for="AppWithinMinutes.LiveTableClass_0_description"&gt;$doc.displayPrettyName('columns', false, false)&lt;/label&gt;
-      &lt;span id='addAvailableColumnHint' class="xHint"&gt;$services.localization.render('platform.appwithinminutes.liveTableEditorColumnsHint')&lt;/span&gt;
+      &lt;label id='availableColumnsLabel' for="AppWithinMinutes.LiveTableClass_0_columns"&gt;$doc.displayPrettyName('columns', false, false)&lt;/label&gt;
+      &lt;span id='availableColumnsHint' class="xHint"&gt;$services.localization.render('platform.appwithinminutes.liveTableEditorColumnsHint')&lt;/span&gt;
     &lt;/dt&gt;
     &lt;dd&gt;#displayPropertyValue('columns')&lt;/dd&gt;
   &lt;/dl&gt;
@@ -538,6 +538,7 @@ XWiki.LiveTableEditor = Class.create({
 
     var picker = new Element('div', {'class': 'columnPicker'}).insert(this.columnsSelect).insert(addButton);
     this.columnsInput.up().insert(picker);
+    $('availableColumnsLabel').setAttribute('for', 'availableColumns');
   },
   _onAddColumn : function(event) {
     event.stop();


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-20988
## PR Changes
* Changed the `for` attribute of the label.
* Linked the \<select> element with its description

## View
***No visual change***
Before the PR vvv
![20988-StateBefore](https://github.com/xwiki/xwiki-platform/assets/28761965/26c0823a-f55f-4b5a-8acc-defc72544c92)
After the PR vvv
![20988-stateAfter](https://github.com/xwiki/xwiki-platform/assets/28761965/8a62b053-322f-47f4-b3bf-cddf01e114d9)


## Notes
The label used to be linked to the input that stays hidden no matter what AFAICS in the code and in tests. A hidden input doesn't need any label: 
> Inputs with the type attribute value of hidden (e.g., type="hidden"). These inputs are hidden and unavailable for user input. They therefore need no label. 

from [Axe documentation](https://dequeuniversity.com/rules/axe/4.4/label)

I decided to go a bit further than fix the error reported on Jira and link the description to the select too since it's already there.

## Tests
An axe core check on the page screenshoted above didn't return any WCAG violation related to the changes in this PR.