### PR TITLE
XWIKI-20974: AWM create application wizard steps lack contrast

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/wizard/wizard.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/wizard/wizard.css
@@ -58,7 +58,6 @@
   color: $theme.textSecondaryColor;
   height: 15px;
   line-height: 15px;
-  opacity: .5;
   width: 15px;
 }
 
@@ -78,7 +77,6 @@
 
 .steps .name.done {
   color: $theme.textSecondaryColor;
-  opacity: .5;
 }
 
 .steps.vertical {


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-20974
## PR Changes
* Removed the opacity from wizard 'done' steps.
## Notes
* This PR is incomplete, it relies on the *currently unmerged* fixes in https://github.com/xwiki/xwiki-platform/pull/2261. It will stay as a draft until this fix for XWIKI-20867 is merged (if the fix for XWIKI-20867 is closed, close this PR).

## View
vvv Before fixes in this PR and https://github.com/xwiki/xwiki-platform/pull/2261
![20974-beforePR](https://github.com/xwiki/xwiki-platform/assets/28761965/a8cafdb6-8ccc-4338-88a9-3600c8ac1adc)

vvv After fixes in this PR and https://github.com/xwiki/xwiki-platform/pull/2261
![20974-afterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/6ed12561-5df2-4cb0-984d-9c2feaf4e25d)
