### PR TITLE
XWIKI-20982: Drawer elements in the color theme editor lack contrast

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-test/xwiki-platform-flamingo-theme-test-docker/src/test/it/org/xwiki/flamingo/test/ui/FlamingoThemeIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-test/xwiki-platform-flamingo-theme-test-docker/src/test/it/org/xwiki/flamingo/test/ui/FlamingoThemeIT.java
@@ -214,7 +214,7 @@ class FlamingoThemeIT
         //assertEquals("rgb(255, 0, 0)", page.getPageBackgroundColor());
         // Test 'lessCode' is correctly handled
         //assertEquals("rgb(0, 0, 255)", page.getTextColor());
-        assertColor(255, 0, 0, page.getPageBackgroundColor());
+        assertColor(255, 218, 218, page.getPageBackgroundColor());
         assertColor(0, 0, 255, page.getTitleColor());
         assertEquals("monospace", page.getTitleFontFamily().toLowerCase());
     }
@@ -262,9 +262,12 @@ class FlamingoThemeIT
         // Verify that the preview is working with the current values
         PreviewBox previewBox = editThemePage.getPreviewBox();
         assertFalse(previewBox.hasError(true));
-        // Select a variable category and change value
+        // Select a variable category and change value.
+        // The default link color is too light to operate viewable changes without breaking contrast.
         editThemePage.selectVariableCategory("Base colors");
-        editThemePage.setVariableValue("xwiki-page-content-bg", "#ff0000");
+        editThemePage.setVariableValue("link-color", "#2c699c");
+        // Change another value. We don't deactivate all WCAG checks, so we need to take care about contrast.
+        editThemePage.setVariableValue("xwiki-page-content-bg", "#ffdada");
         // Again...
         editThemePage.selectVariableCategory("Typography");
         editThemePage.setVariableValue("font-family-base", "Monospace");

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemes/Charcoal.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemes/Charcoal.xml
@@ -794,7 +794,7 @@
       <brand-info>#336699</brand-info>
     </property>
     <property>
-      <brand-primary>#0088CC</brand-primary>
+      <brand-primary>#0075b0</brand-primary>
     </property>
     <property>
       <brand-success>#008000</brand-success>
@@ -836,7 +836,7 @@
       <btn-info-color/>
     </property>
     <property>
-      <btn-primary-bg>#0088CC</btn-primary-bg>
+      <btn-primary-bg>#0075b0</btn-primary-bg>
     </property>
     <property>
       <btn-primary-color>#FFFFFF</btn-primary-color>
@@ -918,7 +918,7 @@
 </lessCode>
     </property>
     <property>
-      <link-color>#0088CC</link-color>
+      <link-color>#0075b0</link-color>
     </property>
     <property>
       <logo/>


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-20982
## PR Changes
* Made the Charcoal.xml link color a bit darker for contrast
* Updated the custom values used in the test suite to avoid breaking contrast needs.

## Note
* This PR also fixes  [XWIKI-20983](https://jira.xwiki.org/browse/XWIKI-20983)
* The charcoal change was made to pass **all** contrast checks in this test suite. It wasn't mentioned in the test, but this fix would have been needed at one point anyways. This change just increases the contrast between backgrounds and the Charcoal link color:
![20982-comparisonLinkColor](https://github.com/xwiki/xwiki-platform/assets/28761965/50b329a2-2226-4178-b836-9ea857106fad)
_Previous (left) and new (right) Charcoal colortheme link color_ 

## Tests
Passed:
* mvn clean install -f xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/ -Pdocker,integration-tests,quality
* mvn clean install -f xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-test/ -Pdocker,integration-tests,quality -Dxwiki.test.ui.wcag=true -Dgradle.cache.local.enabled=false -Dgradle.cache.remote.enabled=false

For the docker tests, no more contrast violation was reported (even though link-color errors were still reported, but that's not the matter here, see [XWIKI-20827](https://jira.xwiki.org/browse/XWIKI-20827)).