### PR TITLE
XWIKI-20997: Invitation displayActionConfirmationForm displays unlabelled form elements

### DIFF
--- a/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/main/resources/Invitation/InvitationMembersCommon.xml
+++ b/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/main/resources/Invitation/InvitationMembersCommon.xml
@@ -127,7 +127,7 @@
            |&lt;label for="messageCheckboxID$checkboxCount" class='sr-only'&gt;
              $escapetool.xml($services.localization.render('xe.invitation.displayMessageTable.checkbox.input.label'))
            &lt;/label&gt;
-           &lt;input type="checkbox" id="messageCheckboxID$checkboxCount" name="messageCheckboxID$checkboxCount"
+           &lt;input type="checkbox" id="messageCheckboxID$checkboxCount" name="messageID"
             value="$message.getProperty('messageID').getValue()" ##
            #set($checkboxCount = $checkboxCount + 1)
            ## If there is only one message in the group, add the convenience of checking the box by default.


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-20997
## PR Changes
* Fixed docker tests
## Tests
After building the module with `mvn clean install -f xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui`, successfully passed the test:
`mvn clean install -f xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-test/ -Pdocker,integration-tests,quality -Dxwiki.test.ui.wcag=true -Dgradle.cache.local.enabled=false -Dgradle.cache.remote.enabled=false`

Tested manually and managed to fix the error highlighted in https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/master/lastCompletedBuild/testReport/org.xwiki.invitation.test.docker/AllIT$NestedInvitationIT/Platform_Builds___main___integration_tests___IT_for_xwiki_platform_core_xwiki_platform_invitation_xwiki_platform_invitation_test_xwiki_platform_invitation_test_docker___Build_for_IT_for_xwiki_platform_core_xwiki_platform_invitation_xwiki_platform_invitation_test_xwiki_platform_invitation_test_docker___cancelInvitation_TestUtils_/

## Note
The test above were failing since https://github.com/xwiki/xwiki-platform/commit/5b145e6d3179c85e37ff5038d1587cc3fb49e423 was merged, see the CI link above, and https://ge.xwiki.org/scans/tests?search.relativeStartTime=P28D&search.tags=master&search.timeZoneId=Europe/Oslo&tests.container=org.xwiki.invitation.test.docker.AllIT$NestedInvitationIT# .
It was caused by an unneeded change of the name of the input, that broke some functionality and the expected element couldn't be found anymore.