### PR TITLE
XWIKI-20758: Administration menu violates tablist structure

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminSheet.xml
@@ -270,7 +270,8 @@
 
 #macro (verticalNavigation $menu $options)
   {{html clean="false"}}
-  &lt;div id="$!options.id" class="panel-group $!options.cssClass"&gt;
+  &lt;section id="$!options.id" class="panel-group $!options.cssClass"
+    aria-label="$escapetool.xml($services.localization.render('administration.menu.label'))"&gt;
     &lt;div class="panel xform"&gt;
       &lt;label for="adminsearchmenu" class="hidden"&gt;$services.localization.render('search')&lt;/label&gt;
       &lt;input type="text" class="form-control panel-group-filter" autocomplete="off" id="adminsearchmenu"
@@ -286,7 +287,7 @@
         $escapetool.xml($services.localization.render('administration.menu.search.noResults'))
       &lt;/div&gt;
     &lt;/div&gt;
-  &lt;/div&gt;
+  &lt;/section&gt;
   {{/html}}
 #end
 
@@ -306,14 +307,14 @@
         href="$!item.url" data-toggle="collapse"#if ("$!options.id" != '') data-parent="#$options.id" #end
         data-target="#panel-body-$escapedId" aria-expanded="$isActive" aria-controls="panel-body-$escapedId"
         title="$!escapetool.xml($item.description)"&gt;$!services.icon.renderHTML($item.icon)$escapetool.xml($name)&lt;/a&gt;
-      &lt;div role='region' class="panel-collapse collapse#if ($isActive) in#end" id="panel-body-$escapedId"
+      &lt;nav class="panel-collapse collapse#if ($isActive) in#end" id="panel-body-$escapedId"
           aria-labelledby="panel-heading-$escapedId"&gt;
         &lt;div class="list-group"&gt;
           #foreach ($child in $children)
             #verticalNavigationItem($child $options)
           #end
         &lt;/div&gt;
-      &lt;/div&gt;
+      &lt;/nav&gt;
     &lt;/div&gt;
   #else
     &lt;a class="list-group-item#if ($isActive) active#end" data-id="$escapedId"

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminSheet.xml
@@ -270,7 +270,7 @@
 
 #macro (verticalNavigation $menu $options)
   {{html clean="false"}}
-  &lt;section id="$!options.id" class="panel-group $!options.cssClass"
+  &lt;nav id="$!options.id" class="panel-group $!options.cssClass"
     aria-label="$escapetool.xml($services.localization.render('administration.menu.label'))"&gt;
     &lt;div class="panel xform"&gt;
       &lt;label for="adminsearchmenu" class="hidden"&gt;$services.localization.render('search')&lt;/label&gt;
@@ -287,7 +287,7 @@
         $escapetool.xml($services.localization.render('administration.menu.search.noResults'))
       &lt;/div&gt;
     &lt;/div&gt;
-  &lt;/section&gt;
+  &lt;/nav&gt;
   {{/html}}
 #end
 
@@ -307,14 +307,14 @@
         href="$!item.url" data-toggle="collapse"#if ("$!options.id" != '') data-parent="#$options.id" #end
         data-target="#panel-body-$escapedId" aria-expanded="$isActive" aria-controls="panel-body-$escapedId"
         title="$!escapetool.xml($item.description)"&gt;$!services.icon.renderHTML($item.icon)$escapetool.xml($name)&lt;/a&gt;
-      &lt;nav class="panel-collapse collapse#if ($isActive) in#end" id="panel-body-$escapedId"
+      &lt;section class="panel-collapse collapse#if ($isActive) in#end" id="panel-body-$escapedId"
           aria-labelledby="panel-heading-$escapedId"&gt;
         &lt;div class="list-group"&gt;
           #foreach ($child in $children)
             #verticalNavigationItem($child $options)
           #end
         &lt;/div&gt;
-      &lt;/nav&gt;
+      &lt;/section&gt;
     &lt;/div&gt;
   #else
     &lt;a class="list-group-item#if ($isActive) active#end" data-id="$escapedId"

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminSheet.xml
@@ -270,7 +270,7 @@
 
 #macro (verticalNavigation $menu $options)
   {{html clean="false"}}
-  &lt;div id="$!options.id" class="panel-group $!options.cssClass" role="tablist" aria-multiselectable="true"&gt;
+  &lt;div id="$!options.id" class="panel-group $!options.cssClass"&gt;
     &lt;div class="panel xform"&gt;
       &lt;label for="adminsearchmenu" class="hidden"&gt;$services.localization.render('search')&lt;/label&gt;
       &lt;input type="text" class="form-control panel-group-filter" autocomplete="off" id="adminsearchmenu"
@@ -302,11 +302,11 @@
     #set ($children = [])
     #sortCollectionOfMapsByField($item.children, 'order', 99999, 'asc', $children)
     &lt;div class="panel panel-default"&gt;
-      &lt;a class="panel-heading#if (!$isActive) collapsed#end" role="tab" id="panel-heading-$escapedId"
+      &lt;a class="panel-heading#if (!$isActive) collapsed#end" id="panel-heading-$escapedId"
         href="$!item.url" data-toggle="collapse"#if ("$!options.id" != '') data-parent="#$options.id" #end
         data-target="#panel-body-$escapedId" aria-expanded="$isActive" aria-controls="panel-body-$escapedId"
         title="$!escapetool.xml($item.description)"&gt;$!services.icon.renderHTML($item.icon)$escapetool.xml($name)&lt;/a&gt;
-      &lt;div class="panel-collapse collapse#if ($isActive) in#end" role="tabpanel" id="panel-body-$escapedId"
+      &lt;div role='region' class="panel-collapse collapse#if ($isActive) in#end" id="panel-body-$escapedId"
           aria-labelledby="panel-heading-$escapedId"&gt;
         &lt;div class="list-group"&gt;
           #foreach ($child in $children)

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminTranslations.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminTranslations.xml
@@ -44,7 +44,7 @@ administration.sectionTitle=Administration: {0}
 administration.sectionTitle.page=Page Administration: {0}
 administration.sectionTitle.wiki=Wiki Administration: {0}
 administration.sectionTitle.global=Global Administration: {0}
-administration.menu.label=Administration category picker.
+administration.menu.label=Administration sections.
 administration.menu.search.hint=Search for...
 administration.menu.search.noResults=No results.
 

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminTranslations.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminTranslations.xml
@@ -44,6 +44,7 @@ administration.sectionTitle=Administration: {0}
 administration.sectionTitle.page=Page Administration: {0}
 administration.sectionTitle.wiki=Wiki Administration: {0}
 administration.sectionTitle.global=Global Administration: {0}
+administration.menu.label=Administration category picker.
 administration.menu.search.hint=Search for...
 administration.menu.search.noResults=No results.
 


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-20758
## PR Changes
* Removed the inappropriate roles from the accordion
* Removed the 'aria-multiselectable' attribute that conveyed wrong information to assistive technology users.

## Notes
See the comments on the jira ticket for explanations on why this solution was chosen.

## View
![20758-afterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/f8e323c4-a672-49bf-a92c-952a2214ea10)
There is no longer 'role does not contain children' error reported by axe-core.