### PR TITLE
XWIKI-21204: Btn-xs style results in buttons that are too small

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/buttons.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/buttons.less
@@ -118,6 +118,12 @@ a.secondary{
   .btn-default;
 }
 
+// Size ===================================================================
+.btn-xs {
+  min-height: @target-size-minimum;
+  min-width: @target-size-minimum;
+}
+
 // Gradients & Mapping ====================================================
 /* These rules need to be applied after since they overwrite the mapping. They cover the usage before Bootstrap adoption. */
 


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21204
## PR Changes
* Added a minimum size for xs-btn from bootstrap in order to match our code style about target size
## View
Before and after the PR being applied, example of the action button in notification, that were slightly changed visually because of this PR. Most xs-btn were already big enough and the added style doesn't change their display.
![21204-beforePR](https://github.com/xwiki/xwiki-platform/assets/28761965/c9a3063a-a887-4e01-8516-a66c5590efe4)
![21204-AfterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/1c471eb3-baec-4486-9aad-e3038770e86e)
