### PR TITLE
XWIKI-20891: Rich select input is not accessible

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -2653,10 +2653,10 @@ Recursive title display detected!##
       aria-activedescendant="${fieldName}_0_option">
       #set ($count = 0)
       #foreach ($category in $options)
+        <span id="${escapedId}-group${count}-label" role='presentation'>
+          $category.name (<span class="xwiki-select-category-count">$category.options.size()</span>)
+        </span>
         <ul role='group' class="xwiki-select-category" aria-labelledby="${escapedId}-group${count}-label">
-          <li id="${escapedId}-group${count}-label" role='presentation'>
-            $category.name (<span class="xwiki-select-category-count">$category.options.size()</span>)
-          </li>
           #foreach ($option in $category.options)
             #if ("$!defaultValue" == $$option.value || ($count == 0 && $firstIsDefaultIfDefaultNull && "$!defaultValue" == ''))
               #set ($checked = 'checked="checked"')


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-20891
## Notes
This is a PR to fix a UI regression introduced in https://github.com/xwiki/xwiki-platform/pull/2182 . More precisely, the regression changes were introduced in https://github.com/xwiki/xwiki-platform/commit/bcd341777cc54503603a51be015dfd329085ae57 .
## PR Changes
* Removed the label from the list, for UI purpose.
## View
Before this PR (regression on the UI)
![20891-regression](https://github.com/xwiki/xwiki-platform/assets/28761965/84ad87b5-eb63-4839-995e-12139ae8f948)
After this PR
![20891-fixed](https://github.com/xwiki/xwiki-platform/assets/28761965/9d0139ed-929b-47c4-9ddb-ac869c27f2be)

## Tests
Passes axe core page tests without triggering a violation.