### PR TITLE
XWIKI-21191: Add support for uploading an attachment from the link quick action

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/QuickActionsIT.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/QuickActionsIT.java
@@ -374,7 +374,7 @@ public class QuickActionsIT extends AbstractCKEditorIT
         textArea.sendKeys(Keys.ENTER);
         qa.waitForItemSubmitted();
 
-        AutocompleteDropdown link = new AutocompleteDropdown();
+        AutocompleteDropdown link = new AutocompleteDropdown().waitForItemSelected("[", "Upload Attachment");
         textArea.sendKeys("ali");
         link.waitForItemSelected("[ali", "alice");
         textArea.sendKeys(Keys.ENTER);

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/EditSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/EditSheet.xml
@@ -222,36 +222,6 @@ define('xwiki-ckeditor', [
     var config = {
       filebrowserUploadUrl: uploadDisabled ? '' : getUploadURL(sourceDocument, 'filebrowser'),
       height: $(element).height(),
-      mentions: [
-        {
-          // We use the source document to compute the feed URL because we want the suggested link references to be
-          // relative to the edited document (we want the editor to output relative references as much as possible).
-          feed: sourceDocument.getURL('get', $.param({
-            sheet: 'CKEditor.LinkSuggestions',
-            outputSyntax: 'plain',
-            language: XWiki.locale
-          // Prevent the curly brackets from being URL encoded because they mark a placeholder that will be replaced
-          // with the text typed by the user (and CKEditor takes care of URL encoding it).
-          }) + '&amp;input={encodedQuery}'),
-          itemTemplate: [
-            '&lt;li data-id="{id}" class="ckeditor-autocomplete-item"&gt;',
-              '&lt;div&gt;',
-                '&lt;span class="ckeditor-autocomplete-item-icon-wrapper"&gt;',
-                  // We have to output both icon types but normally only one is defined and the other is hidden.
-                  '&lt;img src="{iconURL}"/&gt;',
-                  '&lt;span class="{iconClass}"&gt;&lt;/span&gt;',
-                '&lt;/span&gt;',
-                '&lt;span class="ckeditor-autocomplete-item-label"&gt;{label}&lt;/span&gt;',
-              '&lt;/div&gt;',
-              '&lt;div class="ckeditor-autocomplete-item-hint"&gt;{hint}&lt;/div&gt;',
-            '&lt;/li&gt;'].join(''),
-          outputTemplate: '&lt;a href="{url}" data-reference="{typed}|-|{type}|-|{reference}"&gt;{label}&lt;/a&gt;',
-          followingSpace: true,
-          marker: '[',
-          minChars: 0,
-          itemsLimit: 6
-        }
-      ],
       // Used to resolve and serialize relative references. Also used to make HTTP requests with the right context.
       sourceDocument: sourceDocument,
       // The syntax of the edited content is not always the same as the syntax of the source document (which applies to

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/Translations.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/Translations.xml
@@ -61,6 +61,11 @@ ckeditor.plugin.link.anchor=Anchor
 ckeditor.plugin.link.queryString=Query String
 ckeditor.plugin.link.defaultLabel=type the link label
 ckeditor.plugin.link.openInNewTab=Open Link in New Tab
+ckeditor.plugin.link.upload=Upload Attachment
+ckeditor.plugin.link.uploadHint=Link to a newly uploaded attachment.
+ckeditor.plugin.link.uploadProgress=Uploading {0}...
+ckeditor.plugin.link.uploadSuccess=Successfully uploaded {0}
+ckeditor.plugin.link.uploadError=Failed to upload {0}
 
 ckeditor.plugin.list.listType.none=None
 


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-21191

This pull request adds an attachment upload entry in the link autocomplete/quick action.
Here's a preview of the feature:
![link-upload](https://github.com/xwiki/xwiki-platform/assets/132468278/af249321-06cc-4c01-a781-cb8837fa55ac)

Thanks.