### PR TITLE
XWIKI-21062: Pickers are not displayed properly on some Quick Actions on Windows

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-slash/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-slash/plugin.js
@@ -256,6 +256,15 @@
       return withStrictHTMLEncoding(() => {
         return originalAutoCompletePrototype.getHtmlToInsert.apply(this, args);
       });
+    },
+    getTextWatcher: function(...args) {
+      // When pressing enter to select a shortcut Quick Action, the shortcut's textWatcher catches the event
+      // and opens the new drop-down. It however doesn't catch click events by default, which is an other
+      // way to select a Quick Action. This mitigation ensures the textWatchers are updated after
+      // a shortcut Quick Action's html is inserted.
+      const textWatcher = originalAutoCompletePrototype.getTextWatcher.apply(this, args);
+      this.editor.on("afterInsertHtml", function () {textWatcher.check(false);});
+      return textWatcher;
     }
   });
 

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/QuickActionsIT.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/QuickActionsIT.java
@@ -428,8 +428,7 @@ public class QuickActionsIT extends AbstractCKEditorIT
         qa.waitForItemSelected("/emo", "Emoji");
         textArea.sendKeys(Keys.ENTER);
 
-        AutocompleteDropdown emoji = new AutocompleteDropdown();
-        assertEquals("🛩", emoji.getSelectedItem().getLabel());
+        AutocompleteDropdown emoji = new AutocompleteDropdown().waitForItemSelected(":sm", "🛩");
         textArea.sendKeys(Keys.BACK_SPACE, Keys.BACK_SPACE, "cat");
         emoji.waitForItemSelected(":cat", "🐈");
         textArea.sendKeys(Keys.ENTER);
@@ -503,5 +502,23 @@ public class QuickActionsIT extends AbstractCKEditorIT
 
         // Click close on the Find and Replace dialog
         new CKEditorDialog().cancel();
+    }
+    
+    @Test
+    @Order(24)
+    void emojiClickTriggersDropDown() throws Exception
+    {
+        textArea.sendKeys("/emo");
+        AutocompleteDropdown qa = new AutocompleteDropdown();
+        qa.waitForItemSelected("/emo", "Emoji");
+        // Click on the emoji Quick Action.
+        qa.getSelectedItem().click();
+
+        AutocompleteDropdown emoji = new AutocompleteDropdown();
+        textArea.sendKeys(Keys.BACK_SPACE, Keys.BACK_SPACE, "cat");
+        emoji.waitForItemSelected(":cat", "🐈");
+        textArea.sendKeys(Keys.ENTER);
+
+        assertSourceEquals("🐈");
     }
 }

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/AutocompleteDropdown.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/AutocompleteDropdown.java
@@ -67,6 +67,10 @@ public class AutocompleteDropdown extends BaseElement
                 .findElementWithoutWaiting(this.container, By.className("ckeditor-autocomplete-item-shortcut"))
                 .getText();
         }
+        
+        public void click() {
+            container.click();
+        }
     }
 
     /**


### PR DESCRIPTION
JIRA: https://jira.xwiki.org/browse/XWIKI-21062
This PR fixes a bug where clicking (rather than pressing enter) on a drop-down triggering Quick Action would
only show the triggering text without opening the new drop-down.

Preview of the fix:
![quick-click](https://github.com/xwiki/xwiki-platform/assets/132468278/05fad634-fc32-4200-ad8c-8d10d5a67650)

Thanks.