### PR TITLE
XWIKI-20913: More actions dropdown structure is not accessible

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_content.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_content.vm
@@ -310,15 +310,19 @@
   ## Display all the extensions points, including the static ones
   ##
   #define ($menuContent)
-    ## Title for the dropdown content
-    <dt class="dropdown-header sr-only">
-      $escapetool.xml($services.localization.render('core.menu.edit.dropdown.hint'))
-    </dt>
-    <dd>
-     <ul>
-        #displaySecureUIX('org.xwiki.plaftorm.editactions', $staticExtensions)
-     </ul>
-    </dd>
+    #define ($editContent)#displaySecureUIX('org.xwiki.plaftorm.editactions', $staticExtensions))#end
+    ## We need to check that the content is not empty to not generate an empty architecture around it.
+    #if ($stringtool.isNotBlank("$!editContent"))
+      ## Title for the dropdown content
+      <dt class="dropdown-header sr-only">
+        $escapetool.xml($services.localization.render('core.menu.edit.dropdown.hint'))
+      </dt>
+      <dd>
+        <ul>
+          $editContent
+        </ul>
+      </dd>
+    #end
   #end
   #displayMenu('tmEdit', 'pencil', $menuContent, 'core.menu.edit', true, $defaultEditURL, $extraAttributes)
 #end

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_content.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_content.vm
@@ -310,7 +310,7 @@
   ## Display all the extensions points, including the static ones
   ##
   #define ($menuContent)
-    #define ($editContent)#displaySecureUIX('org.xwiki.plaftorm.editactions', $staticExtensions))#end
+    #define ($editContent)#displaySecureUIX('org.xwiki.plaftorm.editactions', $staticExtensions)#end
     ## We need to check that the content is not empty to not generate an empty architecture around it.
     #if ($stringtool.isNotBlank("$!editContent"))
       ## Title for the dropdown content


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-20913
## PR Changes
* Fixed a regression on UI for non advanced users introduced in https://github.com/xwiki/xwiki-platform/commit/4904519d476fbda4873bf8c5a4b3d706e4cc44d5
## Note
The regression allowed the toggler button to display even when the user was not advanced, and when toggled it displayed an empty dropdown.