### PR TITLE
XWIKI-21182: The Image Quick Action doesn't use a relative reference for attachments from the current page

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-image/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-image/plugin.js
@@ -266,8 +266,8 @@
             return "img::" + item.query;
           }
 
-          if (item.id === "_uploadImage") {
-            require(['jquery'], function ($) {
+          require(['jquery', 'resource'], function ($, resource) {
+            if (item.id === "_uploadImage") {
 
               // Reuse attachment suggest code to show the file picker.
               // Provides xwiki-attachments-store and xwiki-file-picker
@@ -326,19 +326,18 @@
                       // Clear the cache so the new image can appear on next usage of the image quick action
                       attachmentService.clearCache();
 
+                      const resourceReference = {...resource.convertEntityReferenceToResourceReference(
+                        XWiki.Model.resolve(attachment.id, XWiki.EntityType.ATTACHMENT),
+                        editor.config.sourceDocument.documentReference),
+                        // Image references are always attachments.
+                        typed: false
+                      };
+
                       // Insert the newly uploaded image
                       imageWidget.insert({
                         setImageData: {
-                          resourceReference: {
-                            type: "attach",
-                            typed: false,
-                            reference: attachment.id
-                          },
-                          src: CKEDITOR.plugins.xwikiResource.getResourceURL({
-                            type: "attach",
-                            typed: false,
-                            reference: attachment.id
-                          }, editor)
+                          resourceReference,
+                          src: CKEDITOR.plugins.xwikiResource.getResourceURL(resourceReference, editor)
                         }
                       });
                     }).catch(() => {
@@ -351,26 +350,23 @@
                     });
                   });
                 });
-
-            });
-
-            return "";
-          }
-
-          // Insert the selected image
-          imageWidget.insert({
-            setImageData: {
-              resourceReference: {
-                type: "attach",
-                typed: false,
-                reference: item.reference
-              },
-              src: CKEDITOR.plugins.xwikiResource.getResourceURL({
-                type: "attach",
-                typed: false,
-                reference: item.reference
-              }, editor)
+              return;
             }
+
+            const resourceReference = {...resource.convertEntityReferenceToResourceReference(
+              XWiki.Model.resolve(item.reference, XWiki.EntityType.ATTACHMENT),
+              editor.config.sourceDocument.documentReference),
+              // Image references are always attachments.
+              typed: false
+            };
+
+            // Insert the selected image
+            imageWidget.insert({
+              setImageData: {
+                resourceReference,
+                src: CKEDITOR.plugins.xwikiResource.getResourceURL(resourceReference, editor)
+              }
+            });
           });
 
           return "";

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/ImagePluginIT.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/ImagePluginIT.java
@@ -580,7 +580,6 @@ class ImagePluginIT extends AbstractCKEditorIT
         
         // Upload an attachment to the page.
         String attachmentName = "image.gif";
-        AttachmentReference attachmentReference = new AttachmentReference(attachmentName, testReference);
         uploadAttachment(setup, testReference, attachmentName);
         
         // Move to the WYSIWYG edition page.
@@ -599,8 +598,7 @@ class ImagePluginIT extends AbstractCKEditorIT
         textArea.sendKeys(Keys.ENTER);
         img.waitForItemSubmitted();
 
-        // Using absolute reference until we fix XWIKI-21182.
-        assertSourceEquals("[[image:" + setup.serializeReference(attachmentReference) + "]]");
+        assertSourceEquals("[[image:image.gif]]");
     }
 
     @Test
@@ -639,9 +637,8 @@ class ImagePluginIT extends AbstractCKEditorIT
         assertIterableEquals(List.of(""), img.getSelectedItem().getBadges());
         textArea.sendKeys(Keys.ENTER);
         img.waitForItemSubmitted();
-        
-        // Using absolute reference until we fix XWIKI-21182.
-        assertSourceEquals("[[image:" + setup.serializeReference(attachmentReference) + "]]");
+
+        assertSourceEquals("[[image:attachmentOtherPage@otherImage.gif]]");
     }
     
     @ParameterizedTest


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-21182

This PR fixes a bug where the image insertion Quick Action always inserted absolute references.
Now the references are relative.