### PR TITLE
XWIKI-19143: Label "Type" is not connected to input while creating article

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/createinline.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/createinline.vm
@@ -233,7 +233,7 @@
       #end
     #end
     <dt>
-      <label>$services.localization.render('core.create.type')</label>
+      <span class='label'>$services.localization.render('core.create.type')</span>
       <span class="xHint">$escapetool.xml($services.localization.render('core.create.type.hint'))</span>
     </dt>
     #set ($defaultValue = $request.type)
@@ -359,7 +359,7 @@
           ## need to show this information elsewhere. Even if the target page reference can't be modified by the user,
           ## they should still see where the page is going to be created.
           <dt>
-            <label>$escapetool.xml($services.localization.render('core.create.pageTitle'))</label>
+            <span class='label'>$escapetool.xml($services.localization.render('core.create.pageTitle'))</span>
           </dt>
           <dl>
             #set ($targetDocumentReference = $services.model.createDocumentReference($name, $spaceReference))


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-19143
## PR Changes
* Removed the label semantics from elements that did not need this semantics and were not fit to fulfill all requirements of labels (namely, have a target designated by the 'for' attribute)

## Note
* This fix extends a bit beyond what was reported in XWIKI-19143, to fix a similar shortcoming with a similar change.
* There is no change in style caused by this PR, because of [forms.less](https://github.com/xwiki/xwiki-platform/blob/6006c3c4ae08e592d12de3230a7cc5cb06dd1f1a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/forms.less#L117)

## View
N/A
## Tests
Passed:
mvn clean install -f xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/ -Pquality -Dxwiki.test.ui.wcag=true -Dgradle.cache.local.enabled=false -Dgradle.cache.remote.enabled=false 