### PR TITLE
XWIKI-21237: The icon list isn't cached in Icon Quick Action.

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-icon/iconService.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-icon/iconService.js
@@ -35,7 +35,8 @@ define('xwiki-iconService', [
     return new Promise(function (resolve, reject) {
 
       if (cachedIconThemes) {
-        return resolve(cachedIconThemes);
+        resolve(cachedIconThemes);
+        return;
       }
 
       $.getJSON(getResourceURL('data_iconthemes'), function (data) {
@@ -51,6 +52,7 @@ define('xwiki-iconService', [
 
       if (cachedIcons[iconTheme]) {
         resolve(cachedIcons[iconTheme]);
+        return;
       }
 
       $.getJSON(getResourceURL('data_icons', {iconTheme}), function (dataIcons) {


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-21237

This PR fixes a caching issue in the Icon Quick Action.
Thanks.