### PR TITLE
XWIKI-20827: Inline links must be distinguishable without relying on color

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/general.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/general.less
@@ -65,6 +65,24 @@ table {
   height: 1em;
 }
 
+/* Underline links that are inline.
+  It's not possible to access text nodes with CSS, so we use the parent of the link element to
+  estimate if the link is in some text. Paragraphs, spans and divs are typically constituted of some text with
+  an inline link. On the contrary, li and dt are not, and we don't want their link child to be underlined.
+  This, added to the specifity of the .wikilink classes,
+  covers most cases seen on XWiki Standard, but is not a perfect selector. */
+p, span, div {
+  & > .wikilink,
+  & > .wikiexternallink,
+  & > .wikiinternallink,
+  & > .wikicreatelink {
+    & > a {
+      text-decoration: underline;
+    }
+  }
+}
+
+
 // Code =======================================================================
 
 pre {


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-20827
## PR Changes
* Added the 'text-decoration: underline' rule to inline links, using a node nature selector.
## View
Here is the home page of XWiki standard after the changes in this PR. We can see that inline links are now underlined. This solves the WCAG issues related to indistinguishability of inline links reported in this issue:
![20827-afterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/fb75121c-218d-438d-852f-ef11c66ff7bb)

Here is the same screenshot, improved with highlights around links (orange: not underlined by the PR; cyan: underlined by the PR):
![20827-afterPRHighlight](https://github.com/xwiki/xwiki-platform/assets/28761965/96eaa202-9050-4860-80dc-552e2164fff0)

For reference, here is a similar screen I took before this PR, highlighting in the same way what links should get underlined:
![InlineAndOutlineLinksExample](https://github.com/xwiki/xwiki-platform/assets/28761965/8568a1d9-5e99-4577-8f8a-b22b96edb46b)


## Tests
Manual tests have been conducted on a few pages of XWiki Standard (e.g. the Home page seen above), this change seems to behave as expected.
This is only a style change, so I didn't run docker tests. 

## Note
This is not a perfect fix, but it should cut down the amount of violations of `link-in-text-block` in the CI (so far, 373 out of the total 585 violations). For example:
* A list, with a wikilink inline, will not underline it.
* A paragraph with just a link (not inline), will be underlined.

This PR makes assumptions on the content of the parents of the links, and those assumptions are correct in most cases, not all cases.