### PR TITLE
XWIKI-21274: Info buttons lack contrast

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemes/Iceberg.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemes/Iceberg.xml
@@ -881,7 +881,7 @@
       <btn-info-bg/>
     </property>
     <property>
-      <btn-info-color/>
+      <btn-info-color>#000000</btn-info-color>
     </property>
     <property>
       <btn-primary-bg>#386da7</btn-primary-bg>


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-21274

Same approach as for https://github.com/xwiki/xwiki-platform/pull/2101, discussed in https://forum.xwiki.org/t/fixing-a11y-contrast-issues-on-the-main-view/11917/7?u=mleduc.

Change the test color for the info buttons from white to black.

**before**

![image](https://github.com/xwiki/xwiki-platform/assets/327856/8b79cf85-177c-480d-93c6-0065e4e01cc7)


**after**

![image](https://github.com/xwiki/xwiki-platform/assets/327856/c011fa9b-fd8c-40bf-92ff-5cc572ad7c87)
