### PR TITLE
XWIKI-21254: Improve the border on buttons

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/buttons.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/buttons.less
@@ -15,18 +15,13 @@
 
 .btn-border(@color) {
   border: 1px solid @color;
-  border-bottom-color: darken(@color, 10%);
-}
-
-.btn-no-border(@color) {
-  border: 1px solid @color;
 }
 
 /* &-.button selectors are added in order to override the mapping and legacy usage of .button class */
 .btn {
   &-default {
     .btn-background(lighten(@btn-default-bg, 5%));
-    .btn-border(@btn-default-bg);
+    .btn-border(darken(@btn-default-bg, 5%));
 
     &:hover, 
     &:focus {
@@ -37,11 +32,11 @@
 
   &-primary {
     .btn-background(@btn-primary-bg);
-    .btn-no-border(@btn-primary-bg);
+    .btn-border(@btn-primary-bg);
 
     &:hover {
       .btn-background(darken(@btn-primary-bg, 5%));
-      .btn-no-border(darken(@btn-primary-bg, 5%));
+      .btn-border(darken(@btn-primary-bg, 5%));
     }
   }
 

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/buttons.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/buttons.less
@@ -18,6 +18,10 @@
   border-bottom-color: darken(@color, 10%);
 }
 
+.btn-no-border(@color) {
+  border: 1px solid @color;
+}
+
 /* &-.button selectors are added in order to override the mapping and legacy usage of .button class */
 .btn {
   border-radius: 8px;
@@ -34,11 +38,11 @@
 
   &-primary {
     .btn-background(@btn-primary-bg);
-    .btn-border(@btn-primary-bg);
+    .btn-no-border(@btn-primary-bg);
 
     &:hover {
       .btn-background(darken(@btn-primary-bg, 5%));
-      .btn-border(@btn-primary-bg);
+      .btn-no-border(@btn-primary-bg);
     }
   }
 

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/buttons.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/buttons.less
@@ -24,7 +24,6 @@
 
 /* &-.button selectors are added in order to override the mapping and legacy usage of .button class */
 .btn {
-  border-radius: 8px;
   &-default {
     .btn-background(lighten(@btn-default-bg, 5%));
     .btn-border(@btn-default-bg);
@@ -42,7 +41,7 @@
 
     &:hover {
       .btn-background(darken(@btn-primary-bg, 5%));
-      .btn-no-border(@btn-primary-bg);
+      .btn-no-border(darken(@btn-primary-bg, 5%));
     }
   }
 
@@ -52,7 +51,7 @@
 
     &:hover {
       .btn-background(darken(@btn-success-bg, 5%));
-      .btn-border(@btn-success-bg);
+      .btn-border(darken(@btn-success-bg, 5%));
     }
   }
 
@@ -62,7 +61,7 @@
 
     &:hover {
       .btn-background(darken(@btn-info-bg, 5%));
-      .btn-border(@btn-info-bg);
+      .btn-border(darken(@btn-info-bg, 5%));
     }
   }
 
@@ -72,7 +71,7 @@
 
     &:hover {
       .btn-background(darken(@btn-warning-bg, 5%));
-      .btn-border(@btn-warning-bg);
+      .btn-border(darken(@btn-warning-bg, 5%));
     }
   }
 
@@ -82,7 +81,7 @@
 
     &:hover {
       .btn-background(darken(@btn-danger-bg, 5%));
-      .btn-border(@btn-danger-bg);
+      .btn-border(darken(@btn-danger-bg, 5%));
     }
   }
 }
@@ -134,7 +133,7 @@ input.button, .buttonwrapper button, .buttonwrapper a {
   .btn-border(@btn-primary-bg);
   &:hover {
     .btn-background(darken(@btn-primary-bg, 5%));
-    .btn-border(@btn-primary-bg);
+    .btn-border(darken(@btn-primary-bg, 5%));
   }
 }
 


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-21254
Forum discussion: https://forum.xwiki.org/t/borders-on-buttons-minimalist-skin-design-2/12619

Build on top of https://github.com/xwiki/xwiki-platform/pull/2316, please do not merge first.

All the buttons are borderless, except the default one (i.e., white) which has a border to distinguish it from the background.

Note: the screenshots below contains the changes on gradient on addition to the change on borders.

## Set of default buttons

### Default

**before**

![image](https://github.com/xwiki/xwiki-platform/assets/327856/2c3ce4d6-a25e-46ea-8782-1c7e63e5f539)


**after**

![image](https://github.com/xwiki/xwiki-platform/assets/327856/b04bd8ef-e3eb-4168-af6e-00da1dfb3487)

## Disabled

**before**

![image](https://github.com/xwiki/xwiki-platform/assets/327856/e813582e-fbba-4f61-9b7b-d405a709fe4b)


**after**

![image](https://github.com/xwiki/xwiki-platform/assets/327856/3a20f8ac-fb65-40ac-9d77-e030882e986a)


## Edit buttons

### Default

**before**

![image](https://github.com/xwiki/xwiki-platform/assets/327856/1e0a238f-d5d0-47aa-be95-e1109d6314c9)


**after**

![image](https://github.com/xwiki/xwiki-platform/assets/327856/2d1aaeac-743a-43c0-83c9-e3e56b8e8e47)

## Comment button

### Default

**before**

![image](https://github.com/xwiki/xwiki-platform/assets/327856/42ee6a00-70c6-4cae-9014-8edccfa04c2a)

**after**

![image](https://github.com/xwiki/xwiki-platform/assets/327856/adf57b88-bab3-4dd7-92d5-8c6b379ff91f)

## Hovers



https://github.com/xwiki/xwiki-platform/assets/327856/f6355ac4-3175-4448-8244-a926959bce3a



