### PR TITLE
XWIKI-21272: History navigation arrows are not perceived as links and lacking contrast

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/misc.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/misc.less
@@ -416,6 +416,7 @@ dl.export-tree-legend dt + dd {
 .changes-info-arrow {
   font-size: 3em;
   line-height: 1;
+  align-self: center;
 }
 
 .changes-body > .changes-body-header {

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/misc.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/misc.less
@@ -357,33 +357,11 @@ dl.export-tree-legend dt + dd {
 
 // Viewer = changes -----------------------------------------------------------
 #changes-info {
-  background-color: @xwiki-background-secondary-color;
-  border: @border-width solid @xwiki-border-color;
   margin-top: (@grid-gutter-width / 2);
   margin-bottom: (@grid-gutter-width / 2);
   padding-top: (@grid-gutter-width / 2);
   padding-bottom: (@grid-gutter-width / 2);
   position: relative;
-  /* Background arrow */
-  &:before {
-    background: @xwiki-page-content-bg;
-    height: 2em;
-    right: 50%;
-    top: 4em;
-    width: 2em;
-  }
-  &:after {
-    border-bottom: 2em solid transparent;
-    border-left: 3em solid @xwiki-page-content-bg;
-    border-top: 2em solid transparent;
-    left: 50%;
-    top: 3em;
-  }
-  &:before, &:after {
-    content: "";
-    display: block;
-    position: absolute;
-  }
 }
 
 #changes-info-boxes {
@@ -407,7 +385,7 @@ dl.export-tree-legend dt + dd {
 }
 
 @media (max-width: @screen-xs-max) {
-  #changes-info:before, #changes-info:after {
+  #changes-info .changes-info-arrow {
     display: none; /* Hide the arrow for small resolutions */
   }
 }
@@ -416,16 +394,27 @@ dl.export-tree-legend dt + dd {
   white-space: nowrap;
 }
 
+.changes-arrow {
+  font-size: inherit;
+}
+
 .changes-arrow, .changes-arrow-left, .changes-arrow-right {
   &, &:hover, &:active, &:visited, &:focus {
-    color: @xwiki-page-content-bg;
-    text-decoration: none;
+    vertical-align: baseline;
     font-weight: 700;
   }
 }
 
-.changes-arrow-left, .changes-arrow-right {
-  font-size: 7em;
+#changes-arrows-box {
+  font-size: 1.5em;
+  flex-basis: 100%;
+  display: flex;
+  justify-content: space-between;
+}
+
+
+.changes-info-arrow {
+  font-size: 3em;
   line-height: 1;
 }
 

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/ChangesPane.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/ChangesPane.java
@@ -33,8 +33,8 @@ import org.xwiki.test.ui.po.diff.RenderedChanges;
  */
 public class ChangesPane extends BaseElement
 {
-    private final static String previousChangeSelector = "#changes-info-boxes > a.changes-arrow-left";
-    private final static String nextChangeSelector = "#changes-info-boxes > a.changes-arrow-right";
+    private final static String previousChangeSelector = "#changes-info-boxes > #changes-arrow-boxes > a.changes-arrow-left";
+    private final static String nextChangeSelector = "#changes-info-boxes > #changes-arrow-boxes > a.changes-arrow-right";
     private final static String previousFromVersionSelector = "#changes-info-box-from .changes-arrow:first-child";
     private final static String nextFromVersionSelector = "#changes-info-box-from .changes-arrow:last-child";
     private final static String previousToVersionSelector = "#changes-info-box-to .changes-arrow:first-child";

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/changesdoc.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/changesdoc.vm
@@ -25,22 +25,22 @@
 #if ("$!previousOrigdocVersion" != '')
   #set ($changesLink = ${xwiki.getURL($tdoc, 'view', "viewer=changes&rev1=${previousOrigdocVersion}&rev2=${rev2}")})
   #set ($changesTitle = $services.localization.render('core.viewers.diff.previousVersion'))
-  #set ($previousOrigdocLink = "<a class='changes-arrow' href='$changesLink' title='$changesTitle'>&lt;</a>")
+  #set ($previousOrigdocLink = "<a class='btn btn-default changes-arrow' href='$changesLink' title='$changesTitle'>$services.icon.renderHTML('left')</a>")
 #end
 #if ("$!nextOrigdocVersion" != '')
   #set ($changesLink = ${xwiki.getURL($tdoc, 'view', "viewer=changes&rev1=${nextOrigdocVersion}&rev2=${rev2}")})
   #set ($changesTitle = $services.localization.render('core.viewers.diff.nextVersion'))
-  #set ($nextOrigdocLink = "<a class='changes-arrow' href='$changesLink' title='$changesTitle'>&gt;</a>")
+  #set ($nextOrigdocLink = "<a class='btn btn-default changes-arrow' href='$changesLink' title='$changesTitle'>$services.icon.renderHTML('right')</a>")
 #end
 #if ("$!previousNewdocVersion" != '')
   #set ($changesLink = ${xwiki.getURL($tdoc, 'view', "viewer=changes&rev1=${rev1}&rev2=${previousNewdocVersion}")})
   #set ($changesTitle = $services.localization.render('core.viewers.diff.previousVersion'))
-  #set ($previousNewdocLink = "<a class='changes-arrow' href='$changesLink' title='$changesTitle'>&lt;</a>")
+  #set ($previousNewdocLink = "<a class='btn btn-default changes-arrow' href='$changesLink' title='$changesTitle'>$services.icon.renderHTML('left')</a>")
 #end
 #if ("$!nextNewdocVersion" != '')
   #set ($changesLink = ${xwiki.getURL($tdoc, 'view', "viewer=changes&rev1=${rev1}&rev2=${nextNewdocVersion}")})
   #set ($changesTitle = $services.localization.render('core.viewers.diff.nextVersion'))
-  #set ($nextNewdocLink = "<a class='changes-arrow' href='$changesLink' title='$changesTitle'>&gt;</a>")
+  #set ($nextNewdocLink = "<a class='btn btn-default changes-arrow' href='$changesLink' title='$changesTitle'>$services.icon.renderHTML('right')</a>")
 #end
 ## Display the previous change arrow only if there is a previous version of the original document and there is no extension version
 #if ("$!previousOrigdocVersion" != '' && "$!previousNewdocVersion" != '')

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/diff_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/diff_macros.vm
@@ -581,20 +581,27 @@
 #macro (displayDocumentChangesHeader $from $to)
   <div id="changes-info">
     <div id="changes-info-boxes">
-      #if ("$!from.previousLink" != '')
-        <a href="$from.previousLink" class="changes-arrow-left"
-          title="$escapetool.xml($services.localization.render('core.viewers.diff.previousChange'))">&lt;</a>
+      #if ("$!from.previousLink" != '' || "$!to.nextLink" != '')
+        <div id='changes-arrows-box'>
+          #if ("$!from.previousLink" != '')
+            <a href="$from.previousLink" class="btn btn-default changes-arrow-left">
+              $services.icon.renderHTML('left') $escapetool.xml($services.localization.render('core.viewers.diff.previousChange'))
+            </a>
+          #end
+          #if ("$!to.nextLink" != '')
+            <a href="$to.nextLink" class="btn btn-default changes-arrow-right">
+              $escapetool.xml($services.localization.render('core.viewers.diff.nextChange')) $services.icon.renderHTML('right')
+            </a>
+          #end
+        </div>
       #end
       <div id="changes-info-box-from" class="changes-info-box">
         #displayDocumentVersionInfo($from.doc $from.version $from.previousVersionLink $from.nextVersionLink 'core.viewers.diff.from')
       </div> ## changes-info-box-from
+      <span role='presentation' class='changes-info-arrow'>$services.icon.renderHTML('right')</span>
       <div id="changes-info-box-to" class="changes-info-box">
         #displayDocumentVersionInfo($to.doc $to.version $to.previousVersionLink $to.nextVersionLink 'core.viewers.diff.to')
       </div> ## changes-info-box-to
-      #if ("$!to.nextLink" != '')
-        <a href="$to.nextLink" class="changes-arrow-right"
-          title="$escapetool.xml($services.localization.render('core.viewers.diff.nextChange'))">&gt;</a>
-      #end
     </div> ## changes-info-boxes
     <div id="changes-info-comment">
       $escapetool.xml($services.localization.render('core.viewers.diff.editComment'))


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21272
@surli reported this issue
## PR Changes
* Replaced the `<` and `>` symbols used for buttons with proper icontheme arrow icons.
* Updated the order of the nodes and structure to fit improvements to the interface
* Updated style to improve usability: action links styled as button, clearer structure of the section, and explicit name on some buttons.
* Updated test selectors

## View
Video demo: https://up1.xwikisas.com/#MxPdvwAXwzg3ketQazbVMw

Before the changes in this PR:
![21272-beforePR](https://github.com/xwiki/xwiki-platform/assets/28761965/ef61ce5f-309f-464a-9c06-bfa18da5829e)

After the changes in this PR:
![21272-afterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/0a437293-a2e4-45e7-9ef4-de992d027922)
