### PR TITLE
XWIKI-18880: Allow to decide where the Mark as read button is put in notifications template

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-macro/xwiki-platform-notifications-macro-ui/src/main/resources/XWiki/Notifications/Code/Macro/NotificationsMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-macro/xwiki-platform-notifications-macro-ui/src/main/resources/XWiki/Notifications/Code/Macro/NotificationsMacro.xml
@@ -400,12 +400,11 @@ require(['jquery', 'XWikiAsyncNotificationsMacro', 'xwiki-events-bridge'], funct
       notif.attr('data-eventtype', entry.type);
       // Put the content
       notif.append(entry.html);
-      // Create the "read" button
-      var readButton = $('&lt;button&gt;');
+      // Enable the "read" button
+      var readButton = notif.find('.notification-event-read-button');
       if (!entry.read &amp;&amp; self.displayReadStatus) {
-        notif.addClass('notification-event-unread');
-        // Add the "mark as read" button
-        notif.find('.notification-content').prepend(readButton);
+        readButton.prop('disabled', false);
+        readButton.removeClass('hidden');
       }
       if (entry.exception) {
         var exceptionBox = $('&lt;div&gt;').addClass('box errormessage');
@@ -420,13 +419,6 @@ require(['jquery', 'XWikiAsyncNotificationsMacro', 'xwiki-events-bridge'], funct
       self.insertElementInMacroContainer(notif);
       // Add the "mark as read" button if the notif is not already read
       if (!entry.read) {
-        // Style the read button
-        readButton.addClass('notification-event-read-button').addClass('btn btn-xs');
-        // Insert the cross icon and an accessible label
-        var readButtonIcon = $("$escapetool.javascript($services.icon.renderHTML('check'))");
-        readButton.attr('aria-label', "$escapetool.javascript($services.localization.render('notifications.macro.markEventAsRead'))");
-        readButton.attr('title', "$escapetool.javascript($services.localization.render('notifications.macro.markEventAsRead'))");
-        readButton.append(readButtonIcon);
         // On click
         readButton.on('click', function() {
           var notif = $(this).parents('div.notification-event');
@@ -595,18 +587,11 @@ require(['jquery', 'XWikiAsyncNotificationsMacro', 'xwiki-events-bridge'], funct
       if (!entry.data('augmented')) {
         // Ensure to not call twice this method.
         entry.data('augmented', true);
-        // Create the "read" button
-        var readButton = $('&lt;button&gt;');
         if (entry.hasClass("notification-event-unread") &amp;&amp; self.displayReadStatus) {
-          // Add the "mark as read" button
-          entry.find('.notification-content').prepend(readButton);
-          // Style the read button
-          readButton.addClass('notification-event-read-button').addClass('btn btn-xs');
-          // Insert the cross icon and an accessible label
-          var readButtonIcon = $("$escapetool.javascript($services.icon.renderHTML('check'))");
-          readButton.attr('aria-label', "$escapetool.javascript($services.localization.render('notifications.macro.markEventAsRead'))");
-          readButton.attr('title', "$escapetool.javascript($services.localization.render('notifications.macro.markEventAsRead'))");
-          readButton.append(readButtonIcon);
+          // Enable the "read" button
+          var readButton = entry.find('.notification-event-read-button');
+          readButton.prop('disabled', false);
+          readButton.removeClass('hidden');
           // On click
           readButton.on('click', function() {
             var notif = $(this).parents('div.notification-event');

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/notification/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/notification/macros.vm
@@ -114,7 +114,7 @@
               aria-label="$escapetool.xml($services.localization.render('notifications.macro.markEventAsRead'))"
               title="$escapetool.xml($services.localization.render('notifications.macro.markEventAsRead'))"
               disabled="disabled">
-        <span class="fa fa-check"></span>
+        $services.icon.renderHTML('check')
       </button>
       $content
       #if ($stringtool.isNotBlank($details))

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/notification/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/notification/macros.vm
@@ -110,6 +110,12 @@
       #end
     </div>
     <div class="col-xs-9 notification-content">
+      <button class="notification-event-read-button btn btn-xs hidden"
+              aria-label="$escapetool.xml($services.localization.render('notifications.macro.markEventAsRead'))"
+              title="$escapetool.xml($services.localization.render('notifications.macro.markEventAsRead'))"
+              disabled="disabled">
+        <span class="fa fa-check"></span>
+      </button>
       $content
       #if ($stringtool.isNotBlank($details))
         <button class="btn btn-xs toggle-notification-event-details" type="submit"


### PR DESCRIPTION
JIRA: https://jira.xwiki.org/browse/XWIKI-18880

  * Insert the read button in the template
  * Enable it in the notification macros if needed

Note that right now these change might have an impact on backward compatibility if an extension uses a customized template for macro and more specifically if they override `displayNotificationEventSkeleton`: they would lose the "Mark as read" button since it was injected dynamically. Now I really doubt we have much extensions overriding it: at least I don't find any occurrence of such override in xwiki-contrib.
Also note that the provided changes have no impact at all on the UI look&feel. 