### PR TITLE
XWIKI-21254: Improve the border on buttons

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/buttons.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/buttons.less
@@ -21,12 +21,12 @@
 .btn {
   &-default {
     .btn-background(lighten(@btn-default-bg, 5%));
-    .btn-border(darken(@btn-default-bg, 5%));
+    .btn-border(darken(@btn-default-bg, 10%));
 
     &:hover, 
     &:focus {
-      .btn-background(@btn-default-bg);
-      .btn-border(@btn-default-bg);
+      .btn-background(lighten(@btn-default-bg, 5%));
+      .btn-border(darken(@btn-default-bg, 20%));
     }
   }
 
@@ -140,12 +140,12 @@ input.button, .buttonwrapper button, .buttonwrapper a {
 
 .buttonwrapper input.secondary, .buttonwrapper button.secondary, .buttonwrapper a.secondary, a.secondary {
   .btn-background(lighten(@btn-default-bg, 5%));
-  .btn-border(@btn-default-bg);
+  .btn-border(darken(@btn-default-bg, 10%));
 
   &:hover, 
   &:focus {
-    .btn-background(@btn-default-bg);
-    .btn-border(@btn-default-bg);
+    .btn-background(lighten(@btn-default-bg, 5%));
+    .btn-border(darken(@btn-default-bg, 20%));
   }
 }
 


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-21254

Fixes some limitations identified with the initial proposal.
1. the background of the default buttons is the same as their border on hover.
2. when the background is grey, the border of the default button is the same as the background
3. on the distribution wizard (and more generally when using the "old" `secondary` class) on button groups, the button borders are missing.

Proposed fix:
Make the border of primary buttons 10% darker than the default grey (`@btn-default-bg`) by default, and 20% on hover.


Some screenshots:
![image](https://github.com/xwiki/xwiki-platform/assets/327856/927f3e07-2b80-46c8-a0bd-4004d7207bf4)
![image](https://github.com/xwiki/xwiki-platform/assets/327856/47684a43-6f57-4950-9406-59d0a383f737)


[Screencast from 11-09-2023 10:58:51.webm](https://github.com/xwiki/xwiki-platform/assets/327856/e1bd7b7b-fbdf-421d-a21a-6bad2e2a47b4)
