### PR TITLE
XWIKI-20904: The generated translation key for standard notification message is too strict

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/notification/email/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/notification/email/macros.vm
@@ -106,18 +106,7 @@
 #end
 
 #macro(displayNotificationDescription $event)
-  #if ($event.users.size() == 1)
-    <div>
-      $services.localization.render("notifications.events.${event.type}.description.by.1user", ["#displayEmailNotificationEventUsers($event.users, true, false)"])
-    </div>
-  #else
-    <div>
-      $services.localization.render("notifications.events.${event.type}.description.by.users", [$event.users.size()])
-    </div>
-    <div>
-      #displayEmailNotificationEventUsers($event.users, true, true)
-    </div>
-  #end
+  #displayCompositeEventDescription($event)
 #end
 
 

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/notification/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/notification/macros.vm
@@ -65,16 +65,7 @@
       #end
     </div>
     <div class="notification-description">
-      #if ($compositeEvent.users.size() == 1)
-        $services.localization.render("notifications.events.${compositeEvent.type}.description.by.1user", ["#displayNotificationEventUsers($compositeEvent.users, true, false)"])
-      #else
-        <div>
-          $services.localization.render("notifications.events.${compositeEvent.type}.description.by.users", [$compositeEvent.users.size()])
-        </div>
-        <div>
-          #displayNotificationEventUsers($compositeEvent.users, true, true)
-        </div>
-      #end
+      #displayCompositeEventDescription($compositeEvent)
       <div><small class="text-muted">$escapetool.xml($services.date.displayTimeAgo($compositeEvent.dates.get(0)))</small></div>
     </div>
   #end
@@ -242,4 +233,46 @@ $xwiki.getPlainUserName($user)##
     <div><small class="text-muted">$escapetool.xml($services.date.displayTimeAgo($compositeEvent.dates.get(0)))</small></div>
   #end
   #displayNotificationEventSkeleton($icon, 'comment', $content, '')
+#end
+
+#macro(displayCompositeEventDescription $compositeEvent)
+  #set ($baseTranslationPrefix = "${compositeEvent.type}")
+  #set ($fallbackTranslationPrefix = "notifications.events.${compositeEvent.type}")
+  #set ($fallbackTranslationSuffix = "description")
+  #set ($fallbackTranslation = "#getNotificationTranslation($baseTranslationPrefix,$fallbackTranslationSuffix,$fallbackTranslationPrefix,[])")
+  #set ($descriptionTranslation = $NULL)
+  #if ($compositeEvent.users.size() == 1)
+    #set ($translationSuffix = "description.by.1user")
+    #set ($translationParameters = ["#displayNotificationEventUsers($compositeEvent.users, true, false)"])
+    #set ($descriptionTranslation = "#getNotificationTranslation($baseTranslationPrefix,$translationSuffix,$fallbackTranslationPrefix,$translationParameters)")
+    #if ("$!descriptionTranslation" != '')
+      $descriptionTranslation
+    #else
+      $fallbackTranslation
+    #end
+  #else
+  <div>
+    #set ($translationSuffix = "description.by.users")
+    #set ($translationParameters = [$compositeEvent.users.size()])
+    #set ($descriptionTranslation = "#getNotificationTranslation($baseTranslationPrefix,$translationSuffix,$fallbackTranslationPrefix,$translationParameters)")
+    #if ("$!descriptionTranslation" != '')
+      $descriptionTranslation
+    #else
+      $fallbackTranslation
+    #end
+  </div>
+  <div>
+    #displayNotificationEventUsers($compositeEvent.users, true, true)
+  </div>
+  #end
+#end
+
+#macro(getNotificationTranslation $prefix $suffix $fallbackPrefix $parameters)
+  #set ($translationResult = $NULL)
+  #set ($translationKey = "${prefix}.${suffix}")
+  #set ($translationResult = $services.localization.render($translationKey, $parameters))
+  #if ("$translationResult" == "$translationKey")
+    #set ($translationResult = $services.localization.render("${fallbackPrefix}.${suffix}", $parameters))
+  #end
+  $translationResult
 #end

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/notification/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/notification/macros.vm
@@ -239,40 +239,31 @@ $xwiki.getPlainUserName($user)##
   #set ($baseTranslationPrefix = "${compositeEvent.type}")
   #set ($fallbackTranslationPrefix = "notifications.events.${compositeEvent.type}")
   #set ($fallbackTranslationSuffix = "description")
-  #set ($fallbackTranslation = "#getNotificationTranslation($baseTranslationPrefix,$fallbackTranslationSuffix,$fallbackTranslationPrefix,[])")
   #set ($descriptionTranslation = $NULL)
   #if ($compositeEvent.users.size() == 1)
     #set ($translationSuffix = "description.by.1user")
+    #set ($translationKeys = [
+      "${baseTranslationPrefix}.${translationSuffix}",
+      "${fallbackTranslationPrefix}.${translationSuffix}",
+      "${baseTranslationPrefix}.${fallbackTranslationSuffix}",
+      "${fallbackTranslationPrefix}.${fallbackTranslationSuffix}"
+    ])
     #set ($translationParameters = ["#displayNotificationEventUsers($compositeEvent.users, true, false)"])
-    #set ($descriptionTranslation = "#getNotificationTranslation($baseTranslationPrefix,$translationSuffix,$fallbackTranslationPrefix,$translationParameters)")
-    #if ("$!descriptionTranslation" != '')
-      $descriptionTranslation
-    #else
-      $fallbackTranslation
-    #end
+    $services.localization.render($translationKeys,$translationParameters)
   #else
   <div>
     #set ($translationSuffix = "description.by.users")
     #set ($translationParameters = [$compositeEvent.users.size()])
-    #set ($descriptionTranslation = "#getNotificationTranslation($baseTranslationPrefix,$translationSuffix,$fallbackTranslationPrefix,$translationParameters)")
-    #if ("$!descriptionTranslation" != '')
-      $descriptionTranslation
-    #else
-      $fallbackTranslation
-    #end
+    #set ($translationKeys = [
+      "${baseTranslationPrefix}.${translationSuffix}",
+      "${fallbackTranslationPrefix}.${translationSuffix}",
+      "${baseTranslationPrefix}.${fallbackTranslationSuffix}",
+      "${fallbackTranslationPrefix}.${fallbackTranslationSuffix}"
+    ])
+    $services.localization.render($translationKeys,$translationParameters)
   </div>
   <div>
     #displayNotificationEventUsers($compositeEvent.users, true, true)
   </div>
   #end
-#end
-
-#macro(getNotificationTranslation $prefix $suffix $fallbackPrefix $parameters)
-  #set ($translationResult = $NULL)
-  #set ($translationKey = "${prefix}.${suffix}")
-  #set ($translationResult = $services.localization.render($translationKey, $parameters))
-  #if ("$translationResult" == "$translationKey")
-    #set ($translationResult = $services.localization.render("${fallbackPrefix}.${suffix}", $parameters))
-  #end
-  $translationResult
 #end


### PR DESCRIPTION
JIRA: https://jira.xwiki.org/browse/XWIKI-20904

This work provides a new macro in the notifications macro to compute the description to display for a composite event. The computation is done as before, based on the number of users concerned by the event. The main change is that the macro performs several fallbacks to try to always display something.