### PR TITLE
XWIKI-18838: Use ARIA landmarks for main page regions

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
@@ -224,6 +224,7 @@
 
 #body.main { // Rule for WYSIWYG frame body.main
   background-color: @xwiki-page-content-bg;
+  box-shadow: none;
 }
 
 #xwikieditor .main {


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-18838
## Context
After we merged https://github.com/xwiki/xwiki-platform/pull/2166 yesterday, @manuelleduc noticed a regression in the WYSIWYG UI:
![18838-2-beforePR](https://github.com/xwiki/xwiki-platform/assets/28761965/f032b8dc-7cb3-4736-a934-59728aa3051a)
This regression is caused by assumptions I had on the '.main' class in XWiki. I did not realize it could be used in a context different than the 'page content container' one. I changed style and this broke the presentation on the WYSIWYG main.
This PR adds an additionnal rule overriding those changes on the WYSIWYG main.

## PR Change
* Patched a grey line appearing in the WYSIWIG editor
## View
![18838-mainLine](https://github.com/xwiki/xwiki-platform/assets/28761965/05f6dad3-436d-4edc-b482-8b38aa70a1db)
