### PR TITLE
XWIKI-21097: Request URI too long error when using opening the notification area

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/pom.xml
@@ -31,7 +31,7 @@
   <name>XWiki Platform - Notifications - API</name>
   <description>Handle notifications</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.41</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.50</xwiki.jacoco.instructionRatio>
     <!-- Name to display by the Extension Manager -->
     <xwiki.extension.name>Notifications API</xwiki.extension.name>
     <!-- Skipping revapi since xwiki-platform-legacy-notifications-api wraps this module and runs checks on it -->

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/src/main/java/org/xwiki/notifications/internal/DefaultCompositeEventStatusManager.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/src/main/java/org/xwiki/notifications/internal/DefaultCompositeEventStatusManager.java
@@ -20,8 +20,9 @@
 package org.xwiki.notifications.internal;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
@@ -46,6 +47,8 @@ import org.xwiki.notifications.CompositeEventStatusManager;
 @Singleton
 public class DefaultCompositeEventStatusManager implements CompositeEventStatusManager
 {
+    private static final int BATCH_SIZE = 50;
+
     @Inject
     private EventStore eventStore;
 
@@ -53,32 +56,38 @@ public class DefaultCompositeEventStatusManager implements CompositeEventStatusM
     public List<CompositeEventStatus> getCompositeEventStatuses(List<CompositeEvent> compositeEvents, String entityId)
         throws Exception
     {
-        // Creating a list of all events to avoid multiple calls to getEventStatuses() and so multiple calls to the
-        // database.
-        List<Event> allEvents = new ArrayList<>();
-        // But maintain a mapping between eventId and their composite event status
-        Map<String, CompositeEventStatus> map = new HashMap<>();
+        // Maintain a mapping between eventId and their composite event status
+        Map<String, CompositeEventStatus> statusMap = new HashMap<>();
+        List<CompositeEventStatus> results = new ArrayList<>();
+        LinkedList<Event> eventsToProcess = new LinkedList<>();
+
+        // Prepare the maps
         for (CompositeEvent compositeEvent : compositeEvents) {
             CompositeEventStatus compositeEventStatus = new CompositeEventStatus(compositeEvent);
+            results.add(compositeEventStatus);
             for (Event event : compositeEvent.getEvents()) {
-                map.put(event.getId(), compositeEventStatus);
+                statusMap.put(event.getId(), compositeEventStatus);
+                eventsToProcess.add(event);
             }
-            allEvents.addAll(compositeEvent.getEvents());
         }
-        // Put the event statuses into the composite events statuses
-        for (EventStatus eventStatus : getEventStatuses(allEvents, entityId)) {
-            map.get(eventStatus.getEvent().getId()).add(eventStatus);
-        }
-        List<CompositeEventStatus> results = new ArrayList<>();
-        // Keep the same order than inputs
-        for (CompositeEvent event : compositeEvents) {
-            results.add(map.get(event.getEvents().get(0).getId()));
-        }
+
+        // Process the events status by batch
+        do {
+            List<Event> subList = new ArrayList<>();
+            for (int i = 0; i < BATCH_SIZE && !eventsToProcess.isEmpty(); i++) {
+                Event event = eventsToProcess.pop();
+                subList.add(event);
+            }
+            for (EventStatus eventStatus : getEventStatuses(subList, entityId)) {
+                statusMap.get(eventStatus.getEvent().getId()).add(eventStatus);
+            }
+        } while (!eventsToProcess.isEmpty());
+
         return results;
     }
 
     private List<EventStatus> getEventStatuses(List<Event> events, String entityId) throws Exception
     {
-        return this.eventStore.getEventStatuses(events, Arrays.asList(entityId));
+        return this.eventStore.getEventStatuses(events, Collections.singletonList(entityId));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/src/test/java/org/xwiki/notifications/internal/DefaultCompositeEventStatusManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/src/test/java/org/xwiki/notifications/internal/DefaultCompositeEventStatusManagerTest.java
@@ -19,15 +19,27 @@
  */
 package org.xwiki.notifications.internal;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.xwiki.eventstream.Event;
+import org.xwiki.eventstream.EventStatus;
+import org.xwiki.eventstream.EventStore;
+import org.xwiki.notifications.CompositeEvent;
 import org.xwiki.notifications.CompositeEventStatus;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests ofr {@link DefaultCompositeEventStatusManager}
@@ -40,11 +52,55 @@ public class DefaultCompositeEventStatusManagerTest
     @InjectMockComponents
     private DefaultCompositeEventStatusManager eventStatusManager;
 
+    @MockComponent
+    private EventStore eventStore;
+
     @Test
     void getCompositeEventStatusesWhenEmpty() throws Exception
     {
         List<CompositeEventStatus> statuses =
             this.eventStatusManager.getCompositeEventStatuses(Collections.emptyList(), null);
         assertTrue(statuses.isEmpty());
+    }
+
+    @Test
+    void getCompositeEventStatusesMultipleLoops() throws Exception
+    {
+        List<CompositeEvent> compositeEvents = new ArrayList<>();
+
+        // We have 55*5 events in total = 275 events
+        // With batches of 50 events, we should perform 6 loops
+        int numberOfCompositeEvents = 55;
+        int numberOfEventsInEach = 5;
+
+
+        for (int i = 0; i < numberOfCompositeEvents; i++) {
+            CompositeEvent compositeEventI = mock(CompositeEvent.class, "compositeEvent" + i);
+            List<Event> eventList = new ArrayList<>();
+            for (int j = 0; j < numberOfEventsInEach; j++) {
+                String eventId = String.format("event_%s_%s", i, j);
+                Event eventJ = mock(Event.class, eventId);
+                when(eventJ.getId()).thenReturn(eventId);
+                eventList.add(eventJ);
+            }
+            when(compositeEventI.getEvents()).thenReturn(eventList);
+            compositeEvents.add(compositeEventI);
+        }
+
+        String entityId = "XWiki.Foo";
+        when(this.eventStore.getEventStatuses(any(), any())).then(invocationOnMock -> {
+            List<Event> eventList = invocationOnMock.getArgument(0);
+            List<String> entity = invocationOnMock.getArgument(1);
+            assertTrue(eventList.size() == 50 || eventList.size() == 25);
+            assertEquals(List.of(entityId), entity);
+            EventStatus eventStatus = mock(EventStatus.class);
+            when(eventStatus.getEvent()).thenReturn(eventList.get(0));
+            return List.of(eventStatus);
+        });
+
+        List<CompositeEventStatus> compositeEventStatuses =
+            this.eventStatusManager.getCompositeEventStatuses(compositeEvents, entityId);
+        assertEquals(55, compositeEventStatuses.size());
+        verify(this.eventStore, times(6)).getEventStatuses(any(), any());
     }
 }


### PR DESCRIPTION
JIRA: https://jira.xwiki.org/browse/XWIKI-21097

  * Change the algorithm to gather statuses in DefaultCompositeEventStatusManager to request per batch instead of requesting everything at once
  * Provide a unit test to cover the changes