### PR TITLE
XWIKI-18838: Use ARIA landmarks for main page regions

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/ViewPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/ViewPage.java
@@ -288,7 +288,7 @@ public class ViewPage extends BasePage
 
     public String getPageBackgroundColor()
     {
-        return getElementCSSValue(By.id("mainContentArea"), "background-color");
+        return getElementCSSValue(By.className("main"), "background-color");
     }
 
     public String getTitleFontFamily()


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-18838
## PR Changes
* Updated test selector for the page background in regards to the changes in layout.less
## Note
This is a patch for [a regression](https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/master/6877/testReport/org.xwiki.flamingo.test.ui/FlamingoThemeIT/Platform_Builds___main___integration_tests___IT_for_xwiki_platform_core_xwiki_platform_flamingo_xwiki_platform_flamingo_theme_xwiki_platform_flamingo_theme_test_xwiki_platform_flamingo_theme_test_docker___Build_for_IT_for_xwiki_platform_core_xwiki_platform_flamingo_xwiki_platform_flamingo_theme_xwiki_platform_flamingo_theme_test_xwiki_platform_flamingo_theme_test_docker___validateColorThemeFeatures_TestUtils__TestInfo_/) introduced in [this previous commit](https://github.com/xwiki/xwiki-platform/commit/22eee6a3f51d8af14357255596ee78644c5a26a1#diff-769e5c7e3d9bd07eeac5769262c5767b3ddb283a4d3e3bd06be2e8b1b56a4438R293).
The element the style was applied on changed, but the selector to check that the correct style was applied did not get updated.