### PR TITLE
XWIKI-18838: Use ARIA landmarks for main page regions

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/hierarchy.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/hierarchy.vm
@@ -19,6 +19,7 @@
 ## ---------------------------------------------------------------------------
 #template('xwikivars.vm')
 #if($isInServletMode) ## Visible only in a page
+  <nav id="hierarchy_breadcrumb" aria-label="$escapetool.xml($services.localization.render("web.hierarchy.label"))">
   #template('hierarchy_macros.vm')
   #######################################################
   ##                   CONTROLLER
@@ -34,4 +35,5 @@
     ##
     #hierarchy($NULL {'id': 'hierarchy', 'limit': 5, 'treeNavigation': true})
   #end
+  </nav>
 #end

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
@@ -225,6 +225,7 @@
 #body.main { // Rule for WYSIWYG frame body.main
   background-color: @xwiki-page-content-bg;
 }
+
 #contentcolumn .main {
   padding-top: 0;
   padding-bottom: 0;

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
@@ -224,7 +224,10 @@
 
 #body.main { // Rule for WYSIWYG frame body.main
   background-color: @xwiki-page-content-bg;
-  box-shadow: none;
+}
+#contentcolumn .main {
+  padding-top: 0;
+  padding-bottom: 0;
 }
 
 #xwikieditor .main {
@@ -291,18 +294,22 @@
   }
 }
 
-.main {
-  background-color: @xwiki-page-content-bg;
-  box-shadow: 0 1px 2px @xwiki-border-color;
-  padding: @line-height-computed @grid-gutter-width;
-}
-
+#hierarchy_breadcrumb,
+#mainContentArea,
 #xdocFooter,
 #docextrapanes {
   background-color: @xwiki-page-content-bg;
   box-shadow: 0 1px 2px @xwiki-border-color;
   margin: 0 -@grid-gutter-width;
   padding: @line-height-computed @grid-gutter-width;
+}
+
+#mainContentArea {
+  padding-top: 0;
+}
+
+#hierarchy_breadcrumb {
+  padding-bottom: 0;
 }
 
 #docextrapanes {

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/view.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/view.vm
@@ -41,7 +41,10 @@
   #if($viewer == 'content')
     #template("contentview.vm")
   #else
-    #template("${viewer}.vm")
+    ## Set as an HTML main for better DOM tree semantics to facilitate navigation with assistive technologies.
+    <main id="mainContentArea" class="xcontent">
+      #template("${viewer}.vm")
+    </main>
   #end
   <div class="clearfloats"></div>
   #if($viewer == 'content')

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -3991,6 +3991,7 @@ rating.votes=Votes
 
 ## Hierarchy
 web.hierarchy.error=Failed to get the full hierarchy.
+web.hierarchy.label=Breadcrumb
 
 ## XWiki Select Widget
 web.widgets.select.filter=Filter


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-18838
## PR Changes
* Added a navigation element wrapping the hierarchy element (accessible name, escaped and localized)
* Updated style to avoid the white border under the page content
* Updated the view template to avoid style issues with secondary viewers

## Notes
Heavily inspired by the changes proposed by @michitux on https://up1.xwikisas.com/#n_dabC3OwYMpcT8c3UfASA
Notable changes to those:
* Removed paddings under the breadcrumb that were extra
* Increased specificity of the 'breadcrumb' id to avoid unwanted collisions
* Updated the view template to avoid style issues with secondary viewers (from what I could see, secondary viewers did not display a hierarchy at the top, that we wanted to exclude, like we do on the contentviwer.vm )

## View
![18838-attachmentsFixed](https://github.com/xwiki/xwiki-platform/assets/28761965/5a5d664f-6035-4e94-ba4c-cb2d3aaa9bc2)
![18838-whiteBordersFixed](https://github.com/xwiki/xwiki-platform/assets/28761965/53a9e29f-37a6-40eb-b007-bd32e7727500)
