### PR TITLE
XWIKI-18838: Use ARIA landmarks for main page regions

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-pageobjects/src/main/java/org/xwiki/flamingo/skin/test/po/UndeletePage.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-pageobjects/src/main/java/org/xwiki/flamingo/skin/test/po/UndeletePage.java
@@ -57,7 +57,7 @@ public class UndeletePage extends BasePage
 
     private static final String DELETED_BATCH_ID_PREFIX = "Deleted Batch ID\n";
 
-    @FindBy(xpath = "//div[@id = 'mainContentArea']/div[@class='xcontent']/form//a[@class = 'panel-collapse-carret']")
+    @FindBy(xpath = "//main[@id = 'mainContentArea']/div[@class='xcontent']/form//a[@class = 'panel-collapse-carret']")
     private WebElement panelToggleLink;
 
     @FindBy(xpath = "//div[@id = 'panel-batch']/div[@class = 'row']/div[@class='col-xs-12 col-lg-4']")
@@ -66,10 +66,10 @@ public class UndeletePage extends BasePage
     @FindBy(xpath = "//div[@id = 'panel-batch']/div[@class = 'row']/div[last()]")
     private WebElement deletedBatchId;
 
-    @FindBy(xpath = "//div[@id = 'mainContentArea']/div[@class = 'xcontent']/form/a[text() = 'Cancel']")
+    @FindBy(xpath = "//main[@id = 'mainContentArea']/div[@class = 'xcontent']/form/a[text() = 'Cancel']")
     private WebElement cancelLink;
 
-    @FindBy(xpath = "//div[@id = 'mainContentArea']/div[@class = 'xcontent']/form/button[text() = 'Restore']")
+    @FindBy(xpath = "//main[@id = 'mainContentArea']/div[@class = 'xcontent']/form/button[text() = 'Restore']")
     private WebElement restoreButton;
 
     /**

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BasePage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BasePage.java
@@ -600,7 +600,7 @@ public class BasePage extends BaseElement
     public String getErrorContent()
     {
         return getDriver()
-            .findElementWithoutWaiting(By.xpath("//div[@id = 'mainContentArea']/pre[contains(@class, 'xwikierror')]"))
+            .findElementWithoutWaiting(By.xpath("//main[@id = 'mainContentArea']/pre[contains(@class, 'xwikierror')]"))
             .getText();
     }
 
@@ -634,7 +634,7 @@ public class BasePage extends BaseElement
     public String getXWikiMessageContent()
     {
         return getDriver()
-            .findElementWithoutWaiting(By.xpath("//div[@id = 'mainContentArea']/div[contains(@class, 'xwikimessage')]"))
+            .findElementWithoutWaiting(By.xpath("//main[@id = 'mainContentArea']/div[contains(@class, 'xwikimessage')]"))
             .getText();
     }
 

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/wikidoesnotexist.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/wikidoesnotexist.vm
@@ -53,7 +53,7 @@ $response.setStatus(404)
       ## Display the standard error message or the custom XWiki.WikiDoesNotExist page from the main wiki
       ##
       <div class='main layoutsubsection'>
-        <div id='mainContentArea'>
+        <main id='mainContentArea'>
           ## Allow the wiki admin to specify a custom wiki error page in the main wiki
           #if ($xwiki.exists('XWiki.WikiDoesNotExist'))
             $xwiki.includeForm('XWiki.WikiDoesNotExist', false)
@@ -63,6 +63,6 @@ $response.setStatus(404)
             #xwikimessageboxend()
           #end
           <div class="clearfloats"></div>
-        </div>## mainContentArea
+        </main>## mainContentArea
       </div>## main
 #template('endpage.vm')


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-18838
## PR Changes
* Fixed page objects selectors to take into account the change to the nature of the mainContentArea node.
* Fixed a mainContentArea that did not get its element nature changed

## Note
The first change allows to fix the regression that created [this test failure ](https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/master/6879/testReport/org.xwiki.flamingo.test.docker/AllIT$NestedDeletePageIT/Platform_Builds___main___integration_tests___IT_for_xwiki_platform_core_xwiki_platform_flamingo_xwiki_platform_flamingo_skin_xwiki_platform_flamingo_skin_test_xwiki_platform_flamingo_skin_test_docker___Build_for_IT_for_xwiki_platform_core_xwiki_platform_flamingo_xwiki_platform_flamingo_skin_xwiki_platform_flamingo_skin_test_xwiki_platform_flamingo_skin_test_docker___deleteChildren_TestUtils__TestReference__TestInfo_/).