### PR TITLE
XWIKI-18838: Use ARIA landmarks for main page regions

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/ViewPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/ViewPage.java
@@ -288,7 +288,7 @@ public class ViewPage extends BasePage
 
     public String getPageBackgroundColor()
     {
-        return getElementCSSValue(By.className("main"), "background-color");
+        return getElementCSSValue(By.id("mainContentArea"), "background-color");
     }
 
     public String getTitleFontFamily()


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-18838

## PR Changes
* Patched a selector for the viewpage background
## Notes
Reverts a change in https://github.com/xwiki/xwiki-platform/commit/6265ae2ac64dbdf627755d9b2c1c2e4cc02a3609 that was rendered false due to the updates in https://github.com/xwiki/xwiki-platform/commit/04911bb1753871c3e9a0a1faf26ac97ef4b57492. 
The selector used to target `#mainContentArea`, but since I modified style rules in `layout.less`, I changed it to `.main`. During a patch last week, the way to implement the style was changed again and we need to select `#mainContentArea` again.

This caused fails on the CI such as [this one](https://ci.xwiki.org/job/XWiki%20Environment%20Tests/job/xwiki-platform/job/master/341/testReport/org.xwiki.flamingo.test.ui/FlamingoThemeIT/MySQL_8__Tomcat_9_jdk17__Chrome___Docker_tests_for_xwiki_platform_flamingo_theme___Build_for_MySQL_8__Tomcat_9_jdk17__Chrome___Docker_tests_for_xwiki_platform_flamingo_theme___validateColorThemeFeatures_TestUtils__TestInfo_/) .