### PR TITLE
XWIKI-19490: Resizing columns in Live Data makes the column title too small

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/table/LayoutTableHeaderNames.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/table/LayoutTableHeaderNames.vue
@@ -182,10 +182,9 @@ export default {
     },
 
     resizeColumnInit (e) {
-      const th = e.currentTarget.closest("th");
-      e.data.leftColumn = th.querySelector(".column-name");
+      e.data.leftColumn = e.currentTarget.closest("th");
       e.data.leftColumnBaseWidth = e.data.leftColumn.getBoundingClientRect()?.width;
-      e.data.rightColumn = this.getNextVisibleProperty(th)?.querySelector(".column-name");
+      e.data.rightColumn = this.getNextVisibleProperty(e.data.leftColumn);
       e.data.rightColumnBaseWidth = e.data.rightColumn.getBoundingClientRect()?.width;
     },
 
@@ -204,8 +203,7 @@ export default {
 
     resetColumnSize (e) {
       const th = e.currentTarget.closest("th");
-      const column = th.querySelector(".column-name");
-      column.style.width = "unset";
+      th.style.width = "unset";
     },
 
   },

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/table/LayoutTableHeaderNames.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/table/LayoutTableHeaderNames.vue
@@ -186,7 +186,7 @@ export default {
       e.data.leftColumn = th.querySelector(".column-name");
       e.data.leftColumnBaseWidth = e.data.leftColumn.getBoundingClientRect()?.width;
       e.data.rightColumn = this.getNextVisibleProperty(th)?.querySelector(".column-name");
-      e.data.rightColumnBaseWidth = e.data.rightColumn?.getBoundingClientRect()?.width;
+      e.data.rightColumnBaseWidth = e.data.rightColumn.getBoundingClientRect()?.width;
     },
 
     resizeColumn (e) {

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/table/LayoutTableHeaderNames.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/table/LayoutTableHeaderNames.vue
@@ -105,7 +105,7 @@
 <script>
 import LivedataEntrySelectorAll from "../../LivedataEntrySelectorAll.vue";
 import XWikiDraggable from "../../utilities/XWikiDraggable.vue";
-import {mousedownmove} from "../../directives.js";
+import { mousedownmove } from "../../directives.js";
 import XWikiIcon from "../../utilities/XWikiIcon";
 
 export default {
@@ -174,49 +174,38 @@ export default {
       this.logic.reorderProperty(e.moved.oldIndex - 1, e.moved.newIndex - 1);
     },
 
-    resizeColumnInit (e) {
-      e.data.column = e.currentTarget.closest("th");
-      e.data.columnName = e.data.column.querySelector(".column-name")
-      e.data.columnBaseWidth = e.data.column.getBoundingClientRect()?.width;
-      e.data.columnNameBaseWidth = e.data.columnName.getBoundingClientRect()?.width;
+    getNextVisibleProperty (th) {
+      while (th.nextElementSibling) {
+        th = th.nextElementSibling;
+        if (th.style.display !== "none") return th;
+      }
+    },
 
-      // Set the width of every column to the current width to prevent jumping during resizing and unset the width of
-      // the table to prevent further scaling.
-      const row = e.data.column.closest("tr");
-      const columns = row.querySelectorAll("th");
-      // First collect all column and column name widths to ensure we capture the current widths before resizing.
-      const columnWidths = [];
-      const columnNameWidths = [];
-      for (const column of columns) {
-        columnWidths.push(column.getBoundingClientRect()?.width);
-        columnNameWidths.push(column.querySelector(".column-name").getBoundingClientRect()?.width);
-      }
-      // Then set the widths.
-      for (let i = 0; i < columns.length; i++) {
-        columns[i].style.width = `${columnWidths[i]}px`;
-        columns[i].querySelector(".column-name").style.width = `${columnNameWidths[i]}px`;
-      }
-      const table = e.data.column.closest("table");
-      table.style.width = "unset";
+    resizeColumnInit (e) {
+      const th = e.currentTarget.closest("th");
+      e.data.leftColumn = th.querySelector(".column-name");
+      e.data.leftColumnBaseWidth = e.data.leftColumn.getBoundingClientRect()?.width;
+      e.data.rightColumn = this.getNextVisibleProperty(th)?.querySelector(".column-name");
+      e.data.rightColumnBaseWidth = e.data.rightColumn?.getBoundingClientRect()?.width;
     },
 
     resizeColumn (e) {
       const offsetX = e.clientX - e.data.clickEvent.clientX;
-      // Resize column
-      const columnWidth = e.data.columnBaseWidth + offsetX;
-      e.data.column.style.width = `${columnWidth}px`;
-      // Resize column name as well as the flex container doesn't resize beyond the width of the name which is supposed
-      // to be abbreviated when the column is too small.
-      e.data.columnName.style.width = `${e.data.columnNameBaseWidth + offsetX}px`;
+      // Resize left column
+      const leftColumnWidth = e.data.leftColumnBaseWidth + offsetX;
+      e.data.leftColumn.style.width = `${leftColumnWidth}px`;
+
+      // Resize right column
+      if (e.data.rightColumn) {
+        const rightColumnWidth = e.data.rightColumnBaseWidth - offsetX;
+        e.data.rightColumn.style.width = `${rightColumnWidth}px`;
+      }
     },
 
     resetColumnSize (e) {
       const th = e.currentTarget.closest("th");
-      for (const column of th.closest("tr").querySelectorAll("th")) {
-        column.style.removeProperty("width");
-        column.querySelector(".column-name").style.removeProperty("width");
-      }
-      th.closest("table").style.removeProperty("width");
+      const column = th.querySelector(".column-name");
+      column.style.width = "unset";
     },
 
   },


### PR DESCRIPTION
* Resize both column and name to properly resize columns.
* Remove the forced width of 100% on the table to make sure column width
  are actually respected and also set all other column width to prevent
  weird resizing effects.
* Resize only the column left of the resizer to make it easier to resize
  single columns. This is also more consistent with other applications
  where you can resize columns like LibreOffice.

Jira issue: https://jira.xwiki.org/browse/XWIKI-19490

This is quite a big UX change, would be nice to get some feedback if we want to change it that much or only a little. We could, e.g., also just resize both column and name which would already be a big improvement and basically prevent the actually reported issue. When I tested it, though, the behavior just felt wrong, still, and you could easily reach states where just clicking the resize handle results in a jump in column size because all columns were shrunk or expanded to reach the 100% width. Also, this changes the reset (when double-clicking on a resize handle) to reset all column widths as to make this work I had to fix all column widths and not just some and resetting one width wouldn't have the effect you would expect I think. Here is a video of the new behavior:

[Screencast_20230918_153744-1.webm](https://github.com/xwiki/xwiki-platform/assets/198317/cb6c99db-7eaa-4ada-a4fc-b4345b6fa3cd)

As you can see in the video, there are still cases where the column can move away from the pointer position, but this now only happens when the table scrolls horizontally due to needing less space than before. I don't know if we could (or would want to) prevent this somehow.