### PR TITLE
XWIKI-21209: Delete filter is slow (seems to load all filters)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/event/NotificationFilterPreferenceDeletedEvent.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/event/NotificationFilterPreferenceDeletedEvent.java
@@ -25,7 +25,7 @@ package org.xwiki.notifications.filters.internal.event;
  * <ul>
  *     <li>source: either a DocumentReference representing the user who used to own the filter, or a WikiReference
  *     if it was a filter set for a wiki</li>
- *     <li>data: the actual internal identifier of the filter as a long</li>
+ *     <li>data: the actual identifier of the filter as a String</li>
  * </ul>
  *
  * @version $Id$

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/event/NotificationFilterPreferenceDeletedEvent.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/event/NotificationFilterPreferenceDeletedEvent.java
@@ -21,7 +21,13 @@ package org.xwiki.notifications.filters.internal.event;
 
 /**
  * Event generated when a notification filter preference is deleted.
- * 
+ * The event is sent with the following information:
+ * <ul>
+ *     <li>source: either a DocumentReference representing the user who used to own the filter, or a WikiReference
+ *     if it was a filter set for a wiki</li>
+ *     <li>data: the actual internal identifier of the filter as a long</li>
+ * </ul>
+ *
  * @version $Id$
  * @since 10.11.4
  * @since 11.2

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/CachedModelBridgeInvalidatorListener.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/CachedModelBridgeInvalidatorListener.java
@@ -25,6 +25,7 @@ import javax.inject.Singleton;
 
 import org.apache.commons.lang3.StringUtils;
 import org.xwiki.component.annotation.Component;
+import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.DocumentReferenceResolver;
 import org.xwiki.model.reference.WikiReference;
 import org.xwiki.notifications.filters.internal.event.NotificationFilterPreferenceAddOrUpdatedEvent;
@@ -83,6 +84,10 @@ public class CachedModelBridgeInvalidatorListener extends AbstractEventListener
                     ((CachedModelBridge) this.bridge).invalidatePreferencefilter(new WikiReference(owner));
                 }
             }
+        } else if (source instanceof DocumentReference) {
+            ((CachedModelBridge) this.bridge).invalidatePreferencefilter((DocumentReference) source);
+        } else if (source instanceof WikiReference) {
+            ((CachedModelBridge) this.bridge).invalidatePreferencefilter((WikiReference) source);
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/NotificationFilterPreferenceStore.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/NotificationFilterPreferenceStore.java
@@ -449,9 +449,7 @@ public class NotificationFilterPreferenceStore
         try {
             return supplier.get();
         } finally {
-            if (wikiReference != null) {
-                context.setWikiReference(currentWiki);
-            }
+            context.setWikiReference(currentWiki);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/event/NotificationFilterPreferenceEventConverter.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/event/NotificationFilterPreferenceEventConverter.java
@@ -20,9 +20,7 @@
 package org.xwiki.notifications.filters.internal.event;
 
 import java.io.Serializable;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -49,8 +47,8 @@ import org.xwiki.observation.remote.converter.AbstractEventConverter;
 @Named("notificationfilterpreference")
 public class NotificationFilterPreferenceEventConverter extends AbstractEventConverter
 {
-    private static final Set<Class<? extends Event>> EVENTS = new HashSet<>(Arrays
-        .asList(NotificationFilterPreferenceAddOrUpdatedEvent.class, NotificationFilterPreferenceDeletedEvent.class));
+    private static final Set<Class<? extends Event>> EVENTS =
+        Set.of(NotificationFilterPreferenceAddOrUpdatedEvent.class);
 
     private static final String PROP_OWNER = "owner";
 


### PR DESCRIPTION
JIRA: https://jira.xwiki.org/browse/XWIKI-21209

  * Refactor NotificationFilterPreferenceStore to ensure to use the right wiki in context when the local store is used
  * Use a query based on the filter internal identifier to perform single deletion, to prevent having to load it
  * Refactor the way NotificationFilterPreferenceDeletedEvent is used to not send the entire filter instance when it's triggered
  * Improve unit tests