### PR TITLE
XWIKI-19449: Livedata table overflows horizontally for container sizes in which livetable fits perfectly fine

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/table/LayoutTableHeaderNames.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/table/LayoutTableHeaderNames.vue
@@ -231,18 +231,22 @@ export default {
   /* Ensure that the name is never smaller than the width of the column, i.e., it always fills the available space even
    when the column has been resized to a smaller width that is prevented by some table cell. */
   min-width: 100%;
+  position: relative;
 }
 
 .layout-table .handle {
   height: 100%;
   margin-left: -@table-cell-padding;
   padding: 0 @table-cell-padding;
+  color: @text-color;
+  background-color: @xwiki-page-content-bg;
   cursor: pointer; /* IE */
   cursor: grab;
   opacity: 0;
+  position: absolute;
 }
 .layout-table .column-name:hover .handle {
-  opacity: 1;
+  opacity: 0.8;
   transition: opacity 0.2s;
 }
 .layout-table .handle .fa {
@@ -253,7 +257,6 @@ export default {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  margin-right: 10px;
 }
 
 .layout-table .sort-icon {


### PR DESCRIPTION
* Remove margin between column title and sort icon
* Put the drag handle on top of the column title with an opacity of 0.8

Jira issue: https://jira.xwiki.org/browse/XWIKI-19449 (with screenshots of the before state)

Here is a screenshot of the new version:

![image](https://github.com/xwiki/xwiki-platform/assets/198317/6eb9d914-57b2-4584-a721-f6c81faa908d)

And here another one to demonstrate how the handle for dragging columns is displayed (in the "Release Date" column):

![XWIKI-19449-LD-with-column-hover](https://github.com/xwiki/xwiki-platform/assets/198317/8ded1eb1-5d4f-4ab3-98a4-0660c6cac246)

Live Data still needs more space, but the difference should be much smaller now. I think the main differences are:

1. Livetable has a smaller padding in the title cells, 8px (default of XWiki) vs. 3px.
2. The sort icon has still less padding (I already reduced it with this commit)

I'm not sure that it is worth giving up this extra space as this space is consistent with other parts of the UI.