### PR TITLE
XWIKI-21329: Dragging the resize handle of a Live Data column leads to a jump in size

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/table/LayoutTableHeaderNames.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/table/LayoutTableHeaderNames.vue
@@ -187,6 +187,21 @@ export default {
       e.data.leftColumnBaseWidth = e.data.leftColumn.getBoundingClientRect()?.width;
       e.data.rightColumn = this.getNextVisibleProperty(th)?.querySelector(".column-name");
       e.data.rightColumnBaseWidth = e.data.rightColumn?.getBoundingClientRect()?.width;
+
+      // Give all column names a fixed width so that relative widths don't change when resizing (in case the current
+      // widths are not the actual column widths).
+      // First, collect all widths, then set them all to avoid that due to the first values being set the other values
+      // change.
+      const widths = [];
+      let columns = th.closest("tr").querySelectorAll(".column-name");
+      // Filter columns that aren't visible to avoid setting a width of zero on them.
+      columns = Array.from(columns).filter(column => column.closest("th").style.display !== "none");
+      for (const column of columns) {
+        widths.push(column.getBoundingClientRect().width);
+      }
+      for (let i = 0; i < columns.length; i++) {
+        columns[i].style.width = `${widths[i]}px`;
+      }
     },
 
     resizeColumn (e) {
@@ -203,9 +218,10 @@ export default {
     },
 
     resetColumnSize (e) {
-      const th = e.currentTarget.closest("th");
-      const column = th.querySelector(".column-name");
-      column.style.width = "unset";
+      // Reset all column sizes as resizing a single column sets sizes for all columns.
+      for (const column of e.currentTarget.closest("tr").querySelectorAll(".column-name")) {
+        column.style.removeProperty("width");
+      }
     },
 
   },


### PR DESCRIPTION
* Set the size of all columns when resizing starts.
* Reset all sizes when resetting column sizes.

Jira issue: https://jira.xwiki.org/browse/XWIKI-21329

Here a video demonstrating both the issue and the solution (note the text at the top):

https://github.com/xwiki/xwiki-platform/assets/198317/20b3aeca-d84a-4d54-ae15-537eccaf985f

This is basically a less drastic version of what I proposed in #2350, taking the feedback from there into account - it still resizes both columns now, and you cannot resize below 100% width.