### PR TITLE
XWIKI-21331: The document cache silently accepts a failed database load when it loads an existing document

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiCacheStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiCacheStore.java
@@ -400,6 +400,15 @@ public class XWikiCacheStore extends AbstractXWikiStore
 
                     LOGGER.debug("Document [{}] was retrieved from persistent storage", key);
 
+                    // If the exists cache indicated that the document should exist, log an error with a
+                    // stacktrace.
+                    if (cachedoc.isNew() && result != null) {
+                        LOGGER.error("Document [{}] was not found in persistent storage but the exists cache "
+                                + "indicated that it should exist. Unless that document has just been deleted, this "
+                                + "is a bug and should be reported.", key,
+                            new Exception());
+                    }
+
                     if (cachedoc.isNew()) {
                         getPageExistCache().set(key, Boolean.FALSE);
                     } else {


### PR DESCRIPTION
* Log an error when a document load fails that shouldn't have failed.

Jira issue: https://jira.xwiki.org/browse/XWIKI-21331

The intention would be to deploy this on xwiki.org with the next update the latest to hopefully get a log when a document disappears.