### PR TITLE
XWIKI-21322: CVE IDs column of the security list does not contain CVE IDs

### DIFF
--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/security/SecurityVulnerabilityDescriptor.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/security/SecurityVulnerabilityDescriptor.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.extension.index.security;
 
+import java.util.Set;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -38,6 +40,8 @@ import us.springett.cvss.Cvss;
 public class SecurityVulnerabilityDescriptor
 {
     private String id;
+
+    private Set<String> aliases;
 
     private String url;
 
@@ -184,6 +188,33 @@ public class SecurityVulnerabilityDescriptor
         return this;
     }
 
+    /**
+     * Retrieves the set of aliases associated with the current object.
+     *
+     * @return a set of aliases, used for vulnerability comparison, two vulnerabilities sharing an alias or an id are
+     *     considered equals
+     * @since 15.9RC1
+     */
+    @Unstable
+    public Set<String> getAliases()
+    {
+        return this.aliases;
+    }
+
+    /**
+     * Sets the set of aliases associated with the current object.
+     *
+     * @param aliases a set of aliases, used for vulnerability comparison, two vulnerabilities sharing an alias or
+     *     an id are considered equals
+     * @return the current object
+     * @since 15.9RC1
+     */
+    public SecurityVulnerabilityDescriptor setAliases(Set<String> aliases)
+    {
+        this.aliases = aliases;
+        return this;
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -204,6 +235,7 @@ public class SecurityVulnerabilityDescriptor
             .append(this.fixVersion, that.fixVersion)
             .append(this.safe, that.safe)
             .append(this.reviews, that.reviews)
+            .append(this.aliases, that.aliases)
             .isEquals();
     }
 
@@ -217,6 +249,7 @@ public class SecurityVulnerabilityDescriptor
             .append(this.fixVersion)
             .append(this.safe)
             .append(this.reviews)
+            .append(this.aliases)
             .toHashCode();
     }
 
@@ -230,6 +263,7 @@ public class SecurityVulnerabilityDescriptor
             .append("fixVersion", this.fixVersion)
             .append("safe", this.safe)
             .append("reviews", this.reviews)
+            .append("aliases", this.aliases)
             .toString();
     }
 }

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/security/SecurityVulnerabilityDescriptor.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/security/SecurityVulnerabilityDescriptor.java
@@ -195,6 +195,7 @@ public class SecurityVulnerabilityDescriptor
      * @return a set of aliases, used for vulnerability comparison, two vulnerabilities sharing an alias or an id are
      *     considered equals
      * @since 15.9RC1
+     * @since 15.5.4
      */
     @Unstable
     public Set<String> getAliases()
@@ -212,6 +213,7 @@ public class SecurityVulnerabilityDescriptor
      *     an id are considered equals
      * @return the current object
      * @since 15.9RC1
+     * @since 15.5.4
      */
     public SecurityVulnerabilityDescriptor setAliases(Set<String> aliases)
     {

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/security/SecurityVulnerabilityDescriptor.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/security/SecurityVulnerabilityDescriptor.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.extension.index.security;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
@@ -198,6 +199,9 @@ public class SecurityVulnerabilityDescriptor
     @Unstable
     public Set<String> getAliases()
     {
+        if (this.aliases == null) {
+            this.aliases = new HashSet<>();
+        }
         return this.aliases;
     }
 

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/security/SecurityVulnerabilityDescriptor.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-index/src/main/java/org/xwiki/extension/index/security/SecurityVulnerabilityDescriptor.java
@@ -55,7 +55,7 @@ public class SecurityVulnerabilityDescriptor
     private String reviews;
 
     /**
-     * @param id the security vulnerability id
+     * @param id the security vulnerability id, by default a CVE id, or another id if no CVE is found
      * @return the current object
      */
     public SecurityVulnerabilityDescriptor setId(String id)
@@ -65,7 +65,7 @@ public class SecurityVulnerabilityDescriptor
     }
 
     /**
-     * @return the security vulnerability id
+     * @return the security vulnerability id, by default a CVE id, or another id if no CVE is found
      */
     public String getId()
     {

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/main/java/org/xwiki/extension/security/internal/analyzer/VulnerabilityIndexer.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/main/java/org/xwiki/extension/security/internal/analyzer/VulnerabilityIndexer.java
@@ -90,7 +90,7 @@ public class VulnerabilityIndexer
             boolean hasNew = securityVulnerabilities.stream()
                 .anyMatch(vulnerability -> {
                     String vulnerabilityId = vulnerability.getId();
-                    Set<String> aliases = Optional.ofNullable(vulnerability.getAliases()).orElse(Set.of());
+                    Set<String> aliases = vulnerability.getAliases();
                     return vulnerability.getScore() > 0
                         && !cveiDs.contains(vulnerabilityId)
                         // To avoid raising a notification for a vulnerability that was already notified with another id

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/main/java/org/xwiki/extension/security/internal/analyzer/VulnerabilityIndexer.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/main/java/org/xwiki/extension/security/internal/analyzer/VulnerabilityIndexer.java
@@ -26,6 +26,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
@@ -89,8 +90,11 @@ public class VulnerabilityIndexer
             boolean hasNew = securityVulnerabilities.stream()
                 .anyMatch(vulnerability -> {
                     String vulnerabilityId = vulnerability.getId();
+                    Set<String> aliases = Optional.ofNullable(vulnerability.getAliases()).orElse(Set.of());
                     return vulnerability.getScore() > 0
                         && !cveiDs.contains(vulnerabilityId)
+                        // To avoid raising a notification for a vulnerability that was already notified with another id
+                        && cveiDs.stream().noneMatch(aliases::contains)
                         && isNotSafe(reviewsMap, vulnerabilityId);
                 });
 

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/main/java/org/xwiki/extension/security/internal/analyzer/osv/OsvResponseAnalyzer.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/main/java/org/xwiki/extension/security/internal/analyzer/osv/OsvResponseAnalyzer.java
@@ -87,7 +87,6 @@ public class OsvResponseAnalyzer
 
     private Optional<SecurityVulnerabilityDescriptor> convert(VulnObject vulnObject, Version currentVersion)
     {
-        // If we are unable to find a CVE, we ignore the vulnerability.
         return resolveId(vulnObject)
             .map(id -> new SecurityVulnerabilityDescriptor()
                 .setId(id)
@@ -114,10 +113,15 @@ public class OsvResponseAnalyzer
      */
     private Optional<String> resolveId(VulnObject vulnObject)
     {
-        return vulnObject.getAliases()
+        Optional<String> first = vulnObject.getAliases()
             .stream()
             .filter(it -> startsWith(it, "CVE-"))
             .findFirst();
+        if (first.isEmpty()) {
+            // We fall back to the first id if no CVE id is found.
+            first = vulnObject.getAliases().stream().findFirst();
+        }
+        return first;
     }
 
     private Optional<VulnObject> analyzeVulnerability(String mavenId, String version, VulnObject vuln)

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/main/java/org/xwiki/extension/security/internal/analyzer/osv/OsvResponseAnalyzer.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/main/java/org/xwiki/extension/security/internal/analyzer/osv/OsvResponseAnalyzer.java
@@ -30,7 +30,6 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
 import org.apache.maven.artifact.versioning.VersionRange;
@@ -45,6 +44,7 @@ import org.xwiki.extension.security.internal.analyzer.osv.model.response.VulnObj
 import org.xwiki.extension.version.Version;
 import org.xwiki.extension.version.internal.DefaultVersion;
 
+import static org.apache.commons.lang3.StringUtils.startsWith;
 import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCauseMessage;
 
 /**
@@ -57,7 +57,6 @@ import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCauseMess
 @Singleton
 public class OsvResponseAnalyzer
 {
-
     @Inject
     private Logger logger;
 
@@ -102,9 +101,7 @@ public class OsvResponseAnalyzer
     {
         Set<String> aliases = new HashSet<>();
         aliases.add(vulnObject.getId());
-        if (vulnObject.getAliases() != null) {
-            aliases.addAll(vulnObject.getAliases());
-        }
+        aliases.addAll(vulnObject.getAliases());
         aliases.remove(id);
         return aliases;
     }
@@ -117,8 +114,10 @@ public class OsvResponseAnalyzer
      */
     private Optional<String> resolveId(VulnObject vulnObject)
     {
-        return Optional.ofNullable(vulnObject.getAliases())
-            .flatMap(aliases -> aliases.stream().filter(it -> StringUtils.startsWith(it, "CVE-")).findFirst());
+        return vulnObject.getAliases()
+            .stream()
+            .filter(it -> startsWith(it, "CVE-"))
+            .findFirst();
     }
 
     private Optional<VulnObject> analyzeVulnerability(String mavenId, String version, VulnObject vuln)

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/main/java/org/xwiki/extension/security/internal/analyzer/osv/OsvResponseAnalyzer.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/main/java/org/xwiki/extension/security/internal/analyzer/osv/OsvResponseAnalyzer.java
@@ -110,8 +110,7 @@ public class OsvResponseAnalyzer
     }
 
     /**
-     * Resolve the ID of the provided {@link VulnObject}. First look for an alias starting with "CVE-", and fallback to
-     * the {@link VulnObject} id if none is found.
+     * Resolve the ID of the provided {@link VulnObject} by looking for an alias starting with "CVE-".
      *
      * @param vulnObject the vulnerability object
      * @return an alias starting with "CVE-", or the original ID if no appropriate alias is found

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/main/java/org/xwiki/extension/security/internal/analyzer/osv/model/response/VulnObject.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/main/java/org/xwiki/extension/security/internal/analyzer/osv/model/response/VulnObject.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.extension.security.internal.analyzer.osv.model.response;
 
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
@@ -161,6 +162,9 @@ public class VulnObject
      */
     public List<String> getAliases()
     {
+        if (this.aliases == null) {
+            this.aliases = new ArrayList<>();
+        }
         return this.aliases;
     }
 

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/main/java/org/xwiki/extension/security/internal/analyzer/osv/model/response/VulnObject.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/main/java/org/xwiki/extension/security/internal/analyzer/osv/model/response/VulnObject.java
@@ -44,6 +44,8 @@ public class VulnObject
 
     private List<SeverityObject> severity;
 
+    private List<String> aliases;
+
     /**
      * @return the affected field
      * @see <a href="https://ossf.github.io/osv-schema/#affected-fields">affected doc</a>
@@ -154,6 +156,24 @@ public class VulnObject
             .min(Comparator.naturalOrder());
     }
 
+    /**
+     * @return the list of aliases associated with this vulnerability
+     */
+    public List<String> getAliases()
+    {
+        return this.aliases;
+    }
+
+    /**
+     * Sets the list of aliases associated with this vulnerability.
+     *
+     * @param aliases the list of aliases to be set
+     */
+    public void setAliases(List<String> aliases)
+    {
+        this.aliases = aliases;
+    }
+
     @Override
     public String toString()
     {
@@ -162,6 +182,7 @@ public class VulnObject
             .append("id", getId())
             .append("references", getReferences())
             .append("severity", getSeverity())
+            .append("aliases", getAliases())
             .toString();
     }
 }

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/test/java/org/xwiki/extension/security/internal/analyzer/osv/OsvResponseAnalyzerTest.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/test/java/org/xwiki/extension/security/internal/analyzer/osv/OsvResponseAnalyzerTest.java
@@ -22,6 +22,7 @@ package org.xwiki.extension.security.internal.analyzer.osv;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.xwiki.extension.index.security.ExtensionSecurityAnalysisResult;
@@ -64,19 +65,22 @@ class OsvResponseAnalyzerTest
 
         ExtensionSecurityAnalysisResult expected = new ExtensionSecurityAnalysisResult();
         SecurityVulnerabilityDescriptor securityVulnerabilityDescriptor0 = new SecurityVulnerabilityDescriptor();
-        securityVulnerabilityDescriptor0.setId("GHSA-4v38-964c-xjmw");
+        securityVulnerabilityDescriptor0.setId("CVE-2023-29510");
+        securityVulnerabilityDescriptor0.setAliases(Set.of("GHSA-4v38-964c-xjmw"));
         securityVulnerabilityDescriptor0.setURL(
             "https://github.com/xwiki/xwiki-platform/security/advisories/GHSA-4v38-964c-xjmw");
         securityVulnerabilityDescriptor0.setScore(9.9);
         securityVulnerabilityDescriptor0.setFixVersion(new DefaultVersion("14.10.2"));
         SecurityVulnerabilityDescriptor securityVulnerabilityDescriptor1 = new SecurityVulnerabilityDescriptor();
-        securityVulnerabilityDescriptor1.setId("GHSA-9j36-3cp4-rh4j");
+        securityVulnerabilityDescriptor1.setId("CVE-2023-29514");
+        securityVulnerabilityDescriptor1.setAliases(Set.of("GHSA-9j36-3cp4-rh4j"));
         securityVulnerabilityDescriptor1.setURL(
             "https://github.com/xwiki/xwiki-platform/security/advisories/GHSA-9j36-3cp4-rh4j");
         securityVulnerabilityDescriptor1.setScore(9.9);
         securityVulnerabilityDescriptor1.setFixVersion(new DefaultVersion("13.10.11"));
         SecurityVulnerabilityDescriptor securityVulnerabilityDescriptor2 = new SecurityVulnerabilityDescriptor();
-        securityVulnerabilityDescriptor2.setId("GHSA-rfh6-mg6h-h668");
+        securityVulnerabilityDescriptor2.setId("CVE-2023-29511");
+        securityVulnerabilityDescriptor2.setAliases(Set.of("GHSA-rfh6-mg6h-h668"));
         securityVulnerabilityDescriptor2.setURL(
             "https://github.com/xwiki/xwiki-platform/security/advisories/GHSA-rfh6-mg6h-h668");
         securityVulnerabilityDescriptor2.setScore(9.9);
@@ -99,7 +103,8 @@ class OsvResponseAnalyzerTest
 
         ExtensionSecurityAnalysisResult expected = new ExtensionSecurityAnalysisResult();
         SecurityVulnerabilityDescriptor securityVulnerabilityDescriptor = new SecurityVulnerabilityDescriptor();
-        securityVulnerabilityDescriptor.setId("VULN_ID");
+        securityVulnerabilityDescriptor.setId("CVE-1");
+        securityVulnerabilityDescriptor.setAliases(Set.of("A1", "VULN_ID"));
         securityVulnerabilityDescriptor.setURL("https://main.ref/");
         securityVulnerabilityDescriptor.setScore(7.5);
         securityVulnerabilityDescriptor.setFixVersion(new DefaultVersion("15.7"));

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/test/resources/analyzeOsvResponse.json
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-index/src/test/resources/analyzeOsvResponse.json
@@ -20,6 +20,7 @@
         }
       ],
       "id": "VULN_ID",
+      "aliases": ["A1", "CVE-1"],
       "references": [
         {
           "type": "WEB",

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-test/xwiki-platform-extension-security-test-docker/src/test/it/org/xwiki/extension/security/test/ui/ExtensionSecurityIT.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-test/xwiki-platform-extension-security-test-docker/src/test/it/org/xwiki/extension/security/test/ui/ExtensionSecurityIT.java
@@ -77,13 +77,13 @@ class ExtensionSecurityIT
                 + "org.xwiki.platform:xwiki-platform-administration-ui/")));
         tableLayout.assertRow("Wikis", "xwiki");
         tableLayout.assertRow("Max CVSS", "9.9");
-        tableLayout.assertRow("CVE IDs", "GHSA-4v38-964c-xjmw (9.9)\n"
-            + "Display reviews for GHSA-4v38-964c-xjmw\n"
+        tableLayout.assertRow("CVE IDs", "CVE-2023-29510 (9.9)\n"
+            + "Display reviews for CVE-2023-29510\n"
             + "\n"
-            + "GHSA-9j36-3cp4-rh4j (9.9)\n"
-            + "Display reviews for GHSA-9j36-3cp4-rh4j\n"
+            + "CVE-2023-29514 (9.9)\n"
+            + "Display reviews for CVE-2023-29514\n"
             + "\n"
-            + "GHSA-mgjw-2wrp-r535 (8.8)");
+            + "CVE-2022-23616 (8.8)");
         tableLayout.assertRow("Latest Fix Version", "140.10.2");
     }
 

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-test/xwiki-platform-extension-security-test-docker/src/test/resources/reviews_source.vm
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-test/xwiki-platform-extension-security-test-docker/src/test/resources/reviews_source.vm
@@ -21,7 +21,7 @@
 ## answer static content with some reviews.
 #set ($map = {
   "reviewsMap": {
-    "GHSA-4v38-964c-xjmw" : [
+    "CVE-2023-29510" : [
       {
         "emitter": "XWiki Development Team",
         "explanation": "expl",
@@ -33,7 +33,7 @@
         "result": "UNSAFE"
       }
     ],
-    "GHSA-9j36-3cp4-rh4j" : [
+    "CVE-2023-29514" : [
       {
         "emitter": "XWiki Development Team",
         "explanation": "expl 3",


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-21322

**Main changes**
- OSV source now returned CVEs as IDs (and so should any other source)
- Results without CVE are ignored
- Nothing of aliases introduced to prevent re-notifying previously stored vulnerabilities with an outdated id