### PR TITLE
XWIKI-21333: Update the weight and font size of headings

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
@@ -264,6 +264,10 @@
   #document-title h1 {
     word-wrap: break-word;
   }
+  #document-title-input {
+    // Override the fixed height as the content is a large heading that would otherwise overflow.
+    height: auto;
+  }
   .document-menu, .document-info {
     margin-top: @line-height-computed;
   }

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/type.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/type.less
@@ -89,8 +89,8 @@
 }
 
 h1.xwikipaneltitle {
-  // Panels headings are the same size as the content's h3 headings.
-  font-size: @font-size-h3;
+  // Panels headings are the same size as the content's h4 headings.
+  font-size: @font-size-h4;
 }
 
 // Muted Usage ============================================================

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/type.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/type.less
@@ -66,9 +66,9 @@
 @font-size-h5: ~"max(@{min-h5-font-size}, min(@{max-h5-font-size}, calc(@{min-h5-font-size} + (@{max-h5-font-size-no} - @{min-h5-font-size-no}) * (100vw - @{min-screen-size}) / (@{max-screen-size-no} - @{min-screen-size-no}))))";
 
 // H6
-@min-h6-font-size: ceil((@font-size-base * pow(@font-size-headings-scale-min, -1)));
+@min-h6-font-size: ceil((@font-size-base * pow(@font-size-headings-scale, -1)));
 @min-h6-font-size-no: unit(@min-h6-font-size);
-@max-h6-font-size: ceil((@font-size-base * pow(@font-size-headings-scale, -1)));
+@max-h6-font-size: ceil((@font-size-base * pow(@font-size-headings-scale-min, -1)));
 @max-h6-font-size-no: unit(@max-h6-font-size);
 @font-size-h6: ~"max(@{min-h6-font-size}, min(@{max-h6-font-size}, calc(@{min-h6-font-size} + (@{max-h6-font-size-no} - @{min-h6-font-size-no}) * (100vw - @{min-screen-size}) / (@{max-screen-size-no} - @{min-screen-size-no}))))";
 

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/type.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/type.less
@@ -20,68 +20,48 @@
 // h2)?
 @font-size-headings-scale: 1.250;
 @font-size-headings-scale-min: 1.125;
-@min-screen-size: 768px;
-@max-screen-size: 1200px;
-@min-screen-size-no: unit(@min-screen-size);
-@max-screen-size-no: unit(@max-screen-size);
+@min-screen-size: 768;
+@max-screen-size: 1200;
 
 // Headings size is following a scale where each level is X times larger than the lower level.
 // Heading 5 is the same size as the base font size
-// The sizes documented for each level are indicative and correspond to a 1.250 scale and a default font size of 14px. 
+
 // H1
-@min-h1-font-size: ceil((@font-size-base * pow(@font-size-headings-scale-min, 4)));
-@min-h1-font-size-no: unit(@min-h1-font-size);
-@max-h1-font-size: ceil((@font-size-base * pow(@font-size-headings-scale, 4)));
-@max-h1-font-size-no: unit(@max-h1-font-size);
-@font-size-h1: ~"max(@{min-h1-font-size}, min(@{max-h1-font-size}, calc(@{min-h1-font-size} + (@{max-h1-font-size-no} - @{min-h1-font-size-no}) * (100vw - @{min-screen-size}) / (@{max-screen-size-no} - @{min-screen-size-no}))))";
-
-
+@min-h1-font-size: unit(ceil((@font-size-base * pow(@font-size-headings-scale-min, 4))));
+@max-h1-font-size: unit(ceil((@font-size-base * pow(@font-size-headings-scale, 4))));
+@font-size-h1: ~"max(@{min-h1-font-size}px, min(@{max-h1-font-size}px, calc(@{min-h1-font-size}px + (@{max-h1-font-size} - @{min-h1-font-size}) * (100vw - @{min-screen-size}px) / (@{max-screen-size} - @{min-screen-size}))))";
 
 // H2
-@min-h2-font-size: ceil((@font-size-base * pow(@font-size-headings-scale-min, 3)));
-@min-h2-font-size-no: unit(@min-h2-font-size);
-@max-h2-font-size: ceil((@font-size-base * pow(@font-size-headings-scale, 3)));
-@max-h2-font-size-no: unit(@max-h2-font-size);
-@font-size-h2: ~"max(@{min-h2-font-size}, min(@{max-h2-font-size}, calc(@{min-h2-font-size} + (@{max-h2-font-size-no} - @{min-h2-font-size-no}) * (100vw - @{min-screen-size}) / (@{max-screen-size-no} - @{min-screen-size-no}))))";
+@min-h2-font-size: unit(ceil((@font-size-base * pow(@font-size-headings-scale-min, 3))));
+@max-h2-font-size: unit(ceil((@font-size-base * pow(@font-size-headings-scale, 3))));
+@font-size-h2: ~"max(@{min-h2-font-size}px, min(@{max-h2-font-size}px, calc(@{min-h2-font-size}px + (@{max-h2-font-size} - @{min-h2-font-size}) * (100vw - @{min-screen-size}px) / (@{max-screen-size} - @{min-screen-size}))))";
 
 // H3
-@min-h3-font-size: ceil((@font-size-base * pow(@font-size-headings-scale-min, 2)));
-@min-h3-font-size-no: unit(@min-h3-font-size);
-@max-h3-font-size: ceil((@font-size-base * pow(@font-size-headings-scale, 2)));
-@max-h3-font-size-no: unit(@max-h3-font-size);
-@font-size-h3: ~"max(@{min-h3-font-size}, min(@{max-h3-font-size}, calc(@{min-h3-font-size} + (@{max-h3-font-size-no} - @{min-h3-font-size-no}) * (100vw - @{min-screen-size}) / (@{max-screen-size-no} - @{min-screen-size-no}))))";
+@min-h3-font-size: unit(ceil((@font-size-base * pow(@font-size-headings-scale-min, 2))));
+@max-h3-font-size: unit(ceil((@font-size-base * pow(@font-size-headings-scale, 2))));
+@font-size-h3: ~"max(@{min-h3-font-size}px, min(@{max-h3-font-size}px, calc(@{min-h3-font-size}px + (@{max-h3-font-size} - @{min-h3-font-size}) * (100vw - @{min-screen-size}px) / (@{max-screen-size} - @{min-screen-size}))))";
 
 // H4
-@min-h4-font-size: ceil((@font-size-base * pow(@font-size-headings-scale-min, 1)));
-@min-h4-font-size-no: unit(@min-h4-font-size);
-@max-h4-font-size: ceil((@font-size-base * pow(@font-size-headings-scale, 1)));
-@max-h4-font-size-no: unit(@max-h4-font-size);
-@font-size-h4: ~"max(@{min-h4-font-size}, min(@{max-h4-font-size}, calc(@{min-h4-font-size} + (@{max-h4-font-size-no} - @{min-h4-font-size-no}) * (100vw - @{min-screen-size}) / (@{max-screen-size-no} - @{min-screen-size-no}))))";
+@min-h4-font-size: unit(ceil((@font-size-base * pow(@font-size-headings-scale-min, 1))));
+@max-h4-font-size: unit(ceil((@font-size-base * pow(@font-size-headings-scale, 1))));
+@font-size-h4: ~"max(@{min-h4-font-size}px, min(@{max-h4-font-size}px, calc(@{min-h4-font-size}px + (@{max-h4-font-size} - @{min-h4-font-size}) * (100vw - @{min-screen-size}px) / (@{max-screen-size} - @{min-screen-size}))))";
 
 // H5
-@min-h5-font-size: ceil((@font-size-base * pow(@font-size-headings-scale-min, 0)));
-@min-h5-font-size-no: unit(@min-h5-font-size);
-@max-h5-font-size: ceil((@font-size-base * pow(@font-size-headings-scale, 0)));
-@max-h5-font-size-no: unit(@max-h5-font-size);
-@font-size-h5: ~"max(@{min-h5-font-size}, min(@{max-h5-font-size}, calc(@{min-h5-font-size} + (@{max-h5-font-size-no} - @{min-h5-font-size-no}) * (100vw - @{min-screen-size}) / (@{max-screen-size-no} - @{min-screen-size-no}))))";
+// The computations are not required for h5 as it is always the size of the base font size.
+@font-size-h5: @font-size-base;
 
 // H6
-@min-h6-font-size: ceil((@font-size-base * pow(@font-size-headings-scale, -1)));
-@min-h6-font-size-no: unit(@min-h6-font-size);
-@max-h6-font-size: ceil((@font-size-base * pow(@font-size-headings-scale-min, -1)));
-@max-h6-font-size-no: unit(@max-h6-font-size);
-@font-size-h6: ~"max(@{min-h6-font-size}, min(@{max-h6-font-size}, calc(@{min-h6-font-size} + (@{max-h6-font-size-no} - @{min-h6-font-size-no}) * (100vw - @{min-screen-size}) / (@{max-screen-size-no} - @{min-screen-size-no}))))";
-
-// The document title is a h1 heading one size higher in the size scale 
-// (e.g., 1.250 larger than the content's h1 headings)
+// Note that the h6 heading is actually getting larger as the screen width decreases.
+@min-h6-font-size: unit(ceil((@font-size-base * pow(@font-size-headings-scale, -1))));
+@max-h6-font-size: unit(ceil((@font-size-base * pow(@font-size-headings-scale-min, -1))));
+@font-size-h6: ~"max(@{min-h6-font-size}px, min(@{max-h6-font-size}px, calc(@{min-h6-font-size}px + (@{max-h6-font-size} - @{min-h6-font-size}) * (100vw - @{min-screen-size}px) / (@{max-screen-size} - @{min-screen-size}))))";
 
 // Document title
-@min-document-title-font-size: ceil((@font-size-base * pow(@font-size-headings-scale-min, 5)));
-@min-document-title-font-size-no: unit(@min-document-title-font-size);
-@max-document-title-font-size: ceil((@font-size-base * pow(@font-size-headings-scale, 5)));
-@max-document-title-font-size-no: unit(@max-document-title-font-size);
-//@font-size-document-title-tmp: calc(~"@{min-document-title-font-size} + (@{max-document-title-font-size-no} - @{min-document-title-font-size-no}) * (100vw - @{min-screen-size}) / (@{max-screen-size-no} - @{min-screen-size-no})"); // Between 35 and 23px according to screen size
-@font-size-document-title: ~"max(@{min-document-title-font-size}, min(@{max-document-title-font-size}, calc(@{min-document-title-font-size} + (@{max-document-title-font-size-no} - @{min-document-title-font-size-no}) * (100vw - @{min-screen-size}) / (@{max-screen-size-no} - @{min-screen-size-no}))))";
+// The document title is a h1 heading one size higher in the size scale 
+// (e.g., 1.250 larger than the content's h1 headings)
+@min-document-title-font-size: unit(ceil((@font-size-base * pow(@font-size-headings-scale-min, 5))));
+@max-document-title-font-size: unit(ceil((@font-size-base * pow(@font-size-headings-scale, 5))));
+@font-size-document-title: ~"max(@{min-document-title-font-size}px, min(@{max-document-title-font-size}px, calc(@{min-document-title-font-size}px + (@{max-document-title-font-size} - @{min-document-title-font-size}) * (100vw - @{min-screen-size}px) / (@{max-screen-size} - @{min-screen-size}))))";
 
 #document-title h1 {
   font-size: @font-size-document-title;

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/type.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/type.less
@@ -15,29 +15,82 @@
 
 // Headings ===============================================================
 
-// Headings are using Modular Scale (i.e. there is an harmonious
-// relationship between values in the scale).
-// We are using http://www.modularscale.com/?1&em&1.125&web&table
-//
-// In addition, we ensure headings are always taller than regular text,
-// which seems more logical even if it does not follow the W3C
-// recommendations.
-//
-@font-size-h1: ceil((@font-size-base * 2.027));
-@font-size-h2: ceil((@font-size-base * 1.802));
-@font-size-h3: ceil((@font-size-base * 1.602));
-@font-size-h4: ceil((@font-size-base * 1.424));
-@font-size-h5: ceil((@font-size-base * 1.266));
-@font-size-h6: ceil((@font-size-base * 1.125));
 
-@font-size-document-title: ceil((@font-size-base * 2.42)); // ~34px
+// Since 15.9RC1: Defines the ratio between two headings levels (e.g., h1 is @font-size-headings-scale times larger than
+// h2)?
+@font-size-headings-scale: 1.250;
+@font-size-headings-scale-min: 1.125;
+@min-screen-size: 768px;
+@max-screen-size: 1200px;
+@min-screen-size-no: unit(@min-screen-size);
+@max-screen-size-no: unit(@max-screen-size);
+
+// Headings size is following a scale where each level is X times larger than the lower level.
+// Heading 5 is the same size as the base font size
+// The sizes documented for each level are indicative and correspond to a 1.250 scale and a default font size of 14px. 
+// H1
+@min-h1-font-size: ceil((@font-size-base * pow(@font-size-headings-scale-min, 4)));
+@min-h1-font-size-no: unit(@min-h1-font-size);
+@max-h1-font-size: ceil((@font-size-base * pow(@font-size-headings-scale, 4)));
+@max-h1-font-size-no: unit(@max-h1-font-size);
+@font-size-h1: ~"max(@{min-h1-font-size}, min(@{max-h1-font-size}, calc(@{min-h1-font-size} + (@{max-h1-font-size-no} - @{min-h1-font-size-no}) * (100vw - @{min-screen-size}) / (@{max-screen-size-no} - @{min-screen-size-no}))))";
+
+
+
+// H2
+@min-h2-font-size: ceil((@font-size-base * pow(@font-size-headings-scale-min, 3)));
+@min-h2-font-size-no: unit(@min-h2-font-size);
+@max-h2-font-size: ceil((@font-size-base * pow(@font-size-headings-scale, 3)));
+@max-h2-font-size-no: unit(@max-h2-font-size);
+@font-size-h2: ~"max(@{min-h2-font-size}, min(@{max-h2-font-size}, calc(@{min-h2-font-size} + (@{max-h2-font-size-no} - @{min-h2-font-size-no}) * (100vw - @{min-screen-size}) / (@{max-screen-size-no} - @{min-screen-size-no}))))";
+
+// H3
+@min-h3-font-size: ceil((@font-size-base * pow(@font-size-headings-scale-min, 2)));
+@min-h3-font-size-no: unit(@min-h3-font-size);
+@max-h3-font-size: ceil((@font-size-base * pow(@font-size-headings-scale, 2)));
+@max-h3-font-size-no: unit(@max-h3-font-size);
+@font-size-h3: ~"max(@{min-h3-font-size}, min(@{max-h3-font-size}, calc(@{min-h3-font-size} + (@{max-h3-font-size-no} - @{min-h3-font-size-no}) * (100vw - @{min-screen-size}) / (@{max-screen-size-no} - @{min-screen-size-no}))))";
+
+// H4
+@min-h4-font-size: ceil((@font-size-base * pow(@font-size-headings-scale-min, 1)));
+@min-h4-font-size-no: unit(@min-h4-font-size);
+@max-h4-font-size: ceil((@font-size-base * pow(@font-size-headings-scale, 1)));
+@max-h4-font-size-no: unit(@max-h4-font-size);
+@font-size-h4: ~"max(@{min-h4-font-size}, min(@{max-h4-font-size}, calc(@{min-h4-font-size} + (@{max-h4-font-size-no} - @{min-h4-font-size-no}) * (100vw - @{min-screen-size}) / (@{max-screen-size-no} - @{min-screen-size-no}))))";
+
+// H5
+@min-h5-font-size: ceil((@font-size-base * pow(@font-size-headings-scale-min, 0)));
+@min-h5-font-size-no: unit(@min-h5-font-size);
+@max-h5-font-size: ceil((@font-size-base * pow(@font-size-headings-scale, 0)));
+@max-h5-font-size-no: unit(@max-h5-font-size);
+@font-size-h5: ~"max(@{min-h5-font-size}, min(@{max-h5-font-size}, calc(@{min-h5-font-size} + (@{max-h5-font-size-no} - @{min-h5-font-size-no}) * (100vw - @{min-screen-size}) / (@{max-screen-size-no} - @{min-screen-size-no}))))";
+
+// H6
+@min-h6-font-size: ceil((@font-size-base * pow(@font-size-headings-scale-min, -1)));
+@min-h6-font-size-no: unit(@min-h6-font-size);
+@max-h6-font-size: ceil((@font-size-base * pow(@font-size-headings-scale, -1)));
+@max-h6-font-size-no: unit(@max-h6-font-size);
+@font-size-h6: ~"max(@{min-h6-font-size}, min(@{max-h6-font-size}, calc(@{min-h6-font-size} + (@{max-h6-font-size-no} - @{min-h6-font-size-no}) * (100vw - @{min-screen-size}) / (@{max-screen-size-no} - @{min-screen-size-no}))))";
+
+// The document title is a h1 heading one size higher in the size scale 
+// (e.g., 1.250 larger than the content's h1 headings)
+
+// Document title
+@min-document-title-font-size: ceil((@font-size-base * pow(@font-size-headings-scale-min, 5)));
+@min-document-title-font-size-no: unit(@min-document-title-font-size);
+@max-document-title-font-size: ceil((@font-size-base * pow(@font-size-headings-scale, 5)));
+@max-document-title-font-size-no: unit(@max-document-title-font-size);
+//@font-size-document-title-tmp: calc(~"@{min-document-title-font-size} + (@{max-document-title-font-size-no} - @{min-document-title-font-size-no}) * (100vw - @{min-screen-size}) / (@{max-screen-size-no} - @{min-screen-size-no})"); // Between 35 and 23px according to screen size
+@font-size-document-title: ~"max(@{min-document-title-font-size}, min(@{max-document-title-font-size}, calc(@{min-document-title-font-size} + (@{max-document-title-font-size-no} - @{min-document-title-font-size-no}) * (100vw - @{min-screen-size}) / (@{max-screen-size-no} - @{min-screen-size-no}))))";
+
 #document-title h1 {
   font-size: @font-size-document-title;
   margin-top: 0;
 }
 
 h1.xwikipaneltitle {
-  font-size: ceil((@font-size-base * 1.42)); // ~18px;
+  // Panels headings are the same size as the content's h3 headings.
+  font-size: @font-size-h3;
 }
 
 // Muted Usage ============================================================

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/variables.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/variables.less
@@ -14,5 +14,5 @@
 // --------------------------------------------------
 
 @border-width:                   1px;
-@headings-font-weight:           400; // See: http://jira.xwiki.org/browse/XWIKI-10838
+@headings-font-weight:           600;
 @nav-tabs-active-link-hover-bg:  @xwiki-page-content-bg;


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-21333

- Replace the headings sizes with a size scale
- Make the headings size proportional to the viewport width, the size is still bounded and won't get smaller below 768px, or larger above 1200px.
- The size scale is based on two headings size scale (1.250 for the larger screens, and 1.125 for the smaller screens)

I agree the code is complex, I'm looking for ways to simply.
Also, if we drop the viewport scale improvement, the code gets muuuch simpler.

## TODO

- [x] fix the page title edition field, which is not high enough for the new text size

## How are headings size computed

Inspired from https://www.smashingmagazine.com/2016/05/fluid-typography/#controlling-the-rate-of-scale

You can find below the actual `font-size` used for `h1` headings with the default values.

- given a screen size between 768px and 1200px;
- `23px` = the minimal font size a `h1` heading can have (on 768px or smaller screens), computed following the formula `14px * pow(1.125, 4)`
- `35px` = the maximal font size a `h1` heading can have (on 1200px or lager screens), , computed following the formula `14px * pow(1.250, 4)`

```css
h1 {
  font-size: max(23px, min(35px, calc(23px + (35 - 23) * (100vw - 768px) / (1200 - 768))));
}}
```

The same goes for the other headings, but the power applies to the ratio is decremented for each sub-level (ranging from 4 for h1 to -1 for h6).

## Home page

### Before

#### 1200

![image](https://github.com/xwiki/xwiki-platform/assets/327856/075c9c2b-0808-437c-b04c-3ee3b98db69a)

#### 768

![image](https://github.com/xwiki/xwiki-platform/assets/327856/89a32688-c841-4e23-bb58-81ed9c57aaea)

### After

#### 1200

[![image](https://github.com/xwiki/xwiki-platform/assets/327856/4f775628-1710-4125-9cc1-b103a8e702b7)](https://github.com/xwiki/xwiki-platform/pull/2360)

#### 768

[![image](https://github.com/xwiki/xwiki-platform/assets/327856/33355fd5-5011-4d97-9c62-08d9cea7b041)](https://github.com/xwiki/xwiki-platform/pull/2360)

## Sandbox

### Before

#### 1200

![image](https://github.com/xwiki/xwiki-platform/assets/327856/079f98f9-0dc9-46b0-9a11-f10aa17a5fa7)

#### 768

![image](https://github.com/xwiki/xwiki-platform/assets/327856/601f9cee-0e91-4204-819b-709c1cfb3e1c)

### After

#### 1200

![image](https://github.com/xwiki/xwiki-platform/assets/327856/1e01d36b-0460-4b9a-b8ec-1a97f9142989)

#### 768

![image](https://github.com/xwiki/xwiki-platform/assets/327856/ae58e0bf-29f5-4d78-a6a9-e91db0839a18)
