### PR TITLE
Improvements to user listing in the rights UI

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiGroupServiceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiGroupServiceImpl.java
@@ -495,6 +495,17 @@ public class XWikiGroupServiceImpl implements XWikiGroupService, EventListener
                     where.append(" and lower(" + fieldPrefix + ".value) like ?" + parameterValues.size());
 
                     fieldMap.put(fieldName, fieldPrefix);
+                } else if (user && matchFields.length == 1 && fieldName.equals("name")) {
+                    // In case we are only looking to mach on the document name, we should also take care of
+                    // filtering on the first name or the last name of the user.
+                    parameterValues.add(HQLLIKE_ALL_SYMBOL + value.toLowerCase() + HQLLIKE_ALL_SYMBOL);
+                    from.append(", StringProperty firstName, StringProperty lastName");
+                    where.append(
+                        "and obj.id = firstName.id.id and firstName.id.name = 'first_name' "
+                      + "and obj.id = lastName.id.id and lastName.id.name = 'last_name' "
+                      + String.format("and (lower(doc.name) like ?%s or lower(firstName.value) like ?%s or "
+                            + "lower(lastName.value) like ?%s)",
+                            parameterValues.size(), parameterValues.size(), parameterValues.size()));
                 } else {
                     parameterValues.add(HQLLIKE_ALL_SYMBOL + value.toLowerCase() + HQLLIKE_ALL_SYMBOL);
                     // We do not support OR filters by default, however this may be useful in the case where users or

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/getusersandgroups.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/getusersandgroups.vm
@@ -171,9 +171,11 @@ $response.setContentType("application/json")
   #set($discard = $row.put("allows"  , $allows.keySet()))
   #set($discard = $row.put("denys"   , $denys.keySet()))
   #if ($uorg == "users")
-    #set($discard = $row.put("userDisplayer", "#displayUser($user.documentReference, {'displayLink': $isLocalUser})"))
+    #set($discard = $row.put("userDisplayer",
+      "#displayUser($user.documentReference, {'displayLink': $isLocalUser, 'showAlias': true})"))
   #else
-    #set($discard = $row.put("userDisplayer", "#displayGroup($user.documentReference, {'displayLink': $isLocalUser})"))
+    #set($discard = $row.put("userDisplayer",
+      "#displayGroup($user.documentReference, {'displayLink': $isLocalUser, 'showAlias': true})"))
   #end
   #if ($uorg == "groups")
     #set($discard = $row.put("isuseringroup", $xwiki.getUser().isUserInGroup($user.fullName)))

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/getusersandgroups.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/getusersandgroups.vm
@@ -162,20 +162,19 @@ $response.setContentType("application/json")
     #end
   #end ## foreach rights object
   #set($row = {})
-  #set($userFirstName = $user.getValue('first_name'))
-  #set($userLastName = $user.getValue('last_name'))
-  #if($stringtool.isNotBlank($userFirstName) || $stringtool.isNotBlank($userLastName))
-    #set($userDisplayName = "$!{userFirstName} $!{userLastName} (${user.name})")
-  #else
-    #set($userDisplayName = $user.name)
-  #end
+  #set($isLocalUser = ($wikiname == 'local'))
   #set($discard = $row.put("username", $user.documentReference.name))
   #set($discard = $row.put("fullname", $username))
-  #set($discard = $row.put("title"   , $userDisplayName))
+  #set($discard = $row.put("title"   , $user.title))
   #set($discard = $row.put("wikiname", $wikiname))
   #set($discard = $row.put("userurl" , $xwiki.getURL($user.fullName)))
   #set($discard = $row.put("allows"  , $allows.keySet()))
   #set($discard = $row.put("denys"   , $denys.keySet()))
+  #if ($uorg == "users")
+    #set($discard = $row.put("userDisplayer", "#displayUser($user.documentReference, {'displayLink': $isLocalUser})"))
+  #else
+    #set($discard = $row.put("userDisplayer", "#displayGroup($user.documentReference, {'displayLink': $isLocalUser})"))
+  #end
   #if ($uorg == "groups")
     #set($discard = $row.put("isuseringroup", $xwiki.getUser().isUserInGroup($user.fullName)))
   #else

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/getusersandgroups.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/getusersandgroups.vm
@@ -162,9 +162,16 @@ $response.setContentType("application/json")
     #end
   #end ## foreach rights object
   #set($row = {})
+  #set($userFirstName = $user.getValue('first_name'))
+  #set($userLastName = $user.getValue('last_name'))
+  #if($stringtool.isNotBlank($userFirstName) || $stringtool.isNotBlank($userLastName))
+    #set($userDisplayName = "$!{userFirstName} $!{userLastName} (${user.name})")
+  #else
+    #set($userDisplayName = $user.name)
+  #end
   #set($discard = $row.put("username", $user.documentReference.name))
   #set($discard = $row.put("fullname", $username))
-  #set($discard = $row.put("title"   , $user.title))
+  #set($discard = $row.put("title"   , $userDisplayName))
   #set($discard = $row.put("wikiname", $wikiname))
   #set($discard = $row.put("userurl" , $xwiki.getURL($user.fullName)))
   #set($discard = $row.put("allows"  , $allows.keySet()))

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -241,7 +241,10 @@ $xwiki.getUserName("xwiki:${username}")
  *   showAlias: false, // whether to show the user alias or not
  *   useInlineHTML: false, // whether to use in-line HTML elements to display the user or not
  *   wrapAvatar: false // whether to wrap the avatar image with a span or not
+ *   displayLink: true // whether to wrap the user name in a link to the user profile
  * }
+ *
+ * @since 15.9
  *#
 #macro (displayUser $arg $options)
   #if ($stringtool.isEmpty($arg))
@@ -256,7 +259,8 @@ $xwiki.getUserName("xwiki:${username}")
   #set ($macro.options = {
     'showAlias': false,
     'useInlineHTML': false,
-    'wrapAvatar': false
+    'wrapAvatar': false,
+    'displayLink': true
   })
   #if ($options.entrySet())
     #set ($discard = $macro.options.putAll($options))
@@ -306,13 +310,20 @@ $xwiki.getUserName("xwiki:${username}")
       #set ($avatarWrapperStart = "<span class=""${type}-avatar-wrapper"">")
       #set ($avatarWrapperEnd = '</span>')
     #end
+    #set($userNameTagAttributes = "class=""${type}-name""")
+    #if ($macro.options.displayLink)
+      #set($userNameTag = 'a')
+      #set($userNameTagAttributes = "$userNameTagAttributes href=""$escapetool.xml($xwiki.getURL($userReference))""")
+    #else
+      #set($userNameTag = 'span')
+    #end
     ## We avoid the whitespace because the users are displayed as inline blocks.
     #set ($discard = $output.addAll([
       "<$userTag class=""$type"" data-reference=""$escapetool.xml($userReference)"">",
         $avatarWrapperStart,
           "<img class=""${type}-avatar"" src=""$escapetool.xml($avatarURL.url)"" alt=""$escapedUserName"" />",
         $avatarWrapperEnd,
-        "<a class=""${type}-name"" href=""$escapetool.xml($xwiki.getURL($userReference))"">$escapedUserName</a>",
+        "<$userNameTag $userNameTagAttributes>$escapedUserName</$userNameTag>",
         $userAliasDisplay,
       "</$userTag>"
     ]))
@@ -332,7 +343,10 @@ $xwiki.getUserName("xwiki:${username}")
  *   showAlias: false, // whether to show the group alias or not
  *   useInlineHTML: false, // whether to use in-line HTML elements to display the group or not
  *   wrapAvatar: false // whether to wrap the avatar image with a span or not
+ *   displayLink: true // whether to wrap the group name in a link to the group profile
  * }
+ *
+ * @since 15.9
  *#
 #macro (displayGroup $arg $options)
   #displayUser($arg $options)

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -241,10 +241,8 @@ $xwiki.getUserName("xwiki:${username}")
  *   showAlias: false, // whether to show the user alias or not
  *   useInlineHTML: false, // whether to use in-line HTML elements to display the user or not
  *   wrapAvatar: false // whether to wrap the avatar image with a span or not
- *   displayLink: true // whether to wrap the user name in a link to the user profile
+ *   displayLink: true // @since 15.9 ; whether to wrap the user name in a link to the user profile
  * }
- *
- * @since 15.9
  *#
 #macro (displayUser $arg $options)
   #if ($stringtool.isEmpty($arg))
@@ -343,10 +341,8 @@ $xwiki.getUserName("xwiki:${username}")
  *   showAlias: false, // whether to show the group alias or not
  *   useInlineHTML: false, // whether to use in-line HTML elements to display the group or not
  *   wrapAvatar: false // whether to wrap the avatar image with a span or not
- *   displayLink: true // whether to wrap the group name in a link to the group profile
+ *   displayLink: true // @since 15.9 ; whether to wrap the group name in a link to the group profile
  * }
- *
- * @since 15.9
  *#
 #macro (displayGroup $arg $options)
   #displayUser($arg $options)

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/usersandgroups/usersandgroups.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/usersandgroups/usersandgroups.js
@@ -442,15 +442,7 @@ function displayUsersAndGroups(row, i, table, idx, form_token, targetDocument)
   } else {
     username.setAttribute('data-title', "$escapetool.javascript($services.localization.render('rightsmanager.username'))");
   }
-  var title = (row.title || row.username);
-  if (row.wikiname == "local") {
-    var a = document.createElement('a');
-    a.href = userurl;
-    a.appendChild(document.createTextNode(title));
-    username.appendChild( a );
-  } else {
-    username.appendChild(document.createTextNode(title));
-  }
+  username.innerHTML = row.userDisplayer;
 
   // We directly retrieve the right names from the livetable headers.
   var rightsNames = [];


### PR DESCRIPTION
Related JIRA issues : 
* [XWIKI-21305](https://jira.xwiki.org/browse/XWIKI-21305) - Use user first name or last name when filtering in the rights livetable
* [XWIKI-21306](https://jira.xwiki.org/browse/XWIKI-21306) - In the user rights UI, display the user first name and last name
* [XWIKI-21349](https://jira.xwiki.org/browse/XWIKI-21349) - Provide parameters to enable or disable linking to user profiles in the user displayer

This PR aims at improving the experience of administrators when administering rights for instances with users who have usernames that do not correspond to their actual first name and last name.