### PR TITLE
XWIKI-21341: The attachment gallery picker is not preserving image ratio when downscaling

### DIFF
--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-picker/xwiki-platform-attachment-picker-webjar/src/main/webjar/attachmentGalleryPicker.js
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-picker/xwiki-platform-attachment-picker-webjar/src/main/webjar/attachmentGalleryPicker.js
@@ -246,7 +246,8 @@ define('xwiki-attachment-picker',
         if (result.mimetype && mimeType.startsWith("image/")) {
           preview = $('<img />')
             .prop('loading', 'lazy')
-            .prop('src', `${downloadURL}?width=150&height=150`)
+            // Preserve the aspect ratio of the image while resizing to a 150x150px box
+            .prop('src', `${downloadURL}?width=150&height=150&keepAspectRatio=true`)
             .prop('alt', filename);
         } else {
           const icon = attachmentsIcon.getIcon({


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-21341