### PR TITLE
XWIKI-21334: Uniformize the rounded edges of visual elements

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminSheet.xml
@@ -962,8 +962,8 @@ require(['jquery'], function($) {
 }
 
 .admin-menu .panel-heading.collapsed {
-  border-bottom-left-radius: 3px;
-  border-bottom-right-radius: 3px;
+  border-bottom-left-radius: 5px;
+  border-bottom-right-radius: 5px;
 }
 
 .admin-menu a.panel-heading {
@@ -985,8 +985,8 @@ require(['jquery'], function($) {
 }
 
 .admin-menu .panel-collapse &gt; .list-group:last-child .list-group-item.last {
-  border-bottom-right-radius: 3px;
-  border-bottom-left-radius: 3px;
+  border-bottom-right-radius: 5px;
+  border-bottom-left-radius: 5px;
 }
 
 .admin-menu .panel.noitems &gt; .panel-heading {

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/TemplateProviderMacros.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/TemplateProviderMacros.xml
@@ -398,7 +398,7 @@
 
 .templateProviderSheet .paths .path-add {
   border: 1px dashed $theme.borderColor;
-  border-radius: 4px;
+  border-radius: 7px;
   cursor: pointer;
   padding: 7px 15px;
 }

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-picker/xwiki-platform-attachment-picker-ui/src/main/resources/Attachment/Picker/Code/AttachmentGalleryPicker.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-picker/xwiki-platform-attachment-picker-ui/src/main/resources/Attachment/Picker/Code/AttachmentGalleryPicker.xml
@@ -303,7 +303,7 @@
   .attachmentGroup.selected {
     background-color: @gray-lighter;
     outline: 1px dotted #CCC;
-    border-radius: 5px;
+    border-radius: 7px;
   }
 
 

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
@@ -1101,7 +1101,7 @@ XWiki.widgets.ModalPopup.prototype.closeDialog = function(event) {
 .gallery_attachmentbox {
   background: $theme.pageContentBackgroundColor;
   border: 1px solid $theme.borderColor;
-  border-radius: 5px;
+  border-radius: 8px;
   float: left;
   margin: ${boxMargin}px;
   overflow: hidden;
@@ -1123,7 +1123,7 @@ XWiki.widgets.ModalPopup.prototype.closeDialog = function(event) {
 .gallery_attachmenttitle {
   background: $theme.backgroundSecondaryColor;
   border-bottom: 1px dotted $theme.borderColor;
-  border-radius: 5px 5px 0px 0px;
+  border-radius: 8px 8px 0px 0px;
   font-size: 85%;
   padding: 3px ${boxPadding}px;
   overflow: hidden;

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-resource/resourcePicker.css
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-resource/resourcePicker.css
@@ -47,7 +47,7 @@
 
 .resourcePicker .resourceDisplay {
   background-color: $theme.backgroundSecondaryColor;
-  border-radius: 4px;
+  border-radius: 7px;
   border: 1px solid $theme.borderColor;
   margin: 6px 0;
   padding: 6px 22px 6px 6px;

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
@@ -219,7 +219,7 @@ a[data-linktype="create"] {
 }
 a[data-linktype="create"]::after {
   background-color: #08C;
-  border-radius: 8px;
+  border-radius: 10px;
   color: white;
   content: "?";
   display: inline-block;

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/EditSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/EditSheet.xml
@@ -828,7 +828,7 @@ a.cke_button.cke_button__insert &gt; span.cke_button_icon.cke_button__insert_ico
  */
 ul.cke_autocomplete_panel {
   border: 1px solid rgba(0, 0, 0, 0.15);
-  border-radius: 4px;
+  border-radius: 7px;
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
   font: inherit;
   padding: 5px 0;
@@ -880,7 +880,7 @@ ul.cke_autocomplete_panel {
   width: 14px;
 }
 .ckeditor-autocomplete-item-icon-wrapper img {
-  border-radius: 3px;
+  border-radius: 5px;
   max-height: 14px;
   max-width: 14px;
   vertical-align: text-top;
@@ -899,7 +899,7 @@ ul.cke_autocomplete_panel {
   justify-content: center;
 }
 .ckeditor-autocomplete-item-preview-wrapper img {
-  border-radius: 3px;
+  border-radius: 5px;
   max-height: 64px;
   max-width: 64px;
   vertical-align: text-top;

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/general.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/general.less
@@ -44,7 +44,7 @@ table {
 .wikicreatelink a:after,
 [contenteditable="true"] a[data-linktype="create"]:after {
   background-color: @link-color;
-  border-radius: 8px;
+  border-radius: 10px;
   color: @xwiki-page-content-bg;
   content: "?";
   display: inline-block;

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/misc.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/misc.less
@@ -502,6 +502,7 @@ a.html-diff-context-toggle {
 // Tree Webjar (XWIKI-15089) ---------------------------------------------------
 .skin-flamingo .jstree-xwiki .jstree-clicked {
   background-color: @nav-link-hover-bg; /* $theme.highlightColor */
+  border-radius: @border-radius-small;
 }
 
 .previewdiff-diff-options {

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/misc.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/misc.less
@@ -505,6 +505,10 @@ a.html-diff-context-toggle {
   border-radius: @border-radius-small;
 }
 
+.skin-flamingo .jstree-xwiki .jstree-anchor:hover {
+  border-radius: @border-radius-small;
+}
+
 .previewdiff-diff-options {
   text-align: center;
 

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/users.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/users.less
@@ -69,7 +69,7 @@ li.group {
 
 .user img.user-avatar,
 .group img.group-avatar {
-  border-radius: 3px;
+  border-radius: 5px;
   max-height: 18px;
   max-width: 18px;
   vertical-align: text-top;

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/variables.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/variables.less
@@ -16,3 +16,7 @@
 @border-width:                   1px;
 @headings-font-weight:           600;
 @nav-tabs-active-link-hover-bg:  @xwiki-page-content-bg;
+
+@border-radius-base:             7px;
+@border-radius-large:            10px;
+@border-radius-small:            5px;

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Paper.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Paper.xml
@@ -2107,7 +2107,7 @@ input[type="checkbox"],
     margin-top: -2px;
     margin-right: 5px;
     border: 2px solid @gray;
-    border-radius: 2px;
+    border-radius: 3px;
     .transition(240ms);
   }
 
@@ -2295,7 +2295,7 @@ input[type="checkbox"],
     .box-shadow(none);
 
     &amp;:last-child {
-      border-radius: 0 3px 3px 0;
+      border-radius: 0 @border-radius-small @border-radius-small 0;
     }
 
     &amp;:last-child {
@@ -2363,7 +2363,7 @@ input[type="checkbox"],
 
 .panel {
   border: none;
-  border-radius: 2px;
+  border-radius: 3px;
   .box-shadow(0 1px 4px rgba(0,0,0,.3));
 
   &amp;-heading {
@@ -2400,14 +2400,14 @@ input[type="checkbox"],
 div.main {
   .box-shadow(0 1px 4px rgba(0,0,0,.3));
   border: medium none;
-  border-radius: 2px;
+  border-radius: 3px;
   margin-top: 20px;
 }
 
 .panel-width-Small div.panel.Applications{
   .box-shadow(0 1px 4px rgba(0,0,0,.3));
   border: medium none;
-  border-radius: 2px;
+  border-radius: 3px;
   margin-top: 5px;
 }</lessCode>
     </property>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Yeti.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Yeti.xml
@@ -2063,7 +2063,7 @@ input[type="checkbox"] {
 
 .breadcrumb {
   border: 1px solid @table-border-color;
-  border-radius: 3px;
+  border-radius: @border-radius-small;
   font-size: 10px;
   font-weight: 300;
   text-transform: uppercase;
@@ -2094,7 +2094,7 @@ input[type="checkbox"] {
   &gt; li:last-child {
     &gt; a,
     &gt; span {
-      border-radius: 3px;
+      border-radius: @border-radius-small;
     }
   }
 

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/Help/Code/ExampleMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/Help/Code/ExampleMacro.xml
@@ -149,7 +149,7 @@
 .macroexample &gt; .tab-content {
   border: 1px solid #DDD;
   border-top: 0 none;
-  border-radius: 0 0 4px 4px;
+  border-radius: 0 0 7px 7px;
   padding: 1em;
 }</code>
     </property>

--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-ui/src/main/resources/IconThemesCode/IconPicker.xml
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-ui/src/main/resources/IconThemesCode/IconPicker.xml
@@ -601,7 +601,7 @@ require(['jquery', 'xwiki-icon-picker'], function($) {
   height: 80px;
   width: 100px;
   text-align: center;
-  border-radius: 4px;
+  border-radius: 7px;
   vertical-align: middle;
   overflow: hidden;
   padding: 10px;

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/LivedataEntrySelectorInfoBar.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/LivedataEntrySelectorInfoBar.vue
@@ -75,7 +75,7 @@ export default {
 .livedata-entry-selector-info-bar {
   margin-bottom: 1rem;
   padding: 12px;
-  border-radius: 5px;
+  border-radius: 8px;
   background-color: @panel-default-heading-bg;
 }
 

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/panels/LivedataAdvancedPanelFilterEntry.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/panels/LivedataAdvancedPanelFilterEntry.vue
@@ -114,7 +114,7 @@ export default {
   visibility: hidden;
   margin-left: 5px;
   padding: 6px 10px;
-  border-radius: 3px;
+  border-radius: @border-radius-small;
   color: currentColor;
 }
 .livedata-filter-container:hover .delete-filter {

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/panels/LivedataAdvancedPanelSort.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/panels/LivedataAdvancedPanelSort.vue
@@ -210,7 +210,7 @@ export default {
   visibility: hidden;
   margin-left: 5px;
   padding: 6px 10px;
-  border-radius: 3px;
+  border-radius: @border-radius-small;
   color: currentColor;
 }
 .livedata-advanced-panel-sort .sort-entry:hover .delete-sort {

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-ui/src/main/resources/XWiki/Mentions/MentionsMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-ui/src/main/resources/XWiki/Mentions/MentionsMacro.xml
@@ -374,7 +374,7 @@ require(['deferred!ckeditor', 'xwiki-suggestUsers', 'jquery', 'xwiki-meta'], fun
     <property>
       <code>.xwiki-mention {
   background-color: $services.mentions.mentionsColor;
-  border-radius: 8px;
+  border-radius: 10px;
   padding: 2px 5px 2px 5px;
 }
 

--- a/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-ui/src/main/resources/Main/MessageSenderMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-messagestream/xwiki-platform-messagestream-ui/src/main/resources/Main/MessageSenderMacro.xml
@@ -378,7 +378,7 @@ return XWiki;
 
 /* User's avatar */
 .messagestream .activitySnapshot .avatar {
-  border-radius: 4px;
+  border-radius: 7px;
   box-shadow: 0 0 2px 1px rgba(128,128,128,0.6);
 }
 

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
@@ -725,9 +725,9 @@ require(['scriptaculous/effects'], function() {
 
 .skin-colibri .panel-width-Small .applicationsPanel li {
   padding: 15px 0;
-  -moz-border-radius: 4px;
-  -webkit-border-radius: 4px;
-  border-radius: 4px;
+  -moz-border-radius: 7px;
+  -webkit-border-radius: 7px;
+  border-radius: 7px;
   margin: 1px 0;
 }
 

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/PanelsCode/NavigationConfigurationSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/PanelsCode/NavigationConfigurationSheet.xml
@@ -696,7 +696,7 @@ ul.exclusion-filter-pages {
 
 ul.exclusion-filter-pages li {
   border: 1px solid @xwiki-border-color;
-  border-radius: 6px;
+  border-radius: 10px;
   display: inline-block;
   margin-bottom: .5em;
   margin-right: .5em;

--- a/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-webjar/src/main/webjar/toolbar.css
+++ b/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-webjar/src/main/webjar/toolbar.css
@@ -17,7 +17,7 @@ div.rt-toolbar {
 }
 
 .rt-toolbar .rt-user-avatar, .rt-toolbar .rt-user-fake-avatar {
-  border-radius: 4px;
+  border-radius: 7px;
   margin: 2px 3px 2px 6px;
   vertical-align: top;
 }

--- a/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wysiwyg/xwiki-platform-realtime-wysiwyg-webjar/src/main/webjar/wysiwygEditor.css
+++ b/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wysiwyg/xwiki-platform-realtime-wysiwyg-webjar/src/main/webjar/wysiwygEditor.css
@@ -29,7 +29,7 @@ div.rt-toolbar .rt-user-list a:hover {
 
 div.rt-toolbar .rt-user-avatar,
 div.rt-toolbar .rt-user-fake-avatar {
-  border-radius: 4px;
+  border-radius: 7px;
   margin: 0 3px 0 0;
   vertical-align: middle;
 }

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/Main/SolrSearch.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/Main/SolrSearch.xml
@@ -648,7 +648,7 @@ a.search-result-highlightAll:after {
   box-shadow: 0 2px 2px rgba(0, 0, 0, 0.2);
   /* Leave space for the bottom shadow. */
   margin-bottom: 1em;
-  border-radius: 4px;
+  border-radius: 7px;
 }
 /* Colibri skin doesn't have the grid system. */
 .skin-colibri .search-facets {

--- a/xwiki-platform-core/xwiki-platform-sharepage/xwiki-platform-sharepage-ui/src/main/resources/XWiki/SharePage.xml
+++ b/xwiki-platform-core/xwiki-platform-sharepage/xwiki-platform-sharepage-ui/src/main/resources/XWiki/SharePage.xml
@@ -723,7 +723,7 @@ Guten Tag ${recipientName},
 .share-dialog .mail-preview {
   background-color: $theme.backgroundSecondaryColor;
   border: 1px solid $theme.borderColor;
-  border-radius: 4px;
+  border-radius: 7px;
   box-shadow: inset 0 0 7px $theme.borderColor;
   padding: 0 10px;
   max-height: 20em;

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/finder.less
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/finder.less
@@ -15,7 +15,7 @@ input[type="text"].xtree-finder.loading {
 div.suggestItems.xtree-finder-suggestions {
   background-clip: padding-box;
   border: 1px solid rgba(0, 0, 0, 0.15);
-  border-radius: 4px;
+  border-radius: 7px;
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.176);
   margin: 2px 0 0;
   padding: 5px 0;

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/main.less
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/main.less
@@ -4,9 +4,9 @@
 	.jstree-anchor,
 	.jstree-animated,
 	.jstree-wholerow { transition:background-color 0.15s, box-shadow 0.15s; }
-	.jstree-hovered { background:@hovered-bg-color; border-radius:2px; box-shadow:inset 0 0 1px @hovered-shadow-color; }
-	.jstree-context { background:@hovered-bg-color; border-radius:2px; box-shadow:inset 0 0 1px @hovered-shadow-color; }
-	.jstree-clicked { background:@clicked-bg-color; border-radius:2px; box-shadow:inset 0 0 1px @clicked-shadow-color; }
+	.jstree-hovered { background:@hovered-bg-color; border-radius:3px; box-shadow:inset 0 0 1px @hovered-shadow-color; }
+	.jstree-context { background:@hovered-bg-color; border-radius:3px; box-shadow:inset 0 0 1px @hovered-shadow-color; }
+	.jstree-clicked { background:@clicked-bg-color; border-radius:3px; box-shadow:inset 0 0 1px @clicked-shadow-color; }
 	.jstree-no-icons .jstree-anchor > .jstree-themeicon { display:none; }
 	.jstree-disabled {
 		background:transparent; color:@disabled-color; opacity:@disabled-opacity;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
@@ -396,7 +396,7 @@
 
 .activity-follow .follow, .activity-follow .following {
   background: $theme.menuAddEntryBackgroundColor 2px center url("$xwiki.getSkinFile('icons/silk/accept.png')") no-repeat;
-  border-radius: 4px;
+  border-radius: 7px;
   color: $theme.menuAddEntryLinkColor !important;
   display: inline-block;
   font-size: 83.3%;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserSheet.xml
@@ -454,7 +454,7 @@ return XWiki;
 
 #avatar img {
   border: 1px solid $theme.borderColor;
-  border-radius: 5px 5px 5px 5px;
+  border-radius: 8px 8px 8px 8px;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.15);
   margin: 0 auto;
   padding: 0.3em;

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/init.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/init.vm
@@ -129,7 +129,7 @@
         color: #4D4D4D;
         border: 1px solid #E8E8E8;
         background-color: #FFF;
-        border-radius: 4px;
+        border-radius: 7px;
         box-shadow: 0px 0px 7px #E8E8E8;
         padding: 1em;
       }

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/notification/email/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/notification/email/macros.vm
@@ -94,7 +94,7 @@
 
 #macro(displayNotificationPage $event)
   <div>
-    <div style="background-color: #f5f5f5; color: #777777; padding: 4px 8px; border-radius: 4px; font-size: 8px;">
+    <div style="background-color: #f5f5f5; color: #777777; padding: 4px 8px; border-radius: 7px; font-size: 8px;">
       #template('hierarchy_macros.vm')
       #hierarchy($event.document, {'id': 'hierarchy', 'limit': 5, 'treeNavigation': false, 'plain': true})
     </div>

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/table/livetable.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/table/livetable.css
@@ -407,7 +407,7 @@ table.livetable {
 
 /* Round the infomessage border and change the padding to uniformize the messages style with Live Data. */
 .xwiki-livetable-container div div.infomessage {
-  border-radius: 4px;
+  border-radius: 7px;
   padding: 0.1em 1em;
 }
 /* </Decoration> */

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/widgets/modalPopup.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/widgets/modalPopup.css
@@ -29,7 +29,7 @@
   color: $theme.panelTextColor;
   border: 1px solid $theme.borderColor;
   background-color: $theme.panelBackgroundColor;
-  border-radius: 4px;
+  border-radius: 7px;
   box-shadow: 0 0 7px $theme.borderColor;
 }
 .xdialog-box {
@@ -75,7 +75,7 @@
       {'color': $theme.panelHeaderBackgroundColor, 'position': '100%'}
     ]
   })
-  border-radius: 4px 4px 0 0;
+  border-radius: 7px 7px 0 0;
   color: $theme.panelHeaderTextColor;
   text-shadow: 0 1px 0 $theme.panelHeaderGradientColor;
 }

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/dashboard/dashboard.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/dashboard/dashboard.css
@@ -17,7 +17,7 @@
       {'color': $theme.panelHeaderBackgroundColor, 'position': '100%'}
     ]
   })
-  border-radius: 4px 4px 0 0;
+  border-radius: 7px 7px 0 0;
   border: 1px solid $theme.borderColor;
   color: $theme.panelHeaderTextColor;
   #css_textShadow('0', '1px', '0', $theme.panelHeaderGradientColor)
@@ -26,13 +26,14 @@
 .panels .gadget, .dashboard-edit .gadget {
   background-color: $theme.panelBackgroundColor;
   margin: 1em 0;
+  border-radius: 7px;
 }
 
 .panels .gadget .gadget-content, .dashboard-edit .gadget .gadget-content {
   background-color: $theme.panelBackgroundColor;
   color: $theme.panelTextColor;
   padding: 10px 15px;
-  border-radius: 0 0 4px 4px;
+  border-radius: 0 0 7px 7px;
   border-width: 0 1px 1px;
   border-style: solid;
   border-color: $theme.borderColor;
@@ -97,7 +98,7 @@
 /* Add button decoration */
 .dashboard-edit .addgadget, .dashboard-edit .addcontainer {
   background: url($xwiki.getSkinFile("icons/silk/add.png")) no-repeat 3px center $theme.menuAddEntryBackgroundColor;
-  border-radius: 4px;
+  border-radius: 7px;
   color: $theme.menuAddEntryLinkColor;
   cursor: pointer;
   float: right;

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/extension/extension.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/extension/extension.css
@@ -315,7 +315,7 @@ ul.innerMenu {
   margin-left: -1px;
 }
 .innerMenu li a {
-  border-radius: 5px 5px 0 0 / 3px 3px 0 0;
+  border-radius: 7px 7px 0 0 / 5px 5px 0 0;
   border-top: 3px solid $theme.borderColor;
   display: inline-block;
   margin: 2px 2em 0 0;
@@ -324,7 +324,7 @@ ul.innerMenu {
   top: 0px;
 }
 .innerMenu li a:hover {
-  border-radius: 5px 5px 0 0;
+  border-radius: 8px 8px 0 0;
   border-top: 5px solid $theme.borderColor;
   margin-top: 0px;
 }
@@ -333,7 +333,7 @@ ul.innerMenu {
   border: 0 none;
   border-top: 5px solid $theme.panelCollapsedBackgroundColor;
   margin-top: 0;
-  border-radius: 0 0 5px 5px;
+  border-radius: 0 0 8px 8px;
   box-shadow: 3px;
 }
 .innerMenu li a.current:after {

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/extension/history.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/extension/history.css
@@ -30,7 +30,7 @@
 .extension-history-sources-body {
   background-clip: padding-box;
   border: 1px solid rgba(0, 0, 0, 0.15);
-  border-radius: 4px;
+  border-radius: 7px;
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.176);
   display: none;
   font-size: 95%;

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/flavor/picker.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/flavor/picker.css
@@ -7,7 +7,7 @@
 
 .xwiki-flavor-picker-results-container {
   border: 1px solid $theme.borderColor;
-  border-radius: 4px;
+  border-radius: 7px;
   box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.075) inset;
   padding: 5px;
   overflow-x: hidden;

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/job/job.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/job/job.css
@@ -52,14 +52,14 @@
 
 .ui-progress-background {
   background-color: transparent;
-  border-radius: 8px 8px 8px 8px;
+  border-radius: 10px 10px 10px 10px;
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.3) inset, 0 1px 0 0 $theme.pageContentBackgroundColor;
   height: 8px;
 }
 
 .ui-progress-bar {
   background-color: $theme.backgroundSecondaryColor;
-  border-radius: 8px 8px 8px 8px;
+  border-radius: 10px 10px 10px 10px;
   height: 8px;
 }
 

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/xwiki.selectize.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/xwiki.selectize.css
@@ -70,7 +70,7 @@
   margin-right: .3em;
 }
 img.xwiki-selectize-option-icon {
-  border-radius: 3px;
+  border-radius: 5px;
   max-height: 18px;
   max-width: 18px;
   vertical-align: text-top;
@@ -88,7 +88,7 @@ a.xwiki-selectize-option-label {
 .selectize-control.async-create > .selectize-input > div.xwiki-selectize-option {
   background-image: none;
   border-left: 2px solid transparent;
-  border-radius: 3px;
+  border-radius: 5px;
   padding-left: 3px;
   padding-right: 3px;
 }

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/viewers/code.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/viewers/code.css
@@ -55,7 +55,7 @@
 .revision .author img {
   max-width: 16px;
   max-height: 16px;
-  border-radius: 3px;
+  border-radius: 5px;
 }
 
 .revision .content {

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/viewers/comments.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/viewers/comments.css
@@ -40,7 +40,7 @@ ul.commentreplies, .reply {
   width: 30px;
 }
 .commentavatar img {
-  border-radius: 4px;
+  border-radius: 7px;
   max-width: 50px;
   max-height: 50px;
 }

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/buttonGroup.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/buttonGroup.css
@@ -56,7 +56,7 @@
   background-color: $theme.pageContentBackgroundColor;
   border: 1px solid $theme.borderColor;
   /* Same border radius as the button. */
-  border-radius: 3px;
+  border-radius: 5px;
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
   /* Hidden by default. */
   display: none;

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/notification.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/notification.css
@@ -19,7 +19,7 @@
   background: #333 2px center no-repeat;
   border: none;
   padding: 8px 15px;
-  border-radius: 4px;
+  border-radius: 7px;
   color: #fff;
   line-height: 20px;
   margin-bottom: 10px;

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/select/select.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/select/select.css
@@ -6,7 +6,7 @@
 
 .xwiki-select-options {
   border: 1px solid #CCC;
-  border-radius: 4px;
+  border-radius: 7px;
   box-shadow: 0px 1px 1px rgba(0, 0, 0, 0.075) inset;
   padding: 5px;
   overflow-x: hidden;

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.css
@@ -54,7 +54,7 @@
 }
 .progress-info .progress, .progress-info .progress-container {
   height: 6px;
-  border-radius: 3px;
+  border-radius: 5px;
 }
 .progress-info .progress {
   background-color: $theme.notificationSuccessColor;
@@ -63,7 +63,7 @@
 }
 .progress-info .progress-container {
   border: 1px solid $theme.notificationSuccessColor;
-  border-radius: 4px;
+  border-radius: 7px;
   -moz-box-sizing: border-box;
   box-sizing: border-box;
   box-shadow: 0 0 5px rgba(0,0,0,.2), inset 0 0 5px rgba(0,0,0,.2);

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-mainwiki/src/main/resources/WikiManager/CreateWiki.xml
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-mainwiki/src/main/resources/WikiManager/CreateWiki.xml
@@ -1608,14 +1608,14 @@ require(['jquery'], function($) {
 
 .ui-progress-background {
   background-color: transparent;
-  border-radius: 8px 8px 8px 8px;
+  border-radius: 10px 10px 10px 10px;
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.3) inset, 0 1px 0 0 $theme.pageContentBackgroundColor;
   height: 8px;
 }
 
 .ui-progress-bar {
   background-color: $theme.backgroundSecondaryColor;
-  border-radius: 8px 8px 8px 8px;
+  border-radius: 10px 10px 10px 10px;
   height: 8px;
 }
 


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-21334

**Changes:**
- Update of the default radius sizes:
  - base: 7px
  - small: 5px
  - large: 10px
- Radius (small) also applied on the clicked document tree element

Note: most color themes are not impacted as they are defining their own radius values.

## Main Page

### Before

![image](https://github.com/xwiki/xwiki-platform/assets/327856/ee182a58-24b7-4109-98d3-69f5df5800c4)

### After

![image](https://github.com/xwiki/xwiki-platform/assets/327856/5e691ee1-7fd7-4269-89b1-e00962fa73d0)

## Edit

### Before

![image](https://github.com/xwiki/xwiki-platform/assets/327856/a6e10a47-b246-4516-b02a-23475df5961e)


### After

![image](https://github.com/xwiki/xwiki-platform/assets/327856/4c1a227b-f26e-4e63-8e1d-ee6e3cd32560)

