### PR TITLE
XWIKI-21384: Lack of contrast on empty option of localization preferences

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/forms.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/forms.less
@@ -172,3 +172,11 @@ select[size="0"], select[size="1"] {
 .input-group img {
   max-width: inherit;
 }
+
+// Use color theme defined variables instead of a hard coded color for the bootstrap select
+#mainContentArea .bootstrap-select > .dropdown-toggle.bs-placeholder,
+#mainContentArea .bootstrap-select > .dropdown-toggle.bs-placeholder:hover,
+#mainContentArea .bootstrap-select > .dropdown-toggle.bs-placeholder:focus,
+#mainContentArea .bootstrap-select > .dropdown-toggle.bs-placeholder:active {
+  .text-muted;
+}


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21384
## PR Change
* Overrode color of the placeholder in bootstrap select with color theme defined color.
## View
[Here is a video demo featuring the updated color and highlighting how it passes WCAG contrast standards.](https://up1.xwikisas.com/#wMVQkPXiFwIDjgU6zicPew)