### PR TITLE
XWIKI-19948: Bad diff information when xobject is deleted

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -7117,7 +7117,10 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
                     List<ObjectDiff> dlist;
                     if (newObj == null) {
                         // The object was deleted.
-                        dlist = new BaseObject().getDiff(originalObj, context);
+                        newObj = new BaseObject();
+                        // We want the xclass reference to be set so that it can resolve the xclass properties.
+                        newObj.setXClassReference(originalObj.getXClassReference());
+                        dlist = newObj.getDiff(originalObj, context);
                         ObjectDiff deleteMarker =
                             new ObjectDiff(originalObj.getXClassReference(), originalObj.getNumber(),
                                 originalObj.getGuid(), ObjectDiff.ACTION_OBJECTREMOVED, "", "", "", "");

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseObject.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseObject.java
@@ -308,8 +308,9 @@ public class BaseObject extends BaseCollection<BaseObjectReference> implements O
             BaseProperty newProperty = (BaseProperty) this.getField(propertyName);
             BaseProperty oldProperty = (BaseProperty) oldObject.getField(propertyName);
             BaseClass bclass = getXClass(context);
-            // if the object was removed current instance doesn't hold any information about the xclass
-            // however the old object will hold the information.
+            // Bulletproofing: in theory the BaseObject is defined with a xclass reference allowing to resolve it
+            // however, it's possible that the reference is not set, in which case we might still find the info
+            // in the old object.
             if (bclass == null) {
                 bclass = oldObject.getXClass(context);
             }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseObject.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseObject.java
@@ -308,6 +308,11 @@ public class BaseObject extends BaseCollection<BaseObjectReference> implements O
             BaseProperty newProperty = (BaseProperty) this.getField(propertyName);
             BaseProperty oldProperty = (BaseProperty) oldObject.getField(propertyName);
             BaseClass bclass = getXClass(context);
+            // if the object was removed current instance doesn't hold any information about the xclass
+            // however the old object will hold the information.
+            if (bclass == null) {
+                bclass = oldObject.getXClass(context);
+            }
             PropertyClass pclass = (PropertyClass) ((bclass == null) ? null : bclass.getField(propertyName));
             String propertyType = (pclass == null) ? "" : pclass.getClassType();
 


### PR DESCRIPTION
  * Ensure to retrieve the xclass even when the xobject has been deleted