### PR TITLE
XWIKI-21386: Change viewer meta data lacks contrast

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/viewers/diff.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/viewers/diff.css
@@ -66,7 +66,7 @@ td.diff-line.diff-line-decision span.diff-decision {
 td.diff-line-meta {
   background-color: $theme.backgroundSecondaryColor;
   color: $theme.textSecondaryColor;
-  padding: .4em .5em;
+  padding: .8em .5em;
 }
 
 .diff-line del {

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/viewers/diff.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/viewers/diff.css
@@ -1,24 +1,5 @@
 #template('colorThemeInit.vm')
 
-/*!
-#macro (toRGBa $hexColor $opacity)
-  #set ($macro.hexColor = "$!hexColor")
-  #if ($macro.hexColor.matches('#[0-9a-fA-F]{3}'))
-    ## Expand the color value.
-    #set ($macro.hexColor = $macro.hexColor.replaceAll('(\w)', '$1$1'))
-  #end
-  #if ($macro.hexColor.matches('#[0-9a-fA-F]{6}'))
-    #set ($integer = 0)
-    #set ($red = $integer.parseInt($macro.hexColor.substring(1,3), 16))
-    #set ($green = $integer.parseInt($macro.hexColor.substring(3,5), 16))
-    #set ($blue = $integer.parseInt($macro.hexColor.substring(5), 16))
-    rgba($red, $green, $blue, $opacity)
-  #end
-#end
-#set ($lightBackgroundSecondaryColor = "#toRGBa($theme.backgroundSecondaryColor, 0.5)")
-#set ($lightTextSecondaryColor = "#toRGBa($theme.textSecondaryColor, 0.5)")
-*/
-
 /**
  * Raw (Wiki Syntax) Diff
  */
@@ -45,7 +26,7 @@
 
 td.diff-line-number {
   border-right: 1px solid $theme.borderColor;
-  color: $lightTextSecondaryColor;
+  color: $theme.textSecondaryColor;
   text-align: center;
   vertical-align: middle;
 }
@@ -83,8 +64,8 @@ td.diff-line.diff-line-decision span.diff-decision {
 }
 
 td.diff-line-meta {
-  background-color: $lightBackgroundSecondaryColor;
-  color: $lightTextSecondaryColor;
+  background-color: $theme.backgroundSecondaryColor;
+  color: $theme.textSecondaryColor;
   padding: .4em .5em;
 }
 


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21386
## PR Changes
* Replaced the half opacity colors with their full opacity alternatives from the color themes (the same as the ones used in .text-muted)
## View
With the Iceberg color theme:
![21386-IcebergAfter](https://github.com/xwiki/xwiki-platform/assets/28761965/f7c21605-cf35-496a-8fcc-6c0ccf71e274)
With the Darkly color theme (the text colors are hard coded, which make them look off, however I can't see an easy solution to get all of these colors from the color theme, and it's not the focus of this PR)
![21386-DarklyAfterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/895dcb4e-a1be-496f-b56a-cd01509d751b)

We can see that with both color themes, the text passes contrast checks, and is overall more readable. However, it's also less subtle and the eye gets caught on it more easily.

## Note
AFAIK this style rule was created by @mflorea in [this commit](https://github.com/xwiki/xwiki-platform/commit/4ec10a623ed99d887340ddb719d395ebe945dddc#diff-cba9da1f0167da707d85622373578942fbb16bed22d59b271a4ffeea2ae5b9d1). 
Do you think reverting those changes on color is correct? Should we change something else to reduce emphasis on this text? 
