### PR TITLE
XWIKI-21373: Tmmoreactions and tmedit focus indications are barely visible

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/buttons.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/buttons.less
@@ -27,6 +27,10 @@
     &:focus {
       .btn-background(lighten(@btn-default-bg, 5%));
       .btn-border(darken(@btn-default-bg, 20%));
+      
+      // Make sure the buttons have a proper focus highlight, 
+      // despite changes from some bootstrap classes such as 'dropdown-toggle'.
+      outline: revert;
     }
   }
 


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21373

## PR Changes
* Added a style rule to override :focus style of the dropdown-toggle buttons set in bootstrap.

## View
![21373-afterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/a4500432-29cf-486d-bd6e-8ea2e10d80d2)
We can see on this screenshot that the outline of the focused button is now following the default user agent (Firefox here) style.