### PR TITLE
Misc: Accessibility rules update

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/WCAGContext.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/WCAGContext.java
@@ -76,8 +76,7 @@ public class WCAGContext
             entry("aria-meter-name", true),
             entry("aria-progressbar-name", true),
             entry("aria-required-attr", true),
-            // Set to true once the build doesn't fail this rule anymore
-            entry("aria-required-children", false),
+            entry("aria-required-children", true),
             entry("aria-required-parent", true),
             entry("aria-roledescription", true),
             entry("aria-roles", true),


### PR DESCRIPTION
Changes to the status of the WCAG rules that are currently not violated. From this point on, all rules set to true will make the build fail when they are violated. The build will only fail on an accessibility regression. See the [XWiki WCAG testing page](https://dev.xwiki.org/xwiki/bin/view/Community/Testing/WCAGTesting#HTesting) for more details about the consequences of these changes.

As of https://ci.xwiki.org/job/XWiki%20Environment%20Tests/job/xwiki-platform/job/master/351/, there are only a few rules that fail through tests:
- aria-allowed-attr 5 violations
- label 67 violations
- duplicate-id 7 violations
- duplicate-id-active 3 violations
- duplicate-id-aria 9 violations
- image-alt 53 violations
- link-in-text-block 441 violations
- select-name 2 violations
- color-contrast 24 violations
- scrollable-region-focusable 1 violation

Total violations: 612

* aria-required-children fixed


There are no additional failing types in [environment test master build #351](https://ci.xwiki.org/job/XWiki%20Environment%20Tests/job/xwiki-platform/job/master/351/)

|  | Count of warning rules | Count of failing rules |
| ------------- | ------------- | ------------- |
| Before this PR | 11 | 50 |
| After this PR | 10 | 51 |

This is a continuation of the process started in https://github.com/xwiki/xwiki-platform/pull/2152, last step before this one was https://github.com/xwiki/xwiki-platform/pull/2267.