### PR TITLE
XWIKI-20696: Accessibility best-practice: use landmarks in view pages

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -845,7 +845,7 @@ aria-label="$escapetool.xml($title)"
 #end
 
 #macro(largepanelheader $title)
-  #panelheader($title, true, false, false)
+#panelheader($title, true, false, false)
 #end
 
 #macro(panelhiddenheader $title)
@@ -854,11 +854,11 @@ aria-label="$escapetool.xml($title)"
 
 ## Changes the semantic role of the panel.
 #macro(navigationPanelHeader $title)
-  #panelheader($title, false, false, true)
+#panelheader($title, false, false, true)
 #end
 
 #macro(largeNavigationPanelHeader $title)
-  #panelheader($title, true, false, true)
+#panelheader($title, true, false, true)
 #end
 
 ###


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-20696
## PR Changes
* Fixed a space related error in the velocity macro definition
## Note
This is fix for a regression reported by @michitux. This regression was introduced in https://github.com/xwiki/xwiki-platform/pull/2133 which added an empty \<p> block above some panels.
## View
After the changes proposed in this PR, we can see that the unintened \<p> node is no longer here:
![20696-demoFix](https://github.com/xwiki/xwiki-platform/assets/28761965/7937b7cf-8d1a-4f14-9d61-1447c1c15039)
