### PR TITLE
XWIKI-21412: Move the Tour Application to xwiki-platform

### DIFF
--- a/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui/src/main/resources/TourCode/TourJS.xml
+++ b/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui/src/main/resources/TourCode/TourJS.xml
@@ -176,12 +176,14 @@ require(['jquery', 'xwiki-meta'], function ($, xm) {
 
     if (showPopover) {
       buttonContainer.addClass('opened');
+      button.removeAttr('hidden');
       popover.attr('open','open');
     }
 
     button.on('click', function() {
       if (showPopover) {
         popover.removeAttr('open');
+        button.attr('hidden', true);
         buttonContainer.removeClass('opened');
       }
 
@@ -195,6 +197,7 @@ require(['jquery', 'xwiki-meta'], function ($, xm) {
       } else {
         tour.restart();
       }
+      button.attr('hidden', true);
       buttonContainer.removeClass('opened');
     });
   }
@@ -346,6 +349,8 @@ require(['jquery', 'xwiki-meta'], function ($, xm) {
             createResumeButton(tour, true);
           } else {
             buttonContainer.addClass('opened');
+            let button = $('#tourResume');
+            button.removeAttr('hidden');
             // Show the popover
             let popover = buttonContainer.find('.popover-content').first();
             popover.attr('open','open');
@@ -545,6 +550,9 @@ require(['jquery', 'xwiki-meta'], function ($, xm) {
 
   &amp; &gt; #tourResume {
     width: fit-content;
+    &amp;[hidden] {
+      display: none;
+    }
   }
 
   &amp; &gt; .popover-content {


### PR DESCRIPTION
**EDIT:** See https://github.com/xwiki/xwiki-platform/pull/2453#issuecomment-1755663113 for an updated PR starting message
______
______

## Issue
Fix for https://ge.xwiki.org/scans/tests?search.relativeStartTime=P28D&search.tags=master&search.timeZoneId=Europe%2FBerlin&tests.container=org.xwiki.tour.test.ui.TourApplicationIT&tests.test=verifyTourFeatures
This is a regression caused by the merge for [TOUR-81](https://jira.xwiki.org/browse/TOUR-81).
## PR Changes
* Updated the 'hidden' attribute of the button when opening/closing the tour modal
* Overrode the .btn 'display' property when this button is hidden.

## View
[Demo video](https://up1.xwikisas.com/#hxyRVwzGJ_h_172P8wWT-w)
We can see on this video that with the changes brought in this PR, the tour button disappears when the tour is opened, as expected by the tests.