### PR TITLE
XWIKI-21375: Videos on the help page don't have alternatives

### DIFF
--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/Help/Code/Translations.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/Help/Code/Translations.xml
@@ -192,6 +192,7 @@ help.videos.videoCard5.topic2=Learn how to use your application
 help.videos.videoCard6.title=Add / Remove Extensions
 help.videos.videoCard6.topic1=Discover how to add/remove extensions using the Extension Manager
 help.videos.videoCard6.topic2=Discover the XWiki Administration UI
+help.videos.hint=The video in this card is an alternative to the documentation behind those links:
 help.videos.watch=Watch
 
 ## Example Macro

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/Help/Code/Translations.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/Help/Code/Translations.xml
@@ -192,7 +192,7 @@ help.videos.videoCard5.topic2=Learn how to use your application
 help.videos.videoCard6.title=Add / Remove Extensions
 help.videos.videoCard6.topic1=Discover how to add/remove extensions using the Extension Manager
 help.videos.videoCard6.topic2=Discover the XWiki Administration UI
-help.videos.hint=The video in this card is an alternative to the documentation behind those links:
+help.videos.hint=The following documentation links provide an alternative to this video.
 help.videos.watch=Watch
 
 ## Example Macro

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/Help/Code/Translations.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/Help/Code/Translations.xml
@@ -192,7 +192,7 @@ help.videos.videoCard5.topic2=Learn how to use your application
 help.videos.videoCard6.title=Add / Remove Extensions
 help.videos.videoCard6.topic1=Discover how to add/remove extensions using the Extension Manager
 help.videos.videoCard6.topic2=Discover the XWiki Administration UI
-help.videos.hint=The following documentation links provide an alternative to this video.
+help.videos.hint=This video showcases XWiki features with a subtitled screencast without audio indications. The following documentation links provide a text alternative to this video.
 help.videos.watch=Watch
 
 ## Example Macro

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/Help/Videos/WebHome.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/Help/Videos/WebHome.xml
@@ -144,10 +144,11 @@
       &lt;/div&gt;
       &lt;ul&gt;
         #foreach ($topic in $data.topics)
-          &lt;li&gt;
-            &lt;a href="$escapetool.html($topic.url)"&gt;
-              $topic.label
-            &lt;/a&gt;
+          &lt;li&gt;#if ($topic.url)
+            &lt;a href="$escapetool.html($topic.url)"&gt;$topic.label&lt;/a&gt;
+          #else 
+            $topic
+          #end
           &lt;/li&gt;
         #end
       &lt;/ul&gt;

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/Help/Videos/WebHome.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/Help/Videos/WebHome.xml
@@ -146,7 +146,7 @@
       &lt;ul&gt;
         #foreach ($topic in $data.topics)
           &lt;li&gt;
-            &lt;a href="$topic.url"&gt;
+            &lt;a href="$escapetool.html($topic.url)"&gt;
               $topic.label
             &lt;/a&gt;
           &lt;/li&gt;

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/Help/Videos/WebHome.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/Help/Videos/WebHome.xml
@@ -107,7 +107,7 @@
   'title': $services.localization.render('help.videos.videoCard5.title'),
   'topics': [
     {
-      'url': $xwiki.getURL('Help.Applications.WebHome'),
+      'url': 'https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/GettingStarted/CreatingABasicApp',
       'label': $services.localization.render('help.videos.videoCard5.topic1')
     },
     {

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/Help/Videos/WebHome.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/Help/Videos/WebHome.xml
@@ -42,50 +42,92 @@
 #set ($videoCards = [{
   'title': $services.localization.render('help.videos.videoCard1.title'),
   'topics': [
-    $services.localization.render('help.videos.videoCard1.topic1'),
-    $services.localization.render('help.videos.videoCard1.topic2')
+    {
+      'url':'https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/GettingStarted/',
+      'label':"$services.localization.render('help.videos.videoCard1.topic1')"
+    },
+    {
+      'url':'https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/Features/Navigate/',
+      'label':"$services.localization.render('help.videos.videoCard1.topic2')"
+    }
   ],
   'url': 'https://www.youtube.com/embed/p5g6aDGOqWY',
   'duration': '4 min'
 }, {
   'title': $services.localization.render('help.videos.videoCard2.title'),
   'topics': [
-    $services.localization.render('help.videos.videoCard2.topic1'),
-    $services.localization.render('help.videos.videoCard2.topic2'),
-    $services.localization.render('help.videos.videoCard2.topic3')
+    {
+      'url': 'https://extensions.xwiki.org/xwiki/bin/view/Extension/Flamingo%20Theme%20Application#HHowtoselectatheme',
+      'label': "$services.localization.render('help.videos.videoCard2.topic1')"
+    },
+    {
+      'url': 'https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/GettingStarted/ChangingTheLogoAndThePanels#HChangingyourwiki27spanels',
+      'label': "$services.localization.render('help.videos.videoCard2.topic2')"
+    },
+    {
+      'url': 'https://extensions.xwiki.org/xwiki/bin/view/Extension/Dashboard%20Macro#HAddinggadgets',
+      'label': "$services.localization.render('help.videos.videoCard2.topic3')"
+    }
   ],
   'url': 'https://www.youtube.com/embed/zX1Itoh3E68',
   'duration': '5 min'
 }, {
   'title': $services.localization.render('help.videos.videoCard3.title'),
   'topics': [
-    $services.localization.render('help.videos.videoCard3.topic1'),
-    $services.localization.render('help.videos.videoCard3.topic2'),
-    $services.localization.render('help.videos.videoCard3.topic3')
+    {
+      'url': 'https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/GettingStarted/CreatingAPage',
+      'label': "$services.localization.render('help.videos.videoCard3.topic1')"
+    },
+    {
+      'url': 'https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/GettingStarted/EditingAPage',
+      'label': "$services.localization.render('help.videos.videoCard3.topic2')"
+    },
+    {
+      'url': 'https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/Features/KeyboardShortcuts#HViewMode',
+      'label': "$services.localization.render('help.videos.videoCard3.topic3')"
+    }
   ],
   'url': 'https://www.youtube.com/embed/onenEu21FIk',
   'duration': '6 min'
 }, {
   'title': $services.localization.render('help.videos.videoCard4.title'),
   'topics': [
-    $services.localization.render('help.videos.videoCard4.topic1'),
-    $services.localization.render('help.videos.videoCard4.topic2')
+    {
+      'url': 'https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/Features/Imports#HImportingOfficedocuments',
+      'label': "$services.localization.render('help.videos.videoCard4.topic1')"
+    },
+    {
+      'url': 'https://extensions.xwiki.org/xwiki/bin/view/Extension/TOC+Macro#HExample1:Simple',
+      'label': "$services.localization.render('help.videos.videoCard4.topic2')"
+    }
   ],
   'url': 'https://www.youtube.com/embed/csQVSRMVclM',
   'duration': '4 min'
 }, {
   'title': $services.localization.render('help.videos.videoCard5.title'),
   'topics': [
-    $services.localization.render('help.videos.videoCard5.topic1'),
-    $services.localization.render('help.videos.videoCard5.topic2')
+    {
+      'url': $xwiki.getURL('Help.Applications.WebHome'),
+      'label': "$services.localization.render('help.videos.videoCard5.topic1')"
+    },
+    {
+      'url':'https://www.xwiki.org/xwiki/bin/view/Documentation/DevGuide/Tutorials/FAQTutorial/FAQTutorialAWM#HCreatingnewFAQentries',
+      'label':"$services.localization.render('help.videos.videoCard5.topic2')"
+    }
   ],
   'url': 'https://www.youtube.com/embed/Pv4jPCaU99g',
   'duration': '7 min'
 }, {
   'title': $services.localization.render('help.videos.videoCard6.title'),
   'topics': [
-    $services.localization.render('help.videos.videoCard6.topic1'),
-    $services.localization.render('help.videos.videoCard6.topic2')
+    {
+      'url':'https://www.xwiki.org/xwiki/bin/view/Documentation/DevGuide/Tutorials/CreatingExtensions/#HInstallinganExtension',
+      'label':"$services.localization.render('help.videos.videoCard6.topic1')"
+    },
+    {
+      'url':'https://extensions.xwiki.org/xwiki/bin/view/Extension/Administration%20Application#HDescription',
+      'label':"$services.localization.render('help.videos.videoCard6.topic2')"
+    }
   ],
   'url': 'https://www.youtube.com/embed/Q4NHu6J5pX4',
   'duration': '3 min'
@@ -100,7 +142,11 @@
       &lt;/div&gt;
       &lt;ul&gt;
         #foreach ($topic in $data.topics)
-          &lt;li&gt;$topic&lt;/li&gt;
+          &lt;li&gt;
+            &lt;a href="$topic.url"&gt;
+              $topic.label
+            &lt;/a&gt;
+          &lt;/li&gt;
         #end
       &lt;/ul&gt;
     &lt;/div&gt;

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/Help/Videos/WebHome.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/Help/Videos/WebHome.xml
@@ -135,14 +135,13 @@
 
 #macro (helpVideoCard $data)
   &lt;div class="videoCard"&gt;
-    &lt;iframe src="$data.url" allowfullscreen title="$escapetool.xml($data.title)" role="presentation" &gt;&lt;/iframe&gt;
+    &lt;iframe src="$data.url" allowfullscreen title="$escapetool.xml($data.title)" 
+        aria-description="$escapetool.html($services.localization.render('help.videos.hint'))" &gt;
+    &lt;/iframe&gt;
     &lt;div class="videoCard-body"&gt;
       &lt;div class="videoCard-title"&gt;
         $escapetool.xml($data.title)
       &lt;/div&gt;
-      &lt;p class='sr-only'&gt;
-        $escapetool.xml($services.localization.render('help.videos.hint'))
-      &lt;/p&gt;
       &lt;ul&gt;
         #foreach ($topic in $data.topics)
           &lt;li&gt;

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/Help/Videos/WebHome.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/Help/Videos/WebHome.xml
@@ -136,7 +136,7 @@
 #macro (helpVideoCard $data)
   &lt;div class="videoCard"&gt;
     &lt;iframe src="$data.url" allowfullscreen title="$escapetool.xml($data.title)" 
-        aria-description="$escapetool.html($services.localization.render('help.videos.hint'))" &gt;
+        aria-description="$escapetool.xml($services.localization.render('help.videos.hint'))" &gt;
     &lt;/iframe&gt;
     &lt;div class="videoCard-body"&gt;
       &lt;div class="videoCard-title"&gt;
@@ -145,9 +145,9 @@
       &lt;ul&gt;
         #foreach ($topic in $data.topics)
           &lt;li&gt;#if ($topic.url)
-            &lt;a href="$escapetool.html($topic.url)"&gt;$topic.label&lt;/a&gt;
-          #else 
-            $topic
+            &lt;a href="$escapetool.xml($topic.url)"&gt;$escapetool.xml($topic.label)&lt;/a&gt;
+          #else
+            $escapetool.xml($topic)
           #end
           &lt;/li&gt;
         #end

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/Help/Videos/WebHome.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/Help/Videos/WebHome.xml
@@ -44,11 +44,11 @@
   'topics': [
     {
       'url': 'https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/GettingStarted/',
-      'label': "$services.localization.render('help.videos.videoCard1.topic1')"
+      'label': $services.localization.render('help.videos.videoCard1.topic1')
     },
     {
       'url': 'https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/Features/Navigate/',
-      'label': "$services.localization.render('help.videos.videoCard1.topic2')"
+      'label': $services.localization.render('help.videos.videoCard1.topic2')
     }
   ],
   'url': 'https://www.youtube.com/embed/p5g6aDGOqWY',
@@ -58,15 +58,15 @@
   'topics': [
     {
       'url': 'https://extensions.xwiki.org/xwiki/bin/view/Extension/Flamingo%20Theme%20Application#HHowtoselectatheme',
-      'label': "$services.localization.render('help.videos.videoCard2.topic1')"
+      'label': $services.localization.render('help.videos.videoCard2.topic1')
     },
     {
       'url': 'https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/GettingStarted/ChangingTheLogoAndThePanels#HChangingyourwiki27spanels',
-      'label': "$services.localization.render('help.videos.videoCard2.topic2')"
+      'label': $services.localization.render('help.videos.videoCard2.topic2')
     },
     {
       'url': 'https://extensions.xwiki.org/xwiki/bin/view/Extension/Dashboard%20Macro#HAddinggadgets',
-      'label': "$services.localization.render('help.videos.videoCard2.topic3')"
+      'label': $services.localization.render('help.videos.videoCard2.topic3')
     }
   ],
   'url': 'https://www.youtube.com/embed/zX1Itoh3E68',
@@ -76,15 +76,15 @@
   'topics': [
     {
       'url': 'https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/GettingStarted/CreatingAPage',
-      'label': "$services.localization.render('help.videos.videoCard3.topic1')"
+      'label': $services.localization.render('help.videos.videoCard3.topic1')
     },
     {
       'url': 'https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/GettingStarted/EditingAPage',
-      'label': "$services.localization.render('help.videos.videoCard3.topic2')"
+      'label': $services.localization.render('help.videos.videoCard3.topic2')
     },
     {
       'url': 'https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/Features/KeyboardShortcuts#HViewMode',
-      'label': "$services.localization.render('help.videos.videoCard3.topic3')"
+      'label': $services.localization.render('help.videos.videoCard3.topic3')
     }
   ],
   'url': 'https://www.youtube.com/embed/onenEu21FIk',
@@ -94,11 +94,11 @@
   'topics': [
     {
       'url': 'https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/Features/Imports#HImportingOfficedocuments',
-      'label': "$services.localization.render('help.videos.videoCard4.topic1')"
+      'label': $services.localization.render('help.videos.videoCard4.topic1')
     },
     {
       'url': 'https://extensions.xwiki.org/xwiki/bin/view/Extension/TOC+Macro#HExample1:Simple',
-      'label': "$services.localization.render('help.videos.videoCard4.topic2')"
+      'label': $services.localization.render('help.videos.videoCard4.topic2')
     }
   ],
   'url': 'https://www.youtube.com/embed/csQVSRMVclM',
@@ -108,11 +108,11 @@
   'topics': [
     {
       'url': $xwiki.getURL('Help.Applications.WebHome'),
-      'label': "$services.localization.render('help.videos.videoCard5.topic1')"
+      'label': $services.localization.render('help.videos.videoCard5.topic1')
     },
     {
       'url': 'https://www.xwiki.org/xwiki/bin/view/Documentation/DevGuide/Tutorials/FAQTutorial/FAQTutorialAWM#HCreatingnewFAQentries',
-      'label': "$services.localization.render('help.videos.videoCard5.topic2')"
+      'label': $services.localization.render('help.videos.videoCard5.topic2')
     }
   ],
   'url': 'https://www.youtube.com/embed/Pv4jPCaU99g',
@@ -122,11 +122,11 @@
   'topics': [
     {
       'url': 'https://www.xwiki.org/xwiki/bin/view/Documentation/DevGuide/Tutorials/CreatingExtensions/#HInstallinganExtension',
-      'label': "$services.localization.render('help.videos.videoCard6.topic1')"
+      'label': $services.localization.render('help.videos.videoCard6.topic1')
     },
     {
       'url': 'https://extensions.xwiki.org/xwiki/bin/view/Extension/Administration%20Application#HDescription',
-      'label': "$services.localization.render('help.videos.videoCard6.topic2')"
+      'label': $services.localization.render('help.videos.videoCard6.topic2')
     }
   ],
   'url': 'https://www.youtube.com/embed/Q4NHu6J5pX4',

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/Help/Videos/WebHome.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/Help/Videos/WebHome.xml
@@ -43,12 +43,12 @@
   'title': $services.localization.render('help.videos.videoCard1.title'),
   'topics': [
     {
-      'url':'https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/GettingStarted/',
-      'label':"$services.localization.render('help.videos.videoCard1.topic1')"
+      'url': 'https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/GettingStarted/',
+      'label': "$services.localization.render('help.videos.videoCard1.topic1')"
     },
     {
-      'url':'https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/Features/Navigate/',
-      'label':"$services.localization.render('help.videos.videoCard1.topic2')"
+      'url': 'https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/Features/Navigate/',
+      'label': "$services.localization.render('help.videos.videoCard1.topic2')"
     }
   ],
   'url': 'https://www.youtube.com/embed/p5g6aDGOqWY',
@@ -111,8 +111,8 @@
       'label': "$services.localization.render('help.videos.videoCard5.topic1')"
     },
     {
-      'url':'https://www.xwiki.org/xwiki/bin/view/Documentation/DevGuide/Tutorials/FAQTutorial/FAQTutorialAWM#HCreatingnewFAQentries',
-      'label':"$services.localization.render('help.videos.videoCard5.topic2')"
+      'url': 'https://www.xwiki.org/xwiki/bin/view/Documentation/DevGuide/Tutorials/FAQTutorial/FAQTutorialAWM#HCreatingnewFAQentries',
+      'label': "$services.localization.render('help.videos.videoCard5.topic2')"
     }
   ],
   'url': 'https://www.youtube.com/embed/Pv4jPCaU99g',
@@ -121,12 +121,12 @@
   'title': $services.localization.render('help.videos.videoCard6.title'),
   'topics': [
     {
-      'url':'https://www.xwiki.org/xwiki/bin/view/Documentation/DevGuide/Tutorials/CreatingExtensions/#HInstallinganExtension',
-      'label':"$services.localization.render('help.videos.videoCard6.topic1')"
+      'url': 'https://www.xwiki.org/xwiki/bin/view/Documentation/DevGuide/Tutorials/CreatingExtensions/#HInstallinganExtension',
+      'label': "$services.localization.render('help.videos.videoCard6.topic1')"
     },
     {
-      'url':'https://extensions.xwiki.org/xwiki/bin/view/Extension/Administration%20Application#HDescription',
-      'label':"$services.localization.render('help.videos.videoCard6.topic2')"
+      'url': 'https://extensions.xwiki.org/xwiki/bin/view/Extension/Administration%20Application#HDescription',
+      'label': "$services.localization.render('help.videos.videoCard6.topic2')"
     }
   ],
   'url': 'https://www.youtube.com/embed/Q4NHu6J5pX4',

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/Help/Videos/WebHome.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/Help/Videos/WebHome.xml
@@ -140,6 +140,9 @@
       &lt;div class="videoCard-title"&gt;
         $escapetool.xml($data.title)
       &lt;/div&gt;
+      &lt;p class='sr-only'&gt;
+        $escapetool.xml($services.localization.render('help.videos.hint'))
+      &lt;/p&gt;
       &lt;ul&gt;
         #foreach ($topic in $data.topics)
           &lt;li&gt;


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21375
## Forum discussion
[Handle videos in the help page](https://forum.xwiki.org/t/handle-videos-in-the-help-page/13220)
## PR Changes
* Changed the list items to anchors sending to different documentation pages
* Added a hint to explicitly set the text alternative of the videos
## View
We can see that now all list items under the videos are anchors that redirect to various sections of the documentation. 
![21375-afterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/4f62a2d9-fbc0-42e5-b5de-45744bcbbd99)
## Notes
The way I implemented the solution we converged to in the discussion is based upon [this example in a proposal of atomic rule for ACT](https://www.w3.org/WAI/standards-guidelines/act/rules/fd26cf/proposed/#test-cases). There is no designated role for alternative to videos in aria, we rely on the user's understanding.
I decided to add a non-visual hint to highlight the bond between the video and its text counterpart. This element would clutter the visual UI, and fills a role for AT users that presentation handles visually.

Here are all the pairs label + URL added in this PR:
*  [Discover the elements displayed on your homepage](https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/GettingStarted/)
* [Start browsing your wiki](https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/Features/Navigate/) 
* [Learn how to change your wiki colour theme ](https://extensions.xwiki.org/xwiki/bin/view/Extension/Flamingo%20Theme%20Application#HHowtoselectatheme)
* [ Learn how to add panels and columns to your wiki look ](https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/GettingStarted/ChangingTheLogoAndThePanels#HChangingyourwiki27spanels)
*  [Learn how to add widgets to a wiki ](https://extensions.xwiki.org/xwiki/bin/view/Extension/Dashboard%20Macro#HAddinggadgets)
*  [Discover how to create a page ](https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/GettingStarted/CreatingAPage)
*  [Learn how to use the WYSIWYG editor ](https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/GettingStarted/EditingAPage)
* [Discover the view and edit modes ](https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/Features/KeyboardShortcuts#HViewMode)
*  [Discover how to import Office Documents to your wiki ](https://www.xwiki.org/xwiki/bin/view/Documentation/UserGuide/Features/Imports#HImportingOfficedocuments)
*  [Learn how to use a "Table of content" macro ](https://extensions.xwiki.org/xwiki/bin/view/Extension/TOC+Macro#HExample1:Simple)
* Discover how to create an application --> http://localhost:8080/xwiki/bin/view/Help/Applications/
*  [Learn how to use your application ](https://www.xwiki.org/xwiki/bin/view/Documentation/DevGuide/Tutorials/FAQTutorial/FAQTutorialAWM#HCreatingnewFAQentries)
* [Discover how to add/remove extensions using the Extension Manager ](https://www.xwiki.org/xwiki/bin/view/Documentation/DevGuide/Tutorials/CreatingExtensions/#HInstallinganExtension)
* [Discover the XWiki Administration UI ](https://extensions.xwiki.org/xwiki/bin/view/Extension/Administration%20Application#HDescription)