### PR TITLE
XWIKI-21437: The XModal close button is not accessible

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/widgets/modalPopup.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/widgets/modalPopup.css
@@ -47,15 +47,7 @@
 }
 .xdialog-close {
   float: right;
-  cursor: pointer;
-  width: .8em;
-  margin-right: .4em;
-  height: 1.4em;
-  text-align : center;
-  font-weight: bold;
-  font-family: Arial, Helvetica, sans-serif;
-  line-height: 1.4em;
-  color: $theme.panelTextColor;
+  margin-right: .8em;
 }
 .xdialog-title .xdialog-close {
   font-size: 1.25em;

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/widgets/modalPopup.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/widgets/modalPopup.js
@@ -79,7 +79,7 @@ widgets.ModalPopup = Class.create({
     }
     // Add the close button
     if (this.options.displayCloseButton) {
-      var closeButton = new Element('div', {'class': 'xdialog-close', 'title': 'Close'}).update("&#215;");
+      var closeButton = new Element('button', {'class': 'btn btn-default xdialog-close', 'title': 'Close'}).update("&#215;");
       closeButton.observe("click", this.closeDialog.bindAsEventListener(this));
       if (this.options.title) {
         title.insert({bottom: closeButton});


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21437
## PR Changes
* Updated style and semantic on the close button
## Tests
Successfully passed [this error in CI](https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/master/6926/testReport/org.xwiki.tour.test.ui/TourApplicationIT/Platform_Builds___main___integration_tests___IT_for_xwiki_platform_core_xwiki_platform_tour_xwiki_platform_tour_test_xwiki_platform_tour_test_tests___Build_for_IT_for_xwiki_platform_core_xwiki_platform_tour_xwiki_platform_tour_test_xwiki_platform_tour_test_tests___verifyTourFeatures/).
## View
![21437-viewAfterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/3babbbea-d143-4ff5-ae7a-ab1c7597e659)
