### PR TITLE
XWIKI-21272: History navigation arrows are not perceived as links and lacking contrast

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/ChangesPane.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/ChangesPane.java
@@ -33,8 +33,8 @@ import org.xwiki.test.ui.po.diff.RenderedChanges;
  */
 public class ChangesPane extends BaseElement
 {
-    private final static String previousChangeSelector = "#changes-info-boxes > #changes-arrow-boxes > a.changes-arrow-left";
-    private final static String nextChangeSelector = "#changes-info-boxes > #changes-arrow-boxes > a.changes-arrow-right";
+    private final static String previousChangeSelector = "#changes-info-boxes > #changes-arrows-box > a.changes-arrow-left";
+    private final static String nextChangeSelector = "#changes-info-boxes > #changes-arrows-box > a.changes-arrow-right";
     private final static String previousFromVersionSelector = "#changes-info-box-from .changes-arrow:first-child";
     private final static String nextFromVersionSelector = "#changes-info-box-from .changes-arrow:last-child";
     private final static String previousToVersionSelector = "#changes-info-box-to .changes-arrow:first-child";

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/src/test/it/org/xwiki/test/ui/CompareVersionsTest.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/src/test/it/org/xwiki/test/ui/CompareVersionsTest.java
@@ -240,9 +240,9 @@ public class CompareVersionsTest extends AbstractTest
         // Version summary.
         String today = new SimpleDateFormat("yyyy/MM/dd").format(new Date());
         assertTrue(changesPane.getFromVersionSummary().startsWith(
-            "From version 1.1 >\nedited by Administrator\non " + today));
+            "From version 1.1\nedited by Administrator\non " + today));
         assertTrue(changesPane.getToVersionSummary().startsWith(
-            "To version < " + currentVersion + "\nedited by Alice\non " + today));
+            "To version " + currentVersion + "\nedited by Alice\non " + today));
         assertEquals("Change comment: Deleted object", changesPane.getChangeComment());
 
         RawChanges rawChanges = changesPane.getRawChanges();


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21272
## PR Changes
* Fixed outdated functional tests
## Note
The [changes merged here](https://github.com/xwiki/xwiki-platform/pull/2323) created [a test fail on the CI](https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/master/lastCompletedBuild/testReport/org.xwiki.test.ui/CompareVersionsTest/Platform_Builds___main___distribution___flavor_test_ui___Build_for_Flavor_Test___UI___testCompareVersionScenario/).
## Tests
Successfully passed `mvn clean install -f xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui -Pdocker -Dxwiki.test.ui.wcag=true -Dgradle.cache.local.enabled=false -Dgradle.cache.remote.enabled=false ` (the failing test suite).