### PR TITLE
XWIKI-21163: WCAG reporting: include a summary of the tests for statistics

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/WCAGContext.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/WCAGContext.java
@@ -214,7 +214,7 @@ public class WCAGContext
 
         private int numberOfChecks(List<Rule> violations)
         {
-            return violations.stream().mapToInt(rule -> rule.getNodes().size()).sum();
+            return (violations == null) ? 0 : violations.stream().mapToInt(rule -> rule.getNodes().size()).sum();
         }
 
         String getFailReport()


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21163
## PR Changes
* Bulletproofed the numberOfChecks function
## Tests
There was [a failure of the WCAG validator on CI](https://ci.xwiki.org/job/XWiki%20Environment%20Tests/job/xwiki-platform/job/master/359/testReport/junit/org.xwiki.export.pdf.test.ui/AllIT$NestedPDFExportIT/MySQL_8_1__Tomcat_9_jdk17__Chrome___Docker_tests_for_xwiki_platform_export_pdf___Build_for_MySQL_8_1__Tomcat_9_jdk17__Chrome___Docker_tests_for_xwiki_platform_export_pdf___largeTable_TestUtils__TestConfiguration_/). This PR fixes this fail and successfully passes `mvn clean install -f xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-test/xwiki-platform-export-pdf-test-docker/ -Pdocker -Dxwiki.test.ui.wcag=true`