### PR TITLE
XWIKI-21412: Move the Tour Application to xwiki-platform

### DIFF
--- a/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-test/xwiki-platform-tour-test-pageobjects/src/main/java/org/xwiki/tour/test/po/PageWithTour.java
+++ b/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-test/xwiki-platform-tour-test-pageobjects/src/main/java/org/xwiki/tour/test/po/PageWithTour.java
@@ -134,7 +134,8 @@ public class PageWithTour extends ViewPage
 
     public boolean hasResumeButton()
     {
-        return getDriver().hasElementWithoutWaiting(By.id("tourResume"));
+        return getDriver().hasElementWithoutWaiting(By.id("tourResume")) 
+            && (getDriver().findElement(By.id("tourResume")).getAttribute("hidden") == null);
     }
 
     public void resume()


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21412
## PR Changes
* Updated the hasResumeButton test function to better interpret the new behaviour of the button.
## Tests
Passed `mvn clean install -f xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-test/xwiki-platform-tour-test-tests/ -Pdocker -Dxwiki.test.ui.wcag=true` that was [failed on CI](https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/master/6932/testReport/junit/org.xwiki.tour.test.ui/TourApplicationIT/Platform_Builds___main___integration_tests___IT_for_xwiki_platform_core_xwiki_platform_tour_xwiki_platform_tour_test_xwiki_platform_tour_test_tests___Build_for_IT_for_xwiki_platform_core_xwiki_platform_tour_xwiki_platform_tour_test_xwiki_platform_tour_test_tests___verifyTourFeatures/).