### PR TITLE
XWIKI-21375: Videos on the help page don't have alternatives

### DIFF
--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/Help/Videos/WebHome.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/Help/Videos/WebHome.xml
@@ -136,8 +136,11 @@
 #macro (helpVideoCard $data)
   &lt;div class="videoCard"&gt;
     &lt;iframe src="$data.url" allowfullscreen title="$escapetool.xml($data.title)" 
-        aria-description="$escapetool.xml($services.localization.render('help.videos.hint'))" &gt;
+        aria-describedby="video_hint_$foreach.index" &gt;
     &lt;/iframe&gt;
+    &lt;span id="video_hint_$foreach.index" class="sr-only"&gt;
+      $escapetool.xml($services.localization.render('help.videos.hint'))
+    &lt;/span&gt;
     &lt;div class="videoCard-body"&gt;
       &lt;div class="videoCard-title"&gt;
         $escapetool.xml($data.title)

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/Help/Videos/WebHome.xml
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/main/resources/Help/Videos/WebHome.xml
@@ -135,7 +135,7 @@
 
 #macro (helpVideoCard $data)
   &lt;div class="videoCard"&gt;
-    &lt;iframe src="$data.url" allowfullscreen title="$escapetool.xml($data.title)" 
+    &lt;iframe src="$data.url" allowfullscreen title="$escapetool.xml($data.title)" role='application'
         aria-describedby="video_hint_$foreach.index" &gt;
     &lt;/iframe&gt;
     &lt;span id="video_hint_$foreach.index" class="sr-only"&gt;


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21375
## PR Changes
* Replaced unstandard aria attribute
## Note
This is a fix for the webstandard regression https://ge.xwiki.org/s/fz2vfc7qvnhue/tests/goal/org.xwiki.platform:xwiki-platform-distribution-flavor-test-webstandards:surefire:test@default/details/org.xwiki.test.webstandards.framework.DefaultValidationTest/Validating%20HTML5%20validity%20for%20%5Bhttp:%2F%2F127.0.0.1:8080%2Fxwiki%2Fbin%2Fview%2FHelp%2FVideos%2FWebHome%5D%20executed%20with%20credentials%20Admin:admin?expanded-stacktrace=WyIwIl0&top-execution=1 introduced in https://github.com/xwiki/xwiki-platform/commit/877d3e64a06ae4814356301f285ec0013178825a