### PR TITLE
XWIKI-21105: Drop the panel-default-text color from the color theme and use the content colors for all panel content, to facilitate contrast

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Cerulean.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Cerulean.xml
@@ -753,7 +753,6 @@
         <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </panel-bg>
-      
       <text-color>
         <customDisplay/>
         <disabled>0</disabled>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Cerulean.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Cerulean.xml
@@ -753,19 +753,7 @@
         <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </panel-bg>
-      <panel-default-text>
-        <customDisplay/>
-        <disabled>0</disabled>
-        <name>panel-default-text</name>
-        <number>46</number>
-        <picker>0</picker>
-        <prettyName>panel-default-text</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </panel-default-text>
+      
       <text-color>
         <customDisplay/>
         <disabled>0</disabled>
@@ -1953,9 +1941,6 @@
     </property>
     <property>
       <panel-bg/>
-    </property>
-    <property>
-      <panel-default-text/>
     </property>
     <property>
       <text-color/>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Cosmo.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Cosmo.xml
@@ -744,19 +744,6 @@
         <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </panel-bg>
-      <panel-default-text>
-        <customDisplay/>
-        <disabled>0</disabled>
-        <name>panel-default-text</name>
-        <number>46</number>
-        <picker>0</picker>
-        <prettyName>panel-default-text</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </panel-default-text>
       <text-color>
         <customDisplay/>
         <disabled>0</disabled>
@@ -1623,7 +1610,7 @@
 @panel-inner-border:          #ddd;
 @panel-footer-bg:             #f5f5f5;
 
-@panel-default-text:          @gray-dark;
+@panel-default-text:          @text-color;
 @panel-default-border:        #ddd;
 @panel-default-heading-bg:    #f5f5f5;
 
@@ -2071,9 +2058,6 @@ a.list-group-item {
     </property>
     <property>
       <panel-bg/>
-    </property>
-    <property>
-      <panel-default-text/>
     </property>
     <property>
       <text-color/>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Cyborg.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Cyborg.xml
@@ -753,19 +753,6 @@
         <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </panel-bg>
-      <panel-default-text>
-        <customDisplay/>
-        <disabled>0</disabled>
-        <name>panel-default-text</name>
-        <number>46</number>
-        <picker>0</picker>
-        <prettyName>panel-default-text</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </panel-default-text>
       <text-color>
         <customDisplay/>
         <disabled>0</disabled>
@@ -2062,9 +2049,6 @@ a.list-group-item {
     </property>
     <property>
       <panel-bg>#060606</panel-bg>
-    </property>
-    <property>
-      <panel-default-text>#ffffff</panel-default-text>
     </property>
     <property>
       <text-color>#999999</text-color>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Darkly.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Darkly.xml
@@ -753,19 +753,6 @@
         <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </panel-bg>
-      <panel-default-text>
-        <customDisplay/>
-        <disabled>0</disabled>
-        <name>panel-default-text</name>
-        <number>46</number>
-        <picker>0</picker>
-        <prettyName>panel-default-text</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </panel-default-text>
       <text-color>
         <customDisplay/>
         <disabled>0</disabled>
@@ -2167,9 +2154,6 @@ a.list-group-item {
     </property>
     <property>
       <panel-bg>#222222</panel-bg>
-    </property>
-    <property>
-      <panel-default-text/>
     </property>
     <property>
       <text-color>#ffffff</text-color>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Flatly.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Flatly.xml
@@ -753,19 +753,6 @@
         <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </panel-bg>
-      <panel-default-text>
-        <customDisplay/>
-        <disabled>0</disabled>
-        <name>panel-default-text</name>
-        <number>46</number>
-        <picker>0</picker>
-        <prettyName>panel-default-text</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </panel-default-text>
       <text-color>
         <customDisplay/>
         <disabled>0</disabled>
@@ -2150,9 +2137,6 @@ a.list-group-item {
     </property>
     <property>
       <panel-bg/>
-    </property>
-    <property>
-      <panel-default-text/>
     </property>
     <property>
       <text-color/>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Journal.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Journal.xml
@@ -744,19 +744,6 @@
         <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </panel-bg>
-      <panel-default-text>
-        <customDisplay/>
-        <disabled>0</disabled>
-        <name>panel-default-text</name>
-        <number>46</number>
-        <picker>0</picker>
-        <prettyName>panel-default-text</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </panel-default-text>
       <text-color>
         <customDisplay/>
         <disabled>0</disabled>
@@ -1956,9 +1943,6 @@
     </property>
     <property>
       <panel-bg/>
-    </property>
-    <property>
-      <panel-default-text/>
     </property>
     <property>
       <text-color/>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Lumen.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Lumen.xml
@@ -744,19 +744,6 @@
         <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </panel-bg>
-      <panel-default-text>
-        <customDisplay/>
-        <disabled>0</disabled>
-        <name>panel-default-text</name>
-        <number>46</number>
-        <picker>0</picker>
-        <prettyName>panel-default-text</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </panel-default-text>
       <text-color>
         <customDisplay/>
         <disabled>0</disabled>
@@ -1625,7 +1612,7 @@
 @panel-inner-border:          transparent;
 @panel-footer-bg:             #f5f5f5;
 
-@panel-default-text:          @gray-dark;
+@panel-default-text:          @text-color;
 @panel-default-border:        transparent;
 @panel-default-heading-bg:    #f5f5f5;
 
@@ -2332,9 +2319,6 @@ a.list-group-item {
     </property>
     <property>
       <panel-bg/>
-    </property>
-    <property>
-      <panel-default-text/>
     </property>
     <property>
       <text-color/>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Paper.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Paper.xml
@@ -744,19 +744,6 @@
         <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </panel-bg>
-      <panel-default-text>
-        <customDisplay/>
-        <disabled>0</disabled>
-        <name>panel-default-text</name>
-        <number>46</number>
-        <picker>0</picker>
-        <prettyName>panel-default-text</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </panel-default-text>
       <text-color>
         <customDisplay/>
         <disabled>0</disabled>
@@ -1623,7 +1610,7 @@
 @panel-inner-border:          #ddd;
 @panel-footer-bg:             #f5f5f5;
 
-@panel-default-text:          @gray-dark;
+@panel-default-text:          @text-color;
 @panel-default-border:        #ddd;
 @panel-default-heading-bg:    #f5f5f5;
 
@@ -2443,9 +2430,6 @@ div.main {
     </property>
     <property>
       <panel-bg/>
-    </property>
-    <property>
-      <panel-default-text/>
     </property>
     <property>
       <text-color/>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Readable.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Readable.xml
@@ -744,19 +744,6 @@
         <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </panel-bg>
-      <panel-default-text>
-        <customDisplay/>
-        <disabled>0</disabled>
-        <name>panel-default-text</name>
-        <number>46</number>
-        <picker>0</picker>
-        <prettyName>panel-default-text</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </panel-default-text>
       <text-color>
         <customDisplay/>
         <disabled>0</disabled>
@@ -1623,7 +1610,7 @@
 @panel-inner-border:          #ddd;
 @panel-footer-bg:             #fff;
 
-@panel-default-text:          @gray-dark;
+@panel-default-text:          @text-color;
 @panel-default-border:        #ddd;
 @panel-default-heading-bg:    #f5f5f5;
 
@@ -2009,9 +1996,6 @@ legend {
     </property>
     <property>
       <panel-bg/>
-    </property>
-    <property>
-      <panel-default-text/>
     </property>
     <property>
       <text-color/>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Sandstone.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Sandstone.xml
@@ -753,19 +753,6 @@
         <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </panel-bg>
-      <panel-default-text>
-        <customDisplay/>
-        <disabled>0</disabled>
-        <name>panel-default-text</name>
-        <number>46</number>
-        <picker>0</picker>
-        <prettyName>panel-default-text</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </panel-default-text>
       <text-color>
         <customDisplay/>
         <disabled>0</disabled>
@@ -2015,9 +2002,6 @@ input,
     </property>
     <property>
       <panel-bg/>
-    </property>
-    <property>
-      <panel-default-text/>
     </property>
     <property>
       <text-color/>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Simplex.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Simplex.xml
@@ -744,19 +744,6 @@
         <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </panel-bg>
-      <panel-default-text>
-        <customDisplay/>
-        <disabled>0</disabled>
-        <name>panel-default-text</name>
-        <number>46</number>
-        <picker>0</picker>
-        <prettyName>panel-default-text</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </panel-default-text>
       <text-color>
         <customDisplay/>
         <disabled>0</disabled>
@@ -1623,7 +1610,7 @@
 @panel-inner-border:          #ddd;
 @panel-footer-bg:             @body-bg;
 
-@panel-default-text:          @gray-dark;
+@panel-default-text:          @text-color;
 @panel-default-border:        #ddd;
 @panel-default-heading-bg:    @panel-footer-bg;
 
@@ -1988,9 +1975,6 @@ label {
     </property>
     <property>
       <panel-bg/>
-    </property>
-    <property>
-      <panel-default-text/>
     </property>
     <property>
       <text-color/>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Slate.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Slate.xml
@@ -753,19 +753,6 @@
         <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </panel-bg>
-      <panel-default-text>
-        <customDisplay/>
-        <disabled>0</disabled>
-        <name>panel-default-text</name>
-        <number>46</number>
-        <picker>0</picker>
-        <prettyName>panel-default-text</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </panel-default-text>
       <text-color>
         <customDisplay/>
         <disabled>0</disabled>
@@ -2273,9 +2260,6 @@ ul.nav.nav-pills.nav-stacked li{
     </property>
     <property>
       <panel-bg>#272b30</panel-bg>
-    </property>
-    <property>
-      <panel-default-text/>
     </property>
     <property>
       <text-color>#c8c8c8</text-color>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Spacelab.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Spacelab.xml
@@ -744,19 +744,6 @@
         <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </panel-bg>
-      <panel-default-text>
-        <customDisplay/>
-        <disabled>0</disabled>
-        <name>panel-default-text</name>
-        <number>46</number>
-        <picker>0</picker>
-        <prettyName>panel-default-text</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </panel-default-text>
       <text-color>
         <customDisplay/>
         <disabled>0</disabled>
@@ -1625,7 +1612,7 @@
 @panel-inner-border:          #ddd;
 @panel-footer-bg:             #f5f5f5;
 
-@panel-default-text:          @gray-dark;
+@panel-default-text:          @text-color;
 @panel-default-border:        #ddd;
 @panel-default-heading-bg:    #f5f5f5;
 
@@ -1962,9 +1949,6 @@
     </property>
     <property>
       <panel-bg/>
-    </property>
-    <property>
-      <panel-default-text/>
     </property>
     <property>
       <text-color/>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Superhero.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Superhero.xml
@@ -753,19 +753,6 @@
         <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </panel-bg>
-      <panel-default-text>
-        <customDisplay/>
-        <disabled>0</disabled>
-        <name>panel-default-text</name>
-        <number>46</number>
-        <picker>0</picker>
-        <prettyName>panel-default-text</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </panel-default-text>
       <text-color>
         <customDisplay/>
         <disabled>0</disabled>
@@ -1634,7 +1621,7 @@
 @panel-inner-border:          transparent;
 @panel-footer-bg:             @table-bg-hover;
 
-@panel-default-text:          @gray-dark;
+@panel-default-text:          @text-color;
 @panel-default-border:        transparent;
 @panel-default-heading-bg:    #f5f5f5;
 
@@ -2175,9 +2162,6 @@ div.main {
     </property>
     <property>
       <panel-bg>#2b3e50</panel-bg>
-    </property>
-    <property>
-      <panel-default-text>#ffffff</panel-default-text>
     </property>
     <property>
       <text-color>#ffffff</text-color>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/United.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/United.xml
@@ -753,19 +753,6 @@
         <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </panel-bg>
-      <panel-default-text>
-        <customDisplay/>
-        <disabled>0</disabled>
-        <name>panel-default-text</name>
-        <number>46</number>
-        <picker>0</picker>
-        <prettyName>panel-default-text</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </panel-default-text>
       <text-color>
         <customDisplay/>
         <disabled>0</disabled>
@@ -1634,7 +1621,7 @@
 @panel-inner-border:          #ddd;
 @panel-footer-bg:             #f5f5f5;
 
-@panel-default-text:          @gray-dark;
+@panel-default-text:          @text-color;
 @panel-default-border:        #ddd;
 @panel-default-heading-bg:    #f5f5f5;
 
@@ -1877,9 +1864,6 @@
     </property>
     <property>
       <panel-bg/>
-    </property>
-    <property>
-      <panel-default-text/>
     </property>
     <property>
       <text-color/>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Yeti.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-bootswatch/src/main/resources/FlamingoThemes/Yeti.xml
@@ -744,19 +744,6 @@
         <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </panel-bg>
-      <panel-default-text>
-        <customDisplay/>
-        <disabled>0</disabled>
-        <name>panel-default-text</name>
-        <number>46</number>
-        <picker>0</picker>
-        <prettyName>panel-default-text</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </panel-default-text>
       <text-color>
         <customDisplay/>
         <disabled>0</disabled>
@@ -1625,7 +1612,7 @@
 @panel-inner-border:          @table-border-color;
 @panel-footer-bg:             #f5f5f5;
 
-@panel-default-text:          @gray-dark;
+@panel-default-text:          @text-color;
 @panel-default-border:        @table-border-color;
 @panel-default-heading-bg:    #f5f5f5;
 
@@ -2255,9 +2242,6 @@ input[type="checkbox"] {
     </property>
     <property>
       <panel-bg/>
-    </property>
-    <property>
-      <panel-default-text/>
     </property>
     <property>
       <text-color/>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemes/Charcoal.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemes/Charcoal.xml
@@ -744,19 +744,6 @@
         <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </panel-bg>
-      <panel-default-text>
-        <customDisplay/>
-        <disabled>0</disabled>
-        <name>panel-default-text</name>
-        <number>46</number>
-        <picker>0</picker>
-        <prettyName>panel-default-text</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </panel-default-text>
       <text-color>
         <customDisplay/>
         <disabled>0</disabled>
@@ -949,9 +936,6 @@
     </property>
     <property>
       <panel-bg>#F5F5F5</panel-bg>
-    </property>
-    <property>
-      <panel-default-text>#333333</panel-default-text>
     </property>
     <property>
       <text-color>#333333</text-color>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemes/Garden.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemes/Garden.xml
@@ -753,19 +753,6 @@
         <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </panel-bg>
-      <panel-default-text>
-        <customDisplay/>
-        <disabled>0</disabled>
-        <name>panel-default-text</name>
-        <number>46</number>
-        <picker>0</picker>
-        <prettyName>panel-default-text</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </panel-default-text>
       <text-color>
         <customDisplay/>
         <disabled>0</disabled>
@@ -971,9 +958,6 @@ body{
     </property>
     <property>
       <panel-bg/>
-    </property>
-    <property>
-      <panel-default-text/>
     </property>
     <property>
       <text-color>#030f02</text-color>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemes/Iceberg.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemes/Iceberg.xml
@@ -753,19 +753,6 @@
         <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </panel-bg>
-      <panel-default-text>
-        <customDisplay/>
-        <disabled>0</disabled>
-        <name>panel-default-text</name>
-        <number>46</number>
-        <picker>0</picker>
-        <prettyName>panel-default-text</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </panel-default-text>
       <table-bg>
         <customDisplay/>
         <disabled>0</disabled>
@@ -1028,9 +1015,6 @@
     </property>
     <property>
       <panel-bg>#fafafa</panel-bg>
-    </property>
-    <property>
-      <panel-default-text/>
     </property>
     <property>
       <table-bg/>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemes/Kitty.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemes/Kitty.xml
@@ -753,19 +753,6 @@
         <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </panel-bg>
-      <panel-default-text>
-        <customDisplay/>
-        <disabled>0</disabled>
-        <name>panel-default-text</name>
-        <number>46</number>
-        <picker>0</picker>
-        <prettyName>panel-default-text</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </panel-default-text>
       <text-color>
         <customDisplay/>
         <disabled>0</disabled>
@@ -961,9 +948,6 @@
     </property>
     <property>
       <panel-bg>#faf2fa</panel-bg>
-    </property>
-    <property>
-      <panel-default-text>#470b47</panel-default-text>
     </property>
     <property>
       <text-color>#633d63</text-color>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemes/Marina.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemes/Marina.xml
@@ -753,19 +753,6 @@
         <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </panel-bg>
-      <panel-default-text>
-        <customDisplay/>
-        <disabled>0</disabled>
-        <name>panel-default-text</name>
-        <number>46</number>
-        <picker>0</picker>
-        <prettyName>panel-default-text</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </panel-default-text>
       <text-color>
         <customDisplay/>
         <disabled>0</disabled>
@@ -968,9 +955,6 @@
     </property>
     <property>
       <panel-bg/>
-    </property>
-    <property>
-      <panel-default-text/>
     </property>
     <property>
       <text-color>#091154</text-color>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/ThemeClass.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/ThemeClass.xml
@@ -740,19 +740,6 @@
       <validationRegExp/>
       <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
     </panel-bg>
-    <panel-default-text>
-      <customDisplay/>
-      <disabled>0</disabled>
-      <name>panel-default-text</name>
-      <number>46</number>
-      <picker>0</picker>
-      <prettyName>panel-default-text</prettyName>
-      <size>30</size>
-      <unmodifiable>0</unmodifiable>
-      <validationMessage/>
-      <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-    </panel-default-text>
     <table-bg>
       <customDisplay/>
       <disabled>0</disabled>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/ThemeSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/ThemeSheet.xml
@@ -124,8 +124,7 @@
     "legend-border-color": "color"
    },
   "panels": {
-    "panel-bg" : "color",
-    "panel-default-text" : "color"
+    "panel-bg" : "color"
   },
   "breadcrumb": {
     "breadcrumb-bg": "color",

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/ThemeTemplate.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/ThemeTemplate.xml
@@ -744,19 +744,6 @@
         <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </panel-bg>
-      <panel-default-text>
-        <customDisplay/>
-        <disabled>0</disabled>
-        <name>panel-default-text</name>
-        <number>46</number>
-        <picker>0</picker>
-        <prettyName>panel-default-text</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <validationMessage/>
-        <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </panel-default-text>
       <text-color>
         <customDisplay/>
         <disabled>0</disabled>
@@ -948,9 +935,6 @@
     </property>
     <property>
       <panel-bg/>
-    </property>
-    <property>
-      <panel-default-text/>
     </property>
     <property>
       <text-color/>


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21105
## PR Changes
* Removed `panel-default-text` from the color theme template and from all the bundled color themes.
* Updated the value of this variable in the advanced section of the color themes where it was used, in order for it to follow regular text color

## Notes
The variable is still available in the color theme, however this PR makes it impossible to change it from the edit UI of a theme, and removes default values (most of the time hard coded for no reason).

See https://forum.xwiki.org/t/color-theme-panel-content/12818 for a discussion about removing this variable from the UI.
