### PR TITLE
XWIKI-21451: The logging form bottom rounded corners have a blank gap

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/panels.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/panels.less
@@ -39,9 +39,12 @@ h1.xwikipaneltitle {
 }
 
 // Panels inside the page =================================================
-.main {
+.main{
   .panel-body {
     background-color: @xwiki-page-content-bg;
+    // Without this radius, the panel background can be displayed over the parent border, when the parent has a rounded
+    // corner.
+    border-radius: inherit;
   }
 }
 

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/panels.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/panels.less
@@ -39,7 +39,7 @@ h1.xwikipaneltitle {
 }
 
 // Panels inside the page =================================================
-.main{
+.main {
   .panel-body {
     background-color: @xwiki-page-content-bg;
     // Without this radius, the panel background can be displayed over the parent border, when the parent has a rounded


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-21451

- Technically a (very old) regression between 7.1 and 7.2, by https://github.com/xwiki/xwiki-platform/commit/8b065192c4f26e13f9d4bbbdf34090055c18e218

**Before**

![image](https://github.com/xwiki/xwiki-platform/assets/327856/be00f4ac-f5a8-4762-9e2c-b7ba90dcbbd9)

**After**

![image](https://github.com/xwiki/xwiki-platform/assets/327856/619f4695-90d0-4a66-b21c-4258f03a261a)


