### PR TITLE
XWIKI-21458: Provide a XJetty based Debian package

### DIFF
--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/pom.xml
@@ -37,6 +37,7 @@
     <module>xwiki-platform-distribution-debian-mysql-common</module>
     <module>xwiki-platform-distribution-debian-pgsql-common</module>
     <module>xwiki-platform-distribution-debian-tomcat</module>
+    <module>xwiki-platform-distribution-debian-xjetty</module>
     <module>xwiki-platform-distribution-debian-solr</module>
   </modules>
   <properties>
@@ -61,6 +62,8 @@
     <debian.bugs>https://jira.xwiki.org</debian.bugs>
     <debian.homepage>http://www.xwiki.org</debian.homepage>
     <debian.controlDir>${project.build.directory}/maven-deb-control-directory</debian.controlDir>
+
+    <xwikiDataDir>/var/lib/xwiki/data</xwikiDataDir>
   </properties>
   <dependencies>
     <dependency>

--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-common/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-common/pom.xml
@@ -37,7 +37,7 @@
 
     <war.path>${project.build.directory}/war</war.path>
 
-    <xwiki.properties.environment.permanentDirectory>/var/lib/xwiki/data</xwiki.properties.environment.permanentDirectory>
+    <xwiki.properties.environment.permanentDirectory>${xwikiDataDir}</xwiki.properties.environment.permanentDirectory>
 
     <xwiki.extension.features>xwiki</xwiki.extension.features>
     <debian.package>xwiki-common</debian.package>

--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.xwiki.platform</groupId>
+    <artifactId>xwiki-platform-distribution-debian</artifactId>
+    <version>15.10-SNAPSHOT</version>
+  </parent>
+  <artifactId>xwiki-platform-distribution-debian-xjetty</artifactId>
+  <name>XWiki Platform - Distribution - Debian - XJetty</name>
+  <packaging>pom</packaging>
+  <description>XWiki Platform - Distribution - XJetty - Tomcat</description>
+  <modules>
+    <module>xwiki-platform-distribution-debian-xjetty-common</module>
+    <module>xwiki-platform-distribution-debian-xjetty-mariadb</module>
+    <module>xwiki-platform-distribution-debian-xjetty-mysql</module>
+    <module>xwiki-platform-distribution-debian-xjetty-pgsql</module>
+  </modules>
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>xwiki-platform-distribution-debian-common</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+      <type>deb</type>
+    </dependency>
+  </dependencies>
+</project>

--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/pom.xml
@@ -30,7 +30,7 @@
   <artifactId>xwiki-platform-distribution-debian-xjetty</artifactId>
   <name>XWiki Platform - Distribution - Debian - XJetty</name>
   <packaging>pom</packaging>
-  <description>XWiki Platform - Distribution - XJetty - Tomcat</description>
+  <description>XWiki Platform - Distribution - XJetty</description>
   <modules>
     <module>xwiki-platform-distribution-debian-xjetty-common</module>
     <module>xwiki-platform-distribution-debian-xjetty-mariadb</module>

--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-common/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-common/pom.xml
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.xwiki.platform</groupId>
+    <artifactId>xwiki-platform-distribution-debian-xjetty</artifactId>
+    <version>15.10-SNAPSHOT</version>
+  </parent>
+  <artifactId>xwiki-platform-distribution-debian-xjetty-common</artifactId>
+  <name>XWiki Platform - Distribution - Debian - XJetty - Common</name>
+  <packaging>deb</packaging>
+  <description>XWiki XJetty common package</description>
+  <properties>
+    <debian.package>xwiki-xjetty-common</debian.package>
+
+    <jetty.filter.path>${project.build.directory}/jetty-filter</jetty.filter.path>
+    <jetty.path>${project.build.directory}/jetty</jetty.path>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-tool-rootwebapp</artifactId>
+      <version>${project.version}</version>
+      <type>war</type>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-tool-jetty-resources</artifactId>
+      <version>${project.version}</version>
+      <type>zip</type>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <!-- Unpack the Jetty files to filter -->
+          <execution>
+            <id>unzip-resources</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.xwiki.platform</groupId>
+                  <artifactId>xwiki-platform-tool-jetty-resources</artifactId>
+                  <version>${platform.version}</version>
+                  <type>zip</type>
+                </artifactItem>
+              </artifactItems>
+              <outputDirectory>${jetty.filter.path}</outputDirectory>
+              <includes>**/start_xwiki*.*</includes>
+            </configuration>
+          </execution>
+          <!-- Unpack the the Jetty files -->
+          <execution>
+            <id>unzip-jetty</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.xwiki.platform</groupId>
+                  <artifactId>xwiki-platform-tool-jetty-resources</artifactId>
+                  <version>${platform.version}</version>
+                  <type>zip</type>
+                </artifactItem>
+              </artifactItems>
+              <outputDirectory>${jetty.path}</outputDirectory>
+              <excludes>**/start_xwiki*.*</excludes>
+            </configuration>
+          </execution>
+          <!-- Unpack the ROOT webapp -->
+          <execution>
+            <id>unzip-jettyrootwebapp</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.xwiki.platform</groupId>
+                  <artifactId>xwiki-platform-tool-rootwebapp</artifactId>
+                  <version>${platform.version}</version>
+                  <type>war</type>
+                </artifactItem>
+              </artifactItems>
+              <outputDirectory>${jetty.path}/webapps/root</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- Filter a few files to replace variable -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>filter-jetty</id>
+            <!-- here the phase you need -->
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${jetty.path}</outputDirectory>
+              <resources>          
+                <resource>
+                  <directory>${jetty.filter.path}</directory>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>              
+            </configuration>            
+          </execution>
+        </executions>
+      </plugin>
+      <!-- Produce deb package -->
+      <plugin>
+        <artifactId>jdeb</artifactId>
+        <groupId>org.vafer</groupId>
+        <configuration>
+          <dataSet combine.children="append">
+            <data>
+              <src>${project.basedir}/src/deb/resources/</src>
+              <type>directory</type>
+              <mapper>
+                <type>perm</type>
+                <prefix />
+              </mapper>
+              <conffile>true</conffile>
+            </data>
+            <data>
+              <src>${jetty.path}</src>
+              <type>directory</type>
+              <mapper>
+                <type>perm</type>
+                <prefix>/usr/lib/xwiki-jetty</prefix>
+              </mapper>
+            </data>
+          </dataSet>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-common/src/deb/control/control
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-common/src/deb/control/control
@@ -1,11 +1,9 @@
-Package: xwiki-common
+Package: xwiki-xjetty-common
 Version: [[version]]
 Section: java
 Priority: optional
-Provides: xwiki
 Architecture: all
-Depends: ucf (>= 0.30), dbconfig-common (>= 1.8.0), openjdk-17-jre-headless | openjdk-11-jre-headless
-Conflicts: xwiki-enterprise-common
+Depends: xwiki-common (= [[version]])
 Maintainer: [[debian.maintainer]]
 License: [[debian.license]]
 Description: [[debian.description]]

--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-common/src/deb/control/postinst
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-common/src/deb/control/postinst
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -e
+#set -x
+
+#########################
+# Rights
+#########################
+
+## Make sure XWiki is able to write in the data folder
+if [ ! 'xwiki' = `stat -c '%U' /var/lib/xwiki/data` ]; then
+  chown -R tomcat.tomcat /var/lib/xwiki/data
+fi
+
+#########################
+# Configuration
+#########################
+
+. /usr/share/debconf/confmodule
+
+#########################
+# Reload the service
+#########################
+
+# Need to reload systemd for the injected xwiki service configuration to be taken into account
+systemctl daemon-reload

--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-common/src/deb/control/postrm
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-common/src/deb/control/postrm
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+#set -x
+
+if [ "$1" = "purge" ] && [ -f /usr/share/debconf/confmodule ]; then
+    . /usr/share/debconf/confmodule
+    db_purge
+fi

--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-common/src/deb/resources/lib/systemd/system/xwiki.service
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-common/src/deb/resources/lib/systemd/system/xwiki.service
@@ -1,0 +1,31 @@
+#
+# Systemd unit file for XWiki
+#
+
+[Unit]
+Description=XWiki Jetty Application Server
+Documentation=https://www.xwiki.org
+After=network.target
+RequiresMountsFor=/var/lib/xwiki/data
+
+[Service]
+# Lifecycle
+Type=simple
+ExecStart=/bin/sh /usr/lib/xwiki-jetty/start_xwiki.sh
+ExecStop=/bin/sh /usr/lib/xwiki-jetty/stop_xwiki.sh
+Restart=on-abort
+
+# Logging
+SyslogIdentifier=xwiki
+
+# Security
+User=xwiki
+Group=xwiki
+PrivateTmp=yes
+NoNewPrivileges=true
+ProtectSystem=strict
+ReadOnlyPaths=/etc/xwiki
+ReadWritePaths=/var/lib/xwiki/data/
+
+[Install]
+WantedBy=multi-user.target

--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-common/src/deb/resources/lib/systemd/system/xwiki.service
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-common/src/deb/resources/lib/systemd/system/xwiki.service
@@ -9,10 +9,12 @@ After=network.target
 RequiresMountsFor=/var/lib/xwiki/data
 
 [Service]
+WorkingDirectory=/var/lib/xwiki/
+
 # Lifecycle
 Type=simple
-ExecStart=/bin/sh /usr/lib/xwiki-jetty/start_xwiki.sh
-ExecStop=/bin/sh /usr/lib/xwiki-jetty/stop_xwiki.sh
+ExecStart=/bin/bash /usr/lib/xwiki-jetty/start_xwiki.sh
+ExecStop=/bin/bash /usr/lib/xwiki-jetty/stop_xwiki.sh
 Restart=on-abort
 
 # Logging

--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-common/src/deb/resources/usr/lib/sysusers.d/xwiki.conf
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-common/src/deb/resources/usr/lib/sysusers.d/xwiki.conf
@@ -1,0 +1,7 @@
+#
+# sysusers.d snippet for creating the xwiki user automatically
+# at install time. See sysusers.d(5) for details.
+#
+
+#Type Name     ID             GECOS                 Home directory   Shell
+u     xwiki   -              "XWiki"                /var/lib/xwiki   /usr/sbin/nologin

--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-mariadb/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-mariadb/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.xwiki.platform</groupId>
+    <artifactId>xwiki-platform-distribution-debian-xjetty</artifactId>
+    <version>15.10-SNAPSHOT</version>
+  </parent>
+  <artifactId>xwiki-platform-distribution-debian-xjetty-mariadb</artifactId>
+  <name>XWiki Platform - Distribution - Debian - XJetty - MariaDB</name>
+  <packaging>deb</packaging>
+  <description>XWiki XJetty/MariaDB based package</description>
+  <properties>
+    <debian.package>xwiki-xjetty-mariadb</debian.package>
+  </properties>
+</project>

--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-mariadb/src/deb/control/config
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-mariadb/src/deb/control/config
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+#set -x
+
+. /usr/share/debconf/confmodule

--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-mariadb/src/deb/control/control
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-mariadb/src/deb/control/control
@@ -1,11 +1,12 @@
-Package: xwiki-common
+Package: xwiki-xjetty-mariadb
 Version: [[version]]
 Section: java
 Priority: optional
-Provides: xwiki
 Architecture: all
-Depends: ucf (>= 0.30), dbconfig-common (>= 1.8.0), openjdk-17-jre-headless | openjdk-11-jre-headless
-Conflicts: xwiki-enterprise-common
+Depends: xwiki-mariadb-common (= [[version]]), xwiki-xjetty-common (= [[version]])
+Provides: xwiki-xjetty-database
+Replaces: xwiki-xjetty-database
+Conflicts: xwiki-xjetty-database
 Maintainer: [[debian.maintainer]]
 License: [[debian.license]]
 Description: [[debian.description]]

--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-mariadb/src/deb/control/postinst
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-mariadb/src/deb/control/postinst
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+#set -x
+
+#########################
+# Restart XWiki
+#########################
+
+# Restart XWiki service (only if it's active)
+if systemctl -q is-active xwiki.service
+then
+ systemctl xwiki restart
+fi

--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-mariadb/src/deb/control/postrm
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-mariadb/src/deb/control/postrm
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+#set -x
+
+if [ "$1" = "purge" ] && [ -e /usr/share/debconf/confmodule ]; then
+    . /usr/share/debconf/confmodule
+    db_purge
+fi

--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-mysql/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-mysql/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.xwiki.platform</groupId>
+    <artifactId>xwiki-platform-distribution-debian-xjetty</artifactId>
+    <version>15.10-SNAPSHOT</version>
+  </parent>
+  <artifactId>xwiki-platform-distribution-debian-xjetty-mysql</artifactId>
+  <name>XWiki Platform - Distribution - Debian - XJetty - MySQL</name>
+  <packaging>deb</packaging>
+  <description>XWiki XJetty/MySQL based package</description>
+  <properties>
+    <debian.package>xwiki-xjetty-mysql</debian.package>
+  </properties>
+</project>

--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-mysql/src/deb/control/config
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-mysql/src/deb/control/config
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+#set -x
+
+. /usr/share/debconf/confmodule

--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-mysql/src/deb/control/control
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-mysql/src/deb/control/control
@@ -1,11 +1,12 @@
-Package: xwiki-common
+Package: xwiki-xjetty-mysql
 Version: [[version]]
 Section: java
 Priority: optional
-Provides: xwiki
 Architecture: all
-Depends: ucf (>= 0.30), dbconfig-common (>= 1.8.0), openjdk-17-jre-headless | openjdk-11-jre-headless
-Conflicts: xwiki-enterprise-common
+Depends: xwiki-mysql-common (= [[version]]), xwiki-xjetty-common (= [[version]])
+Provides: xwiki-tomcat-database
+Replaces: xwiki-tomcat-database
+Conflicts: xwiki-tomcat-database
 Maintainer: [[debian.maintainer]]
 License: [[debian.license]]
 Description: [[debian.description]]

--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-mysql/src/deb/control/postinst
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-mysql/src/deb/control/postinst
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+#set -x
+
+#########################
+# Restart XWiki
+#########################
+
+# Restart XWiki service (only if it's active)
+if systemctl -q is-active xwiki.service
+then
+ systemctl xwiki restart
+fi

--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-mysql/src/deb/control/postrm
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-mysql/src/deb/control/postrm
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+#set -x
+
+if [ "$1" = "purge" ] && [ -e /usr/share/debconf/confmodule ]; then
+    . /usr/share/debconf/confmodule
+    db_purge
+fi

--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-pgsql/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-pgsql/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.xwiki.platform</groupId>
+    <artifactId>xwiki-platform-distribution-debian-xjetty</artifactId>
+    <version>15.10-SNAPSHOT</version>
+  </parent>
+  <artifactId>xwiki-platform-distribution-debian-xjetty-pgsql</artifactId>
+  <name>XWiki Platform - Distribution - Debian - XJetty - Postgres SQL</name>
+  <packaging>deb</packaging>
+  <description>XWiki XJetty/PostgreSQL</description>
+  <properties>
+    <debian.package>xwiki-xjetty-pgsql</debian.package>
+  </properties>
+</project>

--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-pgsql/src/deb/control/config
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-pgsql/src/deb/control/config
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+#set -x
+
+. /usr/share/debconf/confmodule

--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-pgsql/src/deb/control/control
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-pgsql/src/deb/control/control
@@ -1,11 +1,12 @@
-Package: xwiki-common
+Package: xwiki-xjetty-pgsql
 Version: [[version]]
 Section: java
 Priority: optional
-Provides: xwiki
 Architecture: all
-Depends: ucf (>= 0.30), dbconfig-common (>= 1.8.0), openjdk-17-jre-headless | openjdk-11-jre-headless
-Conflicts: xwiki-enterprise-common
+Depends: xwiki-pgsql-common (= [[version]]), xwiki-xjetty-common (= [[version]])
+Provides: xwiki-tomcat-database
+Replaces: xwiki-tomcat-database
+Conflicts: xwiki-tomcat-database
 Maintainer: [[debian.maintainer]]
 License: [[debian.license]]
 Description: [[debian.description]]

--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-pgsql/src/deb/control/postinst
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-pgsql/src/deb/control/postinst
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+#set -x
+
+#########################
+# Restart XWiki
+#########################
+
+# Restart XWiki service (only if it's active)
+if systemctl -q is-active xwiki.service
+then
+ systemctl xwiki restart
+fi

--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-pgsql/src/deb/control/postrm
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-pgsql/src/deb/control/postrm
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+#set -x
+
+if [ "$1" = "purge" ] && [ -e /usr/share/debconf/confmodule ]; then
+    . /usr/share/debconf/confmodule
+    db_purge
+fi


### PR DESCRIPTION
issue: https://jira.xwiki.org/browse/XWIKI-21458

I also added a little change regarding the version of Java installed by default as dependency since:
* we now recommend Java 17 at runtime
* looks like Debian 12+ does not have any Java 11 package anymore