### PR TITLE
XWIKI-21005: CKEditor content on inplace edit uses incorrectly aria-expanded

### DIFF
--- a/xwiki-platform-core/xwiki-platform-edit/xwiki-platform-edit-ui/src/main/resources/XWiki/InplaceEditing.xml
+++ b/xwiki-platform-core/xwiki-platform-edit/xwiki-platform-edit-ui/src/main/resources/XWiki/InplaceEditing.xml
@@ -441,7 +441,8 @@ define('editInPlace', [
         options.afterEdit(xwikiDocument);
         return xwikiDocument;
       }).finally(() =&gt; {
-        $('#xwikicontent').removeClass('loading');
+        // Remove the aria-expanded attribute which is incorrect for role=textbox
+        $('#xwikicontent').removeClass('loading').removeAttr('aria-expanded');
       // Then wait for an action (save, cancel, reload) only if the editors were loaded successfuly.
       }).then(maybeSave)
       // Then unlock the document both when the edit ended with success and with a failure.


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21005
## PR Changes
* Removed the incorrect attribute after loading the CKeditor inplace editor.
## Notes
This attribute is added by default in the CKEditor > wysiwygarea plugin. We make sure to remove it after the initialization of the editor.