### PR TITLE
ICONTHEMES-12: Add aria-hidden attribute to Font Awesome icons

### DIFF
--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-fontawesome/src/main/resources/IconThemes/FontAwesome.xml
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-fontawesome/src/main/resources/IconThemes/FontAwesome.xml
@@ -39,8 +39,8 @@
   <content>## General settings
 xwiki.iconset.type = font
 xwiki.iconset.ssx = IconThemes.FontAwesome
-xwiki.iconset.render.wiki = {{html clean="false"}}&lt;span class="fa fa-$icon"&gt;&lt;/span&gt;{{/html}}
-xwiki.iconset.render.html = &lt;span class="fa fa-$icon"&gt;&lt;/span&gt;
+xwiki.iconset.render.wiki = {{html clean="false"}}&lt;span class="fa fa-$icon" aria-hidden='true'&gt;&lt;/span&gt;{{/html}}
+xwiki.iconset.render.html = &lt;span class="fa fa-$icon" aria-hidden='true'&gt;&lt;/span&gt;
 xwiki.iconset.icon.cssClass = fa fa-$icon
 
 ## XWiki Icon Set (see: http://design.xwiki.org/xwiki/bin/view/Proposal/XWiki+Icon+Set).


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/ICONTHEMES-12
## PR Changes
* Added aria-hidden attribute to Font Awesome icons
## Tests
AFAIK there's not much tests on nodes `.fa`, and the only test does not fail because of the changes in this PR
## View
This PR does not change the visuals, but on the screenshot below, we can see that the accessibility tree displayed by the Firefox inspector is clean (on the opposite to before this PR where it had a node with the code of the icon inside).
![ICONTHEME12-afterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/6302cb4d-003e-4aae-aa46-c6a16ee19b71)
