### PR TITLE
XWIKI-21479: Wizard step icons are not in line with the button style

### DIFF
--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/CreateApplication.xml
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/CreateApplication.xml
@@ -57,7 +57,7 @@
     &lt;ul class="steps vertical"&gt;
       #foreach($step in $awmSteps)
         &lt;li&gt;
-          &lt;span class="number"&gt;$mathtool.add($foreach.index, 1)&lt;/span&gt;
+          &lt;span class="btn btn-xs number"&gt;$mathtool.add($foreach.index, 1)&lt;/span&gt;
           &lt;span class="name"&gt;$services.localization.render("appWithinMinutes.wizardStep.${step}.name")&lt;/span&gt;
           &lt;span class="description"&gt;$services.localization.render("appWithinMinutes.wizardStep.${step}.description")&lt;/span&gt;
         &lt;/li&gt;

--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/WizardStep.xml
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/WizardStep.xml
@@ -47,9 +47,9 @@
     &lt;ul class="steps"&gt;
       #foreach ($step in $awmSteps)
         #set ($index = $foreach.index + 1)
-        #set ($extraClassName = "#if ($stepNumber == $index) active#elseif ($stepNumber &gt; $index) done#end")
+        #set ($extraClassName = "#if ($stepNumber == $index) step-active#elseif ($stepNumber &gt; $index) step-done#end")
         &lt;li&gt;
-          &lt;span class="number$extraClassName"&gt;
+          &lt;span class="btn btn-xs number$extraClassName"&gt;
             #if ($stepNumber &gt; $index)
               &amp;${escapetool.h}10004;
             #else

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/wizard/wizard.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/wizard/wizard.css
@@ -29,53 +29,48 @@
   vertical-align: middle;
 }
 
-.steps .number {
+.steps .number, .steps .number:hover, .steps .number:active {
   background-color: $theme.menuBackgroundColor;
-  border-radius: 10px 10px 10px 10px;
-  box-shadow: 0 -4px 5px rgba(0, 0, 0, 0.05) inset, 0 4px 3px rgba(252, 254, 255, 0.4) inset, 0 2px 1px rgba(0, 0, 0, 0.1);
+  border-radius: 50%;
   color: $theme.menuLinkColor;
+  cursor: unset;
+  box-shadow: none;
   display: inline-block;
   font-weight: 700;
-  font-size: 0.85em;
-  height: 20px;
-  line-height: 20px;
+  line-height: 18px;
   text-align: center;
-  width: 20px;
+  min-height: 22px;
+  min-width: 22px;
 }
 
-.steps .number.active {
+
+.steps .number.step-active {
   background-color: transparent;
   border: 2px solid $theme.notificationSuccessColor;
   color: $theme.notificationSuccessColor;
-  height: 15px;
-  line-height: 15px;
-  width: 15px;
 }
 
-.steps .number.done {
+.steps .number.step-done {
   background-color: transparent;
   border: 2px solid $theme.textSecondaryColor;
   color: $theme.textSecondaryColor;
-  height: 15px;
-  line-height: 15px;
-  width: 15px;
 }
 
 /** Flamingo specific adjustment */
-.skin-flamingo .steps .number.active, .skin-flamingo .steps .number.done {
-  height: 20px;
-  width: 20px;
+.skin-flamingo .steps .number.step-active, .skin-flamingo .steps .number.step-done {
+  height: 24px;
+  width: 24px;
 }
 
 .steps .name {
   color: $theme.titleColor;
 }
 
-.steps .name.active {
+.steps .name.step-active {
   color: $theme.notificationSuccessColor;
 }
 
-.steps .name.done {
+.steps .name.step-done {
   color: $theme.textSecondaryColor;
 }
 

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-mainwiki/src/main/resources/WikiManager/CreateWiki.xml
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-mainwiki/src/main/resources/WikiManager/CreateWiki.xml
@@ -85,7 +85,7 @@
 #macro(wizardHeader $title $currentStepNumber)
   ## Display a step name in the header
   #macro(wizardHeaderStep $name $number $currentStepNumber)
-    &lt;li&gt;&lt;span class="number #if($currentStepNumber==$number)active#end"&gt;$number&lt;/span&gt; &lt;span class="name #if($currentStepNumber==$number)active#end"&gt;$name&lt;/span&gt;&lt;/li&gt;
+    &lt;li&gt;&lt;span class="btn btn-xs number #if($currentStepNumber==$number)step-active#end"&gt;$number&lt;/span&gt; &lt;span class="name #if($currentStepNumber==$number)step-active#end"&gt;$name&lt;/span&gt;&lt;/li&gt;
   #end
 
   &lt;div class="wizard-header"&gt;


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21479
## PR Changes
* Updated style for the wizard step
* Updated the class names to avoid unwanted collision with .btn.active

## View
![wizardStepNotButtons](https://github.com/xwiki/xwiki-platform/assets/28761965/c84c8ff8-e857-47a3-9ac6-ada1596e5036)
^^^ Before the PR ^^^                 vvv After the PR vvv
![21479-afterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/3796b5da-bfd2-4c21-aa6e-5a6074636b67)

## Note
Part of the BFD :)

