### PR TITLE
XWIKI-21507: Inplace Editing title does not respect color expectations and does not have enough contrast on some themes

### DIFF
--- a/xwiki-platform-core/xwiki-platform-edit/xwiki-platform-edit-ui/src/main/resources/XWiki/InplaceEditing.xml
+++ b/xwiki-platform-core/xwiki-platform-edit/xwiki-platform-edit-ui/src/main/resources/XWiki/InplaceEditing.xml
@@ -1338,6 +1338,7 @@ input#document-title-input {
   /* Preserve the heading styles. */
   color: inherit;
   font-size: inherit;
+  background-color: @body-bg;
   /* It seems it's not enough to set the line height for the text input. We also need to set its height. */
   height: @font-size-document-title * @headings-line-height + 2 * (1 + @document-title-input-padding-vertical);
   line-height: @headings-line-height;


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21507
## PR Changes
* Updated background color
## View
![21507-afterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/37c9a73d-a3e6-4287-ae56-d02fcc8baadb)
The green border on the input is just a browser extension I use to highlight focus. It's not a change proposed in this PR :)

