### PR TITLE
XWIKI-21491: Translation keys are displayed instead of translations when the "German (Germany)" locale is set.

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/AllIT.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/AllIT.java
@@ -68,4 +68,10 @@ public class AllIT
     {
     }
     
+    @Nested
+    @DisplayName("Localization")
+    class NestedLocalizationIT extends LocalizationIT
+    {
+    }
+    
 }

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/LocalizationIT.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/LocalizationIT.java
@@ -1,0 +1,87 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.ckeditor.test.ui;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.xwiki.test.docker.junit5.TestReference;
+import org.xwiki.test.docker.junit5.UITest;
+import org.xwiki.test.ui.TestUtils;
+import org.xwiki.ckeditor.test.po.AutocompleteDropdown;
+
+/**
+ * Integration tests for localization support.
+ * 
+ * XWiki's localization support in CKEditor affects all XWiki's
+ * custom CKEditor plugins. QuickActions is only one of the
+ * affected features.
+ * 
+ * @version $Id$
+ * @since 15.5.4
+ * @since 15.9.1
+ * @since 15.10RC1
+ */
+@UITest
+class LocalizationIT extends AbstractCKEditorIT
+{
+    
+    @BeforeAll
+    void beforeAll(TestUtils setup)
+    {
+        setup.loginAsSuperAdmin();
+        
+        // Make WYSIWYG the default editor
+        setup.setPropertyInXWikiPreferences("editor", "String", "Wysiwyg");
+    }
+    
+    @AfterEach
+    void afterEach(TestUtils setup, TestReference testReference)
+    {
+        maybeLeaveEditMode(setup, testReference);
+        setup.setPropertyInXWikiPreferences("default_language", "String", "en");
+    }
+
+    @Test
+    @Order(1)
+    void paragraphQuickAction_en(TestUtils setup, TestReference testReference) {
+        setup.setPropertyInXWikiPreferences("default_language", "String", "en");
+        edit(setup, testReference);
+        
+        // We check the paragraph Quick Action because it is registered
+        // with a CKEditor Integration Translation key.
+        textArea.sendKeys("/p");
+        new AutocompleteDropdown().waitForItemSelected("/p", "Paragraph");
+    }
+    
+    @Test
+    @Order(2)
+    void paragraphQuickAction_de_DE(TestUtils setup, TestReference testReference) {
+        
+        setup.setPropertyInXWikiPreferences("default_language", "String", "de_DE");
+        edit(setup, testReference);
+        
+        // We check the paragraph Quick Action because it is registered
+        // with a CKEditor Integration Translation key.
+        textArea.sendKeys("/abs");
+        new AutocompleteDropdown().waitForItemSelected("/abs", "Absatz");
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/Translations.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/Translations.xml
@@ -464,16 +464,22 @@ ckeditor.plugin.image.imageSelector.documentTreeTab.title=Document Tree
 */
 define(['ckeditor'], function(ckeditor) {
   const translations = $jsontool.serialize($translations);
-  const locale = $jsontool.serialize($xcontext.locale.toString());
   for (const [pluginName, pluginTranslations] of Object.entries(translations)) {
     if (ckeditor.plugins.get(pluginName)) {
       // The specified plugin is already defined.
-      ckeditor.plugins.setLang(pluginName, locale, pluginTranslations);
+      // The CKEditor's lang plugin's detect function gives us the locale code currently
+      // used by ckeditor, in case CKEditor falls back to an other one, we still want
+      // to inject the translations in the running localization.
+      ckeditor.plugins.setLang(pluginName, ckeditor.lang.detect(), pluginTranslations);
     } else {
       // The specified plugin is not defined yet (it could be an external plugin).
       ckeditor.on('instanceCreated', event =&gt; {
         event.editor.on('langLoaded', event =&gt; {
-          if (event.editor.langCode === locale) {
+          // CKEditor uses '-' (dash) as locale separator.
+          const locale = $jsontool.serialize($xcontext.locale.toString().toLowerCase().replace('_', '-'));
+          // We need to check against the initally configured language and not the one in use
+          // because CKEditor might have fallen back to another locale.
+          if (event.editor.config.language === locale) {
             event.editor.lang[pluginName] = pluginTranslations;
           }
         });


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-21491

This pull request provides a fix for a bug where the translations in the CKEditor integration would break when using the `de_DE` locale.

This PR also includes an integration test to detect the bug.