### PR TITLE
XWIKI-21037: Not all items of Drawer are visible and drawer itself don't allow scrolling

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/drawer.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/drawer.less
@@ -36,6 +36,7 @@
   transition: margin-right .6s cubic-bezier(0.190, 1.000, 0.220, 1.000);
   padding: 0;
   border: 0;
+  overflow-y: auto;
   // We overwrite max-height over browser defaults for dialog
   max-height: 100vh;
   


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21037
## PR Changes
* Fixed style

## View 
[Here is a video demo of the change.](https://up1.xwikisas.com/#NWgNqdWNv4QRJJz_0xky_w) We can see that with this change, the vertical overflow is visible when scrolling on the dialog. Scrolling outside of the dialog still scroll the body of the document.
## Note
Improvement of the drawer following the changes in https://github.com/xwiki/xwiki-platform/pull/2282.