### PR TITLE
XWIKI-18007: Drawer menu improvements for accessibility

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/flamingo.js
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/flamingo.js
@@ -77,8 +77,8 @@ require(['jquery'], function($) {
       drawerContainer.on('click', (event) => {
         let drawerzone = event.target.getBoundingClientRect();
         if (event.target === drawerContainer.get(0) &&
-            (drawerzone.left > event.clientX || drawerzone.right < event.clientX
-            || drawerzone.top > event.clientY || drawerzone.bottom < event.clientY)) {
+            (drawerzone.left > event.clientX || drawerzone.right < event.clientX ||
+            drawerzone.top > event.clientY || drawerzone.bottom < event.clientY)) {
           closeDrawer();
         }
       });
@@ -86,7 +86,8 @@ require(['jquery'], function($) {
       drawerContainer.find('.drawer-close').on('click', closeDrawer);
       
       drawerContainer.on('drawer' + index + '.opened', function (event) {
-        // We use the drawer-transitioning class to make sure the transition to slidein is not shortcutted when showing the modal
+        // We use the drawer-transitioning class to make sure the transition to 
+        // slide in is not shortcut when showing the modal
         drawerContainer.addClass('drawer-transitioning');
         drawerOpener.attr('aria-expanded', 'true');
         drawerContainer.get(0).showModal();


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-18007
## PR Changes
* Fixed code style for JSHint
## Notes
* This is a fix for the regression found in CI:
```
00:21:02,330 [INFO] --- jshint-maven-plugin:1.7.2:lint (default) @ xwiki-platform-flamingo-skin-resources ---
00:21:02,332 [INFO] using jshint version 2.13.6
00:21:02,558 [INFO]   /root/workspace/XWiki_xwiki-platform_master/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/dateTimePicker.js
00:21:02,762 [INFO]   /root/workspace/XWiki_xwiki-platform_master/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/localePicker.js
00:21:03,019 [INFO]   /root/workspace/XWiki_xwiki-platform_master/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/flamingo.js
00:21:03,229 [ERROR]    81,13: Misleading line break before '||'; readers may interpret this as an expression boundary.
00:21:03,230 [ERROR]    89,129: Line is too long.
```
This regression was introduced by [this commit for XWIKI-18007](https://github.com/xwiki/xwiki-platform/commit/9f7717901a051d849c08fd7b594f49db4395c225).
* 'To cut' is an irregular verb, and so is 'to shortcut' 