### PR TITLE
XWIKI-21518: Remove unused Jetty context files

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/servletengine/JettyStandaloneExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/servletengine/JettyStandaloneExecutor.java
@@ -119,9 +119,6 @@ public class JettyStandaloneExecutor
                     writer.write(replaceProperty(content, velocityContext));
                 }
             }
-
-            // Step: Remove root webapp since we don't need it
-            FileUtils.forceDelete(new File(jettyDirectory, "jetty/contexts/root.xml"));
         }
 
         // Step: Remove data directory since we will provision again the extensions to account for source changes.


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-21518

This PR removes a reference to a unused Jetty context file in the docker test module.

It is necessary to remove the reference here because it causes the Docker Integration tests to fail at setup time with the following traceback:

```
[INFO] Running org.xwiki.ckeditor.test.ui.AllIT                                                                                                                                                                                              
12:30:11.900 [main] INFO  o.x.t.d.i.j.XWikiDockerExtension - (*) Starting database [HSQLDB_EMBEDDED]...                                                                                                                                      
12:30:11.905 [main] INFO  o.x.t.d.i.j.XWikiDockerExtension - (*) Building custom XWiki WAR...                                                                                                                                                
12:30:11.908 [main] INFO  o.x.t.d.internal.junit5.WARBuilder - XWiki WAR is not fully built in [/home/douakli/dev/xwiki/xwiki-platform/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test

-docker/./target/hsqldb_embedded-default-default-jetty_standalone-default-firefox/jetty/webapps/xwiki], (re)building it!                                                                                                                     
12:30:13.455 [main] INFO  o.x.t.d.internal.junit5.WARBuilder - Using the following extension overrides: []                                                                                                                                   
12:30:13.455 [main] INFO  o.x.t.d.internal.junit5.WARBuilder - Finding version ...                                                                                                                                                           
12:30:14.170 [main] INFO  o.x.t.d.internal.junit5.WARBuilder - Found version = [15.10-SNAPSHOT]                                                                                                                                              
12:30:14.170 [main] INFO  o.x.t.d.internal.junit5.WARBuilder - Resolving distribution dependencies ...                                                                                                                                       
12:30:33.997 [main] INFO  o.x.t.i.maven.MavenResolver - Adding extra JAR to WEB-INF/lib: [org.xwiki.platform:xwiki-platform-notifications-filters-default:jar:15.10-SNAPSHOT]                                                                
12:30:33.997 [main] INFO  o.x.t.i.maven.MavenResolver - Adding extra JAR to WEB-INF/lib: [org.xwiki.platform:xwiki-platform-extension-index:jar:15.10-SNAPSHOT]                                                                              
12:30:33.997 [main] INFO  o.x.t.i.maven.MavenResolver - Adding extra JAR to WEB-INF/lib: [org.xwiki.platform:xwiki-platform-search-solr-query:jar:15.10-SNAPSHOT]                                                                            
12:30:36.576 [main] INFO  o.x.t.d.internal.junit5.WARBuilder - Copying JAR dependencies ...                                                                                                                                                  
12:30:39.327 [main] INFO  o.x.t.d.internal.junit5.WARBuilder - Copying resources to WEB-INF/classes ...                                                                                                                                      
12:30:39.328 [main] INFO  o.x.t.d.internal.junit5.WARBuilder - Expanding WAR dependencies ...                                                                                                                                                
12:30:39.855 [main] INFO  o.x.t.d.internal.junit5.WARBuilder - Copying JDBC driver for database [HSQLDB_EMBEDDED]...                                                                                                                         
12:30:39.856 [main] INFO  o.x.t.d.internal.junit5.WARBuilder - Copying Skin resources ...                                                                                                                                                    
12:30:39.880 [main] INFO  o.x.t.d.internal.junit5.WARBuilder - Generating configuration files for database [HSQLDB_EMBEDDED]...                                                                                                              
12:30:39.960 [main] INFO  o.x.t.d.i.j.XWikiDockerExtension - (*) Starting Servlet container [JETTY_STANDALONE]...                                                                                                                            
12:30:40.011 [main] INFO  o.x.t.d.i.j.s.JettyStandaloneExecutor - Replacing variables in [target/hsqldb_embedded-default-default-jetty_standalone-default-firefox/jetty/start_xwiki.sh]...                                                   
12:30:40.012 [main] INFO  o.x.t.d.i.j.s.JettyStandaloneExecutor - Replacing variables in [target/hsqldb_embedded-default-default-jetty_standalone-default-firefox/jetty/start_xwiki_debug.sh]...                                             
12:30:40.012 [main] INFO  o.x.t.d.i.j.s.JettyStandaloneExecutor - Replacing variables in [target/hsqldb_embedded-default-default-jetty_standalone-default-firefox/jetty/start_xwiki.bat]...                                                  
12:30:40.012 [main] INFO  o.x.t.d.i.j.s.JettyStandaloneExecutor - Replacing variables in [target/hsqldb_embedded-default-default-jetty_standalone-default-firefox/jetty/start_xwiki_debug.bat]...                                            
12:30:40.015 [main] INFO  o.x.t.d.i.j.XWikiDockerExtension - (*) Stopping database [HSQLDB_EMBEDDED]...                                                                                                                                      
12:30:40.015 [main] INFO  o.x.t.d.i.j.XWikiDockerExtension - (*) Stopping Servlet container [JETTY_STANDALONE]...                                                                                                                            
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 29.17 s <<< FAILURE! -- in org.xwiki.ckeditor.test.ui.AllIT                                                                                                          
[ERROR] org.xwiki.ckeditor.test.ui.AllIT -- Time elapsed: 29.17 s <<< ERROR!                                                                                                                                                                 
java.lang.RuntimeException: Error setting up the XWiki testing environment                                                                                                                                                                   
        at org.xwiki.test.docker.internal.junit5.XWikiDockerExtension.raiseException(XWikiDockerExtension.java:533)                                                                                                                          
        at org.xwiki.test.docker.internal.junit5.XWikiDockerExtension.beforeAll(XWikiDockerExtension.java:111)                                                                                                                               
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)                                                                                                                                                                        
Caused by: java.io.IOException: Cannot delete file: ./target/hsqldb_embedded-default-default-jetty_standalone-default-firefox/jetty/jetty/contexts/root.xml                                                                                  
        at org.apache.commons.io.FileUtils.forceDelete(FileUtils.java:1336)                                                                                                                                                                  
        at org.xwiki.test.docker.internal.junit5.servletengine.JettyStandaloneExecutor.start(JettyStandaloneExecutor.java:124)                                                                                                               
        at org.xwiki.test.docker.internal.junit5.servletengine.ServletContainerExecutor.start(ServletContainerExecutor.java:146)                                                                                                             
        at org.xwiki.test.docker.internal.junit5.XWikiDockerExtension.startServletEngine(XWikiDockerExtension.java:456)                                                                                                                      
        at org.xwiki.test.docker.internal.junit5.XWikiDockerExtension.beforeAllInternal(XWikiDockerExtension.java:179)                                                                                                                       
        at org.xwiki.test.docker.internal.junit5.XWikiDockerExtension.beforeAll(XWikiDockerExtension.java:109)                                                                                                                               
        ... 1 more                                          
Caused by: java.io.IOException: DOS or POSIX file operations not available for './target/hsqldb_embedded-default-default-jetty_standalone-default-firefox/jetty/jetty/contexts/root.xml' []

        at org.apache.commons.io.file.PathUtils.setReadOnly(PathUtils.java:1525)                                                                                                                                                             
        at org.apache.commons.io.file.PathUtils.deleteFile(PathUtils.java:583)                                         
        at org.apache.commons.io.file.PathUtils.delete(PathUtils.java:476)                                             
        at org.apache.commons.io.FileUtils.forceDelete(FileUtils.java:1333)                                            
        ... 6 more                                          
```
Thanks.