### PR TITLE
XWIKI-21475: Hide font awesome icons from screen readers

### DIFF
--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-fontawesome/src/main/resources/IconThemes/FontAwesome.xml
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-fontawesome/src/main/resources/IconThemes/FontAwesome.xml
@@ -39,8 +39,8 @@
   <content>## General settings
 xwiki.iconset.type = font
 xwiki.iconset.ssx = IconThemes.FontAwesome
-xwiki.iconset.render.wiki = {{html clean="false"}}&lt;span class="fa fa-$icon" aria-hidden='true'&gt;&lt;/span&gt;{{/html}}
-xwiki.iconset.render.html = &lt;span class="fa fa-$icon" aria-hidden='true'&gt;&lt;/span&gt;
+xwiki.iconset.render.wiki = {{html clean="false"}}&lt;span class="fa fa-$icon" aria-hidden="true"&gt;&lt;/span&gt;{{/html}}
+xwiki.iconset.render.html = &lt;span class="fa fa-$icon" aria-hidden="true"&gt;&lt;/span&gt;
 xwiki.iconset.icon.cssClass = fa fa-$icon
 
 ## XWiki Icon Set (see: http://design.xwiki.org/xwiki/bin/view/Proposal/XWiki+Icon+Set).


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-21475

This PR fixes a Syntax Error in the `TourCode/TourJS` and `XWiki/Notifications/Code/NotificationsDisplayerUIX` jsxs.
These jsxs expect no single quote in the rendered icon code but allows double quotes.

See the following tracebacks:

```
nov. 06, 2023 3:19:50 PM com.google.javascript.jscomp.LoggerErrorManager printSummary

AVERTISSEMENT: 1 error(s), 0 warning(s)

2023-11-06 15:19:50,104 [qtp422392391-607 - http://localhost:8081/xwiki/bin/jsx/XWiki/Notifications/Code/NotificationsDisplayerUIX?language=en&docVersion=1.1] ERROR c.x.x.w.s.JsExtension          - Error at line [61], column [52]: [Pars
e error. ',' expected]  
nov. 06, 2023 3:19:51 PM com.google.javascript.jscomp.LoggerErrorManager println

GRAVE: xwiki:TourCode.TourJS:44:120: ERROR - [JSC_PARSE_ERROR] Parse error. ',' expected

  44|     var button = $('<button id="tourResume" class="btn btn-default btn-xs"><span class="fa fa-info-circle" aria-hidden='true'></span> Show tour</button>').appendTo(buttonContainer);
```

```
nov. 06, 2023 3:19:51 PM com.google.javascript.jscomp.LoggerErrorManager printSummary

AVERTISSEMENT: 1 error(s), 0 warning(s)

2023-11-06 15:19:51,771 [qtp422392391-606 - http://localhost:8081/xwiki/bin/jsx/TourCode/TourJS?language=en&docVersion=1.1] ERROR c.x.x.w.s.JsExtension          - Error at line [44], column [120]: [Parse error. ',' expected]  
nov. 06, 2023 3:19:51 PM com.google.javascript.jscomp.LoggerErrorManager println

GRAVE: xwiki:XWiki.Notifications.Code.NotificationsDisplayerUIX:61:52: ERROR - [JSC_PARSE_ERROR] Parse error. ',' expected

  61|       .html('<span class="fa fa-trash" aria-hidden='true'></span>&nbsp;Clear All')```