### PR TITLE
XWIKI-21475: Hide font awesome icons from screen readers

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsDisplayerUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsDisplayerUIX.xml
@@ -322,7 +322,7 @@ Get the actual notifications.
     }
     var markAllReadButton = $('&lt;a href="#"&gt;')
       .addClass('notification-event-clean')
-      .html('$services.icon.renderHTML("trash")&amp;nbsp;$escapetool.xml($escapetool.javascript($services.localization.render('notifications.menu.clear')))')
+      .html('$escapetool.xml($services.icon.renderHTML("trash"))&amp;nbsp;$escapetool.xml($escapetool.javascript($services.localization.render('notifications.menu.clear')))')
       .on('click', function (event) {
         // Avoid the menu closing
         event.preventDefault();

--- a/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui/src/main/resources/TourCode/TourJS.xml
+++ b/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui/src/main/resources/TourCode/TourJS.xml
@@ -172,7 +172,7 @@ require(['jquery', 'xwiki-meta'], function ($, xm) {
     // Create the popover
     var popover = $('&lt;div class="popover-content"&gt;#tr("tour.popover.show.hint")&lt;/div&gt;').appendTo(buttonContainer);
     // Create the button that will start the tour again
-    var button = $('&lt;button id="tourResume" class="btn btn-default btn-xs"&gt;$services.icon.renderHTML("info") #tr("tour.popover.show")&lt;/button&gt;').appendTo(buttonContainer);
+    var button = $('&lt;button id="tourResume" class="btn btn-default btn-xs"&gt;$escapetool.xml($services.icon.renderHTML("info")) #tr("tour.popover.show")&lt;/button&gt;').appendTo(buttonContainer);
 
     if (showPopover) {
       buttonContainer.addClass('opened');


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21475
## PR Changes
* Added escaping in scripts that failed because of missing escaping of the icons
## Note
This is a complementary fix to the one proposed in https://github.com/xwiki/xwiki-platform/pull/2579. It can still be merged independantly though.