### PR TITLE
XWIKI-18007: Drawer menu improvements for accessibility

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/htmlheader.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/htmlheader.vm
@@ -114,6 +114,7 @@
     ## ---------------------------------------------------------------------------------------------------------------
     ## Hook for inserting Link extensions. This will be replaced with the pulled link references.
     ## ---------------------------------------------------------------------------------------------------------------
+    <!-- com.xpn.xwiki.plugin.skinx.LinkExtensionPlugin -->
     #template("stylesheets.vm")
     #template("javascript.vm")
   </head>


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-18007
## PR Changes
* Reverted the deletion of the link extension hook
## Note
I mistook it for an HTML comment tied to the import of the drawer stylesheet (that's now deprecated) and removed it in https://github.com/xwiki/xwiki-platform/commit/9f7717901a051d849c08fd7b594f49db4395c225#diff-1708dadd6604f196523515864cc8ddcdc3847513d8c3be785d0604386c2b2320L117 . However, this caused multiple UI issues: the lightbox dropdown appeared on the bottom of the page and the jstree icons were wrong:
![lightbox icons at the bottom](https://github.com/xwiki/xwiki-platform/assets/28761965/cd8dd68e-379d-4acd-b64c-502b10d3ca53)
![missing icons for jstree](https://github.com/xwiki/xwiki-platform/assets/28761965/521e9c0e-00cd-4cf2-9f28-1d20493bbfb7)
