### PR TITLE
XWIKI-21521: DefaultSkin form should be accessible

### DIFF
--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-ui/src/main/resources/SkinsCode/XWikiSkinsSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-ui/src/main/resources/SkinsCode/XWikiSkinsSheet.xml
@@ -80,7 +80,7 @@
   #set ($class = $doc.getObject($className).xWikiClass)
   #foreach ($prop in $class.properties)
     #if ($prop.classType != 'TextArea')
-    ; $services.rendering.escape($prop.prettyName, 'xwiki/2.1')
+    ; {{html}}&lt;label&gt;$escapetool.xml($prop.prettyName)&lt;/label&gt;{{/html}}
     : #if($prop.name == 'logo')## Avoid line break
       {{attachmentSelector classname="${className}" property="${services.rendering.escape($prop.name, 'xwiki/2.1')}" filter="png,jpg,gif,svg" displayImage="true"/}}## Avoid line break
     #else$doc.display($prop.name)#end
@@ -449,9 +449,19 @@ require(['jquery', 'xwiki-meta'], function($, xm) {
     $('.deprecatedProperties &gt; dl').hide();
     $('.deprecatedProperties &gt; h2').on('click', onDeprecatedPropertyClicked);
   }
+
+  /**
+   * Function that makes sure the skin edit form is accessible.
+   */
+   
+  var enhanceFormAccessibility = function() {
+    $('#XWiki\\.XWikiSkins_0_name').parent().prev().find('label').attr('for', 'XWiki.XWikiSkins_0_name');
+    $('#XWiki\\.XWikiSkins_0_baseskin').parent().prev().find('label').attr('for', 'XWiki.XWikiSkins_0_baseskin');
+    $('#XWiki\\.XWikiSkins_0_outputSyntax').parent().prev().find('label').attr('for', 'XWiki.XWikiSkins_0_outputSyntax');
+  }
   
   init();
-
+  $(document).ready(enhanceFormAccessibility);
 });
 </code>
     </property>


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21521
## PR Changes
* Changed the definition list term to an HTML `<label>`
* Added a javascript function to link the label with its field.

## Note
Since the ID is built with a prefix that's computed in XWikiDocument.java (L.3824), I did not use velocity to fill up the 'for' attribute of the label when building the page. Instead, I preferred changing the value afterwards with a jquery selector. This is similar to the [solution I used to solve XWIKI-21523](https://github.com/xwiki/xwiki-platform/pull/2581), which is based on former code.

## View
We can see on the screenshot below that an axe-core analysis of the page does not return any violation anymore.
![21521-afterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/de034138-55be-4092-96b8-8a1309190158)

We can see on the screenshot below that, as expected, the fields and labels are linked together. For the logo, the term is changed to a label too, but it has no 'for' attribute. I think this is okay since this is just adding correct semantics to one element. Some more work could be done to clean up the hierarchy and semantics of the logo field, however, this is beyond the scope of this issue, and probably a very low rate of work needed/benefits.
![21521-afterPR2](https://github.com/xwiki/xwiki-platform/assets/28761965/8ec9db95-579d-47e9-a73f-374cac3157c8)
