### PR TITLE
XWIKI-21475: Hide font awesome icons from screen readers

### DIFF
--- a/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui/src/main/resources/TourCode/TourJS.xml
+++ b/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui/src/main/resources/TourCode/TourJS.xml
@@ -172,7 +172,7 @@ require(['jquery', 'xwiki-meta'], function ($, xm) {
     // Create the popover
     var popover = $('&lt;div class="popover-content"&gt;#tr("tour.popover.show.hint")&lt;/div&gt;').appendTo(buttonContainer);
     // Create the button that will start the tour again
-    var button = $('&lt;button id="tourResume" class="btn btn-default btn-xs"&gt;$escapetool.xml($services.icon.renderHTML("info")) #tr("tour.popover.show")&lt;/button&gt;').appendTo(buttonContainer);
+    var button = $($jsontool.serialize("&lt;button id='tourResume' class='btn btn-default btn-xs'&gt;$services.icon.renderHTML('info') #tr('tour.popover.show')&lt;/button&gt;")).appendTo(buttonContainer);
 
     if (showPopover) {
       buttonContainer.addClass('opened');


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21475
## PR Changes
* Fixed broken escaping
## Note
This regression on escaping was introduced in https://github.com/xwiki/xwiki-platform/pull/2582 ...

## View
before the PR, the text in the TOUR opener button is escaped improperly: 
![21475-3-beforePR](https://github.com/xwiki/xwiki-platform/assets/28761965/9f8f7b06-bd58-4e19-bc26-71adc039e551)
After the PR, we can see that the text is back at its expected value:
![21475-afterPR2](https://github.com/xwiki/xwiki-platform/assets/28761965/df2b6522-5068-4b98-b6cd-16c59e98461f)
