### PR TITLE
XWIKI-21376: Live validation prompts should be presented to users without obtaining focus

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/AbstractRegistrationPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/AbstractRegistrationPage.java
@@ -87,14 +87,14 @@ public abstract class AbstractRegistrationPage extends BasePage
     /** @return a list of WebElements representing validation failure messages. Use after calling register() */
     public List<WebElement> getValidationFailureMessages()
     {
-        return getDriver().findElementsWithoutWaiting(By.xpath("//dd/span[@class='LV_validation_message LV_invalid']"));
+        return getDriver().findElementsWithoutWaiting(By.xpath("//dd/span[contains(@class,'LV_validation_message LV_invalid')]"));
     }
 
     /** @return Is the specified message included in the list of validation failure messages. */
     public boolean validationFailureMessagesInclude(String message)
     {
         return getDriver().findElementsWithoutWaiting(
-            By.xpath("//dd/span[@class='LV_validation_message LV_invalid' and . = '" + message + "']")).size() > 0;
+            By.xpath("//dd/span[contains(@class,'LV_validation_message LV_invalid') and . = '" + message + "']")).size() > 0;
     }
 
     /** Try to make LiveValidation validate the forms. */


### PR DESCRIPTION
  * Fix AbstractRegistrationPage page object which is now broken since the introduction of a new CSS class in live validation elements