### PR TITLE
XWIKI-21528: Add a dedicated required rights analyzer API for macros without dependencies

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-cache/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-cache/pom.xml
@@ -41,6 +41,11 @@
       <artifactId>xwiki-commons-cache-api</artifactId>
       <version>${commons.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-security-requiredrights-macro</artifactId>
+      <version>${platform.version}</version>
+    </dependency>
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.xwiki.commons</groupId>

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-cache/src/main/java/org/xwiki/rendering/internal/macro/cache/CacheMacroRequiredRightsAnalyzer.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-cache/src/main/java/org/xwiki/rendering/internal/macro/cache/CacheMacroRequiredRightsAnalyzer.java
@@ -1,0 +1,49 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rendering.internal.macro.cache;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.platform.security.requiredrights.MacroRequiredRightsAnalyzer;
+import org.xwiki.platform.security.requiredrights.MacroRequiredRightReporter;
+import org.xwiki.rendering.block.MacroBlock;
+
+/**
+ * Analyzes required rights for the cache macro.
+ * <p>
+ * This ensures that the content of the id parameter is considered.
+ * </p>
+ * @version $Id$
+ * @since 15.10RC1
+ */
+@Component
+@Singleton
+@Named("cache")
+public class CacheMacroRequiredRightsAnalyzer implements MacroRequiredRightsAnalyzer
+{
+    @Override
+    public void analyze(MacroBlock macroBlock, MacroRequiredRightReporter reporter)
+    {
+        reporter.analyzeContent(macroBlock, macroBlock.getParameter("id"));
+        reporter.analyzeContent(macroBlock, macroBlock.getContent());
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-cache/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-cache/src/main/resources/META-INF/components.txt
@@ -1,1 +1,2 @@
 org.xwiki.rendering.internal.macro.cache.CacheMacro
+org.xwiki.rendering.internal.macro.cache.CacheMacroRequiredRightsAnalyzer

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-cache/src/test/java/org/xwiki/rendering/internal/macro/cache/CacheMacroRequiredRightsAnalyzerTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-cache/src/test/java/org/xwiki/rendering/internal/macro/cache/CacheMacroRequiredRightsAnalyzerTest.java
@@ -1,0 +1,58 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rendering.internal.macro.cache;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.platform.security.requiredrights.MacroRequiredRightReporter;
+import org.xwiki.rendering.block.MacroBlock;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link CacheMacroRequiredRightsAnalyzer}.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+class CacheMacroRequiredRightsAnalyzerTest
+{
+    @InjectMockComponents
+    private CacheMacroRequiredRightsAnalyzer analyzer;
+
+    @Test
+    void analyze()
+    {
+        MacroBlock macroBlock = mock();
+        String idValue = "idValue";
+        String contentValue = "contentValue";
+        when(macroBlock.getParameter("id")).thenReturn(idValue);
+        when(macroBlock.getContent()).thenReturn(contentValue);
+        MacroRequiredRightReporter reporter = mock();
+
+        this.analyzer.analyze(macroBlock, reporter);
+
+        verify(reporter).analyzeContent(macroBlock, idValue);
+        verify(reporter).analyzeContent(macroBlock, contentValue);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/pom.xml
@@ -58,6 +58,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-security-requiredrights-macro</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.xwiki.commons</groupId>
       <artifactId>xwiki-commons-script</artifactId>
       <version>${commons.version}</version>

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/java/org/xwiki/rendering/internal/macro/RawMacroRequiredRightsAnalyzer.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/java/org/xwiki/rendering/internal/macro/RawMacroRequiredRightsAnalyzer.java
@@ -1,0 +1,64 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rendering.internal.macro;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.platform.security.requiredrights.MacroRequiredRight;
+import org.xwiki.platform.security.requiredrights.MacroRequiredRightReporter;
+import org.xwiki.platform.security.requiredrights.MacroRequiredRightsAnalyzer;
+import org.xwiki.rendering.block.MacroBlock;
+import org.xwiki.rendering.parser.ParseException;
+import org.xwiki.rendering.syntax.SyntaxRegistry;
+import org.xwiki.rendering.syntax.SyntaxType;
+
+/**
+ * Analyzes the required rights of the raw macro and reports script right for HTML content.
+ *
+ * @version $Id$
+ * @since 15.10RC1
+ */
+@Component
+@Singleton
+@Named("raw")
+public class RawMacroRequiredRightsAnalyzer implements MacroRequiredRightsAnalyzer
+{
+    @Inject
+    private SyntaxRegistry syntaxRegistry;
+
+    @Override
+    public void analyze(MacroBlock macroBlock, MacroRequiredRightReporter reporter)
+    {
+        try {
+            SyntaxType syntax = this.syntaxRegistry.resolveSyntax(macroBlock.getParameter("syntax")).getType();
+            if (SyntaxType.HTML_FAMILY_TYPES.contains(syntax)) {
+                reporter.report(macroBlock, List.of(MacroRequiredRight.SCRIPT),
+                    "rendering.macro.rawMacroRequiredRights");
+            }
+        } catch (ParseException e) {
+            // Ignore, this should fail the macro or at least won't produce HTML output.
+        }
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/resources/ApplicationResources.properties
@@ -44,3 +44,4 @@
 
 rendering.error.causedBy=Cause: [{0}].
 rendering.error.click=Click on this message for details.
+rendering.macro.rawMacroRequiredRights=Using the raw macro for HTML content requires script right.

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/resources/META-INF/components.txt
@@ -4,6 +4,7 @@
 500:org.xwiki.rendering.internal.util.XWikiErrorBlockGenerator
 500:org.xwiki.rendering.internal.wiki.XWikiWikiModel
 500:org.xwiki.rendering.internal.macro.XWikiHTMLRawBlockFilter
+org.xwiki.rendering.internal.macro.RawMacroRequiredRightsAnalyzer
 org.xwiki.rendering.internal.resolver.AttachmentResourceReferenceEntityReferenceResolver
 org.xwiki.rendering.internal.resolver.DefaultResourceReferenceEntityReferenceResolver
 org.xwiki.rendering.internal.resolver.DocumentResourceReferenceEntityReferenceResolver

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/test/java/org/xwiki/rendering/internal/macro/RawMacroRequiredRightsAnalyzerTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/test/java/org/xwiki/rendering/internal/macro/RawMacroRequiredRightsAnalyzerTest.java
@@ -1,0 +1,86 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rendering.internal.macro;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.xwiki.platform.security.requiredrights.MacroRequiredRight;
+import org.xwiki.platform.security.requiredrights.MacroRequiredRightReporter;
+import org.xwiki.rendering.block.MacroBlock;
+import org.xwiki.rendering.parser.ParseException;
+import org.xwiki.rendering.syntax.Syntax;
+import org.xwiki.rendering.syntax.SyntaxRegistry;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link RawMacroRequiredRightsAnalyzer}.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+class RawMacroRequiredRightsAnalyzerTest
+{
+    private static final String SYNTAX_PARAMETER = "syntax";
+
+    @MockComponent
+    private SyntaxRegistry syntaxRegistry;
+
+    @InjectMockComponents
+    private RawMacroRequiredRightsAnalyzer analyzer;
+
+    private static Stream<Arguments> analyzeTestCases()
+    {
+        return Stream.of(
+            Arguments.of("plain", Syntax.PLAIN_1_0, null),
+            Arguments.of("html", Syntax.HTML_5_0, MacroRequiredRight.SCRIPT)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("analyzeTestCases")
+    void analyze(String syntaxValue, Syntax expectedSyntax, MacroRequiredRight expectedRight) throws ParseException
+    {
+        when(this.syntaxRegistry.resolveSyntax(syntaxValue)).thenReturn(expectedSyntax);
+
+        MacroBlock macroBlock = mock();
+        when(macroBlock.getParameter(SYNTAX_PARAMETER)).thenReturn(syntaxValue);
+
+        MacroRequiredRightReporter reporter = mock();
+        this.analyzer.analyze(macroBlock, reporter);
+
+        verify(this.syntaxRegistry).resolveSyntax(syntaxValue);
+        if (expectedRight != null) {
+            verify(reporter).report(macroBlock, List.of(expectedRight), "rendering.macro.rawMacroRequiredRights");
+        } else {
+            verifyNoInteractions(reporter);
+        }
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/pom.xml
@@ -44,6 +44,11 @@
     </dependency>
     <dependency>
       <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-security-requiredrights-macro</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
       <artifactId>xwiki-platform-oldcore</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/main/java/org/xwiki/platform/security/requiredrights/internal/analyzer/DefaultMacroRequiredRightReporter.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/main/java/org/xwiki/platform/security/requiredrights/internal/analyzer/DefaultMacroRequiredRightReporter.java
@@ -1,0 +1,112 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.platform.security.requiredrights.internal.analyzer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.annotation.InstantiationStrategy;
+import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
+import org.xwiki.platform.security.requiredrights.MacroRequiredRight;
+import org.xwiki.platform.security.requiredrights.MacroRequiredRightReporter;
+import org.xwiki.platform.security.requiredrights.RequiredRight;
+import org.xwiki.platform.security.requiredrights.RequiredRightAnalysisResult;
+import org.xwiki.platform.security.requiredrights.RequiredRightsException;
+import org.xwiki.rendering.block.MacroBlock;
+import org.xwiki.rendering.syntax.Syntax;
+
+/**
+ * Default implementation of {@link MacroRequiredRightReporter}.
+ *
+ * @version $Id$
+ * @since 15.10RC1
+ */
+@Component(roles = DefaultMacroRequiredRightReporter.class)
+@InstantiationStrategy(ComponentInstantiationStrategy.PER_LOOKUP)
+public class DefaultMacroRequiredRightReporter extends AbstractMacroBlockRequiredRightAnalyzer
+    implements MacroRequiredRightReporter
+{
+    private final List<RequiredRightAnalysisResult> results = new ArrayList<>();
+
+    @Override
+    public void report(MacroBlock macroBlock, List<MacroRequiredRight> requiredRights, String summaryTranslationKey,
+        Object... translationParameters)
+    {
+        this.results.add(new RequiredRightAnalysisResult(
+            extractSourceReference(macroBlock),
+            this.translationBlockSupplierProvider.get(summaryTranslationKey, translationParameters),
+            this.macroBlockBlockSupplierProvider.get(macroBlock),
+            requiredRights.stream().map(this::translateMacroRequiredRight).collect(Collectors.toList())
+        ));
+    }
+
+    private RequiredRight translateMacroRequiredRight(MacroRequiredRight macroRequiredRight)
+    {
+        RequiredRight requiredRight;
+
+        switch (macroRequiredRight) {
+            case PROGRAM:
+                requiredRight = RequiredRight.PROGRAM;
+                break;
+            case MAYBE_PROGRAM:
+                requiredRight = RequiredRight.MAYBE_PROGRAM;
+                break;
+            case SCRIPT:
+                requiredRight = RequiredRight.SCRIPT;
+                break;
+            case MAYBE_SCRIPT:
+                requiredRight = RequiredRight.MAYBE_SCRIPT;
+                break;
+            default:
+                requiredRight = null;
+        }
+
+        return requiredRight;
+    }
+
+    @Override
+    public void analyzeContent(MacroBlock macroBlock, String content)
+    {
+        analyzeContent(macroBlock, content, null);
+    }
+
+    @Override
+    public void analyzeContent(MacroBlock macroBlock, String content, Syntax syntax)
+    {
+        if (StringUtils.isNotBlank(content)) {
+            try {
+                this.results.addAll(analyzeMacroContent(macroBlock, content, syntax));
+            } catch (RequiredRightsException e) {
+                this.results.add(reportAnalysisError(macroBlock, e));
+            }
+        }
+    }
+
+    /**
+     * @return the collected results
+     */
+    public List<RequiredRightAnalysisResult> getResults()
+    {
+        return this.results;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/main/java/org/xwiki/platform/security/requiredrights/internal/analyzer/ScriptMacroAnalyzer.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/main/java/org/xwiki/platform/security/requiredrights/internal/analyzer/ScriptMacroAnalyzer.java
@@ -32,6 +32,7 @@ import org.xwiki.model.EntityType;
 import org.xwiki.model.reference.EntityReference;
 import org.xwiki.platform.security.requiredrights.RequiredRight;
 import org.xwiki.platform.security.requiredrights.RequiredRightAnalysisResult;
+import org.xwiki.platform.security.requiredrights.RequiredRightAnalyzer;
 import org.xwiki.platform.security.requiredrights.internal.provider.BlockSupplierProvider;
 import org.xwiki.properties.BeanManager;
 import org.xwiki.rendering.block.MacroBlock;
@@ -50,6 +51,7 @@ import org.xwiki.security.authorization.Right;
 @Singleton
 @Named(ScriptMacroAnalyzer.ID)
 public class ScriptMacroAnalyzer extends AbstractMacroBlockRequiredRightAnalyzer
+    implements RequiredRightAnalyzer<MacroBlock>
 {
     /**
      * The id of this analyzer.
@@ -78,7 +80,7 @@ public class ScriptMacroAnalyzer extends AbstractMacroBlockRequiredRightAnalyzer
     public List<RequiredRightAnalysisResult> analyze(MacroBlock macroBlock)
     {
         Right requiredRight = Right.PROGRAM;
-        Macro<?> macro = getMacro(macroBlock, getTransformationContext(macroBlock));
+        Macro<?> macro = getMacro(macroBlock);
 
         try {
             Object macroParameters =

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/main/resources/ApplicationResources.properties
@@ -70,6 +70,8 @@ security.requiredrights.velocity=The string [{0}] contains "#" or "$" which migh
 ####################
 security.requiredrights.macro.script.program=A [{0}] scripting macro requires programming rights.
 security.requiredrights.macro.script.script=A [{0}] scripting macro requires script rights.
+security.requiredrights.macro.analyzer.error=An error occurred during the analysis of the macro [{0}]. \
+  Please manually check which rights it requires including its contents. Root cause of the error: [{1}].
 
 ####################
 # For objects

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/main/resources/META-INF/components.txt
@@ -1,5 +1,6 @@
 org.xwiki.platform.security.requiredrights.internal.analyzer.XWikiDocumentRequiredRightAnalyzer
 org.xwiki.platform.security.requiredrights.internal.analyzer.DefaultMacroBlockRequiredRightAnalyzer
+org.xwiki.platform.security.requiredrights.internal.analyzer.DefaultMacroRequiredRightReporter
 org.xwiki.platform.security.requiredrights.internal.analyzer.DefaultObjectRequiredRightAnalyzer
 org.xwiki.platform.security.requiredrights.internal.analyzer.XDOMRequiredRightAnalyzer
 org.xwiki.platform.security.requiredrights.internal.analyzer.RequiredRightObjectRequiredRightAnalyzer

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/test/java/org/xwiki/platform/security/requiredrights/internal/analyzer/ScriptMacroAnalyzerTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/test/java/org/xwiki/platform/security/requiredrights/internal/analyzer/ScriptMacroAnalyzerTest.java
@@ -47,7 +47,6 @@ import org.xwiki.rendering.macro.descriptor.MacroDescriptor;
 import org.xwiki.rendering.macro.script.MacroPermissionPolicy;
 import org.xwiki.rendering.macro.script.PrivilegedScriptMacro;
 import org.xwiki.rendering.macro.script.ScriptMacroParameters;
-import org.xwiki.rendering.syntax.Syntax;
 import org.xwiki.security.authorization.Right;
 import org.xwiki.test.annotation.ComponentList;
 import org.xwiki.test.junit5.mockito.ComponentTest;
@@ -185,10 +184,7 @@ class ScriptMacroAnalyzerTest
 
     private void registerMockMacro(String macroName, Macro<?> macro) throws MacroLookupException
     {
-        // Create a fake syntax to create the macro id.
-        Syntax syntax = mock();
-        when(this.macroContentParser.getCurrentSyntax(any())).thenReturn(syntax);
-        MacroId macroId = new MacroId(macroName, syntax);
+        MacroId macroId = new MacroId(macroName, null);
         // Use doReturn() as Mockito has problems with generics.
         doReturn(macro).when(this.macroManager).getMacro(macroId);
     }

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-macro/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-macro/pom.xml
@@ -18,28 +18,29 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
+
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.xwiki.platform</groupId>
-    <artifactId>xwiki-platform-security</artifactId>
+    <artifactId>xwiki-platform-security-requiredrights</artifactId>
     <version>15.10-SNAPSHOT</version>
   </parent>
-  <artifactId>xwiki-platform-security-requiredrights</artifactId>
-  <packaging>pom</packaging>
-  <name>XWiki Platform - Security - Required Rights - Parent POM</name>
-  <description>Parent POM for the Required Rights</description>
-  <modules>
-    <module>xwiki-platform-security-requiredrights-api</module>
-    <module>xwiki-platform-security-requiredrights-default</module>
-    <module>xwiki-platform-security-requiredrights-macro</module>
-  </modules>
-  <profiles>
-    <profile>
-      <id>integration-tests</id>
-      <modules>
-        <module>xwiki-platform-security-requiredrights-test</module>
-      </modules>
-    </profile>
-  </profiles>
+  <artifactId>xwiki-platform-security-requiredrights-macro</artifactId>
+  <name>XWiki Platform - Security - Required Rights - Macro</name>
+  <description>APIs for analyzing rendering macro's required rights</description>
+  <properties>
+    <!-- Name to display by the Extension Manager -->
+    <xwiki.extension.name>Required Rights Macro Analysis API</xwiki.extension.name>
+    <!-- Category to display in the Extension Manager. -->
+    <xwiki.extension.category>api</xwiki.extension.category>
+    <xwiki.jacoco.instructionRatio>0.00</xwiki.jacoco.instructionRatio>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.xwiki.rendering</groupId>
+      <artifactId>xwiki-rendering-api</artifactId>
+      <version>${rendering.version}</version>
+    </dependency>
+  </dependencies>
 </project>

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-macro/src/main/java/org/xwiki/platform/security/requiredrights/MacroRequiredRight.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-macro/src/main/java/org/xwiki/platform/security/requiredrights/MacroRequiredRight.java
@@ -1,0 +1,53 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.platform.security.requiredrights;
+
+import org.xwiki.stability.Unstable;
+
+/**
+ * Represents a required right for a macro. To avoid dependencies on the authorization API, this class provides
+ * constants for common cases.
+ *
+ * @version $Id$
+ * @since 15.10RC1
+ */
+@Unstable
+public enum MacroRequiredRight
+{
+    /**
+     * Programming right is required.
+     */
+    PROGRAM,
+
+    /**
+     * Programming right might be required, but a manual review is needed to confirm if the right is required.
+     */
+    MAYBE_PROGRAM,
+
+    /**
+     * Script right is required.
+     */
+    SCRIPT,
+
+    /**
+     * Script right might be required, but a manual review is needed to confirm if the right is required.
+     */
+    MAYBE_SCRIPT
+}

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-macro/src/main/java/org/xwiki/platform/security/requiredrights/MacroRequiredRightReporter.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-macro/src/main/java/org/xwiki/platform/security/requiredrights/MacroRequiredRightReporter.java
@@ -1,0 +1,69 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.platform.security.requiredrights;
+
+import java.util.List;
+
+import org.xwiki.rendering.block.MacroBlock;
+import org.xwiki.rendering.syntax.Syntax;
+import org.xwiki.stability.Unstable;
+
+/**
+ * Interface for reporting required rights and analyzing macro contents recursively.
+ * <p>
+ * The aim of this interface is to allow macro implementations to report required rights to the caller to avoid
+ * explicit dependencies on the required rights API.
+ * </p>
+ *
+ * @version $Id$
+ * @since 15.10RC1
+ */
+@Unstable
+public interface MacroRequiredRightReporter
+{
+    /**
+     * Reports the given required rights to the caller.
+     *
+     * @param macroBlock the macro block, used to determine metadata like the entity reference but also to show in
+     * the details of the required rights analysis result
+     * @param requiredRights the required rights
+     * @param summaryTranslationKey the translation key for the summary
+     * @param translationParameters the translation parameters for the summary
+     */
+    void report(MacroBlock macroBlock, List<MacroRequiredRight> requiredRights, String summaryTranslationKey,
+        Object... translationParameters);
+
+    /**
+     * Analyzes the given content recursively.
+     *
+     * @param macroBlock the macro block, used to determine metadata like the entity reference
+     * @param content the content to analyze
+     */
+    void analyzeContent(MacroBlock macroBlock, String content);
+
+    /**
+     * Analyzes the given content recursively.
+     *
+     * @param macroBlock the macro block, used to determine metadata like the entity reference
+     * @param content the parsed content to analyze
+     * @param syntax the syntax of the content
+     */
+    void analyzeContent(MacroBlock macroBlock, String content, Syntax syntax);
+}

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-macro/src/main/java/org/xwiki/platform/security/requiredrights/MacroRequiredRightsAnalyzer.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-macro/src/main/java/org/xwiki/platform/security/requiredrights/MacroRequiredRightsAnalyzer.java
@@ -1,0 +1,48 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.platform.security.requiredrights;
+
+import org.xwiki.component.annotation.Role;
+import org.xwiki.rendering.block.MacroBlock;
+import org.xwiki.stability.Unstable;
+
+/**
+ * Analyzes a macro to determine if it requires specific rights.
+ * <p>
+ * This is a simplified version of {@code RequiredRightAnalyzer} that only analyzes macro blocks with the aim of
+ * making it easy to write analyzers for macros that don't have any dependencies apart from the rendering API and
+ * this module.
+ * </p>
+ *
+ * @version $Id$
+ * @since 15.10RC1
+ */
+@Unstable
+@Role
+public interface MacroRequiredRightsAnalyzer
+{
+    /**
+     * Analyzes the given macro block and reports the required rights to the given reporter.
+     *
+     * @param macroBlock the macro block to analyze
+     * @param reporter the reporter to report the required rights to
+     */
+    void analyze(MacroBlock macroBlock, MacroRequiredRightReporter reporter);
+}


### PR DESCRIPTION
This PR introduces a new API for macros to report required rights:

* Add a new API for macros to report required rights.
* Add support for calling these new analyzers in the default macro analyzer.
* Improve error reporting for macro analyzers by displaying an analysis result with the error when the macro analyzer produces an error.

Further, I have included commits that introduce analyzers for the cache and the raw macro to demonstrate the usage of the new API.

Jira issue: https://jira.xwiki.org/browse/XWIKI-21528 and for the analyzers https://jira.xwiki.org/browse/XWIKI-21484 and https://jira.xwiki.org/browse/XWIKI-21485