### PR TITLE
XWIKI-21452: Macros info, success, warning and error are only distinguished by colors

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/messages.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/messages.less
@@ -2,10 +2,36 @@
 // Messages
 // --------------------------------------------------
 
-.successmessage, .errormessage, .warningmessage, .infomessage,
 span.successmessage, span.errormessage, span.warningmessage, span.infomessage, 
-span.box { // Used by: Inline boxes and messages
-  padding: floor(@font-size-base * 0.2);
+span.box { // Used by: Inline boxes
+  padding: 0 floor(@font-size-base * 0.2);
+  & > img {
+    // Style the icons of the message boxes
+    margin: 0 .5rem;
+    vertical-align: sub;
+  }
+}
+
+div.successmessage, div.errormessage, div.warningmessage, div.infomessage {
+  // Used by: message boxes
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  
+  & > p {
+    // Content of the message box
+    flex-grow: 1;
+    flex-basis: 98%;
+  }
+  
+  & > img {
+    // We need to do a hack with the flex because the title is not contained in its own node, 
+    // it's just there in a textnode.
+    min-width: 2%;
+    max-height: 16px;
+    object-fit: contain;
+  }
+  
 }
 
 .box, .plainmessage, // Used by: Code Macro, Success Macro, etc.


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21452
## PR Changes
* Updated style to take into account the addition of an icon in xwiki-rendering

## Tests
No specific test since this is just style changes

## View
![21452-platformPRafter](https://github.com/xwiki/xwiki-platform/assets/28761965/4e2e16bd-04d5-4806-a2a2-6fee1dda4941)
[Video demo](https://up1.xwikisas.com/#gZy-GH4zy0ICnHaXAqBfiA) to check out responsivisity of these style changes

## Note
This PR should be merged on main, only after the appropriate changes have been merged on xwiki-rendering -> https://github.com/xwiki/xwiki-rendering/pull/286 .