### PR TITLE
XWIKI-21533: Page History tab Radio buttons are missing a label

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/historyinline.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/historyinline.vm
@@ -137,11 +137,11 @@ $xwiki.ssfx.use('uicomponents/pagination/pagination.css', true)##
     #end
     #if ($displayCompare)
       <td data-title="$escapetool.xml($services.localization.render('core.viewers.history.from'))">
-        <label class="hidden" for="rev1_$version">$escapetool.xml($services.localization.render('core.viewers.history.from'))</label>
+        <label class="sr-only" for="rev1_$version">$escapetool.xml($services.localization.render('core.viewers.history.from'))</label>
         <input type="radio" name="rev1" id="rev1_$version" value="$version" #if ($foreach.count==2) checked="checked" #end/>
       </td>
       <td data-title="$escapetool.xml($services.localization.render('core.viewers.history.to'))">
-        <label class="hidden" for="rev2_$version">$escapetool.xml($services.localization.render('core.viewers.history.to'))</label>
+        <label class="sr-only" for="rev2_$version">$escapetool.xml($services.localization.render('core.viewers.history.to'))</label>
         <input type="radio" name="rev2" id="rev2_$version" value="$version" #if ($foreach.count==1) checked="checked" #end/>
       </td>
     #end


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21533
## PR Changes
* Modified ALL the labels generated in the history table from `hidden` to `sr-only`
## View
![21533-afterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/661d0b3a-3062-40a3-9d33-d524639869a8)