### PR TITLE
XWIKI-21112: Borders around the docextrapanes look fuzzy

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
@@ -314,8 +314,8 @@
 #mainContentArea, #hierarchy_breadcrumb {
   /* Add a border the same color as the background to preserve vertical alignment with the content of the extra panes,
      despite the left and right border (instead of a shadow previously). */
-  /* border-right: 1px solid @xwiki-page-content-bg; */
-  /* border-left: 1px solid @xwiki-page-content-bg; */
+  //border-right: 1px solid @body-bg;
+  //border-left: 1px solid @body-bg;
 }
 
 /* Protect against nesting of the breadcrumb inside #mainContentArea, e.g., in AdminSheet and other containers that
@@ -346,9 +346,9 @@ already take care of padding and shadow. */
   padding-top: 0;
   /* Add a border the same color as the background to preserve vertical alignment with the content of the extra panes,
      despite the left and right border (instead of a shadow previously). */
-  /* border-right: 1px solid @xwiki-page-content-bg; */
-  /* border-left: 1px solid @xwiki-page-content-bg; */
-  /* border-bottom: 1px solid @xwiki-page-content-bg; */
+   //border-right: 1px solid @body-bg; 
+   //border-left: 1px solid @body-bg; 
+   //border-bottom: 1px solid @body-bg; 
 }
 
 // Tabbar =====================================================================

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
@@ -318,14 +318,19 @@ already take care of padding and shadow. */
   /* Padding and shadow is already in the #mainContentArea element */
   padding-top: 0;
   box-shadow: none;
+  /* Add a border the same color as the background to preserve vertical alignment with the content of the extra panes,
+     despite the left and right border (instead of a shadow previously). */
+  border-right: 1px solid @xwiki-page-content-bg;
+  border-left: 1px solid @xwiki-page-content-bg;
 }
 
 #docextrapanes {
-  box-shadow: 0 1px 2px @xwiki-border-color;
   border-top: 1px solid @xwiki-border-color;
   border-top-left-radius: @border-radius-base;
   border-top-right-radius: @border-radius-base;
   margin-top: -1px;
+  border-left: 1px solid @xwiki-border-color;
+  border-right: 1px solid @xwiki-border-color;
 }
 
 #xdocFooter {
@@ -336,6 +341,11 @@ already take care of padding and shadow. */
   flex-wrap: wrap;
   margin-bottom: floor((@grid-gutter-width / 2));
   padding-top: 0;
+  /* Add a border the same color as the background to preserve vertical alignment with the content of the extra panes,
+     despite the left and right border (instead of a shadow previously). */
+  border-right: 1px solid @xwiki-page-content-bg;
+  border-left: 1px solid @xwiki-page-content-bg;
+  border-bottom: 1px solid @xwiki-page-content-bg;
 }
 
 // Tabbar =====================================================================

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
@@ -311,6 +311,13 @@
   }
 }
 
+#mainContentArea, #hierarchy_breadcrumb {
+  /* Add a border the same color as the background to preserve vertical alignment with the content of the extra panes,
+     despite the left and right border (instead of a shadow previously). */
+  /* border-right: 1px solid @xwiki-page-content-bg; */
+  /* border-left: 1px solid @xwiki-page-content-bg; */
+}
+
 /* Protect against nesting of the breadcrumb inside #mainContentArea, e.g., in AdminSheet and other containers that
 already take care of padding and shadow. */
 #mainContentArea #hierarchy_breadcrumb, #xwikieditor #hierarchy_breadcrumb {
@@ -318,10 +325,6 @@ already take care of padding and shadow. */
   /* Padding and shadow is already in the #mainContentArea element */
   padding-top: 0;
   box-shadow: none;
-  /* Add a border the same color as the background to preserve vertical alignment with the content of the extra panes,
-     despite the left and right border (instead of a shadow previously). */
-  border-right: 1px solid @xwiki-page-content-bg;
-  border-left: 1px solid @xwiki-page-content-bg;
 }
 
 #docextrapanes {
@@ -343,9 +346,9 @@ already take care of padding and shadow. */
   padding-top: 0;
   /* Add a border the same color as the background to preserve vertical alignment with the content of the extra panes,
      despite the left and right border (instead of a shadow previously). */
-  border-right: 1px solid @xwiki-page-content-bg;
-  border-left: 1px solid @xwiki-page-content-bg;
-  border-bottom: 1px solid @xwiki-page-content-bg;
+  /* border-right: 1px solid @xwiki-page-content-bg; */
+  /* border-left: 1px solid @xwiki-page-content-bg; */
+  /* border-bottom: 1px solid @xwiki-page-content-bg; */
 }
 
 // Tabbar =====================================================================

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
@@ -311,13 +311,6 @@
   }
 }
 
-#mainContentArea, #hierarchy_breadcrumb {
-  /* Add a border the same color as the background to preserve vertical alignment with the content of the extra panes,
-     despite the left and right border (instead of a shadow previously). */
-  //border-right: 1px solid @body-bg;
-  //border-left: 1px solid @body-bg;
-}
-
 /* Protect against nesting of the breadcrumb inside #mainContentArea, e.g., in AdminSheet and other containers that
 already take care of padding and shadow. */
 #mainContentArea #hierarchy_breadcrumb, #xwikieditor #hierarchy_breadcrumb {
@@ -344,11 +337,6 @@ already take care of padding and shadow. */
   flex-wrap: wrap;
   margin-bottom: floor((@grid-gutter-width / 2));
   padding-top: 0;
-  /* Add a border the same color as the background to preserve vertical alignment with the content of the extra panes,
-     despite the left and right border (instead of a shadow previously). */
-   //border-right: 1px solid @body-bg; 
-   //border-left: 1px solid @body-bg; 
-   //border-bottom: 1px solid @body-bg; 
 }
 
 // Tabbar =====================================================================


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-21112

## Impacts
- The left and right border of the main content area and extra panes are not blurry anymore

## Question
- [x] A thin blurry line exists between the breadcrumb and main content area, and between the main content area and the doc footer. They are barely visible with the default border color, but can become visible with some color (e.g., the pink I used to make it easier to see the changes in the screenshots below). Is it something that was intentional initially, or something we don't want to keep (see "After bis" below for a version where those lines are not kept)
  - this is a consequence of https://github.com/xwiki/xwiki-platform/pull/2166 and must not be kept.

## Before
![Screenshot 2023-11-13 at 09-55-46 Home - XWiki](https://github.com/xwiki/xwiki-platform/assets/327856/dc8241af-d5f9-4c86-93f6-b5d8a516a390)


## After
![Screenshot 2023-11-13 at 09-55-59 Home - XWiki](https://github.com/xwiki/xwiki-platform/assets/327856/5d76a585-5065-4db3-b817-23f1ec9bf03e)

## After Bis
![Screenshot 2023-11-13 at 10-06-22 Home - XWiki](https://github.com/xwiki/xwiki-platform/assets/327856/16703bb9-2e14-4f47-9f58-8d492a5976a2)



