### PR TITLE
XWIKI-18007: Drawer menu improvements for accessibility

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/flamingo.js
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/flamingo.js
@@ -89,7 +89,6 @@ require(['jquery'], function($) {
         // We use the drawer-transitioning class to make sure the transition to 
         // slide in is not shortcut when showing the modal
         drawerContainer.addClass('drawer-transitioning');
-        drawerOpener.attr('aria-expanded', 'true');
         drawerContainer.get(0).showModal();
         drawerContainer.removeClass('drawer-transitioning');
         // The drawer can be closed by pressing the ESC key
@@ -98,8 +97,9 @@ require(['jquery'], function($) {
             closeDrawer();
           }
         });
+        // At last, we indicate the new state of the drawer on the opener
+        drawerOpener.attr('aria-expanded', 'true');
       }).on('drawer' + index + '.closed', function (event) {
-        drawerOpener.attr('aria-expanded', 'false');
         // When the drawer is closed, collapse sub items
         drawerContainer.find('.drawer-menu-sub-item').removeClass('in').attr('aria-expanded', 'false');
 
@@ -107,6 +107,8 @@ require(['jquery'], function($) {
           drawerContainer.get(0).close();
           drawerContainer.removeClass('drawer-transitioning');
           drawerContainer.get(0).removeEventListener('transitionend', waitTransition);
+          // At last, we indicate the new state of the drawer on the opener
+          drawerOpener.attr('aria-expanded', 'false');
         }
 
         // We use the drawer-transitioning class to give time for the hide modal transition to play.

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/DrawerMenu.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/DrawerMenu.java
@@ -37,6 +37,9 @@ public class DrawerMenu extends BaseElement
 
     @FindBy(id = "tmDrawerActivator")
     private WebElement activator;
+    
+    @FindBy(id = "tmDrawer")
+    private WebElement drawerContainer;
 
     public void toggle()
     {
@@ -108,7 +111,10 @@ public class DrawerMenu extends BaseElement
 
     private void waitForDrawer(boolean visible)
     {
-        getDriver().waitUntilCondition(
-            ExpectedConditions.attributeToBe(this.activator, "aria-expanded", String.valueOf(visible)));
+        if (visible) {
+            getDriver().waitUntilCondition(ExpectedConditions.visibilityOf(this.drawerContainer));
+        } else {
+            getDriver().waitUntilCondition(ExpectedConditions.invisibilityOf(this.drawerContainer));
+        }
     }
 }


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-18007
## PR Changes
* Updated the priority of the attribute change 'aria-expanded' to come last
* Bulletproofed drawermenu to make sure we wait for visibility itself and not an attribute update that promises a state of visibility after some time.
## Notes
This is related to [this CI regression](https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/master/6969/testReport/junit/org.xwiki.flamingo.test.docker/AllIT$NestedDeletePageIT/Platform_Builds___main___integration_tests___IT_for_xwiki_platform_core_xwiki_platform_flamingo_xwiki_platform_flamingo_skin_xwiki_platform_flamingo_skin_test_xwiki_platform_flamingo_skin_test_docker___Build_for_IT_for_xwiki_platform_core_xwiki_platform_flamingo_xwiki_platform_flamingo_skin_xwiki_platform_flamingo_skin_test_xwiki_platform_flamingo_skin_test_docker___deleteOkWhenConfirming/) @surli pointed out last Friday. @michitux helped make sense of the regression :)

The changes on flamingo.js are not necessary, but I think it makes more sense to update things in this order.

## Tests
This passed successfully the tests in the UITest class DeletePageIT (especially deleteOkWhenConfirming that was failing).