### PR TITLE
XWIKI-21113: Borders of the docextrapanes focused tab are hardcoded to grey

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
@@ -345,6 +345,12 @@ already take care of padding and shadow. */
   .nav;
   .nav-tabs;
   margin: 0;
+
+  > li.active > a:focus {
+    border-top-color: @xwiki-border-color;
+    border-left-color: @xwiki-border-color;
+    border-right-color: @xwiki-border-color;
+  }
 }
 
 #docExtrasTabsUl {


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-21113

**Result**

[Screencast from 13-11-2023 15:06:54.webm](https://github.com/xwiki/xwiki-platform/assets/327856/7607bc4d-a8fa-4d51-8a37-dc6f3ce92066)
