### PR TITLE
XWIKI-21545: Preview layout is broken

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/contentview.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/contentview.vm
@@ -63,6 +63,10 @@ $services.progress.startStep('Display the title and content')
       #end
     </div>
   </div>
+  #if ($isPreview)
+    <hr />
+    <div class="bottombuttons sticky-buttons">#template("previewactions.vm")</div>
+  #end
 </main>
 $services.progress.endStep()
 

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/preview.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/preview.vm
@@ -20,8 +20,7 @@
 #template("startpage.vm")
 <div class="main layoutsubsection">
 #template("hierarchy.vm")
+#set($isPreview = true)
 #template("contentview.vm")
-<hr />
-<div class="bottombuttons sticky-buttons">#template("previewactions.vm")</div>
 </div> ## main
 #template("endpage.vm")


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21545
## PR Changes
* Fixed the broken preview
## Note
* This was caused by an oversight when implementing the changes for XWIKI-18838.
* No test was broken by the changes in XWIKI-18838, and I can't find a reference to ".bottombuttons" in the tests, so I suppose this PR will not break any tests.
## View
vvv Before this PR
![21545-beforePR](https://github.com/xwiki/xwiki-platform/assets/28761965/521eecbe-8b5b-4014-a19c-efc797335dd6)
vvv After this PR
![21545-afterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/a71f3a9b-9ac7-4f19-bf5b-26aa5e911f7e)

We can see that the bottom button block was out of the mainContent 'white' block, which was unexpected. This is fixed by this PR.