### PR TITLE
XWIKI-21506: Both customize buttons in XWiki Preferences > Themes don't have top padding

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/forms.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/forms.less
@@ -105,7 +105,6 @@ select[size="0"], select[size="1"] {
         text-transform: uppercase;
         .buttonwrapper a {
           .btn-xs;
-          line-height: 1.3em;
           margin: 0;
           position: absolute;
           right: 0;


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-21506