### PR TITLE
XWIKI-19175: Leaving and rejoining the realtime editing session using  the checkbox doesn't work properly

### DIFF
--- a/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wiki/xwiki-platform-realtime-wiki-test/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wiki/xwiki-platform-realtime-wiki-test/pom.xml
@@ -24,22 +24,27 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.xwiki.platform</groupId>
-    <artifactId>xwiki-platform-realtime</artifactId>
+    <artifactId>xwiki-platform-realtime-wiki</artifactId>
     <version>16.0-SNAPSHOT</version>
   </parent>
-  <artifactId>xwiki-platform-realtime-wiki</artifactId>
-  <name>XWiki Platform - Realtime - Wiki - Parent POM</name>
+  <artifactId>xwiki-platform-realtime-wiki-test</artifactId>
+  <name>XWiki Platform - Realtime - Wiki - Test - Parent POM</name>
   <packaging>pom</packaging>
-  <description>Adds support for real-time wiki syntax (text) editing in XWiki.</description>
+  <description>Tests for the Realtime Wiki Editor</description>
+  <properties>
+    <!-- Don't run backward-compatibility checks in test modules since we don't consider them as public APIs -->
+    <xwiki.revapi.skip>true</xwiki.revapi.skip>
+    <!-- Don't run Checkstyle in test modules -->
+    <xwiki.checkstyle.skip>true</xwiki.checkstyle.skip>
+  </properties>
   <modules>
-    <module>xwiki-platform-realtime-wiki-ui</module>
-    <module>xwiki-platform-realtime-wiki-webjar</module>
+    <module>xwiki-platform-realtime-wiki-test-pageobjects</module>
   </modules>
   <profiles>
     <profile>
-      <id>integration-tests</id>
+      <id>docker</id>
       <modules>
-        <module>xwiki-platform-realtime-wiki-test</module>
+        <module>xwiki-platform-realtime-wiki-test-docker</module>
       </modules>
     </profile>
   </profiles>

--- a/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wiki/xwiki-platform-realtime-wiki-test/xwiki-platform-realtime-wiki-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wiki/xwiki-platform-realtime-wiki-test/xwiki-platform-realtime-wiki-test-docker/pom.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.xwiki.platform</groupId>
+    <artifactId>xwiki-platform-realtime-wiki-test</artifactId>
+    <version>16.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>xwiki-platform-realtime-wiki-test-docker</artifactId>
+  <name>XWiki Platform - Realtime - Wiki - Test - Functional Tests in Docker</name>
+  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
+       see https://jira.xwiki.org/browse/XWIKI-7683 -->
+  <packaging>jar</packaging>
+  <description>Functional Docker-based tests for the Realtime Wiki Editor</description>
+  <properties>
+    <!-- Functional tests are allowed to output content to the console -->
+    <xwiki.surefire.captureconsole.skip>true</xwiki.surefire.captureconsole.skip>
+  </properties>
+  <dependencies>
+    <!-- Runtime dependencies. -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-realtime-wiki-ui</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+      <type>xar</type>
+    </dependency>
+    <!-- The JavaScript code needs to display localized messages and for this it needs to fetch them through REST so we
+      need an implementation of the localization REST API. -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-localization-rest-default</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <!-- We need an implementation of the WebSocket API (using XWiki components) -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>xwiki-platform-websocket</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <!--Test only dependencies. -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-test-docker</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-realtime-wiki-test-pageobjects</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- Realtime synchronization is done through WebSockets. -->
+    <dependency>
+      <groupId>javax.websocket</groupId>
+      <artifactId>javax.websocket-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <testSourceDirectory>src/test/it</testSourceDirectory>
+    <plugins>
+      <!-- We need to explicitly include the failsafe plugin since it's not part of the default maven lifecycle -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+  <profiles>
+    <profile>
+      <id>clover</id>
+      <!-- Add the Clover JAR to the WAR so that it's available at runtime when XWiki executes.
+           It's needed because instrumented jars in the WAR will call Clover APIs at runtime when they execute. -->
+      <dependencies>
+        <dependency>
+          <groupId>org.openclover</groupId>
+          <artifactId>clover</artifactId>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <systemPropertyVariables>
+                <!-- Tell the Docker-based test to activate the Clover profile so that the Clover JAR is added to
+                     WEB-INF/lib -->
+                <xwiki.test.ui.profiles>clover</xwiki.test.ui.profiles>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wiki/xwiki-platform-realtime-wiki-test/xwiki-platform-realtime-wiki-test-docker/src/test/it/org/xwiki/realtime/wiki/test/ui/AllIT.java
+++ b/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wiki/xwiki-platform-realtime-wiki-test/xwiki-platform-realtime-wiki-test-docker/src/test/it/org/xwiki/realtime/wiki/test/ui/AllIT.java
@@ -1,0 +1,46 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.realtime.wiki.test.ui;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.xwiki.test.docker.junit5.UITest;
+
+/**
+ * All UI tests for the real-time Wiki editor.
+ *
+ * @version $Id$
+ * @since 15.5.4
+ * @since 15.10
+ */
+@UITest(
+    extraJARs = {
+        // The WebSocket end-point implementation based on XWiki components needs to be installed as core extension.
+        "org.xwiki.platform:xwiki-platform-websocket",
+    }
+)
+class AllIT
+{
+    @Nested
+    @DisplayName("Realtime Wiki Editor Tests")
+    class NestedRealtimeWikiEditorIT extends RealtimeWikiEditorIT
+    {
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wiki/xwiki-platform-realtime-wiki-test/xwiki-platform-realtime-wiki-test-pageobjects/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wiki/xwiki-platform-realtime-wiki-test/xwiki-platform-realtime-wiki-test-pageobjects/pom.xml
@@ -24,23 +24,18 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.xwiki.platform</groupId>
-    <artifactId>xwiki-platform-realtime</artifactId>
+    <artifactId>xwiki-platform-realtime-wiki-test</artifactId>
     <version>16.0-SNAPSHOT</version>
   </parent>
-  <artifactId>xwiki-platform-realtime-wiki</artifactId>
-  <name>XWiki Platform - Realtime - Wiki - Parent POM</name>
-  <packaging>pom</packaging>
-  <description>Adds support for real-time wiki syntax (text) editing in XWiki.</description>
-  <modules>
-    <module>xwiki-platform-realtime-wiki-ui</module>
-    <module>xwiki-platform-realtime-wiki-webjar</module>
-  </modules>
-  <profiles>
-    <profile>
-      <id>integration-tests</id>
-      <modules>
-        <module>xwiki-platform-realtime-wiki-test</module>
-      </modules>
-    </profile>
-  </profiles>
+  <artifactId>xwiki-platform-realtime-wiki-test-pageobjects</artifactId>
+  <name>XWiki Platform - Realtime - Wiki - Test - Page Objects</name>
+  <packaging>jar</packaging>
+  <description>Page Objects for the Realtime Wiki Editor</description>
+  <dependencies>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-test-ui</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
 </project>

--- a/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wiki/xwiki-platform-realtime-wiki-test/xwiki-platform-realtime-wiki-test-pageobjects/src/main/java/org/xwiki/realtime/wiki/test/po/RealtimeWikiEditor.java
+++ b/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wiki/xwiki-platform-realtime-wiki-test/xwiki-platform-realtime-wiki-test-pageobjects/src/main/java/org/xwiki/realtime/wiki/test/po/RealtimeWikiEditor.java
@@ -1,0 +1,89 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.realtime.wiki.test.po;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.xwiki.test.ui.po.BaseElement;
+
+/**
+ * Represents the Realtime Wiki Editor.
+ * 
+ * @version $Id$
+ * @since 15.5.4
+ * @since 15.10
+ */
+public class RealtimeWikiEditor extends BaseElement
+{
+    @FindBy(className = "realtime-allow")
+    private WebElement allowRealtimeCheckbox;
+
+    @FindBy(id = "xwikimaincontainer")
+    private WebElement mainContainerDiv;
+
+    @FindBy(id = "xwikieditcontent")
+    private WebElement editContentDiv;
+
+    public void sendKeys(CharSequence... keys)
+    {
+        getDriver().executeScript("arguments[0].focus()", editContentDiv);
+        mainContainerDiv.sendKeys(keys);
+    }
+
+    /**
+     * Waits until the given user is present in the list of coeditors.
+     * 
+     * @param user The user to wait for.
+     */
+    public void waitUntilEditingWith(String user)
+    {
+        getDriver().waitUntilElementHasTextContent(By.cssSelector("a.rt-user-link"), user);
+    }
+
+    /**
+     * @return {@code true} if realtime editing is enabled, {@code false} otherwise
+     */
+    public boolean isRealtimeEditing()
+    {
+        return this.allowRealtimeCheckbox.isSelected();
+    }
+
+    /**
+     * Leave the realtime editing session.
+     */
+    public void leaveRealtimeEditing()
+    {
+        if (isRealtimeEditing()) {
+            this.allowRealtimeCheckbox.click();
+        }
+    }
+
+    /**
+     * Join the realtime editing session.
+     */
+    public void joinRealtimeEditing()
+    {
+        if (!isRealtimeEditing()) {
+            this.allowRealtimeCheckbox.click();
+        }
+    }
+
+}

--- a/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wiki/xwiki-platform-realtime-wiki-webjar/src/main/webjar/wikiEditor.js
+++ b/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wiki/xwiki-platform-realtime-wiki-webjar/src/main/webjar/wikiEditor.js
@@ -73,7 +73,8 @@ define('xwiki-realtime-wikiEditor', [
       allowRealtimeCheckbox = Interface.createAllowRealtimeCheckbox(true);
       allowRealtimeCheckbox.on('change', function() {
         if (allowRealtimeCheckbox.prop('checked')) {
-          module.main(editorConfig, docKeys);
+          // TODO: Allow for enabling realtime without reloading the entire page.
+          window.location.href = editorConfig.rtURL;
         } else {
           Interface.realtimeAllowed(false);
           module.onAbort();


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-19175

This PR fixes a bug where leaving and joining a Realtime **wiki** editing session again would show "Synchronizing" in the tool bar instead of the coeditors list.

This PR also brings a functional test for this bug.

Thanks.