### PR TITLE
[Misc] Fix typo 'save fail' -> 'save fails'

### DIFF
--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-instance/xwiki-platform-filter-instance-document/src/main/java/org/xwiki/filter/instance/output/DocumentInstanceOutputProperties.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-instance/xwiki-platform-filter-instance-document/src/main/java/org/xwiki/filter/instance/output/DocumentInstanceOutputProperties.java
@@ -217,12 +217,12 @@ public class DocumentInstanceOutputProperties extends InstanceOutputProperties
     }
 
     /**
-     * @return Indicate if an exception should be thrown if a document save fail.
+     * @return Indicate if an exception should be thrown if a document save fails.
      * @since 6.2.6
      * @since 6.4.2
      */
-    @PropertyName("Stop when document save fail")
-    @PropertyDescription("Indicate if an exception should be thrown if a document save fail")
+    @PropertyName("Stop when document save fails")
+    @PropertyDescription("Indicate if an exception should be thrown if a document save fails")
     public boolean isStoppedWhenSaveFail()
     {
         return this.stoppedWhenSaveFail;


### PR DESCRIPTION
The typo is also in the variable/method names, but changing this would probably be a breaking change.