### PR TITLE
XWIKI-21477: Improve the required rights result reporting

### DIFF
--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-api/src/main/java/org/xwiki/platform/security/requiredrights/RequiredRightAnalysisResult.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-api/src/main/java/org/xwiki/platform/security/requiredrights/RequiredRightAnalysisResult.java
@@ -19,7 +19,6 @@
  */
 package org.xwiki.platform.security.requiredrights;
 
-import java.io.Serializable;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -38,13 +37,13 @@ import org.xwiki.text.XWikiToStringBuilder;
  * @since 15.9RC1
  */
 @Unstable
-public class RequiredRightAnalysisResult implements Serializable
+public class RequiredRightAnalysisResult
 {
     private final EntityReference entityReference;
 
-    private final transient Supplier<Block> summaryMessageProvider;
+    private final Supplier<Block> summaryMessageProvider;
 
-    private final transient Supplier<Block> detailedMessageProvider;
+    private final Supplier<Block> detailedMessageProvider;
 
     private final List<RequiredRight> requiredRights;
 
@@ -125,6 +124,8 @@ public class RequiredRightAnalysisResult implements Serializable
         return new EqualsBuilder()
             .append(this.entityReference, that.entityReference)
             .append(this.requiredRights, that.requiredRights)
+            .append(this.summaryMessageProvider, that.summaryMessageProvider)
+            .append(this.detailedMessageProvider, that.detailedMessageProvider)
             .isEquals();
     }
 
@@ -134,6 +135,8 @@ public class RequiredRightAnalysisResult implements Serializable
         return new HashCodeBuilder(17, 37)
             .append(this.entityReference)
             .append(this.requiredRights)
+            .append(this.summaryMessageProvider)
+            .append(this.detailedMessageProvider)
             .toHashCode();
     }
 }

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/main/java/org/xwiki/platform/security/requiredrights/internal/RequiredRightsChangedResult.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/main/java/org/xwiki/platform/security/requiredrights/internal/RequiredRightsChangedResult.java
@@ -19,9 +19,8 @@
  */
 package org.xwiki.platform.security.requiredrights.internal;
 
-import java.io.Serializable;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -48,11 +47,11 @@ import static org.xwiki.security.authorization.Right.SCRIPT;
  * @version $Id$
  * @since 15.9RC1
  */
-public class RequiredRightsChangedResult implements Serializable
+public class RequiredRightsChangedResult
 {
-    private final Set<RequiredRightAnalysisResult> added = new HashSet<>();
+    private final Set<RequiredRightAnalysisResult> added = new LinkedHashSet<>();
 
-    private final Set<RequiredRightAnalysisResult> removed = new HashSet<>();
+    private final Set<RequiredRightAnalysisResult> removed = new LinkedHashSet<>();
 
     private final Map<Right, Boolean> addedRights = new HashMap<>();
 
@@ -179,6 +178,24 @@ public class RequiredRightsChangedResult implements Serializable
         return this.removedRights.containsValue(true) || this.addedRights.containsValue(true);
     }
 
+    /**
+     * @return the set of added required rights analysis results
+     * @since 15.10RC1
+     */
+    public Set<RequiredRightAnalysisResult> getAdded()
+    {
+        return this.added;
+    }
+
+    /**
+     * @return the set of removed required rights analysis results
+     * @since 15.10RC1
+     */
+    public Set<RequiredRightAnalysisResult> getRemoved()
+    {
+        return this.removed;
+    }
+
     private static Map<EntityReference, Set<RequiredRightAnalysisResult>> makeMap(Set<RequiredRightAnalysisResult> list)
     {
         Map<EntityReference, Set<RequiredRightAnalysisResult>> map = new HashMap<>();
@@ -194,7 +211,7 @@ public class RequiredRightsChangedResult implements Serializable
             if (map.containsKey(entityReference)) {
                 map.get(entityReference).add(requiredRightAnalysisResult);
             } else {
-                map.put(entityReference, new HashSet<>(Set.of(requiredRightAnalysisResult)));
+                map.put(entityReference, new LinkedHashSet<>(Set.of(requiredRightAnalysisResult)));
             }
         }
         return map;

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/main/java/org/xwiki/platform/security/requiredrights/internal/RequiredRightsEditConfirmationChecker.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/main/java/org/xwiki/platform/security/requiredrights/internal/RequiredRightsEditConfirmationChecker.java
@@ -19,7 +19,10 @@
  */
 package org.xwiki.platform.security.requiredrights.internal;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -29,11 +32,17 @@ import javax.inject.Singleton;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.validation.edit.EditConfirmationChecker;
 import org.xwiki.model.validation.edit.EditConfirmationCheckerResult;
+import org.xwiki.platform.security.requiredrights.RequiredRightAnalysisResult;
 import org.xwiki.platform.security.requiredrights.RequiredRightAnalyzer;
 import org.xwiki.platform.security.requiredrights.RequiredRightsException;
 import org.xwiki.platform.security.requiredrights.internal.configuration.RequiredRightsConfiguration;
 import org.xwiki.platform.security.requiredrights.internal.configuration.RequiredRightsConfiguration.RequiredRightDocumentProtection;
+import org.xwiki.platform.security.requiredrights.internal.editconfirmationchecker.RequiredRightAnalysisResultSkipValue;
+import org.xwiki.platform.security.requiredrights.internal.editconfirmationchecker.RequiredRightsChangedResultSkipValue;
+import org.xwiki.rendering.block.Block;
 import org.xwiki.rendering.block.XDOM;
+import org.xwiki.rendering.renderer.BlockRenderer;
+import org.xwiki.rendering.renderer.printer.DefaultWikiPrinter;
 import org.xwiki.script.ScriptContextManager;
 import org.xwiki.security.authorization.ContextualAuthorizationManager;
 import org.xwiki.template.TemplateManager;
@@ -78,6 +87,10 @@ public class RequiredRightsEditConfirmationChecker implements EditConfirmationCh
     @Inject
     private RequiredRightsConfiguration requiredRightsConfiguration;
 
+    @Inject
+    @Named("html/5.0")
+    private BlockRenderer htmlBlockRender;
+
     @Override
     public Optional<EditConfirmationCheckerResult> check()
     {
@@ -104,7 +117,8 @@ public class RequiredRightsEditConfirmationChecker implements EditConfirmationCh
                             .setAttribute("analysisResults", analysisResults, GLOBAL_SCOPE);
                         XDOM message = this.templateManager
                             .executeNoException("security/requiredrights/requiredRightsEditConfirmationChecker.vm");
-                        checkResult = Optional.of(new EditConfirmationCheckerResult(message, false, analysisResults));
+                        checkResult = Optional.of(new EditConfirmationCheckerResult(message, false,
+                            getRequiredRightsChangedSkipValue(analysisResults)));
                     }
                 } catch (RequiredRightsException e) {
                     this.scriptContextManager.getCurrentScriptContext().setAttribute("exception", e, GLOBAL_SCOPE);
@@ -116,5 +130,45 @@ public class RequiredRightsEditConfirmationChecker implements EditConfirmationCh
             }
         }
         return checkResult;
+    }
+
+    /**
+     * Copy a {@link RequiredRightsChangedResult} to produce a serializable {@link RequiredRightsChangedResultSkipValue}
+     * to use as the skip value.
+     *
+     * @param analysisResults the analysis result to copy
+     * @return the serializable skip value
+     */
+    private RequiredRightsChangedResultSkipValue getRequiredRightsChangedSkipValue(
+        RequiredRightsChangedResult analysisResults)
+    {
+        return new RequiredRightsChangedResultSkipValue(analysisResults.getAddedRights(),
+            analysisResults.getRemovedRights(), convertToString(analysisResults.getAdded()),
+            convertToString(analysisResults.getRemoved()));
+    }
+
+    /**
+     * Copy a set of  {@link RequiredRightAnalysisResult} to a list of serializable
+     * {@link RequiredRightAnalysisResultSkipValue}, later contained in a {@link RequiredRightsChangedResultSkipValue},
+     * to use a the skip value.
+     *
+     * @param results the list result to copy
+     * @return the serializable skip value
+     */
+    private List<RequiredRightAnalysisResultSkipValue> convertToString(Set<RequiredRightAnalysisResult> results)
+    {
+        return results.stream()
+            .map(it -> new RequiredRightAnalysisResultSkipValue(
+                it.getEntityReference(),
+                it.getRequiredRights(),
+                render(it.getSummaryMessage()), render(it.getDetailedMessage()
+            ))).collect(Collectors.toList());
+    }
+
+    private String render(Block detailedMessage)
+    {
+        DefaultWikiPrinter printer = new DefaultWikiPrinter();
+        this.htmlBlockRender.render(detailedMessage, printer);
+        return printer.toString();
     }
 }

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/main/java/org/xwiki/platform/security/requiredrights/internal/editconfirmationchecker/RequiredRightAnalysisResultSkipValue.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/main/java/org/xwiki/platform/security/requiredrights/internal/editconfirmationchecker/RequiredRightAnalysisResultSkipValue.java
@@ -1,0 +1,99 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.platform.security.requiredrights.internal.editconfirmationchecker;
+
+import java.io.Serializable;
+import java.util.List;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.xwiki.model.reference.EntityReference;
+import org.xwiki.platform.security.requiredrights.RequiredRight;
+import org.xwiki.platform.security.requiredrights.RequiredRightAnalysisResult;
+import org.xwiki.platform.security.requiredrights.internal.RequiredRightsEditConfirmationChecker;
+
+/**
+ * Holds sub-values, corresponding to a serializable version of {@link RequiredRightAnalysisResult}. They are contained
+ * by {@link RequiredRightsChangedResultSkipValue}, and used for the {@link RequiredRightsEditConfirmationChecker}
+ * results when previously forced.
+ *
+ * @version $Id$
+ * @since 15.10RC1
+ */
+public class RequiredRightAnalysisResultSkipValue implements Serializable
+{
+    private final EntityReference entityReference;
+
+    private final List<RequiredRight> requiredRights;
+
+    private final String summary;
+
+    private final String detailed;
+
+    /**
+     * Constructs a new object, for the value of a {@link RequiredRightAnalysisResult}.
+     *
+     * @param entityReference the entity reference
+     * @param requiredRights the list of required rights
+     * @param summary the summary message as a string
+     * @param detailed the detailed message as a string
+     */
+    public RequiredRightAnalysisResultSkipValue(EntityReference entityReference, List<RequiredRight> requiredRights,
+        String summary, String detailed)
+    {
+
+        this.entityReference = entityReference;
+        this.requiredRights = requiredRights;
+        this.summary = summary;
+        this.detailed = detailed;
+    }
+
+    @Override
+    public boolean equals(Object object)
+    {
+        if (this == object) {
+            return true;
+        }
+
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+
+        RequiredRightAnalysisResultSkipValue that = (RequiredRightAnalysisResultSkipValue) object;
+
+        return new EqualsBuilder()
+            .append(this.entityReference, that.entityReference)
+            .append(this.requiredRights, that.requiredRights)
+            .append(this.summary, that.summary)
+            .append(this.detailed, that.detailed)
+            .isEquals();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return new HashCodeBuilder(17, 37)
+            .append(this.entityReference)
+            .append(this.requiredRights)
+            .append(this.summary)
+            .append(this.detailed)
+            .toHashCode();
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/main/java/org/xwiki/platform/security/requiredrights/internal/editconfirmationchecker/RequiredRightsChangedResultSkipValue.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/main/java/org/xwiki/platform/security/requiredrights/internal/editconfirmationchecker/RequiredRightsChangedResultSkipValue.java
@@ -1,0 +1,99 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.platform.security.requiredrights.internal.editconfirmationchecker;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.xwiki.platform.security.requiredrights.RequiredRightAnalysisResult;
+import org.xwiki.platform.security.requiredrights.internal.RequiredRightsChangedResult;
+import org.xwiki.platform.security.requiredrights.internal.RequiredRightsEditConfirmationChecker;
+import org.xwiki.security.authorization.Right;
+
+/**
+ * Holds a serializable copy of {@link RequiredRightsChangedResult}, used for
+ * {@link RequiredRightsEditConfirmationChecker} results comparison, when previously forced.
+ *
+ * @version $Id$
+ * @since 15.10RC1
+ */
+public class RequiredRightsChangedResultSkipValue implements Serializable
+{
+    private final Map<Right, Boolean> addedRights;
+
+    private final Map<Right, Boolean> removedRights;
+
+    private final List<RequiredRightAnalysisResultSkipValue> added;
+
+    private final List<RequiredRightAnalysisResultSkipValue> removed;
+
+    /**
+     * Creates a new instance of the RequiredRightsChangedSkipValue class.
+     *
+     * @param addedRights a map of rights that have been added
+     * @param removedRights a map of rights that have been removed
+     * @param added a list of serialized {@link RequiredRightAnalysisResult} for the added results
+     * @param removed a list of serialized {@link RequiredRightAnalysisResult} for the removed results
+     */
+    public RequiredRightsChangedResultSkipValue(Map<Right, Boolean> addedRights, Map<Right, Boolean> removedRights,
+        List<RequiredRightAnalysisResultSkipValue> added, List<RequiredRightAnalysisResultSkipValue> removed)
+    {
+
+        this.addedRights = addedRights;
+        this.removedRights = removedRights;
+        this.added = added;
+        this.removed = removed;
+    }
+
+    @Override
+    public boolean equals(Object object)
+    {
+        if (this == object) {
+            return true;
+        }
+
+        if (object == null || getClass() != object.getClass()) {
+            return false;
+        }
+
+        RequiredRightsChangedResultSkipValue that = (RequiredRightsChangedResultSkipValue) object;
+
+        return new EqualsBuilder()
+            .append(this.addedRights, that.addedRights)
+            .append(this.removedRights, that.removedRights)
+            .append(this.added, that.added)
+            .append(this.removed, that.removed)
+            .isEquals();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return new HashCodeBuilder(17, 37)
+            .append(this.addedRights)
+            .append(this.removedRights)
+            .append(this.added)
+            .append(this.removed)
+            .toHashCode();
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/test/java/org/xwiki/platform/security/requiredrights/internal/RequiredRightsEditConfirmationCheckerTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/test/java/org/xwiki/platform/security/requiredrights/internal/RequiredRightsEditConfirmationCheckerTest.java
@@ -19,7 +19,6 @@
  */
 package org.xwiki.platform.security.requiredrights.internal;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -32,7 +31,6 @@ import javax.script.ScriptContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.xwiki.model.document.DocumentAuthors;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.validation.edit.EditConfirmationCheckerResult;
@@ -192,9 +190,7 @@ class RequiredRightsEditConfirmationCheckerTest
             WordBlock wordBlock = invocation.getArgument(0);
             printer.print(wordBlock.getWord());
             return null;
-        })
-            .when(this.htmlBlockRender)
-            .render(Mockito.<Block>any(), any());
+        }).when(this.htmlBlockRender).render(any(Block.class), any());
 
         RequiredRightsChangedResult result = new RequiredRightsChangedResult();
         DocumentReference documentReference = new DocumentReference("xwiki", "Space", "Page");

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/test/java/org/xwiki/platform/security/requiredrights/internal/RequiredRightsEditConfirmationCheckerTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/test/java/org/xwiki/platform/security/requiredrights/internal/RequiredRightsEditConfirmationCheckerTest.java
@@ -19,15 +19,20 @@
  */
 package org.xwiki.platform.security.requiredrights.internal;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
+import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Provider;
 import javax.script.ScriptContext;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.xwiki.model.document.DocumentAuthors;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.validation.edit.EditConfirmationCheckerResult;
@@ -35,7 +40,13 @@ import org.xwiki.platform.security.requiredrights.RequiredRightAnalysisResult;
 import org.xwiki.platform.security.requiredrights.RequiredRightAnalyzer;
 import org.xwiki.platform.security.requiredrights.RequiredRightsException;
 import org.xwiki.platform.security.requiredrights.internal.configuration.RequiredRightsConfiguration;
+import org.xwiki.platform.security.requiredrights.internal.editconfirmationchecker.RequiredRightAnalysisResultSkipValue;
+import org.xwiki.platform.security.requiredrights.internal.editconfirmationchecker.RequiredRightsChangedResultSkipValue;
+import org.xwiki.rendering.block.Block;
+import org.xwiki.rendering.block.WordBlock;
 import org.xwiki.rendering.block.XDOM;
+import org.xwiki.rendering.renderer.BlockRenderer;
+import org.xwiki.rendering.renderer.printer.DefaultWikiPrinter;
 import org.xwiki.script.ScriptContextManager;
 import org.xwiki.security.authorization.ContextualAuthorizationManager;
 import org.xwiki.security.authorization.Right;
@@ -51,7 +62,7 @@ import static com.xpn.xwiki.doc.XWikiDocument.CKEY_TDOC;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -106,6 +117,10 @@ class RequiredRightsEditConfirmationCheckerTest
 
     @Mock
     private ScriptContext scriptContext;
+
+    @Inject
+    @Named("html/5.0")
+    private BlockRenderer htmlBlockRender;
 
     @BeforeEach
     void setUp() throws Exception
@@ -168,12 +183,34 @@ class RequiredRightsEditConfirmationCheckerTest
     @Test
     void check()
     {
+        Block summary = new WordBlock("summary");
+        Block details = new WordBlock("details");
+
         when(this.requiredRightsConfiguration.getDocumentProtection()).thenReturn(WARNING);
+        doAnswer(invocation -> {
+            DefaultWikiPrinter printer = invocation.getArgument(1);
+            WordBlock wordBlock = invocation.getArgument(0);
+            printer.print(wordBlock.getWord());
+            return null;
+        })
+            .when(this.htmlBlockRender)
+            .render(Mockito.<Block>any(), any());
+
         RequiredRightsChangedResult result = new RequiredRightsChangedResult();
-        result.add(mock(RequiredRightAnalysisResult.class), Right.SCRIPT, true, false);
+        DocumentReference documentReference = new DocumentReference("xwiki", "Space", "Page");
+        result.add(new RequiredRightAnalysisResult(documentReference,
+                () -> summary,
+                () -> details, List.of()),
+            Right.SCRIPT,
+            true,
+            false);
         when(this.requiredRightsChangedFilter.filter(any(), any())).thenReturn(result);
-        assertEquals(Optional.of(new EditConfirmationCheckerResult(XDOM, false, result)),
-            this.editConfirmationChecker.check());
+        Optional<EditConfirmationCheckerResult> expected = Optional.of(new EditConfirmationCheckerResult(XDOM, false,
+            new RequiredRightsChangedResultSkipValue(Map.of(Right.SCRIPT, false), Map.of(),
+                List.of(new RequiredRightAnalysisResultSkipValue(documentReference, List.of(), "summary", "details")),
+                List.of())));
+        Optional<EditConfirmationCheckerResult> check = this.editConfirmationChecker.check();
+        assertEquals(expected, check);
         verify(this.templateManager)
             .executeNoException("security/requiredrights/requiredRightsEditConfirmationChecker.vm");
     }

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-test/xwiki-platform-security-requiredrights-test-docker/src/test/it/org/xwiki/security/requiredrights/test/ui/RequiredRightsIT.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-test/xwiki-platform-security-requiredrights-test-docker/src/test/it/org/xwiki/security/requiredrights/test/ui/RequiredRightsIT.java
@@ -73,7 +73,7 @@ class RequiredRightsIT
 
         setup.createUserAndLogin("U1", "U1p");
 
-        // Create a page with a title containing a string that could be interpreted as velocity.
+        // Create a page with two velocity macros, by an user without script right.
         setup.createPage(testReference, "{{velocity}}macro1{{/velocity}}\n"
             + "{{velocity}}macro2{{/velocity}}", "");
 

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-test/xwiki-platform-security-requiredrights-test-docker/src/test/it/org/xwiki/security/requiredrights/test/ui/RequiredRightsIT.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-test/xwiki-platform-security-requiredrights-test-docker/src/test/it/org/xwiki/security/requiredrights/test/ui/RequiredRightsIT.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 @UITest(properties = {
     "xwikiPropertiesAdditionalProperties=security.requiredRights.protection=warning",
-    "xwikiCfgPlugins=com.xpn.xwiki.plugin.skinx.JsResourceSkinExtensionPlugin," 
+    "xwikiCfgPlugins=com.xpn.xwiki.plugin.skinx.JsResourceSkinExtensionPlugin,"
         + "com.xpn.xwiki.plugin.skinx.CssResourceSkinExtensionPlugin"
 })
 class RequiredRightsIT
@@ -62,5 +62,40 @@ class RequiredRightsIT
             requiredRightsPreEditCheckElement.getSummary(0));
         requiredRightsPreEditCheckElement.toggleDetailedMessage(0);
         assertEquals("The title is [Hello $a].", requiredRightsPreEditCheckElement.getDetailedMessage(0));
+    }
+
+    @Test
+    void checkContentWithVelocityMacro(TestUtils setup, TestReference testReference)
+    {
+        setup.loginAsSuperAdmin();
+
+        setup.deletePage(testReference);
+
+        setup.createUserAndLogin("U1", "U1p");
+
+        // Create a page with a title containing a string that could be interpreted as velocity.
+        setup.createPage(testReference, "{{velocity}}macro1{{/velocity}}\n"
+            + "{{velocity}}macro2{{/velocity}}", "");
+
+        setup.loginAsSuperAdmin();
+
+        setup.gotoPage(testReference, "edit");
+
+        RequiredRightsPreEditCheckElement requiredRightsPreEditCheckElement = new RequiredRightsPreEditCheckElement()
+            .toggleDetails();
+        assertEquals(2, requiredRightsPreEditCheckElement.count());
+        assertEquals("A [velocity] scripting macro requires script rights.",
+            requiredRightsPreEditCheckElement.getSummary(0));
+        requiredRightsPreEditCheckElement.toggleDetailedMessage(0);
+        assertEquals("Content\n"
+            + "the velocity script to execute\n"
+            + "macro1", requiredRightsPreEditCheckElement.getDetailedMessage(0));
+
+        assertEquals("A [velocity] scripting macro requires script rights.",
+            requiredRightsPreEditCheckElement.getSummary(1));
+        requiredRightsPreEditCheckElement.toggleDetailedMessage(1);
+        assertEquals("Content\n"
+            + "the velocity script to execute\n"
+            + "macro2", requiredRightsPreEditCheckElement.getDetailedMessage(1));
     }
 }


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-21477


* Fix a regression where results involving the same rights are wrongfully considered equals.

Follow up of https://github.com/xwiki/xwiki-platform/pull/2598 and https://github.com/xwiki/xwiki-platform/pull/2595