### PR TITLE
Misc: Select does not scroll

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/FormContainerElement.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/FormContainerElement.java
@@ -174,7 +174,9 @@ public class FormContainerElement extends BaseElement
 
     public SelectElement getSelectElement(By by)
     {
-        return this.new SelectElement(getFormElement().findElement(by));
+        WebElement element = getFormElement().findElement(by);
+        getDriver().scrollTo(element);
+        return this.new SelectElement(element);
     }
 
     public class SelectElement extends BaseElement


### PR DESCRIPTION
## PR Changes
* Forced scrolling on selection

## Notes
* Fix for the CI fail: https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/master/6982/testReport/junit/org.xwiki.test.ui/SkinxTest/Platform_Builds___main___distribution___flavor_test_ui___Build_for_Flavor_Test___UI___testJavascriptExtension/
* I'm not sure of how the scrollTo function works, it's supposed to be called when doing `getFormElement().findElement(by)`, but it did not work properly from here. If I had to guess, it's because the context is limited to the formElement, so it does not try to scroll the whole page but just the form, which does not work. In any case, I added a scrollTo call from the driver, so it works properly here.

## Tests
After re building with ` mvn clean install -f xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui  -Dxwiki.checkstyle.skip=true -Dxwiki.surefire.captureconsole.skip=true -Dxwiki.revapi.skip=true -Dxwiki.spoon.skip=true -Dxwiki.enforcer.skip=true`, the tests in `mvn clean install -f xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/ -Dpattern="SkinxTest#testJavascriptExtension"` were successfully passed, even with a window size similar to the CI conditions. With the same window size and without those changes, I could reproduce the CI failure consistently locally.