### PR TITLE
XWIKI-21579: Invalid lang HTML Tag when "German (Germany)" locale is set

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
@@ -59,7 +59,7 @@
   #else
     &lt;!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"&gt;
   #end
-  &lt;html xmlns="http://www.w3.org/1999/xhtml" lang="$xcontext.locale" xml:lang="$xcontext.locale"&gt;
+  &lt;html xmlns="http://www.w3.org/1999/xhtml" lang="$xcontext.locale.toLanguageTag()" xml:lang="$xcontext.locale"&gt;
     &lt;head&gt;
       &lt;meta http-equiv="Content-Type" content="text/html; charset=$xwiki.encoding" /&gt;
       ## Add HTML tags inside the page's head element, provided by UI Extensions implementing the 

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/htmlheader.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/htmlheader.vm
@@ -61,7 +61,7 @@
   #addMetaAttribute($metaAttributes, 'user-reference', $!services.model.serialize($xcontext.userReference, 'default'))
 #end
 
-<html xmlns="http://www.w3.org/1999/xhtml" lang="$xcontext.locale" xml:lang="$xcontext.locale" $stringtool.join($metaAttributes, ' ')>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="$xcontext.locale.toLanguageTag()" xml:lang="$xcontext.locale" $stringtool.join($metaAttributes, ' ')>
   <head>
     ## ---------------------------------------------------------------------------------------------------------------
     ## Ensure that the Content-Type meta directive is the first one in the header.

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/office.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/office.vm
@@ -20,7 +20,7 @@
 <?xml version="1.0" encoding="$xwiki.encoding" ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
     "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="$xcontext.locale" xml:lang="$xcontext.locale">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="$xcontext.locale.toLanguageTag()" xml:lang="$xcontext.locale">
 <head>
 <title>$escapetool.html($request.attachment)</title>
 <meta http-equiv="Content-Type" content="text/html; charset=$xwiki.encoding" />


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21579
## PR Changes
* Used the method from the java Locale object that's appropriate for our use case
## Notes
* I searched all occurences for `lang="$xcontext` in the xwiki-platform codebase and replaced the `Locale` .toString call to get the return value from the appropriate method instead. The `Locale` class from java.util has a function just for this use case: [toLanguageTag()](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Locale.html?is-external=true#forLanguageTag(java.lang.String)). This is enough of a fix for the accessibility test that initiated the reporting of this issue to pass and should be enough for long term.
* This fix was not found earlier, because most of our testing and every default instance is configured on the `en` locale, which has no subtag (the `Locale` `toString()` and its `forLanguageTag()` return the same value). 

## View
On the screenshot below, we can see the return values of both the former and new values proposed for the lang attribute.
![21579-demo](https://github.com/xwiki/xwiki-platform/assets/28761965/201ff5e4-3a4b-4f9a-a2f8-a6535cb3f45d)
On the screenshot below, we can see that the `<html>` block has an attribute `lang` which has a correct value (for the sake of the demo, default language has been updated to en-GB).
![21579-demo2](https://github.com/xwiki/xwiki-platform/assets/28761965/bc5b3e73-268b-4617-a8d2-ccdeffb889e6)

