### PR TITLE
XWIKI-21482: Introduce a required rights analyzer for the HTML macro

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/pom.xml
@@ -98,6 +98,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-xml</artifactId>
+      <version>${commons.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
     </dependency>

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/java/org/xwiki/rendering/internal/macro/HTMLMacroRequiredRightsAnalyzer.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/java/org/xwiki/rendering/internal/macro/HTMLMacroRequiredRightsAnalyzer.java
@@ -1,0 +1,108 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rendering.internal.macro;
+
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.w3c.dom.Document;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.platform.security.requiredrights.MacroRequiredRight;
+import org.xwiki.platform.security.requiredrights.MacroRequiredRightReporter;
+import org.xwiki.platform.security.requiredrights.MacroRequiredRightsAnalyzer;
+import org.xwiki.properties.ConverterManager;
+import org.xwiki.rendering.block.MacroBlock;
+import org.xwiki.xml.html.HTMLCleaner;
+import org.xwiki.xml.html.HTMLCleanerConfiguration;
+import org.xwiki.xml.html.filter.HTMLFilter;
+import org.xwiki.xml.internal.html.filter.SanitizerDetectorFilter;
+
+/**
+ * Required rights analyzer for the HTML macro.
+ *
+ * @version $Id$
+ * @since 15.10
+ */
+@Component
+@Singleton
+@Named("html")
+public class HTMLMacroRequiredRightsAnalyzer implements MacroRequiredRightsAnalyzer
+{
+    private static final String TRANSLATION_PREFIX = "rendering.macro.htmlRequiredRights.";
+
+    @Inject
+    private HTMLCleaner htmlCleaner;
+
+    @Inject
+    private ConverterManager converter;
+
+    @Inject
+    @Named(SanitizerDetectorFilter.ID)
+    private HTMLFilter restrictedFilterDetector;
+
+    @Override
+    public void analyze(MacroBlock macroBlock, MacroRequiredRightReporter reporter)
+    {
+        boolean wiki = Boolean.TRUE.equals(this.converter.convert(Boolean.class, macroBlock.getParameter("wiki")));
+        String cleanParameter = macroBlock.getParameter("clean");
+        // Cleaning is enabled by default.
+        boolean clean =
+            cleanParameter == null || Boolean.TRUE.equals(this.converter.convert(Boolean.class, cleanParameter));
+
+        if (wiki) {
+            reporter.analyzeContent(macroBlock, macroBlock.getContent());
+        }
+
+        if (!clean) {
+            reporter.report(macroBlock, List.of(MacroRequiredRight.SCRIPT),
+                TRANSLATION_PREFIX + "noClean");
+        } else if (wiki) {
+            reporter.report(macroBlock, List.of(MacroRequiredRight.MAYBE_SCRIPT),
+                TRANSLATION_PREFIX + "wikiContent");
+        } else {
+            HTMLCleanerConfiguration cleanerConfiguration = this.htmlCleaner.getDefaultConfiguration();
+            Map<String, String> parameters = new HashMap<>(cleanerConfiguration.getParameters());
+            // Assume HTML 5 as there is no real way to determine the target version of the rendering action. Also,
+            // the analysis shouldn't really be affected by the HTML version.
+            parameters.put(HTMLCleanerConfiguration.HTML_VERSION, "5");
+            cleanerConfiguration.setParameters(parameters);
+
+            // Add the filter for detecting content that would be filtered by restricted mode.
+            List<HTMLFilter> filters = new ArrayList<>(cleanerConfiguration.getFilters());
+            filters.add(this.restrictedFilterDetector);
+            cleanerConfiguration.setFilters(filters);
+
+            Document document = this.htmlCleaner.clean(new StringReader(macroBlock.getContent()), cleanerConfiguration);
+            if (Boolean.parseBoolean(document.getDocumentElement()
+                .getAttribute(SanitizerDetectorFilter.ATTRIBUTE_FILTERED)))
+            {
+                reporter.report(macroBlock, List.of(MacroRequiredRight.SCRIPT),
+                    TRANSLATION_PREFIX + "dangerousContent");
+            }
+        }
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/resources/ApplicationResources.properties
@@ -45,3 +45,9 @@
 rendering.error.causedBy=Cause: [{0}].
 rendering.error.click=Click on this message for details.
 rendering.macro.rawMacroRequiredRights=Using the raw macro for HTML content requires script right.
+
+rendering.macro.htmlRequiredRights.noClean=An HTML macro with cleaning disabled requires script right.
+rendering.macro.htmlRequiredRights.wikiContent=An HTML macro with wiki content could require script right depending \
+  on the content, please review the content carefully.
+rendering.macro.htmlRequiredRights.dangerousContent=An HTML macro that contains content that would be removed by \
+  cleaning in restricted mode requires script right to avoid restricted cleaning.

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/resources/META-INF/components.txt
@@ -4,6 +4,7 @@
 500:org.xwiki.rendering.internal.util.XWikiErrorBlockGenerator
 500:org.xwiki.rendering.internal.wiki.XWikiWikiModel
 500:org.xwiki.rendering.internal.macro.XWikiHTMLRawBlockFilter
+org.xwiki.rendering.internal.macro.HTMLMacroRequiredRightsAnalyzer
 org.xwiki.rendering.internal.macro.RawMacroRequiredRightsAnalyzer
 org.xwiki.rendering.internal.resolver.AttachmentResourceReferenceEntityReferenceResolver
 org.xwiki.rendering.internal.resolver.DefaultResourceReferenceEntityReferenceResolver

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/test/java/org/xwiki/rendering/internal/macro/HTMLMacroRequiredRightsAnalyzerTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/test/java/org/xwiki/rendering/internal/macro/HTMLMacroRequiredRightsAnalyzerTest.java
@@ -1,0 +1,133 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rendering.internal.macro;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
+import org.xwiki.platform.security.requiredrights.MacroRequiredRight;
+import org.xwiki.platform.security.requiredrights.MacroRequiredRightReporter;
+import org.xwiki.properties.ConverterManager;
+import org.xwiki.rendering.block.MacroBlock;
+import org.xwiki.rendering.listener.Listener;
+import org.xwiki.test.annotation.ComponentList;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+import org.xwiki.xml.html.DefaultHTMLCleanerComponentList;
+import org.xwiki.xml.internal.html.filter.SanitizerDetectorFilter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit test for {@link HTMLMacroRequiredRightsAnalyzer}.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+@DefaultHTMLCleanerComponentList
+@ComponentList(SanitizerDetectorFilter.class)
+class HTMLMacroRequiredRightsAnalyzerTest
+{
+    private static final String HTML_MACRO_ID = "html";
+
+    @MockComponent
+    private ConverterManager converterManager;
+
+    @InjectMockComponents
+    private HTMLMacroRequiredRightsAnalyzer htmlMacroRequiredRightsAnalyzer;
+
+    @BeforeEach
+    void setUp()
+    {
+        when(this.converterManager.convert(eq(Boolean.class), any())).thenAnswer(invocation -> {
+            String parameter = invocation.getArgument(1);
+            return Boolean.valueOf(parameter);
+        });
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "<a href='javascript:alert()'>test, true, false, true",
+        "<a href='https://xwiki.org'>XWiki, true, false, false",
+        "<div>, false, false, true",
+        "<div>**wiki**, false, true, true",
+        "<div>**wiki**, true, true, true",
+    })
+    void analyze(String content, boolean clean, boolean wiki, boolean needsScript)
+    {
+        MacroBlock macroBlock = new MacroBlock(HTML_MACRO_ID,
+            Map.of("wiki", String.valueOf(wiki), "clean", String.valueOf(clean)),
+            content, false);
+
+        MacroRequiredRightReporter reporter = mock();
+        this.htmlMacroRequiredRightsAnalyzer.analyze(macroBlock, reporter);
+
+        if (wiki) {
+            verify(reporter).analyzeContent(macroBlock, content);
+        }
+
+        if (needsScript) {
+            // Capture the required rights to assert different values depending on the parameters.
+            ArgumentCaptor<List<MacroRequiredRight>> argumentCaptor = ArgumentCaptor.captor();
+            verify(reporter).report(eq(macroBlock), argumentCaptor.capture(), anyString());
+            List<MacroRequiredRight> requiredRights = argumentCaptor.getValue();
+            // For wiki syntax with cleaning enabled, we cannot analyze the content in advance, so we cannot be sure.
+            // For other cases, the result is clear, either cleaning is explicitly disabled or dangerous content has
+            // been detected.
+            if (wiki && clean) {
+                assertEquals(List.of(MacroRequiredRight.MAYBE_SCRIPT), requiredRights);
+            } else {
+                assertEquals(List.of(MacroRequiredRight.SCRIPT), requiredRights);
+            }
+        } else {
+            verifyNoMoreInteractions(reporter);
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "Comment: <!-- comment -->, true",
+        "<a href='https://xwiki.org'>XWiki, false",
+    })
+    void analyzeWithoutParameters(String content, boolean scriptRequired)
+    {
+        MacroBlock macroBlock = new MacroBlock(HTML_MACRO_ID, Listener.EMPTY_PARAMETERS, content, false);
+
+        MacroRequiredRightReporter reporter = mock();
+        this.htmlMacroRequiredRightsAnalyzer.analyze(macroBlock, reporter);
+
+        if (scriptRequired) {
+            verify(reporter).report(eq(macroBlock), eq(List.of(MacroRequiredRight.SCRIPT)), anyString());
+        }
+        verifyNoMoreInteractions(reporter);
+    }
+}


### PR DESCRIPTION
* Add a required rights analyzer for the HTML macro.
* Add a unit test that is almost an integration test as it tests with a real HTML cleaner.

Jira issue: https://jira.xwiki.org/browse/XWIKI-21482

This depends on xwiki/xwiki-commons#651.