### PR TITLE
XWIKI-21583: Invitation decline link lacks contrast

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/variablesInit.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/variablesInit.vm
@@ -261,7 +261,7 @@
   @state-danger-bg:                     #f8ecec;
   @state-success-bg:                    #e5f3df;
   @state-info-bg:                       #e1f1f9;
-  ## We want to keep overwritting the @brand-danger value from bootstrap as it does not pass contrast checks on #fff
+  ## We override the @brand-danger value from bootstrap as it does not pass contrast checks on #fff
   @brand-danger:                        #cc3333;
 #end
 

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/variablesInit.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/variablesInit.vm
@@ -261,6 +261,8 @@
   @state-danger-bg:                     #f8ecec;
   @state-success-bg:                    #e5f3df;
   @state-info-bg:                       #e1f1f9;
+  ## We want to keep overwritting the @brand-danger value from bootstrap as it does not pass contrast checks on #fff
+  @brand-danger:                        #cc3333;
 #end
 
 ##############################################

--- a/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/main/resources/Invitation/InvitationCommon.xml
+++ b/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/main/resources/Invitation/InvitationCommon.xml
@@ -778,7 +778,7 @@
       <messageBodyTemplate>{{velocity}}
 #set($discard = "#template('colorThemeInit.vm')")
 #if("$!theme" == "")
- #set($theme = {"linkColor":"#4791BC"})
+ #set($theme = {"linkColor":"#4791BC", "notificationErrorColor":"#ca302c"}})
 #end
 #set($userName = $xwiki.getUserName($xcontext.getUser(), false))
 #set($wikiName = $xwiki.getRequestURL().replaceAll("http://([^/:]*).*$", "$1"))
@@ -786,7 +786,8 @@
 #set($linkStyle = "color:$theme.get('linkColor');text-decoration:none;")
 #set($bigText = "font-size:130%;")
 #set($joinLink = "float:left;")
-#set($declineLink = "color:#f88;float:right;text-decoration:none;")
+#set($dangerColor = $theme.notificationErrorColor)
+#set($declineLink = "color:$dangerColor;float:right;text-decoration:none;")
 
 $services.localization.render('xe.invitation.emailContent.userHasInvitedYouToJoinWiki', [$userName, $wikiName])
 


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21583
## PR Changes
* Updated variablesInit to overwrite the default value got from bootstrap even when there's no theme
* Updated InvitationCommon.xml to match the changes made previously in InvitationConfig.xml
## Tests
Running `mvn clean install -f xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-test -Dxwiki.test.ui.wcag=true -Pdocker` now only returns two WCAG violations, that are unrelated to contrast, and not the 9 or so extra that are currently returned in CI.

## View
Here is a demonstration of this link on an instance without a theme. We can see that unlike before, the link is correctly initialized to the expected value and not to the one from bootstrap.
![21583-demoOnInstance](https://github.com/xwiki/xwiki-platform/assets/28761965/950916b4-35b3-4c75-96cf-6a4d0252d32d)
