### PR TITLE
XWIKI-21584: Mentions do not have enough contrast

### DIFF
--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-ui/src/main/resources/XWiki/Mentions/Configuration.xml
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-ui/src/main/resources/XWiki/Mentions/Configuration.xml
@@ -355,13 +355,13 @@
       </selfMentionsColor>
     </class>
     <property>
-      <mentionsColor>rgba(194, 194, 194, 0.8)</mentionsColor>
+      <mentionsColor>@breadcrumb-bg</mentionsColor>
     </property>
     <property>
       <quoteActivated>1</quoteActivated>
     </property>
     <property>
-      <selfMentionsColor>rgba(255, 0, 1, 0.5)</selfMentionsColor>
+      <selfMentionsColor>@btn-danger-bg</selfMentionsColor>
     </property>
   </object>
 </xwikidoc>

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-ui/src/main/resources/XWiki/Mentions/MentionsMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-ui/src/main/resources/XWiki/Mentions/MentionsMacro.xml
@@ -374,12 +374,15 @@ require(['deferred!ckeditor', 'xwiki-suggestUsers', 'jquery', 'xwiki-meta'], fun
     <property>
       <code>.xwiki-mention {
   background-color: $services.mentions.mentionsColor;
-  border-radius: 10px;
-  padding: 2px 5px 2px 5px;
+  border-radius: @border-radius-small;
+  padding: 1px 5px 1px 5px;
+  border: 1px solid @dropdown-divider-bg;
 }
 
 .xwiki-mention.user.self {
   background-color: $services.mentions.selfMentionsColor;
+  color: @btn-danger-color;
+  border: 0;
 }
 
 .xwiki-mention.removed {
@@ -391,7 +394,7 @@ blockquote.mention-quote {
 }</code>
     </property>
     <property>
-      <contentType>CSS</contentType>
+      <contentType>LESS</contentType>
     </property>
     <property>
       <name/>


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21584
## PR Changes
* Updated the default style of mentions
## View
vvv Before the PR
![21584-beforePR](https://github.com/xwiki/xwiki-platform/assets/28761965/8e108384-e0c9-4af0-bc9a-f76d966a2a80)
vvv After the PR
![21584-afterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/0a5d4290-db78-4870-82d3-39ec3f93bde7)

## Note
This is a style change, but I also took the opportunity to remove hard-coded transparent colors. Hard coded is against best practice, and adding transparency does not make sense in this context, the mention is too small to cover anything.