### PR TITLE
XWIKI-21585: Hidden headers add unwanted padding

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/action-menus.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/action-menus.less
@@ -319,6 +319,11 @@
 
   .btn-group > dl.dropdown-menu {
     & > dt.dropdown-header {
+      &.sr-only {
+        // Overwrite bootstrap default style that would take priority on .sr-only style
+        padding: 0;
+      }
+      
       // Use the bootstrap style for our semantic architecture
       &:extend(li.dropdown-header);
       font-weight: initial;


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21585
## PR Changes
* Overwrote bootstrap style to give priority to the .sr-only over .dropdown-header
## View
vvv Before the PR
![unwantedPadding](https://github.com/xwiki/xwiki-platform/assets/28761965/5588a187-72a9-40c9-8dc1-b2916b756710)
We can see that the .sr-only element is not fully hidden, which adds a bit of padding in places where there should be none.
vvv After the PR
![21585-afterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/50957077-9cc3-4c42-8640-2edc52348c36)
There is no padding for those elements, as expected.
