### PR TITLE
XWIKI-20829: LiveData image alt with silk icons

### DIFF
--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-ui/src/main/resources/IconThemes/Silk.xml
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-ui/src/main/resources/IconThemes/Silk.xml
@@ -38,8 +38,8 @@
   <hidden>true</hidden>
   <content>## General settings
 xwiki.iconset.type = image
-xwiki.iconset.render.wiki = [[image:path:$xwiki.getSkinFile("icons/silk/${icon}.png")||data-xwiki-lightbox="false"]]
-xwiki.iconset.render.html = &lt;img src="$xwiki.getSkinFile("icons/silk/${icon}.png")" alt="Icon" data-xwiki-lightbox="false" /&gt;
+xwiki.iconset.render.wiki = [[image:path:$xwiki.getSkinFile("icons/silk/${icon}.png")||alt="" data-xwiki-lightbox="false"]]
+xwiki.iconset.render.html = &lt;img src="$xwiki.getSkinFile("icons/silk/${icon}.png")" alt="" data-xwiki-lightbox="false" /&gt;
 xwiki.iconset.icon.url = $xwiki.getSkinFile("icons/silk/${icon}.png")
 
 ## XWiki Icon Set (see: http://design.xwiki.org/xwiki/bin/view/Proposal/XWiki+Icon+Set).

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/utilities/XWikiIcon.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/utilities/XWikiIcon.vue
@@ -22,6 +22,7 @@
   <img
     v-if="isImage"
     :src="url"
+    alt=""
   />
   <span
     v-else-if="isFont"


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-20829
## PR Changes
* Updated the silk icon theme and the XWikiIcon template to take into account the new code style
## Note
Since now we have a codestyle rule to assert that all icons should come wioth a text besides them, we can sefely make the assumption that the icon has no semantic meaning (or just a duplicate of the text besides it, which makes it recommended to not display to AT users).