### PR TITLE
XWIKI-21599: Theme creation form uses a silk icon

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/WebHomeSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/WebHomeSheet.xml
@@ -268,6 +268,7 @@
     {{html}}
       &lt;div class="theme-creation-form" &gt;
         &lt;form action="$doc.getURL()" method="post" class="form-inline"&gt;
+          $services.icon.renderHTML('add')
           &lt;input type="hidden" name="form_token" value="$services.csrf.token" /&gt;
           &lt;input type="hidden" name="action" value="create"/&gt;
           &lt;label for="newThemeName" class="hidden"&gt;$services.localization.render('platform.flamingo.themes.home.newThemeName')&lt;/label&gt;
@@ -620,10 +621,9 @@
 }
 
 .theme-creation-form form {
-  background: url("$xwiki.getSkinFile('icons/silk/add.png')") no-repeat .2em center $theme.backgroundSecondaryColor;
   border: 1px dotted $theme.borderColor;
   display: inline-block;
-  padding: .5em .5em .5em 22px;
+  padding: .5em;
   margin-bottom: 1em;
 }
 

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/WebHomeSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/WebHomeSheet.xml
@@ -621,7 +621,6 @@
 }
 
 .theme-creation-form form {
-  border: 1px dotted $theme.borderColor;
   display: inline-block;
   padding: .5em;
   margin-bottom: 1em;


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21599
## PR Changes
* Replaced the silk icon reference with a tangible iconset icon
## View
Before the PR
![ThemeCreationFormSilkIcon](https://github.com/xwiki/xwiki-platform/assets/28761965/2a9a5ccd-1148-4129-ab58-c25c9d34e233)
After the PR
![21599-afterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/2e0b45d8-07d2-4127-a775-b5555bc20f0a)
