### PR TITLE
XWIKI-21574: Errors in the wiki console when exporting a page as HTML

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsDisplayerUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsDisplayerUIX.xml
@@ -854,7 +854,7 @@ require(['jquery', 'xwiki-meta', 'xwiki-bootstrap-switch'], function ($, xm) {
 }
 
 .notifications-toggles .bootstrap-switch .bootstrap-switch-label {
-  background-image: linear-gradient($theme.buttonSecondaryGradientColor, $theme.buttonSecondaryBackgroundColor 50%);
+  background-color: $theme.buttonSecondaryBackgroundColor;
   color: $theme.buttonSecondaryTextColor;
 }
 


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21574
## PR Changes
* Removed the use of the variable interpreted to ""
## View
Before the PR
![21574-beforePR](https://github.com/xwiki/xwiki-platform/assets/28761965/9a36130b-5747-4b0f-8887-643e94f959dd)
After the PR
![21574-afterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/2ac7c54d-5798-4ce8-a07d-28f523da9c4a)
There is a slight change in the style of the toggle label, however this is barely noticeable even when flashing from one version to the other.
## Test
When running the HTML export on a page without the changes, I was able to reproduce the issue described (16.0-snapshot local distrib). With the changes, no error happened in the xwiki console, and the export ended successfully. :)

## Note
This PR should be cherry picked for 14.10.20 and 15.5.4