### PR TITLE
XWIKI-18624: more reliable Tomcat restart after XWiki installation / …

### DIFF
--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-tomcat/xwiki-platform-distribution-debian-tomcat9-mariadb/src/deb/control/postinst
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-tomcat/xwiki-platform-distribution-debian-tomcat9-mariadb/src/deb/control/postinst
@@ -8,7 +8,7 @@ set -e
 #########################
 
 # Restart tomcat9 service (only if it's active)
-if systemctl -q is-enabled tomcat9.service
+if ( systemctl -q is-active tomcat9.service || systemctl -q is-enabled tomcat9.service )
 then
   deb-systemd-invoke restart tomcat9.service
 fi

--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-tomcat/xwiki-platform-distribution-debian-tomcat9-mysql/src/deb/control/postinst
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-tomcat/xwiki-platform-distribution-debian-tomcat9-mysql/src/deb/control/postinst
@@ -8,7 +8,7 @@ set -e
 #########################
 
 # Restart tomcat9 service (only if it's active)
-if systemctl -q is-enabled tomcat9.service
+if ( systemctl -q is-active tomcat9.service || systemctl -q is-enabled tomcat9.service )
 then
   deb-systemd-invoke restart tomcat9.service
 fi

--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-tomcat/xwiki-platform-distribution-debian-tomcat9-pgsql/src/deb/control/postinst
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-tomcat/xwiki-platform-distribution-debian-tomcat9-pgsql/src/deb/control/postinst
@@ -8,7 +8,7 @@ set -e
 #########################
 
 # Restart tomcat9 service (only if it's active)
-if systemctl -q is-enabled tomcat9.service
+if ( systemctl -q is-active tomcat9.service || systemctl -q is-enabled tomcat9.service )
 then
   deb-systemd-invoke restart tomcat9.service
 fi


### PR DESCRIPTION
…upgrade

If the service is running, we need to restart it in any case, no matter if it's enabled or not.
However is-active does not always seem to work if the package just gets installed (see XWIKI-18624), so also check if it's only enabled and try to restart it then.

See https://forum.xwiki.org/t/no-tomcat-restart-after-xwiki-lts-debian-package-upgrade/13505 for discussion.