### PR TITLE
XWIKI-13999: Use the available horizontal space for page titles

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/contentheader.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/contentheader.vm
@@ -17,8 +17,8 @@
 ## Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 ## 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 ## ---------------------------------------------------------------------------
-<div class="row document-header">
-  <section class="document-info col-xs-12 #if($displayContentMenu)col-md-7#end"
+<div class="document-header">
+  <section class="document-info"
     aria-label="$escapetool.xml($services.localization.render('core.document.header.info.label'))">
     ## --------------------------------------------------------
     ## Display UI Extensions before the title element
@@ -47,7 +47,7 @@
     #end
   </section>
   #if($displayContentMenu)
-    <nav class="document-menu col-xs-12 col-md-5"
+    <nav class="document-menu"
       aria-label="$escapetool.xml($services.localization.render('core.document.header.menu.nav.label'))">
       #template("menus_content.vm")
     </nav>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
@@ -260,6 +260,8 @@
 .document-header {
   margin-top: -@line-height-computed;
   margin-bottom: @line-height-computed;
+  display: flex;
+  flex-wrap: wrap;
   #document-title h1 {
     word-wrap: break-word;
   }
@@ -269,6 +271,14 @@
   }
   .document-menu, .document-info {
     margin-top: @line-height-computed;
+  }
+  .document-info {
+    flex-grow: 1;
+  }
+  .document-menu {
+    margin-left: auto;
+    padding-left: @grid-gutter-width;
+    white-space: nowrap;
   }
 }
 


### PR DESCRIPTION
* Remove fixed columns from the document header.
* Use flexbox to dynamically grow the page title while still wrapping it when it doesn't fit.

I added a padding to the buttons as otherwise there was no more space between the buttons and the title. I'm not sure that this is the correct padding.

Jira issue: https://jira.xwiki.org/browse/XWIKI-13999

View mode with long title that wraps:

![image](https://github.com/xwiki/xwiki-platform/assets/198317/15fc9db9-d20c-4b5e-af12-b79c0f378cfd)

View mode with long title that doesn't wrap:

![image](https://github.com/xwiki/xwiki-platform/assets/198317/0dfe0e35-918f-4e37-b240-f142e03d260b)

Edit mode:

![image](https://github.com/xwiki/xwiki-platform/assets/198317/e846c26f-12d9-42b7-b09e-e6f6c8deee5a)