### PR TITLE
Second attempt at XWIKI-21447: Incorrect results when typing slowly in filter fields

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/webjar/liveDataSource.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/webjar/liveDataSource.js
@@ -21,15 +21,15 @@
 define('xwiki-livedata-source', ['module', 'jquery'], function(module, $) {
   'use strict';
 
-  var baseURL = module.config().contextPath + '/rest/liveData/sources/';
+  const baseURL = module.config().contextPath + '/rest/liveData/sources/';
 
   const entriesRequests = {};
 
-  var getEntries = function(liveDataQuery) {
-    var source = liveDataQuery.source;
-    var entriesURL = getEntriesURL(liveDataQuery.source);
+  function getEntries(liveDataQuery) {
+    const source = liveDataQuery.source;
+    const entriesURL = getEntriesURL(liveDataQuery.source);
 
-    var parameters = {
+    const parameters = {
       properties: liveDataQuery.properties,
       offset: liveDataQuery.offset,
       limit: liveDataQuery.limit
@@ -80,7 +80,7 @@ define('xwiki-livedata-source', ['module', 'jquery'], function(module, $) {
       .finally(cleanupRequest.bind(null, entriesRequest, sourceKey));
   };
 
-  var cleanupRequest = function(requestToClean, sourceKey) {
+  function cleanupRequest(requestToClean, sourceKey) {
     // We reset the request object to null for two reasons:
     // - avoid keeping an object we don't need anymore in memory, preventing it
     //   from being GC'd
@@ -95,13 +95,13 @@ define('xwiki-livedata-source', ['module', 'jquery'], function(module, $) {
     }
   };
 
-  var getEntriesURL = function(source) {
-    var entriesURL = baseURL + encodeURIComponent(source.id) + '/entries';
+  function getEntriesURL(source) {
+    const entriesURL = baseURL + encodeURIComponent(source.id) + '/entries';
     return addSourcePathParameters(source, entriesURL);
   };
 
   function addSourcePathParameters(source, url) {
-    var parameters = {
+    const parameters = {
       // Make sure the response is not retrieved from cache (IE11 doesn't obey the caching HTTP headers).
       timestamp: new Date().getTime(),
       namespace: `wiki:${XWiki.currentWiki}`
@@ -117,7 +117,7 @@ define('xwiki-livedata-source', ['module', 'jquery'], function(module, $) {
     const url = `${baseURL}${encodedSourceId}/entries/${encodedEntryId}/properties/${encodedPropertyId}`
     return addSourcePathParameters(source, url);
   }
-  
+
   function getEntryURL(source, entryId) {
     const encodedSourceId = encodeURIComponent(source.id);
     const encodedEntryId = encodeURIComponent(entryId);
@@ -125,7 +125,7 @@ define('xwiki-livedata-source', ['module', 'jquery'], function(module, $) {
     return addSourcePathParameters(source, url);
   }
 
-  var addSourceParameters = function(parameters, source) {
+  function addSourceParameters(parameters, source) {
     $.each(source, (key, value) => {
       if (key !== 'id') {
         parameters['sourceParams.' + key] = value;
@@ -133,17 +133,17 @@ define('xwiki-livedata-source', ['module', 'jquery'], function(module, $) {
     });
   };
 
-  var toLiveData = function(data) {
+  function toLiveData(data) {
     return {
       count: data.count,
       entries: data.entries.map(entry => entry.values)
     };
   };
 
-  var addEntry = function(source, entry) {
+  function addEntry(source, entry) {
     return Promise.resolve($.post(getEntriesURL(source), entry).then(e => e.values));
   };
-  
+
   function updateEntry(source, entryId, values) {
     return Promise.resolve($.ajax({
       type: 'PUT',
@@ -153,17 +153,13 @@ define('xwiki-livedata-source', ['module', 'jquery'], function(module, $) {
     }));
   }
 
-  var getTranslations = function(locale, prefix, keys) {
+  function getTranslations(locale, prefix, key) {
     const translationsURL = `${module.config().contextPath}/rest/wikis/${XWiki.currentWiki}/localization/translations`;
-    return Promise.resolve($.getJSON(translationsURL, $.param({
-      locale: locale,
-      prefix: prefix,
-      key: keys
-    }, true)).then(toTranslationsMap));
+    return Promise.resolve($.getJSON(translationsURL, $.param({locale, prefix, key}, true)).then(toTranslationsMap));
   };
 
-  var toTranslationsMap = function(responseJSON) {
-    var translationsMap = {};
+  function toTranslationsMap(responseJSON) {
+    const translationsMap = {};
     responseJSON.translations?.forEach(translation => translationsMap[translation.key] = translation.rawSource);
     return translationsMap;
   };
@@ -180,7 +176,7 @@ define('xwiki-livedata-source', ['module', 'jquery'], function(module, $) {
   return {
     getEntries,
     addEntry,
-    updateEntry, 
+    updateEntry,
     updateEntryProperty,
     getTranslations
   };


### PR DESCRIPTION
Hi,

We had to revert https://github.com/xwiki/xwiki-platform/pull/2487 because it was causing issues when several live tables are on the same page: requests for one live data table could be aborted by another live data table loading. And this is likely because it is usual that all the livetables on a page load at the same time, at page load time.

This second attempt only cancels requests from the same source.

I see a potential issue and the draft status: if several live tables are on a page with the same source and load at the same time, one of the live table might not load. I'm not sure how we could handle this. Should we resolve all the promises corresponding to requests we abort when a request of the same source completes? But then this might cause that tables to "blink"?

WDYT @mflorea @manuelleduc?