### PR TITLE
XWIKI-21439: Security Cache ConflictingInsertionException

### DIFF
--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/reference/EntityReference.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/reference/EntityReference.java
@@ -32,6 +32,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.xwiki.model.EntityType;
 import org.xwiki.model.internal.reference.DefaultSymbolScheme;
 import org.xwiki.model.internal.reference.LocalizedStringEntityReferenceSerializer;
+import org.xwiki.stability.Unstable;
 
 /**
  * Represents a reference to an Entity (Document, Attachment, Space, Wiki, etc).
@@ -511,6 +512,43 @@ public class EntityReference implements Serializable, Cloneable, Comparable<Enti
         }
 
         return actualParent != null;
+    }
+
+    /**
+     * Get a reference that is equal to this reference with all parameters removed.
+     *
+     * @param recursive whether to remove parameters recursively from all ancestors
+     * @return the reference without parameters
+     * @since 15.10.1
+     * @since 15.5.5
+     * @since 14.10.20
+     */
+    @Unstable
+    public EntityReference removeParameters(boolean recursive)
+    {
+        EntityReference current;
+        if (!recursive) {
+            if (getParameters().isEmpty()) {
+                current = this;
+            } else {
+                current = new EntityReference(getName(), getType(), getParent());
+            }
+        } else {
+            current = null;
+
+            for (EntityReference entry : getReversedReferenceChain()) {
+                // Create a new reference with the same name and type as the current one but without parameters, but
+                // only if this is actually necessary, i.e., if there are actually any parameters or any ancestor has
+                // been modified.
+                if (entry.getParent() == current && entry.getParameters().isEmpty()) {
+                    current = entry;
+                } else {
+                    current = new EntityReference(entry.getName(), entry.getType(), current);
+                }
+            }
+        }
+
+        return current;
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/EntityReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/EntityReferenceTest.java
@@ -51,6 +51,12 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 public class EntityReferenceTest
 {
+    private static final String SPACE_NAME = "space";
+
+    private static final String WIKI_NAME = "wiki";
+
+    private static final String PAGE_NAME = "page";
+
     private Map<String, Serializable> getParamMap(int nb)
     {
         Map<String, Serializable> map = new HashMap<>(nb);
@@ -73,10 +79,10 @@ public class EntityReferenceTest
     @Test
     public void extractReference()
     {
-        EntityReference wiki = new EntityReference("wiki", EntityType.WIKI);
+        EntityReference wiki = new EntityReference(WIKI_NAME, EntityType.WIKI);
         EntityReference space1 = new EntityReference("space1", EntityType.SPACE, wiki);
         EntityReference space2 = new EntityReference("space2", EntityType.SPACE, space1);
-        EntityReference reference = new EntityReference("page", EntityType.DOCUMENT, space2);
+        EntityReference reference = new EntityReference(PAGE_NAME, EntityType.DOCUMENT, space2);
 
         assertSame(wiki, reference.extractReference(EntityType.WIKI));
         assertSame(space2, reference.extractReference(EntityType.SPACE));
@@ -87,10 +93,10 @@ public class EntityReferenceTest
     @Test
     public void extractFirstReference()
     {
-        EntityReference wiki = new EntityReference("wiki", EntityType.WIKI);
+        EntityReference wiki = new EntityReference(WIKI_NAME, EntityType.WIKI);
         EntityReference space1 = new EntityReference("space1", EntityType.SPACE, wiki);
         EntityReference space2 = new EntityReference("space2", EntityType.SPACE, space1);
-        EntityReference reference = new EntityReference("page", EntityType.DOCUMENT, space2);
+        EntityReference reference = new EntityReference(PAGE_NAME, EntityType.DOCUMENT, space2);
 
         assertSame(wiki, reference.extractFirstReference(EntityType.WIKI));
         assertSame(space1, reference.extractFirstReference(EntityType.SPACE));
@@ -101,18 +107,18 @@ public class EntityReferenceTest
     @Test
     public void getRoot()
     {
-        EntityReference wiki = new EntityReference("wiki", EntityType.WIKI);
+        EntityReference wiki = new EntityReference(WIKI_NAME, EntityType.WIKI);
         EntityReference reference =
-            new EntityReference("page", EntityType.DOCUMENT, new EntityReference("space", EntityType.SPACE, wiki));
+            new EntityReference(PAGE_NAME, EntityType.DOCUMENT, new EntityReference(SPACE_NAME, EntityType.SPACE, wiki));
         assertSame(wiki, reference.getRoot());
     }
 
     @Test
     public void getReversedReferenceChain()
     {
-        EntityReference wiki = new EntityReference("wiki", EntityType.WIKI);
-        EntityReference space = new EntityReference("space", EntityType.SPACE, wiki);
-        EntityReference reference = new EntityReference("page", EntityType.DOCUMENT, space);
+        EntityReference wiki = new EntityReference(WIKI_NAME, EntityType.WIKI);
+        EntityReference space = new EntityReference(SPACE_NAME, EntityType.SPACE, wiki);
+        EntityReference reference = new EntityReference(PAGE_NAME, EntityType.DOCUMENT, space);
 
         List<EntityReference> list = reference.getReversedReferenceChain();
 
@@ -129,11 +135,11 @@ public class EntityReferenceTest
         Map<String, Serializable> map2 = getParamMap(1);
 
         EntityReference parent =
-            new EntityReference("space", EntityType.SPACE, new EntityReference("wiki", EntityType.WIKI, null, map2));
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI, null, map2));
 
-        EntityReference reference = new EntityReference("page", EntityType.DOCUMENT, parent, map1);
+        EntityReference reference = new EntityReference(PAGE_NAME, EntityType.DOCUMENT, parent, map1);
 
-        assertEquals("page", reference.getName());
+        assertEquals(PAGE_NAME, reference.getName());
         assertSame(EntityType.DOCUMENT, reference.getType());
         assertSame(parent, reference.getParent());
         assertTrue(checkParamMap(reference, map1));
@@ -143,35 +149,35 @@ public class EntityReferenceTest
     @Test
     public void validateEquals()
     {
-        EntityReference reference1 = new EntityReference("page", EntityType.DOCUMENT,
-            new EntityReference("space", EntityType.SPACE, new EntityReference("wiki", EntityType.WIKI)));
+        EntityReference reference1 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI)));
 
-        EntityReference reference2 = new EntityReference("page", EntityType.DOCUMENT,
-            new EntityReference("space", EntityType.SPACE, new EntityReference("wiki", EntityType.WIKI)));
+        EntityReference reference2 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI)));
 
-        EntityReference reference3 = new EntityReference("page", EntityType.DOCUMENT,
-            new EntityReference("space", EntityType.SPACE, new EntityReference("wiki2", EntityType.WIKI)));
+        EntityReference reference3 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference("wiki2", EntityType.WIKI)));
 
-        EntityReference reference4 = new EntityReference("page", EntityType.DOCUMENT,
-            new EntityReference("space2", EntityType.SPACE, new EntityReference("wiki", EntityType.WIKI)));
+        EntityReference reference4 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
+            new EntityReference("space2", EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI)));
 
         EntityReference reference5 = new EntityReference("page2", EntityType.DOCUMENT,
-            new EntityReference("space", EntityType.SPACE, new EntityReference("wiki", EntityType.WIKI)));
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI)));
 
-        EntityReference reference6 = new EntityReference("page", EntityType.DOCUMENT);
+        EntityReference reference6 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT);
 
         Map<String, Serializable> map = getParamMap(3);
-        EntityReference reference7 = new EntityReference("page", EntityType.DOCUMENT,
-            new EntityReference("space", EntityType.SPACE, new EntityReference("wiki", EntityType.WIKI)), map);
+        EntityReference reference7 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI)), map);
 
-        EntityReference reference8 = new EntityReference("page", EntityType.DOCUMENT,
-            new EntityReference("space", EntityType.SPACE, new EntityReference("wiki", EntityType.WIKI)), map);
+        EntityReference reference8 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI)), map);
 
-        EntityReference reference9 = new EntityReference("page", EntityType.DOCUMENT,
-            new EntityReference("space", EntityType.SPACE, new EntityReference("wiki", EntityType.WIKI), map));
+        EntityReference reference9 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI), map));
 
-        EntityReference reference10 = new EntityReference("page", EntityType.DOCUMENT,
-            new EntityReference("space", EntityType.SPACE, new EntityReference("wiki", EntityType.WIKI, null, map)));
+        EntityReference reference10 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI, null, map)));
 
         assertTrue(reference1.equals(reference1));
         assertTrue(reference1.equals(reference2));
@@ -179,7 +185,7 @@ public class EntityReferenceTest
         assertFalse(reference1.equals(reference4));
         assertFalse(reference1.equals(reference5));
         assertFalse(reference1.equals(reference6));
-        assertEquals(reference6, new EntityReference("page", EntityType.DOCUMENT));
+        assertEquals(reference6, new EntityReference(PAGE_NAME, EntityType.DOCUMENT));
         assertFalse(reference1.equals(reference7));
         assertTrue(reference7.equals(reference8));
         assertFalse(reference1.equals(reference9));
@@ -191,17 +197,17 @@ public class EntityReferenceTest
     @Test
     public void equalsTo()
     {
-        EntityReference documentReference = new EntityReference("page", EntityType.DOCUMENT,
-            new EntityReference("space", EntityType.SPACE, new EntityReference("wiki", EntityType.WIKI)));
+        EntityReference documentReference = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI)));
 
         EntityReference localdocumentReference =
-            new EntityReference("page", EntityType.DOCUMENT, new EntityReference("space", EntityType.SPACE));
+            new EntityReference(PAGE_NAME, EntityType.DOCUMENT, new EntityReference(SPACE_NAME, EntityType.SPACE));
 
         assertTrue(localdocumentReference.equals(documentReference, EntityType.SPACE));
         assertTrue(documentReference.equals(localdocumentReference, EntityType.SPACE));
 
         EntityReference localdocumentReference2 =
-            new EntityReference("page", EntityType.DOCUMENT, new EntityReference("space2", EntityType.SPACE));
+            new EntityReference(PAGE_NAME, EntityType.DOCUMENT, new EntityReference("space2", EntityType.SPACE));
 
         assertFalse(localdocumentReference.equals(localdocumentReference2, EntityType.SPACE));
     }
@@ -210,10 +216,10 @@ public class EntityReferenceTest
     public void equalsFromTo()
     {
         EntityReference documentReference = new EntityReference("page1", EntityType.DOCUMENT,
-            new EntityReference("space", EntityType.SPACE, new EntityReference("wiki", EntityType.WIKI)));
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI)));
 
         EntityReference spaceReference =
-            new EntityReference("space", EntityType.SPACE, new EntityReference("wiki2", EntityType.WIKI));
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference("wiki2", EntityType.WIKI));
 
         assertTrue(spaceReference.equals(documentReference, EntityType.SPACE, EntityType.SPACE));
         assertTrue(documentReference.equals(spaceReference, EntityType.SPACE, EntityType.SPACE));
@@ -225,9 +231,9 @@ public class EntityReferenceTest
     @Test
     public void equalsNonRecursive()
     {
-        EntityReference documentReference1 = new EntityReference("page", EntityType.DOCUMENT,
-            new EntityReference("space", EntityType.SPACE, new EntityReference("wiki", EntityType.WIKI)));
-        EntityReference documentReference2 = new EntityReference("page", EntityType.DOCUMENT,
+        EntityReference documentReference1 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI)));
+        EntityReference documentReference2 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
             new EntityReference("space2", EntityType.SPACE, new EntityReference("wiki2", EntityType.WIKI)));
 
         assertTrue(documentReference1.equalsNonRecursive(documentReference2));
@@ -238,35 +244,35 @@ public class EntityReferenceTest
     @Test
     public void validateHashCode()
     {
-        EntityReference reference1 = new EntityReference("page", EntityType.DOCUMENT,
-            new EntityReference("space", EntityType.SPACE, new EntityReference("wiki", EntityType.WIKI)));
+        EntityReference reference1 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI)));
 
-        EntityReference reference2 = new EntityReference("page", EntityType.DOCUMENT,
-            new EntityReference("space", EntityType.SPACE, new EntityReference("wiki", EntityType.WIKI)));
+        EntityReference reference2 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI)));
 
-        EntityReference reference3 = new EntityReference("page", EntityType.DOCUMENT,
-            new EntityReference("space", EntityType.SPACE, new EntityReference("wiki2", EntityType.WIKI)));
+        EntityReference reference3 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference("wiki2", EntityType.WIKI)));
 
-        EntityReference reference4 = new EntityReference("page", EntityType.DOCUMENT,
-            new EntityReference("space2", EntityType.SPACE, new EntityReference("wiki", EntityType.WIKI)));
+        EntityReference reference4 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
+            new EntityReference("space2", EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI)));
 
         EntityReference reference5 = new EntityReference("page2", EntityType.DOCUMENT,
-            new EntityReference("space", EntityType.SPACE, new EntityReference("wiki", EntityType.WIKI)));
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI)));
 
-        EntityReference reference6 = new EntityReference("page", EntityType.DOCUMENT);
+        EntityReference reference6 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT);
 
         Map<String, Serializable> map = getParamMap(3);
-        EntityReference reference7 = new EntityReference("page", EntityType.DOCUMENT,
-            new EntityReference("space", EntityType.SPACE, new EntityReference("wiki", EntityType.WIKI)), map);
+        EntityReference reference7 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI)), map);
 
-        EntityReference reference8 = new EntityReference("page", EntityType.DOCUMENT,
-            new EntityReference("space", EntityType.SPACE, new EntityReference("wiki", EntityType.WIKI)), map);
+        EntityReference reference8 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI)), map);
 
-        EntityReference reference9 = new EntityReference("page", EntityType.DOCUMENT,
-            new EntityReference("space", EntityType.SPACE, new EntityReference("wiki", EntityType.WIKI), map));
+        EntityReference reference9 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI), map));
 
-        EntityReference reference10 = new EntityReference("page", EntityType.DOCUMENT,
-            new EntityReference("space", EntityType.SPACE, new EntityReference("wiki", EntityType.WIKI, null, map)));
+        EntityReference reference10 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI, null, map)));
 
         assertEquals(reference1.hashCode(), reference1.hashCode());
         assertEquals(reference1.hashCode(), reference2.hashCode());
@@ -274,7 +280,7 @@ public class EntityReferenceTest
         assertFalse(reference1.hashCode() == reference4.hashCode());
         assertFalse(reference1.hashCode() == reference5.hashCode());
         assertFalse(reference1.hashCode() == reference6.hashCode());
-        assertEquals(reference6.hashCode(), new EntityReference("page", EntityType.DOCUMENT).hashCode());
+        assertEquals(reference6.hashCode(), new EntityReference(PAGE_NAME, EntityType.DOCUMENT).hashCode());
         assertFalse(reference1.hashCode() == reference7.hashCode());
         assertEquals(reference7.hashCode(), reference8.hashCode());
         assertFalse(reference1.hashCode() == reference9.hashCode());
@@ -393,13 +399,13 @@ public class EntityReferenceTest
         Map<String, Serializable> map2 = getParamMap(2);
         Map<String, Serializable> map3 = getParamMap(1);
 
-        EntityReference wiki = new EntityReference("wiki", EntityType.WIKI, null, map3);
+        EntityReference wiki = new EntityReference(WIKI_NAME, EntityType.WIKI, null, map3);
 
-        EntityReference space = new EntityReference("space", EntityType.SPACE, wiki, map2);
+        EntityReference space = new EntityReference(SPACE_NAME, EntityType.SPACE, wiki, map2);
         EntityReference space2 =
             new EntityReference("space2", EntityType.SPACE, new EntityReference("wiki2", EntityType.WIKI));
 
-        EntityReference reference = new EntityReference("page", EntityType.DOCUMENT, space, map1);
+        EntityReference reference = new EntityReference(PAGE_NAME, EntityType.DOCUMENT, space, map1);
         EntityReference referenceSpace2 = reference.replaceParent(space2);
 
         assertNotSame(reference, referenceSpace2);
@@ -416,13 +422,13 @@ public class EntityReferenceTest
         Map<String, Serializable> map2 = getParamMap(2);
         Map<String, Serializable> map3 = getParamMap(1);
 
-        EntityReference wiki = new EntityReference("wiki", EntityType.WIKI, null, map3);
+        EntityReference wiki = new EntityReference(WIKI_NAME, EntityType.WIKI, null, map3);
         EntityReference wiki2 = new EntityReference("wiki2", EntityType.WIKI);
 
-        EntityReference space = new EntityReference("space", EntityType.SPACE, wiki, map2);
+        EntityReference space = new EntityReference(SPACE_NAME, EntityType.SPACE, wiki, map2);
         EntityReference space2 = new EntityReference("space2", EntityType.SPACE, wiki);
 
-        EntityReference reference = new EntityReference("page", EntityType.DOCUMENT, space, map1);
+        EntityReference reference = new EntityReference(PAGE_NAME, EntityType.DOCUMENT, space, map1);
         EntityReference referenceSpace2 = reference.replaceParent(space, space2);
         EntityReference referenceWiki2 = reference.replaceParent(wiki, wiki2);
 
@@ -443,10 +449,10 @@ public class EntityReferenceTest
     @Test
     public void replaceUnknownParent2()
     {
-        EntityReference wiki = new EntityReference("wiki", EntityType.WIKI);
+        EntityReference wiki = new EntityReference(WIKI_NAME, EntityType.WIKI);
         EntityReference wiki2 = new EntityReference("wiki2", EntityType.WIKI);
 
-        EntityReference space = new EntityReference("space", EntityType.SPACE, wiki);
+        EntityReference space = new EntityReference(SPACE_NAME, EntityType.SPACE, wiki);
 
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
             () -> space.replaceParent(new EntityReference("nowiki", EntityType.WIKI), wiki2));
@@ -460,7 +466,7 @@ public class EntityReferenceTest
     public void constructorCloneNullReference()
     {
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new EntityReference(null,
-            new EntityReference("wiki", EntityType.WIKI), new EntityReference("wiki2", EntityType.WIKI)));
+            new EntityReference(WIKI_NAME, EntityType.WIKI), new EntityReference("wiki2", EntityType.WIKI)));
 
         assertEquals("Cloned reference must not be null", e.getMessage());
     }
@@ -471,14 +477,14 @@ public class EntityReferenceTest
         Map<String, Serializable> map1 = getParamMap(3);
         Map<String, Serializable> map2 = getParamMap(2);
 
-        EntityReference wiki = new EntityReference("wiki", EntityType.WIKI, null, map2);
+        EntityReference wiki = new EntityReference(WIKI_NAME, EntityType.WIKI, null, map2);
 
-        EntityReference space = new EntityReference("space", EntityType.SPACE, wiki, map1);
-        EntityReference spaceAlone = new EntityReference("space", EntityType.SPACE, null, map1);
+        EntityReference space = new EntityReference(SPACE_NAME, EntityType.SPACE, wiki, map1);
+        EntityReference spaceAlone = new EntityReference(SPACE_NAME, EntityType.SPACE, null, map1);
 
-        EntityReference reference = new EntityReference("page", EntityType.DOCUMENT, space);
-        EntityReference referenceSpace = new EntityReference("page", EntityType.DOCUMENT).appendParent(space);
-        EntityReference referenceWiki = new EntityReference("page", EntityType.DOCUMENT, spaceAlone).appendParent(wiki);
+        EntityReference reference = new EntityReference(PAGE_NAME, EntityType.DOCUMENT, space);
+        EntityReference referenceSpace = new EntityReference(PAGE_NAME, EntityType.DOCUMENT).appendParent(space);
+        EntityReference referenceWiki = new EntityReference(PAGE_NAME, EntityType.DOCUMENT, spaceAlone).appendParent(wiki);
 
         assertNotSame(reference, referenceSpace);
         assertEquals(reference, referenceSpace);
@@ -495,9 +501,9 @@ public class EntityReferenceTest
         Map<String, Serializable> map1 = getParamMap(3);
         Map<String, Serializable> map2 = getParamMap(2);
 
-        EntityReference wiki = new EntityReference("wiki", EntityType.WIKI);
-        EntityReference space = new EntityReference("space", EntityType.SPACE, wiki, map2);
-        EntityReference reference = new EntityReference("page", EntityType.DOCUMENT, space, map1);
+        EntityReference wiki = new EntityReference(WIKI_NAME, EntityType.WIKI);
+        EntityReference space = new EntityReference(SPACE_NAME, EntityType.SPACE, wiki, map2);
+        EntityReference reference = new EntityReference(PAGE_NAME, EntityType.DOCUMENT, space, map1);
         EntityReference referenceSpace = reference.removeParent(space);
         EntityReference referenceWiki = reference.removeParent(wiki);
 
@@ -515,7 +521,7 @@ public class EntityReferenceTest
     @Test
     public void hasParent()
     {
-        EntityReference wiki = new EntityReference("wiki", EntityType.WIKI);
+        EntityReference wiki = new EntityReference(WIKI_NAME, EntityType.WIKI);
         EntityReference alice = new EntityReference("alice", EntityType.SPACE, wiki);
         EntityReference bob = new EntityReference("bob", EntityType.SPACE, alice);
         EntityReference carol = new EntityReference("carol", EntityType.DOCUMENT, bob);
@@ -550,9 +556,9 @@ public class EntityReferenceTest
         ObjectOutputStream oos = new ObjectOutputStream(baos);
 
         EntityReference reference =
-            new EntityReference("page", EntityType.DOCUMENT,
-                new EntityReference("space", EntityType.SPACE,
-                    new EntityReference("wiki", EntityType.WIKI, null, getParamMap(1)), getParamMap(2)),
+            new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
+                new EntityReference(SPACE_NAME, EntityType.SPACE,
+                    new EntityReference(WIKI_NAME, EntityType.WIKI, null, getParamMap(1)), getParamMap(2)),
                 getParamMap(3));
 
         oos.writeObject(reference);
@@ -568,15 +574,15 @@ public class EntityReferenceTest
     @Test
     public void validateToString()
     {
-        EntityReference reference1 = new EntityReference("page", EntityType.DOCUMENT,
-            new EntityReference("space", EntityType.SPACE, new EntityReference("wiki", EntityType.WIKI)));
+        EntityReference reference1 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI)));
         assertEquals("Document wiki:space.page", reference1.toString());
 
-        EntityReference reference2 = new EntityReference("page", EntityType.DOCUMENT);
+        EntityReference reference2 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT);
         assertEquals("Document page", reference2.toString());
 
         EntityReference reference3 =
-            new EntityReference("page", EntityType.DOCUMENT, new EntityReference("space", EntityType.SPACE));
+            new EntityReference(PAGE_NAME, EntityType.DOCUMENT, new EntityReference(SPACE_NAME, EntityType.SPACE));
         assertEquals("Document space.page", reference3.toString());
 
         // We don't handle parameters in Entity Reference because they're internal and not exposed and at the moment
@@ -584,10 +590,44 @@ public class EntityReferenceTest
         Map<String, Serializable> map = new HashMap<>();
         map.put("key1", "value1");
         EntityReference reference4 =
-            new EntityReference("page", EntityType.DOCUMENT, new EntityReference("space", EntityType.SPACE), map);
+            new EntityReference(PAGE_NAME, EntityType.DOCUMENT, new EntityReference(SPACE_NAME, EntityType.SPACE), map);
         assertEquals("Document space.page", reference4.toString());
 
         EntityReference reference5 = new EntityReference("attachment", EntityType.ATTACHMENT, reference1);
         assertEquals("Attachment wiki:space.page@attachment", reference5.toString());
+    }
+
+    @Test
+    void removeParameters()
+    {
+        EntityReference parent =
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI));
+        EntityReference reference = new EntityReference(PAGE_NAME, EntityType.DOCUMENT, parent);
+        EntityReference referenceWithParameters = new EntityReference(PAGE_NAME, EntityType.DOCUMENT, parent,
+            Map.of("key", "value"));
+
+        EntityReference recursiveResult = referenceWithParameters.removeParameters(true);
+        assertEquals(reference, recursiveResult);
+        EntityReference nonRecursiveResult = referenceWithParameters.removeParameters(false);
+        assertEquals(reference, nonRecursiveResult);
+        assertSame(parent, recursiveResult.getParent());
+        assertSame(parent, nonRecursiveResult.getParent());
+    }
+
+    @Test
+    void removeParametersRecursive()
+    {
+        EntityReference parent =
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI,
+                Map.of("wikiKey", "wikiValue")), Map.of("spaceKey", "spaceValue"));
+        EntityReference reference = new EntityReference(PAGE_NAME, EntityType.DOCUMENT, parent);
+        EntityReference parentWithoutParameters =
+            new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI));
+        EntityReference referenceWithoutParameters =
+            new EntityReference(PAGE_NAME, EntityType.DOCUMENT, parentWithoutParameters);
+
+        assertEquals(referenceWithoutParameters, reference.removeParameters(true));
+        assertSame(reference, reference.removeParameters(false));
+        assertEquals(parentWithoutParameters, parent.removeParameters(true));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/internal/XWikiBridge.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/internal/XWikiBridge.java
@@ -55,6 +55,7 @@ public interface XWikiBridge
     /**
      * Right now the security module logic only works with DOCUMENT based reference so PAGE reference need to be
      * converted.
+     * This also removes parameters from the reference as they aren't supported by the security module.
      * 
      * @param reference the reference
      * @return the compatible reference

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-bridge/src/main/java/org/xwiki/security/internal/DefaultXWikiBridge.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-bridge/src/main/java/org/xwiki/security/internal/DefaultXWikiBridge.java
@@ -121,10 +121,9 @@ public class DefaultXWikiBridge implements XWikiBridge
 
         // Discard the parameters since they are not used by the authorization system but cause issues when comparing
         // references for equality.
-        EntityReference noParameterReference = removeParameters(reference);
-
         // Make sure the reference is complete
-        EntityReference compatibleReference = this.currentResolver.resolve(noParameterReference, reference.getType());
+        EntityReference compatibleReference = this.currentResolver.resolve(reference.removeParameters(true),
+            reference.getType());
 
         // Convert to PAGE reference to DOCUMENT reference since the security system design does not work well with PAGE
         // one (which have different kinds of right at the same level)
@@ -135,17 +134,5 @@ public class DefaultXWikiBridge implements XWikiBridge
         }
 
         return compatibleReference;
-    }
-
-    private static EntityReference removeParameters(EntityReference reference)
-    {
-        EntityReference parent = null;
-        EntityReference result = null;
-        for (EntityReference entry : reference.getReversedReferenceChain()) {
-            result = new EntityReference(entry.getName(), entry.getType(), parent);
-            parent = result;
-        }
-
-        return result;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-bridge/src/main/java/org/xwiki/security/internal/DefaultXWikiBridge.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-bridge/src/main/java/org/xwiki/security/internal/DefaultXWikiBridge.java
@@ -119,8 +119,12 @@ public class DefaultXWikiBridge implements XWikiBridge
             return reference;
         }
 
+        // Discard the parameters since they are not used by the authorization system but cause issues when comparing
+        // references for equality.
+        EntityReference noParameterReference = removeParameters(reference);
+
         // Make sure the reference is complete
-        EntityReference compatibleReference = this.currentResolver.resolve(reference, reference.getType());
+        EntityReference compatibleReference = this.currentResolver.resolve(noParameterReference, reference.getType());
 
         // Convert to PAGE reference to DOCUMENT reference since the security system design does not work well with PAGE
         // one (which have different kinds of right at the same level)
@@ -131,5 +135,17 @@ public class DefaultXWikiBridge implements XWikiBridge
         }
 
         return compatibleReference;
+    }
+
+    private static EntityReference removeParameters(EntityReference reference)
+    {
+        EntityReference parent = null;
+        EntityReference result = null;
+        for (EntityReference entry : reference.getReversedReferenceChain()) {
+            result = new EntityReference(entry.getName(), entry.getType(), parent);
+            parent = result;
+        }
+
+        return result;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-bridge/src/test/java/org/xwiki/security/internal/DefaultXWikiBridgeTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-bridge/src/test/java/org/xwiki/security/internal/DefaultXWikiBridgeTest.java
@@ -40,6 +40,7 @@ import com.xpn.xwiki.test.junit5.mockito.OldcoreTest;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -105,8 +106,10 @@ public class DefaultXWikiBridgeTest
         when(this.currentResolver.resolve(any(), eq(EntityType.DOCUMENT)))
             .thenAnswer(invocation -> invocation.getArgument(0));
 
-        assertEquals(noParameterReference, this.bridge.toCompatibleEntityReference(documentReference));
-        assertNotEquals(documentReference, this.bridge.toCompatibleEntityReference(documentReference));
+        EntityReference actual = this.bridge.toCompatibleEntityReference(documentReference);
+        assertEquals(noParameterReference, actual);
+        assertNotEquals(documentReference, actual);
+        assertSame(parentReference, actual.getParent());
     }
 
     @Test
@@ -121,7 +124,19 @@ public class DefaultXWikiBridgeTest
         when(this.currentResolver.resolve(any(), eq(EntityType.DOCUMENT)))
             .thenAnswer(invocation -> invocation.getArgument(0));
 
-        assertEquals(noParameterReference, this.bridge.toCompatibleEntityReference(documentReference));
-        assertNotEquals(documentReference, this.bridge.toCompatibleEntityReference(documentReference));
+        EntityReference actual = this.bridge.toCompatibleEntityReference(documentReference);
+        assertEquals(noParameterReference, actual);
+        assertNotEquals(documentReference, actual);
+    }
+
+    @Test
+    void toCompatibleEntityReferenceWithoutParametersReturnsSame()
+    {
+        DocumentReference documentReference = new DocumentReference("wiki", "space", "page");
+
+        when(this.currentResolver.resolve(any(), eq(EntityType.DOCUMENT)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        assertSame(documentReference, this.bridge.toCompatibleEntityReference(documentReference));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-bridge/src/test/java/org/xwiki/security/internal/DefaultXWikiBridgeTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-bridge/src/test/java/org/xwiki/security/internal/DefaultXWikiBridgeTest.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.security.internal;
 
+import java.util.Map;
+
 import javax.inject.Named;
 
 import org.junit.jupiter.api.Test;
@@ -27,6 +29,7 @@ import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
 import org.xwiki.model.reference.EntityReferenceResolver;
 import org.xwiki.model.reference.PageReference;
+import org.xwiki.model.reference.SpaceReference;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
 
@@ -35,7 +38,10 @@ import com.xpn.xwiki.test.junit5.mockito.InjectMockitoOldcore;
 import com.xpn.xwiki.test.junit5.mockito.OldcoreTest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
@@ -87,5 +93,35 @@ public class DefaultXWikiBridgeTest
             this.oldcore.getXWikiContext());
 
         assertEquals(documentReference, this.bridge.toCompatibleEntityReference(pageReference));
+    }
+
+    @Test
+    void toCompatibleEntityReferenceWithParameters()
+    {
+        SpaceReference parentReference = new SpaceReference("wiki", "space");
+        DocumentReference documentReference = new DocumentReference("page", parentReference, Map.of("param", "value"));
+        DocumentReference noParameterReference = new DocumentReference("page", parentReference);
+
+        when(this.currentResolver.resolve(any(), eq(EntityType.DOCUMENT)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        assertEquals(noParameterReference, this.bridge.toCompatibleEntityReference(documentReference));
+        assertNotEquals(documentReference, this.bridge.toCompatibleEntityReference(documentReference));
+    }
+
+    @Test
+    void toCompatibleEntityReferenceWithRecursiveParameters()
+    {
+        EntityReference wikiReference = new EntityReference("wiki", EntityType.WIKI, Map.of("wiki", "wikiValue"));
+        EntityReference spaceReference = new EntityReference("space", EntityType.SPACE, wikiReference,
+            Map.of("space", "spaceValue"));
+        DocumentReference documentReference = new DocumentReference("page", spaceReference, Map.of("param", "value"));
+        DocumentReference noParameterReference = new DocumentReference("wiki", "space", "page");
+
+        when(this.currentResolver.resolve(any(), eq(EntityType.DOCUMENT)))
+            .thenAnswer(invocation -> invocation.getArgument(0));
+
+        assertEquals(noParameterReference, this.bridge.toCompatibleEntityReference(documentReference));
+        assertNotEquals(documentReference, this.bridge.toCompatibleEntityReference(documentReference));
     }
 }


### PR DESCRIPTION
* Remove parameters from entity references when constructing a security reference.

Jira issue: https://jira.xwiki.org/browse/XWIKI-21439