### PR TITLE
XWIKI-14787: $blacklistedSpaces are not working anymore

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/javascript.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/javascript.vm
@@ -214,7 +214,6 @@ XWiki.docisnew = null;
 #end
 XWiki.docsyntax = "$!doc.getSyntax().toIdString()";
 XWiki.docvariant = "$!{escapetool.javascript($docvariant.replace('&amp;', '&'))}";
-XWiki.blacklistedSpaces = [ #foreach($space in $blacklistedSpaces)#if($foreach.count > 1),#end"$space"#end ];
 XWiki.hasEdit = $hasEdit;
 XWiki.hasProgramming = $hasProgramming;
 XWiki.hasBackupPackImportRights =#if ($xwiki.package) $xwiki.package.hasBackupPackImportRights()#else false#end;

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/Main/Spaces.xml
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/Main/Spaces.xml
@@ -456,10 +456,9 @@ $xwiki.ssx.use('Main.Spaces')##
   ## List spaces.
   ##
   #foreach($space in $spaceList)
-    ## Display space only if the user has view right on space home and if the space is not blacklisted.
-    ## $blacklistedSpaces is set in xwikivars.vm
+    ## Display space only if the user has view right on space home
     #set ($spaceHomeDocumentReference = $services.model.resolveSpace($space))
-    #if($xwiki.hasAccessLevel('view', $services.model.serialize($spaceHomeDocumentReference)) &amp;&amp; !$blacklistedSpaces.contains($space))
+    #if($xwiki.hasAccessLevel('view', $services.model.serialize($spaceHomeDocumentReference)))
       &lt;li class="xitem xunderline xhighlight space"&gt;
         &lt;div class="xitemcontainer"&gt;
           &lt;div class="spSpaceName"&gt;&lt;a href="$xwiki.getURL($spaceHomeDocumentReference)"&gt;${escapetool.xml($space)}&lt;/a&gt;&lt;/div&gt;

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Backlinks.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Backlinks.xml
@@ -126,7 +126,7 @@
 #foreach ($docname in $backlinks)
   #if ($docname != $previousDoc)
     #set ($backlinkDoc = $xwiki.getDocument($docname).getTranslatedDocument())
-    #if ($backlinkDoc &amp;&amp; !$blacklistedSpaces.contains($backlinkDoc.space))
+    #if ($backlinkDoc &amp;&amp; !$backlinkDoc.isHidden())
       #set ($discard = $backlinkDocs.add($backlinkDoc))
     #end
   #end

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Backlinks.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Backlinks.xml
@@ -126,7 +126,7 @@
 #foreach ($docname in $backlinks)
   #if ($docname != $previousDoc)
     #set ($backlinkDoc = $xwiki.getDocument($docname).getTranslatedDocument())
-    #if ($backlinkDoc &amp;&amp; !$backlinkDoc.isHidden())
+    #if ($backlinkDoc &amp;&amp; ($services.user.properties.displayHiddenDocuments() || !$backlinkDoc.isHidden()))
       #set ($discard = $backlinkDocs.add($backlinkDoc))
     #end
   #end

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Spaces.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Spaces.xml
@@ -128,7 +128,7 @@
 #foreach ($space in $services.query.xwql('SELECT DISTINCT doc.space FROM Document doc order by doc.space').addFilter('hidden').execute())
   #set ($spaceReference     = $services.model.resolveSpace($space))
   #set ($spaceHomeReference = $services.model.createDocumentReference($defaultSpaceHomePage, $spaceReference))
-  #if ($hasAdmin || ($services.security.authorization.hasAccess('view', $spaceHomeReference) &amp;&amp; !$blacklistedSpaces.contains($space)))
+  #if ($hasAdmin || ($services.security.authorization.hasAccess('view', $spaceHomeReference)))
     ## We use HTML here because we don't have a tool to escape wiki syntax in space name.
     * {{html}}&lt;a href="$xwiki.getURL($spaceHomeReference)"
         #if ($space == $doc.space)class="currentspace"#end&gt;$escapetool.xml($space)&lt;/a&gt;{{/html}}

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-ui/src/main/resources/Main/Tags.xml
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-ui/src/main/resources/Main/Tags.xml
@@ -85,7 +85,7 @@ $xwiki.ssx.use('Main.Tags')##
       === $services.localization.render('xe.tag.alldocs', ["//${wikiEscapedTag}//"]) ===
 
       #if ($list.size()&gt; 0)
-        {{html}}#displayDocumentList($list false $blacklistedSpaces){{/html}}
+        {{html}}#displayDocumentList($list false $NULL){{/html}}
       #else
         (% class='noitems' %)$services.localization.render('xe.tag.notags')
       #end

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/informationinline.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/informationinline.vm
@@ -150,7 +150,7 @@ $xwiki.jsfx.use('uicomponents/edit/editableProperty.js', {'forceSkinAction': tru
         $escapetool.xml($services.localization.render('core.viewers.information.noIncludedPages'))
       </span>
     #else
-      #displayDocumentList($includedPages false $blacklistedSpaces)
+      #displayDocumentList($includedPages false $NULL)
     #end
   </dd>
   ",
@@ -171,7 +171,7 @@ $xwiki.jsfx.use('uicomponents/edit/editableProperty.js', {'forceSkinAction': tru
         $escapetool.xml($services.localization.render('core.viewers.information.noBacklinks'))
       </span>
     #else
-      #displayDocumentList($backlinks false $blacklistedSpaces)
+      #displayDocumentList($backlinks false $NULL)
     #end
   </dd>
   ",

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -1113,14 +1113,14 @@ $html
  *
  * @param docNames list of document names.
  * @param displaySpaces true to group documents by space.
- * @param blacklistedSpaces spaces to exclude from the list.
+ * @param ignoredSpaces spaces to exclude from the list.
  *#
-#macro(displayDocumentList $docNames $displaySpaces $blacklistedSpaces)
+#macro(displayDocumentList $docNames $displaySpaces $ignoredSpaces)
   #set($documentList = [])
   #foreach($docName in $docNames)
     #if($xwiki.hasAccessLevel("view", $xcontext.user, $docName))
       #set($document = $xwiki.getDocument($docName).getTranslatedDocument())
-      #if(("$!blacklistedSpaces" != '' && !$blacklistedSpaces.contains($document.getSpace())) || ("$!blacklistedSpaces" == '' && ($services.user.properties.displayHiddenDocuments() || !$document.isHidden())))
+      #if(("$!ignoredSpaces" != '' && !$ignoredSpaces.contains($document.getSpace())) || $services.user.properties.displayHiddenDocuments() || !$document.isHidden())
         #set($discard = $documentList.add($document))
       #end
     #end

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -1120,7 +1120,7 @@ $html
   #foreach($docName in $docNames)
     #if($xwiki.hasAccessLevel("view", $xcontext.user, $docName))
       #set($document = $xwiki.getDocument($docName).getTranslatedDocument())
-      #if(("$!ignoredSpaces" != '' && !$ignoredSpaces.contains($document.getSpace())) || $services.user.properties.displayHiddenDocuments() || !$document.isHidden())
+      #if(!$ignoredSpaces.contains($document.getSpace()) && ($services.user.properties.displayHiddenDocuments() || !$document.isHidden()))
         #set($discard = $documentList.add($document))
       #end
     #end

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -767,7 +767,7 @@ $fn
     #end
     #foreach ($childDocName in $page.children)
       #set ($childDoc = $xwiki.getDocument($childDocName))
-      #if ($childDoc && !$childDoc.isHidden())
+      #if ($childDoc && ($services.user.properties.displayHiddenDocuments() || !$childDoc.isHidden()))
         #if ($withPageBreaks)
           #pagebreak()
         #end

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -1120,7 +1120,7 @@ $html
   #foreach($docName in $docNames)
     #if($xwiki.hasAccessLevel("view", $xcontext.user, $docName))
       #set($document = $xwiki.getDocument($docName).getTranslatedDocument())
-      #if(!$document.isHidden() && !$blacklistedSpaces.contains($document.getSpace()))
+      #if(("$!blacklistedSpaces" != '' && !$blacklistedSpaces.contains($document.getSpace())) || ("$!blacklistedSpaces" == '' && ($services.user.properties.displayHiddenDocuments() || !$document.isHidden())))
         #set($discard = $documentList.add($document))
       #end
     #end

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -767,7 +767,7 @@ $fn
     #end
     #foreach ($childDocName in $page.children)
       #set ($childDoc = $xwiki.getDocument($childDocName))
-      #if ($childDoc && !$blacklistedSpaces.contains($childDoc.getSpace()))
+      #if ($childDoc && !$childDoc.isHidden())
         #if ($withPageBreaks)
           #pagebreak()
         #end
@@ -1120,7 +1120,7 @@ $html
   #foreach($docName in $docNames)
     #if($xwiki.hasAccessLevel("view", $xcontext.user, $docName))
       #set($document = $xwiki.getDocument($docName).getTranslatedDocument())
-      #if(!$blacklistedSpaces.contains($document.getSpace()))
+      #if(!$document.isHidden() && !$blacklistedSpaces.contains($document.getSpace()))
         #set($discard = $documentList.add($document))
       #end
     #end

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/xwikivars.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/xwikivars.vm
@@ -104,15 +104,6 @@
 ## - guest users who have admin rights (i.e. when the wiki is empty with no rights set)
 ## =====================================================================================
 #set ($isAdvancedUser = (($isGuest && $hasAdmin) || $services.user.allProperties.type == 'ADVANCED'))
-## ======================================================================================
-## Compute list of spaces to blacklist so that simple users don't see them.
-## TODO : replace this list by a hidden space feature.
-## ======================================================================================
-#if ($hasAdmin || $isAdvancedUser)
-  #set ($blacklistedSpaces = [])
-#else
-  #set ($blacklistedSpaces = ['Import', 'Panels', 'Scheduler', 'Stats', 'XAppClasses', 'XAppSheets', 'XAppTemplates', 'XWiki', 'WatchCode', 'WatchSheets', 'XApp', 'WatchAdmin', 'Watch', 'ColorThemes', 'AnnotationCode'])
-#end
 #set ($parent ="<a href='$parentDoc.getURL()'>$escapetool.xml(${parentDoc.displayTitle})</a>")
 #if ($tdoc)
   #set ($headertitle = "<a href='$viewUrl'>$escapetool.xml(${tdoc.displayTitle})</a>")

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/compatibility.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/compatibility.js
@@ -396,4 +396,10 @@ Object.extend(XWiki.constants, {
   head.insert(new Element('meta', {'name': 'language', 'content': html.readAttribute('lang')}));
 })();
 
+/**
+ * Use to hold the list of blacklistedSpaces: this concept has been removed in favor of the hidden attribute in pages.
+ * @deprecated since 16.0RC1
+ */
+XWiki.blacklistedSpaces = XWiki.blacklistedSpaces || [];
+
 })();


### PR DESCRIPTION
JIRA: https://jira.xwiki.org/browse/XWIKI-14787

$blacklistedSpaces is an old variable that should have been deprecated a long time ago in favor of the hidden property of documents. Apparently it never was and we still have a few occurrences of it in the code. 
This PR is about cleaning those. 

Get rid of the $blacklistedSpaces variable defined in xwikivars.vm and remove remaining occurences. Uses XWikiDocument#isHidden in the few places where it wasn't yet the case.
Note that I kept the $blacklistedSpaces parameter of the macro `displayDocumentList` since it could still be used but the condition now check both that parameter and the hidden property. 