### PR TITLE
XWIKI-11762: $displayTooltip method seem to be broken

### DIFF
--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/XWikiCompatibilityAspect.aj
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/XWikiCompatibilityAspect.aj
@@ -1465,4 +1465,37 @@ public privileged aspect XWikiCompatibilityAspect
         // invalid XWikiDocument object as it's been deleted...
         sourceDoc.clone(newDocument);
     }
+
+    @Deprecated(since = "16.0RC1")
+    public String XWiki.addTooltip(String html, String message, String params, XWikiContext context)
+    {
+        StringBuilder buffer = new StringBuilder();
+        buffer.append("<span class=\"tooltip_span\" onmouseover=\"");
+        buffer.append(params);
+        buffer.append("; return escape('");
+        buffer.append(message.replaceAll("'", "\\'"));
+        buffer.append("');\">");
+        buffer.append(html);
+        buffer.append("</span>");
+
+        return buffer.toString();
+    }
+
+    @Deprecated(since = "16.0RC1")
+    public String XWiki.addTooltipJS(XWikiContext context)
+    {
+        StringBuilder buffer = new StringBuilder();
+        buffer.append("<script src=\"");
+        buffer.append(getSkinFile("ajax/wzToolTip.js", context));
+        buffer.append("\"></script>");
+        // buffer.append("<div id=\"dhtmltooltip\"></div>");
+
+        return buffer.toString();
+    }
+
+    @Deprecated(since = "16.0RC1")
+    public String XWiki.addTooltip(String html, String message, XWikiContext context)
+    {
+        return addTooltip(html, message, "this.WIDTH='300'", context);
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/api/DocumentCompatibilityAspect.aj
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/api/DocumentCompatibilityAspect.aj
@@ -97,4 +97,39 @@ public privileged aspect DocumentCompatibilityAspect
     {
         return this.doc.getTranslationList(getXWikiContext());
     }
+
+    /**
+     * Displays the tooltip of the given field. This function uses the active object or will find the first object that
+     * has the given field.
+     *
+     * @param fieldname fieldname to display the tooltip of
+     * @return the tooltip display of the field.
+     * @deprecated since 16.0RC1, this method doesn't work for a long time since flamingo skin
+     */
+    @Deprecated(since = "16.0RC1")
+    public String Document.displayTooltip(String fieldname)
+    {
+        if (this.currentObj == null) {
+            return this.doc.displayTooltip(fieldname, getXWikiContext());
+        } else {
+            return this.doc.displayTooltip(fieldname, this.currentObj.getBaseObject(), getXWikiContext());
+        }
+    }
+
+    /**
+     * Displays the tooltip of the given field of the given object.
+     *
+     * @param fieldname fieldname to display the tooltip of
+     * @param obj Object to find the class to display the tooltip of
+     * @return the tooltip display of the field.
+     * @deprecated since 16.0RC1, this method doesn't work for a long time since flamingo skin
+     */
+    @Deprecated(since = "16.0RC1")
+    public String Document.displayTooltip(String fieldname, Object obj)
+    {
+        if (obj == null) {
+            return "";
+        }
+        return this.doc.displayTooltip(fieldname, obj.getBaseObject(), getXWikiContext());
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/api/XWikiCompatibilityAspect.aj
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/api/XWikiCompatibilityAspect.aj
@@ -1245,4 +1245,45 @@ public privileged aspect XWikiCompatibilityAspect
     {
         return hasProgrammingRights() ? this.xwiki.invokeServletAndReturnAsString(url, getXWikiContext()) : null;
     }
+
+    /**
+     * Inserts a tooltip using toolTip.js
+     *
+     * @param html HTML viewed
+     * @param message HTML Tooltip message
+     * @param params Parameters in Javascropt added to the tooltip config
+     * @return HTML with working tooltip
+     * @deprecated since 16.0RC1, this method doesn't work for a long time since flamingo skin
+     */
+    @Deprecated(since = "16.0RC1")
+    public String XWiki.addTooltip(String html, String message, String params)
+    {
+        return this.xwiki.addTooltip(html, message, params, getXWikiContext());
+    }
+
+    /**
+     * Inserts a tooltip using toolTip.js
+     *
+     * @param html HTML viewed
+     * @param message HTML Tooltip message
+     * @return HTML with working tooltip
+     * @deprecated since 16.0RC1, this method doesn't work for a long time since flamingo skin
+     */
+    @Deprecated(since = "16.0RC1")
+    public String XWiki.addTooltip(String html, String message)
+    {
+        return this.xwiki.addTooltip(html, message, getXWikiContext());
+    }
+
+    /**
+     * Inserts the tooltip Javascript
+     *
+     * @return
+     * @deprecated since 16.0RC1, this method doesn't work for a long time since flamingo skin
+     */
+    @Deprecated(since = "16.0RC1")
+    public String XWiki.addTooltipJS()
+    {
+        return this.xwiki.addTooltipJS(getXWikiContext());
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/doc/XWikiDocumentCompatibilityAspect.aj
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/doc/XWikiDocumentCompatibilityAspect.aj
@@ -584,4 +584,38 @@ privileged public aspect XWikiDocumentCompatibilityAspect
             backlinkDocumentReferences,
             childDocumentReferences, context);
     }
+
+    @Deprecated(since = "16.0RC1")
+    public String XWikiDocument.displayTooltip(String fieldname, XWikiContext context)
+        {
+            try {
+                BaseObject object = getXObject();
+                if (object == null) {
+                    object = getFirstObject(fieldname, context);
+                }
+                return displayTooltip(fieldname, object, context);
+            } catch (Exception e) {
+                return "";
+            }
+        }
+
+        @Deprecated(since = "16.0RC1")
+        public String XWikiDocument.displayTooltip(String fieldname, BaseObject obj, XWikiContext context)
+        {
+            String result = "";
+
+            try {
+                PropertyClass pclass = (PropertyClass) obj.getXClass(context).get(fieldname);
+                String tooltip = pclass.getTooltip(context);
+                if ((tooltip != null) && (!tooltip.trim().equals(""))) {
+                    String img = "<img src=\"" + context.getWiki().getSkinFile("info.gif", context)
+                        + "\" class=\"tooltip_image\" align=\"middle\" />";
+                    result = context.getWiki().addTooltip(img, tooltip, context);
+                }
+            } catch (Exception e) {
+
+            }
+
+            return result;
+        }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
@@ -7378,36 +7378,6 @@ public class XWiki implements EventListener
         return doc.validate(context);
     }
 
-    public String addTooltip(String html, String message, String params, XWikiContext context)
-    {
-        StringBuilder buffer = new StringBuilder();
-        buffer.append("<span class=\"tooltip_span\" onmouseover=\"");
-        buffer.append(params);
-        buffer.append("; return escape('");
-        buffer.append(message.replaceAll("'", "\\'"));
-        buffer.append("');\">");
-        buffer.append(html);
-        buffer.append("</span>");
-
-        return buffer.toString();
-    }
-
-    public String addTooltipJS(XWikiContext context)
-    {
-        StringBuilder buffer = new StringBuilder();
-        buffer.append("<script src=\"");
-        buffer.append(getSkinFile("ajax/wzToolTip.js", context));
-        buffer.append("\"></script>");
-        // buffer.append("<div id=\"dhtmltooltip\"></div>");
-
-        return buffer.toString();
-    }
-
-    public String addTooltip(String html, String message, XWikiContext context)
-    {
-        return addTooltip(html, message, "this.WIDTH='300'", context);
-    }
-
     public String addMandatory(XWikiContext context)
     {
         String star =

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Document.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Document.java
@@ -1620,37 +1620,6 @@ public class Document extends Api
     }
 
     /**
-     * Displays the tooltip of the given field. This function uses the active object or will find the first object that
-     * has the given field.
-     *
-     * @param fieldname fieldname to display the tooltip of
-     * @return the tooltip display of the field.
-     */
-    public String displayTooltip(String fieldname)
-    {
-        if (this.currentObj == null) {
-            return this.doc.displayTooltip(fieldname, getXWikiContext());
-        } else {
-            return this.doc.displayTooltip(fieldname, this.currentObj.getBaseObject(), getXWikiContext());
-        }
-    }
-
-    /**
-     * Displays the tooltip of the given field of the given object.
-     *
-     * @param fieldname fieldname to display the tooltip of
-     * @param obj Object to find the class to display the tooltip of
-     * @return the tooltip display of the field.
-     */
-    public String displayTooltip(String fieldname, Object obj)
-    {
-        if (obj == null) {
-            return "";
-        }
-        return this.doc.displayTooltip(fieldname, obj.getBaseObject(), getXWikiContext());
-    }
-
-    /**
      * Displays the given field. The display mode will be decided depending on page context (edit or inline context will
      * display in edit, view context in view) This function uses the active object or will find the first object that
      * has the given field. This function can return html inside and html macro

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/XWiki.java
@@ -2778,41 +2778,6 @@ public class XWiki extends Api
         return this.xwiki.getUniquePageName(space, name, getXWikiContext());
     }
 
-    /**
-     * Inserts a tooltip using toolTip.js
-     *
-     * @param html HTML viewed
-     * @param message HTML Tooltip message
-     * @param params Parameters in Javascropt added to the tooltip config
-     * @return HTML with working tooltip
-     */
-    public String addTooltip(String html, String message, String params)
-    {
-        return this.xwiki.addTooltip(html, message, params, getXWikiContext());
-    }
-
-    /**
-     * Inserts a tooltip using toolTip.js
-     *
-     * @param html HTML viewed
-     * @param message HTML Tooltip message
-     * @return HTML with working tooltip
-     */
-    public String addTooltip(String html, String message)
-    {
-        return this.xwiki.addTooltip(html, message, getXWikiContext());
-    }
-
-    /**
-     * Inserts the tooltip Javascript
-     *
-     * @return
-     */
-    public String addTooltipJS()
-    {
-        return this.xwiki.addTooltipJS(getXWikiContext());
-    }
-
     /*
      * Inserts a Mandatory asterix
      */

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -3581,37 +3581,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
         }
     }
 
-    public String displayTooltip(String fieldname, XWikiContext context)
-    {
-        try {
-            BaseObject object = getXObject();
-            if (object == null) {
-                object = getFirstObject(fieldname, context);
-            }
-            return displayTooltip(fieldname, object, context);
-        } catch (Exception e) {
-            return "";
-        }
-    }
 
-    public String displayTooltip(String fieldname, BaseObject obj, XWikiContext context)
-    {
-        String result = "";
-
-        try {
-            PropertyClass pclass = (PropertyClass) obj.getXClass(context).get(fieldname);
-            String tooltip = pclass.getTooltip(context);
-            if ((tooltip != null) && (!tooltip.trim().equals(""))) {
-                String img = "<img src=\"" + context.getWiki().getSkinFile("info.gif", context)
-                    + "\" class=\"tooltip_image\" align=\"middle\" />";
-                result = context.getWiki().addTooltip(img, tooltip, context);
-            }
-        } catch (Exception e) {
-
-        }
-
-        return result;
-    }
 
     /**
      * @param fieldname the name of the field to display


### PR DESCRIPTION
JIRA: https://jira.xwiki.org/browse/XWIKI-11762

Deprecate all #displayTooltip and #addTooltip method and move them to legacy as they don't work since colibri according to @mflorea