### PR TITLE
XWIKI-21659: Provide entry index in data attribute of LiveData

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/layouts/cards/LayoutCards.spec.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/layouts/cards/LayoutCards.spec.js
@@ -99,7 +99,8 @@ describe('LayoutCards.vue', () => {
             data: {
               data: {
                 entries: [
-                  {id: 1}
+                  {id: "idx1"},
+                  {id: "idx2"}
                 ]
               }
             }
@@ -111,9 +112,14 @@ describe('LayoutCards.vue', () => {
     // Manual trigger of the afterEntryFetch event.
     afterEntryFetchWrapper.callback();
     await Vue.nextTick();
-    let cards = wrapper.findAllComponents(LayoutCardsCard);
-    expect(cards.length).toBe(1);
-    expect(cards.at(0).props()).toStrictEqual({entry: {id: 1}});
+    const cards = wrapper.findAllComponents(LayoutCardsCard);
+    expect(cards.length).toBe(2);
+    expect(cards.at(0).props()).toStrictEqual({entry: {id: "idx1"}});
+    expect(cards.at(1).props()).toStrictEqual({entry: {id: "idx2"}});
+    expect(cards.at(0).attributes("data-livedata-entry-index")).toBe("0");
+    expect(cards.at(0).attributes("data-livedata-entry-id")).toBe("idx1");
+    expect(cards.at(1).attributes("data-livedata-entry-index")).toBe("1");
+    expect(cards.at(1).attributes("data-livedata-entry-id")).toBe("idx2");
     expect(wrapper.find('.noentries-card').exists()).toBe(false);
   })
 })

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/layouts/cards/LayoutCards.spec.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/layouts/cards/LayoutCards.spec.js
@@ -99,8 +99,7 @@ describe('LayoutCards.vue', () => {
             data: {
               data: {
                 entries: [
-                  {id: "idx1"},
-                  {id: "idx2"}
+                  {id: 1}
                 ]
               }
             }
@@ -113,13 +112,11 @@ describe('LayoutCards.vue', () => {
     afterEntryFetchWrapper.callback();
     await Vue.nextTick();
     const cards = wrapper.findAllComponents(LayoutCardsCard);
-    expect(cards.length).toBe(2);
-    expect(cards.at(0).props()).toStrictEqual({entry: {id: "idx1"}});
-    expect(cards.at(1).props()).toStrictEqual({entry: {id: "idx2"}});
-    expect(cards.at(0).attributes("data-livedata-entry-index")).toBe("0");
-    expect(cards.at(0).attributes("data-livedata-entry-id")).toBe("idx1");
-    expect(cards.at(1).attributes("data-livedata-entry-index")).toBe("1");
-    expect(cards.at(1).attributes("data-livedata-entry-id")).toBe("idx2");
+    expect(cards.length).toBe(1);
+    expect(cards.at(0).props()).toStrictEqual({
+      entry: {id: 1},
+      entryIdx: 0
+    });
     expect(wrapper.find('.noentries-card').exists()).toBe(false);
   })
 })

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/layouts/cards/LayoutCardsCard.spec.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/layouts/cards/LayoutCardsCard.spec.js
@@ -1,0 +1,73 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+import {shallowMount} from '@vue/test-utils';
+import _ from 'lodash';
+import LayoutCardsCard from "../../../../layouts/cards/LayoutCardsCard";
+
+/**
+ * Vue Component initializer for LayoutCardsCard component. Since this component creates a deep hierarchy of
+ * sub-components, we use `shallowMount` to initialize the wrapper.
+ *
+ * The default option object is merged with the `option` parameter.
+ *
+ * @param options an optional option object use to customize the initialized component
+ * @returns {*} a shallow wrapper for the LayoutCardsCard component
+ */
+function initWrapper(options = {}) {
+  return shallowMount(LayoutCardsCard, _.merge({
+    provide: {
+      logic: {
+        getEntryId: (e) => e.id,
+        isSelectionEnabled: () => false,
+        getLayoutDescriptor: () => {
+          return {titleProperty: 'title'}
+        },
+        isPropertyVisible: () => false,
+        getPropertyDescriptors: () => {
+          return [];
+        },
+        data: {
+          query: {
+            properties: []
+          }
+        }
+      }
+    },
+    mocks: {
+      $t: (key) => key
+    }
+  }, options))
+}
+
+describe('LayoutCardsCard.vue', () => {
+  it('Root element had an index and an id', async () => {
+    const wrapper = initWrapper({
+      propsData: {
+        entry: {
+          id: "idA",
+          title: "title"
+        },
+        entryIdx: 1,
+      }
+    });
+    expect(wrapper.attributes("data-livedata-entry-index")).toBe("1")
+    expect(wrapper.attributes("data-livedata-entry-id")).toBe("idA")
+  })
+})

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/layouts/table/LayoutTable.spec.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/layouts/table/LayoutTable.spec.js
@@ -99,7 +99,8 @@ describe('LayoutTable.vue', () => {
             data: {
               data: {
                 entries: [
-                  {id: 1}
+                  {id: "idx1"},
+                  {id: "idx2"}
                 ]
               }
             }
@@ -111,9 +112,14 @@ describe('LayoutTable.vue', () => {
     // Manual trigger of the afterEntryFetch event.
     afterEntryFetchWrapper.callback();
     await Vue.nextTick();
-    let rows = wrapper.findAllComponents(LayoutTableRow);
-    expect(rows.length).toBe(1)
-    expect(rows.at(0).props()).toStrictEqual({entry: {id: 1}})
+    const rows = wrapper.findAllComponents(LayoutTableRow);
+    expect(rows.length).toBe(2);
+    expect(rows.at(0).props()).toStrictEqual({entry: {id: "idx1"}});
+    expect(rows.at(1).props()).toStrictEqual({entry: {id: "idx2"}});
+    expect(rows.at(0).attributes("data-livedata-entry-index")).toBe("0");
+    expect(rows.at(0).attributes("data-livedata-entry-id")).toBe("idx1");
+    expect(rows.at(1).attributes("data-livedata-entry-index")).toBe("1");
+    expect(rows.at(1).attributes("data-livedata-entry-id")).toBe("idx2");
     expect(wrapper.find('.noentries-card').exists()).toBe(false)
   })
 })

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/layouts/table/LayoutTable.spec.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/layouts/table/LayoutTable.spec.js
@@ -99,8 +99,7 @@ describe('LayoutTable.vue', () => {
             data: {
               data: {
                 entries: [
-                  {id: "idx1"},
-                  {id: "idx2"}
+                  {id: 1}
                 ]
               }
             }
@@ -113,13 +112,11 @@ describe('LayoutTable.vue', () => {
     afterEntryFetchWrapper.callback();
     await Vue.nextTick();
     const rows = wrapper.findAllComponents(LayoutTableRow);
-    expect(rows.length).toBe(2);
-    expect(rows.at(0).props()).toStrictEqual({entry: {id: "idx1"}});
-    expect(rows.at(1).props()).toStrictEqual({entry: {id: "idx2"}});
-    expect(rows.at(0).attributes("data-livedata-entry-index")).toBe("0");
-    expect(rows.at(0).attributes("data-livedata-entry-id")).toBe("idx1");
-    expect(rows.at(1).attributes("data-livedata-entry-index")).toBe("1");
-    expect(rows.at(1).attributes("data-livedata-entry-id")).toBe("idx2");
+    expect(rows.length).toBe(1)
+    expect(rows.at(0).props()).toStrictEqual({
+      entry: {id: 1},
+      entryIdx: 0
+    })
     expect(wrapper.find('.noentries-card').exists()).toBe(false)
   })
 })

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/layouts/table/LayoutTableRow.spec.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/layouts/table/LayoutTableRow.spec.js
@@ -1,0 +1,70 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+import {shallowMount} from '@vue/test-utils';
+import _ from 'lodash';
+import LayoutTableRow from "../../../../layouts/table/LayoutTableRow";
+
+/**
+ * Vue Component initializer for LayoutTableRow component. Since this component creates a deep hierarchy of
+ * sub-components, we use `shallowMount` to initialize the wrapper.
+ *
+ * The default option object is merged with the `option` parameter.
+ *
+ * @param options an optional option object use to customize the initialized component
+ * @returns {*} a shallow wrapper for the LayoutTableRow component
+ */
+function initWrapper(options = {}) {
+  return shallowMount(LayoutTableRow, _.merge({
+    provide: {
+      logic: {
+        getEntryId: (e) => e.id,
+        isSelectionEnabled: () => false,
+        isPropertyVisible: () => false,
+        getPropertyDescriptors: () => {
+          return [];
+        },
+        data: {
+          query: {
+            properties: []
+          }
+        }
+      }
+    },
+    mocks: {
+      $t: (key) => key
+    }
+  }, options))
+}
+
+describe('LayoutTableRow.vue', () => {
+  it('Root element had an index and an id', async () => {
+    const wrapper = initWrapper({
+      propsData: {
+        entry: {
+          id: "idA",
+          title: "title"
+        },
+        entryIdx: 1,
+      }
+    });
+    expect(wrapper.attributes("data-livedata-entry-index")).toBe("1")
+    expect(wrapper.attributes("data-livedata-entry-id")).toBe("idA")
+  })
+})

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/cards/LayoutCards.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/cards/LayoutCards.vue
@@ -65,7 +65,8 @@
         v-for="(entry, idx) in entries"
         :key="`card-${logic.getEntryId(entry)}-${idx}`"
         :entry="entry"
-        :data-index="idx"
+        :data-livedata-entry-index="idx"
+        :data-livedata-entry-id="logic.getEntryId(entry)"
       />
 
       <!-- Component to create a new entry -->

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/cards/LayoutCards.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/cards/LayoutCards.vue
@@ -65,6 +65,7 @@
         v-for="(entry, idx) in entries"
         :key="`card-${logic.getEntryId(entry)}-${idx}`"
         :entry="entry"
+        :data-index="idx"
       />
 
       <!-- Component to create a new entry -->

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/cards/LayoutCards.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/cards/LayoutCards.vue
@@ -65,8 +65,7 @@
         v-for="(entry, idx) in entries"
         :key="`card-${logic.getEntryId(entry)}-${idx}`"
         :entry="entry"
-        :data-livedata-entry-index="idx"
-        :data-livedata-entry-id="logic.getEntryId(entry)"
+        :entry-idx="idx"
       />
 
       <!-- Component to create a new entry -->

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/cards/LayoutCardsCard.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/cards/LayoutCardsCard.vue
@@ -25,7 +25,11 @@
   inside the Livedata configuration.
 -->
 <template>
-  <div class="card">
+  <div
+      class="card"
+      :data-livedata-entry-index="entryIdx"
+      :data-livedata-entry-id="logic.getEntryId(entry)"
+  >
 
     <!-- Card title-->
     <div class="card-title">
@@ -108,6 +112,11 @@ export default {
 
   props: {
     entry: Object,
+    // TODO: document
+    entryIdx: {
+      type: Number,
+      required: true
+    }
   },
 
   computed: {

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/cards/LayoutCardsCard.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/cards/LayoutCardsCard.vue
@@ -112,7 +112,13 @@ export default {
 
   props: {
     entry: Object,
-    // TODO: document
+    /**
+     * Index of the entry in the entries array.
+     * @since 14.10.20
+     * @since 15.5.5
+     * @since 15.10.1
+     * @since 16.0RC1
+     */
     entryIdx: {
       type: Number,
       required: true

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/table/LayoutTable.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/table/LayoutTable.vue
@@ -75,8 +75,7 @@
             v-for="(entry, idx) in entries"
             :key="`table-${logic.getEntryId(entry)}-${idx}`"
             :entry="entry"
-            :data-livedata-entry-index="idx"
-            :data-livedata-entry-id="logic.getEntryId(entry)"
+            :entry-idx="idx"
           />
 
           <!-- Component to create a new entry -->

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/table/LayoutTable.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/table/LayoutTable.vue
@@ -75,6 +75,7 @@
             v-for="(entry, idx) in entries"
             :key="`table-${logic.getEntryId(entry)}-${idx}`"
             :entry="entry"
+            :data-index="idx"
           />
 
           <!-- Component to create a new entry -->

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/table/LayoutTable.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/table/LayoutTable.vue
@@ -75,7 +75,8 @@
             v-for="(entry, idx) in entries"
             :key="`table-${logic.getEntryId(entry)}-${idx}`"
             :entry="entry"
-            :data-index="idx"
+            :data-livedata-entry-index="idx"
+            :data-livedata-entry-id="logic.getEntryId(entry)"
           />
 
           <!-- Component to create a new entry -->

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/table/LayoutTableRow.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/table/LayoutTableRow.vue
@@ -22,7 +22,10 @@
   It format an entry as an html row, with an entry selector on the left
 -->
 <template>
-  <tr>
+  <tr 
+      :data-livedata-entry-index="entryIdx"
+      :data-livedata-entry-id="logic.getEntryId(entry)"
+  >
 
     <!-- Entry Select -->
     <td
@@ -69,6 +72,11 @@ export default {
 
   props: {
     entry: Object,
+    // TODO: document
+    entryIdx: {
+      type: Number,
+      required: true
+    }
   },
 
   computed: {

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/table/LayoutTableRow.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/table/LayoutTableRow.vue
@@ -72,7 +72,13 @@ export default {
 
   props: {
     entry: Object,
-    // TODO: document
+    /**
+     * Index of the entry in the entries array.
+     * @since 14.10.20
+     * @since 15.5.5
+     * @since 15.10.1
+     * @since 16.0RC1
+     */
     entryIdx: {
       type: Number,
       required: true


### PR DESCRIPTION
  * Add `data-livedata-entry-index` and `data-livedata-entry-id` attributes on the parent DOM node of the entries, for both cards and table layouts

See: 
![Capture d’écran du 2023-12-04 11-42-27](https://github.com/xwiki/xwiki-platform/assets/1478232/22330790-62cd-448e-b237-9d930639fd39)
![Capture d’écran du 2023-12-04 11-42-05](https://github.com/xwiki/xwiki-platform/assets/1478232/b33a3f06-685d-4ab7-a3a3-1344c805adf3)

