### PR TITLE
XWIKI-15065: Replace Silk icons with Icon Themes values in attachments Upload component

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -1416,6 +1416,10 @@ core.widgets.html5upload.error.invalidSize=The file {0} is too large. Please cho
 core.widgets.html5upload.error.aborted=The upload of {0} has been canceled
 core.widgets.html5upload.status.finishing=Waiting for server confirmation for {0}...
 core.widgets.html5upload.status.finished=Attachment uploaded: {0} ({1})
+core.widgets.html5upload.status.icon.inprogress=Upload in progress
+core.widgets.html5upload.status.icon.done=Upload finished successfully
+core.widgets.html5upload.status.icon.canceled=Upload canceled
+core.widgets.html5upload.status.icon.error=Upload ended in an error
 core.widgets.html5upload.hideStatus=Hide upload status
 
 ### Watchlist (1.2M2)

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/SolrRatingsManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/SolrRatingsManagerTest.java
@@ -28,7 +28,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.css
@@ -8,19 +8,28 @@
   background: $theme.highlightColor none 2px .8em no-repeat;
   margin: .5em 0;
   clear: both;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.2em 1em;
 }
-.upload-inprogress {
+
+.upload-status .status-icon {
+  display: none;
+}
+
+.upload-status.upload-inprogress .status-icon.icon-inprogress,
+.upload-status.upload-done .status-icon.icon-done,
+.upload-status.upload-canceled .status-icon.icon-canceled,
+.upload-status.upload-error .status-icon.icon-error {
+  display: inherit;
+}
+.status-icon.icon-inprogress {
+  height: 14px;
+  width: 17px;
   background-image: url("$xwiki.getSkinFile('icons/xwiki/spinner.gif')");
 }
-.upload-done {
-  background-image: url("$xwiki.getSkinFile('icons/silk/tick.png')");
-}
-.upload-canceled {
-  background-image: url("$xwiki.getSkinFile('icons/silk/cancel.png')");
-}
-.upload-error {
-  background-image: url("$xwiki.getSkinFile('icons/silk/delete.png')");
-}
+
 .progress-info, .file-info {
   font-size: .91em;
 }
@@ -39,7 +48,7 @@
   margin: 0;
 }
 .progress-info {
-  clear: right;
+  flex-basis: 100%;
   opacity: 0.5;
 }
 .upload-inprogress .progress-info {
@@ -71,7 +80,13 @@
   margin: 0.3em 0;
   width: 100%;
 }
-.upload-canceled .file-info .file-name, .upload-error .file-info .file-name {
+.upload-done .status-icon.icon-done {
+  color: $theme.notificationSuccessColor;
+}
+.upload-canceled .file-info .file-name,
+.upload-canceled .status-icon.icon-canceled,
+.upload-error .file-info .file-name,
+.upload-error .status-icon.icon-error {
   color: $theme.notificationErrorColor;
 }
 .upload-canceled .progress-info .progress-container {

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.css
@@ -13,11 +13,9 @@
   align-items: center;
   gap: 0.2em 1em;
 }
-
 .upload-status .status-icon {
   display: none;
 }
-
 .upload-status.upload-inprogress .status-icon.icon-inprogress,
 .upload-status.upload-done .status-icon.icon-done,
 .upload-status.upload-canceled .status-icon.icon-canceled,
@@ -29,7 +27,6 @@
   width: 17px;
   background-image: url("$xwiki.getSkinFile('icons/xwiki/spinner.gif')");
 }
-
 .progress-info, .file-info {
   font-size: .91em;
 }

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.js
@@ -125,16 +125,16 @@ var XWiki = (function(XWiki) {
       // Set up the icons and their text alternatives
       // The inprogress icon is a special case, we set the content using a GIF background in CSS
       statusUI.STATUS_ICON_INPROGRESS = UploadUtils.createDiv('status-icon icon-inprogress', '');
-      statusUI.STATUS_ICON_INPROGRESS_ALTERNATIVE = UploadUtils.createSpan('sr-only',"$services.localization.render('core.widgets.html5upload.status.icon.inprogress')");
+      statusUI.STATUS_ICON_INPROGRESS_ALTERNATIVE = UploadUtils.createSpan('sr-only', "$!escapetool.javascript($services.localization.render('core.widgets.html5upload.status.icon.inprogress'))");
       statusUI.STATUS_ICON_INPROGRESS.insert(statusUI.STATUS_ICON_INPROGRESS_ALTERNATIVE);
       statusUI.STATUS_ICON_DONE = UploadUtils.createDiv('status-icon icon-done', "$!escapetool.javascript($services.icon.renderHTML('check'))");
-      statusUI.STATUS_ICON_DONE_ALTERNATIVE = UploadUtils.createSpan('sr-only',"$services.localization.render('core.widgets.html5upload.status.icon.done')");
+      statusUI.STATUS_ICON_DONE_ALTERNATIVE = UploadUtils.createSpan('sr-only', "$!escapetool.javascript($services.localization.render('core.widgets.html5upload.status.icon.done'))");
       statusUI.STATUS_ICON_DONE.insert(statusUI.STATUS_ICON_DONE_ALTERNATIVE);
       statusUI.STATUS_ICON_CANCELED = UploadUtils.createDiv('status-icon icon-canceled', "$!escapetool.javascript($services.icon.renderHTML('remove'))");
-      statusUI.STATUS_ICON_CANCELED_ALTERNATIVE = UploadUtils.createSpan('sr-only',"$services.localization.render('core.widgets.html5upload.status.icon.canceled')");
+      statusUI.STATUS_ICON_CANCELED_ALTERNATIVE = UploadUtils.createSpan('sr-only', "$!escapetool.javascript($services.localization.render('core.widgets.html5upload.status.icon.canceled'))");
       statusUI.STATUS_ICON_CANCELED.insert(statusUI.STATUS_ICON_CANCELED_ALTERNATIVE);
       statusUI.STATUS_ICON_ERROR = UploadUtils.createDiv('status-icon icon-error', "$!escapetool.javascript($services.icon.renderHTML('error'))");
-      statusUI.STATUS_ICON_ERROR_ALTERNATIVE = UploadUtils.createSpan('sr-only',"$services.localization.render('core.widgets.html5upload.status.icon.error')");
+      statusUI.STATUS_ICON_ERROR_ALTERNATIVE = UploadUtils.createSpan('sr-only', "$!escapetool.javascript($services.localization.render('core.widgets.html5upload.status.icon.error'))");
       statusUI.STATUS_ICON_ERROR.insert(statusUI.STATUS_ICON_ERROR_ALTERNATIVE);
       statusUI.UPLOAD_STATUS.insert(statusUI.STATUS_ICON_INPROGRESS).insert(statusUI.STATUS_ICON_DONE).insert(statusUI.STATUS_ICON_CANCELED).insert(statusUI.STATUS_ICON_ERROR);
       
@@ -142,7 +142,7 @@ var XWiki = (function(XWiki) {
         statusUI.FILE_INFO   = UploadUtils.createDiv('file-info');
         (statusUI.FILE_NAME  = UploadUtils.createSpan('file-name', this.file.name)).title = this.file.type;
         statusUI.FILE_SIZE   = UploadUtils.createSpan('file-size', ' (' + UploadUtils.bytesToSize(this.file.size) + ')');
-        statusUI.FILE_CANCEL = UploadUtils.createButton("$services.localization.render('core.widgets.html5upload.item.cancel')", this.cancelUpload.bindAsEventListener(this));
+        statusUI.FILE_CANCEL = UploadUtils.createButton("$!escapetool.javascript($services.localization.render('core.widgets.html5upload.item.cancel'))", this.cancelUpload.bindAsEventListener(this));
         // TODO MIME type icon?
 
         statusUI.FILE_INFO.insert(statusUI.FILE_NAME).insert(statusUI.FILE_SIZE).insert(statusUI.FILE_CANCEL);
@@ -248,7 +248,7 @@ var XWiki = (function(XWiki) {
       this.request && this.request.abort();
       this.canceled = true;
       clearInterval(this.timer);
-      this.statusUI.FILE_CANCEL.addClassName('upload-canceled-label').removeClassName('buttonwrapper').update("$services.localization.render('core.widgets.html5upload.item.canceled')");
+      this.statusUI.FILE_CANCEL.addClassName('upload-canceled-label').removeClassName('buttonwrapper').update("$!escapetool.javascript($services.localization.render('core.widgets.html5upload.item.canceled'))");
       this.statusUI.UPLOAD_STATUS.removeClassName('upload-inprogress').addClassName('upload-canceled');
     },
 
@@ -409,12 +409,12 @@ var XWiki = (function(XWiki) {
 
     /** Templates for feedback messages displayed to the user. */
     messages : {
-      UNKNOWN_ERROR         : new Template("$services.localization.render('core.widgets.html5upload.error.unknown', ['#{name}'])"),
-      INVALID_FILE_TYPE     : new Template("$services.localization.render('core.widgets.html5upload.error.invalidType', ['#{name}'])"),
-      UPLOAD_LIMIT_EXCEEDED : new Template("$services.localization.render('core.widgets.html5upload.error.invalidSize', ['#{name}', '#{size}'])"),
-      UPLOAD_ABORTED        : new Template("$services.localization.render('core.widgets.html5upload.error.aborted', ['#{name}'])"),
-      UPLOAD_FINISHING      : new Template("$services.localization.render('core.widgets.html5upload.status.finishing', ['#{name}'])"),
-      UPLOAD_FINISHED       : new Template("$services.localization.render('core.widgets.html5upload.status.finished', ['#{name}', '#{size}'])")
+      UNKNOWN_ERROR         : new Template("$!escapetool.javascript($services.localization.render('core.widgets.html5upload.error.unknown', ['#{name}']))"),
+      INVALID_FILE_TYPE     : new Template("$!escapetool.javascript($services.localization.render('core.widgets.html5upload.error.invalidType', ['#{name}']))"),
+      UPLOAD_LIMIT_EXCEEDED : new Template("$!escapetool.javascript($services.localization.render('core.widgets.html5upload.error.invalidSize', ['#{name}', '#{size}']))"),
+      UPLOAD_ABORTED        : new Template("$!escapetool.javascript($services.localization.render('core.widgets.html5upload.error.aborted', ['#{name}']))"),
+      UPLOAD_FINISHING      : new Template("$!escapetool.javascript($services.localization.render('core.widgets.html5upload.status.finishing', ['#{name}']))"),
+      UPLOAD_FINISHED       : new Template("$!escapetool.javascript($services.localization.render('core.widgets.html5upload.status.finished', ['#{name}', '#{size}']))")
     },
 
     /**
@@ -485,11 +485,11 @@ var XWiki = (function(XWiki) {
       statusUI.CONTAINER = UploadUtils.createDiv('upload-status-container');
       statusUI.LIST = UploadUtils.createDiv('upload-status-list');
       statusUI.CANCEL = UploadUtils.createButton(
-        "$services.localization.render('core.widgets.html5upload.cancelAll')",
+        "$!escapetool.javascript($services.localization.render('core.widgets.html5upload.cancelAll'))",
          this.cancelUpload.bindAsEventListener(this)
       );
       statusUI.HIDE = UploadUtils.createButton(
-        "$services.localization.render('core.widgets.html5upload.hideStatus')",
+        "$!escapetool.javascript($services.localization.render('core.widgets.html5upload.hideStatus'))",
          this.hideUploadStatus.bindAsEventListener(this)
       );
       statusUI.HIDE.hide();

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.js
@@ -121,7 +121,23 @@ var XWiki = (function(XWiki) {
       var statusUI = this.statusUI = {};
 
       statusUI.UPLOAD_STATUS = UploadUtils.createDiv('upload-status upload-inprogress');
-
+      
+      // Set up the icons and their text alternatives
+      // The inprogress icon is a special case, we set the content using a GIF background in CSS
+      statusUI.STATUS_ICON_INPROGRESS = UploadUtils.createDiv('status-icon icon-inprogress', '');
+      statusUI.STATUS_ICON_INPROGRESS_ALTERNATIVE = UploadUtils.createSpan('sr-only',"$services.localization.render('core.widgets.html5upload.status.icon.inprogress')");
+      statusUI.STATUS_ICON_INPROGRESS.insert(statusUI.STATUS_ICON_INPROGRESS_ALTERNATIVE);
+      statusUI.STATUS_ICON_DONE = UploadUtils.createDiv('status-icon icon-done', "$!escapetool.javascript($services.icon.renderHTML('check'))");
+      statusUI.STATUS_ICON_DONE_ALTERNATIVE = UploadUtils.createSpan('sr-only',"$services.localization.render('core.widgets.html5upload.status.icon.done')");
+      statusUI.STATUS_ICON_DONE.insert(statusUI.STATUS_ICON_DONE_ALTERNATIVE);
+      statusUI.STATUS_ICON_CANCELED = UploadUtils.createDiv('status-icon icon-canceled', "$!escapetool.javascript($services.icon.renderHTML('remove'))");
+      statusUI.STATUS_ICON_CANCELED_ALTERNATIVE = UploadUtils.createSpan('sr-only',"$services.localization.render('core.widgets.html5upload.status.icon.canceled')");
+      statusUI.STATUS_ICON_CANCELED.insert(statusUI.STATUS_ICON_CANCELED_ALTERNATIVE);
+      statusUI.STATUS_ICON_ERROR = UploadUtils.createDiv('status-icon icon-error', "$!escapetool.javascript($services.icon.renderHTML('error'))");
+      statusUI.STATUS_ICON_ERROR_ALTERNATIVE = UploadUtils.createSpan('sr-only',"$services.localization.render('core.widgets.html5upload.status.icon.error')");
+      statusUI.STATUS_ICON_ERROR.insert(statusUI.STATUS_ICON_ERROR_ALTERNATIVE);
+      statusUI.UPLOAD_STATUS.insert(statusUI.STATUS_ICON_INPROGRESS).insert(statusUI.STATUS_ICON_DONE).insert(statusUI.STATUS_ICON_CANCELED).insert(statusUI.STATUS_ICON_ERROR);
+      
       if (this.options.enableFileInfo) {
         statusUI.FILE_INFO   = UploadUtils.createDiv('file-info');
         (statusUI.FILE_NAME  = UploadUtils.createSpan('file-name', this.file.name)).title = this.file.type;

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.js
@@ -18,6 +18,21 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 var XWiki = (function(XWiki) {
+  var l10n = {
+    "core.widgets.html5upload.status.icon.inprogress" : "$!escapetool.javascript($services.localization.render('core.widgets.html5upload.status.icon.inprogress'))",
+    "core.widgets.html5upload.status.icon.done" : "$!escapetool.javascript($services.localization.render('core.widgets.html5upload.status.icon.done'))",
+    "core.widgets.html5upload.status.icon.canceled" : "$!escapetool.javascript($services.localization.render('core.widgets.html5upload.status.icon.canceled'))",
+    "core.widgets.html5upload.status.icon.error" : "$!escapetool.javascript($services.localization.render('core.widgets.html5upload.status.icon.error'))",
+    "core.widgets.html5upload.item.cancel" : "$!escapetool.javascript($services.localization.render('core.widgets.html5upload.item.cancel'))",
+    "core.widgets.html5upload.item.canceled" : "$!escapetool.javascript($services.localization.render('core.widgets.html5upload.item.canceled'))",
+    "core.widgets.html5upload.cancelAll" : "$!escapetool.javascript($services.localization.render('core.widgets.html5upload.cancelAll'))",
+    "core.widgets.html5upload.hideStatus" : "$!escapetool.javascript($services.localization.render('core.widgets.html5upload.hideStatus'))"
+  };
+  var icons = {
+    'check' : "$!escapetool.javascript($services.icon.renderHTML('check'))",
+    'remove' : "$!escapetool.javascript($services.icon.renderHTML('remove'))",
+    'error' : "$!escapetool.javascript($services.icon.renderHTML('error'))",
+  }
   // Only enable this widget if the needed JS APIs are present
   if (typeof (File) === 'undefined' || typeof (FormData) === 'undefined' || typeof (XMLHttpRequest) === 'undefined') {return XWiki;}
 
@@ -121,28 +136,28 @@ var XWiki = (function(XWiki) {
       var statusUI = this.statusUI = {};
 
       statusUI.UPLOAD_STATUS = UploadUtils.createDiv('upload-status upload-inprogress');
-      
+
       // Set up the icons and their text alternatives
       // The inprogress icon is a special case, we set the content using a GIF background in CSS
       statusUI.STATUS_ICON_INPROGRESS = UploadUtils.createDiv('status-icon icon-inprogress', '');
-      statusUI.STATUS_ICON_INPROGRESS_ALTERNATIVE = UploadUtils.createSpan('sr-only', "$!escapetool.javascript($services.localization.render('core.widgets.html5upload.status.icon.inprogress'))");
+      statusUI.STATUS_ICON_INPROGRESS_ALTERNATIVE = UploadUtils.createSpan('sr-only', l10n['core.widgets.html5upload.status.icon.inprogress']);
       statusUI.STATUS_ICON_INPROGRESS.insert(statusUI.STATUS_ICON_INPROGRESS_ALTERNATIVE);
-      statusUI.STATUS_ICON_DONE = UploadUtils.createDiv('status-icon icon-done', "$!escapetool.javascript($services.icon.renderHTML('check'))");
-      statusUI.STATUS_ICON_DONE_ALTERNATIVE = UploadUtils.createSpan('sr-only', "$!escapetool.javascript($services.localization.render('core.widgets.html5upload.status.icon.done'))");
+      statusUI.STATUS_ICON_DONE = UploadUtils.createDiv('status-icon icon-done', icons['check']);
+      statusUI.STATUS_ICON_DONE_ALTERNATIVE = UploadUtils.createSpan('sr-only', l10n['core.widgets.html5upload.status.icon.done']);
       statusUI.STATUS_ICON_DONE.insert(statusUI.STATUS_ICON_DONE_ALTERNATIVE);
-      statusUI.STATUS_ICON_CANCELED = UploadUtils.createDiv('status-icon icon-canceled', "$!escapetool.javascript($services.icon.renderHTML('remove'))");
-      statusUI.STATUS_ICON_CANCELED_ALTERNATIVE = UploadUtils.createSpan('sr-only', "$!escapetool.javascript($services.localization.render('core.widgets.html5upload.status.icon.canceled'))");
+      statusUI.STATUS_ICON_CANCELED = UploadUtils.createDiv('status-icon icon-canceled', icons['remove']);
+      statusUI.STATUS_ICON_CANCELED_ALTERNATIVE = UploadUtils.createSpan('sr-only', l10n['core.widgets.html5upload.status.icon.canceled']);
       statusUI.STATUS_ICON_CANCELED.insert(statusUI.STATUS_ICON_CANCELED_ALTERNATIVE);
-      statusUI.STATUS_ICON_ERROR = UploadUtils.createDiv('status-icon icon-error', "$!escapetool.javascript($services.icon.renderHTML('error'))");
-      statusUI.STATUS_ICON_ERROR_ALTERNATIVE = UploadUtils.createSpan('sr-only', "$!escapetool.javascript($services.localization.render('core.widgets.html5upload.status.icon.error'))");
+      statusUI.STATUS_ICON_ERROR = UploadUtils.createDiv('status-icon icon-error', icons['error']);
+      statusUI.STATUS_ICON_ERROR_ALTERNATIVE = UploadUtils.createSpan('sr-only', l10n['core.widgets.html5upload.status.icon.error']);
       statusUI.STATUS_ICON_ERROR.insert(statusUI.STATUS_ICON_ERROR_ALTERNATIVE);
       statusUI.UPLOAD_STATUS.insert(statusUI.STATUS_ICON_INPROGRESS).insert(statusUI.STATUS_ICON_DONE).insert(statusUI.STATUS_ICON_CANCELED).insert(statusUI.STATUS_ICON_ERROR);
-      
+
       if (this.options.enableFileInfo) {
         statusUI.FILE_INFO   = UploadUtils.createDiv('file-info');
         (statusUI.FILE_NAME  = UploadUtils.createSpan('file-name', this.file.name)).title = this.file.type;
         statusUI.FILE_SIZE   = UploadUtils.createSpan('file-size', ' (' + UploadUtils.bytesToSize(this.file.size) + ')');
-        statusUI.FILE_CANCEL = UploadUtils.createButton("$!escapetool.javascript($services.localization.render('core.widgets.html5upload.item.cancel'))", this.cancelUpload.bindAsEventListener(this));
+        statusUI.FILE_CANCEL = UploadUtils.createButton(l10n['core.widgets.html5upload.item.cancel'], this.cancelUpload.bindAsEventListener(this));
         // TODO MIME type icon?
 
         statusUI.FILE_INFO.insert(statusUI.FILE_NAME).insert(statusUI.FILE_SIZE).insert(statusUI.FILE_CANCEL);
@@ -248,7 +263,7 @@ var XWiki = (function(XWiki) {
       this.request && this.request.abort();
       this.canceled = true;
       clearInterval(this.timer);
-      this.statusUI.FILE_CANCEL.addClassName('upload-canceled-label').removeClassName('buttonwrapper').update("$!escapetool.javascript($services.localization.render('core.widgets.html5upload.item.canceled'))");
+      this.statusUI.FILE_CANCEL.addClassName('upload-canceled-label').removeClassName('buttonwrapper').update(l10n['core.widgets.html5upload.item.canceled']);
       this.statusUI.UPLOAD_STATUS.removeClassName('upload-inprogress').addClassName('upload-canceled');
     },
 
@@ -485,11 +500,11 @@ var XWiki = (function(XWiki) {
       statusUI.CONTAINER = UploadUtils.createDiv('upload-status-container');
       statusUI.LIST = UploadUtils.createDiv('upload-status-list');
       statusUI.CANCEL = UploadUtils.createButton(
-        "$!escapetool.javascript($services.localization.render('core.widgets.html5upload.cancelAll'))",
+        l10n['core.widgets.html5upload.cancelAll'],
          this.cancelUpload.bindAsEventListener(this)
       );
       statusUI.HIDE = UploadUtils.createButton(
-        "$!escapetool.javascript($services.localization.render('core.widgets.html5upload.hideStatus'))",
+        l10n['core.widgets.html5upload.hideStatus'],
          this.hideUploadStatus.bindAsEventListener(this)
       );
       statusUI.HIDE.hide();


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-15065
## PR Changes
* Added icons to the generated nodes and removed their unsemantic counterpart from css backgrounds

## Note
I decided to go with a CSS only logic: instead of creating and deleting the icons based on the status, we use the logic already in place to hide/show the icons (all created at the start). There's only 4 of them, and they are not generated on every page load, so I think this is an appropriate solution.

## View
Here is a screenshot from the issue report on Jira:
<img width="576" alt="upload" src="https://github.com/xwiki/xwiki-platform/assets/28761965/0ccde8ba-2842-44e5-96d0-723079eb4448">
Hereafter is a screeenshot of the same UI after the changes proposed in this PR
![15065-afterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/3621b493-f218-4cb1-a101-c1a629efc039)
