### PR TITLE
XWIKI-18971: Number property input does not take into account the current locale to parse floating numbers

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/NumberClassTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/NumberClassTest.java
@@ -19,37 +19,46 @@
  */
 package com.xpn.xwiki.objects.classes;
 
-import org.junit.Rule;
-import org.junit.Test;
+import java.util.Locale;
 
+import org.junit.jupiter.api.Test;
+
+import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.objects.BaseProperty;
-import com.xpn.xwiki.test.MockitoOldcoreRule;
+import com.xpn.xwiki.test.MockitoOldcore;
+import com.xpn.xwiki.test.junit5.mockito.InjectMockitoOldcore;
+import com.xpn.xwiki.test.junit5.mockito.OldcoreTest;
 import com.xpn.xwiki.test.reference.ReferenceComponentList;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit tests for the {@link NumberClass} class.
  * 
  * @version $Id$
  */
+@OldcoreTest
 @ReferenceComponentList
 public class NumberClassTest
 {
-    @Rule
-    public MockitoOldcoreRule oldcore = new MockitoOldcoreRule();
+    @InjectMockitoOldcore
+    public MockitoOldcore oldcore;
 
-    /** Test the fromString method. */
     @Test
-    public void testFromString()
+    void fromStringWithLong()
     {
         // Create a default Number property
         NumberClass nc = new NumberClass();
         BaseClass bc = new BaseClass();
         bc.setName("Some.Class");
         nc.setObject(bc);
+        XWikiDocument document = mock(XWikiDocument.class);
+        nc.setOwnerDocument(document);
+        when(document.getLocale()).thenReturn(Locale.FRENCH);
 
         // A String value containing non-numeric caracters can not be respresented as a numeric value, so this sould
         // return null
@@ -73,6 +82,51 @@ public class NumberClassTest
         // An integer value should lead to creating an object containing that integer as value
         p = nc.fromString("4");
         assertNotNull(p);
-        assertEquals(4, Integer.parseInt(p.getValue().toString()));
+        assertEquals(4L, p.getValue());
+    }
+
+    @Test
+    void fromStringWithFloat()
+    {
+        // Create a default Number property
+        NumberClass nc = new NumberClass();
+        BaseClass bc = new BaseClass();
+        bc.setName("Some.Class");
+        nc.setObject(bc);
+        nc.setNumberType(NumberClass.TYPE_FLOAT);
+        XWikiDocument document = mock(XWikiDocument.class);
+        nc.setOwnerDocument(document);
+        when(document.getLocale()).thenReturn(Locale.FRENCH);
+
+        // A String value containing non-numeric caracters can not be respresented as a numeric value, so this sould
+        // return null
+        assertNull(nc.fromString("asd"));
+
+        BaseProperty p;
+
+        // A null value should lead to creating an object with an empty value
+        p = nc.fromString(null);
+        assertNotNull(p);
+        assertNull(p.getValue());
+
+        // An empty String should lead to creating an object with an empty value
+        p = nc.fromString("");
+        assertNotNull(p);
+        assertNull(p.getValue());
+
+        // Very long values are handled by Float
+        p = nc.fromString("1111111111111111111111111111111111");
+        assertNotNull(p);
+        assertEquals(1.1111111111111111E33f, p.getValue());
+
+        // An integer value should lead to creating an object containing that integer as value
+        p = nc.fromString("4");
+        assertNotNull(p);
+        assertEquals(4.0f, p.getValue());
+
+        // We're using french locale
+        p = nc.fromString("4,738");
+        assertNotNull(p);
+        assertEquals(4.738f, p.getValue());
     }
 }


### PR DESCRIPTION
Use a NumberFormat instance based on the locale of the owner document for parsing number values.
I also simplified a bit the code of NumberClass#fromString, started refactoring of NumberClassTest, but it's still missing lots of test cases.

Also it's still a WIP: right now we've several unit tests failing in oldcore because of this: probably because the owner document is now mandatory for this method. We might need a fallback in case no owner document is specified.