### PR TITLE
XWIKI-21650: The XModal close button new style does not fit in its context

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/widgets/modalPopup.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/widgets/modalPopup.css
@@ -42,34 +42,27 @@
     width: 400px; /* Should be: @modal-md */
   }
 }
-.xdialog-box .xdialog-content {
+.xdialog-box .xdialog-content,
+.xdialog-box > .xdialog-close {
   margin: .8em;
 }
-.xdialog-close {
+.xdialog-box > .xdialog-close {
   float: right;
-  margin-right: .8em;
 }
 .xdialog-title .xdialog-close {
   font-size: 1.25em;
-  margin-right: -0.56em;
-  margin-top: -0.24em;
   color: $theme.panelHeaderTextColor;
 }
 .xdialog-title {
-  font-size: 80%;
-  font-weight: bold;
-  padding: .3em 1.2em .3em .8em;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem;
   background-color: $theme.panelHeaderBackgroundColor;
-  #css3_backgroundLinearGradient({
-     'to': 'bottom',
-     'colors': [
-      {'color': $theme.panelHeaderGradientColor, 'position': '0%'},
-      {'color': $theme.panelHeaderBackgroundColor, 'position': '100%'}
-    ]
-  })
   border-radius: 7px 7px 0 0;
+  font-weight: bold;
+  font-size: 110%;
   color: $theme.panelHeaderTextColor;
-  text-shadow: 0 1px 0 $theme.panelHeaderGradientColor;
 }
 .xdialog-box .xform {
   width: 100%;

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/widgets/modalPopup.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/widgets/modalPopup.css
@@ -29,8 +29,7 @@
   color: $theme.panelTextColor;
   border: 1px solid $theme.borderColor;
   background-color: $theme.panelBackgroundColor;
-  border-radius: 7px;
-  box-shadow: 0 0 7px $theme.borderColor;
+  border-radius: 10px;
 }
 .xdialog-box {
   max-height: 100%; /* Needed because of position: fixed */
@@ -54,15 +53,9 @@
   color: $theme.panelHeaderTextColor;
 }
 .xdialog-title {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1rem;
-  background-color: $theme.panelHeaderBackgroundColor;
-  border-radius: 7px 7px 0 0;
-  font-weight: bold;
-  font-size: 110%;
-  color: $theme.panelHeaderTextColor;
+  font-size: 142%;
+  padding: 15px;
+  border-bottom: 1px solid $theme.borderColor;
 }
 .xdialog-box .xform {
   width: 100%;

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/widgets/modalPopup.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/widgets/modalPopup.js
@@ -79,7 +79,7 @@ widgets.ModalPopup = Class.create({
     }
     // Add the close button
     if (this.options.displayCloseButton) {
-      var closeButton = new Element('button', {'class': 'btn btn-default btn-xs xdialog-close', 'title': 'Close'})
+      var closeButton = new Element('button', {'class': 'close xdialog-close', 'title': 'Close'})
         .update("$!escapetool.javascript($services.icon.renderHTML('cross'))");
       closeButton.observe("click", this.closeDialog.bindAsEventListener(this));
       if (this.options.title) {
@@ -99,10 +99,10 @@ widgets.ModalPopup = Class.create({
     });
     switch(this.options.verticalPosition) {
       case "top":
-        this.dialogBox.setStyle({"top": "0"});
+        this.dialogBox.setStyle({"top": "30px"});
         break;
       case "bottom":
-        this.dialogBox.setStyle({"bottom": "0"});
+        this.dialogBox.setStyle({"bottom": "30px"});
         break;
       default:
         // TODO: smart alignment according to the actual height

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/widgets/modalPopup.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/widgets/modalPopup.js
@@ -79,7 +79,8 @@ widgets.ModalPopup = Class.create({
     }
     // Add the close button
     if (this.options.displayCloseButton) {
-      var closeButton = new Element('button', {'class': 'btn btn-default xdialog-close', 'title': 'Close'}).update("&#215;");
+      var closeButton = new Element('button', {'class': 'btn btn-default btn-xs xdialog-close', 'title': 'Close'})
+        .update("$!escapetool.javascript($services.icon.renderHTML('cross'))");
       closeButton.observe("click", this.closeDialog.bindAsEventListener(this));
       if (this.options.title) {
         title.insert({bottom: closeButton});


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21650
## PR Changes
* Updated style of the title section of the xdialog
* Added the class btn-xs to the close button (avoid it being way too large )
* Replaced the content with a cross icon (no need for alternative because there's a title on the button)
## Notes
I decided to review a bit the style of this dialog header: replaced the `X` in the close button with a proper icon, made the text larger than regular instead of smaller, added padding and replaced float positioning with a flex, replaced the gradient background with a flat color
## View
Here are a few screenshots of the close button in different use cases. We can see that it looks okay now, whether it's inside a xdialog-title container or not:
![21650-afterPR3](https://github.com/xwiki/xwiki-platform/assets/28761965/161655dd-c16f-45cc-931c-809b2e2c6dda)
![21650-afterPR2](https://github.com/xwiki/xwiki-platform/assets/28761965/4777b816-0452-4d83-a3d5-c52f39cce571)
![21650-afterPR1](https://github.com/xwiki/xwiki-platform/assets/28761965/1fc458cd-8b63-42f7-b175-065e8ed7b609)

Here are the screenshots of those same UIs, before the PR, for reference (taken from the Jira ticket):

![image-2023-12-07-17-35-33-778](https://github.com/xwiki/xwiki-platform/assets/28761965/c2bbfc2a-e88b-48fa-826d-2580dc029013)
![modalAppEntryCloselooksWrong](https://github.com/xwiki/xwiki-platform/assets/28761965/0f7f283a-f1ef-468b-ae93-596c21d9f866)
