### PR TITLE
XWIKI-14088: Ensure that implied rights are consistent

### DIFF
--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -193,6 +193,19 @@
                 </item>
               </differences>
             </revapi.differences>
+            <revapi.differences>
+              <differences>
+                <item>
+                  <code>java.field.serialVersionUIDChanged</code>
+                  <old>field org.xwiki.security.authorization.Right.serialVersionUID</old>
+                  <new>field org.xwiki.security.authorization.Right.serialVersionUID</new>
+                  <oldSerialVersionUID>1</oldSerialVersionUID>
+                  <newSerialVersionUID>2</newSerialVersionUID>
+                  <justification>Needed to add a new field for needed rights, unlikely to cause real issues in practice as we're not storing serialized rights.</justification>
+                  <criticality>highlight</criticality>
+                </item>
+              </differences>
+            </revapi.differences>
           </analysisConfiguration>
         </configuration>
       </plugin>

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/RightDescription.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/RightDescription.java
@@ -22,6 +22,7 @@ package org.xwiki.security.authorization;
 import java.util.Set;
 
 import org.xwiki.model.EntityType;
+import org.xwiki.stability.Unstable;
 
 /**
  * Describe a {@link Right}, allow adding new Rights, also implemented by the {@link Right} class.
@@ -60,6 +61,16 @@ public interface RightDescription
      * return {@code null} instead of an empty set.
      */
     Set<Right> getImpliedRights();
+
+    /**
+     * @return a set of rights that are needed for this right to be granted
+     * @since 15.10.2
+     */
+    @Unstable
+    default Set<Right> getNeededRights()
+    {
+        return Set.of();
+    }
 
     /**
      * @return a set of entity type for which this right should be enabled. Special type Right.FARM (==null) could


### PR DESCRIPTION
* Add a new concept of rights that are needed for another right.
* Deny rights that are missing a needed right.
* Add unit tests.

Forum discussion: https://forum.xwiki.org/t/should-denied-view-right-deny-other-rights-or-be-overridden-by-other-rights/13557

I'm marking this as a draft as long as the forum discussion hasn't been concluded.