### PR TITLE
XWIKI-21370: Header structure uses too many H1

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/EditIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/EditIT.java
@@ -934,7 +934,7 @@ public class EditIT
             "disabledSyntaxes", "plain/1.0,xdom+xml/current,xwiki/2.0,xhtml/5,html/5.0");
         setup.deletePage(testReference);
 
-        String pageContent = "= First heading =\n"
+        String pageContent = "== First heading ==\n"
             + "\n"
             + "Paragraph containing some **bold content**.\n"
             + "\n"

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-pageobjects/src/main/java/org/xwiki/panels/test/po/PageLayoutTabContent.java
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-pageobjects/src/main/java/org/xwiki/panels/test/po/PageLayoutTabContent.java
@@ -130,7 +130,7 @@ public class PageLayoutTabContent extends BaseElement
 
     public void dragPanelToColumn(String panelName, Column column)
     {
-        String cssSelector = String.format(".panel.%s h1", panelName);
+        String cssSelector = String.format(".panel.%s h2", panelName);
         WebElement element = getDriver().findElementWithoutWaiting(By.cssSelector(cssSelector));
         if (column == Column.RIGHT) {
             getDriver().dragAndDrop(element, rightPanels);
@@ -141,7 +141,7 @@ public class PageLayoutTabContent extends BaseElement
 
     public void removePanelFromColumn(String panelName, Column column)
     {
-        String cssSelector = String.format("#%%s .panel.%s h1", panelName);
+        String cssSelector = String.format("#%%s .panel.%s h2", panelName);
 
         if (column == Column.RIGHT) {
             cssSelector = String.format(cssSelector, "rightPanels");


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21370
## PR Changes
* Fixed test regressions introduced in https://github.com/xwiki/xwiki-platform/commit/92c46a63a954990fb64e95b78a4a4e112cb1583a
## Tests
Passed successfully :
* `mvn clean install -f xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test -Pdocker -Dxwiki.checkstyle.skip=true -Dxwiki.enforcer.skip=true -Dxwiki.revapi.skip=true` ([failure reference](https://ci.xwiki.org/job/XWiki%20Environment%20Tests/job/xwiki-platform/job/master/413/testReport/org.xwiki.panels.test.ui.docker/AllIT$NestedPanelsAdministrationIT/MariaDB_10_11__Tomcat_9_jdk17__Firefox___Docker_tests_for_xwiki_platform_panels___Build_for_MariaDB_10_11__Tomcat_9_jdk17__Firefox___Docker_tests_for_xwiki_platform_panels___resetPanels/))
*  `mvn clean install -f xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker -Pdocker -Dxwiki.checkstyle.skip=true -Dxwiki.enforcer.skip=true -Dxwiki.revapi.skip=true`([failure reference](https://ci.xwiki.org/job/XWiki%20Environment%20Tests/job/xwiki-platform/job/master/413/testReport/org.xwiki.flamingo.test.docker/AllIT$NestedEditIT/MariaDB_10_11__Tomcat_9_jdk17__Firefox___Docker_tests_for_xwiki_platform_flamingo_skin___Build_for_MariaDB_10_11__Tomcat_9_jdk17__Firefox___Docker_tests_for_xwiki_platform_flamingo_skin___switchSyntaxFromWikiEditMode_TestUtils__TestReference_/))