### PR TITLE
XWIKI-21702: Too big button for closing the drawer in a minimal distribution

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/drawer.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/drawer.less
@@ -96,7 +96,7 @@
       }
 
       // Avatar styling
-      img {
+      img.avatar {
         border-radius: 50%;
         height: 50px;
         width: 50px;


### PR DESCRIPTION
 ## Jira
https://jira.xwiki.org/browse/XWIKI-21702
## PR Changes
* Refined the selector for style of the avatar in order to avoid unexpected collision with the new icon in the close drawer button (when it's an image, using Silk)
## View
Button with the silk icon theme, before the PR
![21702-beforePR](https://github.com/xwiki/xwiki-platform/assets/28761965/69abf947-efc6-420c-85fb-3f72ec9ea7be)
Button with the silk icon theme, after the PR
![21702-afterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/bf114954-d9bd-4e18-8995-36787251603a)
We can see that the button is much smaller after the PR, it's indeed of a similar size to the button when using font awesome:
![21702-withFA](https://github.com/xwiki/xwiki-platform/assets/28761965/50c276d1-8cbd-4b6f-82d8-eebc1a08b1e3)


## Test
Since this is just a style change on a very specific element, I did not proceed to further testing than the checks available in the screenshots above.