### PR TITLE
XWIKI-20435: Pencil icon in user profile can be displayed white over white and thus not be visible

### DIFF
--- a/xwiki-platform-core/xwiki-platform-dashboard/xwiki-platform-dashboard-ui/src/main/resources/Dashboard/XWikiUserDashboardSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-dashboard/xwiki-platform-dashboard-ui/src/main/resources/Dashboard/XWikiUserDashboardSheet.xml
@@ -285,8 +285,8 @@
           #if($xcontext.action == 'view' &amp;&amp; $hasEdit)
             &lt;div class="editProfileCategory"&gt;
               &lt;a title="$escapetool.xml($services.localization.render('platform.core.profile.category.dashboard.edit'))"
-                  href="$doc.getURL('edit', 'category=dashboard')" class="btn btn-xs"&gt;
-                &lt;span class="action-icon"&gt;$services.icon.renderHTML('pencil')&lt;/span&gt;
+                  href="$doc.getURL('edit', 'category=dashboard')" class="btn btn-xs btn-default"&gt;
+                $services.icon.renderHTML('pencil')
                 &lt;span class='sr-only'&gt;$escapetool.xml($services.localization.render('platform.core.profile.category.dashboard.edit'))&lt;/span&gt;
               &lt;/a&gt;
             &lt;/div&gt;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserPreferencesSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserPreferencesSheet.xml
@@ -277,8 +277,8 @@
       #if ($xcontext.action == 'view' &amp;&amp; $hasEdit)
         &lt;div class="editProfileCategory"&gt;
           &lt;a title="$!escapetool.xml($services.localization.render('platform.core.profile.category.preferences.edit'))"
-              href="$doc.getURL('edit', 'category=preferences')" class="btn btn-xs"&gt;
-            &lt;span class="action-icon"&gt;$services.icon.renderHTML('pencil')&lt;/span&gt;
+              href="$doc.getURL('edit', 'category=preferences')" class="btn btn-xs btn-default"&gt;
+            $services.icon.renderHTML('pencil')
             &lt;span class='sr-only'&gt;$!escapetool.xml($services.localization.render(
               'platform.core.profile.category.preferences.edit'))&lt;/span&gt;
           &lt;/a&gt;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
@@ -609,8 +609,8 @@ $services.localization.render('platform.core.profile.category.profile.disabled')
     #if($xcontext.action == 'view' &amp;&amp; $hasEdit)
       &lt;div class='editProfileCategory'&gt;
         &lt;a title="$escapetool.xml($services.localization.render('platform.core.profile.category.profile.edit'))"
-           href="$doc.getURL('edit', 'editor=inline&amp;amp;category=profile')" class="btn btn-xs"&gt;
-          &lt;span class="action-icon"&gt;$services.icon.renderHTML('pencil')&lt;/span&gt;
+           href="$doc.getURL('edit', 'editor=inline&amp;amp;category=profile')" class="btn btn-xs btn-default"&gt;
+          $services.icon.renderHTML('pencil')
           &lt;span class='sr-only'&gt;$escapetool.xml($services.localization.render('platform.core.profile.category.profile.edit'))&lt;/span&gt;
         &lt;/a&gt;
       &lt;/div&gt;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserSheet.xml
@@ -515,8 +515,8 @@ return XWiki;
 }
 
 .column h1, .column h2 {
-  font-size:115%;
-  margin:10px 0;
+  font-size: 115%;
+  margin: 10px 0;
 }
 
 .column h3 {
@@ -537,7 +537,7 @@ div.userDashboard, #dashboardPane .dashboard {
 
 /* ----- Profile ----- */
 td.recentChangesLeft, .recentChangesMoreActions {
-  display:none;
+  display: none;
 }
 
 td.recentChangesRight {
@@ -588,9 +588,9 @@ div.editProfileCategory {
 }
 
 span#avatarUpload {
-  display:block;
-  width:$tabswidth;
-  position:absolute;
+  display: block;
+  width: $tabswidth;
+  position: absolute;
   font-size: 10px;
   font-weight: bold;
   background-color: white;
@@ -605,28 +605,35 @@ span#avatarUpload {
   margin: 0;
   padding: 0;
 }
+
 #networkPane .following li {
   padding: 2px 20px 2px 2px;
 }
+
 #networkPane .following li:hover {
   background-color: $theme.highlightColor;
 }
+
 #networkPane .following img {
   float: left;
   margin-right: 5px;
 }
+
 #networkPane .following .user-info {
   float: left;
 }
+
 #networkPane .following .user-id {
   font-size: .8em;
   font-weight: 900;
 }
+
 #networkPane .following .unfollow {
   float: right;
   margin-right: -16px;
   padding: 0;
 }
+
 ## --------------------------------------
 ## Picker style
 .attachment-picker {
@@ -634,6 +641,7 @@ span#avatarUpload {
   margin: auto;
   width: 100%;
 }
+
 .attachment-picker p {
   padding: 0;
   margin: 0;
@@ -642,6 +650,7 @@ span#avatarUpload {
 .attachment-picker .picture {
   z-index: -1;
 }
+
 .attachment-picker .buttonwrapper {
   margin: 0;
 }

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserSheet.xml
@@ -575,7 +575,7 @@ div.userInfo input[type="text"], div.userInfo input[type="password"], div.userIn
 }
 
 div.editProfileCategory {
-  float:right;
+  float: right;
 }
 
 

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserSheet.xml
@@ -578,21 +578,6 @@ div.editProfileCategory {
   float:right;
 }
 
-div.editProfileCategory {
-  float:right;
-  a.btn-xs {
-    background-color: @xwiki-page-content-bg;
-    border: 1px solid @xwiki-border-color;
-    .action-icon {
-      font-size: larger;
-      color: @btn-default-color;
-    }
-    &amp;:hover, &amp;:active, &amp;:focus {
-      border-color: darken(@dropdown-divider-bg, 10%);
-    }
-  }
-}
-
 
 /* Watchlist */
 


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-20435
## PR Changes
* Replaced the custom color mappings with a bootstrap standard class for the action button
## Notes
* It's still possible to display the pencil icon in white over white, but at least now it breaks contrast with the same conditions as any other `btn-default` (e.g. action buttons for page editing and creation).
* I also took the opportunity to remove a duplicated non color related style: ` div.editProfileCategory { float: right;}` and fix the codestyle in the CSS block where those changes are done