### PR TITLE
XWIKI-21370: Header structure uses too many H1

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/edit.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/edit.vm
@@ -151,6 +151,9 @@
       </div>
     #end
     #if (($editor == 'wiki' || $editor == 'wysiwyg') && !$request.section)
+      <h1 class="sr-only">
+        $services.localization.render('core.editors.content.title', [$escapetool.xml($doc.plainTitle), $doc.getURL()])
+      </h1>
       <div id="editMeta" class="col-xs-12#if ($displayContentMenu) col-md-7#end">
         #template('editmeta.vm')
       </div>

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -1257,6 +1257,7 @@ platform.web.editors.class.pageTitle=Editing class {0}
 platform.web.editors.rights.pageTitle=Editing access rights for {0}
 platform.web.editors.unknown.pageTitle=Editing {0}
 
+core.editors.content.title=Editing title and content of <a href="{1}">{0}</a>
 core.editors.content.parentField.label=Parent
 core.editors.content.parentField.edit=(edit)
 core.editors.content.parentField.edit.title=Edit parent

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/pom.xml
@@ -255,8 +255,6 @@
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=Annotations
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=Invitation
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=Search
-                /xwiki/bin/import/XWiki/Import?editor=globaladmin&amp;section=Import
-                /xwiki/bin/admin/XWiki/Export?editor=globaladmin&amp;section=Export
                 /xwiki/bin/edit/XWiki/XWikiPreferences?editor=wysiwyg
                 /xwiki/bin/edit/XWiki/XWikiPreferences?editor=wiki
                 /xwiki/bin/edit/XWiki/XWikiPreferences?editor=object


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21370
## PR Changes
* Added a sr-only title for wiki and wysiwyg pages
* Removed two empty pages from the distribution flavor tests...
## Note
Looking at the failure reports on CI https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/stable-15.10.x/34/testReport/junit/org.xwiki.test.webstandards/CustomDutchWebGuidelinesValidationTest/Platform_Builds___main___distribution___flavor_test_webstandards___Build_for_Flavor_Test___Webstandards_______22/ and https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/stable-15.10.x/34/testReport/junit/org.xwiki.test.webstandards/CustomDutchWebGuidelinesValidationTest/Platform_Builds___main___distribution___flavor_test_webstandards___Build_for_Flavor_Test___Webstandards_______53/ ), it seems like there is no content on those pages (search for `mainContentArea`). Therefore I don't see a problem in removing them from those tests.