### PR TITLE
XWIKI-21370: Header structure uses too many H1

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/test/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/test/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroTest.java
@@ -253,10 +253,10 @@ class DefaultWikiMacroTest
 
         assertXHTML(
             "<h2 id=\"Hheading\" class=\"wikigeneratedid\"><span>heading</span></h2>"
-                + "<ul class=\"wikitoc\">"
+                + "<ul class=\"wikitoc\"><li class=\"nodirectchild\"><ul>"
                 + "<li><span class=\"wikilink\"><a href=\"#Hheading\">heading</a></span></li>"
-                + "</ul>",
-            "= heading\n\n{{wikimacro1 param1=\"value1\" param2=\"value2\"/}}");
+                + "</ul></li></ul>",
+            "== heading\n\n{{wikimacro1 param1=\"value1\" param2=\"value2\"/}}");
     }
 
     /**


### PR DESCRIPTION
## Jira
https://jira.xwiki.org/browse/XWIKI-21370
## PR Changes
* Fixed a broken test
## Notes
* The changes in the expected results are related to https://jira.xwiki.org/browse/XRENDERING-732 .
* This commit should be cherry picked on 15.10.x

## Tests
This passed successfully the build:
* `mvn clean install -f xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store -Pdocker -Dxwiki.checkstyle.skip=true -Dxwiki.enforcer.skip=true -Dxwiki.revapi.skip=true`

This build [failed on CI](https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/stable-15.10.x/38/testReport/junit/org.xwiki.rendering.wikimacro.internal/DefaultWikiMacroTest/Platform_Builds___main___Build_for_Main___executeWhenInnerMacro/).