### PR TITLE
XWIKI-21712: In create screen, set focus to the title input field by default

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/locationPicker_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/locationPicker_macros.vm
@@ -47,7 +47,7 @@
       </dt>
       <dd>
         <input type="text" id="$escapetool.xml($!{options.id})Title" name="$escapetool.xml($titleField.name)" value="$!escapedValue"
-          class="location-title-field" placeholder="$!escapetool.xml($services.localization.render($titleField.placeholder))" />
+          class="location-title-field" placeholder="$!escapetool.xml($services.localization.render($titleField.placeholder))" autofocus />
       </dd>
     #elseif ($titleField)
       <dt class="hidden"></dt>


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-21712

**Live changes: [Video demo](https://up1.xwikisas.com/#0KmSUenKWkmlbbpgKfEmZg)**

This PR implements the use of `autofocus` attribute for simplicity purposes (instead of going with the JS solutions), see more at: [autofocus - MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus)

This has the following accessibility compromises though (as also described in the MDN article):

1. When autofocus is assigned, screen-readers "teleport" their user to the form control without warning them beforehand.

2. Automatically focusing on a control can cause the page to scroll on load.
**(Not relevant since the `TITLE` field is at the top).**

3. The screen reader **might** not announce anything before the label.

(CC: @slauriere)