### PR TITLE
XWIKI-14873: Accordeon in the Administration misses an indicator to show they are expandable

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminSheet.xml
@@ -304,9 +304,12 @@
     #sortCollectionOfMapsByField($item.children, 'order', 99999, 'asc', $children)
     &lt;div class="panel panel-default"&gt;
       &lt;a class="panel-heading#if (!$isActive) collapsed#end" id="panel-heading-$escapedId"
-        href="$!item.url" data-toggle="collapse"#if ("$!options.id" != '') data-parent="#$options.id" #end
-        data-target="#panel-body-$escapedId" aria-expanded="$isActive" aria-controls="panel-body-$escapedId"
-        title="$!escapetool.xml($item.description)"&gt;$!services.icon.renderHTML($item.icon)$escapetool.xml($name)&lt;/a&gt;
+      href="$!item.url" data-toggle="collapse"#if ("$!options.id" != '') data-parent="#$options.id" #end
+      data-target="#panel-body-$escapedId" aria-expanded="$isActive" aria-controls="panel-body-$escapedId"
+      title="$!escapetool.xml($item.description)"&gt;
+        &lt;span&gt;$!services.icon.renderHTML($item.icon)$escapetool.xml($name)&lt;/span&gt;
+        &lt;div&gt;$services.icon.renderHTML('caret-down')&lt;/div&gt;
+      &lt;/a&gt;
       &lt;section class="panel-collapse collapse#if ($isActive) in#end" id="panel-body-$escapedId"
           aria-labelledby="panel-heading-$escapedId"&gt;
         &lt;div class="list-group"&gt;
@@ -967,20 +970,35 @@ require(['jquery'], function($) {
 }
 
 .admin-menu a.panel-heading {
-  display: block;
+  display: flex;
   font-size: 100%;
 }
+
+.admin-menu a.panel-heading span {
+  flex-grow: 1;
+}
+
 .admin-menu a.panel-heading:not(.collapsed) {
   background-color: $theme.menuBackgroundColor;
   color: $theme.menuLinkColor;
 }
+
+/* Rotate the carret on collapse. */
+.admin-menu a.panel-heading.collapsed &gt; *:last-child {
+  transform: rotate(90deg);
+}
+
+.admin-menu a.panel-heading &gt; *:last-child {
+  transition: transform 200ms ease-in-out;
+}
+
 .admin-menu a.panel-heading:active,
 .admin-menu a.panel-heading:focus,
 .admin-menu a.panel-heading:hover {
   text-decoration: none;
 }
 
-.admin-menu .panel-heading &gt; *:first-child {
+.admin-menu .panel-heading &gt; span &gt; *:first-child {
   margin-right: .8em;
 }
 


### PR DESCRIPTION
# Jira
https://jira.xwiki.org/browse/XWIKI-14873
# PR Changes
* Added carets to the accordeon headers
# Note
I decided to make the caret orientation  consistent with the one already used for dropdowns in the horizontal menus.
# View
[Here is a demo of the UI with the carets.](https://up1.xwikisas.com/#m9rBSekAaak8frDkgVrHzg)

Before the PR
![14873-beforePR](https://github.com/xwiki/xwiki-platform/assets/28761965/bbf61445-b93e-45db-b197-3fde2fdaee8a)
After the PR
![14873-afterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/2e17f77a-a782-4a8e-8ca1-88f2045ba3bd)