### PR TITLE
XWIKI-21721: Add back tests for Import and Export pages

### DIFF
--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/pom.xml
@@ -255,6 +255,8 @@
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=Annotations
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=Invitation
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=Search
+                /xwiki/bin/import/XWiki/XWikiPreferences?editor=globaladmin&amp;section=Import
+                /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=Export
                 /xwiki/bin/edit/XWiki/XWikiPreferences?editor=wysiwyg
                 /xwiki/bin/edit/XWiki/XWikiPreferences?editor=wiki
                 /xwiki/bin/edit/XWiki/XWikiPreferences?editor=object


### PR DESCRIPTION
# Jira
https://jira.xwiki.org/browse/XWIKI-21721
# PR Change
* Added back the removed tests.
# Tests
The tests added in this PR did pass successfully `mvn clean install -f xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards -Dxwiki.enforcer.skip=true`.

# Merging strategy
Since this is not a critical test, I don't think it's worth the risk to backport it. IMO it should just be merged on master (as of writing, 16.0.0-SNAPSHOT).