### PR TITLE
XWIKI-21783: Add a check to ensure we don't have two migrations with same DB version

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/AbstractDataMigrationManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/AbstractDataMigrationManager.java
@@ -49,6 +49,7 @@ import com.xpn.xwiki.XWikiConfig;
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.internal.store.hibernate.HibernateConfiguration;
+import com.xpn.xwiki.store.migration.hibernate.HibernateDataMigration;
 
 /**
  * Template for {@link DataMigrationManager}.
@@ -338,9 +339,9 @@ public abstract class AbstractDataMigrationManager implements DataMigrationManag
     @Override
     public void initialize() throws InitializationException
     {
+        checkMigrationsVersions();
         try {
             SortedMap<XWikiDBVersion, XWikiMigration> availableMigrations = new TreeMap<>();
-
             Map<XWikiDBVersion, XWikiMigration> forcedMigrations = getForcedMigrations();
             if (!forcedMigrations.isEmpty()) {
                 availableMigrations.putAll(forcedMigrations);
@@ -348,28 +349,65 @@ public abstract class AbstractDataMigrationManager implements DataMigrationManag
                 Set<String> ignoredMigrations = new HashSet<>(this.hibernateConfiguration.getIgnoredMigrations());
                 for (DataMigration migrator : getAllMigrations()) {
                     XWikiDBVersion migratorVersion = migrator.getVersion();
-                    if (ignoredMigrations.contains(migrator.getClass().getName())
-                        || ignoredMigrations.contains(migratorVersion.toString())) {
+                    if (isMigrationIgnored(migrator, ignoredMigrations)) {
                         continue;
                     }
                     XWikiMigration migration = new XWikiMigration(migrator, false);
-                    if (!availableMigrations.containsKey(migratorVersion)) {
-                        availableMigrations.put(migratorVersion, migration);
-                    } else {
-                        throw new InitializationException(
-                            String.format("A migration with version [%s] already exists.", migratorVersion));
-                    }
+                    availableMigrations.put(migratorVersion, migration);
                 }
             }
 
             this.targetVersion =
-                (availableMigrations.size() > 0) ? availableMigrations.lastKey() : new XWikiDBVersion(0);
+                (!availableMigrations.isEmpty()) ? availableMigrations.lastKey() : new XWikiDBVersion(0);
             this.migrations = availableMigrations.values();
         } catch (Exception e) {
             throw new InitializationException("Migration Manager initialization failed", e);
         }
 
         this.observationManager.addListener(new WikiDeletedEventListener());
+    }
+
+    public boolean isMigrationIgnored(DataMigration migration, Set<String> ignoredMigrations)
+    {
+        return ignoredMigrations.contains(migration.getClass().getName())
+            || ignoredMigrations.contains(migration.getVersion().toString());
+    }
+
+    /**
+     * Ensure we don't have two migrations with same DB version.
+     *
+     * @throws InitializationException in case we found same DB version or the list of migration cannot be obtained.
+     */
+    private void checkMigrationsVersions() throws InitializationException
+    {
+        try {
+            List<HibernateDataMigration> migrationList =
+                this.componentManager.getInstanceList(HibernateDataMigration.class);
+            Set<String> ignoredMigrations = new HashSet<>(this.hibernateConfiguration.getIgnoredMigrations());
+            Map<XWikiDBVersion, String> hintMap = new HashMap<>();
+            for (HibernateDataMigration dataMigration : migrationList) {
+                XWikiDBVersion version = dataMigration.getVersion();
+                if (hintMap.containsKey(version)) {
+                    if (isMigrationIgnored(dataMigration, ignoredMigrations)) {
+                        this.logger.warn("Two migrations with same version [{}] were found: [{}] and [{}] but "
+                            + "migration [{}] is ignored.",
+                            version,
+                            hintMap.get(version),
+                            dataMigration.getClass().getName(),
+                            dataMigration.getClass().getName());
+                    } else {
+                        throw new InitializationException(
+                            String.format("Two migrations with same version [%s] were found: [%s] and [%s]",
+                                version,
+                                hintMap.get(version),
+                                dataMigration.getClass().getName()));
+                    }
+                }
+                hintMap.put(version, dataMigration.getClass().getName());
+            }
+        } catch (ComponentLookupException e) {
+            throw new InitializationException("Unable to retrieve the list of hibernate data migrations", e);
+        }
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/AbstractDataMigrationManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/AbstractDataMigrationManager.java
@@ -357,8 +357,7 @@ public abstract class AbstractDataMigrationManager implements DataMigrationManag
                 }
             }
 
-            this.targetVersion =
-                (!availableMigrations.isEmpty()) ? availableMigrations.lastKey() : new XWikiDBVersion(0);
+            this.targetVersion = !availableMigrations.isEmpty() ? availableMigrations.lastKey() : new XWikiDBVersion(0);
             this.migrations = availableMigrations.values();
         } catch (Exception e) {
             throw new InitializationException("Migration Manager initialization failed", e);
@@ -375,6 +374,8 @@ public abstract class AbstractDataMigrationManager implements DataMigrationManag
 
     /**
      * Ensure we don't have two migrations with same DB version.
+     * Note that it's possible to use the ignored migrations feature to bypass this check: if two migrations has same
+     * version one can ignore them in which case there will be only a warning.
      *
      * @throws InitializationException in case we found same DB version or the list of migration cannot be obtained.
      */

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/AbstractDataMigrationManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/AbstractDataMigrationManager.java
@@ -347,12 +347,18 @@ public abstract class AbstractDataMigrationManager implements DataMigrationManag
             } else {
                 Set<String> ignoredMigrations = new HashSet<>(this.hibernateConfiguration.getIgnoredMigrations());
                 for (DataMigration migrator : getAllMigrations()) {
+                    XWikiDBVersion migratorVersion = migrator.getVersion();
                     if (ignoredMigrations.contains(migrator.getClass().getName())
-                        || ignoredMigrations.contains(migrator.getVersion().toString())) {
+                        || ignoredMigrations.contains(migratorVersion.toString())) {
                         continue;
                     }
                     XWikiMigration migration = new XWikiMigration(migrator, false);
-                    availableMigrations.put(migrator.getVersion(), migration);
+                    if (!availableMigrations.containsKey(migratorVersion)) {
+                        availableMigrations.put(migratorVersion, migration);
+                    } else {
+                        throw new InitializationException(
+                            String.format("A migration with version [%s] already exists.", migratorVersion));
+                    }
                 }
             }
 


### PR DESCRIPTION
JIRA: https://jira.xwiki.org/browse/XWIKI-21783

  * Fail the data migration manager initialization if two migrations are found with same version.