### PR TITLE
XWIKI-21784: Long names cause avatar to disappear from Drawer and the 'Close the drawer' button to be shifted out of view

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/drawer.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/drawer.less
@@ -100,7 +100,7 @@
         border-radius: 50%;
         height: 50px;
         width: 50px;
-        // We ovwerwrite the default and avoid squishing down the image when the account name next to it is too large
+        // Overwrite the default for img and avoid squishing down the avatar when the account name is too large
         max-width: unset;
       }
 

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/drawer.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/drawer.less
@@ -100,6 +100,8 @@
         border-radius: 50%;
         height: 50px;
         width: 50px;
+        // We ovwerwrite the default and avoid squishing down the image when the account name next to it is too large
+        max-width: unset;
       }
 
       .brand-links {
@@ -121,6 +123,8 @@
         .brand-user {
           color: @xwiki-drawer-brand-user-color;
           font-weight: 400;
+          // Make sure we wrap the name whatever its length.
+          overflow-wrap: anywhere;
         }
       }
     }


### PR DESCRIPTION
# Jira
https://jira.xwiki.org/browse/XWIKI-21784
# PR Changes
* Removed the max-width set on the avatar that allowed it to get squished down

# Note
This relies on the fix provided in https://github.com/xwiki/xwiki-platform/pull/2748. Without this fix, only the default icon will be fixed, which is to say, the change will not have any influence.

# View
![21784-afterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/cfa7ee91-0cdc-49c6-a393-8e5fa00dc97a)
We can see on this screenshot that the user name is wrapped in the middle of the word.
