### PR TITLE
XWIKI-21785: Bullets are displayed next to flag icons in the Languages List in Drawer

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/drawer.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/drawer.less
@@ -39,7 +39,7 @@
   overflow-y: auto;
   // We overwrite max-height over browser defaults for dialog
   max-height: 100vh;
-
+  
   &::backdrop {
     opacity: 0;
     background-color: #fff - @xwiki-page-content-bg;

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/drawer.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/drawer.less
@@ -39,7 +39,7 @@
   overflow-y: auto;
   // We overwrite max-height over browser defaults for dialog
   max-height: 100vh;
-  
+
   &::backdrop {
     opacity: 0;
     background-color: #fff - @xwiki-page-content-bg;
@@ -147,12 +147,12 @@
 
   // Sub Item =============================================================
   .drawer-dropdown-menu {
-    &.collapsing {
-      /* Overwrite display:none from drawer.js in order to enable the collapse transition. */
-      display: block;
-    }
+    box-sizing: border-box;
+    width: 100%;
+    margin: 0;
+    padding: 0;
 
-    a {
+    a.drawer-menu-item {
       padding-left: @xwiki-drawer-menu-subitem-indent;
     }
   }


### PR DESCRIPTION
# Jira
https://jira.xwiki.org/browse/XWIKI-21785
# PR Changes
* Added back style lost when removing the drawer dependency
* Removed some useless style
* Increased specificity for the padding-left of the submenu items so that they would be correctly offset
# View

Before the regression vvv
![21785-beforeRegression](https://github.com/xwiki/xwiki-platform/assets/28761965/a8585a10-877c-4cb5-9970-fa2c1f6ee457)
Before the PR vvv
![21785-beforePR](https://github.com/xwiki/xwiki-platform/assets/28761965/6431a72a-72c2-4713-9c7f-cded46c0ba0a)
After the fix vvv
![21785-afterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/9fa793d1-ab63-4aa8-90ec-3c75d6647415)
