### PR TITLE
XWIKI-21756: Missing border at the bottom of docextrapanes

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
@@ -321,12 +321,12 @@ already take care of padding and shadow. */
 }
 
 #docextrapanes {
-  border-top: 1px solid @xwiki-border-color;
+  border: 1px solid @xwiki-border-color;
   border-top-left-radius: @border-radius-base;
   border-top-right-radius: @border-radius-base;
   margin-top: -1px;
-  border-left: 1px solid @xwiki-border-color;
-  border-right: 1px solid @xwiki-border-color;
+  /* Makes the bottom border hidden below the footer on pages with a long content (longer than the viewport height). */
+  margin-bottom: -1px;
 }
 
 #xdocFooter {


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-21756

# Changes

## Description

Introduce back a border at the bottom of docextrapane.

# Screenshots & Video

## Little content

### Broken

![image](https://github.com/xwiki/xwiki-platform/assets/327856/35e7d3cb-5e2d-43bc-8162-3d99f35ef398)


### 14.10.x

![image](https://github.com/xwiki/xwiki-platform/assets/327856/94fe9de0-8acb-432f-8691-655bb507f353)


### Fixed

![image](https://github.com/xwiki/xwiki-platform/assets/327856/5020ee64-2856-4c2c-9de9-b8ea1ba51d0b)


## More content

![image](https://github.com/xwiki/xwiki-platform/assets/327856/ae3c424c-491f-4ae4-b235-89b32d173951)

# Executed Tests

- Visit of various pages with various amounts of content.
- `mvn clean install -Pquality -pl :xwiki-platform-flamingo-skin-resources`

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * stable-15.10.x