### PR TITLE
XWIKI-21773: Admin section: make the WYSIWYG section pass webstandard tests

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/VelocityMacros.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/VelocityMacros.xml
@@ -218,7 +218,7 @@
 
 #macro (displayCKEditorConfigProperty $configDoc $propName $action)
   &lt;dt&gt;
-    &lt;label&gt;$configDoc.displayPrettyName($propName)&lt;/label&gt;
+    &lt;label for="CKEditor.ConfigClass_0_${propName}"&gt;$configDoc.displayPrettyName($propName)&lt;/label&gt;
     &lt;span class="xHint"&gt;$escapetool.xml($services.localization.render("CKEditor.ConfigClass_${propName}.hint"))&lt;/span&gt;
   &lt;/dt&gt;
   &lt;dd&gt;#displayCKEditorConfigPropertyValue($configDoc $propName $action)&lt;/dd&gt;

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/pom.xml
@@ -284,8 +284,7 @@
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=Delete
                 <!-- Editing -->
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=Editing
-                <!-- /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=WYSIWYG
-                  TODO https://jira.xwiki.org/browse/XWIKI-21773 -->
+                /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=WYSIWYG
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=Syntaxes
                 <!-- /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=nameStrategies
                   TODO https://jira.xwiki.org/browse/XWIKI-21775 -->


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-21773

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Fixed the input labels
* Removed the comment from the test for WYSIWYG

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* It's not the same fix as XWIKI-21523 because we can't rely on javascript enhancements of the form, and we need to provide the label for the input that gets hidden by javascript.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
* Successfully passed `mvn clean install -f xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards -Dxwiki.test.startXWiki=false`


# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Only on master.