### PR TITLE
XWIKI-21772: Admin section: make user directory pass webstandard tests

### DIFF
--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/pom.xml
@@ -249,8 +249,7 @@
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=Rights
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=usersgroups.extensionrights
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=UserProfile
-                <!--/xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=userdirectory
-                  TODO https://jira.xwiki.org/browse/XWIKI-21772 -->
+                /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=userdirectory
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=Registration
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=Invitation
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=Authentication

--- a/xwiki-platform-tools/xwiki-platform-tool-standards-validator/src/main/java/org/xwiki/validator/HTML5DutchWebGuidelinesValidator.java
+++ b/xwiki-platform-tools/xwiki-platform-tool-standards-validator/src/main/java/org/xwiki/validator/HTML5DutchWebGuidelinesValidator.java
@@ -1160,12 +1160,16 @@ public class HTML5DutchWebGuidelinesValidator extends AbstractHTML5Validator
                 if (id != null) {
                     // Looking for the label associated to the input.
                     boolean hasLabel = false;
-                    for (Element label : getElement(ELEM_BODY).getElementsByTag("label")) {
+                    String labelTagName = "label";
+                    for (Element label : getElement(ELEM_BODY).getElementsByTag(labelTagName)) {
                         if (id.equals(label.attr("for"))) {
                             hasLabel = true;
                             break;
                         }
                     }
+                    // From MDN webdocs: Alternatively, you can nest the <input> directly inside the <label>,
+                    // in which case the for and id attributes are not needed because the association is implicit
+                    hasLabel = hasLabel || input.parent().tag().getName().equals(labelTagName);
                     assertTrue(Type.ERROR, message, hasLabel);
                 }
             }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-21772

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Fixed the input label validation to allow another standard HTML way to link the label to its input.
* Removed the comment from the test for WYSIWYG

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The dutchwebguideline rule implementation did not take into account all possibilities for binding a label and an input, as defined in https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label#examples

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
* Successfully passed `mvn clean install -f xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards`


# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Only on master.