### PR TITLE
XWIKI-21774: Admin section: make the panel wizard section pass webstandard tests

### DIFF
--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/PanelWizard.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/PanelWizard.xml
@@ -193,7 +193,7 @@
     #end
   #end
   #set ($panelsPerRow = 3)
-  (% id="dhtmltooltip" style="visibility: hidden;" %)((()))
+  (% id="dhtmltooltip" %)((()))
   #if ($request.place)
     #set ($ajaxurl = $xwiki.getDocument('Panels.PanelLayoutUpdate').getURL('get', "xpage=plain&amp;outputSyntax=plain&amp;place=$!{escapetool.url($request.place)}&amp;prefsdoc=${escapetool.url($currentDoc)}&amp;form_token=${escapetool.url($services.csrf.getToken())}"))
   #else
@@ -632,6 +632,7 @@
 }
 
 #dhtmltooltip {
+  display: none;
   background-color: $theme.highlightColor;
   border: 1px solid $theme.borderColor;
   padding: 2px 4px;

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/pom.xml
@@ -262,8 +262,7 @@
                 <!-- Look and feel -->
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=Themes
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=menu.name
-                <!-- /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=Panels.PanelWizard
-                  TODO https://jira.xwiki.org/browse/XWIKI-21774 -->
+                /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=Panels.PanelWizard
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=panels.applications
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=panels.navigation
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=Presentation


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-21774

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Replaced inline styling with regular style for the panel wizard tooltip
* Removed the comment from the test for the panel wizard

## Clarifications

* The inline styling was unecessary, and could easily be replaced with some default styling. This default styling is overrode. Note that later on, inline styling is still added with javascript, but the main objective of this PR is to pass the test.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
* Successfully passed `mvn clean install -f xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards -Dxwiki.test.startXWiki=false`
* With manual test, I made sure that the functionnality still works. The tooltip still appears and disappears without any unexpected behavior.


# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Only on master.