### PR TITLE
XWIKI-21775: Admin section: make the name strategy section pass webstandard tests

### DIFF
--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-ui/src/main/resources/XWiki/EntityNameValidation/Administration.xml
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-ui/src/main/resources/XWiki/EntityNameValidation/Administration.xml
@@ -72,7 +72,7 @@
           &lt;/dl&gt;
           &lt;dl&gt;
             &lt;dt&gt;
-              &lt;label for="newForbiddenCharacter"&gt;$services.localization.render('entitynamevalidation.replacementCharacter.newReplacementCharacter.label')&lt;/label&gt;
+              &lt;label for="newReplacementCharacter"&gt;$services.localization.render('entitynamevalidation.replacementCharacter.newReplacementCharacter.label')&lt;/label&gt;
               &lt;span class='xHint'&gt;$services.localization.render('entitynamevalidation.replacementCharacter.newReplacementCharacter.hint')&lt;/span&gt;
             &lt;/dt&gt;
             &lt;dd&gt;

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/pom.xml
@@ -287,8 +287,7 @@
                 <!-- /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=WYSIWYG
                   TODO https://jira.xwiki.org/browse/XWIKI-21773 -->
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=Syntaxes
-                <!-- /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=nameStrategies
-                  TODO https://jira.xwiki.org/browse/XWIKI-21775 -->
+                /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=nameStrategies
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=SyntaxHighlighting
                 <!-- Mail -->
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=emailSend
@@ -337,15 +336,6 @@
                 /xwiki/bin/view/Main/AllDocs?view=deletedDocs
                 /xwiki/bin/view/Main/AllDocs?view=deletedAttachments
               </urlsToTestAsAdmin>
-              <urlsToTestAsGuest />
-              <rssUrlsToTestAsAdmin>
-                /xwiki/bin/view/Main/DatabaseSearch?xpage=plain&amp;outputSyntax=plain&amp;text=wiki
-                /xwiki/bin/get/Main/DatabaseSearch?outputSyntax=plain&amp;space=&amp;text=wiki
-              </rssUrlsToTestAsAdmin>
-              <rssUrlsToTestAsGuest>
-                /xwiki/bin/view/Main/DatabaseSearch?xpage=plain&amp;outputSyntax=plain&amp;text=wiki
-                /xwiki/bin/get/Main/DatabaseSearch?outputSyntax=plain&amp;space=&amp;text=wiki
-              </rssUrlsToTestAsGuest>
               <!-- Used only in office importer tests -->
               <openOfficeExecutable>${openOfficeExecutable}</openOfficeExecutable>
             </systemPropertyVariables>

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/pom.xml
@@ -336,6 +336,15 @@
                 /xwiki/bin/view/Main/AllDocs?view=deletedDocs
                 /xwiki/bin/view/Main/AllDocs?view=deletedAttachments
               </urlsToTestAsAdmin>
+              <urlsToTestAsGuest />
+              <rssUrlsToTestAsAdmin>
+                /xwiki/bin/view/Main/DatabaseSearch?xpage=plain&amp;outputSyntax=plain&amp;text=wiki
+                /xwiki/bin/get/Main/DatabaseSearch?outputSyntax=plain&amp;space=&amp;text=wiki
+              </rssUrlsToTestAsAdmin>
+              <rssUrlsToTestAsGuest>
+                /xwiki/bin/view/Main/DatabaseSearch?xpage=plain&amp;outputSyntax=plain&amp;text=wiki
+                /xwiki/bin/get/Main/DatabaseSearch?outputSyntax=plain&amp;space=&amp;text=wiki
+              </rssUrlsToTestAsGuest>
               <!-- Used only in office importer tests -->
               <openOfficeExecutable>${openOfficeExecutable}</openOfficeExecutable>
             </systemPropertyVariables>


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-21775

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Fixed the `for` attribute of a label
* Removed the comment from the test for WYSIWYG

## Clarifications

* The label must have been copy/pasted too fast and not properly tested afterwards, because it pointed towards the same input field as its predecessor. Once the cause of this error was figured out, it was a pretty straightforward fix.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
* Successfully passed `mvn clean install -f xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards -Dxwiki.test.startXWiki=false` after updating the live distribution with the changes in this PR.


# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Only on master.