### PR TITLE
XWIKI-21777: Admin section: make the PDF export section pass webstandard tests

### DIFF
--- a/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-ui/src/main/resources/XWiki/PDFExport/ConfigurationSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-ui/src/main/resources/XWiki/PDFExport/ConfigurationSheet.xml
@@ -106,7 +106,7 @@
     &lt;select id="pdfGenerator"&gt;
       #foreach ($pdfGenerator in ['userBrowser', 'chromeDockerContainer', 'remoteChrome'])
         &lt;option value="$escapetool.xml($pdfGenerator)"
-            #if ($pdfGenerator == $selectedPDFGenerator)selected="selected"#end
+            #if ($pdfGenerator == $selectedPDFGenerator)selected="selected" #end
             title="$escapetool.xml($services.localization.render("export.pdf.generator.${pdfGenerator}.hint"))"&gt;
           $escapetool.xml($services.localization.render("export.pdf.generator.${pdfGenerator}.label"))
         &lt;/option&gt;

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/pom.xml
@@ -274,8 +274,7 @@
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=Localization
                 /xwiki/bin/import/XWiki/XWikiPreferences?editor=globaladmin&amp;section=Import
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=Export
-                <!-- /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=export.pdf
-                  TODO https://jira.xwiki.org/browse/XWIKI-21777 -->
+                /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=export.pdf
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=Programming
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=Annotations
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=XWiki.OfficeImporterAdmin


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-21777

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Added a missing space between attributes in the pdf generator select
* Replaced the comment with an actual test for the export PDF section

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
No visual change.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
* Successfully passed `mvn clean install -f xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards -Dxwiki.test.startXWiki=false` after updating the live distribution with the changes in this PR.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Merge only on master.