### PR TITLE
XWIKI-21807: Error when adding two properties of the same name not properly displayed in class editor

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/PropAddAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/PropAddAction.java
@@ -20,8 +20,6 @@
 package com.xpn.xwiki.web;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -39,14 +37,13 @@ import com.xpn.xwiki.objects.meta.MetaClass;
 import com.xpn.xwiki.objects.meta.PropertyMetaClass;
 import com.xpn.xwiki.util.Util;
 
+import static org.apache.http.protocol.HTTP.PLAIN_TEXT_TYPE;
+
 @Component
 @Named("propadd")
 @Singleton
 public class PropAddAction extends XWikiAction
 {
-    private static final String PROPERTY_ERROR_ALREADY_EXISTS_ERROR_MESSAGE =
-        "action.addClassProperty.error.alreadyExists";
-
     @Override
     protected Class<? extends XWikiForm> getFormClass()
     {
@@ -84,15 +81,12 @@ public class PropAddAction extends XWikiAction
         BaseClass bclass = doc.getXClass();
         bclass.setName(doc.getFullName());
         if (bclass.get(propName) != null) {
-            context.put("message", PROPERTY_ERROR_ALREADY_EXISTS_ERROR_MESSAGE);
-            List<String> parameters = new ArrayList<String>();
-            parameters.add(propName);
-            context.put("messageParameters", parameters);
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            String localizedMessage =
+                localizePlainOrReturnKey("action.addClassProperty.error.alreadyExists", propName);
             try {
-                String localizedMessage =
-                    localizePlainOrReturnKey(PROPERTY_ERROR_ALREADY_EXISTS_ERROR_MESSAGE, propName);
                 response.getWriter().write(localizedMessage);
+                response.setContentType(PLAIN_TEXT_TYPE);
             } catch (IOException e) {
                 throw new XWikiException("Failed to access the response writer", e);
             }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/PropAddAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/PropAddAction.java
@@ -19,8 +19,6 @@
  */
 package com.xpn.xwiki.web;
 
-import java.io.IOException;
-
 import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.servlet.http.HttpServletResponse;
@@ -36,8 +34,6 @@ import com.xpn.xwiki.objects.classes.PropertyClass;
 import com.xpn.xwiki.objects.meta.MetaClass;
 import com.xpn.xwiki.objects.meta.PropertyMetaClass;
 import com.xpn.xwiki.util.Util;
-
-import static org.apache.http.protocol.HTTP.PLAIN_TEXT_TYPE;
 
 @Component
 @Named("propadd")
@@ -81,15 +77,9 @@ public class PropAddAction extends XWikiAction
         BaseClass bclass = doc.getXClass();
         bclass.setName(doc.getFullName());
         if (bclass.get(propName) != null) {
-            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             String localizedMessage =
                 localizePlainOrReturnKey("action.addClassProperty.error.alreadyExists", propName);
-            try {
-                response.getWriter().write(localizedMessage);
-                response.setContentType(PLAIN_TEXT_TYPE);
-            } catch (IOException e) {
-                throw new XWikiException("Failed to access the response writer", e);
-            }
+            writeAjaxErrorResponse(HttpServletResponse.SC_BAD_REQUEST, localizedMessage, context);
             return false;
         } else {
             MetaClass mclass = xwiki.getMetaclass();

--- a/xwiki-platform-core/xwiki-platform-xclass/xwiki-platform-xclass-test/xwiki-platform-xclass-test-docker/src/test/it/org/xwiki/xclass/test/ui/ClassSheetIT.java
+++ b/xwiki-platform-core/xwiki-platform-xclass/xwiki-platform-xclass-test/xwiki-platform-xclass-test-docker/src/test/it/org/xwiki/xclass/test/ui/ClassSheetIT.java
@@ -92,6 +92,9 @@ class ClassSheetIT
         // Add a property.
         ClassEditPage classEditor = classSheetPage.clickDefineClassLink();
         classEditor.addProperty("color", "String").setPrettyName("Your favorite color");
+        // Test that adding a property with an existing name returns a notification error.
+        classEditor.addPropertyWithoutWaiting("color", "String");
+        classEditor.waitForNotificationErrorMessage("Property color already exists");
         classEditor.clickSaveAndView();
 
         // Add a new property.


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-21807

# Changes

* Don't rely on the status message which is not supported since jetty 10.x (https://github.com/jetty/jetty.project/issues/3225)
* Instead, set the status message as the response body and stop the action there (return false)

## Description

<!-- Describe the main changes brought in this PR. -->

* [x] Add a functional tests

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```bash
mvn clean install -Pquality,integration-tests,docker,legacy -pl :xwiki-platform-oldcore,:xwiki-platform-xclass-test-docker,:xwiki-platform-legacy-oldcore -Dit.test=ClassSheetIT
```

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * stable-15.5.x
  * stable-15.10.x