### PR TITLE
XWIKI-21791: The background of unread events displayed with "Load older notifications" is not grey anymore, but white

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-macro/xwiki-platform-notifications-macro-ui/src/main/resources/XWiki/Notifications/Code/Macro/NotificationsMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-macro/xwiki-platform-notifications-macro-ui/src/main/resources/XWiki/Notifications/Code/Macro/NotificationsMacro.xml
@@ -243,7 +243,7 @@ require(['jquery', 'XWikiAsyncNotificationsMacro', 'xwiki-events-bridge'], funct
    *
    * Deprecated: This macro relies only on REST API calls which don't allow all usecases to display notifications.
    * In particular, the macro won't benefits from the Skin Extension capabilities when displayed with it.
-   * It is strongly recommended to now use the XWikiAsyncNotificationMacro defined in the other JSX.
+   * It is strongly recommended to now use the XWikiAsyncNotificationsMacro defined in the other JSX.
    *
    * Except the first one, all the parameters are optional in the constructor. If they are not provided, the macro will
    * load them from the DOM element, where they should be present with the "data-" attributes.
@@ -289,7 +289,7 @@ require(['jquery', 'XWikiAsyncNotificationsMacro', 'xwiki-events-bridge'], funct
     self.pages = pages != undefined ? pages : self.macro.attr('data-pages');
     self.users = users != undefined ? users : self.macro.attr('data-users');
     self.tags = tags != undefined ? tags : self.macro.attr('data-tags');
-    console.warn("XWikiNotificationMacro is now deprecated. Please consider using XWikiAsyncNotificationMacro instead.");
+    console.warn("XWikiNotificationMacro is now deprecated. Please consider using XWikiAsyncNotificationsMacro instead.");
 
     /**
      * Function that load notifications.
@@ -403,6 +403,8 @@ require(['jquery', 'XWikiAsyncNotificationsMacro', 'xwiki-events-bridge'], funct
       // Enable the "read" button
       var readButton = notif.find('.notification-event-read-button');
       if (!entry.read &amp;&amp; self.displayReadStatus) {
+        // Make sure the style of the notification is in line with its status.
+        notif.addClass('notification-event-unread');
         readButton.prop('disabled', false);
         readButton.removeClass('hidden');
       }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-21791
# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added back the JS class addition removed in XWIKI-18880
* Fixed a couple comments

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The changes for XWIKI-18880 are only about putting the button at the right place, not about knowing if the state of the event is read or not, which is still done in the JS.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
## Before
![21791-beforePR](https://github.com/xwiki/xwiki-platform/assets/28761965/97112d16-655e-438a-a6e8-d5e5258632ac)
## After
![21791-afterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/bd750d32-8fbf-44b9-8597-0e1ac8645eca)

We can see that after the PR, all unread notifications have the proper class, even those loaded via the `Load more` button.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Manual tests on a local distribution (see screenshots).
This behavior was an obvious regression so I doubt any test would have been changed to fit the regression. Moreover, I can't see any tests changed in [the commit where the regression was introduced](https://github.com/xwiki/xwiki-platform/pull/2335/files#diff-df6b621d8b03f4a097acf7d488c8f1d0f0a564637113d346c58b0da1983b8476).
# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.x