### PR TITLE
XWIKI-13967: Confusion between Supported Languages and Default Languages when multilingual is set to no

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/LocalizationAdministrationSectionPage.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/LocalizationAdministrationSectionPage.java
@@ -22,6 +22,7 @@ package org.xwiki.administration.test.po;
 import java.util.Arrays;
 import java.util.List;
 
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.xwiki.test.ui.po.BootstrapSelect;
@@ -52,7 +53,8 @@ public class LocalizationAdministrationSectionPage extends AdministrationSection
         waitUntilActionButtonIsLoaded();
         // Wait for asynchronous widgets to be loaded
         getDriver().waitUntilCondition(driver -> multiLingualSelect.isDisplayed() && defaultLanguageSelect.isDisplayed()
-            && supportedLanguagesSelect.isDisplayed());
+            && (multiLingualSelect.findElement(By.xpath(".//option[@value='0']")).isSelected()
+            || supportedLanguagesSelect.isDisplayed()));
     }
 
     public void setMultiLingual(boolean isMultiLingual)


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->


# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Fixed a test that should have been updated with [the fixes for XWIKI-13967](https://github.com/xwiki/xwiki-platform/pull/2770)

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* When loading the page, the driver is waiting on all elements to be visible. In some conditions, we decided that one of those would not be visible. Therefore it blocked the driver and [failed the test](https://ci.xwiki.org/job/XWiki%20Environment%20Tests/job/xwiki-platform/job/master/447/testReport/junit/org.xwiki.localization.test.ui/AllIT$NestedLocalizationIT/PostgreSQL_16__Tomcat_9_jdk17__Chrome___Docker_tests_for_xwiki_platform_localization___Build_for_PostgreSQL_16__Tomcat_9_jdk17__Chrome___Docker_tests_for_xwiki_platform_localization___changeLanguageInMonolingualModeUsingTheAdministrationPreference_TestUtils__TestReference_/). Added an alternative to the block being displayed, in line with the expected behavior we implemented in previous changes.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
N/A
Test changes only.
# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
After building the updated  pageobject LocalizationAdministrationSectionPage with `mvn clean install -f xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects`, the build `mvn clean install -f xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-test/xwiki-platform-localization-test-docker/ -Dxwiki.test.ui.browser="chrome"` was passed successfully. The same build without the browser option (on firefox) passed succesfully too.
# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-15.10.x needed because the regression cause https://github.com/xwiki/xwiki-platform/pull/2770 was backported too.