### PR TITLE
XWIKI-21819: Customizations in the detection of the current color the…

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/colorThemeInit.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/colorThemeInit.vm
@@ -72,6 +72,11 @@
 ##
 ## Overwrite with the values set in the custom theme
 #if (!$themeObj)
+## This algorithm for detecting the current color theme here is synchronized with the one in
+## org.xwiki.lesscss.internal.colortheme.CurrentColorThemeGetter.getCurrentColorTheme(boolean, String).
+## Don't customize it only in this file, it can cause LESS compilation cache issues.
+## See https://jira.xwiki.org/browse/XWIKI-21819 .
+##
 ## First, try to take the theme from the request URL
     #set ($themeDocFullName = "$!{request.colorTheme}")
 ## Second, try to take the theme from the preferences (user, space, wiki)


### PR DESCRIPTION
…me in colorThemeInit.vm can result in wrongly cached less compiled resources

* Added comment warning against the customization of colorThemeInit.vm in colorThemeInit.vm

# Jira URL

https://jira.xwiki.org/browse/XWIKI-21819

# Changes

## Description

This commit only adds a warning about the issue https://jira.xwiki.org/browse/XWIKI-21819 , doesn't fix it.
The warning should help with avoiding this limitation and building working code.