### PR TITLE
XWIKI-21778: Admin section: make the Extension section pass webstandard tests

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/rating_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/rating_macros.vm
@@ -36,7 +36,9 @@
     <div class="rating-header $cssclass">$ratinglabel</div>
     <div class="rating-stars">
         <ul class="star-rating ${cssclass}-star #if($locked) locked #end">
-            <li class="current-rating" style="width:${width}%;"></li>
+            <li class="current-rating">
+                <meter class="average-rating" min="0" max="5" value="$rating"/>
+            </li>
             #set($cls = ["one-star", "two-stars", "three-stars", "four-stars", "five-stars"])
             #foreach($r in [1..5])
                 #set($i = $r - 1)

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/rating/rating.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/rating/rating.css
@@ -22,8 +22,7 @@
   display: inline;
 }
 
-.star-rating a,
-.star-rating .current-rating {
+.star-rating a {
   position: absolute;
   top: 0;
   left: 0;
@@ -66,7 +65,7 @@
   z-index: 2;
 }
 
-.star-rating .current-rating {
+.star-rating .average-rating {
   z-index: 1;
   background-position: left center;
 }
@@ -115,4 +114,33 @@ ul.locked a {
   margin-right: 5px;
   float: right;
   position: relative;
+}
+
+.star-rating .current-rating {
+  display: block;
+  height: 100%;
+}
+
+.average-rating {
+  position: relative;
+  color: transparent;
+  display: block;
+  height: 100%;
+  width: 100%;
+  background: none;
+}
+
+/* Remove default background for */
+.average-rating::-webkit-meter-bar {
+  background: none;
+  border: none;
+}
+
+
+.average-rating::-webkit-meter-optimum-value {
+  background: url("star.gif") left repeat-x;
+}
+
+.average-rating:-moz-meter-optimum::-moz-meter-bar {
+  background: url("star.gif") left repeat-x;
 }

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/rating/rating.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/rating/rating.css
@@ -127,20 +127,22 @@ ul.locked a {
   display: block;
   height: 100%;
   width: 100%;
+  /* Remove default background for Firefox */
   background: none;
 }
 
-/* Remove default background for */
+/* Remove default background for Chrome & Safari */
 .average-rating::-webkit-meter-bar {
   background: none;
   border: none;
 }
 
-
+/* Add the stars for Chrome & Safari */
 .average-rating::-webkit-meter-optimum-value {
   background: url("star.gif") left repeat-x;
 }
 
+/* Add the stars for Firefox */
 .average-rating:-moz-meter-optimum::-moz-meter-bar {
   background: url("star.gif") left repeat-x;
 }

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/pom.xml
@@ -255,8 +255,7 @@
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=Invitation
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=Authentication
                 <!-- Extensions -->
-                <!-- /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=XWiki.Extensions
-                  TODO https://jira.xwiki.org/browse/XWIKI-21778 -->
+                /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=XWiki.Extensions
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=XWiki.ExtensionHistory
                 /xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&amp;section=XWiki.ExtensionUpdater
                 <!-- Look and feel -->


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-21778

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Replaced inline styling with a use of the meter element
* Added the webstandard test for the extension section.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The meter style options are not standard HTML yet, so multiple style need to be used for webkit based browsers and Firefox. Changes have been tested manually with Firefox 121 and Chrome 120
* Regarding accessibility, it seems like the doc about meter on the Aria Practice Guide is [not up to date](https://github.com/w3c/aria-practices/issues/2905)

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
No UI Change expected.
before vvv
![21778-beforePR](https://github.com/xwiki/xwiki-platform/assets/28761965/c6653adb-e267-4118-8868-137cecb595c0)
after (Firefox) vvv
![21778-afterPRfirefox](https://github.com/xwiki/xwiki-platform/assets/28761965/d38acfd1-09c2-420c-84cb-8903c71efee0)
after (Chrome) vvv
![21778-afterPRChrome](https://github.com/xwiki/xwiki-platform/assets/28761965/bb96ab9f-fe6e-4f31-b1f3-5869d425e684)

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Successfully passed `mvn clean install -f xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards -Dxwiki.test.startXWiki=false` for the added page `/xwiki/bin/admin/XWiki/XWikiPreferences?editor=globaladmin&section=XWiki.Extensions`.
Manual tests for Firefox 121 and Chrome 120. Browser support is pretty approximative, it might be necessary to check it on Safari and Edge too, even though it should be okay (based on Webkit like Chrome).

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A