### PR TITLE
XWIKI-21822: A column can't be without panels

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/layoutvars.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/layoutvars.vm
@@ -84,9 +84,6 @@
        #set($leftPanels = $xwiki.getSpacePreference("leftPanels"))
     #end
   #end
-  #if($leftPanels == "")
-      #set($showLeftPanels = "0")
-  #end
 #end
 
 #if($showRightPanels)
@@ -99,9 +96,6 @@
     #if($rightPanels == "")
       #set($rightPanels = $xwiki.getSpacePreference("rightPanels"))
     #end
-  #end
-  #if($rightPanels == "")
-      #set($showRightPanels = "0")
   #end
 #end
 


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-21822

# Changes

## Description

Currently, even if "Both columns" is selected in the Panels admin, if all the panels of one column are removed, the column will not be displayed

**Warning:** This is still a draft for good reason, that simple change seems to have unexpected impact and I need to run more tests.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

## Main Page

### Before

![image](https://github.com/xwiki/xwiki-platform/assets/327856/124c1f73-4ca0-4001-9fc2-bdcab2ecbdb0)


### After

See the empty column on the right.

![image](https://github.com/xwiki/xwiki-platform/assets/327856/68ba84e3-3d3b-4448-a389-8e0c1b677189)


## Panels Admins

### Before

See the "Left column" being select while I only removed the panels from the rights column initially.

![image](https://github.com/xwiki/xwiki-platform/assets/327856/f8c9455f-95ad-438e-b0a8-58b60f40021d)


### After

![image](https://github.com/xwiki/xwiki-platform/assets/327856/96123522-87b0-4115-aca1-ff9dbb12a379)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
mvn clean install -pl :xwiki-platform-flamingo-skin-resources,:xwiki-platform-panels-test-docker -Pquality,integration-tests,docker
```

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * 16.0.0
  * 15.10.6
  * 15.5.5