### PR TITLE
XWIKI-21618: The wizard step-done icons are hard coded

### DIFF
--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/WizardStep.xml
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/WizardStep.xml
@@ -51,7 +51,7 @@
         &lt;li&gt;
           &lt;span class="btn btn-xs number$extraClassName"&gt;
             #if ($stepNumber &gt; $index)
-              &amp;${escapetool.h}10004;
+              $services.icon.renderHTML('check')
             #else
               $index
             #end


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-21618
# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Replaced the hard coded character with an icon from the iconTheme


# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Before the changes proposed in this PR:
![applicationWizardHardCoded](https://github.com/xwiki/xwiki-platform/assets/28761965/9e94344f-0e37-45c7-b056-bf073167ffdc)
After the changes proposed in this PR:
Font Awesome icon theme
![21618-afterPRfa](https://github.com/xwiki/xwiki-platform/assets/28761965/de2a2b7b-c55d-4781-8325-f24b827bd476)
Silk icon theme
![21618-afterPRsilk](https://github.com/xwiki/xwiki-platform/assets/28761965/a461d03a-43ad-4685-855f-977c7466d1bf)

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Only manual checks. From what I can see, there's no test covering elements related to .step-done .
# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * EDIT: after discussing on the chat, it seems like it's better to backport small bugfixes like this one to 15.10.X