### PR TITLE
[Misc] Fix UsersGroupsRightsManagementIT failing test

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/pom.xml
@@ -64,6 +64,13 @@
       <version>${project.version}</version>
       <type>xar</type>
     </dependency>
+    <!-- The UserProfile sheet is used to disable/enable user profiles -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-user-profile-ui</artifactId>
+      <version>${project.version}</version>
+      <type>xar</type>
+    </dependency>
     <!-- ================================
          Test only dependencies
          ================================ -->

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/UsersGroupsRightsManagementIT.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/UsersGroupsRightsManagementIT.java
@@ -45,7 +45,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @UITest(properties = {
     // Add the RightsManagerPlugin needed by the test
-    "xwikiCfgPlugins=com.xpn.xwiki.plugin.rightsmanager.RightsManagerPlugin"
+    "xwikiCfgPlugins=com.xpn.xwiki.plugin.rightsmanager.RightsManagerPlugin",
+    // Programming rights are required to disable/enable user profiles (cf. XWIKI-21238)
+    "xwikiPropertiesAdditionalProperties=test.prchecker.excludePattern=.*:XWiki\\.XWikiUserProfileSheet"
 })
 public class UsersGroupsRightsManagementIT
 {


### PR DESCRIPTION
# Changes

## Description

* Add necessary dependencies and missing programming rights, following https://github.com/xwiki/xwiki-platform/commit/cf8d5b73a911199be8ac91a98a3ec2e3e8d7529f.

## Clarifications

N/A

# Screenshots & Video

N/A

# Executed Tests

The tests in UsersGroupsRightsManagementIT now pass locally.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-14.10.x
  * stable-15.5.x
  * stable-15.10.x
  * stable-16.0.x