### PR TITLE
XWIKI-21842: The search bar takes too much width when folded

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/action-menus.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/action-menus.less
@@ -121,8 +121,7 @@
     border-radius: 0;
     border: 0;
     min-width: 0;
-    transform-origin: 100% 50%;
-    transition: transform 300ms ease-in-out;
+    transition: width 300ms ease-in-out, padding 300ms ease-in-out;
     width: 200px; // we need to set a width in pixels otherwise the transition is not applied nicely
   }
 
@@ -144,7 +143,8 @@
     }
     // The input has no width (it's hidden basically, but we need to set the width to 0 to have the nice transition)
     & + #headerglobalsearchinput { // we need to be that specific to be applied
-      transform: scaleX(0);
+      width: 0;
+      padding: 0;
     }
   }
 }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-21842
# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Replaced the ScaleX transition with a width + padding one.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->
* This is a heavier implementation because layout needs to be recalculated multiple times (at multiple ), but we actually want layout to move around depending on the state of the search toggle, so it's worth it.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
[Here is a demo of the changes brought in this PR](https://youtu.be/EjNdrz491JU), highlighted by following the steps described in the ticket.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
No maven command ran. Changes are only styles. Moreover, this is a followup on https://github.com/xwiki/xwiki-platform/pull/2163/files, which did not change any tests beyond some webstandards (https://github.com/xwiki/xwiki-platform/pull/2193, unrelated to the changes in this PR).

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.X because the regression got introduced in 15.5 and this fix is very safe.