### PR TITLE
XWIKI-21729: Bad interaction between quick search and the drawer

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/QuickSearchUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/QuickSearchUIX.xml
@@ -136,6 +136,7 @@
       globalSearch.addClass('globalsearch-close');
       globalSearchButton.attr('aria-expanded', 'false');
       globalSearchInput.attr('disabled','');
+      document.fire('xwiki:suggest:collapsed');
     }
 
     // Open the global search when the user click on the global search button

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-webjar/src/main/webjar/searchSuggest.js
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-webjar/src/main/webjar/searchSuggest.js
@@ -127,7 +127,8 @@ var XWiki = (function (XWiki) {
      * Callback triggered when the suggest element is collapsed, because of a focusout event for example.
      */
     onSuggestCollapsed: function(event) {
-      /* We match the collapse of the input field timing to close the suggest panel. */
+      /* We match the collapse of the input field timing to close the suggest panel.
+         As of 16.2.0-RC1, this value is defined in action-menus.less -> #headerglobalsearchinput */
       this.suggest.resetTimeout(300);
     },
 

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-webjar/src/main/webjar/searchSuggest.js
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-webjar/src/main/webjar/searchSuggest.js
@@ -127,7 +127,8 @@ var XWiki = (function (XWiki) {
      * Callback triggered when the suggest element is collapsed, because of a focusout event for example.
      */
     onSuggestCollapsed: function(event) {
-      this.suggest.clearSuggestions();
+      /* We match the collapse of the input field timing to close the suggest panel. */
+      this.suggest.resetTimeout(300);
     },
 
     /**

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-webjar/src/main/webjar/searchSuggest.js
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-webjar/src/main/webjar/searchSuggest.js
@@ -129,7 +129,7 @@ var XWiki = (function (XWiki) {
     onSuggestCollapsed: function(event) {
       /* We match the collapse of the input field timing to close the suggest panel.
          As of 16.2.0-RC1, this value is defined in action-menus.less -> #headerglobalsearchinput */
-      this.suggest.resetTimeout(300);
+      this.suggest.resetTimeout($('#headerglobalsearchinput').css('transition-duration'));
     },
 
     /**

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggest.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggest.js
@@ -1033,11 +1033,14 @@ var XWiki = (function(XWiki){
   /**
    * Reset timeout
    */
-  resetTimeout: function()
+  resetTimeout: function(timeout)
   {
+    if(!timeout) {
+      timeout = 1000;
+    }
     clearTimeout(this.toID);
     var pointer = this;
-    this.toID = setTimeout(function () { pointer.clearSuggestions() }, 1000);
+    this.toID = setTimeout(function () { pointer.clearSuggestions() }, timeout);
   },
 
   /**


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-21729
# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Fired an event that was overwise unused
* Fixed its listener
* Added an optional argument for the suggest resetTimeout function (to allow a more precise control of the suggest panel)


# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Video demo: https://youtu.be/_XcDOmUG870
# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
None, because 'cause changes' in [XWIKI-16140](https://jira.xwiki.org/browse/XWIKI-16140) and/or [XWIKI-20733](https://jira.xwiki.org/browse/XWIKI-20733) did not impact any tests (except webstandards, for reasons unrelated to the changes in this PR).
# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.X to match with XWIKI-16140 and XWIKI-20733. IMO this is quite a low risk backport.