### PR TITLE
XWIKI-21849: No link to next page at the bottom of LiveData

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/LivedataBottombar.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/LivedataBottombar.vue
@@ -37,13 +37,3 @@ export default {
   name: "LivedataBottombar",
 };
 </script>
-
-
-<style>
-.livedata-bottombar {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-}
-</style>

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/cards/LayoutCards.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/cards/LayoutCards.vue
@@ -76,6 +76,7 @@
       <div v-if="entriesFetched && entries.length === 0" class="noentries-card">
         {{ $t('livedata.bottombar.noEntries') }}
       </div>
+      <LivedataPagination/>
     </LivedataBottombar>
 
   </div>

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/table/LayoutTable.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/table/LayoutTable.vue
@@ -90,6 +90,7 @@
       <div v-if="entriesFetched && entries.length === 0" class="noentries-table">
         {{ $t('livedata.bottombar.noEntries') }}
       </div>
+      <LivedataPagination/>
     </LivedataBottombar>
   </div>
 </template>


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-21849

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Introduce the pagination at the bottom of the table and cards layouts

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Add a `LivedataPagination` in the `LivedataBottombar` of `LayoutCards` and `LayoutTable`.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

## Empty LD

### Before

![image](https://github.com/xwiki/xwiki-platform/assets/327856/370df824-bd18-4967-bf8d-adde030223d8)

### After

![image](https://github.com/xwiki/xwiki-platform/assets/327856/fb3b2059-7009-4109-8af6-ce4c3b9753aa)

## LD With Content

### Before

![image](https://github.com/xwiki/xwiki-platform/assets/327856/c0218a88-4f30-46a3-9cf6-ec0a5a076b7b)


### After

![image](https://github.com/xwiki/xwiki-platform/assets/327856/b4a4b900-6b06-4b4a-b583-867192db6a3d)

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
mvn clean install \
  -Pquality,integration-tests,docker \
  -pl :xwiki-platform-livedata-webjar -amd -f xwiki-platform-core/xwiki-platform-livedata
```

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * [ ]  stable-14.10.x
  * [ ] stable-15.5.x
  * [x] stable-15.10.x