### PR TITLE
XWIKI-12788: Introduce skin extension plugins for webjar resources

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-webjar/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-webjar/pom.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.xwiki.platform</groupId>
+    <artifactId>xwiki-platform-notifications</artifactId>
+    <version>16.1.0-SNAPSHOT</version>
+  </parent>
+  <packaging>webjar</packaging>
+  <artifactId>xwiki-platform-notifications-webjar</artifactId>
+  <name>XWiki Platform - Notifications - WebJar</name>
+  <properties>
+    <!-- Name to display by the Extension Manager -->
+    <xwiki.extension.name>Notifications WebJar</xwiki.extension.name>
+    <!-- Vite is already taking care of minification and bundling in an efficient way. -->
+    <xwiki.minification.skip>true</xwiki.minification.skip>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.webjars.npm</groupId>
+      <artifactId>vue</artifactId>
+      <version>2.7.16</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-livedata-webjar</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.webjars</groupId>
+      <artifactId>jquery</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.webjars</groupId>
+      <artifactId>bootstrap-switch</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-vue-resources</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/vue</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>src/main/vue</directory>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+          <execution>
+            <!-- Copy the generated Vue components to the WebJar folder. -->
+            <id>copy-vue-components</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${project.version}</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${project.build.directory}/vue/dist</directory>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- Skip jsHint because we use ESLint through the frontend-maven-plugin -->
+      <plugin>
+        <groupId>org.xwiki.contrib</groupId>
+        <artifactId>jshint-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default-lint</id>
+            <phase>none</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.github.eirslett</groupId>
+        <artifactId>frontend-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>install-node-and-npm</id>
+            <goals>
+              <goal>install-node-and-npm</goal>
+            </goals>
+            <configuration>
+              <nodeVersion>v20.11.0</nodeVersion>
+              <npmVersion>10.3.0</npmVersion>
+            </configuration>
+          </execution>
+          <execution>
+            <id>npm-install</id>
+            <goals>
+              <goal>npm</goal>
+            </goals>
+            <configuration>
+              <arguments>ci</arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>npm-run-build</id>
+            <goals>
+              <goal>npm</goal>
+            </goals>
+            <configuration>
+              <arguments>run build</arguments>
+            </configuration>
+          </execution>
+          <execution>
+            <id>npm-run-lint</id>
+            <goals>
+              <goal>npm</goal>
+            </goals>
+            <configuration>
+              <arguments>run lint</arguments>
+            </configuration>
+            <phase>test</phase>
+          </execution>
+        </executions>
+        <configuration>
+          <workingDirectory>${project.build.directory}/vue</workingDirectory>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/xwiki-platform-core/xwiki-platform-webjars/xwiki-platform-webjars-api/src/main/java/org/xwiki/webjars/internal/WebjarUrlResolver.java
+++ b/xwiki-platform-core/xwiki-platform-webjars/xwiki-platform-webjars-api/src/main/java/org/xwiki/webjars/internal/WebjarUrlResolver.java
@@ -1,0 +1,354 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.webjars.internal;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.slf4j.Logger;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.extension.Extension;
+import org.xwiki.extension.repository.CoreExtensionRepository;
+import org.xwiki.extension.repository.InstalledExtensionRepository;
+import org.xwiki.resource.ResourceReference;
+import org.xwiki.resource.ResourceReferenceSerializer;
+import org.xwiki.resource.SerializeResourceReferenceException;
+import org.xwiki.resource.UnsupportedResourceReferenceException;
+import org.xwiki.url.ExtendedURL;
+import org.xwiki.wiki.descriptor.WikiDescriptorManager;
+
+/**
+ * Compute an XWiki WebJars URL for provided paramarers (resource name, webjar id, path, or version).
+ *
+ * @version $Id$
+ * @since 16.1.0RC1
+ */
+@Singleton
+@Component(roles = WebjarUrlResolver.class)
+public class WebjarUrlResolver
+{
+    /**
+     * The default {@code groupId} for Maven projects that produce WebJars.
+     */
+    public static final String DEFAULT_WEBJAR_GROUP_ID = "org.webjars";
+
+    private static final String RESOURCE_SEPARATOR = "/";
+
+    /**
+     * The name of the parameter that specifies the WebJar version.
+     */
+    private static final String VERSION = "version";
+
+    /**
+     * The name of the parameter that specifies the wiki in which the resource is located. If not specified then the
+     * wiki used will be the current wiki.
+     */
+    private static final String WIKI = "wiki";
+
+    @Inject
+    private Logger logger;
+
+    /**
+     * Used to check if the WebJar is a core extension and to get its version.
+     */
+    @Inject
+    private CoreExtensionRepository coreExtensionRepository;
+
+    /**
+     * Used to check if the WebJar is an installed extension and to get its version.
+     */
+    @Inject
+    private InstalledExtensionRepository installedExtensionRepository;
+
+    /**
+     * Used to get the id of the current wiki in order to determine the current extension namespace.
+     */
+    @Inject
+    private WikiDescriptorManager wikiDescriptorManager;
+
+    @Inject
+    private ResourceReferenceSerializer<ResourceReference, ExtendedURL> defaultResourceReferenceSerializer;
+
+    /**
+     * Creates an URL that can be used to load a resource (JavaScript, CSS, etc.) from a WebJar in the current wiki.
+     *
+     * @param resourceName the resource asked using the format {@code <webjarId>/<version>/<path/to/resource>} (e.g.
+     *     {@code angular/2.1.11/angular.js"})
+     * @return the computed URL
+     */
+    public String url(String resourceName)
+    {
+        if (StringUtils.isEmpty(resourceName)) {
+            return null;
+        }
+
+        String[] parts = resourceName.split(RESOURCE_SEPARATOR, 3);
+        if (parts.length < 3) {
+            this.logger.warn("Invalid webjar resource name [{}]. Expected format is 'webjarId/version/path'",
+                resourceName);
+            return null;
+        }
+
+        // Prefix the webjarId with a fake groupId just to make sure that the colon character (:) is not interpreted as
+        // separator in the webjarId. This is required in order to ensure that the behavior of this method doesn't
+        // change. Note that the groupdId is ignored if the WebJar version is specified so the fake groupId won't have
+        // any effect.
+        return url("fakeGroupId:" + parts[0], null, parts[2], Collections.singletonMap(
+            VERSION, parts[1]));
+    }
+
+    /**
+     * Creates an URL that can be used to load a resource (JavaScript, CSS, etc.) from a WebJar in the current wiki.
+     *
+     * @param webjarId the id of the WebJar that contains the resource; the format of the WebJar id is
+     *     {@code groupId:artifactId} (e.g. {@code org.xwiki.platform:xwiki-platform-job-webjar}), where the
+     *     {@code groupId} can be omitted if it is {@link WebjarUrlResolver#DEFAULT_WEBJAR_GROUP_ID} (i.e.
+     *     {@code angular} translates to {@code org.webjars:angular})
+     * @param path the path within the WebJar, starting from the version folder (e.g., you should pass just
+     *     {@code angular.js} if the actual path is {@code META-INF/resources/webjars/angular/2.1.11/angular.js})
+     * @return the URL to load the WebJar resource (relative to the context path of the web application)
+     */
+    public String url(String webjarId, String path)
+    {
+        return url(webjarId, null, path, null);
+    }
+
+    /**
+     * Creates an URL that can be used to load a resource (JavaScript, CSS, etc.) from a WebJar in the passed
+     * namespace.
+     *
+     * @param webjarId the id of the WebJar that contains the resource; the format of the WebJar id is
+     *     {@code groupId:artifactId} (e.g. {@code org.xwiki.platform:xwiki-platform-job-webjar}), where the
+     *     {@code groupId} can be omitted if it is {@link WebjarUrlResolver#DEFAULT_WEBJAR_GROUP_ID} (i.e.
+     *     {@code angular} translates to {@code org.webjars:angular})
+     * @param namespace the namespace in which the webjars resources will be loaded from (e.g., for a wiki namespace
+     *     you should use the format {@code wiki:<wikiId>}). If null then defaults to the current wiki namespace. And if
+     *     the passed namespace doesn't exist, falls back to the main wiki namespace
+     * @param path the path within the WebJar, starting from the version folder (e.g., you should pass just
+     *     {@code angular.js} if the actual path is {@code META-INF/resources/webjars/angular/2.1.11/angular.js})
+     * @return the URL to load the WebJar resource (relative to the context path of the web application)
+     * @since 8.1M2
+     */
+    public String url(String webjarId, String namespace, String path)
+    {
+        return url(webjarId, namespace, path, null);
+    }
+
+    /**
+     * Creates an URL that can be used to load a resource (JavaScript, CSS, etc.) from a WebJar.
+     *
+     * @param webjarId the id of the WebJar that contains the resource; the format of the WebJar id is
+     *     {@code groupId:artifactId} (e.g. {@code org.xwiki.platform:xwiki-platform-job-webjar}), where the
+     *     {@code groupId} can be omitted if it is {@link WebjarUrlResolver#DEFAULT_WEBJAR_GROUP_ID} (i.e.
+     *     {@code angular} translates to {@code org.webjars:angular})
+     * @param path the path within the WebJar, starting from the version folder (e.g., you should pass just
+     *     {@code angular.js} if the actual path is {@code META-INF/resources/webjars/angular/2.1.11/angular.js})
+     * @param params additional query string parameters to add to the returned URL; there are two known (reserved)
+     *     parameters: {@code version} (the WebJar version) and {@code evaluate} (a boolean parameter that specifies if
+     *     the requested resource has Velocity code that needs to be evaluated); besides these you can pass whatever
+     *     parameters you like (they will be taken into account or not depending on the resource)
+     * @return the URL to load the WebJar resource (relative to the context path of the web application)
+     */
+    public String url(String webjarId, String path, Map<String, ?> params)
+    {
+        // For backward-compatibility reasons, we still support passing the target wiki in parameters
+        String namespace = null;
+        if (params != null) {
+            // For backward-compatibility reasons we still support passing the target wiki in parameters
+            String wikiId = (String) params.get(WIKI);
+            if (!StringUtils.isEmpty(wikiId)) {
+                namespace = constructNamespace(wikiId);
+            }
+        }
+
+        return url(webjarId, namespace, path, params);
+    }
+
+    /**
+     * Creates an URL that can be used to load a resource (JavaScript, CSS, etc.) from a WebJar in the passed
+     * namespace.
+     *
+     * @param webjarId the id of the WebJar that contains the resource; the format of the WebJar id is
+     *     {@code groupId:artifactId} (e.g. {@code org.xwiki.platform:xwiki-platform-job-webjar}), where the
+     *     {@code groupId} can be omitted if it is {@link WebjarUrlResolver#DEFAULT_WEBJAR_GROUP_ID} (i.e.
+     *     {@code angular} translates to {@code org.webjars:angular})
+     * @param namespace the namespace in which the webjars resources will be loaded from (e.g., for a wiki namespace
+     *     you should use the format {@code wiki:<wikiId>}). If null then defaults to the current wiki namespace. And if
+     *     the passed namespace doesn't exist, falls back to the main wiki namespace
+     * @param path the path within the WebJar, starting from the version folder (e.g., you should pass just
+     *     {@code angular.js} if the actual path is {@code META-INF/resources/webjars/angular/2.1.11/angular.js})
+     * @param params additional query string parameters to add to the returned URL; there are two known (reserved)
+     *     parameters: {@code version} (the WebJar version) and {@code evaluate} (a boolean parameter that specifies if
+     *     the requested resource has Velocity code that needs to be evaluated); besides these you can pass whatever
+     *     parameters you like (they will be taken into account or not depending on the resource)
+     * @return the URL to load the WebJar resource (relative to the context path of the web application)
+     * @since 8.1M2
+     */
+    public String url(String webjarId, String namespace, String path, Map<String, ?> params)
+    {
+        if (StringUtils.isEmpty(webjarId)) {
+            return null;
+        }
+
+        String groupId = DEFAULT_WEBJAR_GROUP_ID;
+        String artifactId = webjarId;
+        int groupSeparatorPosition = webjarId.indexOf(':');
+        if (groupSeparatorPosition >= 0) {
+            // A different group id.
+            groupId = webjarId.substring(0, groupSeparatorPosition);
+            artifactId = webjarId.substring(groupSeparatorPosition + 1);
+        }
+        String extensionId = String.format("%s:%s", groupId, artifactId);
+
+        Map<String, Object> urlParams = new LinkedHashMap<>();
+        if (params != null) {
+            urlParams.putAll(params);
+        }
+
+        // For backward-compatibility reasons we still support passing the target wiki in parameters. However we need
+        // to remove it from the params if that's the case since we don't want to output a URL with the wiki id in the
+        // query string (since the namespace is now part of the URL).
+        urlParams.remove(WIKI);
+
+        // Construct a WebJarsResourceReference so that we can serialize it!
+        WebJarsResourceReference resourceReference;
+        String version = (String) urlParams.remove(VERSION);
+        if (version == null) {
+            // Try to determine the version based on the extensions that are currently installed or provided by default.
+            Extension extension = getExtension(extensionId, namespace);
+            if (extension != null) {
+                // Generate the URL based on the found extension
+                resourceReference = getResourceReference(getArtifactId(extension.getId().getId()),
+                    extension.getId().getVersion().getValue(), namespace, path, urlParams);
+            } else {
+                // Fallback on a URL which does not include the version
+                resourceReference = getResourceReference(artifactId, null, namespace, path, urlParams);
+            }
+        } else {
+            // The version was explicitly indicated
+            resourceReference = getResourceReference(artifactId, version, namespace, path, urlParams);
+        }
+
+        ExtendedURL extendedURL;
+        try {
+            extendedURL = this.defaultResourceReferenceSerializer.serialize(resourceReference);
+        } catch (SerializeResourceReferenceException | UnsupportedResourceReferenceException e) {
+            this.logger.warn("Error while serializing WebJar URL for id [{}], path = [{}]. Root cause = [{}]", webjarId,
+                path, ExceptionUtils.getRootCauseMessage(e));
+            return null;
+        }
+
+        return extendedURL.serialize();
+    }
+
+    private String getArtifactId(String extensionId)
+    {
+        String artifactId = extensionId;
+        int groupSeparatorPosition = extensionId.indexOf(':');
+        if (groupSeparatorPosition >= 0) {
+            artifactId = extensionId.substring(groupSeparatorPosition + 1);
+        }
+
+        return artifactId;
+    }
+
+    private WebJarsResourceReference getResourceReference(String artifactId, String version, String namespace,
+        String path, Map<String, Object> urlParams)
+    {
+        List<String> segments = new ArrayList<>();
+        segments.add(artifactId);
+        // Don't include the version if it's not specified and there's no installed/core extension that matches the
+        // given WebJar id.
+        if (version != null) {
+            segments.add(version);
+        }
+        segments.addAll(Arrays.asList(path.split(RESOURCE_SEPARATOR)));
+
+        // When a JavaScript resource is loaded using RequireJS the resource URL must not include the ".js" suffix (by
+        // default) if the URL is relative and doesn't have a query string. Before XWIKI-10881 (Introduce a proper
+        // "webjars" type instead of reusing the "bin" type) all WebJar URLs had a query string (the resource path) so
+        // we were forced to specify the ".js" suffix when using RequireJS. The resource path is currently no longer
+        // part of the query string and thus the ".js" suffix must now be omitted (otherwise RequireJS will ask for
+        // ".js.js"), unless the resource has parameters (e.g. the resource is evaluated). In order to preserve
+        // backwards compatibility with existing extensions and also in order to fix this mess (the developer doesn't
+        // know when to put the ".js" suffix and when not) we have decided to add a fake query string if the ".js"
+        // suffix is specified and there is no query string (thus preventing RequireJS from requesting ".js.js").
+        if (path.endsWith(".js") && urlParams.isEmpty()) {
+            urlParams.put("r", "1");
+        }
+
+        WebJarsResourceReference resourceReference =
+            new WebJarsResourceReference(resolveNamespace(namespace), segments);
+        for (Map.Entry<String, Object> parameterEntry : urlParams.entrySet()) {
+            resourceReference.addParameter(parameterEntry.getKey(), parameterEntry.getValue());
+        }
+
+        return resourceReference;
+    }
+
+    private Extension getExtension(String extensionId, String namespace)
+    {
+        // Look for WebJars that are core extensions.
+        Extension extension = this.coreExtensionRepository.getCoreExtension(extensionId);
+        if (extension == null) {
+            // Look for WebJars that are installed on the passed namespace (if defined), the current wiki or the main
+            // wiki.
+            String selectedNamespace = resolveNamespace(namespace);
+            extension = this.installedExtensionRepository.getInstalledExtension(extensionId, selectedNamespace);
+            if (extension == null) {
+                // Fallback by looking in the main wiki
+                selectedNamespace = constructNamespace(this.wikiDescriptorManager.getMainWikiId());
+                extension = this.installedExtensionRepository.getInstalledExtension(extensionId, selectedNamespace);
+            }
+        }
+
+        return extension;
+    }
+
+    private String resolveNamespace(String namespace)
+    {
+        String resolvedNamespace;
+        if (StringUtils.isNotEmpty(namespace)) {
+            resolvedNamespace = namespace;
+        } else {
+            resolvedNamespace = constructNamespace(getCurrentWikiId());
+        }
+        return resolvedNamespace;
+    }
+
+    private String getCurrentWikiId()
+    {
+        return this.wikiDescriptorManager.getCurrentWikiId();
+    }
+
+    private String constructNamespace(String wikiId)
+    {
+        return String.format("wiki:%s", wikiId);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-webjars/xwiki-platform-webjars-api/src/main/java/org/xwiki/webjars/script/WebJarsScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-webjars/xwiki-platform-webjars-api/src/main/java/org/xwiki/webjars/script/WebJarsScriptService.java
@@ -19,36 +19,19 @@
  */
 package org.xwiki.webjars.script;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
-import org.xwiki.extension.Extension;
-import org.xwiki.extension.repository.CoreExtensionRepository;
-import org.xwiki.extension.repository.InstalledExtensionRepository;
-import org.xwiki.resource.ResourceReference;
-import org.xwiki.resource.ResourceReferenceSerializer;
-import org.xwiki.resource.SerializeResourceReferenceException;
-import org.xwiki.resource.UnsupportedResourceReferenceException;
 import org.xwiki.script.service.ScriptService;
-import org.xwiki.url.ExtendedURL;
-import org.xwiki.webjars.internal.WebJarsResourceReference;
-import org.xwiki.wiki.descriptor.WikiDescriptorManager;
+import org.xwiki.webjars.internal.WebjarUrlResolver;
 
 /**
  * Make it easy to use WebJars in scripts. For example it can compute an XWiki WebJars URL.
- * 
+ *
  * @version $Id$
  * @since 6.0M1
  */
@@ -57,300 +40,100 @@ import org.xwiki.wiki.descriptor.WikiDescriptorManager;
 @Singleton
 public class WebJarsScriptService implements ScriptService
 {
-    private static final String RESOURCE_SEPARATOR = "/";
-
-    /**
-     * The name of the parameter that specifies the WebJar version.
-     */
-    private static final String VERSION = "version";
-
-    /**
-     * The name of the parameter that specifies the wiki in which the resource is located. If not specified then
-     * the wiki used will be the current wiki.
-     */
-    private static final String WIKI = "wiki";
-
-    /**
-     * The default {@code groupId} for Maven projects that produce WebJars.
-     */
-    private static final String DEFAULT_WEBJAR_GROUP_ID = "org.webjars";
-
     @Inject
-    private Logger logger;
-
-    /**
-     * Used to check if the WebJar is a core extension and to get its version.
-     */
-    @Inject
-    private CoreExtensionRepository coreExtensionRepository;
-
-    /**
-     * Used to check if the WebJar is an installed extension and to get its version.
-     */
-    @Inject
-    private InstalledExtensionRepository installedExtensionRepository;
-
-    /**
-     * Used to get the id of the current wiki in order to determine the current extension namespace.
-     */
-    @Inject
-    private WikiDescriptorManager wikiDescriptorManager;
-
-    @Inject
-    private ResourceReferenceSerializer<ResourceReference, ExtendedURL> defaultResourceReferenceSerializer;
+    private WebjarUrlResolver webjarUrlResolver;
 
     /**
      * Creates an URL that can be used to load a resource (JavaScript, CSS, etc.) from a WebJar in the current wiki.
      *
-     * @param resourceName the resource asked using the format {@code <webjarId>/<version>/<path/to/resource>}
-     *                     (e.g. {@code angular/2.1.11/angular.js"})
+     * @param resourceName the resource asked using the format {@code <webjarId>/<version>/<path/to/resource>} (e.g.
+     *     {@code angular/2.1.11/angular.js"})
      * @return the computed URL
      */
     public String url(String resourceName)
     {
-        if (StringUtils.isEmpty(resourceName)) {
-            return null;
-        }
-
-        String[] parts = resourceName.split(RESOURCE_SEPARATOR, 3);
-        if (parts.length < 3) {
-            logger.warn("Invalid webjar resource name [{}]. Expected format is 'webjarId/version/path'", resourceName);
-            return null;
-        }
-
-        // Prefix the webjarId with a fake groupId just to make sure that the colon character (:) is not interpreted as
-        // separator in the webjarId. This is required in order to ensure that the behavior of this method doesn't
-        // change. Note that the groupdId is ignored if the WebJar version is specified so the fake groupId won't have
-        // any effect.
-        return url("fakeGroupId:" + parts[0], null, parts[2], Collections.singletonMap(VERSION, parts[1]));
+        return this.webjarUrlResolver.url(resourceName);
     }
 
     /**
      * Creates an URL that can be used to load a resource (JavaScript, CSS, etc.) from a WebJar in the current wiki.
      *
      * @param webjarId the id of the WebJar that contains the resource; the format of the WebJar id is
-     *            {@code groupId:artifactId} (e.g. {@code org.xwiki.platform:xwiki-platform-job-webjar}), where the
-     *            {@code groupId} can be omitted if it is {@link #DEFAULT_WEBJAR_GROUP_ID} (i.e. {@code angular}
-     *            translates to {@code org.webjars:angular})
-     * @param path the path within the WebJar, starting from the version folder (e.g. you should pass just
-     *            {@code angular.js} if the actual path is {@code META-INF/resources/webjars/angular/2.1.11/angular.js})
+     *     {@code groupId:artifactId} (e.g. {@code org.xwiki.platform:xwiki-platform-job-webjar}), where the
+     *     {@code groupId} can be omitted if it is {@link WebjarUrlResolver#DEFAULT_WEBJAR_GROUP_ID} (i.e.
+     *     {@code angular} translates to {@code org.webjars:angular})
+     * @param path the path within the WebJar, starting from the version folder (e.g., you should pass just
+     *     {@code angular.js} if the actual path is {@code META-INF/resources/webjars/angular/2.1.11/angular.js})
      * @return the URL to load the WebJar resource (relative to the context path of the web application)
      */
     public String url(String webjarId, String path)
     {
-        return url(webjarId, null, path, null);
+        return this.webjarUrlResolver.url(webjarId, path);
     }
 
     /**
-     * Creates an URL that can be used to load a resource (JavaScript, CSS, etc.) from a WebJar in the passed namespace.
-     * 
+     * Creates an URL that can be used to load a resource (JavaScript, CSS, etc.) from a WebJar in the passed
+     * namespace.
+     *
      * @param webjarId the id of the WebJar that contains the resource; the format of the WebJar id is
-     *            {@code groupId:artifactId} (e.g. {@code org.xwiki.platform:xwiki-platform-job-webjar}), where the
-     *            {@code groupId} can be omitted if it is {@link #DEFAULT_WEBJAR_GROUP_ID} (i.e. {@code angular}
-     *            translates to {@code org.webjars:angular})
-     * @param namespace the namespace in which the webjars resources will be loaded from (e.g. for a wiki namespace you
-     *                  should use the format {@code wiki:<wikiId>}). If null then defaults to the current wiki
-     *                  namespace. And if the passed namespace doesn't exist, falls back to the main wiki namespace
-     * @param path the path within the WebJar, starting from the version folder (e.g. you should pass just
-     *            {@code angular.js} if the actual path is {@code META-INF/resources/webjars/angular/2.1.11/angular.js})
+     *     {@code groupId:artifactId} (e.g. {@code org.xwiki.platform:xwiki-platform-job-webjar}), where the
+     *     {@code groupId} can be omitted if it is {@link WebjarUrlResolver#DEFAULT_WEBJAR_GROUP_ID} (i.e. {@code angular} translates to
+     *     {@code org.webjars:angular})
+     * @param namespace the namespace in which the webjars resources will be loaded from (e.g., for a wiki namespace
+     *     you should use the format {@code wiki:<wikiId>}). If null then defaults to the current wiki namespace. And if
+     *     the passed namespace doesn't exist, falls back to the main wiki namespace
+     * @param path the path within the WebJar, starting from the version folder (e.g., you should pass just
+     *     {@code angular.js} if the actual path is {@code META-INF/resources/webjars/angular/2.1.11/angular.js})
      * @return the URL to load the WebJar resource (relative to the context path of the web application)
      * @since 8.1M2
      */
     public String url(String webjarId, String namespace, String path)
     {
-        return url(webjarId, namespace, path, null);
+        return this.webjarUrlResolver.url(webjarId, namespace, path);
     }
 
     /**
      * Creates an URL that can be used to load a resource (JavaScript, CSS, etc.) from a WebJar.
-     * 
+     *
      * @param webjarId the id of the WebJar that contains the resource; the format of the WebJar id is
-     *            {@code groupId:artifactId} (e.g. {@code org.xwiki.platform:xwiki-platform-job-webjar}), where the
-     *            {@code groupId} can be omitted if it is {@link #DEFAULT_WEBJAR_GROUP_ID} (i.e. {@code angular}
-     *            translates to {@code org.webjars:angular})
-     * @param path the path within the WebJar, starting from the version folder (e.g. you should pass just
-     *            {@code angular.js} if the actual path is {@code META-INF/resources/webjars/angular/2.1.11/angular.js})
+     *     {@code groupId:artifactId} (e.g. {@code org.xwiki.platform:xwiki-platform-job-webjar}), where the
+     *     {@code groupId} can be omitted if it is {@link WebjarUrlResolver#DEFAULT_WEBJAR_GROUP_ID} (i.e. {@code angular} translates to
+     *     {@code org.webjars:angular})
+     * @param path the path within the WebJar, starting from the version folder (e.g., you should pass just
+     *     {@code angular.js} if the actual path is {@code META-INF/resources/webjars/angular/2.1.11/angular.js})
      * @param params additional query string parameters to add to the returned URL; there are two known (reserved)
-     *            parameters: {@code version} (the WebJar version) and {@code evaluate} (a boolean parameter that
-     *            specifies if the requested resource has Velocity code that needs to be evaluated); besides these you
-     *            can pass whatever parameters you like (they will be taken into account or not depending on the
-     *            resource)
+     *     parameters: {@code version} (the WebJar version) and {@code evaluate} (a boolean parameter that specifies if
+     *     the requested resource has Velocity code that needs to be evaluated); besides these you can pass whatever
+     *     parameters you like (they will be taken into account or not depending on the resource)
      * @return the URL to load the WebJar resource (relative to the context path of the web application)
      */
     public String url(String webjarId, String path, Map<String, ?> params)
     {
-        // For backward-compatibility reasons, we still support passing the target wiki in parameters
-        String namespace = null;
-        if (params != null) {
-            // For backward-compatibility reasons we still support passing the target wiki in parameters
-            String wikiId = (String) params.get(WIKI);
-            if (!StringUtils.isEmpty(wikiId)) {
-                namespace = constructNamespace(wikiId);
-            }
-        }
-
-        return url(webjarId, namespace, path, params);
+        return this.webjarUrlResolver.url(webjarId, path, params);
     }
 
     /**
-     * Creates an URL that can be used to load a resource (JavaScript, CSS, etc.) from a WebJar in the passed namespace.
+     * Creates an URL that can be used to load a resource (JavaScript, CSS, etc.) from a WebJar in the passed
+     * namespace.
      *
      * @param webjarId the id of the WebJar that contains the resource; the format of the WebJar id is
-     *            {@code groupId:artifactId} (e.g. {@code org.xwiki.platform:xwiki-platform-job-webjar}), where the
-     *            {@code groupId} can be omitted if it is {@link #DEFAULT_WEBJAR_GROUP_ID} (i.e. {@code angular}
-     *            translates to {@code org.webjars:angular})
-     * @param namespace the namespace in which the webjars resources will be loaded from (e.g. for a wiki namespace you
-     *                  should use the format {@code wiki:<wikiId>}). If null then defaults to the current wiki
-     *                  namespace. And if the passed namespace doesn't exist, falls back to the main wiki namespace
-     * @param path the path within the WebJar, starting from the version folder (e.g. you should pass just
-     *            {@code angular.js} if the actual path is {@code META-INF/resources/webjars/angular/2.1.11/angular.js})
+     *     {@code groupId:artifactId} (e.g. {@code org.xwiki.platform:xwiki-platform-job-webjar}), where the
+     *     {@code groupId} can be omitted if it is {@link WebjarUrlResolver#DEFAULT_WEBJAR_GROUP_ID} (i.e. {@code angular} translates to
+     *     {@code org.webjars:angular})
+     * @param namespace the namespace in which the webjars resources will be loaded from (e.g., for a wiki namespace
+     *     you should use the format {@code wiki:<wikiId>}). If null then defaults to the current wiki namespace. And if
+     *     the passed namespace doesn't exist, falls back to the main wiki namespace
+     * @param path the path within the WebJar, starting from the version folder (e.g., you should pass just
+     *     {@code angular.js} if the actual path is {@code META-INF/resources/webjars/angular/2.1.11/angular.js})
      * @param params additional query string parameters to add to the returned URL; there are two known (reserved)
-     *            parameters: {@code version} (the WebJar version) and {@code evaluate} (a boolean parameter that
-     *            specifies if the requested resource has Velocity code that needs to be evaluated); besides these you
-     *            can pass whatever parameters you like (they will be taken into account or not depending on the
-     *            resource)
+     *     parameters: {@code version} (the WebJar version) and {@code evaluate} (a boolean parameter that specifies if
+     *     the requested resource has Velocity code that needs to be evaluated); besides these you can pass whatever
+     *     parameters you like (they will be taken into account or not depending on the resource)
      * @return the URL to load the WebJar resource (relative to the context path of the web application)
      * @since 8.1M2
      */
     public String url(String webjarId, String namespace, String path, Map<String, ?> params)
     {
-        if (StringUtils.isEmpty(webjarId)) {
-            return null;
-        }
-
-        String groupId = DEFAULT_WEBJAR_GROUP_ID;
-        String artifactId = webjarId;
-        int groupSeparatorPosition = webjarId.indexOf(':');
-        if (groupSeparatorPosition >= 0) {
-            // A different group id.
-            groupId = webjarId.substring(0, groupSeparatorPosition);
-            artifactId = webjarId.substring(groupSeparatorPosition + 1);
-        }
-        String extensionId = String.format("%s:%s", groupId, artifactId);
-
-        Map<String, Object> urlParams = new LinkedHashMap<>();
-        if (params != null) {
-            urlParams.putAll(params);
-        }
-
-        // For backward-compatibility reasons we still support passing the target wiki in parameters. However we need
-        // to remove it from the params if that's the case since we don't want to output a URL with the wiki id in the
-        // query string (since the namespace is now part of the URL).
-        urlParams.remove(WIKI);
-
-        // Construct a WebJarsResourceReference so that we can serialize it!
-        WebJarsResourceReference resourceReference;
-        String version = (String) urlParams.remove(VERSION);
-        if (version == null) {
-            // Try to determine the version based on the extensions that are currently installed or provided by default.
-            Extension extension = getExtension(extensionId, namespace);
-            if (extension != null) {
-                // Generate the URL based on the found extension
-                resourceReference = getResourceReference(getArtifactId(extension.getId().getId()),
-                    extension.getId().getVersion().getValue(), namespace, path, urlParams);
-            } else {
-                // Fallback on a URL which does not include the version
-                resourceReference = getResourceReference(artifactId, null, namespace, path, urlParams);
-            }
-        } else {
-            // The version was explicitly indicated
-            resourceReference = getResourceReference(artifactId, version, namespace, path, urlParams);
-        }
-
-        ExtendedURL extendedURL;
-        try {
-            extendedURL = this.defaultResourceReferenceSerializer.serialize(resourceReference);
-        } catch (SerializeResourceReferenceException | UnsupportedResourceReferenceException e) {
-            this.logger.warn("Error while serializing WebJar URL for id [{}], path = [{}]. Root cause = [{}]", webjarId,
-                path, ExceptionUtils.getRootCauseMessage(e));
-            return null;
-        }
-
-        return extendedURL.serialize();
-    }
-
-    private String getArtifactId(String extensionId)
-    {
-        String artifactId = extensionId;
-        int groupSeparatorPosition = extensionId.indexOf(':');
-        if (groupSeparatorPosition >= 0) {
-            artifactId = extensionId.substring(groupSeparatorPosition + 1);
-        }
-
-        return artifactId;
-    }
-
-    private WebJarsResourceReference getResourceReference(String artifactId, String version, String namespace,
-        String path, Map<String, Object> urlParams)
-    {
-        List<String> segments = new ArrayList<>();
-        segments.add(artifactId);
-        // Don't include the version if it's not specified and there's no installed/core extension that matches the
-        // given WebJar id.
-        if (version != null) {
-            segments.add(version);
-        }
-        segments.addAll(Arrays.asList(path.split(RESOURCE_SEPARATOR)));
-
-        // When a JavaScript resource is loaded using RequireJS the resource URL must not include the ".js" suffix (by
-        // default) if the URL is relative and doesn't have a query string. Before XWIKI-10881 (Introduce a proper
-        // "webjars" type instead of reusing the "bin" type) all WebJar URLs had a query string (the resource path) so
-        // we were forced to specify the ".js" suffix when using RequireJS. The resource path is currently no longer
-        // part of the query string and thus the ".js" suffix must now be omitted (otherwise RequireJS will ask for
-        // ".js.js"), unless the resource has parameters (e.g. the resource is evaluated). In order to preserve
-        // backwards compatibility with existing extensions and also in order to fix this mess (the developer doesn't
-        // know when to put the ".js" suffix and when not) we have decided to add a fake query string if the ".js"
-        // suffix is specified and there is no query string (thus preventing RequireJS from requesting ".js.js").
-        if (path.endsWith(".js") && urlParams.isEmpty()) {
-            urlParams.put("r", "1");
-        }
-
-        WebJarsResourceReference resourceReference =
-            new WebJarsResourceReference(resolveNamespace(namespace), segments);
-        for (Map.Entry<String, Object> parameterEntry : urlParams.entrySet()) {
-            resourceReference.addParameter(parameterEntry.getKey(), parameterEntry.getValue());
-        }
-
-        return resourceReference;
-    }
-
-    private Extension getExtension(String extensionId, String namespace)
-    {
-        // Look for WebJars that are core extensions.
-        Extension extension = this.coreExtensionRepository.getCoreExtension(extensionId);
-        if (extension == null) {
-            // Look for WebJars that are installed on the passed namespace (if defined), the current wiki or the main
-            // wiki.
-            String selectedNamespace = resolveNamespace(namespace);
-            extension = this.installedExtensionRepository.getInstalledExtension(extensionId, selectedNamespace);
-            if (extension == null) {
-                // Fallback by looking in the main wiki
-                selectedNamespace = constructNamespace(this.wikiDescriptorManager.getMainWikiId());
-                extension = this.installedExtensionRepository.getInstalledExtension(extensionId, selectedNamespace);
-            }
-        }
-
-        return extension;
-    }
-
-    private String resolveNamespace(String namespace)
-    {
-        String resolvedNamespace;
-        if (StringUtils.isNotEmpty(namespace)) {
-            resolvedNamespace = namespace;
-        } else {
-            resolvedNamespace = constructNamespace(getCurrentWikiId());
-        }
-        return resolvedNamespace;
-    }
-
-    private String getCurrentWikiId()
-    {
-        return this.wikiDescriptorManager.getCurrentWikiId();
-    }
-
-    private String constructNamespace(String wikiId)
-    {
-        return String.format("wiki:%s", wikiId);
+        return this.webjarUrlResolver.url(webjarId, namespace, path, params);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-webjars/xwiki-platform-webjars-api/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-webjars/xwiki-platform-webjars-api/src/main/resources/META-INF/components.txt
@@ -5,3 +5,4 @@ org.xwiki.webjars.internal.FilesystemResourceReferenceSerializer
 org.xwiki.webjars.script.WebJarsScriptService
 org.xwiki.webjars.internal.filter.LessWebJarsResourceFilter
 org.xwiki.webjars.internal.filter.VelocityWebJarsResourceFilter
+org.xwiki.webjars.internal.WebjarUrlResolver

--- a/xwiki-platform-core/xwiki-platform-webjars/xwiki-platform-webjars-api/src/test/java/org/xwiki/webjars/internal/WebjarUrlResolverTest.java
+++ b/xwiki-platform-core/xwiki-platform-webjars/xwiki-platform-webjars-api/src/test/java/org/xwiki/webjars/internal/WebjarUrlResolverTest.java
@@ -17,7 +17,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.xwiki.webjars;
+package org.xwiki.webjars.internal;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -47,13 +47,12 @@ import static org.mockito.Mockito.when;
  * Unit tests for {@link org.xwiki.webjars.script.WebJarsScriptService}.
  *
  * @version $Id$
- * @since 6.0M1
  */
 @ComponentTest
-class WebJarsScriptServiceTest
+class WebjarUrlResolverTest
 {
     @InjectMockComponents
-    private WebJarsScriptService scriptService;
+    private WebjarUrlResolver scriptService;
 
     @MockComponent
     private ResourceReferenceSerializer<ResourceReference, ExtendedURL> serializer;

--- a/xwiki-platform-core/xwiki-platform-webjars/xwiki-platform-webjars-api/src/test/java/org/xwiki/webjars/script/WebJarsScriptServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-webjars/xwiki-platform-webjars-api/src/test/java/org/xwiki/webjars/script/WebJarsScriptServiceTest.java
@@ -1,0 +1,82 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.webjars.script;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+import org.xwiki.webjars.internal.WebjarUrlResolver;
+
+import static org.mockito.Mockito.verify;
+
+/**
+ * Test of {@link WebJarsScriptService}.
+ *
+ * @version $Id$
+ * @since 6.0M1
+ */
+@ComponentTest
+class WebJarsScriptServiceTest
+{
+    @InjectMockComponents
+    private WebJarsScriptService webJarsScriptService;
+
+    @MockComponent
+    private WebjarUrlResolver webjarUrlResolver;
+
+    @Test
+    void urlWithResourceName()
+    {
+        this.webJarsScriptService.url("resourceName");
+        verify(this.webjarUrlResolver).url("resourceName");
+    }
+
+    @Test
+    void urlWithWebjarIdAndPath()
+    {
+        this.webJarsScriptService.url("webjarId", "path");
+        verify(this.webjarUrlResolver).url("webjarId", "path");
+    }
+
+    @Test
+    void urlWithWebjarIdNamespaceAndPath()
+    {
+        this.webJarsScriptService.url("webjarId", "ns", "path");
+        verify(this.webjarUrlResolver).url("webjarId", "ns", "path");
+    }
+
+    @Test
+    void urlWithWebjarIdPathAndParams()
+    {
+        this.webJarsScriptService.url("webjarId", "path", Map.of("a", "b"));
+        verify(this.webjarUrlResolver).url("webjarId", "path", Map.of("a", "b"));
+
+    }
+
+    @Test
+    void urlWithWebjarIdNamespacePathAndParams()
+    {
+        this.webJarsScriptService.url("webjarId", "ns", "path", Map.of("a", "b"));
+        verify(this.webjarUrlResolver).url("webjarId", "ns","path", Map.of("a", "b"));
+    }
+}


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-12788
<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Allow to use a webjar url in a SkinExtension.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Provide the internal component `WebjarUrlResolver`, mostly by moving the business logic of `WebJarsScriptService`
* Now it enough to get a correct webjar url, which can then be used with the `linkx` skins extension 

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
mvn clean install -f xwiki-platform-core/xwiki-platform-webjars/xwiki-platform-webjars-api -Pquality
```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A