### PR TITLE
XWIKI-21869: Upgrade to jstree 3.3.16

### DIFF
--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/pom.xml
@@ -34,7 +34,7 @@
   <properties>
     <!-- Name to display by the Extension Manager -->
     <xwiki.extension.name>Tree Widget</xwiki.extension.name>
-    <jstree.version>3.3.15</jstree.version>
+    <jstree.version>3.3.16</jstree.version>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-21869

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Updated version.
## Clarification

The webjar upgrade is done, so now this can safely be merge (see https://github.com/webjars/jstree/issues/29#event-11754385658)

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Successfully passed `mvn clean install -amd -f xwiki-platform-core/xwiki-platform-tree -pl :xwiki-platform-tree-webjar  -Pquality,integration-tests,docker` :)
# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.X (blocking fix for https://jira.xwiki.org/browse/XWIKI-21851 which should be backported )