### PR TITLE
XWIKI-21851: Found page in the Page Tree macro with a Solr field cannot be opened by left-clicking

### DIFF
--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/finder.js
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/finder.js
@@ -34,6 +34,9 @@ define(['jquery', 'jsTree', 'xwiki-events-bridge'], function($) {
     }
   };
 
+  // We want to still activate the links with a click even after they are selected from the finder.
+  $.jstree.defaults.core.allow_reselect = true;
+
   var createSuggestInput = function(options) {
     var input = document.createElement('input');
     input.type = 'text';


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-21851

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Updated the default option (introduced in JSTree 3.3.16) to allow reactivation of a link that's already selected.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
[Video demo](https://youtu.be/tyoQDWhFdVY)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Properly passed `mvn clean install -amd -f xwiki-platform-core/xwiki-platform-tree -pl :xwiki-platform-tree-webjar  -Pquality,integration-tests,docker` after updating the .pom with the correct version of jstree.
Manual tests were conducted and did end up successful, see video demo. I had some issues getting my local distribution to get the updated jar, in the end I realized it was pulling it from cache...

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.X (regression introduced when updating to jstree 3.3.15 in 15.2-rc1)