### PR TITLE
XWIKI-21884: Uploading files during page creation step will mark XWikiGuest as creator

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/BaseAttachmentsResource.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/BaseAttachmentsResource.java
@@ -56,6 +56,7 @@ import org.xwiki.rest.internal.RangeIterable;
 import org.xwiki.rest.internal.Utils;
 import org.xwiki.rest.model.jaxb.Attachment;
 import org.xwiki.rest.model.jaxb.Attachments;
+import org.xwiki.user.UserReferenceResolver;
 
 import com.xpn.xwiki.XWiki;
 import com.xpn.xwiki.XWikiContext;
@@ -126,6 +127,10 @@ public class BaseAttachmentsResource extends XWikiResource
     @Inject
     @Named("context")
     private Provider<ComponentManager> componentManagerProvider;
+
+    @Inject
+    @Named("document")
+    private UserReferenceResolver<DocumentReference> documentReferenceUserReferenceResolver;
 
     /**
      * @param scope where to retrieve the attachments from; it should be a reference to a wiki, space or document
@@ -411,7 +416,11 @@ public class BaseAttachmentsResource extends XWikiResource
                 String.format("Failed to instantiate a [%s] component.", AttachmentValidator.class.getName()), e);
         }
 
-        // Set the document author.
+        // Set the document creator / author.
+        if (document.isNew()) {
+            document.getAuthors()
+                .setCreator(this.documentReferenceUserReferenceResolver.resolve(xcontext.getUserReference()));
+        }
         document.setAuthorReference(xcontext.getUserReference());
 
         // Calculate and store the attachment media type.


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-21884

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* check if the document where the current attachment is created is actually a new document and set the creator in this case

## Clarifications

* for more context on when the issue can occur, there is https://jira.xwiki.org/browse/XWIKI-16476 and https://jira.xwiki.org/browse/XWIKI-16476 . These introduced the bug on Office Viewer Macro, but it is the reproducible for other macros that use the attachment picker as a parameter
<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->


# Screenshots & Video

**Before:**

![createdByGuestUser](https://github.com/xwiki/xwiki-platform/assets/22794181/f4cd504c-91eb-4f13-bdef-894842ebe62f)

**After:**

![guestUserCreatorAfter](https://github.com/xwiki/xwiki-platform/assets/22794181/e2455bd1-dab5-45f3-a003-d17f9395aec4)

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Run  `mvn clean install -Pquality,integration-tests,docker` in module `xwiki-platform-rest`.

# Expected merging strategy

* Prefers squash: Yes 
* Backport on branches:
  * stable-15.10.x