### PR TITLE
XWIKI-21864: Menu Application:  If list element is a link, the xDropdown-header-toggle drops to a new line and other weirdness

### DIFF
--- a/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
@@ -853,9 +853,16 @@ require(['jquery','xwiki-l10n!menu-ui-translation-keys'], function($, l10n) {
               }
             }
             /* When in dropdown we also have a link, reset the duplicated padding */
-            &amp; &gt; span &gt; a {
+            &amp; &gt; .xDropdown-header &gt; span &gt; a {
               padding: 0;
               display: inherit;
+            }
+            /* Reposition the toggle when in a dropdown of fixed size
+              to avoid eating away at the bit of space we have for the text. */
+            &amp; &gt; .xDropdown-header &gt; .xDropdown-header-toggle {
+              position: absolute;
+              right: 0;
+              top: 0;
             }
           }
           /* Separator horizontal inside menu */


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-21864
# Changes

## Description

<!-- Describe the main changes brought in this PR. -->


* Fixed incorrect padding on link section headers in the submenus
* Positioned the toggle absolutely

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* One selector was incorrect.
*  Positioned the toggle absolutely in those sections so that it doesn't eat away at space the text had before and force a linebreak where there used to be none.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Manual tests video demo: https://youtu.be/QU14vb_BkV4

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Only manual (see video). This is an extra patch upon the changes in https://github.com/xwiki/xwiki-platform/pull/2078/files which did not fail any build.
Moreover, this patch is style only so I doubt it could break any test.
# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.X (requested on LTS)