### PR TITLE
XWIKI-21894: JSC_PARSE_ERROR in Tour.WebHome

### DIFF
--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-fontawesome/src/main/resources/IconThemes/FontAwesome.xml
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-fontawesome/src/main/resources/IconThemes/FontAwesome.xml
@@ -39,8 +39,8 @@
   <content>## General settings
 xwiki.iconset.type = font
 xwiki.iconset.css = $services.webjars.url('org.webjars:font-awesome', 'css/font-awesome.min.css')
-xwiki.iconset.render.wiki = {{html clean="false"}}&lt;span class="fa fa-$icon" aria-hidden='true'&gt;&lt;/span&gt;{{/html}}
-xwiki.iconset.render.html = &lt;span class="fa fa-$icon" aria-hidden='true'&gt;&lt;/span&gt;
+xwiki.iconset.render.wiki = {{html clean="false"}}&lt;span class="fa fa-$icon" aria-hidden="true"&gt;&lt;/span&gt;{{/html}}
+xwiki.iconset.render.html = &lt;span class="fa fa-$icon" aria-hidden="true"&gt;&lt;/span&gt;
 xwiki.iconset.icon.cssClass = fa fa-$icon
 
 ## XWiki Icon Set (see: http://design.xwiki.org/xwiki/bin/view/Proposal/XWiki+Icon+Set).


### PR DESCRIPTION
# Changes

## JIRA

https://jira.xwiki.org/browse/XWIKI-21894

## Description

Use double quotes for `aria-hidden` attribute value. I.e.: `aria-hidden="true"`.

## Clarifications

The single quotes leads to error for example with tour extension:
```
xwiki:Tour.WebHome:17:78: ERROR - [JSC_PARSE_ERROR] Parse error. ',' expected
  17|       $('<a class="action actionLaunch"><span class="fa fa-play" aria-hidden='true'></span> Launch</a>')
                                                                                    ^
1 error(s), 0 warning(s)
```

# Executed Tests

`./mvnw -e install -f xwiki-platform-core/xwiki-platform-icon/pom.xml`