### PR TITLE
XWIKI-20616: Update jstree files and remove reference to throbber.gif

### DIFF
--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/base.less
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/base.less
@@ -1,10 +1,17 @@
 // base jstree
 .jstree-node, .jstree-children, .jstree-container-ul { display:block; margin:0; padding:0; list-style-type:none; list-style-image:none; }
 .jstree-node { white-space:nowrap; }
-.jstree-anchor { display:inline-block; color:black; white-space:nowrap; padding:0 4px 0 1px; margin:0; vertical-align:top; }
+// XWiki customization start
+//.jstree-anchor { display:inline-block; color:black; white-space:nowrap; padding:0 4px 0 1px; margin:0; vertical-align:top; }
+.jstree-anchor { display:inline-block; white-space:nowrap; padding:0 4px 0 1px; margin:0; vertical-align:top; }
+// XWiki customization end
 .jstree-anchor:focus { outline:0; }
-.jstree-anchor, .jstree-anchor:link, .jstree-anchor:visited, .jstree-anchor:hover, .jstree-anchor:active { text-decoration:none; color:inherit; }
-.jstree-icon { display:inline-block; text-decoration:none; margin:0; padding:0; vertical-align:top; text-align:center; }
+// XWiki customization start
+// .jstree-anchor, .jstree-anchor:link, .jstree-anchor:visited, .jstree-anchor:hover, .jstree-anchor:active { text-decoration:none; color:inherit; }
+// .jstree-icon { display:inline-block; text-decoration:none; margin:0; padding:0; vertical-align:top; text-align:center; }
+.jstree-anchor, .jstree-anchor:link, .jstree-anchor:visited, .jstree-anchor:hover, .jstree-anchor:active { text-decoration:none; }
+.jstree-icon { color:@text-color; display:inline-block; text-decoration:none; margin:0; padding:0; vertical-align:top; text-align:center; }
+// XWiki customization end
 .jstree-icon:empty { display:inline-block; text-decoration:none; margin:0; padding:0; vertical-align:top; text-align:center; }
 .jstree-ocl { cursor:pointer; }
 .jstree-leaf > .jstree-ocl { cursor:default; }
@@ -15,6 +22,36 @@
 .jstree-no-icons .jstree-themeicon,
 .jstree-anchor > .jstree-themeicon-hidden { display:none; }
 .jstree-hidden, .jstree-node.jstree-hidden { display:none; }
+
+// XWiki customization start
+.jstree-no-links {
+  .jstree-anchor:focus {
+    outline: 0;
+  }
+  .jstree-anchor,
+  .jstree-anchor:link,
+  .jstree-anchor:visited,
+  .jstree-anchor:hover,
+  .jstree-anchor:active {
+    color: inherit;
+    text-decoration: none;
+  }
+}
+
+.jstree-no-link {
+  &.jstree-anchor:focus {
+    outline: 0;
+  }
+  &.jstree-anchor,
+  &.jstree-anchor:link,
+  &.jstree-anchor:visited,
+  &.jstree-anchor:hover,
+  &.jstree-anchor:active {
+    color: inherit;
+    text-decoration: none;
+  }
+}
+// XWiki customization end
 
 // base jstree rtl
 .jstree-rtl {

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/base.less
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/base.less
@@ -1,10 +1,10 @@
 // base jstree
 .jstree-node, .jstree-children, .jstree-container-ul { display:block; margin:0; padding:0; list-style-type:none; list-style-image:none; }
 .jstree-node { white-space:nowrap; }
-.jstree-anchor { display:inline-block; white-space:nowrap; padding:0 4px 0 1px; margin:0; vertical-align:top; }
+.jstree-anchor { display:inline-block; color:black; white-space:nowrap; padding:0 4px 0 1px; margin:0; vertical-align:top; }
 .jstree-anchor:focus { outline:0; }
-.jstree-anchor, .jstree-anchor:link, .jstree-anchor:visited, .jstree-anchor:hover, .jstree-anchor:active { text-decoration:none; }
-.jstree-icon { color:@text-color; display:inline-block; text-decoration:none; margin:0; padding:0; vertical-align:top; text-align:center; }
+.jstree-anchor, .jstree-anchor:link, .jstree-anchor:visited, .jstree-anchor:hover, .jstree-anchor:active { text-decoration:none; color:inherit; }
+.jstree-icon { display:inline-block; text-decoration:none; margin:0; padding:0; vertical-align:top; text-align:center; }
 .jstree-icon:empty { display:inline-block; text-decoration:none; margin:0; padding:0; vertical-align:top; text-align:center; }
 .jstree-ocl { cursor:pointer; }
 .jstree-leaf > .jstree-ocl { cursor:default; }
@@ -15,34 +15,6 @@
 .jstree-no-icons .jstree-themeicon,
 .jstree-anchor > .jstree-themeicon-hidden { display:none; }
 .jstree-hidden, .jstree-node.jstree-hidden { display:none; }
-
-.jstree-no-links {
-  .jstree-anchor:focus {
-    outline: 0;
-  }
-  .jstree-anchor,
-  .jstree-anchor:link,
-  .jstree-anchor:visited,
-  .jstree-anchor:hover,
-  .jstree-anchor:active {
-    color: inherit;
-    text-decoration: none;
-  }
-}
-
-.jstree-no-link {
-  &.jstree-anchor:focus {
-    outline: 0;
-  }
-  &.jstree-anchor,
-  &.jstree-anchor:link,
-  &.jstree-anchor:visited,
-  &.jstree-anchor:hover,
-  &.jstree-anchor:active {
-    color: inherit;
-    text-decoration: none;
-  }
-}
 
 // base jstree rtl
 .jstree-rtl {
@@ -66,6 +38,7 @@
 .jstree-contextmenu .jstree-anchor {
 	-webkit-user-select: none; /* disable selection/Copy of UIWebView */
 	-webkit-touch-callout: none; /* disable the IOS popup when long-press on a link */
+	user-select: none;
 }
 .vakata-context {
 	display:none;
@@ -81,6 +54,7 @@
 		}
 		> a:focus { outline:0; }
 	}
+	.vakata-context-no-icons { margin-left:0; }
 	.vakata-context-hover > a { position:relative; background-color:#e8eff7; box-shadow:0 0 2px #0a6aa1; }
 	.vakata-context-separator {
 		> a, > a:hover { background:white; border:0; border-top:1px solid #e2e3e3; height:1px; min-height:1px; max-height:1px; padding:0; margin:0 0 0 2.4em; border-left:1px solid #e0e0e0; text-shadow:0 0 0 transparent; box-shadow:0 0 0 transparent; border-radius:0; }

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/main.less
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/main.less
@@ -4,15 +4,26 @@
 	.jstree-anchor,
 	.jstree-animated,
 	.jstree-wholerow { transition:background-color 0.15s, box-shadow 0.15s; }
-	.jstree-hovered { background:@hovered-bg-color; border-radius:2px; box-shadow:inset 0 0 1px @hovered-shadow-color; }
-	.jstree-context { background:@hovered-bg-color; border-radius:2px; box-shadow:inset 0 0 1px @hovered-shadow-color; }
-	.jstree-clicked { background:@clicked-bg-color; border-radius:2px; box-shadow:inset 0 0 1px @clicked-shadow-color; }
+	// XWiki customization start
+	// .jstree-hovered { background:@hovered-bg-color; border-radius:2px; box-shadow:inset 0 0 1px @hovered-shadow-color; }
+	// .jstree-context { background:@hovered-bg-color; border-radius:2px; box-shadow:inset 0 0 1px @hovered-shadow-color; }
+	// .jstree-clicked { background:@clicked-bg-color; border-radius:2px; box-shadow:inset 0 0 1px @clicked-shadow-color; }
+	.jstree-hovered { background:@hovered-bg-color; border-radius:3px; box-shadow:inset 0 0 1px @hovered-shadow-color; }
+	.jstree-context { background:@hovered-bg-color; border-radius:3px; box-shadow:inset 0 0 1px @hovered-shadow-color; }
+	.jstree-clicked { background:@clicked-bg-color; border-radius:3px; box-shadow:inset 0 0 1px @clicked-shadow-color; }
+	// XWiki customization end
 	.jstree-no-icons .jstree-anchor > .jstree-themeicon { display:none; }
 	.jstree-disabled {
-		background:transparent; color:@disabled-color;
+		// XWiki customization start
+		// background:transparent; color:@disabled-color;
+		background:transparent; color:@disabled-color; opacity:@disabled-opacity;
+		// XWiki customization end
 		&.jstree-hovered { background:transparent; box-shadow:none; }
 		&.jstree-clicked { background:@disabled-bg-color; }
-		> .jstree-icon { opacity:0.8; filter: url("data:image/svg+xml;utf8,<svg xmlns=\'http://www.w3.org/2000/svg\'><filter id=\'jstree-grayscale\'><feColorMatrix type=\'matrix\' values=\'0.3333 0.3333 0.3333 0 0 0.3333 0.3333 0.3333 0 0 0.3333 0.3333 0.3333 0 0 0 0 0 1 0\'/></filter></svg>#jstree-grayscale"); /* Firefox 10+ */ filter: gray; /* IE6-9 */ -webkit-filter: grayscale(100%); /* Chrome 19+ & Safari 6+ */ }
+		// XWiki customization start
+		// > .jstree-icon { opacity:0.8; filter: url("data:image/svg+xml;utf8,<svg xmlns=\'http://www.w3.org/2000/svg\'><filter id=\'jstree-grayscale\'><feColorMatrix type=\'matrix\' values=\'0.3333 0.3333 0.3333 0 0 0.3333 0.3333 0.3333 0 0 0.3333 0.3333 0.3333 0 0 0 0 0 1 0\'/></filter></svg>#jstree-grayscale"); /* Firefox 10+ */ filter: gray; /* IE6-9 */ -webkit-filter: grayscale(100%); /* Chrome 19+ & Safari 6+ */ }
+		> .jstree-icon { filter: url("data:image/svg+xml;utf8,<svg xmlns=\'http://www.w3.org/2000/svg\'><filter id=\'jstree-grayscale\'><feColorMatrix type=\'matrix\' values=\'0.3333 0.3333 0.3333 0 0 0.3333 0.3333 0.3333 0 0 0.3333 0.3333 0.3333 0 0 0 0 0 1 0\'/></filter></svg>#jstree-grayscale"); /* Firefox 10+ */ filter: gray; /* IE6-9 */ -webkit-filter: grayscale(100%); /* Chrome 19+ & Safari 6+ */ }
+		// XWiki customization end
 	}
 	// search
 	.jstree-search { font-style:italic; color:@search-result-color; font-weight:bold; }

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/main.less
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/main.less
@@ -4,15 +4,15 @@
 	.jstree-anchor,
 	.jstree-animated,
 	.jstree-wholerow { transition:background-color 0.15s, box-shadow 0.15s; }
-	.jstree-hovered { background:@hovered-bg-color; border-radius:3px; box-shadow:inset 0 0 1px @hovered-shadow-color; }
-	.jstree-context { background:@hovered-bg-color; border-radius:3px; box-shadow:inset 0 0 1px @hovered-shadow-color; }
-	.jstree-clicked { background:@clicked-bg-color; border-radius:3px; box-shadow:inset 0 0 1px @clicked-shadow-color; }
+	.jstree-hovered { background:@hovered-bg-color; border-radius:2px; box-shadow:inset 0 0 1px @hovered-shadow-color; }
+	.jstree-context { background:@hovered-bg-color; border-radius:2px; box-shadow:inset 0 0 1px @hovered-shadow-color; }
+	.jstree-clicked { background:@clicked-bg-color; border-radius:2px; box-shadow:inset 0 0 1px @clicked-shadow-color; }
 	.jstree-no-icons .jstree-anchor > .jstree-themeicon { display:none; }
 	.jstree-disabled {
-		background:transparent; color:@disabled-color; opacity:@disabled-opacity;
+		background:transparent; color:@disabled-color;
 		&.jstree-hovered { background:transparent; box-shadow:none; }
 		&.jstree-clicked { background:@disabled-bg-color; }
-		> .jstree-icon { filter: url("data:image/svg+xml;utf8,<svg xmlns=\'http://www.w3.org/2000/svg\'><filter id=\'jstree-grayscale\'><feColorMatrix type=\'matrix\' values=\'0.3333 0.3333 0.3333 0 0 0.3333 0.3333 0.3333 0 0 0.3333 0.3333 0.3333 0 0 0 0 0 1 0\'/></filter></svg>#jstree-grayscale"); /* Firefox 10+ */ filter: gray; /* IE6-9 */ -webkit-filter: grayscale(100%); /* Chrome 19+ & Safari 6+ */ }
+		> .jstree-icon { opacity:0.8; filter: url("data:image/svg+xml;utf8,<svg xmlns=\'http://www.w3.org/2000/svg\'><filter id=\'jstree-grayscale\'><feColorMatrix type=\'matrix\' values=\'0.3333 0.3333 0.3333 0 0 0.3333 0.3333 0.3333 0 0 0.3333 0.3333 0.3333 0 0 0 0 0 1 0\'/></filter></svg>#jstree-grayscale"); /* Firefox 10+ */ filter: gray; /* IE6-9 */ -webkit-filter: grayscale(100%); /* Chrome 19+ & Safari 6+ */ }
 	}
 	// search
 	.jstree-search { font-style:italic; color:@search-result-color; font-weight:bold; }
@@ -43,17 +43,17 @@
 .jstree-@{theme-name} {
 	.jstree-theme(24px, "@{image-path}32px.png", 32px);
 	&.jstree-rtl .jstree-node { background-image:url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAACAQMAAAB49I5GAAAABlBMVEUAAAAdHRvEkCwcAAAAAXRSTlMAQObYZgAAAAxJREFUCNdjAAMOBgAAGAAJMwQHdQAAAABJRU5ErkJggg=="); }
-	&.jstree-rtl .jstree-last { background:transparent; }
+	&.jstree-rtl .jstree-last { background-image:none;  }
 }
 .jstree-@{theme-name}-small {
 	.jstree-theme(18px, "@{image-path}32px.png", 32px);
 	&.jstree-rtl .jstree-node { background-image:url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAACAQMAAABv1h6PAAAABlBMVEUAAAAdHRvEkCwcAAAAAXRSTlMAQObYZgAAAAxJREFUCNdjAAMHBgAAiABBI4gz9AAAAABJRU5ErkJggg=="); }
-	&.jstree-rtl .jstree-last { background:transparent; }
+	&.jstree-rtl .jstree-last { background-image:none;  }
 }
 .jstree-@{theme-name}-large {
 	.jstree-theme(32px, "@{image-path}32px.png", 32px);
 	&.jstree-rtl .jstree-node { background-image:url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAACAQMAAAAD0EyKAAAABlBMVEUAAAAdHRvEkCwcAAAAAXRSTlMAQObYZgAAAAxJREFUCNdjgIIGBgABCgCBvVLXcAAAAABJRU5ErkJggg=="); }
-	&.jstree-rtl .jstree-last { background:transparent; }
+	&.jstree-rtl .jstree-last { background-image:none;  }
 }
 
 // mobile theme attempt

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/mixins.less
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/mixins.less
@@ -17,7 +17,7 @@
 	.jstree-node,
 	.jstree-icon { background-image:url("@{image}"); }
 	.jstree-node { background-position:-(@image-height * 9 + @correction) -@correction; background-repeat:repeat-y; }
-	.jstree-last { background:transparent; }
+	.jstree-last { background-image:none; }
 
 	.jstree-open > .jstree-ocl { background-position:-(@image-height * 4 + @correction) -@correction; }
 	.jstree-closed > .jstree-ocl { background-position:-(@image-height * 3 + @correction) -@correction; }
@@ -67,7 +67,7 @@
 
 	&.jstree-rtl {
 		.jstree-node { background-image:url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAACAQMAAAB49I5GAAAABlBMVEUAAAAdHRvEkCwcAAAAAXRSTlMAQObYZgAAAAxJREFUCNdjAAMOBgAAGAAJMwQHdQAAAABJRU5ErkJggg=="); background-position: 100% 1px; background-repeat:repeat-y; }
-		.jstree-last { background:transparent; }
+		.jstree-last { background-image:none; }
 		.jstree-open > .jstree-ocl { background-position:-(@image-height * 4 + @correction) -(@image-height * 1 + @correction); }
 		.jstree-closed > .jstree-ocl { background-position:-(@image-height * 3 + @correction) -(@image-height * 1 + @correction); }
 		.jstree-leaf > .jstree-ocl { background-position:-(@image-height * 2 + @correction) -(@image-height * 1 + @correction); }
@@ -80,7 +80,8 @@
 	}
 	.jstree-themeicon-custom { background-color:transparent; background-image:none; background-position:0 0; }
 
-	> .jstree-container-ul .jstree-loading > .jstree-ocl { background:url("@{image-path}throbber.gif") center center no-repeat; }
+	// This line is commented out compared to upstream source as throbber.gif is not available in xwiki-platofrm-tree-webjar and this style is override in tree.less to use spinner.gif.
+	//> .jstree-container-ul .jstree-loading > .jstree-ocl { background:url("@{image-path}throbber.gif") center center no-repeat; }
 
 	.jstree-file { background:url("@{image}") -(@image-height * 3 + @correction) -(@image-height * 2 + @correction) no-repeat; }
 	.jstree-folder { background:url("@{image}") -(@image-height * 8 + @correction) -(@correction) no-repeat; }
@@ -101,5 +102,4 @@
 	.jstree-ellipsis { overflow: hidden; }
 	// base height + PADDINGS!
 	.jstree-ellipsis .jstree-anchor { width: calc(100% ~"-" (@base-height + 5px)); text-overflow: ellipsis; overflow: hidden; }
-	.jstree-ellipsis.jstree-no-icons .jstree-anchor { width: calc(100% ~"-" 5px); }
 }

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/mixins.less
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/mixins.less
@@ -80,8 +80,10 @@
 	}
 	.jstree-themeicon-custom { background-color:transparent; background-image:none; background-position:0 0; }
 
+	// XWiki customization start
 	// This line is commented out compared to upstream source as throbber.gif is not available in xwiki-platofrm-tree-webjar and this style is override in tree.less to use spinner.gif.
-	//> .jstree-container-ul .jstree-loading > .jstree-ocl { background:url("@{image-path}throbber.gif") center center no-repeat; }
+	// > .jstree-container-ul .jstree-loading > .jstree-ocl { background:url("@{image-path}throbber.gif") center center no-repeat; }
+	// XWiki customization end
 
 	.jstree-file { background:url("@{image}") -(@image-height * 3 + @correction) -(@image-height * 2 + @correction) no-repeat; }
 	.jstree-folder { background:url("@{image}") -(@image-height * 8 + @correction) -(@correction) no-repeat; }

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/responsive.less
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/responsive.less
@@ -51,7 +51,7 @@
 	.jstree-checkbox { background-image:url("@{image-path}@{base-height}.png"); background-size:(@base-height * 3) (@base-height * 6); }
 
 	.jstree-node { background-position:-(@base-height * 2) 0; background-repeat:repeat-y; }
-	.jstree-last { background:transparent; }
+	.jstree-last { background-image:none; }
 	.jstree-leaf > .jstree-ocl { background-position:-(@base-height * 1) -(@base-height * 3); }
 	.jstree-last > .jstree-ocl { background-position:-(@base-height * 1) -(@base-height * 4); }
 	/*


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-20616

# Changes

## Description

* Update files provided by `jstree` to use the ones provided in version `3.3.16` (version of `jstree` referenced in the `pom.xml`).
* Comment out the reference to `throbber.gif` in `jstree` `mixins.less` file as the gif file is no part of `xwiki-platform-tree-webjar` and rule is override in `tree.less` to use `spinner.gif`.

## Clarifications

* By looking at files such as [`xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/mixins.less`](https://github.com/xwiki/xwiki-platform/blob/52e78eb4d31a8b449cd9422412edb947df0f71c1/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/mixins.less) it appears they were part of version `3.3.5` or earlier (see for example this [diff](https://github.com/vakata/jstree/compare/3.3.5..3.3.6#diff-c6eea180a2a3a75378b36f8ba3d678924453a910d9c7fe1d5a7a0fd6721405ac) of `src/themes/mixins.less` file between version `3.3.5` and `3.3.6`). As [`pom.xml` specifies version `3.3.16`](https://github.com/xwiki/xwiki-platform/blob/52e78eb4d31a8b449cd9422412edb947df0f71c1/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/pom.xml#L37) this commit update files included in `xwiki-platform-tree-webjar` that are coming from `jstree` project.
* Removing the reference to `throbber.gif` is a way to remove warning in the log that are probably triggered by search bot parsing the CSS. This doesn't seems to trigger any issue in XWiki with normal user interaction.

# Executed Tests

`./mvnw -Psnapshot,dev clean install -f xwiki-platform-core/xwiki-platform-tree/pom.xml` (with Java 17 and Maven 3.9.6)