### PR TITLE
XWIKI-21894: JSC_PARSE_ERROR in  Tour.WebHome

### DIFF
--- a/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui/src/main/resources/Tour/WebHome.xml
+++ b/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui/src/main/resources/Tour/WebHome.xml
@@ -256,7 +256,7 @@
 
     // Add a launch tour link to the actions column.
     if (row.find('.actionLaunch').length == 0) {
-      $('&lt;a class="action actionLaunch"&gt;$services.icon.renderHTML("play") $escapetool.javascript($escapetool.xml($services.localization.render("tour.livetable._actions.launch")))&lt;/a&gt;')
+      $('&lt;a class="action actionLaunch"&gt;$escapetool.javascript($services.icon.renderHTML("play")) $escapetool.javascript($escapetool.xml($services.localization.render("tour.livetable._actions.launch")))&lt;/a&gt;')
         .attr('href', targetPageDocument.getURL('view', 'startTour=true'))
         .css('padding-left', '1px').appendTo(row.find('.actions'));
     }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-21894
# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Added proper escaping to the icon

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The icon was not escaped, which explains the fail. The previous commit fixed the error, but didn't tackle the root cause.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Manual tests. Changes are not about front-end API.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * No, same as https://github.com/xwiki/xwiki-platform/pull/2895