### PR TITLE
XWIKI-17702: Annotation anchor not working when "show annotations" is off

### DIFF
--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-test/xwiki-platform-annotation-test-docker/src/test/it/org/xwiki/annotation/test/ui/AnnotationsIT.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-test/xwiki-platform-annotation-test-docker/src/test/it/org/xwiki/annotation/test/ui/AnnotationsIT.java
@@ -178,6 +178,7 @@ class AnnotationsIT
     }
 
     @Test
+    @Order(4)
     void showAnnotationsByClickingOnAQuote(TestUtils setup, TestReference testReference)
     {
         // Adds 200 'a' after the content to make sure the content is not on-screen when the comment pane is visible.

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-test/xwiki-platform-annotation-test-docker/src/test/it/org/xwiki/annotation/test/ui/AnnotationsIT.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-test/xwiki-platform-annotation-test-docker/src/test/it/org/xwiki/annotation/test/ui/AnnotationsIT.java
@@ -80,9 +80,9 @@ class AnnotationsIT
         setup.login(USER_NAME, USER_PASS);
     }
 
-    // TODO: This test must currently not be first. We can get back to a more natural order once XWIKI-9759 is fixed
+    // TODO: This test must currently be last. We can get back to a more natural order once XWIKI-9759 is fixed
     @Test
-    @Order(3)
+    @Order(4)
     void addAnnotationTranslation(TestUtils setup, TestReference testReference,
         LogCaptureConfiguration logCaptureConfiguration) throws Exception
     {
@@ -178,7 +178,7 @@ class AnnotationsIT
     }
 
     @Test
-    @Order(4)
+    @Order(3)
     void showAnnotationsByClickingOnAQuote(TestUtils setup, TestReference testReference)
     {
         // Adds 200 'a' after the content to make sure the content is not on-screen when the comment pane is visible.

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-test/xwiki-platform-annotation-test-pageobjects/src/main/java/org/xwiki/annotation/test/po/AnnotatableViewPage.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-test/xwiki-platform-annotation-test-pageobjects/src/main/java/org/xwiki/annotation/test/po/AnnotatableViewPage.java
@@ -321,6 +321,6 @@ public class AnnotatableViewPage extends BaseElement
      */
     public WebElement getAnnotationTextById(int id)
     {
-        return getDriver().findElement(By.cssSelector("span.annotation.ID%d".formatted(id)));
+        return getDriver().findElement(By.cssSelector(String.format("span.annotation.ID%d", id)));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-test/xwiki-platform-annotation-test-pageobjects/src/main/java/org/xwiki/annotation/test/po/AnnotatableViewPage.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-test/xwiki-platform-annotation-test-pageobjects/src/main/java/org/xwiki/annotation/test/po/AnnotatableViewPage.java
@@ -310,4 +310,17 @@ public class AnnotatableViewPage extends BaseElement
             "//div[contains(@class, 'annotation')][a[contains(@href,'#" + annotationId + "')]]"))
             .getAttribute("id").replace("xwikicomment_", ""));
     }
+
+    /**
+     * Search for an annotation by its id and return the corresponding web element.
+     *
+     * @param id the id of the annotation to search for
+     * @return the web element of the requested annotation
+     * @since 16.2.0RC1
+     * @since 15.10.7
+     */
+    public WebElement getAnnotationTextById(int id)
+    {
+        return getDriver().findElement(By.cssSelector("span.annotation.ID%d".formatted(id)));
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Script.xml
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Script.xml
@@ -623,6 +623,32 @@ XWiki.Annotation = Class.create({
     document.observe('xwiki:docextra:loaded', this.addDeleteListenersInTab.bindAsEventListener(this));
     document.observe('xwiki:docextra:loaded', this.addEditListenersInTab.bindAsEventListener(this));
     document.observe('xwiki:docextra:loaded', this.addValidateListenersInTab.bindAsEventListener(this));
+    // List for clicks on annotated texts on the comments. 
+    // Takes care to load the annotations and to make them visible before moving
+    // the user to the anchor corresponding to the requested annotation.
+    require(['jquery'], ($) =&gt; {
+      $(document).on('click', 'blockquote.annotatedText', (event) =&gt; {
+        if(this.fetchedAnnotations) {
+          // In this case the annotations are just made visible (if need be). This is synchrnous and
+          // we can just let the click event bubble up.
+          this.setAnnotationVisibility(true);
+          this.toggleAnnotations(this.displayingAnnotations);
+        } else {
+          // In this case we need to fetch the annotations fist. As this is asynchronous we need to wait for 
+          // the annotations to be fetched before moving the user to the anchor.
+          this.fetchAnnotations(true);
+          event.preventDefault();
+          // Wait for fetchedAnnotations to become true before changing the location, as otherwise
+          // the anchor wouldn't be present and the user wouldn't scroll to the right location.
+          const intervalId = setInterval(() =&gt; {
+            if(this.fetchedAnnotations) {
+              clearInterval(intervalId);
+              window.location = $(event.target).parents('a').attr('href');
+            }
+          })
+        }
+      });
+    });
     // refresh the annotations displayed on the document when an annotation is deleted as a comment, that is from the comments tab when annotations are merged with comments
     document.observe('xwiki:annotation:tab:deleted', this.refreshAnnotationsOnCommentDelete.bindAsEventListener(this));
     // register the key shortcuts for adding an annotation

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/CommentsTab.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/CommentsTab.java
@@ -265,4 +265,19 @@ public class CommentsTab extends BaseElement
         getDriver().findElement(
             By.xpath(String.format("//div[@id='xwikicomment_%d']//a[contains(@class, 'commentreply')]", id))).click();
     }
+
+    /**
+     * Click on the annotation of a given id.
+     *
+     * @param id the id of the comment
+     * @since 16.2.0RC1
+     * @since 15.10.7
+     */
+    public void clickOnAnnotationQuote(int id)
+    {
+        getDriver()
+            .findElement(By.id("xwikicomment_%d".formatted(id)))
+            .findElement(By.cssSelector("blockquote.annotatedText"))
+            .click();
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/CommentsTab.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/CommentsTab.java
@@ -276,7 +276,7 @@ public class CommentsTab extends BaseElement
     public void clickOnAnnotationQuote(int id)
     {
         getDriver()
-            .findElement(By.id("xwikicomment_%d".formatted(id)))
+            .findElement(By.id(String.format("xwikicomment_%d", id)))
             .findElement(By.cssSelector("blockquote.annotatedText"))
             .click();
     }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-17702

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Listen for the clicks on the quotes of annotations in the comments sections.
  * fetch the annotations if needed
  * make the annotations visible
  * go to the anchor

TODO:
* [x] add functional test

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
```
mvn clean install \
  -Pquality,integration-tests,docker \
  -pl :xwiki-platform-annotation-test-docker,:xwiki-platform-annotation-test-pageobjects,:xwiki-platform-test-ui
```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-15.10.x
  * stable-16.1.x