### PR TITLE
XWIKI-21922: Introduce methods to fetch a subset of revisions in XWikiVersioningStoreInterface

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Document.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Document.java
@@ -1426,7 +1426,7 @@ public class Document extends Api
      *
      * @param criteria criteria used to match versions
      * @return the number of matching versions
-     * @since 15.10.7
+     * @since 15.10.8
      * @since 16.2.0RC1
      */
     @Unstable

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Document.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Document.java
@@ -1421,6 +1421,20 @@ public class Document extends Api
         return this.doc.getRevisions(getXWikiContext());
     }
 
+    /**
+     * Counts the number of document versions matching criteria like author, minimum creation date, etc.
+     *
+     * @param criteria criteria used to match versions
+     * @return the number of matching versions
+     * @since 15.10.7
+     * @since 16.2.0RC1
+     */
+    @Unstable
+    public long getRevisionsCount(RevisionCriteria criteria) throws XWikiException
+    {
+        return this.doc.getRevisionsCount(criteria, getXWikiContext());
+    }
+
     public String[] getRecentRevisions() throws XWikiException
     {
         return this.doc.getRecentRevisions(5, getXWikiContext());
@@ -1432,7 +1446,7 @@ public class Document extends Api
     }
 
     /**
-     * Get document versions matching criterias like author, minimum creation date, etc.
+     * Gets document versions matching criteria like author, minimum creation date, etc.
      *
      * @param criteria criteria used to match versions
      * @return a list of matching versions

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/criteria/impl/RevisionCriteriaFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/criteria/impl/RevisionCriteriaFactory.java
@@ -115,7 +115,7 @@ public class RevisionCriteriaFactory
      *
      * @param includeMinorVersions include minor versions in the set
      * @return a new revision criteria
-     * @since 15.10.7
+     * @since 15.10.8
      * @since 16.2.0RC1
      */
     @Unstable

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/criteria/impl/RevisionCriteriaFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/criteria/impl/RevisionCriteriaFactory.java
@@ -19,6 +19,8 @@
  */
 package com.xpn.xwiki.criteria.impl;
 
+import org.xwiki.stability.Unstable;
+
 public class RevisionCriteriaFactory
 {
     public RevisionCriteriaFactory()
@@ -106,5 +108,20 @@ public class RevisionCriteriaFactory
         boolean includeMinorVersions)
     {
         return new RevisionCriteria(author, period, RangeFactory.createAllRange(), includeMinorVersions);
+    }
+
+    /**
+     * Creates a revision criteria matching every revision, filtering only minor versions.
+     *
+     * @param includeMinorVersions include minor versions in the set
+     * @return a new revision criteria
+     * @since 15.10.7
+     * @since 16.2.0RC1
+     */
+    @Unstable
+    public RevisionCriteria createRevisionCriteria(boolean includeMinorVersions)
+    {
+        return new RevisionCriteria("", PeriodFactory.createMaximumPeriod(), RangeFactory.createAllRange(),
+            includeMinorVersions);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -2650,7 +2650,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
      * @param criteria criteria used to match versions
      * @param context the XWiki context
      * @return the number of matching versions
-     * @since 15.10.7
+     * @since 15.10.8
      * @since 16.2.0RC1
      */
     @Unstable

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -52,6 +52,7 @@ import java.util.Vector;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -2643,6 +2644,21 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
         return getVersioningStore(context).getXWikiDocVersions(this, context);
     }
 
+    /**
+     * Counts the number of document versions matching criteria like author, minimum creation date, etc.
+     *
+     * @param criteria criteria used to match versions
+     * @param context the XWiki context
+     * @return the number of matching versions
+     * @since 15.10.7
+     * @since 16.2.0RC1
+     */
+    @Unstable
+    public long getRevisionsCount(RevisionCriteria criteria, XWikiContext context) throws XWikiException
+    {
+        return getVersioningStore(context).getXWikiDocVersionsCount(this, criteria, context);
+    }
+
     public String[] getRecentRevisions(int nb, XWikiContext context) throws XWikiException
     {
         try {
@@ -2668,52 +2684,15 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
     }
 
     /**
-     * Get document versions matching criterias like author, minimum creation date, etc.
+     * Gets document versions matching criteria like author, minimum creation date, etc.
      *
      * @param criteria criteria used to match versions
      * @return a list of matching versions
      */
     public List<String> getRevisions(RevisionCriteria criteria, XWikiContext context) throws XWikiException
     {
-        List<String> results = new ArrayList<String>();
-
-        Version[] revisions = getRevisions(context);
-
-        XWikiRCSNodeInfo nextNodeinfo = null;
-        XWikiRCSNodeInfo nodeinfo;
-        for (Version revision : revisions) {
-            nodeinfo = nextNodeinfo;
-            nextNodeinfo = getRevisionInfo(revision.toString(), context);
-
-            if (nodeinfo == null) {
-                continue;
-            }
-
-            // Minor/Major version matching
-            if (criteria.getIncludeMinorVersions() || !nextNodeinfo.isMinorEdit()) {
-                // Author matching
-                if (criteria.getAuthor().equals("") || criteria.getAuthor().equals(nodeinfo.getAuthor())) {
-                    // Date range matching
-                    Date versionDate = nodeinfo.getDate();
-                    if (versionDate.after(criteria.getMinDate()) && versionDate.before(criteria.getMaxDate())) {
-                        results.add(nodeinfo.getVersion().toString());
-                    }
-                }
-            }
-        }
-
-        nodeinfo = nextNodeinfo;
-        if (nodeinfo != null) {
-            if (criteria.getAuthor().equals("") || criteria.getAuthor().equals(nodeinfo.getAuthor())) {
-                // Date range matching
-                Date versionDate = nodeinfo.getDate();
-                if (versionDate.after(criteria.getMinDate()) && versionDate.before(criteria.getMaxDate())) {
-                    results.add(nodeinfo.getVersion().toString());
-                }
-            }
-        }
-
-        return criteria.getRange().subList(results);
+        return getVersioningStore(context).getXWikiDocVersions(this, criteria, context).stream()
+            .map(Version::toString).collect(Collectors.toCollection(ArrayList::new));
     }
 
     public XWikiRCSNodeInfo getRevisionInfo(String version, XWikiContext context) throws XWikiException

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -2691,8 +2691,10 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
      */
     public List<String> getRevisions(RevisionCriteria criteria, XWikiContext context) throws XWikiException
     {
+        // We collect explicitly into an ArrayList to ensure mutability of the resulting list.
         return getVersioningStore(context).getXWikiDocVersions(this, criteria, context).stream()
-            .map(Version::toString).collect(Collectors.toCollection(ArrayList::new));
+            .map(Version::toString)
+            .collect(Collectors.toCollection(ArrayList::new));
     }
 
     public XWikiRCSNodeInfo getRevisionInfo(String version, XWikiContext context) throws XWikiException

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateVersioningStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateVersioningStore.java
@@ -39,6 +39,7 @@ import com.xpn.xwiki.XWiki;
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.criteria.impl.RevisionCriteria;
+import com.xpn.xwiki.criteria.impl.RevisionCriteriaFactory;
 import com.xpn.xwiki.doc.XWikiAttachment;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.doc.XWikiDocumentArchive;
@@ -108,7 +109,8 @@ public class XWikiHibernateVersioningStore extends XWikiHibernateBaseStore imple
     @Override
     public Version[] getXWikiDocVersions(XWikiDocument doc, XWikiContext context) throws XWikiException
     {
-        return getXWikiDocVersions(doc, new RevisionCriteria(null, null, null, true), context).toArray(new Version[0]);
+        return getXWikiDocVersions(doc, new RevisionCriteriaFactory().createRevisionCriteria(true), context)
+            .toArray(new Version[0]);
     }
 
     @Override
@@ -138,7 +140,7 @@ public class XWikiHibernateVersioningStore extends XWikiHibernateBaseStore imple
     public XWikiDocumentArchive getXWikiDocumentArchive(XWikiDocument doc, XWikiContext inputxcontext)
         throws XWikiException
     {
-        return getXWikiDocumentArchive(doc, new RevisionCriteria(null, null, null, true), inputxcontext);
+        return getXWikiDocumentArchive(doc, new RevisionCriteriaFactory().createRevisionCriteria(true), inputxcontext);
     }
 
     private XWikiDocumentArchive getXWikiDocumentArchive(XWikiDocument doc, RevisionCriteria criteria,
@@ -172,7 +174,7 @@ public class XWikiHibernateVersioningStore extends XWikiHibernateBaseStore imple
     public void loadXWikiDocArchive(XWikiDocumentArchive archivedoc, boolean bTransaction, XWikiContext context)
         throws XWikiException
     {
-        loadXWikiDocArchive(archivedoc, new RevisionCriteria(null, null, null, true), context);
+        loadXWikiDocArchive(archivedoc, new RevisionCriteriaFactory().createRevisionCriteria(true), context);
     }
 
     private void loadXWikiDocArchive(XWikiDocumentArchive archivedoc, RevisionCriteria criteria, XWikiContext context)
@@ -312,7 +314,7 @@ public class XWikiHibernateVersioningStore extends XWikiHibernateBaseStore imple
     protected List<XWikiRCSNodeInfo> loadAllRCSNodeInfo(XWikiContext context, final long id, boolean bTransaction)
         throws XWikiException
     {
-        return loadRCSNodeInfo(context, id, new RevisionCriteria(null, null, null, true));
+        return loadRCSNodeInfo(context, id, new RevisionCriteriaFactory().createRevisionCriteria(true));
     }
 
     /**
@@ -324,7 +326,7 @@ public class XWikiHibernateVersioningStore extends XWikiHibernateBaseStore imple
      * @return loaded RCS nodes content
      * @throws XWikiException if any error
      */
-    protected List<XWikiRCSNodeInfo> loadRCSNodeInfo(XWikiContext context, final long id, RevisionCriteria criteria)
+    private List<XWikiRCSNodeInfo> loadRCSNodeInfo(XWikiContext context, final long id, RevisionCriteria criteria)
         throws XWikiException
     {
         return executeRead(context, session -> {
@@ -390,7 +392,7 @@ public class XWikiHibernateVersioningStore extends XWikiHibernateBaseStore imple
      * @return the number of matching RCS nodes
      * @throws XWikiException if any error
      */
-    protected long getRCSNodeInfoCount(XWikiContext context, final long id, RevisionCriteria criteria)
+    private long getRCSNodeInfoCount(XWikiContext context, final long id, RevisionCriteria criteria)
         throws XWikiException
     {
         return executeRead(context, session -> {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateVersioningStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateVersioningStore.java
@@ -21,15 +21,12 @@ package com.xpn.xwiki.store;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
+import java.util.Deque;
+import java.util.LinkedList;
 import java.util.List;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,12 +39,14 @@ import org.xwiki.user.UserReferenceSerializer;
 import com.xpn.xwiki.XWiki;
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.criteria.impl.RevisionCriteria;
 import com.xpn.xwiki.doc.XWikiAttachment;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.doc.XWikiDocumentArchive;
 import com.xpn.xwiki.doc.rcs.XWikiRCSNodeContent;
 import com.xpn.xwiki.doc.rcs.XWikiRCSNodeId;
 import com.xpn.xwiki.doc.rcs.XWikiRCSNodeInfo;
+import com.xpn.xwiki.store.hibernate.query.VersioningStoreQueryFactory;
 import com.xpn.xwiki.web.Utils;
 
 /**
@@ -62,8 +61,6 @@ public class XWikiHibernateVersioningStore extends XWikiHibernateBaseStore imple
 {
     /** Logger. */
     private static final Logger LOGGER = LoggerFactory.getLogger(XWikiHibernateVersioningStore.class);
-
-    private static final String FIELD_DOCID = "docId";
 
     /**
      * This allows to initialize our storage engine. The hibernate config file path is taken from xwiki.cfg or directly
@@ -112,17 +109,22 @@ public class XWikiHibernateVersioningStore extends XWikiHibernateBaseStore imple
     @Override
     public Version[] getXWikiDocVersions(XWikiDocument doc, XWikiContext context) throws XWikiException
     {
+        return getXWikiDocVersions(doc, new RevisionCriteria(null, null, null, true), context).toArray(new Version[0]);
+    }
+
+    @Override
+    public Collection<Version> getXWikiDocVersions(XWikiDocument doc, RevisionCriteria criteria, XWikiContext context)
+        throws XWikiException
+    {
         try {
-            XWikiDocumentArchive archive = getXWikiDocumentArchive(doc, context);
+            XWikiDocumentArchive archive = getXWikiDocumentArchive(doc, criteria, context);
             if (archive == null) {
-                return new Version[0];
+                return Collections.emptyList();
             }
             Collection<XWikiRCSNodeInfo> nodes = archive.getNodes();
-            Version[] versions = new Version[nodes.size()];
-            Iterator<XWikiRCSNodeInfo> it = nodes.iterator();
-            for (int i = 0; i < versions.length; i++) {
-                XWikiRCSNodeInfo node = it.next();
-                versions[versions.length - 1 - i] = node.getId().getVersion();
+            Deque<Version> versions = new LinkedList<>();
+            for (XWikiRCSNodeInfo node : nodes) {
+                versions.addFirst(node.getId().getVersion());
             }
             return versions;
         } catch (Exception e) {
@@ -137,6 +139,12 @@ public class XWikiHibernateVersioningStore extends XWikiHibernateBaseStore imple
     public XWikiDocumentArchive getXWikiDocumentArchive(XWikiDocument doc, XWikiContext inputxcontext)
         throws XWikiException
     {
+        return getXWikiDocumentArchive(doc, new RevisionCriteria(null, null, null, true), inputxcontext);
+    }
+
+    private XWikiDocumentArchive getXWikiDocumentArchive(XWikiDocument doc, RevisionCriteria criteria,
+        XWikiContext inputxcontext) throws XWikiException
+    {
         XWikiDocumentArchive archiveDoc = doc.getDocumentArchive();
         if (archiveDoc != null) {
             return archiveDoc;
@@ -150,7 +158,7 @@ public class XWikiHibernateVersioningStore extends XWikiHibernateBaseStore imple
                 context.setWikiId(doc.getDatabase());
             }
             archiveDoc = new XWikiDocumentArchive(doc.getDocumentReference().getWikiReference(), doc.getId());
-            loadXWikiDocArchive(archiveDoc, true, context);
+            loadXWikiDocArchive(archiveDoc, criteria, context);
             doc.setDocumentArchive(archiveDoc);
         } finally {
             context.setWikiId(db);
@@ -165,8 +173,14 @@ public class XWikiHibernateVersioningStore extends XWikiHibernateBaseStore imple
     public void loadXWikiDocArchive(XWikiDocumentArchive archivedoc, boolean bTransaction, XWikiContext context)
         throws XWikiException
     {
+        loadXWikiDocArchive(archivedoc, new RevisionCriteria(null, null, null, true), context);
+    }
+
+    private void loadXWikiDocArchive(XWikiDocumentArchive archivedoc, RevisionCriteria criteria, XWikiContext context)
+        throws XWikiException
+    {
         try {
-            List<XWikiRCSNodeInfo> nodes = loadAllRCSNodeInfo(context, archivedoc.getId(), bTransaction);
+            List<XWikiRCSNodeInfo> nodes = loadRCSNodeInfo(context, archivedoc.getId(), criteria);
             archivedoc.setNodes(nodes);
         } catch (Exception e) {
             Object[] args = { Long.valueOf(archivedoc.getId()) };
@@ -288,29 +302,36 @@ public class XWikiHibernateVersioningStore extends XWikiHibernateBaseStore imple
     }
 
     /**
+     * Loads all the RCS nodes present in the archive of a given document.
+     *
      * @param context the XWiki context
      * @param id {@link XWikiRCSNodeContent#getId()}
      * @param bTransaction should store to use old transaction(false) or create new (true)
-     * @return loaded rcs node content
+     * @return loaded RCS nodes content
      * @throws XWikiException if any error
      */
     protected List<XWikiRCSNodeInfo> loadAllRCSNodeInfo(XWikiContext context, final long id, boolean bTransaction)
         throws XWikiException
     {
+        return loadRCSNodeInfo(context, id, new RevisionCriteria(null, null, null, true));
+    }
+
+    /**
+     * Loads a part of the RCS nodes present in the archive of a given document, based on criteria.
+     *
+     * @param context the XWiki context
+     * @param id {@link XWikiRCSNodeContent#getId()}
+     * @param criteria the criteria matching the nodes to load
+     * @return loaded RCS nodes content
+     * @throws XWikiException if any error
+     */
+    protected List<XWikiRCSNodeInfo> loadRCSNodeInfo(XWikiContext context, final long id, RevisionCriteria criteria)
+        throws XWikiException
+    {
         return executeRead(context, session -> {
             try {
-                CriteriaBuilder builder = session.getCriteriaBuilder();
-                CriteriaQuery<XWikiRCSNodeInfo> query = builder.createQuery(XWikiRCSNodeInfo.class);
-                Root<XWikiRCSNodeInfo> root = query.from(XWikiRCSNodeInfo.class);
-
-                query.select(root);
-
-                Predicate[] predicates = new Predicate[2];
-                predicates[0] = builder.equal(root.get("id").get(FIELD_DOCID), id);
-                predicates[1] = builder.isNotNull(root.get("diff"));
-                query.where(predicates);
-
-                List<XWikiRCSNodeInfo> nodes = session.createQuery(query).getResultList();
+                List<XWikiRCSNodeInfo> nodes =
+                    VersioningStoreQueryFactory.getRCSNodeInfoQuery(session, id, criteria).getResultList();
 
                 // Remember the wiki where the nodes are from
                 nodes.forEach(n -> n.getId().setWikiReference(context.getWikiReference()));
@@ -320,7 +341,7 @@ public class XWikiHibernateVersioningStore extends XWikiHibernateBaseStore imple
                 // This happens when the database has wrong values...
                 LOGGER.error("Invalid history for document [{}]", id, e);
 
-                return Collections.<XWikiRCSNodeInfo>emptyList();
+                return Collections.emptyList();
             }
         });
     }
@@ -351,11 +372,39 @@ public class XWikiHibernateVersioningStore extends XWikiHibernateBaseStore imple
     public void deleteArchive(final XWikiDocument doc, boolean bTransaction, XWikiContext context) throws XWikiException
     {
         executeWrite(context, session -> {
-            session
-                .createQuery("delete from " + XWikiRCSNodeInfo.class.getName() + " where id." + FIELD_DOCID + '=' + ':'
-                    + FIELD_DOCID)
-                .setParameter(FIELD_DOCID, doc.getId()).executeUpdate();
+            VersioningStoreQueryFactory.getDeleteArchiveQuery(session, doc.getId()).executeUpdate();
             return null;
+        });
+    }
+
+    @Override
+    public long getXWikiDocVersionsCount(XWikiDocument doc, RevisionCriteria criteria, XWikiContext context)
+        throws XWikiException
+    {
+        return getRCSNodeInfoCount(context, doc.getId(), criteria);
+    }
+
+    /**
+     * Counts the number of RCS nodes present in the archive of a given document, based on criteria.
+     *
+     * @param context the XWiki context
+     * @param id {@link XWikiRCSNodeContent#getId()}
+     * @param criteria the criteria matching the nodes to count
+     * @return the number of matching RCS nodes
+     * @throws XWikiException if any error
+     */
+    protected long getRCSNodeInfoCount(XWikiContext context, final long id, RevisionCriteria criteria)
+        throws XWikiException
+    {
+        return executeRead(context, session -> {
+            try {
+                return VersioningStoreQueryFactory.getRCSNodeInfoCountQuery(session, id, criteria).getSingleResult();
+            } catch (IllegalArgumentException e) {
+                // This happens when the database has wrong values...
+                LOGGER.error("Encountered invalid history when computing archive size for document [{}]", id, e);
+
+                return Long.valueOf(0);
+            }
         });
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateVersioningStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateVersioningStore.java
@@ -20,7 +20,6 @@
 package com.xpn.xwiki.store;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
@@ -119,7 +118,7 @@ public class XWikiHibernateVersioningStore extends XWikiHibernateBaseStore imple
         try {
             XWikiDocumentArchive archive = getXWikiDocumentArchive(doc, criteria, context);
             if (archive == null) {
-                return Collections.emptyList();
+                return List.of();
             }
             Collection<XWikiRCSNodeInfo> nodes = archive.getNodes();
             Deque<Version> versions = new LinkedList<>();
@@ -338,10 +337,8 @@ public class XWikiHibernateVersioningStore extends XWikiHibernateBaseStore imple
 
                 return nodes;
             } catch (IllegalArgumentException e) {
-                // This happens when the database has wrong values...
-                LOGGER.error("Invalid history for document [{}]", id, e);
-
-                return Collections.emptyList();
+                throw new XWikiException(
+                    String.format("Encountered invalid history when fetching archive for document [%s]", id), e);
             }
         });
     }
@@ -400,10 +397,8 @@ public class XWikiHibernateVersioningStore extends XWikiHibernateBaseStore imple
             try {
                 return VersioningStoreQueryFactory.getRCSNodeInfoCountQuery(session, id, criteria).getSingleResult();
             } catch (IllegalArgumentException e) {
-                // This happens when the database has wrong values...
-                LOGGER.error("Encountered invalid history when computing archive size for document [{}]", id, e);
-
-                return Long.valueOf(0);
+                throw new XWikiException(
+                    String.format("Encountered invalid history when computing archive size for document [%s]", id), e);
             }
         });
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiVersioningStoreInterface.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiVersioningStoreInterface.java
@@ -111,7 +111,7 @@ public interface XWikiVersioningStoreInterface
      * @param criteria criteria used to match versions
      * @param context the XWiki context
      * @return the matching versions
-     * @since 15.10.7
+     * @since 15.10.8
      * @since 16.2.0RC1
      */
     @Unstable
@@ -130,7 +130,7 @@ public interface XWikiVersioningStoreInterface
      * @param criteria criteria used to match versions
      * @param context the XWiki context
      * @return the number of matching versions
-     * @since 15.10.7
+     * @since 15.10.8
      * @since 16.2.0RC1
      */
     @Unstable

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiVersioningStoreInterface.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiVersioningStoreInterface.java
@@ -19,15 +19,23 @@
  */
 package com.xpn.xwiki.store;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+
 import org.suigeneris.jrcs.rcs.Version;
 import org.xwiki.component.annotation.Role;
+import org.xwiki.stability.Unstable;
 
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.criteria.impl.RevisionCriteria;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.doc.XWikiDocumentArchive;
 import com.xpn.xwiki.doc.rcs.XWikiRCSNodeContent;
 import com.xpn.xwiki.doc.rcs.XWikiRCSNodeId;
+import com.xpn.xwiki.doc.rcs.XWikiRCSNodeInfo;
 
 /**
  * Interface for manipulate document history.
@@ -46,6 +54,79 @@ public interface XWikiVersioningStoreInterface
     void updateXWikiDocArchive(XWikiDocument doc, boolean bTransaction, XWikiContext context) throws XWikiException;
 
     Version[] getXWikiDocVersions(XWikiDocument doc, XWikiContext context) throws XWikiException;
+
+    /**
+     * Gets versions from a given document matching criteria like author, minimum creation date, etc.
+     *
+     * @param doc the document
+     * @param criteria criteria used to match versions
+     * @param context the XWiki context
+     * @return the matching versions
+     * @since 15.10.7
+     * @since 16.2.0RC1
+     */
+    @Unstable
+    default Collection<Version> getXWikiDocVersions(XWikiDocument doc, RevisionCriteria criteria, XWikiContext context)
+        throws XWikiException
+    {
+        List<String> results = new ArrayList<>();
+
+        Version[] revisions = getXWikiDocVersions(doc, context);
+        XWikiDocumentArchive archive = getXWikiDocumentArchive(doc, context);
+
+        XWikiRCSNodeInfo nextNodeinfo = null;
+        XWikiRCSNodeInfo nodeinfo;
+        for (Version revision : revisions) {
+            nodeinfo = nextNodeinfo;
+            nextNodeinfo = archive.getNode(revision);
+
+            if (nodeinfo == null) {
+                continue;
+            }
+
+            // Minor/Major version matching
+            if (criteria.getIncludeMinorVersions() || !nextNodeinfo.isMinorEdit()) {
+                // Author matching
+                if (criteria.getAuthor().equals("") || criteria.getAuthor().equals(nodeinfo.getAuthor())) {
+                    // Date range matching
+                    Date versionDate = nodeinfo.getDate();
+                    if (versionDate.after(criteria.getMinDate()) && versionDate.before(criteria.getMaxDate())) {
+                        results.add(nodeinfo.getVersion().toString());
+                    }
+                }
+            }
+        }
+
+        nodeinfo = nextNodeinfo;
+        if (nodeinfo != null) {
+            if (criteria.getAuthor().isEmpty() || criteria.getAuthor().equals(nodeinfo.getAuthor())) {
+                // Date range matching
+                Date versionDate = nodeinfo.getDate();
+                if (versionDate.after(criteria.getMinDate()) && versionDate.before(criteria.getMaxDate())) {
+                    results.add(nodeinfo.getVersion().toString());
+                }
+            }
+        }
+
+        return criteria.getRange().subList(results).stream().map(Version::new).toList();
+    }
+
+    /**
+     * Gets the number of versions from a given document matching criteria like author, minimum creation date, etc.
+     *
+     * @param doc the document
+     * @param criteria criteria used to match versions
+     * @param context the XWiki context
+     * @return the number of matching versions
+     * @since 15.10.7
+     * @since 16.2.0RC1
+     */
+    @Unstable
+    default long getXWikiDocVersionsCount(XWikiDocument doc, RevisionCriteria criteria, XWikiContext context)
+        throws XWikiException
+    {
+        return getXWikiDocVersions(doc, criteria, context).size();
+    };
 
     XWikiDocument loadXWikiDoc(XWikiDocument doc, String version, XWikiContext context) throws XWikiException;
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/query/VersioningStoreQueryFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/query/VersioningStoreQueryFactory.java
@@ -42,7 +42,7 @@ import com.xpn.xwiki.doc.rcs.XWikiRCSNodeInfo;
  *
  * @param <T> the type of element returned by the query
  * @version $Id$
- * @since 15.10.7
+ * @since 15.10.8
  * @since 16.2.0RC1
  */
 @Unstable

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/query/VersioningStoreQueryFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/query/VersioningStoreQueryFactory.java
@@ -1,0 +1,200 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xpn.xwiki.store.hibernate.query;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+
+import org.hibernate.Session;
+import org.hibernate.query.Query;
+
+import com.xpn.xwiki.criteria.impl.Range;
+import com.xpn.xwiki.criteria.impl.RevisionCriteria;
+import com.xpn.xwiki.doc.rcs.XWikiRCSNodeInfo;
+
+/**
+ * Helper class to build Hibernate queries for a VersioningStore.
+ *
+ * @param <T> the type of element returned by the query
+ * @version $Id$
+ * @since 15.10.7
+ * @since 16.2.0RC1
+ */
+public final class VersioningStoreQueryFactory<T>
+{
+    private static final String FIELD_ID = "id";
+
+    private static final String FIELD_AUTHOR = "author";
+
+    private static final String FIELD_DATE = "date";
+
+    private static final String FIELD_DIFF = "diff";
+
+    private static final String FIELD_DOCID = "docId";
+
+    private static final String FIELD_VERSION1 = "version1";
+
+    private static final String FIELD_VERSION2 = "version2";
+
+    private final Root<XWikiRCSNodeInfo> root;
+
+    private final CriteriaBuilder builder;
+
+    private final CriteriaQuery<T> criteriaQuery;
+
+    private final Session session;
+
+    private Query<T> query;
+
+    private VersioningStoreQueryFactory(Class<T> clazz, Session session)
+    {
+        this.session = session;
+        this.builder = session.getCriteriaBuilder();
+        this.criteriaQuery = this.builder.createQuery(clazz);
+        this.root = this.criteriaQuery.from(XWikiRCSNodeInfo.class);
+    }
+
+    private void filterByDocumentId(final long id)
+    {
+        this.criteriaQuery.where(
+            this.builder.equal(this.root.get(FIELD_ID).get(FIELD_DOCID), id),
+            this.builder.isNotNull(this.root.get(FIELD_DIFF))
+        );
+    }
+
+    private void applyCriteria(RevisionCriteria criteria)
+    {
+        List<Predicate> predicates = new ArrayList<>();
+
+        if (!criteria.getAuthor().isEmpty()) {
+            predicates.add(this.builder.equal(this.root.get(FIELD_AUTHOR), criteria.getAuthor()));
+        }
+
+        Date minDate = criteria.getMinDate();
+        // Hibernate requires positive timestamps.
+        if (minDate.getTime() < 0) {
+            minDate = new Date(0);
+        }
+        predicates.add(this.builder.between(this.root.get(FIELD_DATE), minDate, criteria.getMaxDate()));
+
+        if (!criteria.getIncludeMinorVersions()) {
+            predicates.add(this.builder.equal(this.root.get(FIELD_ID).get(FIELD_VERSION2), 1));
+        }
+
+        this.criteriaQuery.where(predicates.toArray(new Predicate[0]));
+    }
+
+    private void applyRange(Range range)
+    {
+        int start = range.getStart();
+        int size = range.getSize();
+
+        if (start > 0 || start == 0 && size >= 0) {
+            this.criteriaQuery.orderBy(this.builder.asc(this.root.get(FIELD_ID).get(FIELD_VERSION1)),
+                this.builder.asc(this.root.get(FIELD_ID).get(FIELD_VERSION2)));
+        } else {
+            this.criteriaQuery.orderBy(this.builder.desc(this.root.get(FIELD_ID).get(FIELD_VERSION1)),
+                this.builder.desc(this.root.get(FIELD_ID).get(FIELD_VERSION2)));
+            start = -start;
+            size = -size;
+        }
+
+        this.query = this.session.createQuery(this.criteriaQuery);
+
+        if (size >= 0) {
+            this.query.setFirstResult(start);
+            this.query.setMaxResults(size);
+        } else {
+            int newStart = Math.max(0, start + size);
+            this.query.setFirstResult(newStart);
+            this.query.setMaxResults(start - newStart);
+        }
+    }
+
+    /**
+     * Returns a query to completely delete the archive for a given document.
+     *
+     * @param session the hibernate session
+     * @param id the id of the document
+     * @return the created query
+     */
+    public static Query<?> getDeleteArchiveQuery(Session session, final long id)
+    {
+        return
+            session
+                .createQuery("delete from " + XWikiRCSNodeInfo.class.getName() + " where id." + FIELD_DOCID + '=' + ':'
+                    + FIELD_DOCID)
+                .setParameter(FIELD_DOCID, id);
+    }
+
+    /**
+     * Returns a query to count the number of RCS nodes present in the archive of a given document.
+     *
+     * @param session the hibernate session
+     * @param id the id of the document
+     * @param criteria filtering criteria for the counted nodes (can be null)
+     * @return the created query
+     */
+    public static Query<Long> getRCSNodeInfoCountQuery(Session session, final long id, RevisionCriteria criteria)
+    {
+        VersioningStoreQueryFactory<Long> queryBuilder = new VersioningStoreQueryFactory<>(Long.class, session);
+
+        queryBuilder.criteriaQuery.select(queryBuilder.builder.count(queryBuilder.root));
+        queryBuilder.filterByDocumentId(id);
+
+        if (criteria != null) {
+            queryBuilder.applyCriteria(criteria);
+        }
+
+        return session.createQuery(queryBuilder.criteriaQuery);
+    }
+
+    /**
+     * Returns a query to fetch the RCS nodes present in the archive of a given document.
+     *
+     * @param session the hibernate session
+     * @param id the id of the document
+     * @param criteria filtering criteria for the counted nodes (can be null)
+     * @return the created query
+     */
+    public static Query<XWikiRCSNodeInfo> getRCSNodeInfoQuery(Session session, final long id, RevisionCriteria criteria)
+    {
+        VersioningStoreQueryFactory<XWikiRCSNodeInfo> queryBuilder =
+            new VersioningStoreQueryFactory<>(XWikiRCSNodeInfo.class, session);
+
+        queryBuilder.criteriaQuery.select(queryBuilder.root);
+        queryBuilder.filterByDocumentId(id);
+
+        if (criteria != null) {
+            queryBuilder.applyCriteria(criteria);
+            queryBuilder.applyRange(criteria.getRange());
+            return queryBuilder.query;
+        }
+
+        return session.createQuery(queryBuilder.criteriaQuery);
+    }
+
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/XWikiVersioningStoreInterfaceTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/XWikiVersioningStoreInterfaceTest.java
@@ -1,0 +1,148 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xpn.xwiki.store;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.suigeneris.jrcs.rcs.Version;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.criteria.impl.Period;
+import com.xpn.xwiki.criteria.impl.RangeFactory;
+import com.xpn.xwiki.criteria.impl.RevisionCriteria;
+import com.xpn.xwiki.criteria.impl.RevisionCriteriaFactory;
+import com.xpn.xwiki.doc.XWikiDocumentArchive;
+import com.xpn.xwiki.doc.rcs.XWikiRCSNodeId;
+import com.xpn.xwiki.doc.rcs.XWikiRCSNodeInfo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for the default methods of {@link XWikiVersioningStoreInterface}.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+public class XWikiVersioningStoreInterfaceTest
+{
+    @Spy
+    private XWikiVersioningStoreInterface versioningStore;
+
+    @Mock
+    private XWikiDocumentArchive archive;
+
+    @BeforeEach
+    void setUp() throws XWikiException
+    {
+        SortedMap<Version, XWikiRCSNodeInfo> archiveNodes = new TreeMap<>();
+        Stream.of(
+            Arguments.of(new Version(1, 1), "Author1", 1000L),
+            Arguments.of(new Version(1, 2), "Author2", 2000L),
+            Arguments.of(new Version(1, 3), "Author1", 3000L),
+            Arguments.of(new Version(2, 1), "Author2", 4000L),
+            Arguments.of(new Version(3, 1), "Author1", 5000L),
+            Arguments.of(new Version(3, 2), "Author1", 6000L),
+            Arguments.of(new Version(4, 1), "Author2", 7000L),
+            Arguments.of(new Version(5, 1), "Author1", 8000L),
+            Arguments.of(new Version(5, 2), "Author1", 9000L)
+        ).forEach(arguments -> {
+            XWikiRCSNodeInfo node = new XWikiRCSNodeInfo();
+            XWikiRCSNodeId nodeId = new XWikiRCSNodeId(null, 42, (Version) arguments.get()[0]);
+            node.setId(nodeId);
+            node.setAuthor((String) arguments.get()[1]);
+            node.setDate(new Date((Long) arguments.get()[2]));
+            archiveNodes.put((Version) arguments.get()[0], node);
+        });
+
+        when(this.archive.getNode(any(Version.class))).thenAnswer(i -> {
+            Version version = i.getArgument(0);
+            return archiveNodes.getOrDefault(version, null);
+        });
+
+        List<Version> versions = archiveNodes.keySet().stream().sorted().collect(Collectors.toList());
+        Collections.reverse(versions);
+        when(this.versioningStore.getXWikiDocVersions(any(), any())).thenReturn(versions.toArray(new Version[0]));
+        when(this.versioningStore.getXWikiDocumentArchive(any(), any())).thenReturn(this.archive);
+    }
+
+    @Test
+    void testGetVersionsDefaultCriteria() throws XWikiException
+    {
+        RevisionCriteria criteria = new RevisionCriteria();
+        Collection<Version> versions = this.versioningStore.getXWikiDocVersions(null, criteria, null);
+        long versionsCount = this.versioningStore.getXWikiDocVersionsCount(null, criteria, null);
+        assertEquals(5, versions.size());
+        assertEquals(5, versionsCount);
+        assertIterableEquals(List.of("1.3", "2.1", "3.2", "4.1", "5.2"),
+            versions.stream().map(Version::toString).collect(Collectors.toList()));
+    }
+
+    @Test
+    void testGetVersionsFilterAuthor() throws XWikiException
+    {
+        RevisionCriteria criteria = new RevisionCriteriaFactory().createRevisionCriteria("Author1", true);
+        Collection<Version> versions = this.versioningStore.getXWikiDocVersions(null, criteria, null);
+        long versionsCount = this.versioningStore.getXWikiDocVersionsCount(null, criteria, null);
+        assertEquals(6, versions.size());
+        assertEquals(6, versionsCount);
+        assertIterableEquals(List.of("1.1", "1.3", "3.1", "3.2", "5.1", "5.2"),
+            versions.stream().map(Version::toString).collect(Collectors.toList()));
+    }
+
+    @Test
+    void testGetVersionsFilterDate() throws XWikiException
+    {
+        RevisionCriteria criteria = new RevisionCriteriaFactory().createRevisionCriteria(new Period(1999L, 6001L),
+            true);
+        Collection<Version> versions = this.versioningStore.getXWikiDocVersions(null, criteria, null);
+        long versionsCount = this.versioningStore.getXWikiDocVersionsCount(null, criteria, null);
+        assertEquals(5, versions.size());
+        assertEquals(5, versionsCount);
+        assertIterableEquals(List.of("1.2", "1.3", "2.1", "3.1", "3.2"),
+            versions.stream().map(Version::toString).collect(Collectors.toList()));
+    }
+
+    @Test
+    void testGetLastVersion() throws XWikiException
+    {
+        RevisionCriteria criteria = new RevisionCriteriaFactory().createRevisionCriteria();
+        criteria.setRange(RangeFactory.getLAST());
+        Collection<Version> versions = this.versioningStore.getXWikiDocVersions(null, criteria, null);
+        assertEquals(1, versions.size());
+        assertIterableEquals(List.of("5.2"),
+            versions.stream().map(Version::toString).collect(Collectors.toList()));
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/hibernate/query/VersioningStoreQueryFactoryTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/hibernate/query/VersioningStoreQueryFactoryTest.java
@@ -1,0 +1,329 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xpn.xwiki.store.hibernate.query;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Stream;
+
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Order;
+import javax.persistence.criteria.Path;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+
+import org.hibernate.Session;
+import org.hibernate.query.Query;
+import org.hibernate.query.criteria.internal.CriteriaBuilderImpl;
+import org.hibernate.query.criteria.internal.OrderImpl;
+import org.hibernate.query.criteria.internal.expression.LiteralExpression;
+import org.hibernate.query.criteria.internal.predicate.BetweenPredicate;
+import org.hibernate.query.criteria.internal.predicate.ComparisonPredicate;
+import org.hibernate.query.criteria.internal.predicate.NullnessPredicate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+
+import com.xpn.xwiki.criteria.impl.Period;
+import com.xpn.xwiki.criteria.impl.RangeFactory;
+import com.xpn.xwiki.criteria.impl.RevisionCriteria;
+import com.xpn.xwiki.criteria.impl.RevisionCriteriaFactory;
+import com.xpn.xwiki.doc.rcs.XWikiRCSNodeInfo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link VersioningStoreQueryFactory}.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+public class VersioningStoreQueryFactoryTest
+{
+    @Mock
+    private Session session;
+
+    @Mock
+    private CriteriaBuilderImpl builder;
+
+    @Mock
+    private Root<XWikiRCSNodeInfo> root;
+
+    @Mock
+    private CriteriaQuery<XWikiRCSNodeInfo> criteriaQueryNodeInfo;
+
+    @Mock
+    private CriteriaQuery<Long> criteriaQueryLong;
+
+    @Mock
+    private Query<XWikiRCSNodeInfo> queryNodeInfo;
+
+    @Mock
+    private Query<Long> queryLong;
+
+    @Mock
+    private Query queryAny;
+
+    @Captor
+    private ArgumentCaptor<Predicate[]> predicatesCaptor;
+
+    @Captor
+    private ArgumentCaptor<Order[]> orderCaptor;
+
+    @BeforeEach
+    void setUp()
+    {
+        when(this.session.getCriteriaBuilder()).thenReturn(this.builder);
+
+        when(this.builder.createQuery(XWikiRCSNodeInfo.class)).thenReturn(this.criteriaQueryNodeInfo);
+        when(this.builder.createQuery(Long.class)).thenReturn(this.criteriaQueryLong);
+
+        when(this.builder.equal(any(), any(Object.class))).thenAnswer(i -> {
+            ComparisonPredicate predicate = mock(ComparisonPredicate.class);
+            when(predicate.getComparisonOperator()).thenReturn(ComparisonPredicate.ComparisonOperator.EQUAL);
+            when(predicate.getLeftHandOperand()).thenReturn(i.getArgument(0));
+            when(predicate.getRightHandOperand()).thenReturn(new LiteralExpression(null, i.getArgument(1)));
+            return predicate;
+        });
+
+        when(this.builder.isNotNull(any())).thenAnswer(i -> {
+            NullnessPredicate predicate = mock(NullnessPredicate.class);
+            when(predicate.getOperand()).thenReturn(i.getArgument(0));
+            when(predicate.isNegated()).thenReturn(true);
+            return predicate;
+        });
+
+        when(this.builder.between(Mockito.<Path<Date>>any(), Mockito.<Date>any(), any())).thenAnswer(i -> {
+            BetweenPredicate<?> predicate = mock(BetweenPredicate.class);
+            when(predicate.getExpression()).thenReturn(i.getArgument(0));
+            when(predicate.getLowerBound()).thenReturn(new LiteralExpression(null, i.getArgument(1)));
+            when(predicate.getUpperBound()).thenReturn(new LiteralExpression(null, i.getArgument(2)));
+            return predicate;
+        });
+
+        when(this.builder.asc(any())).thenAnswer(i -> new OrderImpl(i.getArgument(0), true));
+        when(this.builder.desc(any())).thenAnswer(i -> new OrderImpl(i.getArgument(0), false));
+
+        // With this mock we rely on toString() to check that the relative path is correct.
+        when(this.root.get(anyString())).thenAnswer(i -> {
+            Path<?> path = mock(Path.class);
+            String pString = "mocked " + i.getArgument(0, String.class);
+            when(path.toString()).thenReturn(pString);
+            when(path.get(anyString())).thenAnswer(i3 -> {
+                Path<?> path2 = mock(Path.class);
+                when(path2.toString()).thenReturn(pString + "." + i3.getArgument(0, String.class));
+                return path2;
+            });
+            return path;
+        });
+
+        when(this.criteriaQueryNodeInfo.from(XWikiRCSNodeInfo.class)).thenReturn(this.root);
+        when(this.criteriaQueryLong.from(XWikiRCSNodeInfo.class)).thenReturn(this.root);
+        when(this.session.createQuery(this.criteriaQueryNodeInfo)).thenReturn(this.queryNodeInfo);
+        when(this.session.createQuery(this.criteriaQueryLong)).thenReturn(this.queryLong);
+        when(this.session.createQuery(anyString())).thenReturn(this.queryAny);
+        when(this.queryAny.setParameter(anyString(), any())).thenReturn(this.queryAny);
+    }
+
+    @Test
+    void testDeleteArchiveQuery()
+    {
+        VersioningStoreQueryFactory.getDeleteArchiveQuery(this.session, 42L);
+        verify(this.session).createQuery("delete from " + XWikiRCSNodeInfo.class.getName()
+            + " where id.docId=:docId");
+        verify(this.queryAny).setParameter("docId", 42L);
+    }
+
+    @Test
+    void testRCSNodeInfoCountQueryWithoutCriteria()
+    {
+        VersioningStoreQueryFactory.getRCSNodeInfoCountQuery(this.session, 42L, null);
+        verify(this.criteriaQueryLong).where(this.predicatesCaptor.capture());
+
+        List<Predicate> predicates = Arrays.asList(this.predicatesCaptor.getValue());
+        assertEquals(2, predicates.size());
+
+        ComparisonPredicate idPredicate = (ComparisonPredicate) predicates.get(0);
+        LiteralExpression<Long> idExpression = (LiteralExpression<Long>) idPredicate.getRightHandOperand();
+        assertEquals(ComparisonPredicate.ComparisonOperator.EQUAL, idPredicate.getComparisonOperator());
+        assertEquals("mocked id.docId", idPredicate.getLeftHandOperand().toString());
+        assertEquals(42L, idExpression.getLiteral());
+
+        NullnessPredicate nonNullDiffPredicate = (NullnessPredicate) predicates.get(1);
+        assertTrue(nonNullDiffPredicate.isNegated());
+        assertEquals("mocked diff", nonNullDiffPredicate.getOperand().toString());
+    }
+
+    @Test
+    void testRCSNodeInfoCountQueryWithAuthorCriteria()
+    {
+        VersioningStoreQueryFactory.getRCSNodeInfoCountQuery(this.session, 42L,
+            new RevisionCriteriaFactory().createRevisionCriteria("TestAuthor", true));
+        verify(this.criteriaQueryLong).where(this.predicatesCaptor.capture());
+
+        List<Predicate> predicates = Arrays.asList(this.predicatesCaptor.getValue());
+        assertEquals(4, predicates.size());
+
+        ComparisonPredicate authorPredicate = (ComparisonPredicate) predicates.get(2);
+        LiteralExpression<String> authorExpression = (LiteralExpression<String>) authorPredicate.getRightHandOperand();
+        assertEquals(ComparisonPredicate.ComparisonOperator.EQUAL, authorPredicate.getComparisonOperator());
+        assertEquals("mocked author", authorPredicate.getLeftHandOperand().toString());
+        assertEquals("TestAuthor", authorExpression.getLiteral());
+
+        BetweenPredicate<Date> datePredicate = (BetweenPredicate<Date>) predicates.get(3);
+        LiteralExpression<Date> dateLowerExpression = (LiteralExpression<Date>) datePredicate.getLowerBound();
+        LiteralExpression<Date> dateUpperExpression = (LiteralExpression<Date>) datePredicate.getUpperBound();
+        assertEquals("mocked date", datePredicate.getExpression().toString());
+        assertEquals(new Date(0L), dateLowerExpression.getLiteral());
+        assertEquals(new Date(Long.MAX_VALUE), dateUpperExpression.getLiteral());
+    }
+
+    @Test
+    void testRCSNodeInfoCountQueryWithDateCriteria()
+    {
+        VersioningStoreQueryFactory.getRCSNodeInfoCountQuery(this.session, 42L,
+            new RevisionCriteriaFactory().createRevisionCriteria(new Period(1000L, 2000L), true));
+        verify(this.criteriaQueryLong).where(this.predicatesCaptor.capture());
+
+        List<Predicate> predicates = Arrays.asList(this.predicatesCaptor.getValue());
+        assertEquals(3, predicates.size());
+
+        BetweenPredicate<Date> datePredicate = (BetweenPredicate<Date>) predicates.get(2);
+        LiteralExpression<Date> dateLowerExpression = (LiteralExpression<Date>) datePredicate.getLowerBound();
+        LiteralExpression<Date> dateUpperExpression = (LiteralExpression<Date>) datePredicate.getUpperBound();
+        assertEquals("mocked date", datePredicate.getExpression().toString());
+        assertEquals(new Date(1000L), dateLowerExpression.getLiteral());
+        assertEquals(new Date(2000L), dateUpperExpression.getLiteral());
+    }
+
+    @Test
+    void testRCSNodeInfoQueryWithoutCriteria()
+    {
+        VersioningStoreQueryFactory.getRCSNodeInfoQuery(this.session, 42L, null);
+        verify(this.criteriaQueryNodeInfo).where(this.predicatesCaptor.capture());
+
+        List<Predicate> predicates = Arrays.asList(this.predicatesCaptor.getValue());
+        assertEquals(2, predicates.size());
+
+        ComparisonPredicate idPredicate = (ComparisonPredicate) predicates.get(0);
+        LiteralExpression<Long> idExpression = (LiteralExpression<Long>) idPredicate.getRightHandOperand();
+        assertEquals(ComparisonPredicate.ComparisonOperator.EQUAL, idPredicate.getComparisonOperator());
+        assertEquals("mocked id.docId", idPredicate.getLeftHandOperand().toString());
+        assertEquals(42L, idExpression.getLiteral());
+
+        NullnessPredicate nonNullDiffPredicate = (NullnessPredicate) predicates.get(1);
+        assertTrue(nonNullDiffPredicate.isNegated());
+        assertEquals("mocked diff", nonNullDiffPredicate.getOperand().toString());
+    }
+
+    @Test
+    void testRCSNodeInfoQueryWithAuthorCriteria()
+    {
+        VersioningStoreQueryFactory.getRCSNodeInfoQuery(this.session, 42L,
+            new RevisionCriteriaFactory().createRevisionCriteria("TestAuthor", true));
+        verify(this.criteriaQueryNodeInfo).where(this.predicatesCaptor.capture());
+
+        List<Predicate> predicates = Arrays.asList(this.predicatesCaptor.getValue());
+        assertEquals(4, predicates.size());
+
+        ComparisonPredicate authorPredicate = (ComparisonPredicate) predicates.get(2);
+        LiteralExpression<String> authorExpression = (LiteralExpression<String>) authorPredicate.getRightHandOperand();
+        assertEquals(ComparisonPredicate.ComparisonOperator.EQUAL, authorPredicate.getComparisonOperator());
+        assertEquals("mocked author", authorPredicate.getLeftHandOperand().toString());
+        assertEquals("TestAuthor", authorExpression.getLiteral());
+
+        BetweenPredicate<Date> datePredicate = (BetweenPredicate<Date>) predicates.get(3);
+        LiteralExpression<Date> dateLowerExpression = (LiteralExpression<Date>) datePredicate.getLowerBound();
+        LiteralExpression<Date> dateUpperExpression = (LiteralExpression<Date>) datePredicate.getUpperBound();
+        assertEquals("mocked date", datePredicate.getExpression().toString());
+        assertEquals(new Date(0L), dateLowerExpression.getLiteral());
+        assertEquals(new Date(Long.MAX_VALUE), dateUpperExpression.getLiteral());
+    }
+
+    @Test
+    void testRCSNodeInfoQueryWithDateCriteria()
+    {
+        VersioningStoreQueryFactory.getRCSNodeInfoQuery(this.session, 42L,
+            new RevisionCriteriaFactory().createRevisionCriteria(new Period(1000L, 2000L), true));
+        verify(this.criteriaQueryNodeInfo).where(this.predicatesCaptor.capture());
+
+        List<Predicate> predicates = Arrays.asList(this.predicatesCaptor.getValue());
+        assertEquals(3, predicates.size());
+
+        BetweenPredicate<Date> datePredicate = (BetweenPredicate<Date>) predicates.get(2);
+        LiteralExpression<Date> dateLowerExpression = (LiteralExpression<Date>) datePredicate.getLowerBound();
+        LiteralExpression<Date> dateUpperExpression = (LiteralExpression<Date>) datePredicate.getUpperBound();
+        assertEquals("mocked date", datePredicate.getExpression().toString());
+        assertEquals(new Date(1000L), dateLowerExpression.getLiteral());
+        assertEquals(new Date(2000L), dateUpperExpression.getLiteral());
+    }
+
+    static Stream<Arguments> rangesProvider()
+    {
+        return Stream.of(
+            // Range 0 / 10 : will return the first 10 elements
+            Arguments.of(0, 10, 0, 10, true),
+            // Range -2 / 10 : will return the last 2 elements (not enough elements for 10)
+            Arguments.of(-2, 10, 0, 2, false),
+            // Range -2 / -10 : will return the last 10 elements after skipping the last 2
+            Arguments.of(-2, -10, 2, 10, false),
+            // Range 2 / 10 : will return the first 10 elements after skipping the first 2
+            Arguments.of(2, 10, 2, 10, true),
+            // Range 2 / -10 : will return the first 2 elements (not enough elements for 10)
+            Arguments.of(2, -10, 0, 2, true),
+            // Range 0 / -10 : will return the last 10 elements
+            Arguments.of(0, -10, 0, 10, false));
+    }
+
+    @ParameterizedTest
+    @MethodSource("rangesProvider")
+    void testRCSNodeInfoQueryWithRange(int startRange, int sizeRange, int start, int size, boolean ascending)
+    {
+        RevisionCriteria criteria = new RevisionCriteriaFactory().createRevisionCriteria(true);
+        criteria.setRange(RangeFactory.createRange(startRange, sizeRange));
+        VersioningStoreQueryFactory.getRCSNodeInfoQuery(this.session, 42L, criteria);
+        verify(this.criteriaQueryNodeInfo).orderBy(this.orderCaptor.capture());
+
+        List<Order> orders = Arrays.asList(this.orderCaptor.getValue());
+        assertEquals(2, orders.size());
+
+        verify(this.criteriaQueryNodeInfo).orderBy(this.orderCaptor.capture());
+        assertEquals("mocked id.version1", orders.get(0).getExpression().toString());
+        assertEquals(ascending, orders.get(0).isAscending());
+        assertEquals("mocked id.version2", orders.get(1).getExpression().toString());
+        assertEquals(ascending, orders.get(1).isAscending());
+        verify(this.queryNodeInfo).setFirstResult(start);
+        verify(this.queryNodeInfo).setMaxResults(size);
+    }
+}


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-21922

# Changes

## Description

* Introduce two new methods to `XWikiVersioningStoreInterface`: `getXWikiDocVersions` and `getXWikiDocVersionsCount`, both taking an instance of `RevisionCriteria` as parameter. They both have a default implementation that work by using the existing `getXWikiDocVersions` and filtering the results.
* Introduce an implementations for both methods in `XWikiHibernateVersioningStore`.
* Add the methods `XWikiDocument.getRevisionsCount` and `Document.getRevisionsCount` to expose the new count method.
* Edit `XWikiDocument.getRevisions(RevisionCriteria)` to use the new fetch method. The existing filtering was used as a basis for the default implementation of `XWikiVersioningStoreInterface.getXWikiDocVersions`.
* Move hibernate queries from `XWikiHibernateVersioningStore` to a new `VersioningStoreQueryFactory` class to even out class fan-out complexity.

## Clarifications

* https://forum.xwiki.org/t/introduce-methods-to-fetch-a-subset-of-revisions-in-xwikiversioningstoreinterface/14078/8

# Screenshots & Video

N/A

# Executed Tests

A XWiki instance was run with the applied patches and everything was working as expected. A substantial speed-up was noticed in Velocity code using `XWikiDocument.getRevisions` for documents with more than 200k revisions.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * stable-15.10.x