### PR TITLE
XWIKI-9961: Improve performances for displaying the history tab

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/historyinline.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/historyinline.vm
@@ -34,9 +34,7 @@
 #set ($minorVersions = (!$xwiki.hasMinorEdit()) || ("$!request.showminor" == 'true'))
 ## Revision criteria. The following requests for all versions, filtered by the minorVersions option.
 #set ($criteria = $xwiki.criteriaService.revisionCriteriaFactory.createRevisionCriteria('', $minorVersions))
-#set ($versions = $tdoc.getRevisions($criteria))
-#set ($discard = $collectiontool.reverseModifiable($versions))
-#set ($totalVersions = $versions.size())
+#set ($totalVersions = $tdoc.getRevisionsCount($criteria))
 #if ($totalVersions == 0)
   #warning ($services.localization.render('core.viewers.history.empty'))
 #else


### PR DESCRIPTION
This requires merging https://github.com/xwiki/xwiki-platform/pull/2925 first.

# Jira URL

https://jira.xwiki.org/browse/XWIKI-9961

# Changes

## Description

* Stop loading the complete history from DB to get the history size.

## Clarifications

Parts of the performance issues are already fixed by https://github.com/xwiki/xwiki-platform/pull/2925.

# Screenshots & Video

N/A

# Executed Tests

This patch was applied on an instance and displaying the history for a document of around 200k revisions was substantially faster. The pagination worked as expected, both with minor revisions shown and hidden.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * stable-15.10.x