### PR TITLE
XWIKI-21809: ClassCastException in DefaultEventConverterManager on a cluster environment

### DIFF
--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/internal/AbstractAsynchronousEventStore.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/internal/AbstractAsynchronousEventStore.java
@@ -439,21 +439,25 @@ public abstract class AbstractAsynchronousEventStore implements EventStore, Init
         task.future.complete(output);
 
         // Notify event listeners
+        Object notificationOuput = task.output;
+        if (task.output instanceof Optional<?>) {
+            notificationOuput = ((Optional<?>) task.output).orElse(null);
+        }
         switch (task.type) {
             case DELETE_EVENT:
-                this.observation.notify(new EventStreamDeletedEvent(), task.output);
+                this.observation.notify(new EventStreamDeletedEvent(), notificationOuput);
                 break;
 
             case DELETE_EVENT_BY_ID:
-                this.observation.notify(new EventStreamDeletedEvent(), task.output);
+                this.observation.notify(new EventStreamDeletedEvent(), notificationOuput);
                 break;
 
             case SAVE_EVENT:
-                this.observation.notify(new EventStreamAddedEvent(), task.output);
+                this.observation.notify(new EventStreamAddedEvent(), notificationOuput);
                 break;
 
             case DELETE_STATUS:
-                this.observation.notify(new EventStatusDeletedEvent(), task.output);
+                this.observation.notify(new EventStatusDeletedEvent(), notificationOuput);
                 break;
 
             case DELETE_STATUSES:
@@ -461,15 +465,15 @@ public abstract class AbstractAsynchronousEventStore implements EventStore, Init
                 break;
 
             case SAVE_STATUS:
-                this.observation.notify(new EventStatusAddOrUpdatedEvent(), task.output);
+                this.observation.notify(new EventStatusAddOrUpdatedEvent(), notificationOuput);
                 break;
 
             case DELETE_MAIL_ENTITY:
-                this.observation.notify(new MailEntityDeleteEvent(), task.output);
+                this.observation.notify(new MailEntityDeleteEvent(), notificationOuput);
                 break;
 
             case SAVE_MAIL_ENTITY:
-                this.observation.notify(new MailEntityAddedEvent(), task.output);
+                this.observation.notify(new MailEntityAddedEvent(), notificationOuput);
                 break;
 
             default:

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/internal/AbstractAsynchronousEventStore.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/internal/AbstractAsynchronousEventStore.java
@@ -440,44 +440,52 @@ public abstract class AbstractAsynchronousEventStore implements EventStore, Init
 
         // Notify event listeners
         Object notificationOuput = task.output;
+        boolean skipNotify = false;
         if (task.output instanceof Optional<?>) {
-            notificationOuput = ((Optional<?>) task.output).orElse(null);
+            Optional<?> optionalOutput = (Optional<?>) task.output;
+            if (optionalOutput.isPresent()) {
+                notificationOuput = optionalOutput.get();
+            } else {
+                skipNotify = true;
+            }
         }
-        switch (task.type) {
-            case DELETE_EVENT:
-                this.observation.notify(new EventStreamDeletedEvent(), notificationOuput);
-                break;
+        if (!skipNotify) {
+            switch (task.type) {
+                case DELETE_EVENT:
+                    this.observation.notify(new EventStreamDeletedEvent(), notificationOuput);
+                    break;
 
-            case DELETE_EVENT_BY_ID:
-                this.observation.notify(new EventStreamDeletedEvent(), notificationOuput);
-                break;
+                case DELETE_EVENT_BY_ID:
+                    this.observation.notify(new EventStreamDeletedEvent(), notificationOuput);
+                    break;
 
-            case SAVE_EVENT:
-                this.observation.notify(new EventStreamAddedEvent(), notificationOuput);
-                break;
+                case SAVE_EVENT:
+                    this.observation.notify(new EventStreamAddedEvent(), notificationOuput);
+                    break;
 
-            case DELETE_STATUS:
-                this.observation.notify(new EventStatusDeletedEvent(), notificationOuput);
-                break;
+                case DELETE_STATUS:
+                    this.observation.notify(new EventStatusDeletedEvent(), notificationOuput);
+                    break;
 
-            case DELETE_STATUSES:
-                this.observation.notify(new EventStatusDeletedEvent(), null);
-                break;
+                case DELETE_STATUSES:
+                    this.observation.notify(new EventStatusDeletedEvent(), null);
+                    break;
 
-            case SAVE_STATUS:
-                this.observation.notify(new EventStatusAddOrUpdatedEvent(), notificationOuput);
-                break;
+                case SAVE_STATUS:
+                    this.observation.notify(new EventStatusAddOrUpdatedEvent(), notificationOuput);
+                    break;
 
-            case DELETE_MAIL_ENTITY:
-                this.observation.notify(new MailEntityDeleteEvent(), notificationOuput);
-                break;
+                case DELETE_MAIL_ENTITY:
+                    this.observation.notify(new MailEntityDeleteEvent(), notificationOuput);
+                    break;
 
-            case SAVE_MAIL_ENTITY:
-                this.observation.notify(new MailEntityAddedEvent(), notificationOuput);
-                break;
+                case SAVE_MAIL_ENTITY:
+                    this.observation.notify(new MailEntityAddedEvent(), notificationOuput);
+                    break;
 
-            default:
-                break;
+                default:
+                    break;
+            }
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/AsynchronousEventStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/AsynchronousEventStoreTest.java
@@ -37,9 +37,14 @@ import org.xwiki.eventstream.EventQuery;
 import org.xwiki.eventstream.EventSearchResult;
 import org.xwiki.eventstream.EventStatus;
 import org.xwiki.eventstream.EventStreamException;
+import org.xwiki.eventstream.events.EventStreamAddedEvent;
+import org.xwiki.eventstream.events.MailEntityAddedEvent;
+import org.xwiki.eventstream.events.MailEntityDeleteEvent;
+import org.xwiki.observation.ObservationManager;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectComponentManager;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
 import org.xwiki.test.mockito.MockitoComponentManager;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -47,6 +52,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 
 /**
  * Validate {@link AbstractAsynchronousEventStore}.
@@ -265,6 +273,9 @@ public class AsynchronousEventStoreTest
     @InjectMockComponents
     private TestAbstractAsynchronousEventStore store;
 
+    @MockComponent
+    private ObservationManager observation;
+
     private DefaultEvent event(String id)
     {
         DefaultEvent event = new DefaultEvent();
@@ -404,12 +415,22 @@ public class AsynchronousEventStoreTest
         assertSame(status21, this.store.events.get(event2.getId()).mailstatuses.get(status21.getEntityId()));
         assertSame(status24, this.store.events.get(event2.getId()).mailstatuses.get(status24.getEntityId()));
 
+        verify(this.observation).notify(any(EventStreamAddedEvent.class), eq(event1));
+        verify(this.observation).notify(any(EventStreamAddedEvent.class), eq(event2));
+        verify(this.observation).notify(any(MailEntityAddedEvent.class), eq(status11));
+        verify(this.observation).notify(any(MailEntityAddedEvent.class), eq(status13));
+        verify(this.observation).notify(any(MailEntityAddedEvent.class), eq(status21));
+        verify(this.observation).notify(any(MailEntityAddedEvent.class), eq(status24));
+
+
         this.store.deleteMailEntityEvent(status11).get();
 
         assertNull(this.store.events.get(event1.getId()).mailstatuses.get(status11.getEntityId()));
         assertSame(status13, this.store.events.get(event1.getId()).mailstatuses.get(status13.getEntityId()));
         assertSame(status21, this.store.events.get(event2.getId()).mailstatuses.get(status21.getEntityId()));
         assertSame(status24, this.store.events.get(event2.getId()).mailstatuses.get(status24.getEntityId()));
+
+        verify(this.observation).notify(any(MailEntityDeleteEvent.class), eq(status11));
     }
 
     @Test


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-21809

# Changes

## Description

Some task output is Optional and we never want the Optional in the notification data: we do want what the Optional contains.
This PR provides a test to expose the bug and a naive fix.

## Clarifications

I've not been able to provide a better fix as it would involve breaking APIs to not return Optional. On the long run I'm not sure it was really necessary to have Optional for the APIs here: it's basically only used to support backward compatibility with the legacy store AFAICS, so the Optional is never empty with the new store... 

# Executed Tests

`mvn clean install -Pquality` on `xwiki-platform-eventstream`

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * 15.10.x
  * 14.10.x (?)