### PR TITLE
XWIKI-21935: Annotate Live Data entries with a data property corresponding to the entry id

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/LivedataDisplayer.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/LivedataDisplayer.vue
@@ -51,7 +51,7 @@
     the table is refreshed.
   -->
   <component
-    class="livedata-displayer"
+    :class="['livedata-displayer', propertyId]"
     :is="`Displayer${this.capitalize(this.displayerId)}`"
     :property-id="propertyId"
     :entry="entry"

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/LivedataDisplayer.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/LivedataDisplayer.vue
@@ -51,7 +51,8 @@
     the table is refreshed.
   -->
   <component
-    :class="['livedata-displayer', propertyId]"
+    class="livedata-displayer"
+    :data-livedata-property-id="propertyId"
     :is="`Displayer${this.capitalize(this.displayerId)}`"
     :property-id="propertyId"
     :entry="entry"


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-21935

## Forum discussion

https://forum.xwiki.org/t/annotate-live-data-entries-with-a-class-corresponding-to-the-entry-id/14153

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Add a class corresponding to the entry id at the root of each displayer

## Example

Below is the html of a cell presenting an attachment file size. Before, the only element allowing to specifically identify the cell by its property type was the `data-title`, which is translated.
The `filesize` class is now added aside the `livedata-displayer`.

```html
<td data-title="File size" class="cell">
    <div class="livedata-displayer" data-livedata-property-id="filesize"><!-- The data-livedata-property-id property old the property id of the displayer -->
        <div data-tippy-component-trigger="" tabindex="0">
            <div class="view">
                <div>
                    <div class="html-wrapper"> <span class="size" data-size="44816">43.8 KB</span>
                    </div>
                </div>
            </div>
        </div>
    </div>
</td>
```

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
mvn clean install \
  -f xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar \
  -Pquality
```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A