### PR TITLE
Update NotificationsResource description to comply with Checkstyle

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/main/java/org/xwiki/notifications/rest/NotificationsResource.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/main/java/org/xwiki/notifications/rest/NotificationsResource.java
@@ -128,7 +128,7 @@ public interface NotificationsResource
      * parameters. For example, the parameter "blackList" could be very long, and the associated URL with the GET method
      * would be too long (generating HTTP 414 error).
      * <p>
-     * While the signature of the method changed from Java point of view in 16.2.0RC1, it's still exactly the same API from
+     * While signature of the method changed from Java point of view in 16.2.0RC1, it's still exactly the same API from
      * REST point of view so the same &#64;since has been kept.
      *
      * @return notifications


### PR DESCRIPTION
Hello 👋🏻 
I am an active contributor at Checkstyle.

We've had a failing CI of workflow related to `xwiki`
Investigation of the issue led me to this error :

```
[INFO] Starting audit...
[ERROR] /home/circleci/project/.ci-temp/xwiki-platform/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/main/java/org/xwiki/notifications/rest/NotificationsResource.java:131: Line is longer than 120 characters (found 123). [LineLength] Audit done.
[INFO] There is 1 error reported by Checkstyle 10.14.0-SNAPSHOT with checkstyle.xml ruleset. [ERROR] src/main/java/org/xwiki/notifications/rest/NotificationsResource.java:[131] (sizes) LineLength: Line is longer than 120 characters (found 123).

```
I have updated specific description comments belonging to file NotificationsResource.java to comply with Checkstyle rules.

Hope this is all good !!