### PR TITLE
XWIKI-21944: Allow live data action to be async

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/LiveDataActionDescriptor.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/LiveDataActionDescriptor.java
@@ -64,8 +64,7 @@ public class LiveDataActionDescriptor extends BaseDescriptor
     private String urlProperty;
 
     /**
-     * Async is a boolean object so that the field is not serialized when not explicitly defined. A {@code null} value
-     * is equivalent to a {@code false} value.
+     * Holds the properties required to execute the action asynchronously.
      */
     private LiveDataAsyncActionDescriptor async;
 
@@ -199,7 +198,7 @@ public class LiveDataActionDescriptor extends BaseDescriptor
     }
 
     /**
-     * @return the descriptor for handling this action asynchronously
+     * @return the properties to execute this action asynchronously
      * @since 16.2.0RC1
      */
     @Unstable
@@ -209,7 +208,7 @@ public class LiveDataActionDescriptor extends BaseDescriptor
     }
 
     /**
-     * @param async the descriptor for handling this action asynchronously
+     * @param async the properties to execute this action asynchronously
      * @since 16.2.0RC1
      */
     @Unstable

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/LiveDataActionDescriptor.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/LiveDataActionDescriptor.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 
 /**
  * Describes a live data action.
- *
+ * 
  * @version $Id$
  * @since 12.10.1
  * @since 13.0
@@ -69,8 +69,6 @@ public class LiveDataActionDescriptor extends BaseDescriptor
      */
     private LiveDataAsyncActionDescriptor async;
 
-    
-
     /**
      * Default constructor.
      */
@@ -80,7 +78,7 @@ public class LiveDataActionDescriptor extends BaseDescriptor
 
     /**
      * Creates a new descriptor for the specified action.
-     *
+     * 
      * @param id the action id
      */
     public LiveDataActionDescriptor(String id)
@@ -98,7 +96,7 @@ public class LiveDataActionDescriptor extends BaseDescriptor
 
     /**
      * Sets the action pretty name.
-     *
+     * 
      * @param name the new pretty name
      */
     public void setName(String name)
@@ -116,7 +114,7 @@ public class LiveDataActionDescriptor extends BaseDescriptor
 
     /**
      * Sets the action description.
-     *
+     * 
      * @param description the new action description
      */
     public void setDescription(String description)
@@ -134,7 +132,7 @@ public class LiveDataActionDescriptor extends BaseDescriptor
 
     /**
      * Sets the icon meta data.
-     *
+     * 
      * @param icon the new icon meta data
      */
     public void setIcon(Map<String, Object> icon)
@@ -144,7 +142,7 @@ public class LiveDataActionDescriptor extends BaseDescriptor
 
     /**
      * @return the live data property used to determine if the current user is allowed to perform this action on a given
-     *     live data entry
+     *         live data entry
      * @since 12.10.4
      * @since 13.0
      */
@@ -156,9 +154,9 @@ public class LiveDataActionDescriptor extends BaseDescriptor
     /**
      * Sets the live data property to be used to determine if the current user is allowed to perform this action on a
      * given live data entry.
-     *
+     * 
      * @param allowProperty the live data property used to determine if the current user is allowed to perform this
-     *     action on a given live data entry
+     *            action on a given live data entry
      * @since 12.10.4
      * @since 13.0
      */
@@ -179,9 +177,9 @@ public class LiveDataActionDescriptor extends BaseDescriptor
 
     /**
      * Sets the live data property that holds the URL that can be used to perform this action on a given entry.
-     *
-     * @param urlProperty the live data property that holds the URL that can be used to perform this action on a
-     *     given entry
+     * 
+     * @param urlProperty the live data property that holds the URL that can be used to perform this action on a given
+     *            entry
      * @since 12.10.4
      * @since 13.0
      */

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/LiveDataActionDescriptor.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/LiveDataActionDescriptor.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 
 /**
  * Describes a live data action.
- * 
+ *
  * @version $Id$
  * @since 12.10.1
  * @since 13.0
@@ -67,13 +67,9 @@ public class LiveDataActionDescriptor extends BaseDescriptor
      * Async is a boolean object so that the field is not serialized when not explicitly defined. A {@code null} value
      * is equivalent to a {@code false} value.
      */
-    private Boolean async;
+    private LiveDataAsyncActionDescriptor async;
 
-    private String loadingMessage;
-
-    private String successMessage;
-
-    private String failureMessage;
+    
 
     /**
      * Default constructor.
@@ -84,7 +80,7 @@ public class LiveDataActionDescriptor extends BaseDescriptor
 
     /**
      * Creates a new descriptor for the specified action.
-     * 
+     *
      * @param id the action id
      */
     public LiveDataActionDescriptor(String id)
@@ -102,7 +98,7 @@ public class LiveDataActionDescriptor extends BaseDescriptor
 
     /**
      * Sets the action pretty name.
-     * 
+     *
      * @param name the new pretty name
      */
     public void setName(String name)
@@ -120,7 +116,7 @@ public class LiveDataActionDescriptor extends BaseDescriptor
 
     /**
      * Sets the action description.
-     * 
+     *
      * @param description the new action description
      */
     public void setDescription(String description)
@@ -138,7 +134,7 @@ public class LiveDataActionDescriptor extends BaseDescriptor
 
     /**
      * Sets the icon meta data.
-     * 
+     *
      * @param icon the new icon meta data
      */
     public void setIcon(Map<String, Object> icon)
@@ -148,7 +144,7 @@ public class LiveDataActionDescriptor extends BaseDescriptor
 
     /**
      * @return the live data property used to determine if the current user is allowed to perform this action on a given
-     *         live data entry
+     *     live data entry
      * @since 12.10.4
      * @since 13.0
      */
@@ -160,9 +156,9 @@ public class LiveDataActionDescriptor extends BaseDescriptor
     /**
      * Sets the live data property to be used to determine if the current user is allowed to perform this action on a
      * given live data entry.
-     * 
+     *
      * @param allowProperty the live data property used to determine if the current user is allowed to perform this
-     *            action on a given live data entry
+     *     action on a given live data entry
      * @since 12.10.4
      * @since 13.0
      */
@@ -183,9 +179,9 @@ public class LiveDataActionDescriptor extends BaseDescriptor
 
     /**
      * Sets the live data property that holds the URL that can be used to perform this action on a given entry.
-     * 
-     * @param urlProperty the live data property that holds the URL that can be used to perform this action on a given
-     *            entry
+     *
+     * @param urlProperty the live data property that holds the URL that can be used to perform this action on a
+     *     given entry
      * @since 12.10.4
      * @since 13.0
      */
@@ -205,84 +201,22 @@ public class LiveDataActionDescriptor extends BaseDescriptor
     }
 
     /**
-     * @return {@code true} if the action is asynchronous, {@code false} otherwise. {@code null} is equivalent to
-     *     {@code false}
+     * @return the descriptor for handling this action asynchronously
      * @since 16.2.0RC1
      */
     @Unstable
-    public Boolean isAsync()
+    public LiveDataAsyncActionDescriptor getAsync()
     {
         return this.async;
     }
 
     /**
-     * @param async {@code true} if the action is asynchronous, {@code false} otherwise
+     * @param async the descriptor for handling this action asynchronously
      * @since 16.2.0RC1
      */
     @Unstable
-    public void setAsync(boolean async)
+    public void setAsync(LiveDataAsyncActionDescriptor async)
     {
         this.async = async;
-    }
-
-    /**
-     * @return the localized async action loading message, only used when {@link  #async} is {@code true}
-     * @since 16.2.0RC1
-     */
-    @Unstable
-    public String getLoadingMessage()
-    {
-        return this.loadingMessage;
-    }
-
-    /**
-     * @param loadingMessage the localized async action loading message, only used when {@link  #async} is
-     *     {@code true}
-     * @since 16.2.0RC1
-     */
-    @Unstable
-    public void setLoadingMessage(String loadingMessage)
-    {
-        this.loadingMessage = loadingMessage;
-    }
-
-    /**
-     * @return the localized async action success message, only used when {@link  #async} is {@code true}
-     * @since 16.2.0RC1
-     */
-    @Unstable
-    public String getSuccessMessage()
-    {
-        return this.successMessage;
-    }
-
-    /**
-     * @param successMessage the localized async action success message, only used when {@link  #async} is {@code true}
-     * @since 16.2.0RC1
-     */
-    @Unstable
-    public void setSuccessMessage(String successMessage)
-    {
-        this.successMessage = successMessage;
-    }
-
-    /**
-     * @return the localized async action error message, only used when {@link  #async} is {@code true}
-     * @since 16.2.0RC1
-     */
-    @Unstable
-    public String getFailureMessage()
-    {
-        return this.failureMessage;
-    }
-
-    /**
-     * @param failureMessage the localized async action error message, only used when {@link  #async} is {@code true}
-     * @since 16.2.0RC1
-     */
-    @Unstable
-    public void setFailureMessage(String failureMessage)
-    {
-        this.failureMessage = failureMessage;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/LiveDataActionDescriptor.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/LiveDataActionDescriptor.java
@@ -22,6 +22,8 @@ package org.xwiki.livedata;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.xwiki.stability.Unstable;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 /**
@@ -60,6 +62,18 @@ public class LiveDataActionDescriptor extends BaseDescriptor
      * Specifies the live data property that holds the URL that can be used to perform this action on a given entry.
      */
     private String urlProperty;
+
+    /**
+     * Async is a boolean object so that the field is not serialized when not explicitly defined. A {@code null} value
+     * is equivalent to a {@code false} value.
+     */
+    private Boolean async;
+
+    private String loadingMessage;
+
+    private String successMessage;
+
+    private String failureMessage;
 
     /**
      * Default constructor.
@@ -188,5 +202,87 @@ public class LiveDataActionDescriptor extends BaseDescriptor
         if (this.icon == null) {
             this.icon = new HashMap<>();
         }
+    }
+
+    /**
+     * @return {@code true} if the action is asynchronous, {@code false} otherwise. {@code null} is equivalent to
+     *     {@code false}
+     * @since 16.2.0RC1
+     */
+    @Unstable
+    public Boolean isAsync()
+    {
+        return this.async;
+    }
+
+    /**
+     * @param async {@code true} if the action is asynchronous, {@code false} otherwise
+     * @since 16.2.0RC1
+     */
+    @Unstable
+    public void setAsync(boolean async)
+    {
+        this.async = async;
+    }
+
+    /**
+     * @return the localized async action loading message, only used when {@link  #async} is {@code true}
+     * @since 16.2.0RC1
+     */
+    @Unstable
+    public String getLoadingMessage()
+    {
+        return this.loadingMessage;
+    }
+
+    /**
+     * @param loadingMessage the localized async action loading message, only used when {@link  #async} is
+     *     {@code true}
+     * @since 16.2.0RC1
+     */
+    @Unstable
+    public void setLoadingMessage(String loadingMessage)
+    {
+        this.loadingMessage = loadingMessage;
+    }
+
+    /**
+     * @return the localized async action success message, only used when {@link  #async} is {@code true}
+     * @since 16.2.0RC1
+     */
+    @Unstable
+    public String getSuccessMessage()
+    {
+        return this.successMessage;
+    }
+
+    /**
+     * @param successMessage the localized async action success message, only used when {@link  #async} is {@code true}
+     * @since 16.2.0RC1
+     */
+    @Unstable
+    public void setSuccessMessage(String successMessage)
+    {
+        this.successMessage = successMessage;
+    }
+
+    /**
+     * @return the localized async action error message, only used when {@link  #async} is {@code true}
+     * @since 16.2.0RC1
+     */
+    @Unstable
+    public String getFailureMessage()
+    {
+        return this.failureMessage;
+    }
+
+    /**
+     * @param failureMessage the localized async action error message, only used when {@link  #async} is {@code true}
+     * @since 16.2.0RC1
+     */
+    @Unstable
+    public void setFailureMessage(String failureMessage)
+    {
+        this.failureMessage = failureMessage;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/LiveDataAsyncActionDescriptor.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/LiveDataAsyncActionDescriptor.java
@@ -24,6 +24,9 @@ import java.util.Map;
 import org.xwiki.stability.Unstable;
 
 /**
+ * The properties required to execute an action asynchrously. This includes status messages (loading, success,
+ * failure...) as well as technical http client parameters to for developers to adapt the requests to their own needs.
+ *
  * @version $Id$
  * @since 16.2.0RC1
  */

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/LiveDataAsyncActionDescriptor.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/LiveDataAsyncActionDescriptor.java
@@ -1,0 +1,121 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.livedata;
+
+import org.xwiki.stability.Unstable;
+
+/**
+ * @version $Id$
+ * @since 16.2.0RC1
+ */
+@Unstable
+public class LiveDataAsyncActionDescriptor
+{
+    private String loadingMessage;
+
+    private String successMessage;
+
+    private String failureMessage;
+
+    private String confirmationMessage;
+
+    private String httpMethod;
+
+    /**
+     * @return the localized async action loading message
+     */
+    public String getLoadingMessage()
+    {
+        return this.loadingMessage;
+    }
+
+    /**
+     * @param loadingMessage the localized async action loading message
+     */
+    public void setLoadingMessage(String loadingMessage)
+    {
+        this.loadingMessage = loadingMessage;
+    }
+
+    /**
+     * @return the localized async action success message
+     */
+    public String getSuccessMessage()
+    {
+        return this.successMessage;
+    }
+
+    /**
+     * @param successMessage the localized async action success message
+     */
+    public void setSuccessMessage(String successMessage)
+    {
+        this.successMessage = successMessage;
+    }
+
+    /**
+     * @return the localized async action error message
+     */
+    public String getFailureMessage()
+    {
+        return this.failureMessage;
+    }
+
+    /**
+     * @param failureMessage the localized async action error message
+     */
+    public void setFailureMessage(String failureMessage)
+    {
+        this.failureMessage = failureMessage;
+    }
+
+    /**
+     * @return the http method to use when performing the asynchronous action
+     */
+    public String getHttpMethod()
+    {
+        return this.httpMethod;
+    }
+
+    /**
+     * @param httpMethod the http method to use when performing the asynchronous action
+     */
+    public void setHttpMethod(String httpMethod)
+    {
+        this.httpMethod = httpMethod;
+    }
+
+    /**
+     * @return an optional confirmation message to ask for confirmation before performing the action
+     */
+    public String getConfirmationMessage()
+    {
+        return this.confirmationMessage;
+    }
+
+    /**
+     * @param confirmationMessage an optional confirmation message to ask for confirmation before performing the
+     *     action
+     */
+    public void setConfirmationMessage(String confirmationMessage)
+    {
+        this.confirmationMessage = confirmationMessage;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/LiveDataAsyncActionDescriptor.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/LiveDataAsyncActionDescriptor.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.livedata;
 
+import java.util.Map;
+
 import org.xwiki.stability.Unstable;
 
 /**
@@ -37,6 +39,10 @@ public class LiveDataAsyncActionDescriptor
     private String confirmationMessage;
 
     private String httpMethod;
+
+    private String body;
+
+    private Map<String, String> headers;
 
     /**
      * @return the localized async action loading message
@@ -117,5 +123,37 @@ public class LiveDataAsyncActionDescriptor
     public void setConfirmationMessage(String confirmationMessage)
     {
         this.confirmationMessage = confirmationMessage;
+    }
+
+    /**
+     * @return an optional request body
+     */
+    public String getBody()
+    {
+        return this.body;
+    }
+
+    /**
+     * @param body an optional request body
+     */
+    public void setBody(String body)
+    {
+        this.body = body;
+    }
+
+    /**
+     * @return an optional map of headers to pass to the request
+     */
+    public Map<String, String> getHeaders()
+    {
+        return this.headers;
+    }
+
+    /**
+     * @param headers an optional map of headers to pass to the request
+     */
+    public void setHeaders(Map<String, String> headers)
+    {
+        this.headers = headers;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/pom.xml
@@ -77,6 +77,12 @@
       <version>${project.version}</version>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>org.xwiki.rendering</groupId>
+      <artifactId>xwiki-rendering-macro-message</artifactId>
+      <version>${rendering.version}</version>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
   <build>
     <testSourceDirectory>src/test/it</testSourceDirectory>

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/src/test/it/org/xwiki/livedata/test/ui/LiveDataIT.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/src/test/it/org/xwiki/livedata/test/ui/LiveDataIT.java
@@ -301,7 +301,8 @@ class LiveDataIT
                       "httpMethod": "POST",
                       "loadingMessage": "Loading",
                       "successMessage": "Delete Success",
-                      "failureMessage": "Failed"
+                      "failureMessage": "Failed",
+                      "
                     }
                   }]
               }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/src/test/it/org/xwiki/livedata/test/ui/LiveDataIT.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/src/test/it/org/xwiki/livedata/test/ui/LiveDataIT.java
@@ -40,9 +40,9 @@ import org.xwiki.model.reference.SpaceReference;
 import org.xwiki.rest.model.jaxb.Page;
 import org.xwiki.test.docker.junit5.TestReference;
 import org.xwiki.test.docker.junit5.UITest;
-import org.xwiki.test.docker.junit5.servletengine.ServletEngine;
 import org.xwiki.test.ui.TestUtils;
 import org.xwiki.test.ui.po.SuggestInputElement;
+import org.xwiki.test.ui.po.ViewPage;
 import org.xwiki.test.ui.po.editor.ClassEditPage;
 import org.xwiki.test.ui.po.editor.StaticListClassEditElement;
 import org.xwiki.text.StringUtils;
@@ -302,7 +302,10 @@ class LiveDataIT
                       "loadingMessage": "Loading",
                       "successMessage": "Delete Success",
                       "failureMessage": "Failed",
-                      "
+                      "body": "newBacklinkTarget=&updateLinks=false&autoRedirect=false&form_token=${services.csrf.token}&confirm=1&async=true",
+                      "headers": {
+                        "Content-Type": "application/x-www-form-urlencoded"
+                      }
                     }
                   }]
               }
@@ -310,8 +313,12 @@ class LiveDataIT
             """);
         createXClass(testUtils, testReference);
         createXObjects(testUtils, testReference);
-        testUtils.gotoPage(testReference);
-        throw new RuntimeException("SNAPS");
+        ViewPage viewPage = testUtils.gotoPage(testReference);
+        TableLayoutElement tableLayout = new LiveDataElement("test").getTableLayout();
+        assertEquals(3, tableLayout.countRows());
+        tableLayout.clickAction(1, "delete");
+        viewPage.waitForNotificationSuccessMessage("Delete Success");
+        assertEquals(2, tableLayout.countRows());
     }
 
     private void initLocalization(TestUtils testUtils, TestReference testReference) throws Exception

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/DisplayerActions.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/DisplayerActions.vue
@@ -116,10 +116,14 @@ export default {
           const resource = this.sanitizeUrl(this.entry[action.urlProperty]);
 
           const options = {
-            "method": async.method
+            "method": async.httpMethod
           };
           if (async.body) {
             options.body = async.body;
+          }
+          
+          if(async.headers) {
+            options.headers = async.headers;
           }
 
           const response = await fetch(resource, options)

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/DisplayerActions.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/DisplayerActions.vue
@@ -100,16 +100,6 @@ export default {
       const {async} = action;
       if (async) {
         event.preventDefault();
-        const notif = new XWiki.widgets.Notification(async.loadingMessage, 'inprogress');
-        const resource = this.sanitizeUrl(this.entry[async.urlProperty]);
-        const options = {
-          "method": async.method
-        };
-
-        if (async.body) {
-          options.body = async.body;
-        }
-
         const confirmed = await new Promise((resolve) => {
           if (async.confirmationMessage) {
             new XWiki.widgets.ConfirmationBox({
@@ -122,8 +112,18 @@ export default {
             resolve(true)
           }
         })
-
         if (confirmed) {
+          const notif = new XWiki.widgets.Notification(async.loadingMessage, 'inprogress');
+          const resource = this.sanitizeUrl(this.entry[action.urlProperty]);
+
+          const options = {
+            "method": async.method
+          };
+          if (async.body) {
+            options.body = async.body;
+
+          }
+
           const response = await fetch(resource, options)
 
           if (response.ok) {

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/DisplayerActions.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/DisplayerActions.vue
@@ -120,7 +120,6 @@ export default {
           };
           if (async.body) {
             options.body = async.body;
-
           }
 
           const response = await fetch(resource, options)

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/DisplayerActions.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/DisplayerActions.vue
@@ -51,7 +51,6 @@
         >
           <XWikiIcon :iconDescriptor="action.icon" /><span class="action-name">{{ action.name }}</span>
         </a>
-        
       </div>
     </template>
 
@@ -125,7 +124,6 @@ export default {
           }
 
           const response = await fetch(resource, options)
-
           if (response.ok) {
             notif.replace(new XWiki.widgets.Notification(async.successMessage, 'done'));
             this.logic.updateEntries();

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/DisplayerActions.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/displayers/DisplayerActions.vue
@@ -47,6 +47,7 @@
           :class="'action action_' + action.id"
           :title="action.description"
           :href="sanitizeUrl(entry[action.urlProperty]) || '#'"
+          @click="handleClick($event, action)"
         >
           <XWikiIcon :iconDescriptor="action.icon" /><span class="action-name">{{ action.name }}</span>
         </a>
@@ -93,7 +94,24 @@ export default {
         .map(action => this.logic.getActionDescriptor(action));
     },
   },
-
+  methods: {
+    async handleClick(event, action) {
+      if(action.async) {
+        event.preventDefault();
+        const notif = new XWiki.widgets.Notification(action.loadingMessage, 'inprogress');
+        const response = await fetch(this.sanitizeUrl(this.entry[action.urlProperty]), {
+          "method": "GET"
+        })
+        
+        if(response.ok) {
+          notif.replace(new XWiki.widgets.Notification(action.successMessage, 'done'));
+          this.logic.updateEntries();
+        } else {
+          notif.replace(new XWiki.widgets.Notification(action.failureMessage, 'error'));
+        }
+      }
+    }
+  }
 };
 </script>
 


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-21944

# Proposal

https://forum.xwiki.org/t/introduce-the-notion-of-async-action-in-live-data/14155

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* All actions to be executed asynchronously

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Livetable has a loosely defined notion of async action, allowing to make an action asynchronous
* This is a first step toward the same for LD in simple cases where a get action with no specific error handling is required

1. prevent the default click behavior
2. show a loading notification message
3. send a get request to the configured action URL
4. in case of success, replace the loading with a success notification message
5. in case of failure, replace the loading with a success notification message

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
mvn clean install \
  -pl :xwiki-platform-livedata-api,:xwiki-platform-livedata-webjar \
  -f xwiki-platform-core/xwiki-platform-livedata \
  -amd \
  -Pquality,integration-tests,docker
```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A