### PR TITLE
XWIKI-21879: $xwiki.getURLContent() does not forward credentials

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
@@ -6679,6 +6679,9 @@ public class XWiki implements EventListener
         throws IOException
     {
         HttpClient client = getHttpClient(timeout, userAgent);
+        
+        // otherwise there is no authentification credentials will be sent
+        client.getParams().setAuthenticationPreemptive(true);
 
         // pass our credentials to HttpClient, they will only be used for
         // authenticating to servers with realm "realm", to authenticate agains
@@ -6744,6 +6747,9 @@ public class XWiki implements EventListener
         throws IOException
     {
         HttpClient client = getHttpClient(timeout, userAgent);
+
+        // otherwise there is no authentification credentials will be sent
+        client.getParams().setAuthenticationPreemptive(true);
 
         // pass our credentials to HttpClient, they will only be used for
         // authenticating to servers with realm "realm", to authenticate agains


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-21879
# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added `setAuthenticationPreemptive(true)` to `HttpClient` parameters. Otherwise the given credentials for basic auth were ignored.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* I guess, there is no additional explanations needed since the PR is 2 lines long.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 