### PR TITLE
XWIKI-14873: Accordeon in the Administration misses an indicator to show they are expandable

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/AdministrationMenu.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/AdministrationMenu.java
@@ -52,7 +52,7 @@ public class AdministrationMenu extends BaseElement
 
     private By categoryByName(String categoryName)
     {
-        return By.xpath(".//a[contains(@class, 'panel-heading') and . = '" + categoryName + "']");
+        return By.xpath(".//a[contains(@class, 'panel-heading') and normalize-space(.) = '" + categoryName + "']");
     }
 
     private By categoryById(String categoryId)
@@ -112,7 +112,7 @@ public class AdministrationMenu extends BaseElement
 
     private By sectionByName(String categoryName, String sectionName)
     {
-        return By.xpath(".//a[contains(@class, 'panel-heading') and . = '" + categoryName
+        return By.xpath(".//a[contains(@class, 'panel-heading') and normalize-space(.) = '" + categoryName
             + "']/following-sibling::*//a[contains(@class, 'list-group-item') and . = '" + sectionName + "']");
     }
 


### PR DESCRIPTION




# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Updated selectors in the Administration pageobject

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The merge of https://github.com/xwiki/xwiki-platform/pull/2774 broke administration tests. It ended up being because the content of a selector was added some newlines. I decided to add a `normalize-space` call on this content to pass the test again with minimal changes.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
None, test only PR.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Successfully passed `mvn clean install -f xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker -Pdocker -Dit.test=AdministrationIT -Dgradle.cache.local.enabled=false -Dgradle.cache.remote.enabled=false`. Note that when building I get a massive chunk of logs for `java.lang.RuntimeException: Failed to get [role = [interface org.xwiki.search.solr.internal.api.SolrIndexer] hint = [default]]`, seemingly caused by `java.lang.ClassNotFoundException: jakarta.ws.rs.core.Application `. It doesn't fail the build, but I can't be sure the tests are properly build. Just before the last build I made, the test failed correctly on a fix that was not properly applied (set the normalize-space on line 116 instead of 115). So I'm not 100% sure these tests were relevant but there's still evidence towards the docker build passing.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None (same as https://github.com/xwiki/xwiki-platform/pull/2774)