### PR TITLE
XWIKI-20632: Page searched by its exact name is not found in a page picker for a macro parameter when its subtree is larger than 10 pages

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/PagePickerIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/PagePickerIT.java
@@ -77,7 +77,7 @@ class PagePickerIT
         setup.loginAsSuperAdmin();
 
         String childName = "Child";
-        for (int i = 0; i < 20; i++) {
+        for (int i = 0; i < 11; i++) {
             DocumentReference childReference = new DocumentReference(childName + i,
                 reference.getLastSpaceReference());
             setup.createPage(childReference, "Test page " + i, "Child page " + i);

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/PagePickerIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/PagePickerIT.java
@@ -19,13 +19,18 @@
  */
 package org.xwiki.flamingo.test.docker;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
+import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.test.docker.junit5.TestReference;
 import org.xwiki.test.docker.junit5.UITest;
 import org.xwiki.test.ui.TestUtils;
 import org.xwiki.test.ui.po.SuggestInputElement;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Functional tests for the Page Picker.
@@ -35,6 +40,8 @@ import org.xwiki.test.ui.po.SuggestInputElement;
 @UITest
 class PagePickerIT
 {
+    private static final String PICKER_ID = "pagePickerTest";
+
     /**
      * See XWIKI-16078: Selected (and deleted) users/subgroups are not displayed properly in drop-down when editing a
      * group
@@ -45,12 +52,12 @@ class PagePickerIT
     {
         setup.loginAsSuperAdmin();
         String pageName = reference.getLastSpaceReference().getName();
-        setup.createPage(reference,
-            "{{velocity}}{{html}}#pagePicker({'id': 'pagePickerTest', 'multiple': true}){{/html}}{{/velocity}}",
+        setup.createPage(reference, String.format(
+                "{{velocity}}{{html}}#pagePicker({'id': '%s', 'multiple': true}){{/html}}{{/velocity}}", PICKER_ID),
             pageName);
 
         SuggestInputElement pagePicker =
-            new SuggestInputElement(setup.getDriver().findElementWithoutWaiting(By.id("pagePickerTest")));
+            new SuggestInputElement(setup.getDriver().findElementWithoutWaiting(By.id(PICKER_ID)));
 
         // Make sure the picker is ready. TODO: remove once XWIKI-19056 is closed.
         pagePicker.click().waitForSuggestions();
@@ -58,5 +65,39 @@ class PagePickerIT
         pagePicker.sendKeys(pageName.substring(0, 3)).waitForSuggestions().selectByVisibleText(pageName);
         pagePicker.clearSelectedSuggestions().sendKeys(pageName.substring(0, 3)).waitForSuggestions()
             .selectByVisibleText(pageName);
+    }
+
+    /**
+     * Verify that spaces can be selected even if they contain many children.
+     */
+    @Test
+    @Order(2)
+    void selectSpaceWithManyChildren(TestUtils setup, TestReference reference) throws Exception
+    {
+        setup.loginAsSuperAdmin();
+
+        String childName = "Child";
+        for (int i = 0; i < 20; i++) {
+            DocumentReference childReference = new DocumentReference(childName + i,
+                reference.getLastSpaceReference());
+            setup.createPage(childReference, "Test page " + i, "Child page " + i);
+        }
+
+        String pageName = reference.getLastSpaceReference().getName();
+        setup.createPage(reference,
+            String.format("{{velocity}}{{html}}#pagePicker({'id': '%s'}){{/html}}{{/velocity}}", PICKER_ID),
+            pageName);
+
+        SuggestInputElement pagePicker =
+            new SuggestInputElement(setup.getDriver().findElementWithoutWaiting(By.id(PICKER_ID)));
+
+        // Search for the space and ensure that we get it (and just that space, not any of the children).
+        List<SuggestInputElement.SuggestionElement> suggestions =
+            pagePicker.sendKeys(pageName).waitForSuggestions().getSuggestions();
+        assertEquals(1, suggestions.size());
+        assertEquals(pageName, suggestions.get(0).getLabel());
+        // Just to be sure that searching for the children also works, search and select the first child.
+        pagePicker.clear().sendKeys(childName).waitForSuggestions()
+            .selectByVisibleText("Child page 0");
     }
 }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/BaseSearchResult.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/BaseSearchResult.java
@@ -175,14 +175,20 @@ public class BaseSearchResult extends XWikiResource
                         .equals("space")) ? "" : ", doc." + orderField;
             }
 
+            String addSpace = "";
+            if (searchScopes.contains(SearchScope.NAME)) {
+                // Join the space to get the last space name.
+                addSpace = "left join XWikiSpace as space on doc.space = space.reference";
+            }
+
             if (space != null) {
                 f.format("select distinct doc.fullName, doc.space, doc.name, doc.language");
                 f.format(addColumn);
-                f.format(" from XWikiDocument as doc where doc.space = :space and ( ");
+                f.format(" from XWikiDocument as doc %s where doc.space = :space and ( ", addSpace);
             } else {
                 f.format("select distinct doc.fullName, doc.space, doc.name, doc.language");
                 f.format(addColumn);
-                f.format(" from XWikiDocument as doc where ( ");
+                f.format(" from XWikiDocument as doc %s where ( ", addSpace);
             }
 
             /* Look for scopes related to pages */
@@ -196,8 +202,8 @@ public class BaseSearchResult extends XWikiResource
                         acceptedScopes++;
                         break;
                     case NAME:
-                        String matchTerminalPage = "doc.name <> :defaultDocName and upper(doc.fullName) like :keywords";
-                        String matchNestedPage = "doc.name = :defaultDocName and upper(doc.space) like :keywords";
+                        String matchTerminalPage = "doc.name <> :defaultDocName and upper(doc.name) like :keywords";
+                        String matchNestedPage = "doc.name = :defaultDocName and upper(space.name) like :keywords";
                         f.format("((%s) or (%s)) ", matchTerminalPage, matchNestedPage);
                         acceptedScopes++;
                         break;

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/WikisResourceIT.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/WikisResourceIT.java
@@ -24,6 +24,7 @@ import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.httpclient.methods.GetMethod;
@@ -60,6 +61,7 @@ import org.xwiki.test.ui.TestUtils;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class WikisResourceIT extends AbstractHttpIT
 {
@@ -115,6 +117,48 @@ public class WikisResourceIT extends AbstractHttpIT
 
             checkLinks(wiki);
         }
+    }
+
+    @Test
+    public void testSearchWikisName() throws Exception
+    {
+        this.testUtils.rest().delete(reference);
+        this.testUtils.rest().savePage(reference, "Name Content", "Name Title " + this.pageName);
+
+        GetMethod getMethod = executeGet(
+            String.format("%s?scope=name&q=" + this.pageName, buildURI(WikiSearchResource.class, getWiki())));
+        SearchResults searchResults = (SearchResults) unmarshaller.unmarshal(getMethod.getResponseBodyAsStream());
+
+        // Ensure that the terminal page is found by its name.
+        int resultSize = searchResults.getSearchResults().size();
+        assertEquals(1, resultSize);
+        assertEquals(this.fullName, searchResults.getSearchResults().get(0).getPageFullName());
+
+        // Create a non-terminal page with the same "name" but this time as last space.
+        List<String> nonTerminalSpaces = List.of(this.spaces.get(0), this.pageName);
+        DocumentReference nonTerminalReference = new DocumentReference(this.wikiName, nonTerminalSpaces, "WebHome");
+        String nonTerminalFullName = String.join(".", nonTerminalSpaces) + "." + "WebHome";
+        this.testUtils.rest().savePage(nonTerminalReference, "content2" + this.pageName, "title2" + this.pageName);
+
+        getMethod = executeGet(
+            String.format("%s?scope=name&q=" + this.pageName, buildURI(WikiSearchResource.class, getWiki())));
+        searchResults = (SearchResults) unmarshaller.unmarshal(getMethod.getResponseBodyAsStream());
+
+        // Ensure that searching by name finds both terminal and non-terminal page.
+        resultSize = searchResults.getSearchResults().size();
+        assertEquals(2, resultSize);
+        List<String> foundPages = searchResults.getSearchResults().stream()
+            .map(SearchResult::getPageFullName)
+            .collect(Collectors.toList());
+        assertTrue(foundPages.contains(this.fullName));
+        assertTrue(foundPages.contains(nonTerminalFullName));
+
+        // Ensure that searching by space finds neither the terminal nor the non-terminal page.
+        getMethod =
+            executeGet(String.format("%s?scope=name&q=" + this.spaces.get(0),
+                buildURI(WikiSearchResource.class, getWiki())));
+        searchResults = (SearchResults) unmarshaller.unmarshal(getMethod.getResponseBodyAsStream());
+        assertEquals(0, searchResults.getSearchResults().size());
     }
 
     @Test


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-20632

# Changes

## Description

* Search only in the actual page name, not in the space hierarchy.

## Clarifications

* As explained in the comments on the issue, the search was never supposed to take the space hierarchy into account. This changes the code to follow the specification.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI change except that the search results are different now.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manually tested the change, still need to see if we have any existing tests.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-15.10.x