### PR TITLE
XWIKI-21959: Provide user timezone information in xwiki-meta

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/htmlheader.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/htmlheader.vm
@@ -60,6 +60,8 @@
 #if ("$!xcontext.userReference" != '')
   #addMetaAttribute($metaAttributes, 'user-reference', $!services.model.serialize($xcontext.userReference, 'default'))
 #end
+## If user is guest we fallback on wiki timezone, so we always provide the value.
+#addMetaAttribute($metaAttributes, 'user-timezone', $xwiki.getUserTimeZone())
 
 <html xmlns="http://www.w3.org/1999/xhtml" lang="$xcontext.locale.toLanguageTag()" xml:lang="$xcontext.locale.toLanguageTag()" $stringtool.join($metaAttributes, ' ')>
   <head>

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/meta.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/meta.js
@@ -57,6 +57,8 @@ define(['jquery', 'xwiki-entityReference', 'xwiki-events-bridge'], function($, X
         // Since 12.3RC1
         // Note that the 'data-xwiki-locale' attribute is set since XWiki 10.4RC1 but it hasn't been exposed here.
         self.locale = html.data('xwiki-locale');
+        // Since 16.2.0RC1
+        self.userTimeZone = html.data('xwiki-user-timezone');
       } else {
         // Case 2: meta information are stored in deprecated <meta> tags
         // (in colibri)


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-21959

# Changes

## Description

Provide user timezone information in xwiki-meta

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Rebuilt an xwiki distrib and checked the result of accessing the value from a script.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * maybe 15.10.x and 14.10.x depending on the related bug https://jira.xwiki.org/browse/XWIKI-21924