### PR TITLE
XWIKI-21778: Admin section: make the Extension section pass webstandard tests

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/SearchSuggestSourceSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/SearchSuggestSourceSheet.xml
@@ -75,7 +75,7 @@
         $services.rendering.escape($!object.getProperty($property.name).value, 'xwiki/2.1')
       #end
   #else
-    :
+    : (% class='hidden' %)
   #end
 #end
 )))

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/rating_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/rating_macros.vm
@@ -37,7 +37,7 @@
     <div class="rating-stars">
         <ul class="star-rating ${cssclass}-star #if($locked) locked #end">
             <li class="current-rating">
-                <meter class="average-rating" min="0" max="5" value="$rating"/>
+                <meter class="average-rating" min="0" max="5" value="$rating">$rating</meter>
             </li>
             #set($cls = ["one-star", "two-stars", "three-stars", "four-stars", "five-stars"])
             #foreach($r in [1..5])


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-21778

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added content for the `<dl>` in searchSuggest.
* Replaced the self closing syntax for the meter in Extensions with a proper open + close syntax.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* For searchsuggest, the xwiki syntax was not parsed the way I thought it did. I added an empty paragraph inside of the `<dl>`, and this was enough for it to be added to the DOM (without any paragraph inside)
* For Extension, the self-closing HTML syntax used was not standard for a non void element like `<meter>`
* Note that this commit solves both errors related to the merges of XWIKI-21778 and XWIKI-21779. Both are pretty small fixes, and they have a similar context, so I took the liberty to propose them together.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
We can see in the screenshot under that the searchSuggest now properly has dl items even if they are empty
![21778-2-searchSuggestHasDL](https://github.com/xwiki/xwiki-platform/assets/28761965/06259aea-8204-46b8-9501-580f550ba373)



# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual test to check that changes didn't break display.
Successfully ran `mvn clean install -f xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards -Dxwiki.test.startXWiki=false` in those conditions:
* Changes were applied on the local distribution that was used in the tests.
* Removed most of the content of urlsToTestAsAdmin from the POM to not test unneeded things, left only the two failures found in CI at Extensions and SearchSuggest admin sections
* Removed `dwgValidator`, `rssValidator` and `xwikiValidator` from the AllTests, since those didn't fail either.

Those removal made it faster to test what was failing, bringing the build down to 10 minutes on my machine. It still failed without applying the changes in this PR.
# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * No (same as https://github.com/xwiki/xwiki-platform/pull/2812 and https://github.com/xwiki/xwiki-platform/pull/2816)