### PR TITLE
XWIKI-21967: Dragging to resize the columns from Affected Children Live Data causes the page to be deleted without user's confirmation

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/table/LayoutTableHeaderNames.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/layouts/table/LayoutTableHeaderNames.vue
@@ -60,8 +60,7 @@
       <!-- Wrapper for the column header -->
       <div class="column-name">
         <!-- Property Name -->
-        <button 
-          class="handle"
+        <button type="button" class="handle"
           @click="sort(property)"
           @keydown.left="keyboardDragNDrop($event, -1)"
           @keydown.right="keyboardDragNDrop($event, 1)"
@@ -83,7 +82,8 @@
       <!--
           Specify the handle to resize properties
         -->
-      <button class="resize-handle btn btn-xs btn-default" :title="$t('livedata.action.resizeColumn.hint')"
+      <button type="button" class="resize-handle btn btn-xs btn-default"
+              :title="$t('livedata.action.resizeColumn.hint')"
               v-mousedownmove="mouseResizeColumnInit"
               @mousedownmove="mouseResizeColumn"
               @keydown.left="keyboardResizeColumn($event, -10)"


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-21967

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added a type to the dragNdrop buttons to avoid them accidentally submitting a form they were included in.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
After the PR changes, the resize and reorder handles have `type="button"`. They don't submit the form the LiveData is included in anymore.
![21967-afterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/fc414903-9b51-4c9c-846b-915f3bb41425)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Successfully built `mvn clean install -f xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar -Pquality,integration-tests,docker`.
After that, I included the JAR in my local distribution with `ln -s -f ~/Documents/xwiki-platform/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/target/xwiki-platform-livedata-webjar-16.2.0-SNAPSHOT.jar xwiki-platform-livedata-webjar-16.2.0-SNAPSHOT.jar` in  the folder `/webapps/xwiki/WEB-INF/lib`.
With the updated code on my local distrib, I was able to test out the bug (that I previously made sure to reproduce on this distrib with the old code). I couldn't reproduce the unexpected behavior reported with the updated code, and the DOM changed as expected (see screenshot above).

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None (same as https://github.com/xwiki/xwiki-platform/pull/2475, merged on master mid-january)