### PR TITLE
XWIKI-12674: Replace Restlet with Jersey

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-jersey/src/main/java/org/xwiki/rest/jersey/internal/RestletJacksonContextResolver.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-jersey/src/main/java/org/xwiki/rest/jersey/internal/RestletJacksonContextResolver.java
@@ -24,8 +24,8 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.Provider;
 
-import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 
 /**
@@ -48,9 +48,9 @@ public class RestletJacksonContextResolver implements ContextResolver<ObjectMapp
     {
         JsonMapper.Builder builder = JsonMapper.builder();
 
-        // Disable all annotation handling to make sure Jackson is not going to try to take into account JAX-RS
-        // annotations
-        builder.disable(MapperFeature.USE_ANNOTATIONS);
+        // Configure to use just the Jackson annotation introspector, not the JAX-RS one as this is XWiki's legacy
+        // behavior.
+        builder.annotationIntrospector(new JacksonAnnotationIntrospector());
 
         this.objectMapper = builder.build();
     }


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-12674

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Re-enable the Jackson annotation introspector.

## Clarifications

* Before moving to Jersey, XWiki used Jackson annotations when serializing and deserializing to/from JSON in the REST API. This re-enables Jackson annotation support while keep JAXB annotations disabled.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
mvn clean install -Pintegration-tests,docker,legacy,standalone,quality -pl :xwiki-platform-rest-jersey,:xwiki-platform-livedata-test-docker
```

I tested manually that Jackson annotations work again, no idea how to easily add a test for that feature, from what I can see we're not using this in XWiki itself.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None.