### PR TITLE
XWIKI-21966: Cannot exit horizontal drop-down menu using accessibility tools

### DIFF
--- a/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
@@ -226,6 +226,18 @@ require(['jquery','xwiki-l10n!menu-ui-translation-keys'], function($, l10n) {
       $(dropDownHeader).next().addClass('xDropdown-menu');
   });
 
+  $('.xDropdown-menu').each(function() {
+     this.addEventListener('keyup', function(event) {
+       if (event.key === 'Escape') {
+         // We change the state of the parent xDropdown
+         this.parentNode.classList.remove('open');
+         // We set the focus on the toggle button of the section we just collapsed
+         this.parentNode.querySelector(':scope > .xDropdown-header > .xDropdown-header-toggle').focus();
+       }
+       event.stopPropagation();
+     });
+  });
+
   $('.menu-horizontal .xDropdown').each(function() {
     // In case of horizontal menus, make it so that a class is added on hover, instead of using the :hover pseudo-class
     this.addEventListener("mouseover", function() {


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-21966
# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Added an event listener to close the currently navigated dropdown with `Escape`

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* When focusing menu dropdown, pressing escape will collapse it and focus the toggler.
* Handling the focus `manually` is a thing to avoid. In this case:
  * the focus is on an element that got hidden, so we should move it to somewhere where it makes sense to have it 
  * we don't move it far from the context we were in (only a couple tabs away in most cases)
  * we move it to an known and expected node

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
[Video demo to highlight the new behaviour](https://youtu.be/AmmzWLpd6gk)

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests, see the video demo.
This component is not automatically tested (see changes in https://github.com/xwiki/xwiki-platform/pull/2078, which did not break any test), so no further testing.
# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.X : The changes are pretty safe and have a small scope.