### PR TITLE
XWIKI-21597: Make the rights UI use icon themes

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/GlobalRightsAdministrationSectionPage.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/GlobalRightsAdministrationSectionPage.java
@@ -24,6 +24,9 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.xwiki.test.ui.po.EditRightsPane;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 /**
  * Represents the actions possible on the Global Rights Administration Page.
  *
@@ -68,9 +71,9 @@ public class GlobalRightsAdministrationSectionPage extends AdministrationSection
 
     private void setAuthenticatedView(boolean enabled)
     {
-        String desiredAltValue = enabled ? "yes" : "no";
-
-        if (!this.forceAuthenticatedViewLink.getAttribute("alt").equals(desiredAltValue)) {
+        String desiredCheckedValue = enabled ? "checked" : null;
+        String initialCheckedValue = this.forceAuthenticatedViewLink.getAttribute("checked");
+        if (initialCheckedValue == null || !initialCheckedValue.equals(desiredCheckedValue)) {
             this.forceAuthenticatedViewLink.click();
 
             // Wait for the setting to apply. Wait longer than usual in this case in an attempt to avoid some false
@@ -78,8 +81,13 @@ public class GlobalRightsAdministrationSectionPage extends AdministrationSection
             int defaultTimeout = getDriver().getTimeout();
             try {
                 getDriver().setTimeout(defaultTimeout * 2);
-                getDriver().waitUntilElementHasAttributeValue(
-                    By.id(this.forceAuthenticatedViewLink.getAttribute("id")), "alt", desiredAltValue);
+                if (enabled) {
+                    getDriver().waitUntilElementHasAttributeValue(
+                        By.id(this.forceAuthenticatedViewLink.getAttribute("id")), "checked", "true");
+                } else {
+                    getDriver().waitUntilCondition(driver ->
+                        this.forceAuthenticatedViewLink.getAttribute("checked") == null);
+                }
             } finally {
                 // Restore the utils timeout for other tests.
                 getDriver().setTimeout(defaultTimeout);

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/EditRightsPane.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/EditRightsPane.java
@@ -56,15 +56,15 @@ public class EditRightsPane extends BaseElement
     /** The possible states of an access right box. */
     public enum State
     {
-        NONE("/xwiki/resources/js/xwiki/usersandgroups/img/none.png"),
-        ALLOW("/xwiki/resources/js/xwiki/usersandgroups/img/allow.png"),
-        DENY("/xwiki/resources/js/xwiki/usersandgroups/img/deny1.png");
+        NONE("none"),
+        ALLOW("yes"),
+        DENY("no");
 
-        String imageURL;
+        String buttonClass;
 
-        State(String imageURL)
+        State(String buttonClass)
         {
-            this.imageURL = imageURL;
+            this.buttonClass = buttonClass;
         }
 
         State getNextState()
@@ -72,12 +72,12 @@ public class EditRightsPane extends BaseElement
             return values()[(ordinal() + 1) % values().length];
         }
 
-        static State getButtonImageState(WebElement button)
+        static State getButtonState(WebElement button)
         {
             for (State s : values()) {
                 //  The URL may contain query string parameters (e.g. starting with 11.1RC1 the resource URLs can now
                 //  contain a query parameter to avoid cache issue) and we don't care about that to identify the state.
-                if ((button.getAttribute("src").contains(s.imageURL))) {
+                if ((button.getAttribute("class").contains(s.buttonClass))) {
                     return s;
                 }
             }
@@ -119,9 +119,9 @@ public class EditRightsPane extends BaseElement
      */
     public State getGuestRight(String rightName)
     {
-        final By iconLocator = By.xpath(String.format("//tr[@id='unregistered']/td[@data-title='%s']/button/img", rightName));
-        final WebElement icon = getDriver().findElement(iconLocator);
-        return State.getButtonImageState(icon);
+        final By buttonLocator = By.xpath(String.format("//tr[@id='unregistered']/td[@data-title='%s']/button", rightName));
+        final WebElement button = getDriver().findElement(buttonLocator);
+        return State.getButtonState(button);
     }
 
     public State getRight(String entityName, Right right)
@@ -139,13 +139,13 @@ public class EditRightsPane extends BaseElement
      */
     public State getRight(String entityName, String rightName)
     {
-        final By iconLocator =
+        final By buttonLocator =
             By.xpath(String.format(
                 "//*[@id='usersandgroupstable-display']//tr[./td[@class='username']//a[contains(@href, '%s')]]"
-                    + "/td[@data-title='%s']/button/img",
+                    + "/td[@data-title='%s']/button",
                 entityName, rightName));
-        final WebElement icon = getDriver().findElement(iconLocator);
-        return State.getButtonImageState(icon);
+        final WebElement button = getDriver().findElement(buttonLocator);
+        return State.getButtonState(button);
     }
 
     public boolean hasEntity(String entityName)
@@ -172,15 +172,15 @@ public class EditRightsPane extends BaseElement
             getDriver().executeJavascript(
                 "window.__oldConfirm = window.confirm; window.confirm = function() { return true; };");
             final By buttonLocator = By.xpath(
-                String.format("*//tr[@id='unregistered']/td[@data-title='%s']/button/img", rightName));
+                String.format("*//tr[@id='unregistered']/td[@data-title='%s']/button", rightName));
             final WebElement button = getDriver().findElement(buttonLocator);
-            State currentState = State.getButtonImageState(button);
+            State currentState = State.getButtonState(button);
             button.click();
             // Note: Selenium 2.0a4 returns a relative URL when calling getAttribute("src") but since we moved to
             // Selenium 2.0a7 it returns a *full* URL even though the DOM has a relative URL as in:
             // <img src="/xwiki/resources/js/xwiki/usersandgroups/img/allow.png">
-            getDriver().waitUntilElementContainsAttributeValue(buttonLocator, "src",
-                currentState.getNextState().imageURL);
+            getDriver().waitUntilElementContainsAttributeValue(buttonLocator, "class",
+                currentState.getNextState().buttonClass);
         } finally {
             getDriver().executeJavascript("window.confirm = window.__oldConfirm;");
         }
@@ -212,14 +212,14 @@ public class EditRightsPane extends BaseElement
             final By buttonLocator =
                 By.xpath(
                     String.format("//*[@id='usersandgroupstable-display']//tr[./td[@class='username']"
-                        + "//a[contains(@href, '%s')]]/td[@data-title='%s']/button/img", entityName, rightName));
+                        + "//a[contains(@href, '%s')]]/td[@data-title='%s']/button", entityName, rightName));
             final WebElement button = getDriver().findElement(buttonLocator);
-            State currentState = State.getButtonImageState(button).getNextState();
+            State currentState = State.getButtonState(button).getNextState();
             button.click();
             // Note: Selenium 2.0a4 returns a relative URL when calling getAttribute("src") but since we moved to
             // Selenium 2.0a7 it returns a *full* URL even though the DOM has a relative URL as in:
             // <img src="/xwiki/resources/js/xwiki/usersandgroups/img/allow.png">
-            getDriver().waitUntilElementContainsAttributeValue(buttonLocator, "src", currentState.imageURL);
+            getDriver().waitUntilElementContainsAttributeValue(buttonLocator, "class", currentState.buttonClass);
         } finally {
             getDriver().executeJavascript("window.confirm = window.__oldConfirm;");
         }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-21597
# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Updated tests: 
  * EditRightsPane used a custom class to hold the state of the icon. Replaced the reliance on the icon URL with the class on the button. Renamed everything in this class to let go off the icon, which is just a style thing and should not be based upon for such logic. 
  * Changed the GlobalRightsAdministrationSectionPage object to fit the new attributes used on the checkbox.



# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
None, test only modifications.
# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
This PR solves two sets of regressions seen on CI:
* Successfully passed `mvn clean install -f xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects; mvn clean install -f xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker -Pdocker,integration-tests -Dit.test=LoginIT`, related to regression https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/master/7167/testReport/org.xwiki.flamingo.test.docker/AllIT$NestedLoginIT/Platform_Builds___main___integration_tests___IT_for_xwiki_platform_core_xwiki_platform_flamingo_xwiki_platform_flamingo_skin_xwiki_platform_flamingo_skin_test_xwiki_platform_flamingo_skin_test_docker___Build_for_IT_for_xwiki_platform_core_xwiki_platform_flamingo_xwiki_platform_flamingo_skin_xwiki_platform_flamingo_skin_test_xwiki_platform_flamingo_skin_test_docker___redirectBackAfterLogin_TestUtils__XWikiWebDriver__TestReference_/
* Successfully passed `mvn clean install -f xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui; mvn clean install -f xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker -Dit.test=UsersGroupsRightsManagementIT -Pdocker`, related to regression https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/master/7167/testReport/org.xwiki.administration.test.ui/AllIT$NestedUsersGroupsRightsManagementIT/Platform_Builds___main___integration_tests___IT_for_xwiki_platform_core_xwiki_platform_administration_xwiki_platform_administration_test_xwiki_platform_administration_test_docker___Build_for_IT_for_xwiki_platform_core_xwiki_platform_administration_xwiki_platform_administration_test_xwiki_platform_administration_test_docker___createAndDeleteGroup_TestUtils__TestReference_/
* (after building the changes) `mvn clean install -f xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-docker -Pdocker -Dit.test=NestedAllDocsIT` successfully passed, related to regression https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/master/7167/testReport/org.xwiki.index.test.ui.docker/AllIT$NestedAllDocsIT/Platform_Builds___main___integration_tests___IT_for_xwiki_platform_core_xwiki_platform_index_xwiki_platform_index_test_xwiki_platform_index_test_docker___Build_for_IT_for_xwiki_platform_core_xwiki_platform_index_xwiki_platform_index_test_xwiki_platform_index_test_docker___verifyAllDocs_TestUtils__TestInfo__TestReference_/


# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * No backport (same as https://github.com/xwiki/xwiki-platform/pull/2649)