### PR TITLE
XWIKI-21969: User Sheet headers are not bold as expected

### DIFF
--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserSheet.xml
@@ -514,6 +514,7 @@ return XWiki;
 }
 
 .column h1, .column h2 {
+  font-weight: bold;
   font-size: 115%;
   margin: 10px 0;
 }


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-21969
# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added back bold on the title

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* See ticket content on Jira

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Before PR
![21969-beforePR](https://github.com/xwiki/xwiki-platform/assets/28761965/b4152a6a-d942-46ce-927f-0f940e8203d5)
After PR
![21969-afterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/9dbba64e-6f2f-4c67-aab3-73e66d23ad62)

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
None, because it's a low scope style to solve a regression that was not found in CI.
# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.X