### PR TITLE
XWIKI-21972: FilterList shouldn't force using a contains operator in LiveData

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/resources/liveDataConfiguration.json
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/resources/liveDataConfiguration.json
@@ -14,7 +14,8 @@
     "filters": [
       {
         "id": "text",
-        "operators": ["contains", "startsWith", "equals"]
+        "operators": ["contains", "startsWith", "equals"],
+        "defaultOperator": "contains"
       },
       {
         "id": "number",
@@ -22,20 +23,24 @@
           {"id": "equals", "name": "="},
           {"id": "less", "name": "<"},
           {"id": "greater", "name": ">"}
-        ]
+        ],
+        "defaultOperator": "equals"
       },
       {
         "id": "boolean",
-        "operators": ["equals"]
+        "operators": ["equals"],
+        "defaultOperator": "equals"
       },
       {
         "id": "date",
         "operators": ["between", "before", "after", "contains"],
-        "dateFormat": "yyyy/MM/dd HH:mm"
+        "dateFormat": "yyyy/MM/dd HH:mm",
+        "defaultOperator": "between"
       },
       {
         "id": "list",
-        "operators": ["equals", "startsWith", "contains", "empty"]
+        "operators": ["equals", "startsWith", "contains", "empty"],
+        "defaultOperator": "contains"
       }
     ],
 

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/test/resources/DefaultLiveDataConfigurationResolver.test
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/test/resources/DefaultLiveDataConfigurationResolver.test
@@ -104,6 +104,7 @@
     "filters":[
       {
         "id":"text",
+        "defaultOperator":"contains",
         "operators":[
           {"id":"contains","name":"contains"},
           {"id":"startsWith","name":"startsWith"},
@@ -112,6 +113,7 @@
       },
       {
         "id":"number",
+        "defaultOperator":"equals",
         "operators":[
           {"id":"equals","name":"="},
           {"id":"less","name":"<"},
@@ -120,12 +122,14 @@
       },
       {
         "id":"boolean",
+        "defaultOperator":"equals",
         "operators":[
           {"id":"equals","name":"Equals"}
         ]
       },
       {
         "id":"date",
+        "defaultOperator":"between",
         "operators":[
           {"id":"between","name":"between"},
           {"id":"before","name":"before"},
@@ -136,6 +140,7 @@
       },
       {
         "id":"list",
+        "defaultOperator":"contains",
         "operators":[
           {"id":"equals","name":"Equals"},
           {"id":"startsWith","name":"startsWith"},

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/test/resources/withInitialize.json
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/test/resources/withInitialize.json
@@ -28,6 +28,7 @@
     "propertyTypes" : [ ],
     "filters" : [ {
       "id" : "text",
+      "defaultOperator" : "contains",
       "operators" : [ {
         "id" : "contains",
         "name" : "contains"
@@ -40,6 +41,7 @@
       } ]
     }, {
       "id" : "number",
+      "defaultOperator" : "equals",
       "operators" : [ {
         "id" : "equals",
         "name" : "="
@@ -52,12 +54,14 @@
       } ]
     }, {
       "id" : "boolean",
+      "defaultOperator" : "equals",
       "operators" : [ {
         "id" : "equals",
         "name" : "Equals"
       } ]
     }, {
       "id" : "date",
+      "defaultOperator" : "between",
       "operators" : [ {
         "id" : "between",
         "name" : "between"
@@ -74,6 +78,7 @@
       "dateFormat" : "yyyy/MM/dd HH:mm"
     }, {
       "id" : "list",
+      "defaultOperator" : "contains",
       "operators" : [ {
         "id" : "equals",
         "name" : "Equals"

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataPropertyStore.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataPropertyStore.java
@@ -71,6 +71,8 @@ import com.xpn.xwiki.objects.classes.PropertyClass;
 @InstantiationStrategy(ComponentInstantiationStrategy.PER_LOOKUP)
 public class LiveTableLiveDataPropertyStore extends WithParameters implements LiveDataPropertyDescriptorStore
 {
+    private static final String EQUALS_OPERATOR = "equals";
+
     @Inject
     @Named("current")
     private DocumentReferenceResolver<String> currentDocumentReferenceResolver;
@@ -159,10 +161,10 @@ public class LiveTableLiveDataPropertyStore extends WithParameters implements Li
         // The returned property value is the displayer output.
         descriptor.setDisplayer(new DisplayerDescriptor("xObjectProperty"));
         if (xproperty instanceof ListClass) {
-            descriptor.setFilter(new FilterDescriptor("list"));
+            FilterDescriptor filterList = new FilterDescriptor("list");
             if (xproperty instanceof LevelsClass) {
                 // We need to provide a list of maps of value / labels so that selectize can interpret them.
-                descriptor.getFilter().setParameter("options", ((LevelsClass) xproperty).getList(xcontext)
+                filterList.setParameter("options", ((LevelsClass) xproperty).getList(xcontext)
                     .stream()
                     .map(item -> Map.of(
                         "value", item,
@@ -170,15 +172,17 @@ public class LiveTableLiveDataPropertyStore extends WithParameters implements Li
                     ))
                     .collect(Collectors.toList()));
             } else {
-                descriptor.getFilter().setParameter("searchURL", getSearchURL(xproperty));
+                filterList.setParameter("searchURL", getSearchURL(xproperty));
             }
             if (xproperty.newProperty() instanceof StringListProperty) {
                 // The default live table results page currently supports only exact matching for list properties with
                 // multiple selection and no relational storage (selected values are stored concatenated on a single
                 // database column).
-                descriptor.getFilter().addOperator("empty", null);
-                descriptor.getFilter().addOperator("equals", null);
+                filterList.addOperator("empty", null);
+                filterList.addOperator(EQUALS_OPERATOR, null);
+                filterList.setDefaultOperator(EQUALS_OPERATOR);
             }
+            descriptor.setFilter(filterList);
         } else if (xproperty instanceof DateClass) {
             String dateFormat = ((DateClass) xproperty).getDateFormat();
             if (!StringUtils.isEmpty(dateFormat)) {

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataPropertyStore.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataPropertyStore.java
@@ -160,7 +160,6 @@ public class LiveTableLiveDataPropertyStore extends WithParameters implements Li
         descriptor.setDisplayer(new DisplayerDescriptor("xObjectProperty"));
         if (xproperty instanceof ListClass) {
             descriptor.setFilter(new FilterDescriptor("list"));
-            descriptor.getFilter().addOperator("empty", null);
             if (xproperty instanceof LevelsClass) {
                 // We need to provide a list of maps of value / labels so that selectize can interpret them.
                 descriptor.getFilter().setParameter("options", ((LevelsClass) xproperty).getList(xcontext)
@@ -177,6 +176,7 @@ public class LiveTableLiveDataPropertyStore extends WithParameters implements Li
                 // The default live table results page currently supports only exact matching for list properties with
                 // multiple selection and no relational storage (selected values are stored concatenated on a single
                 // database column).
+                descriptor.getFilter().addOperator("empty", null);
                 descriptor.getFilter().addOperator("equals", null);
             }
         } else if (xproperty instanceof DateClass) {

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataPropertyStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataPropertyStoreTest.java
@@ -218,6 +218,7 @@ class LiveTableLiveDataPropertyStoreTest
         LiveDataPropertyDescriptor.OperatorDescriptor operator2 = new LiveDataPropertyDescriptor.OperatorDescriptor();
         operator2.setId("equals");
         filter3.setOperators(List.of(operator1, operator2));
+        filter3.setDefaultOperator("equals");
         filter3.setParameter("searchURL",
             "/xwiki/rest/wikis/wiki/classes/Some.Class/properties/status/values?fp={encodedQuery}");
         descriptor3.setFilter(filter3);

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataPropertyStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataPropertyStoreTest.java
@@ -231,10 +231,6 @@ class LiveTableLiveDataPropertyStoreTest
         descriptor4.setDisplayer(displayer4);
         LiveDataPropertyDescriptor.FilterDescriptor filter4 = new LiveDataPropertyDescriptor.FilterDescriptor();
         filter4.setId("list");
-        LiveDataPropertyDescriptor.OperatorDescriptor operatorEmpty =
-            new LiveDataPropertyDescriptor.OperatorDescriptor();
-        operatorEmpty.setId("empty");
-        filter4.setOperators(List.of(operatorEmpty));
         filter4.setParameter("options", List.of(
             Map.of("value", "edit", "label", "Edit right"),
             Map.of("value", "delete", "label", "delete")

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/filters/FilterList.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/filters/FilterList.vue
@@ -92,10 +92,12 @@ export default {
             // When no values are selected, simply remove the filter.
             this.removeFilter();
           } else if (value !== this.value) {
-            // If the selected value has an empty value, then use the empty filter, otherwise use the contains filter.
+            // If the selected value has an empty value, then use the empty operator, otherwise use the default operator
+            // Note that this imply that any filter list descriptor needs to have an empty operator defined.
             if (value === '') {
               this.applyFilter(value, 'empty');
             } else {
+              // Fallback on default operator.
               this.applyFilter(value);
             }
           }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/filters/FilterList.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/filters/FilterList.vue
@@ -93,7 +93,11 @@ export default {
             this.removeFilter();
           } else if (value !== this.value) {
             // If the selected value has an empty value, then use the empty filter, otherwise use the contains filter.
-            this.applyFilter(value, value === '' ? 'empty' : 'contains');
+            if (value === '') {
+              this.applyFilter(value, 'empty');
+            } else {
+              this.applyFilter(value);
+            }
           }
         },
       };


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-21972

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Fallback on  the default operator in FilterList instead of forcing using contains.
* Provide default operator for all base filters
* Prevent LiveTable source to override operators for the filter list defined in a property descriptor: we only want to override the operator in the specific case of a StringList for which we only equals and empty

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* It's possible that a filter descriptor defines another default operator than contains (e.g. equals) and that the custom LD entry store expects the operator to never be contains: it's quite surprising to always obtain a contains whenever it's not even described in the filter descriptor... 

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Ran `mvn clean install -Pquality,integration-tests,docker` on xwiki-platform-livedata

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.x