### PR TITLE
XWIKI-21747: Some filters cannot be activated on the Solr search results page when resizing the browser tab

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/Main/SolrSearch.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/Main/SolrSearch.xml
@@ -719,6 +719,7 @@ a.search-result-highlightAll:after {
   margin: 0 .2em;
   display: flex;
   justify-content: space-between;
+  position: relative;
 }
 
 .search-facet-header:after {
@@ -728,10 +729,9 @@ a.search-result-highlightAll:after {
   content: "";
   display: block;
   height: 0;
-  margin: 2.45em 0 0;
   position: absolute;
   right: 0;
-  top: 0;
+  bottom: 0;
   width: 100%;
 }
 

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/Main/SolrSearch.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/Main/SolrSearch.xml
@@ -717,6 +717,8 @@ a.search-result-highlightAll:after {
   cursor: pointer;
   line-height: 1.4em;
   margin: 0 .2em;
+  display: flex;
+  justify-content: space-between;
 }
 
 .search-facet-header:after {
@@ -761,11 +763,7 @@ a.search-result-highlightAll:after {
 
 .search-facet .search-facet-header .facet-toggler, button.facet-value-toggler {
   background: transparent;
-  float: right;
-}
-
-button.facet-value-toggler:not(:active) {
-  color: $theme.btn-primary-color;
+  transition: background-color .2s ease-in-out;
 }
 
 .search-facet .search-facet-header .facet-toggler:active, button.facet-value-toggler:active {
@@ -819,6 +817,7 @@ button.facet-value-toggler:not(:active) {
 }
 
 .search-facet-body .itemName,
+.search-facet-body .facet-value-toggler,
 .search-facet-body .more {
   /* Remove link styling */
   color: $theme.textColor;


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-21747

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* L720-721: Fixed the display of the facet header when zooming,now using flex instead of inline. Thanks to those changes, the wrapping will not affect the dropdown button.
* L722 + L729 + L732 : improved styling on the separator line under the header to avoid it breaking UI with high zoom levels where there's wrapping in the headers
* L764: Added a transition to smoothen out a state transition that was quite harsh
* L766: removed an incorrect style
* L820: set the text color on the toggler inside facets, that were a different shade of grey before.


## Clarification
* L720-721 are the solution to this issue, others are small improvements close to this issue.


# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
beforePR (Firefox 180% zoom)
![21747-beforePRFF180](https://github.com/xwiki/xwiki-platform/assets/28761965/7a139c95-348b-41f4-a361-680d1d53568a)
afterPR (Firefox 180% zoom)
![21747-afterPRFF180](https://github.com/xwiki/xwiki-platform/assets/28761965/75a030f7-08b3-433a-8a4e-8d426fad0a4f)
afterPR (Firefox 210% zoom - 3 lines wrapped) We can see that the separator line under the header is properly placed, unlike before. We decided to position it with `bottom` inside of giving it a hard coded margin-top that would lead to it crossing the header content when it wrapped on multiple lines.
![21747-afterPRFF210](https://github.com/xwiki/xwiki-platform/assets/28761965/0d3e835b-9b66-4b16-b0bf-dac35401c2cf)



# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
None, style only changes, low scope and not hiding anything.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.X (same as https://jira.xwiki.org/browse/XWIKI-20931)