### PR TITLE
XWIKI-21977 : Module xwiki-platform-legacy-oldcore does not expose the same extension features as xwiki-platform-oldcore

### DIFF
--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -33,6 +33,19 @@
     <!-- JS/CSS minification is on by default, this property is used in order to able to skip minification when the
          debug profile is active. It can also be used from the command line to skip minification -->
     <xwiki.minification.skip>false</xwiki.minification.skip>
+    <!-- Define here extension features that will be used within some modules and their legacy versions -->
+    <!-- Extension features of xwiki-platform-oldcore -->
+    <xwiki.platform.oldcore.extension.features>
+      <!-- Old names of this module used for retro compatibility when resolving dependencies of old extensions -->
+      com.xpn.xwiki.platform:xwiki-core,
+
+      <!-- The old org.xwiki.platform:xwiki-platform-filter-instance-oldcore has been merged with oldcore -->
+      org.xwiki.platform:xwiki-platform-filter-instance-oldcore,
+
+      <!-- A contrib extension to use with versions of oldcore which does not support authservice API -->
+      org.xwiki.contrib:authservice-backport-api,
+      org.xwiki.contrib:authservice-backport-default
+    </xwiki.platform.oldcore.extension.features>
   </properties>
   <build>
     <pluginManagement>

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/pom.xml
@@ -35,7 +35,7 @@
     <!-- The features provided by this module so that it's found when resolving extension that pretty much never depend on this one -->
     <xwiki.extension.features>
       org.xwiki.platform:xwiki-platform-oldcore,
-      com.xpn.xwiki.platform:xwiki-core
+      ${xwiki.platform.oldcore.extension.features}
     </xwiki.extension.features>
     <xwiki.jacoco.instructionRatio>0.00</xwiki.jacoco.instructionRatio>
     <!-- TODO: Remove once the tests have been fixed to not output anything to the console! -->

--- a/xwiki-platform-core/xwiki-platform-oldcore/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-oldcore/pom.xml
@@ -32,17 +32,7 @@
   <packaging>jar</packaging>
   <description>XWiki Platform - Old Core</description>
   <properties>
-    <xwiki.extension.features>
-      <!-- Old names of this module used for retro compatibility when resolving dependencies of old extensions -->
-      com.xpn.xwiki.platform:xwiki-core,
-
-      <!-- The old org.xwiki.platform:xwiki-platform-filter-instance-oldcore has been merged with oldcore -->
-      org.xwiki.platform:xwiki-platform-filter-instance-oldcore,
-
-      <!-- A contrib extension to use with versions of oldcore which does not support authservice API -->
-      org.xwiki.contrib:authservice-backport-api,
-      org.xwiki.contrib:authservice-backport-default
-    </xwiki.extension.features>
+    <xwiki.extension.features>${xwiki.platform.oldcore.extension.features}</xwiki.extension.features>
     <!-- Skipping revapi since xwiki-platform-legacy-oldcore wraps this module and runs checks on it -->
     <xwiki.revapi.skip>true</xwiki.revapi.skip>
     <xwiki.jacoco.instructionRatio>0.38</xwiki.jacoco.instructionRatio>


### PR DESCRIPTION
* Move oldcore extension features to a property of xwiki-platform-core
* Re-use property in oldcore and legacy-oldcore modules

https://jira.xwiki.org/browse/XWIKI-21977