### PR TITLE
XWIKI-21922: Introduce methods to fetch a subset of revisions in XWikiVersioningStoreInterface

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/criteria/impl/RevisionCriteria.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/criteria/impl/RevisionCriteria.java
@@ -21,6 +21,8 @@ package com.xpn.xwiki.criteria.impl;
 
 import java.util.Date;
 
+import org.xwiki.stability.Unstable;
+
 /**
  * information about document versions used to retreive a set of document versions.
  *
@@ -159,5 +161,22 @@ public class RevisionCriteria
     public void setIncludeMinorVersions(boolean includeMinorVersions)
     {
         this.includeMinorVersions = includeMinorVersions;
+    }
+
+    /**
+     * Checks that the criteria are all-inclusive.
+     *
+     * @return false if some revisions might be filtered out by these criteria, true otherwise.
+     * @since 15.10.8
+     * @since 16.2.0RC1
+     */
+    @Unstable
+    public boolean isAllInclusive()
+    {
+        return this.includeMinorVersions
+            && this.getAuthor().isEmpty()
+            && this.getRange().getSize() == 0
+            && this.getPeriod().getStart() == Long.MIN_VALUE
+            && this.getPeriod().getEnd() == Long.MAX_VALUE;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateVersioningStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateVersioningStore.java
@@ -147,7 +147,8 @@ public class XWikiHibernateVersioningStore extends XWikiHibernateBaseStore imple
         XWikiContext inputxcontext) throws XWikiException
     {
         XWikiDocumentArchive archiveDoc = doc.getDocumentArchive();
-        if (archiveDoc != null) {
+        // We only retrieve a cached archive if we want a complete one.
+        if (archiveDoc != null && criteria.isAllInclusive()) {
             return archiveDoc;
         }
 
@@ -160,7 +161,10 @@ public class XWikiHibernateVersioningStore extends XWikiHibernateBaseStore imple
             }
             archiveDoc = new XWikiDocumentArchive(doc.getDocumentReference().getWikiReference(), doc.getId());
             loadXWikiDocArchive(archiveDoc, criteria, context);
-            doc.setDocumentArchive(archiveDoc);
+            // We only store the archive if it is a complete one.
+            if (criteria.isAllInclusive()) {
+                doc.setDocumentArchive(archiveDoc);
+            }
         } finally {
             context.setWikiId(db);
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/query/VersioningStoreQueryFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/query/VersioningStoreQueryFactory.java
@@ -121,10 +121,10 @@ public final class VersioningStoreQueryFactory<T>
         int start = range.getStart();
         int size = range.getSize();
 
-        if (start > 0 || start == 0 && size >= 0) {
+        if (start > 0 && size != 0 || start == 0 && size > 0) {
             this.criteriaQuery.orderBy(this.builder.asc(this.root.get(FIELD_ID).get(FIELD_VERSION1)),
                 this.builder.asc(this.root.get(FIELD_ID).get(FIELD_VERSION2)));
-        } else {
+        } else if (size != 0) {
             this.criteriaQuery.orderBy(this.builder.desc(this.root.get(FIELD_ID).get(FIELD_VERSION1)),
                 this.builder.desc(this.root.get(FIELD_ID).get(FIELD_VERSION2)));
             start = -start;
@@ -133,10 +133,10 @@ public final class VersioningStoreQueryFactory<T>
 
         this.query = this.session.createQuery(this.criteriaQuery);
 
-        if (size >= 0) {
+        if (size > 0) {
             this.query.setFirstResult(start);
             this.query.setMaxResults(size);
-        } else {
+        } else if (size < 0) {
             int newStart = Math.max(0, start + size);
             this.query.setFirstResult(newStart);
             this.query.setMaxResults(start - newStart);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/hibernate/query/VersioningStoreQueryFactoryTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/hibernate/query/VersioningStoreQueryFactoryTest.java
@@ -58,8 +58,10 @@ import com.xpn.xwiki.doc.rcs.XWikiRCSNodeInfo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -325,5 +327,19 @@ public class VersioningStoreQueryFactoryTest
         assertEquals(ascending, orders.get(1).isAscending());
         verify(this.queryNodeInfo).setFirstResult(start);
         verify(this.queryNodeInfo).setMaxResults(size);
+    }
+
+    @Test
+    void testRCSNodeInfoQueryWithAllRange()
+    {
+        // When the size of the range is 0 (ALL), there should be no filtering done.
+        RevisionCriteria criteria = new RevisionCriteriaFactory().createRevisionCriteria(true);
+        for (int start : new int[] {-10, 0, 10}) {
+            criteria.setRange(RangeFactory.createRange(start, 0));
+            VersioningStoreQueryFactory.getRCSNodeInfoQuery(this.session, 42L, criteria);
+        }
+        verify(this.criteriaQueryNodeInfo, never()).orderBy(Mockito.<Order[]>any());
+        verify(this.queryNodeInfo, never()).setFirstResult(anyInt());
+        verify(this.queryNodeInfo, never()).setMaxResults(anyInt());
     }
 }


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-21922

# Changes

## Description

* Support properly RevisionCriteria ranges that include all revisions.
* Only cache XWikiDocumentArchive when they are fully loaded.

## Clarifications

In the previous PR (https://github.com/xwiki/xwiki-platform/pull/2925) I missed a case with ranges: when the size is 0, every revision should be included. This lead to several tests failing in the CI, but it is now working properly.
Also, when investigating this, I noticed I overlooked some caching operations done on document archives which were incompatible with the implementation of the new API. Partial archives could be stored and reused later, possibly ignoring criteria. A fix for that is also provided, but this one will impact performances until https://github.com/xwiki/xwiki-platform/pull/2926 and https://github.com/xwiki/xwiki-platform/pull/2927 are also merged.

# Screenshots & Video

N/A

# Executed Tests

Previously failing tests were successfully run with these patches.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-15.10.x