### PR TITLE
XWIKI-21971: No options when using LiveData with a LevelsClass column

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/BaseDescriptor.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/BaseDescriptor.java
@@ -21,7 +21,7 @@ package org.xwiki.livedata;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.xwiki.text.XWikiToStringBuilder;
 
 /**
  * Base class for various live data configuration descriptors.
@@ -75,7 +75,8 @@ public class BaseDescriptor extends WithParameters
     @Override
     public String toString()
     {
-        return new ToStringBuilder(this)
+        return new XWikiToStringBuilder(this)
+            .appendSuper(super.toString())
             .append("id", id)
             .toString();
     }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/BaseDescriptor.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/BaseDescriptor.java
@@ -21,6 +21,7 @@ package org.xwiki.livedata;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * Base class for various live data configuration descriptors.
@@ -69,5 +70,13 @@ public class BaseDescriptor extends WithParameters
         }
 
         return false;
+    }
+
+    @Override
+    public String toString()
+    {
+        return new ToStringBuilder(this)
+            .append("id", id)
+            .toString();
     }
 }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/LiveDataPropertyDescriptor.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/LiveDataPropertyDescriptor.java
@@ -26,7 +26,7 @@ import java.util.Map;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.xwiki.text.XWikiToStringBuilder;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -42,6 +42,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 public class LiveDataPropertyDescriptor
 {
     private static final String NAME = "name";
+
     /**
      * Holds the filter configuration.
      */
@@ -161,7 +162,8 @@ public class LiveDataPropertyDescriptor
         @Override
         public String toString()
         {
-            return new ToStringBuilder(this)
+            return new XWikiToStringBuilder(this)
+                .appendSuper(super.toString())
                 .append("defaultOperator", defaultOperator)
                 .append("operators", operators)
                 .toString();
@@ -239,7 +241,8 @@ public class LiveDataPropertyDescriptor
         @Override
         public String toString()
         {
-            return new ToStringBuilder(this)
+            return new XWikiToStringBuilder(this)
+                .appendSuper(super.toString())
                 .append(NAME, name)
                 .toString();
         }
@@ -608,7 +611,8 @@ public class LiveDataPropertyDescriptor
     @Override
     public String toString()
     {
-        return new ToStringBuilder(this)
+        return new XWikiToStringBuilder(this)
+            .appendSuper(super.toString())
             .append("id", id)
             .append(NAME, name)
             .append("description", description)

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/LiveDataPropertyDescriptor.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/LiveDataPropertyDescriptor.java
@@ -24,6 +24,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
@@ -37,6 +41,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class LiveDataPropertyDescriptor
 {
+    private static final String NAME = "name";
     /**
      * Holds the filter configuration.
      */
@@ -126,6 +131,41 @@ public class LiveDataPropertyDescriptor
                 this.operators = new ArrayList<>();
             }
         }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            FilterDescriptor that = (FilterDescriptor) o;
+
+            return new EqualsBuilder().appendSuper(super.equals(o))
+                .append(defaultOperator, that.defaultOperator).append(operators, that.operators).isEquals();
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return new HashCodeBuilder(23, 87)
+                .appendSuper(super.hashCode())
+                .append(defaultOperator).append(operators)
+                .toHashCode();
+        }
+
+        @Override
+        public String toString()
+        {
+            return new ToStringBuilder(this)
+                .append("defaultOperator", defaultOperator)
+                .append("operators", operators)
+                .toString();
+        }
     }
 
     /**
@@ -171,6 +211,37 @@ public class LiveDataPropertyDescriptor
         public void setName(String name)
         {
             this.name = name;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            OperatorDescriptor that = (OperatorDescriptor) o;
+
+            return new EqualsBuilder().appendSuper(super.equals(o)).append(name, that.name)
+                .isEquals();
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return new HashCodeBuilder(17, 69).appendSuper(super.hashCode()).append(name).toHashCode();
+        }
+
+        @Override
+        public String toString()
+        {
+            return new ToStringBuilder(this)
+                .append(NAME, name)
+                .toString();
         }
     }
 
@@ -504,5 +575,52 @@ public class LiveDataPropertyDescriptor
         if (this.filter == null) {
             this.filter = new FilterDescriptor();
         }
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        LiveDataPropertyDescriptor that = (LiveDataPropertyDescriptor) o;
+
+        return new EqualsBuilder().append(id, that.id).append(name, that.name)
+            .append(description, that.description).append(icon, that.icon).append(type, that.type)
+            .append(sortable, that.sortable).append(visible, that.visible).append(filterable, that.filterable)
+            .append(editable, that.editable).append(displayer, that.displayer).append(filter, that.filter)
+            .append(styleName, that.styleName).isEquals();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return new HashCodeBuilder(27, 37).append(id).append(name).append(description).append(icon).append(type)
+            .append(sortable).append(visible).append(filterable).append(editable).append(displayer).append(filter)
+            .append(styleName).toHashCode();
+    }
+
+    @Override
+    public String toString()
+    {
+        return new ToStringBuilder(this)
+            .append("id", id)
+            .append(NAME, name)
+            .append("description", description)
+            .append("icon", icon)
+            .append("type", type)
+            .append("sortable", sortable)
+            .append("visible", visible)
+            .append("filterable", filterable)
+            .append("editable", editable)
+            .append("displayer", displayer)
+            .append("filter", filter)
+            .append("styleName", styleName)
+            .toString();
     }
 }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/WithParameters.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/WithParameters.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
+import org.xwiki.text.XWikiToStringBuilder;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
@@ -82,5 +83,13 @@ public class WithParameters
         }
 
         return false;
+    }
+
+    @Override
+    public String toString()
+    {
+        return new XWikiToStringBuilder(this)
+            .append("parameters", parameters)
+            .toString();
     }
 }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataPropertyStore.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataPropertyStore.java
@@ -169,7 +169,7 @@ public class LiveTableLiveDataPropertyStore extends WithParameters implements Li
                         "value", item,
                         "label", getRightTranslationWithFallback(item)
                     ))
-                    .toList());
+                    .collect(Collectors.toList()));
             } else {
                 descriptor.getFilter().setParameter("searchURL", getSearchURL(xproperty));
             }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataPropertyStore.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataPropertyStore.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
@@ -43,6 +44,7 @@ import org.xwiki.livedata.LiveDataPropertyDescriptor.DisplayerDescriptor;
 import org.xwiki.livedata.LiveDataPropertyDescriptor.FilterDescriptor;
 import org.xwiki.livedata.LiveDataPropertyDescriptorStore;
 import org.xwiki.livedata.WithParameters;
+import org.xwiki.localization.ContextualLocalizationManager;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.DocumentReferenceResolver;
 import org.xwiki.model.reference.EntityReferenceSerializer;
@@ -87,6 +89,9 @@ public class LiveTableLiveDataPropertyStore extends WithParameters implements Li
     @Named("local")
     private EntityReferenceSerializer<String> localEntityReferenceSerializer;
 
+    @Inject
+    private ContextualLocalizationManager localizationManager;
+
     @Override
     public Collection<LiveDataPropertyDescriptor> get() throws LiveDataException
     {
@@ -129,6 +134,16 @@ public class LiveTableLiveDataPropertyStore extends WithParameters implements Li
         }
     }
 
+    // TODO: we should have a helper in the localization component for this kind of fallback
+    private String getRightTranslationWithFallback(String right)
+    {
+        String result = this.localizationManager.getTranslationPlain("rightsmanager." + right);
+        if (StringUtils.isEmpty(result)) {
+            result = right;
+        }
+        return result;
+    }
+
     private LiveDataPropertyDescriptor getLiveDataPropertyDescriptor(PropertyClass xproperty)
     {
         XWikiContext xcontext = this.xcontextProvider.get();
@@ -147,7 +162,14 @@ public class LiveTableLiveDataPropertyStore extends WithParameters implements Li
             descriptor.setFilter(new FilterDescriptor("list"));
             descriptor.getFilter().addOperator("empty", null);
             if (xproperty instanceof LevelsClass) {
-                descriptor.getFilter().setParameter("options", ((LevelsClass) xproperty).getList(xcontext));
+                // We need to provide a list of maps of value / labels so that selectize can interpret them.
+                descriptor.getFilter().setParameter("options", ((LevelsClass) xproperty).getList(xcontext)
+                    .stream()
+                    .map(item -> Map.of(
+                        "value", item,
+                        "label", getRightTranslationWithFallback(item)
+                    ))
+                    .toList());
             } else {
                 descriptor.getFilter().setParameter("searchURL", getSearchURL(xproperty));
             }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataPropertyStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataPropertyStoreTest.java
@@ -21,6 +21,8 @@ package org.xwiki.livedata.internal.livetable;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
 import javax.inject.Named;
 import javax.inject.Provider;
@@ -172,92 +174,75 @@ class LiveTableLiveDataPropertyStoreTest
 
         when(xclass.getEnabledProperties()).thenReturn(Arrays.asList(dateField, computedField, listField, levelsField));
 
-//        LiveDataPropertyDescriptor descriptor0 = new LiveDataPropertyDescriptor();
-//        descriptor0.setId("doc.title");
-//
-//        LiveDataPropertyDescriptor descriptor1 = new LiveDataPropertyDescriptor();
-//        descriptor1.setId("birthdate");
-//        descriptor1.setName("Birthdate");
-//        descriptor1.setDescription("The date when you were born.");
-//        descriptor1.setType("date");
-//        LiveDataPropertyDescriptor.DisplayerDescriptor displayer1 =
-//            new LiveDataPropertyDescriptor.DisplayerDescriptor();
-//        displayer1.setId("xObjectProperty");
-//        descriptor1.setDisplayer(displayer1);
-//        LiveDataPropertyDescriptor.FilterDescriptor filter1 = new LiveDataPropertyDescriptor.FilterDescriptor();
-//        filter1.setId("date");
-//        filter1.setParameter("dateFormat", "h:mm a");
-//        descriptor1.setFilter(filter1);
-//
-//        LiveDataPropertyDescriptor descriptor2 = new LiveDataPropertyDescriptor();
-//        descriptor2.setId("total");
-//        descriptor2.setName("Total");
-//        descriptor2.setDescription("The computed total amount.");
-//        descriptor2.setType("Computed");
-//        LiveDataPropertyDescriptor.DisplayerDescriptor displayer2 =
-//            new LiveDataPropertyDescriptor.DisplayerDescriptor();
-//        displayer2.setId("xObjectProperty");
-//        descriptor2.setDisplayer(displayer2);
-//
-//        LiveDataPropertyDescriptor descriptor3 = new LiveDataPropertyDescriptor();
-//        descriptor3.setId("status");
-//        descriptor3.setName("Status");
-//        descriptor3.setDescription("The status.");
-//        descriptor3.setType("List");
-//        descriptor3.setSortable(false);
-//        LiveDataPropertyDescriptor.DisplayerDescriptor displayer3 =
-//            new LiveDataPropertyDescriptor.DisplayerDescriptor();
-//        displayer3.setId("xObjectProperty");
-//        descriptor3.setDisplayer(displayer3);
-//        LiveDataPropertyDescriptor.FilterDescriptor filter3 = new LiveDataPropertyDescriptor.FilterDescriptor();
-//        filter3.setId("list");
-//        LiveDataPropertyDescriptor.OperatorDescriptor operator1 = new LiveDataPropertyDescriptor.OperatorDescriptor();
-//        operator1.setId("empty");
-//        LiveDataPropertyDescriptor.OperatorDescriptor operator2 = new LiveDataPropertyDescriptor.OperatorDescriptor();
-//        operator1.setId("equals");
-//        filter3.setOperators(List.of(operator1, operator2));
-//        filter3.setParameter("searchURL",
-//            "/xwiki/rest/wikis/wiki/classes/Some.Class/properties/status/values?fp={encodedQuery}");
-//        descriptor3.setFilter(filter3);
-//
-//        LiveDataPropertyDescriptor descriptor4 = new LiveDataPropertyDescriptor();
-//        descriptor4.setId("levels");
-//        descriptor4.setType("Levels");
-//        LiveDataPropertyDescriptor.DisplayerDescriptor displayer4 =
-//            new LiveDataPropertyDescriptor.DisplayerDescriptor();
-//        displayer4.setId("xObjectProperty");
-//        descriptor4.setDisplayer(displayer4);
-//        LiveDataPropertyDescriptor.FilterDescriptor filter4 = new LiveDataPropertyDescriptor.FilterDescriptor();
-//        filter4.setId("list");
-//        LiveDataPropertyDescriptor.OperatorDescriptor operatorEmpty =
-//            new LiveDataPropertyDescriptor.OperatorDescriptor();
-//        operatorEmpty.setId("empty");
-//        filter4.setOperators(List.of(operatorEmpty));
-//        filter4.setParameter("options", List.of(
-//            Map.of("value", "edit", "label", "Edit right"),
-//            Map.of("value", "delete", "label", "delete")
-//        ));
-//        descriptor4.setFilter(filter4);
+        LiveDataPropertyDescriptor descriptor0 = new LiveDataPropertyDescriptor();
+        descriptor0.setId("doc.title");
 
-        StringBuilder expectedClassProps = new StringBuilder();
-        expectedClassProps.append("{'id':'birthdate','name':'Birthdate','description':'The date when you were born.'"
-            + ",'type':'Date','displayer':{'id':'xObjectProperty'},'filter':{'id':'date','dateFormat':'h:mm a'}},");
-        expectedClassProps.append("{'id':'total','name':'Total','description':'The computed total amount.',"
-            + "'type':'Computed','displayer':{'id':'xObjectProperty'}},");
-        expectedClassProps.append("{'id':'status','name':'Status','description':'The status.',"
-            + "'type':'List','sortable':false,'displayer':{'id':'xObjectProperty'},"
-            + "'filter':{'id':'list','operators':[{'id':'empty'},{'id':'equals'}],"
-            + "'searchURL':'/xwiki/rest/wikis/wiki/classes/Some.Class/properties/status/values?fp={encodedQuery}'}},");
-        expectedClassProps.append("{'id':'levels','type':'Levels','displayer':{'id':'xObjectProperty'},"
-            + "'filter':{'id':'list','operators':[{'id':'empty'}],"
-            + "'options':[{'label':'Edit right','value': 'edit'},{'label':'delete','value':'delete'}]}}");
+        LiveDataPropertyDescriptor descriptor1 = new LiveDataPropertyDescriptor();
+        descriptor1.setId("birthdate");
+        descriptor1.setName("Birthdate");
+        descriptor1.setDescription("The date when you were born.");
+        descriptor1.setType("Date");
+        LiveDataPropertyDescriptor.DisplayerDescriptor displayer1 =
+            new LiveDataPropertyDescriptor.DisplayerDescriptor();
+        displayer1.setId("xObjectProperty");
+        descriptor1.setDisplayer(displayer1);
+        LiveDataPropertyDescriptor.FilterDescriptor filter1 = new LiveDataPropertyDescriptor.FilterDescriptor();
+        filter1.setId("date");
+        filter1.setParameter("dateFormat", "h:mm a");
+        descriptor1.setFilter(filter1);
 
+        LiveDataPropertyDescriptor descriptor2 = new LiveDataPropertyDescriptor();
+        descriptor2.setId("total");
+        descriptor2.setName("Total");
+        descriptor2.setDescription("The computed total amount.");
+        descriptor2.setType("Computed");
+        LiveDataPropertyDescriptor.DisplayerDescriptor displayer2 =
+            new LiveDataPropertyDescriptor.DisplayerDescriptor();
+        displayer2.setId("xObjectProperty");
+        descriptor2.setDisplayer(displayer2);
+
+        LiveDataPropertyDescriptor descriptor3 = new LiveDataPropertyDescriptor();
+        descriptor3.setId("status");
+        descriptor3.setName("Status");
+        descriptor3.setDescription("The status.");
+        descriptor3.setType("List");
+        descriptor3.setSortable(false);
+        LiveDataPropertyDescriptor.DisplayerDescriptor displayer3 =
+            new LiveDataPropertyDescriptor.DisplayerDescriptor();
+        displayer3.setId("xObjectProperty");
+        descriptor3.setDisplayer(displayer3);
+        LiveDataPropertyDescriptor.FilterDescriptor filter3 = new LiveDataPropertyDescriptor.FilterDescriptor();
+        filter3.setId("list");
+        LiveDataPropertyDescriptor.OperatorDescriptor operator1 = new LiveDataPropertyDescriptor.OperatorDescriptor();
+        operator1.setId("empty");
+        LiveDataPropertyDescriptor.OperatorDescriptor operator2 = new LiveDataPropertyDescriptor.OperatorDescriptor();
+        operator2.setId("equals");
+        filter3.setOperators(List.of(operator1, operator2));
+        filter3.setParameter("searchURL",
+            "/xwiki/rest/wikis/wiki/classes/Some.Class/properties/status/values?fp={encodedQuery}");
+        descriptor3.setFilter(filter3);
+
+        LiveDataPropertyDescriptor descriptor4 = new LiveDataPropertyDescriptor();
+        descriptor4.setId("levels");
+        descriptor4.setType("Levels");
+        LiveDataPropertyDescriptor.DisplayerDescriptor displayer4 =
+            new LiveDataPropertyDescriptor.DisplayerDescriptor();
+        displayer4.setId("xObjectProperty");
+        descriptor4.setDisplayer(displayer4);
+        LiveDataPropertyDescriptor.FilterDescriptor filter4 = new LiveDataPropertyDescriptor.FilterDescriptor();
+        filter4.setId("list");
+        LiveDataPropertyDescriptor.OperatorDescriptor operatorEmpty =
+            new LiveDataPropertyDescriptor.OperatorDescriptor();
+        operatorEmpty.setId("empty");
+        filter4.setOperators(List.of(operatorEmpty));
+        filter4.setParameter("options", List.of(
+            Map.of("value", "edit", "label", "Edit right"),
+            Map.of("value", "delete", "label", "delete")
+        ));
+        descriptor4.setFilter(filter4);
         Collection<LiveDataPropertyDescriptor> properties = this.propertyStore.get();
 
-//        assertEquals(List.of(descriptor0, descriptor1, descriptor2, descriptor3, descriptor4), properties);
-        String expectedJSON =
-            "[" + getExpectedDocPropsJSON() + "," + expectedClassProps.toString().replace('\'', '"') + "]";
-        assertEquals(expectedJSON, this.objectMapper.writeValueAsString(properties));
+        assertEquals(List.of(descriptor0, descriptor1, descriptor2, descriptor3, descriptor4), properties);
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataPropertyStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataPropertyStoreTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.xwiki.livedata.LiveDataConfiguration;
 import org.xwiki.livedata.LiveDataPropertyDescriptor;
+import org.xwiki.localization.ContextualLocalizationManager;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.DocumentReferenceResolver;
 import org.xwiki.model.reference.EntityReferenceSerializer;
@@ -87,6 +88,9 @@ class LiveTableLiveDataPropertyStoreTest
     @MockComponent
     @Named("local")
     private EntityReferenceSerializer<String> localEntityReferenceSerializer;
+
+    @MockComponent
+    private ContextualLocalizationManager localizationManager;
 
     @Mock
     private XWikiContext xcontext;
@@ -163,7 +167,77 @@ class LiveTableLiveDataPropertyStoreTest
         when(levelsField.getClassType()).thenReturn("Levels");
         when(levelsField.getList(this.xcontext)).thenReturn(Arrays.asList("edit", "delete"));
 
+        // We only mock this one to check the fallback
+        when(this.localizationManager.getTranslationPlain("rightsmanager.edit")).thenReturn("Edit right");
+
         when(xclass.getEnabledProperties()).thenReturn(Arrays.asList(dateField, computedField, listField, levelsField));
+
+//        LiveDataPropertyDescriptor descriptor0 = new LiveDataPropertyDescriptor();
+//        descriptor0.setId("doc.title");
+//
+//        LiveDataPropertyDescriptor descriptor1 = new LiveDataPropertyDescriptor();
+//        descriptor1.setId("birthdate");
+//        descriptor1.setName("Birthdate");
+//        descriptor1.setDescription("The date when you were born.");
+//        descriptor1.setType("date");
+//        LiveDataPropertyDescriptor.DisplayerDescriptor displayer1 =
+//            new LiveDataPropertyDescriptor.DisplayerDescriptor();
+//        displayer1.setId("xObjectProperty");
+//        descriptor1.setDisplayer(displayer1);
+//        LiveDataPropertyDescriptor.FilterDescriptor filter1 = new LiveDataPropertyDescriptor.FilterDescriptor();
+//        filter1.setId("date");
+//        filter1.setParameter("dateFormat", "h:mm a");
+//        descriptor1.setFilter(filter1);
+//
+//        LiveDataPropertyDescriptor descriptor2 = new LiveDataPropertyDescriptor();
+//        descriptor2.setId("total");
+//        descriptor2.setName("Total");
+//        descriptor2.setDescription("The computed total amount.");
+//        descriptor2.setType("Computed");
+//        LiveDataPropertyDescriptor.DisplayerDescriptor displayer2 =
+//            new LiveDataPropertyDescriptor.DisplayerDescriptor();
+//        displayer2.setId("xObjectProperty");
+//        descriptor2.setDisplayer(displayer2);
+//
+//        LiveDataPropertyDescriptor descriptor3 = new LiveDataPropertyDescriptor();
+//        descriptor3.setId("status");
+//        descriptor3.setName("Status");
+//        descriptor3.setDescription("The status.");
+//        descriptor3.setType("List");
+//        descriptor3.setSortable(false);
+//        LiveDataPropertyDescriptor.DisplayerDescriptor displayer3 =
+//            new LiveDataPropertyDescriptor.DisplayerDescriptor();
+//        displayer3.setId("xObjectProperty");
+//        descriptor3.setDisplayer(displayer3);
+//        LiveDataPropertyDescriptor.FilterDescriptor filter3 = new LiveDataPropertyDescriptor.FilterDescriptor();
+//        filter3.setId("list");
+//        LiveDataPropertyDescriptor.OperatorDescriptor operator1 = new LiveDataPropertyDescriptor.OperatorDescriptor();
+//        operator1.setId("empty");
+//        LiveDataPropertyDescriptor.OperatorDescriptor operator2 = new LiveDataPropertyDescriptor.OperatorDescriptor();
+//        operator1.setId("equals");
+//        filter3.setOperators(List.of(operator1, operator2));
+//        filter3.setParameter("searchURL",
+//            "/xwiki/rest/wikis/wiki/classes/Some.Class/properties/status/values?fp={encodedQuery}");
+//        descriptor3.setFilter(filter3);
+//
+//        LiveDataPropertyDescriptor descriptor4 = new LiveDataPropertyDescriptor();
+//        descriptor4.setId("levels");
+//        descriptor4.setType("Levels");
+//        LiveDataPropertyDescriptor.DisplayerDescriptor displayer4 =
+//            new LiveDataPropertyDescriptor.DisplayerDescriptor();
+//        displayer4.setId("xObjectProperty");
+//        descriptor4.setDisplayer(displayer4);
+//        LiveDataPropertyDescriptor.FilterDescriptor filter4 = new LiveDataPropertyDescriptor.FilterDescriptor();
+//        filter4.setId("list");
+//        LiveDataPropertyDescriptor.OperatorDescriptor operatorEmpty =
+//            new LiveDataPropertyDescriptor.OperatorDescriptor();
+//        operatorEmpty.setId("empty");
+//        filter4.setOperators(List.of(operatorEmpty));
+//        filter4.setParameter("options", List.of(
+//            Map.of("value", "edit", "label", "Edit right"),
+//            Map.of("value", "delete", "label", "delete")
+//        ));
+//        descriptor4.setFilter(filter4);
 
         StringBuilder expectedClassProps = new StringBuilder();
         expectedClassProps.append("{'id':'birthdate','name':'Birthdate','description':'The date when you were born.'"
@@ -175,10 +249,12 @@ class LiveTableLiveDataPropertyStoreTest
             + "'filter':{'id':'list','operators':[{'id':'empty'},{'id':'equals'}],"
             + "'searchURL':'/xwiki/rest/wikis/wiki/classes/Some.Class/properties/status/values?fp={encodedQuery}'}},");
         expectedClassProps.append("{'id':'levels','type':'Levels','displayer':{'id':'xObjectProperty'},"
-            + "'filter':{'id':'list','operators':[{'id':'empty'}],'options':['edit','delete']}}");
+            + "'filter':{'id':'list','operators':[{'id':'empty'}],"
+            + "'options':[{'label':'Edit right','value': 'edit'},{'label':'delete','value':'delete'}]}}");
 
         Collection<LiveDataPropertyDescriptor> properties = this.propertyStore.get();
 
+//        assertEquals(List.of(descriptor0, descriptor1, descriptor2, descriptor3, descriptor4), properties);
         String expectedJSON =
             "[" + getExpectedDocPropsJSON() + "," + expectedClassProps.toString().replace('\'', '"') + "]";
         assertEquals(expectedJSON, this.objectMapper.writeValueAsString(properties));


### PR DESCRIPTION
 # Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-21971

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

 * Provide a list of maps of label / values in case of LevelsClass

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Selectize is expecting a list of entries value/labels to create the options, and not a list of strings

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Ran `mvn clean install -Pquality` on module livedata.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.x