### PR TITLE
XWIKI-18046: Layout issues on Administration's Rights section

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminSheet.xml
@@ -943,6 +943,10 @@ require(['jquery'], function($) {
 
 #admin-page-content .usersorgroupsnames {
   white-space: nowrap;
+  /* Triple of the value for the .right column. This is useful to make sure the columns are somwhat balanced when
+    there is only one right (e.g. extension rights with a default flavor).
+    Keeping them balanced is useful to make sure the filters are displayed properly, which is especially important
+    on a subwiki where we have to find a place to display the scope selector. */
   width: 27%;
 }
 

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminSheet.xml
@@ -894,6 +894,10 @@ require(['jquery'], function($) {
   vertical-align: middle;
 }
 
+#admin-page-content .usersorgroupsnames label &gt; input[type="radio"] {
+  vertical-align: unset;
+}
+
 /**
  * Category Overview
  */
@@ -937,6 +941,15 @@ require(['jquery'], function($) {
   border-color: transparent;
 }
 
+#admin-page-content .usersorgroupsnames {
+  white-space: nowrap;
+  width: 27%;
+}
+
+#usersandgroupstable-filters-scope {
+  white-space: nowrap;
+}
+
 #usersandgroupstable-filters #name {
     width: 65%;
 }
@@ -953,6 +966,10 @@ require(['jquery'], function($) {
 
 .rights-settings dt input {
   vertical-align: top;
+}
+
+.xform #usersandgroupstable select {
+  width: unset;
 }
 
 /**

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminSheet.xml
@@ -944,7 +944,7 @@ require(['jquery'], function($) {
 #admin-page-content .usersorgroupsnames {
   white-space: nowrap;
   /* Triple of the value for the .right column. This is useful to make sure the columns are somewhat balanced when
-    there is only one right (e.g. extension rights with a default flavor).
+    there is only one right (e.g., extension rights with a default flavor).
     Keeping them balanced is useful to make sure the filters are displayed properly, which is especially important
     on a subwiki where we have to find a place to display the scope selector. */
   width: 27%;

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminSheet.xml
@@ -943,7 +943,7 @@ require(['jquery'], function($) {
 
 #admin-page-content .usersorgroupsnames {
   white-space: nowrap;
-  /* Triple of the value for the .right column. This is useful to make sure the columns are somwhat balanced when
+  /* Triple of the value for the .right column. This is useful to make sure the columns are somewhat balanced when
     there is only one right (e.g. extension rights with a default flavor).
     Keeping them balanced is useful to make sure the filters are displayed properly, which is especially important
     on a subwiki where we have to find a place to display the scope selector. */

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/rightsUI.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/rightsUI.vm
@@ -207,6 +207,8 @@ $xwiki.ssfx.use('js/xwiki/table/livetable.css', true)
             </tr>
             <tr id="usersandgroupstable-filters">
               ## Users/groups filter
+              ## We split the column amount in between the two objects as evenly as possible.
+              ## This way we can make sure both element have enough space to display correctly.
               #set ($colsp = ($maxlevel+2)/2)
               <td colspan="$colsp">
                 <label for="name">$services.localization.render('rightsmanager.searchfilter')</label>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/rightsUI.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/rightsUI.vm
@@ -205,18 +205,14 @@ $xwiki.ssfx.use('js/xwiki/table/livetable.css', true)
                 #end
               #end
             </tr>
-            <tr id="unregistered">
-              ## Rights for guests, statically displayed outside the livetable
-              <td id="unreguser" data-title="$escapetool.xml($services.localization.render('rightsmanager.username'))">$services.localization.render('rightsmanager.unregisteredusers')</td>
-              #foreach ($i in [0..$maxlevel])
-                #if ($currentAllowed[$i])
-                  <td class="rights" id="td${levelsRights.get($i)}" data-title="$escapetool.xml($services.localization.render("rightsmanager.${levelsRights.get($i)}"))"></td>
-                #end
-              #end
-            </tr>
             <tr id="usersandgroupstable-filters">
               ## Users/groups filter
-              <td><label for="name">$services.localization.render('rightsmanager.searchfilter')</label><input id="name" name="name" type="text"/>
+              #set ($colsp = ($maxlevel+2)/2)
+              <td colspan="$colsp">
+                <label for="name">$services.localization.render('rightsmanager.searchfilter')</label>
+                <input id="name" name="name" type="text"/>
+              </td>
+              <td colspan="$colsp">
                 #if(!$xcontext.isMainWiki()) #set($mainwk = false) #else #set($mainwk = true) #end
                 #if(!$mainwk) ## display the combobox only in a local wiki
                   <div id="usersandgroupstable-filters-scope">
@@ -230,9 +226,17 @@ $xwiki.ssfx.use('js/xwiki/table/livetable.css', true)
                 #else
                   <input type="hidden" name="wiki" value="local"/>
                 #end
-                #set ($colsp = $maxlevel + 1)
+                <input type="hidden" name="clsname" value="$clsname" />
               </td>
-              <td colspan="$colsp"><input type="hidden" name="clsname" value="$clsname" /></td>
+            </tr>
+            <tr id="unregistered">
+              ## Rights for guests, statically displayed outside the livetable
+              <td id="unreguser" data-title="$escapetool.xml($services.localization.render('rightsmanager.username'))">$services.localization.render('rightsmanager.unregisteredusers')</td>
+              #foreach ($i in [0..$maxlevel])
+                #if ($currentAllowed[$i])
+                  <td class="rights" id="td${levelsRights.get($i)}" data-title="$escapetool.xml($services.localization.render("rightsmanager.${levelsRights.get($i)}"))"></td>
+                #end
+              #end
             </tr>
           </thead>
           ## Livetable placeholder, will be filled in from Javascript

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/rightsUI.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/rightsUI.vm
@@ -228,7 +228,7 @@ $xwiki.ssfx.use('js/xwiki/table/livetable.css', true)
                 #else
                   <input type="hidden" name="wiki" value="local"/>
                 #end
-                <input type="hidden" name="clsname" value="$clsname" />
+                <input type="hidden" name="clsname" value="$escapetool.xml($clsname)" />
               </td>
             </tr>
             <tr id="unregistered">


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-18046
(also fixes https://jira.xwiki.org/browse/XWIKI-21539 )

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Unset the vertical align of radio buttons to pick user/group that caused a weird display due to an unexpected collision
* Limited the size of the first column of the table when there's not many rights along it
* Removed auto wrapping on some elements where it created inconsistencies in UI (still looks good without it)
* Overrode an unexpected collision between xform and the rights table (only for extension rights)
* Moved the line for the unregistered user rights to be just above the actual table lines (looks more consistent than regular line (almost) -> filter -> regular line)
* Tweaked colspans on filter elements to have them display side to side using the whole length of the table

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

This video highlights how the admin sections `Rights` and `Extension rights` are displayed on a 2560*1440 px (2K) display with Firefox. I made sure to increase the zoom level according to what's described in my comments on the ticket to show that we can't reproduce the display inconsistencies reported. Those admin sections are tested both on the main wiki and a default subwiki. At the end of the video are a few quick transitions from mainwiki to subwiki display to highlight the icnreased consistencies between those interfaces.

https://github.com/xwiki/xwiki-platform/assets/28761965/472ce06a-e181-47ad-ad89-7f90fd793dfb


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Built the changes successfully with `mvn clean install -f xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui -Pdocker,integration-tests,quality` and `mvn clean install -f xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources`.
I quickly checked out pageObject `GlobalRightsAdministrationSectionPage` and baseElement `EditRightsPane`, it didn't seem like I broke selectors.
Successfully passed `mvn clean install -f xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test -Pdocker,integration-tests,quality` , which should contain most docker tests that might have been impacted by the changes.


# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, non critical fixes, and relatively dangerous since they update DOM in the rights editor.