### PR TITLE
XWIKI-21922: Introduce methods to fetch a subset of revisions in XWikiVersioningStoreInterface

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/query/VersioningStoreQueryFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/query/VersioningStoreQueryFactory.java
@@ -93,11 +93,16 @@ public final class VersioningStoreQueryFactory<T>
             }
 
             Date minDate = criteria.getMinDate();
+            Date maxDate = criteria.getMaxDate();
             // Hibernate requires positive timestamps.
             if (minDate.getTime() < 0) {
                 minDate = new Date(0);
             }
-            predicates.add(this.builder.between(this.root.get(FIELD_DATE), minDate, criteria.getMaxDate()));
+            // Most databases store timestamps as seconds, using integers.
+            if (maxDate.getTime() > Integer.MAX_VALUE * 1000L) {
+                maxDate = new Date(Integer.MAX_VALUE * 1000L);
+            }
+            predicates.add(this.builder.between(this.root.get(FIELD_DATE), minDate, maxDate));
 
             if (!criteria.getIncludeMinorVersions()) {
                 // In this case, we keep only the highest minor version for each major version.

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/query/VersioningStoreQueryFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/query/VersioningStoreQueryFactory.java
@@ -98,7 +98,8 @@ public final class VersioningStoreQueryFactory<T>
             if (minDate.getTime() < 0) {
                 minDate = new Date(0);
             }
-            // Most databases store timestamps as seconds, using integers.
+            // Most databases (e.g., MariaDB) store timestamps as seconds, using integers. As such we cannot go
+            // higher than Integer.MAX_VALUE seconds.
             if (maxDate.getTime() > Integer.MAX_VALUE * 1000L) {
                 maxDate = new Date(Integer.MAX_VALUE * 1000L);
             }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/hibernate/query/VersioningStoreQueryFactoryTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/hibernate/query/VersioningStoreQueryFactoryTest.java
@@ -208,7 +208,7 @@ public class VersioningStoreQueryFactoryTest
         LiteralExpression<Date> dateUpperExpression = (LiteralExpression<Date>) datePredicate.getUpperBound();
         assertEquals("mocked date", datePredicate.getExpression().toString());
         assertEquals(new Date(0L), dateLowerExpression.getLiteral());
-        assertEquals(new Date(Long.MAX_VALUE), dateUpperExpression.getLiteral());
+        assertEquals(new Date(Integer.MAX_VALUE * 1000L), dateUpperExpression.getLiteral());
     }
 
     @Test
@@ -270,7 +270,7 @@ public class VersioningStoreQueryFactoryTest
         LiteralExpression<Date> dateUpperExpression = (LiteralExpression<Date>) datePredicate.getUpperBound();
         assertEquals("mocked date", datePredicate.getExpression().toString());
         assertEquals(new Date(0L), dateLowerExpression.getLiteral());
-        assertEquals(new Date(Long.MAX_VALUE), dateUpperExpression.getLiteral());
+        assertEquals(new Date(Integer.MAX_VALUE * 1000L), dateUpperExpression.getLiteral());
     }
 
     @Test


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-21922

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Fix date filtering for MySQL, MariaDB, PostgreSQL and Oracle.

## Clarifications

The previous implementation of date filtering relied on timestamps stored as doubles, which can be too large for most of the DB backends we target. The queries now enforce timestamps smaller than 2038 which is the maximum supported in these databases.

# Screenshots & Video

N/A

# Executed Tests

N/A

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-15.10.x