### PR TITLE
XWIKI-12674: Replace Restlet with Jersey

### DIFF
--- a/xwiki-platform-core/xwiki-platform-container/xwiki-platform-container-servlet/src/main/java/org/xwiki/container/servlet/filters/internal/SetCharacterEncodingFilter.java
+++ b/xwiki-platform-core/xwiki-platform-container/xwiki-platform-container-servlet/src/main/java/org/xwiki/container/servlet/filters/internal/SetCharacterEncodingFilter.java
@@ -104,12 +104,14 @@ public class SetCharacterEncodingFilter implements Filter
     {
         // Conditionally select and set the character encoding to be used
         if (ignore || (request.getCharacterEncoding() == null)) {
-            String encoding = selectEncoding(request);
-            if (encoding != null) {
-                request.setCharacterEncoding(encoding);
+            String selectedEncoding = selectEncoding(request);
+            if (selectedEncoding != null) {
+                request.setCharacterEncoding(selectedEncoding);
             }
         }
-        // Set the default encoding for the response.
+        // Set the default encoding for the response. Use the same encoding as the request as this is supposed to be
+        // the encoding that XWiki uses in general. It is not clear that XWiki in general supports any encoding besides
+        // UTF-8, though.
         response.setCharacterEncoding(this.encoding);
         // Pass control on to the next filter
         chain.doFilter(request, response);

--- a/xwiki-platform-core/xwiki-platform-container/xwiki-platform-container-servlet/src/main/java/org/xwiki/container/servlet/filters/internal/SetCharacterEncodingFilter.java
+++ b/xwiki-platform-core/xwiki-platform-container/xwiki-platform-container-servlet/src/main/java/org/xwiki/container/servlet/filters/internal/SetCharacterEncodingFilter.java
@@ -30,14 +30,16 @@ import javax.servlet.ServletResponse;
 
 /**
  * <p>
- * Example filter that sets the character encoding to be used in parsing the incoming request,
- * either unconditionally or only if the client did not specify a character encoding. Configuration
- * of this filter is based on the following initialization parameters:
+ * Filter that sets the character encoding to be used in parsing the incoming request,
+ * either unconditionally or only if the client did not specify a character encoding. Further, the default encoding of
+ * the response is set to the same character encoding. Configuration of this filter is based on the following
+ * initialization parameters:
  * </p>
  * <ul>
  * <li><strong>encoding</strong> - The character encoding to be configured for this request,
  * either conditionally or unconditionally based on the <code>ignore</code> initialization
- * parameter. This parameter is required, so there is no default.</li>
+ * parameter. This same encoding is also used as default for the response. This parameter is required, so there is no
+ * default.</li>
  * <li><strong>ignore</strong> - If set to "true", any character encoding specified by the client
  * is ignored, and the value returned by the <code>selectEncoding()</code> method is set. If set
  * to "false, <code>selectEncoding()</code> is called <strong>only</strong> if the client has not
@@ -107,6 +109,8 @@ public class SetCharacterEncodingFilter implements Filter
                 request.setCharacterEncoding(encoding);
             }
         }
+        // Set the default encoding for the response.
+        response.setCharacterEncoding(this.encoding);
         // Pass control on to the next filter
         chain.doFilter(request, response);
     }

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/WEB-INF/web.xml
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/WEB-INF/web.xml
@@ -53,7 +53,9 @@
   <!-- Filter that sets a custom encoding to all requests, since usually clients don't specify
        the encoding used for submitting the request, so by default containers fall back to the
        encoding globally configured in their settings. This allows XWiki to use a custom encoding,
-       without affecting the whole container (and the other applications hosted). -->
+       without affecting the whole container (and the other applications hosted).
+       The same encoding is also used as default for the response when the encoding is not explicitly
+       specified with the content type. -->
   <filter>
     <filter-name>Set Character Encoding</filter-name>
     <filter-class>org.xwiki.container.servlet.filters.internal.SetCharacterEncodingFilter</filter-class>


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-12674

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Set a default encoding for the response as Jersey doesn't seem to set one.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Tomcat uses ISO-8859-1 by default which means that any response that doesn't explicitly set the character set will have broken UTF-8 characters. As XWiki basically always uses UTF-8 it makes sense to set a default to UTF-8.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

`mvn clean install -U -Pdocker,legacy,integration-tests,snapshotModules -pl :xwiki-platform-container-servlet,:xwiki-platform-office-test-docker -Dmaven.test.failure.ignore -Dmaven.build.dir=target/mysql-8.3-pom-tomcat-9-jdk17-chrome -Dxwiki.checkstyle.skip=true -Dxwiki.surefire.captureconsole.skip=true -Dxwiki.revapi.skip=true -Dxwiki.spoon.skip=true -Dxwiki.enforcer.skip=true -Dxwiki.test.ui.database=mysql -Dxwiki.test.ui.databaseTag=8.3 -Dxwiki.test.ui.jdbcVersion=pom -Dxwiki.test.ui.servletEngine=tomcat -Dxwiki.test.ui.servletEngineTag=9-jdk17 -Dxwiki.test.ui.browser=chrome -Dxwiki.test.ui.wcag=true -DjenkinsAgentName="a4-004bxqhg9po1p`

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
   * To be decided, maybe if we discover that this also affects resources outside Jersey.