### PR TITLE
XWIKI-21625: You shouldn't have to force the page lock to enter a realtime editing session

### DIFF
--- a/xwiki-platform-core/xwiki-platform-edit/xwiki-platform-edit-ui/src/main/resources/XWiki/InplaceEditing.xml
+++ b/xwiki-platform-core/xwiki-platform-edit/xwiki-platform-edit-ui/src/main/resources/XWiki/InplaceEditing.xml
@@ -39,6 +39,8 @@
   <content>{{velocity wiki="false"}}
 #if ($request.action == 'lock')
   ## This could be moved later to a Velocity template (e.g. lock.vm).
+  ## We set the editor variable to be able to detect the inplace editor within the edit confirmation checkers.
+  #set ($editor = 'inplace')
   #template('edit_macros.vm')
   #getEditConfirmation()
   #if ($editConfirmation)

--- a/xwiki-platform-core/xwiki-platform-realtime/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-realtime/pom.xml
@@ -32,6 +32,7 @@
   <packaging>pom</packaging>
   <description>Adds support for real-time editing in XWiki.</description>
   <modules>
+    <module>xwiki-platform-realtime-api</module>
     <module>xwiki-platform-realtime-ui</module>
     <module>xwiki-platform-realtime-webjar</module>
     <module>xwiki-platform-realtime-wiki</module>

--- a/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-api/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-api/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.xwiki.platform</groupId>
+    <artifactId>xwiki-platform-realtime</artifactId>
+    <version>16.5.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>xwiki-platform-realtime-api</artifactId>
+  <name>XWiki Platform - Realtime - API</name>
+  <description>XWiki Platform - Realtime - API</description>
+  <properties>
+    <xwiki.jacoco.instructionRatio>0.98</xwiki.jacoco.instructionRatio>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-model-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-sheet-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-netflux-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-wysiwyg-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-oldcore</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <!-- Test dependencies. -->
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-tool-test-component</artifactId>
+      <version>${commons.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-api/src/main/java/org/xwiki/realtime/internal/DefaultRealtimeEditorManager.java
+++ b/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-api/src/main/java/org/xwiki/realtime/internal/DefaultRealtimeEditorManager.java
@@ -1,0 +1,145 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.realtime.internal;
+
+import java.util.List;
+import java.util.Locale;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.apache.commons.lang.StringUtils;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.container.Container;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.netflux.EntityChannel;
+import org.xwiki.netflux.EntityChannelStore;
+import org.xwiki.script.ScriptContextManager;
+import org.xwiki.script.service.ScriptService;
+import org.xwiki.sheet.SheetManager;
+import org.xwiki.wysiwyg.script.WysiwygEditorScriptService;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.doc.XWikiDocument;
+
+/**
+ * Determines the currently selected editor based on XWiki and Script contexts. Determines wether a realtime session is
+ * active for a given editor using the Netflux Channel Store.
+ * 
+ * @version $Id$
+ * @since 15.10.11
+ * @since 16.4.1
+ * @since 16.5.0RC1
+ */
+@Component
+@Singleton
+public class DefaultRealtimeEditorManager implements RealtimeEditorManager
+{
+    private static final String EDITOR_KEY = "editor";
+
+    private static final String WYSIWYG = "wysiwyg";
+
+    @Inject
+    private Provider<XWikiContext> xwikiContextProvider;
+
+    @Inject
+    private EntityChannelStore entityChannelStore;
+
+    @Inject
+    private SheetManager sheetManager;
+
+    @Inject
+    private ScriptContextManager scriptContextManager;
+
+    @Inject
+    @Named(WYSIWYG)
+    private ScriptService wysiwygEditorScriptService;
+
+    @Inject
+    private Container container;
+
+    @Override
+    public String getSelectedEditor()
+    {
+        // When there is an editor query parameter, it is the selected editor.
+        String requestEditor = (String) this.container.getRequest().getProperty(EDITOR_KEY);
+        if (!StringUtils.isEmpty(requestEditor)) {
+            return requestEditor;
+        }
+
+        // The inplace editor comes with a custom InplaceEditing sheet that handles the locking confirmation.
+        // To handle this special case, and potential future others, we add the possibility to set the selected
+        // editor through the editor variable in the ScriptContext.
+        String scontextEditor = (String) this.scriptContextManager.getCurrentScriptContext().getAttribute(EDITOR_KEY);
+        if (!StringUtils.isEmpty(scontextEditor)) {
+            return scontextEditor;
+        }
+
+        // Otherwise, we fallback to the default editor:
+        // This part is taken from the getDefaultDocumentEditor macro
+        // defined in macros.vm from xwiki-platform-web-templates.
+
+        // If a sheet matches the edit action for this document and no specific editor was specified,
+        // the inline form editor will be used.
+        XWikiContext context = this.xwikiContextProvider.get();
+        XWikiDocument document = (XWikiDocument) context.get("tdoc");
+        if (!this.sheetManager.getSheets(document, context.getAction()).isEmpty()) {
+            return "inline";
+        }
+
+        // If the default editor is set to Wysiwyg, it will be used if possible.
+        String xwikiEditorPreference = context.getWiki().getEditorPreference(context);
+        if (WYSIWYG.equals(xwikiEditorPreference) && ((WysiwygEditorScriptService) wysiwygEditorScriptService)
+            .isSyntaxSupported(document.getSyntax().toIdString())) {
+            return xwikiEditorPreference;
+        }
+
+        return "wiki";
+    }
+
+    @Override
+    public boolean sessionIsActive(DocumentReference target, Locale locale, String editor)
+    {
+        // The inplace and WYSIWYG realtime editors both use the same "wysiwyg" channel.
+        String session = editor;
+        if (session.equals("inplace")) {
+            session = WYSIWYG;
+        }
+
+        // We can't directly specify the path because a document might have multiple fields.
+        // Instead, we check all the channels matching the given editor.
+        List<EntityChannel> channels = this.entityChannelStore.getChannels(target);
+        for (EntityChannel channel : channels) {
+            List<String> path = channel.getPath();
+            if (!path.isEmpty()) {
+                String pathSession = path.get(path.size() - 1);
+                String pathLocale = path.get(0);
+                // When the channel is the one we are looking for, check that it has users.
+                if (pathSession.equals(session) && pathLocale.equals(locale.toLanguageTag())
+                    && channel.getUserCount() > 0) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-api/src/main/java/org/xwiki/realtime/internal/RealtimeEditorManager.java
+++ b/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-api/src/main/java/org/xwiki/realtime/internal/RealtimeEditorManager.java
@@ -1,0 +1,60 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.realtime.internal;
+
+import java.util.Locale;
+
+import org.xwiki.component.annotation.Role;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.stability.Unstable;
+
+/**
+ * Allows to probe for active realtime sessions.
+ * 
+ * @version $Id$
+ * @since 15.10.11
+ * @since 16.4.1
+ * @since 16.5.0RC1
+ */
+@Unstable
+@Role
+public interface RealtimeEditorManager
+{
+
+    /**
+     * Determine the currently selected editor. Expected outputs can be but are not limited to "inplace", "inline",
+     * "wysiwyg", "wiki"...
+     * 
+     * @return the currently selected editor.
+     */
+    String getSelectedEditor();
+
+    /**
+     * Determine if there is an active realtime session for the given document translation and edit mode.
+     * 
+     * @param target specifies which document to check
+     * @param locale explicitly specifies the translation of the document to be selected. The default value will not be
+     *            inferred from context when locale is set to Locale.ROOT
+     * @param editor specifies with which editor the realtime session is going to run
+     * @return {@code true} if there is an active session, {@code false} otherwise.
+     */
+    boolean sessionIsActive(DocumentReference target, Locale locale, String editor);
+
+}

--- a/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-api/src/main/java/org/xwiki/realtime/internal/XWikiRealtimeDocumentLockEditConfirmationChecker.java
+++ b/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-api/src/main/java/org/xwiki/realtime/internal/XWikiRealtimeDocumentLockEditConfirmationChecker.java
@@ -1,0 +1,73 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.realtime.internal;
+
+import java.util.Optional;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.xwiki.model.validation.edit.EditConfirmationCheckerResult;
+import org.xwiki.model.validation.edit.XWikiDocumentLockEditConfirmationChecker;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.doc.XWikiDocument;
+
+/**
+ * Checks if a realtime session is running, otherwise: check if the document is locked.
+ *
+ * @version $Id$
+ * @since 15.10.11
+ * @since 16.4.1
+ * @since 16.5.0RC1
+ */
+@Singleton
+@Named(XWikiRealtimeDocumentLockEditConfirmationChecker.XWIKI_DOCUMENT_LOCK_COMPONENT_NAME)
+public class XWikiRealtimeDocumentLockEditConfirmationChecker extends XWikiDocumentLockEditConfirmationChecker
+{
+    // We need to reuse the same component name as XWikiDocumentLockEditConfirmationChecker to override it.
+    static final String XWIKI_DOCUMENT_LOCK_COMPONENT_NAME = "documentLock";
+
+    @Inject
+    private Provider<XWikiContext> xwikiContextProvider;
+
+    @Inject
+    private RealtimeEditorManager realtimeEditorManager;
+
+    Optional<EditConfirmationCheckerResult> parentCheck()
+    {
+        // We wrap the super call in a separate function to simplify unit testing.
+        return super.check();
+    }
+
+    @Override
+    public Optional<EditConfirmationCheckerResult> check()
+    {
+        XWikiContext context = this.xwikiContextProvider.get();
+        XWikiDocument tdoc = (XWikiDocument) context.get("tdoc");
+        if (realtimeEditorManager.sessionIsActive(tdoc.getDocumentReference(), tdoc.getRealLocale(),
+            realtimeEditorManager.getSelectedEditor())) {
+            return Optional.empty();
+        }
+        return parentCheck();
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-api/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-api/src/main/resources/META-INF/components.txt
@@ -1,0 +1,2 @@
+org.xwiki.realtime.internal.DefaultRealtimeEditorManager
+500:org.xwiki.realtime.internal.XWikiRealtimeDocumentLockEditConfirmationChecker

--- a/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-api/src/test/java/org/xwiki/realtime/internal/DefaultRealtimeEditorManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-api/src/test/java/org/xwiki/realtime/internal/DefaultRealtimeEditorManagerTest.java
@@ -1,0 +1,247 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.xwiki.realtime.internal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
+import javax.inject.Provider;
+import javax.script.ScriptContext;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.xwiki.container.Container;
+import org.xwiki.container.Request;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.netflux.EntityChannel;
+import org.xwiki.netflux.EntityChannelStore;
+import org.xwiki.rendering.syntax.Syntax;
+import org.xwiki.script.ScriptContextManager;
+import org.xwiki.script.service.ScriptService;
+import org.xwiki.sheet.SheetManager;
+import org.xwiki.test.annotation.BeforeComponent;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+import org.xwiki.test.mockito.MockitoComponentManager;
+import org.xwiki.wysiwyg.script.WysiwygEditorScriptService;
+
+import com.xpn.xwiki.XWiki;
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.doc.XWikiDocument;
+
+@ComponentTest
+class DefaultRealtimeEditorManagerTest
+{
+
+    private static final String WIKI = "wiki";
+
+    private static final String WYSIWYG = "wysiwyg";
+
+    private static final String EDITOR = "editor";
+
+    private static final String EDIT = "edit";
+
+    private static final String EN = "en";
+
+    private static final String CONTENT = "content";
+
+    @InjectMockComponents
+    private DefaultRealtimeEditorManager realtimeEditorManager;
+
+    @MockComponent
+    private Provider<XWikiContext> xwikiContextProvider;
+
+    @MockComponent
+    private EntityChannelStore entityChannelStore;
+
+    @MockComponent
+    private SheetManager sheetManager;
+
+    @MockComponent
+    private ScriptContextManager scriptContextManager;
+
+    @MockComponent
+    private Container container;
+
+    @Mock
+    private Request request;
+
+    @Mock
+    private ScriptContext scriptContext;
+
+    @Mock
+    private XWikiContext xwikiContext;
+
+    @Mock
+    private XWikiDocument document;
+
+    @Mock
+    private XWiki wiki;
+
+    EntityChannel channel;
+
+    private WysiwygEditorScriptService wysiwygEditorScriptService;
+
+    private List<String> path;
+
+    @BeforeComponent
+    void beforeComponent(MockitoComponentManager componentManager) throws Exception
+    {
+        // The tested code casts the injected ScriptService to a WysiwygEditorScriptService.
+        // To allow for this cast, we need to mock the WysiwygEditorScriptService class directly.
+        wysiwygEditorScriptService = mock(WysiwygEditorScriptService.class);
+        componentManager.registerComponent(ScriptService.class, WYSIWYG, wysiwygEditorScriptService);
+    }
+
+    @BeforeEach
+    void setup() throws Exception {
+        // Common configuration for getSelectedEditor.
+        
+        when(container.getRequest()).thenReturn(request);
+        when(scriptContextManager.getCurrentScriptContext()).thenReturn(scriptContext);
+        
+        // Set the wiki editor preference to a value other than wysiwyg.
+        when(wiki.getEditorPreference(xwikiContext)).thenReturn("other");
+        
+        // Always set the document syntax to XWiki 2.1.
+        // We change the supported syntaxes rather than the document syntax.
+        when(document.getSyntax()).thenReturn(Syntax.XWIKI_2_1);
+        
+        // The current document is open in edit mode.
+        when(xwikiContext.get("tdoc")).thenReturn(document);
+        when(xwikiContext.getAction()).thenReturn(EDIT);
+        when(xwikiContext.getWiki()).thenReturn(wiki);
+        when(xwikiContextProvider.get()).thenReturn(xwikiContext);
+        
+        // This case is the default test configuration, but we test both.
+        when(wysiwygEditorScriptService.isSyntaxSupported(Syntax.XWIKI_2_1.toIdString())).thenReturn(false);
+
+        // Configuration for sessionIsActive.
+        
+        // Define a channel with one user.
+        path = Arrays.asList(EN, CONTENT, WIKI);
+        
+        channel = new EntityChannel(null, path, "");
+        channel.setUserCount(1);
+        List<EntityChannel> channels = Arrays.asList(channel);
+        when(entityChannelStore.getChannels(Mockito.any())).thenReturn(channels);
+    }
+
+    @Test
+    void getSelectedEditorFromQueryString()
+    {
+        when(request.getProperty(EDITOR)).thenReturn("testQuery");
+        assertEquals("testQuery", realtimeEditorManager.getSelectedEditor());
+    }
+
+    @Test
+    void getSelectedEditorFromScriptContext()
+    {
+        when(scriptContext.getAttribute(EDITOR)).thenReturn("testScript");
+        assertEquals("testScript", realtimeEditorManager.getSelectedEditor());
+    }
+
+    @Test
+    void getSelectedEditorDefaultInline()
+    {
+        DocumentReference[] sheets = {new DocumentReference("xwiki", "XWiki", "sheet")};
+        when(sheetManager.getSheets(document, EDIT)).thenReturn(Arrays.asList(sheets));
+        assertEquals("inline", realtimeEditorManager.getSelectedEditor());
+    }
+
+    @Test
+    void getSelectedEditorDefaultWysiwygSupported()
+    {
+        when(wysiwygEditorScriptService.isSyntaxSupported(Syntax.XWIKI_2_1.toIdString())).thenReturn(true);
+        when(wiki.getEditorPreference(xwikiContext)).thenReturn(WYSIWYG);
+        assertEquals(WYSIWYG, realtimeEditorManager.getSelectedEditor());
+    }
+
+    @Test
+    void getSelectedEditorDefaultWysiwygNotSupported()
+    {
+        when(wiki.getEditorPreference(xwikiContext)).thenReturn(WYSIWYG);
+        assertEquals(WIKI, realtimeEditorManager.getSelectedEditor());
+    }
+
+    @Test
+    void getSelectedEditorDefaultOther()
+    {
+        assertEquals(WIKI, realtimeEditorManager.getSelectedEditor());
+    }
+
+    @Test
+    void sessionIsActiveSameEditor()
+    {
+        assertTrue(realtimeEditorManager.sessionIsActive(null, Locale.ENGLISH, WIKI));
+    }
+
+    @Test
+    void sessionIsActiveSameEditorNoUser()
+    {
+        channel.setUserCount(0);
+        assertFalse(realtimeEditorManager.sessionIsActive(null, Locale.ENGLISH, WIKI));
+    }
+
+    @Test
+    void sessionIsActiveDifferentEditor()
+    {
+        assertFalse(realtimeEditorManager.sessionIsActive(null, Locale.ENGLISH, WYSIWYG));
+    }
+
+    @Test
+    void sessionIsActiveDifferentLocale()
+    {
+        assertFalse(realtimeEditorManager.sessionIsActive(null, Locale.GERMAN, WIKI));
+    }
+
+    @Test
+    void sessionIsActiveWysiwygAndInplace()
+    {
+        path = Arrays.asList(EN, CONTENT, WYSIWYG);
+        channel = new EntityChannel(null, path, "");
+        channel.setUserCount(1);
+        List<EntityChannel> channels = Arrays.asList(channel);
+        when(entityChannelStore.getChannels(Mockito.any())).thenReturn(channels);
+        assertTrue(realtimeEditorManager.sessionIsActive(null, Locale.ENGLISH, "inplace"));
+    }
+
+    @Test
+    void sessionIsActiveEmptyPath()
+    {
+        path = Arrays.asList();
+        channel = new EntityChannel(null, path, "");
+        channel.setUserCount(1);
+        List<EntityChannel> channels = Arrays.asList(channel);
+        when(entityChannelStore.getChannels(Mockito.any())).thenReturn(channels);
+        assertFalse(realtimeEditorManager.sessionIsActive(null, Locale.ENGLISH, WIKI));
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-api/src/test/java/org/xwiki/realtime/internal/XWikiRealtimeDocumentLockEditConfirmationCheckerTest.java
+++ b/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-api/src/test/java/org/xwiki/realtime/internal/XWikiRealtimeDocumentLockEditConfirmationCheckerTest.java
@@ -1,0 +1,112 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.xwiki.realtime.internal;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Locale;
+import java.util.Optional;
+
+import javax.inject.Provider;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.validation.edit.EditConfirmationCheckerResult;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.doc.XWikiDocument;
+
+@ComponentTest
+class XWikiRealtimeDocumentLockEditConfirmationCheckerTest
+{
+
+    private static final String WYSIWYG = "wysiwyg";
+
+    // We use the Spy decorator on the class to test because we need to mock the
+    // super call.
+    @Spy
+    @InjectMockComponents
+    private XWikiRealtimeDocumentLockEditConfirmationChecker xwikiRealtimeDocumentLockEditConfirmationChecker;
+
+    @MockComponent
+    private RealtimeEditorManager realtimeEditorManager;
+
+    @MockComponent
+    private Provider<XWikiContext> xwikiContextProvider;
+
+    @Mock
+    private XWikiContext xwikiContext;
+
+    @Mock
+    private XWikiDocument document;
+
+    @Mock
+    private DocumentReference reference;
+
+    @Mock
+    private EditConfirmationCheckerResult editConfirmationCheckerResult;
+
+    @BeforeEach
+    void setup()
+    {
+        when(document.getRealLocale()).thenReturn(Locale.ENGLISH);
+        when(document.getDocumentReference()).thenReturn(reference);
+        when(xwikiContext.get("tdoc")).thenReturn(document);
+        when(xwikiContextProvider.get()).thenReturn(xwikiContext);
+ 
+        // We consider the active session case the default, but we test both.
+        when(realtimeEditorManager.getSelectedEditor()).thenReturn(WYSIWYG);
+        when(realtimeEditorManager.sessionIsActive(reference, Locale.ENGLISH, WYSIWYG)).thenReturn(true);
+        
+        // Provide a dummy result for the super call.
+        doReturn(Optional.of(mock(EditConfirmationCheckerResult.class))).when(xwikiRealtimeDocumentLockEditConfirmationChecker).parentCheck();
+    }
+
+    @Test
+    void checkWhenActive()
+    {
+        assertTrue(xwikiRealtimeDocumentLockEditConfirmationChecker.check().isEmpty());
+        // When the session is active, we should override the behavior of the parent class.
+        // Thus the parent check should *not* be called.
+        verify(xwikiRealtimeDocumentLockEditConfirmationChecker, times(0)).parentCheck();
+    }
+
+    @Test
+    void checkWhenInactive()
+    {
+        when(realtimeEditorManager.sessionIsActive(reference, Locale.ENGLISH, WYSIWYG)).thenReturn(false);
+        assertTrue(xwikiRealtimeDocumentLockEditConfirmationChecker.check().isPresent());
+        // When the session is not active, we should use the behavior of the parent class.
+        // The parent check should be called.
+        verify(xwikiRealtimeDocumentLockEditConfirmationChecker, times(1)).parentCheck();
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-ui/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-ui/pom.xml
@@ -60,6 +60,13 @@
       <version>${project.version}</version>
       <scope>runtime</scope>
     </dependency>
+    <!-- Override the Locked page warning. -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>xwiki-platform-realtime-api</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
     <!-- JavaScript dependencies -->
     <dependency>
       <groupId>org.webjars</groupId>

--- a/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wysiwyg/xwiki-platform-realtime-wysiwyg-test/xwiki-platform-realtime-wysiwyg-test-docker/src/test/it/org/xwiki/realtime/wysiwyg/test/ui/AllIT.java
+++ b/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wysiwyg/xwiki-platform-realtime-wysiwyg-test/xwiki-platform-realtime-wysiwyg-test-docker/src/test/it/org/xwiki/realtime/wysiwyg/test/ui/AllIT.java
@@ -60,4 +60,10 @@ class AllIT
     class NestedRealtimeWYSIWYGEditorIT extends RealtimeWYSIWYGEditorIT
     {
     }
+    
+    @Nested
+    @DisplayName("Realtime Multi-User WYSIWYG Editor Tests")
+    class NestedRealtimeWYSIWYGMultiUserIT extends RealtimeWYSIWYGMultiUserIT
+    {
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wysiwyg/xwiki-platform-realtime-wysiwyg-test/xwiki-platform-realtime-wysiwyg-test-docker/src/test/it/org/xwiki/realtime/wysiwyg/test/ui/RealtimeWYSIWYGMultiUserIT.java
+++ b/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wysiwyg/xwiki-platform-realtime-wysiwyg-test/xwiki-platform-realtime-wysiwyg-test-docker/src/test/it/org/xwiki/realtime/wysiwyg/test/ui/RealtimeWYSIWYGMultiUserIT.java
@@ -1,0 +1,166 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.realtime.wysiwyg.test.ui;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.WindowType;
+import org.xwiki.realtime.wysiwyg.test.po.RealtimeCKEditor;
+import org.xwiki.realtime.wysiwyg.test.po.RealtimeRichTextAreaElement;
+import org.xwiki.realtime.wysiwyg.test.po.RealtimeWYSIWYGEditPage;
+import org.xwiki.test.docker.junit5.TestReference;
+import org.xwiki.test.docker.junit5.UITest;
+import org.xwiki.test.ui.TestUtils;
+
+/**
+ * Multi User functional tests for the Realtime WYSIWYG Editor.
+ * 
+ * @version $Id$
+ * @since 15.10.11
+ * @since 16.4.1
+ * @since 16.5.0RC1
+ */
+@UITest(properties = {"xwikiDbHbmCommonExtraMappings=notification-filter-preferences.hbm.xml",}, extraJARs = {
+    // The WebSocket end-point implementation based on XWiki components needs to be installed as core extension.
+    "org.xwiki.platform:xwiki-platform-websocket",
+
+    // It's currently not possible to install a JAR contributing a Hibernate mapping file as an Extension. Thus
+    // we need to provide the JAR inside WEB-INF/lib. See https://jira.xwiki.org/browse/XWIKI-8271
+    "org.xwiki.platform:xwiki-platform-notifications-filters-default",})
+class RealtimeWYSIWYGMultiUserIT extends AbstractRealtimeWYSIWYGEditorIT
+{
+    private static final String TEST_STRING = "Hello from Bob!";
+
+    // Note: There is currently no solution to have multiple browser sessions running at the same time with Selenium.
+    // The following tests take advantage of the fact that the user doesn't get disconnected of a realtime session
+    // when logging out on another tab.
+
+    @BeforeEach
+    void beforeEach(TestUtils setup, TestReference testReference)
+    {
+        // When working with different users during tests, there is a risk to end up logged in any account.
+        // We make sure that we are logged-in as alice when starting each test.
+        setup.createUserAndLogin("alice", "pass", "editor", "Wysiwyg");
+    }
+
+    @Test
+    @Order(1)
+    void noLockWarningSameEditor(TestUtils setup, TestReference testReference)
+    {
+        //
+        // First Tab
+        //
+
+        // We are already logged-in as alice, edit the page as alice, effectively locking it.
+        RealtimeWYSIWYGEditPage firstEditPage = RealtimeWYSIWYGEditPage.gotoPage(testReference);
+        RealtimeCKEditor firstEditor = firstEditPage.getContenEditor();
+        RealtimeRichTextAreaElement firstTextArea = firstEditor.getRichTextArea();
+
+        //
+        // Second Tab
+        //
+        setup.getDriver().switchTo().newWindow(WindowType.TAB).getWindowHandle();
+
+        // Log in as bob. This will log alice out but will not release the lock nor terminate her realtime session.
+        setup.createUserAndLogin("bob", "pass", "editor", "Wysiwyg");
+
+        // Edit the same page as bob, alice still has the lock, but because she is active in the realtime session
+        // no warning message should be handled.
+        RealtimeWYSIWYGEditPage secondEditPage = RealtimeWYSIWYGEditPage.gotoPage(testReference);
+
+        // If we get the editor, that means there was no warning.
+        RealtimeCKEditor secondEditor = secondEditPage.getContenEditor();
+
+        // Write some text to check that we joined the same session.
+        RealtimeRichTextAreaElement secondTextArea = secondEditor.getRichTextArea();
+        secondTextArea.sendKeys(TEST_STRING);
+
+        //
+        // First Tab
+        //
+
+        setup.getDriver().switchTo().window(firstTabHandle);
+        firstTextArea.waitUntilTextContains(TEST_STRING);
+
+    }
+
+    @Test
+    @Order(2)
+    void lockWarningSameEditor(TestUtils setup, TestReference testReference)
+    {
+        //
+        // First Tab
+        //
+
+        // We are already logged-in as alice, edit the page as alice, effectively locking it.
+        RealtimeWYSIWYGEditPage firstEditPage = RealtimeWYSIWYGEditPage.gotoPage(testReference);
+        firstEditPage.getContenEditor();
+
+        // Leaving the realtime session should not release the lock.
+        firstEditPage.leaveRealtimeEditing();
+
+        //
+        // Second Tab
+        //
+        setup.getDriver().switchTo().newWindow(WindowType.TAB).getWindowHandle();
+
+        // Log in as bob. This will log alice out but will not release the lock.
+        setup.createUserAndLogin("bob", "pass", "editor", "Wysiwyg");
+
+        // Edit the same page as bob, alice still has the lock, but because she is not active in the realtime session
+        // a warning message should appear.
+        setup.gotoPage(testReference, "edit", "editor=wysiwyg");
+
+        // Check that we did not get to the edit page.
+        assertFalse(setup.isInWYSIWYGEditMode());
+    }
+
+    @Test
+    @Order(3)
+    void lockWarningWysiwygAndWikiEditors(TestUtils setup, TestReference testReference)
+    {
+        //
+        // First Tab
+        //
+
+        // We are already logged-in as alice, edit the page as alice, effectively locking it.
+        RealtimeWYSIWYGEditPage firstEditPage = RealtimeWYSIWYGEditPage.gotoPage(testReference);
+        RealtimeCKEditor firstEditor = firstEditPage.getContenEditor();
+
+        //
+        // Second Tab
+        //
+        setup.getDriver().switchTo().newWindow(WindowType.TAB).getWindowHandle();
+
+        // Log in as bob. This will log alice out but will not release the lock nor terminate her realtime session.
+        setup.createUserAndLogin("bob", "pass", "editor", "Wysiwyg");
+
+        // Edit the same page as bob, alice still has the lock, but because she is using a different editor
+        // a warning message should appear.
+        setup.gotoPage(testReference, "edit", "editor=wiki");
+
+        // Check that we did not get to the edit page.
+        assertFalse(setup.isInWYSIWYGEditMode());
+    }
+
+}


### PR DESCRIPTION
# Jira URL
https://jira.xwiki.org/browse/XWIKI-21625

# Changes

## Description

This PR adds an EditConfirmationChecker to the Realtime extension, allowing it to bypass the default XWikiDocumentLockEditConfirmationChecker which handles reporting locked pages warning.
Locked pages won't generate a warning when edited if a realtime session is active.

This PR also include new tests for this bug, they are located in `xwiki-platform-realtime-wysiwyg-test-docker`.

# Executed Tests

`xwiki-platform-realtime-wysiwyg-test-docker` using `mvn clean install` in the project directory.
Results: 
```
[ERROR] Failures: 
[ERROR]   AllIT$NestedRealtimeWYSIWYGEditorIT>RealtimeWYSIWYGEditorIT.inplaceEditableMacro:362 expected: <my info message
one two three> but was: <my info two three message>
[ERROR] Errors: 
[ERROR]   AllIT$NestedRealtimeWYSIWYGEditorIT>RealtimeWYSIWYGEditorIT.editSameMacro:680 » NoSuchElement No value present
[INFO] 
[ERROR] Tests run: 14, Failures: 1, Errors: 1, Skipped: 0
```
The failures and errors seem unrelated to the changes brought by this PR.


`xwiki-platform-realtime-api` using `mvn clean verify` in the project directory.
Results:
```
Tests run: 14, Failures: 0, Errors: 0, Skipped: 0
```

# Expected merging strategy

* Prefers squash: No, there is a single commit.
* Backport on branches:
  * stable-16.4.x
  * stable-15.10.x
 
Note: Despite the changes mainly being in the `xwiki-platform-realtime` extension, this fix changes the behaviour of confirmation checks. `xwiki-platform-realtime` being bundled in the Standard Flavour, I believe it is better to double check that the changes do not risk breaking important use cases before merging.

Thanks,
Dorian.