### PR TITLE
XWIKI-22010: The rights buttons for Unregistered Users do not display anymore the value set after page refresh

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/rightsUI.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/rightsUI.vm
@@ -129,7 +129,7 @@ $xwiki.ssfx.use('js/xwiki/table/livetable.css', true)
     #end
   #end
 #end
-#set ($r = [])
+#set ($guestRights = [])
 #foreach ($i in [0..$maxlevel])
   #set ($value = 0)
   #if ($allowWins.contains($i))
@@ -145,7 +145,7 @@ $xwiki.ssfx.use('js/xwiki/table/livetable.css', true)
       #set ($value = 1)
     #end
   #end
-  #set ($discard = $r.add($value))
+  #set ($discard = $guestRights.add($value))
 #end
 
 <div id="xwikieditcontent">
@@ -323,11 +323,10 @@ $xwiki.ssfx.use('js/xwiki/table/livetable.css', true)
 
   function startup() {
     if (XWiki && XWiki.widgets && XWiki.widgets.LiveTable) {
-
-    #if ($isWorkspace)
-      window.groupScopeIndex = 0;
-      hideScopeForUsers() || Event.observe(window, 'load', hideScopeForUsers);
-    #end
+      #if ($isWorkspace)
+        window.groupScopeIndex = 0;
+        hideScopeForUsers() || Event.observe(window, 'load', hideScopeForUsers);
+      #end
 
       window.activeRights = [#foreach($i in [0..$maxlevel])#if ($currentAllowed[$i])"$levelsRights.get($i)",#end#end];
       window.saveUrl = "$saveUrl";
@@ -340,11 +339,11 @@ $xwiki.ssfx.use('js/xwiki/table/livetable.css', true)
       // the callback function is called from LiveTable with 3 arguments
       var callback = function(row, i, table, idx) { return displayUsersAndGroups(row, i, table, idx, "$!{services.csrf.getToken()}", targetDocument) };
       var ta = new XWiki.widgets.LiveTable("$url", "usersandgroupstable", callback, {"filtersNode": $('usersandgroupstable')});
-    #foreach($i in [0..$maxlevel])
-      #if ($currentAllowed[$i])
-        var chbx${i} = new MSCheckbox($("td${levelsRights.get($i)}"), "${levelsRights.get($i)}", window.saveUrl, "${r.get($i)}");
+      #foreach($i in [0..$maxlevel])
+        #if ($currentAllowed[$i])
+          var chbx${i} = new MSCheckbox($("td${levelsRights.get($i)}"), "${levelsRights.get($i)}", window.saveUrl, $guestRights.get($i));
+        #end
       #end
-    #end
       Event.observe(window, 'load', function() {
         if($('uorgg').checked && !$('unregistered').hasClassName('hidden')) {
           $('unregistered').addClassName('hidden');
@@ -352,13 +351,13 @@ $xwiki.ssfx.use('js/xwiki/table/livetable.css', true)
           $('unregistered').removeClassName('hidden');
         }
       });
-    #if("$!editor" == 'globaladmin' && $isStandardRights)
-      Event.observe($('authenticate_view'), 'click', setBooleanPropertyFromLiveCheckbox($('authenticate_view'), '$xwiki.getURL('XWiki.XWikiPreferences', 'save', "form_token=$!{services.csrf.getToken()}")', 'XWiki.XWikiPreferences', 0));
-      Event.observe($('authenticate_edit'), 'click', setBooleanPropertyFromLiveCheckbox($('authenticate_edit'), '$xwiki.getURL('XWiki.XWikiPreferences', 'save', "form_token=$!{services.csrf.getToken()}")', 'XWiki.XWikiPreferences', 0));
-    #end
-    #if($guest_comment_captcha_prop && $isStandardRights)
-      Event.observe($('guest_comment_requires_captcha'), 'click', setBooleanPropertyFromLiveCheckbox($('guest_comment_requires_captcha'), '$targetDocument.getURL('save', "form_token=$!{services.csrf.getToken()}")', 'XWiki.XWikiPreferences', 0));
-    #end
+      #if("$!editor" == 'globaladmin' && $isStandardRights)
+        Event.observe($('authenticate_view'), 'click', setBooleanPropertyFromLiveCheckbox($('authenticate_view'), '$xwiki.getURL('XWiki.XWikiPreferences', 'save', "form_token=$!{services.csrf.getToken()}")', 'XWiki.XWikiPreferences', 0));
+        Event.observe($('authenticate_edit'), 'click', setBooleanPropertyFromLiveCheckbox($('authenticate_edit'), '$xwiki.getURL('XWiki.XWikiPreferences', 'save', "form_token=$!{services.csrf.getToken()}")', 'XWiki.XWikiPreferences', 0));
+      #end
+      #if($guest_comment_captcha_prop && $isStandardRights)
+        Event.observe($('guest_comment_requires_captcha'), 'click', setBooleanPropertyFromLiveCheckbox($('guest_comment_requires_captcha'), '$targetDocument.getURL('save', "form_token=$!{services.csrf.getToken()}")', 'XWiki.XWikiPreferences', 0));
+      #end
       return true;
     }
     return false;

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/rightsUI.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/rightsUI.vm
@@ -342,7 +342,7 @@ $xwiki.ssfx.use('js/xwiki/table/livetable.css', true)
       var ta = new XWiki.widgets.LiveTable("$url", "usersandgroupstable", callback, {"filtersNode": $('usersandgroupstable')});
     #foreach($i in [0..$maxlevel])
       #if ($currentAllowed[$i])
-        var chbx${i} = new MSCheckbox($("td${levelsRights.get($i)}"), "${levelsRights.get($i)}", window.saveUrl, "${r.get($i)}");
+        var chbx${i} = new MSCheckbox($("td${levelsRights.get($i)}"), "${levelsRights.get($i)}", window.saveUrl, $r.get($i));
       #end
     #end
       Event.observe(window, 'load', function() {

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/rightsUI.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/rightsUI.vm
@@ -129,7 +129,7 @@ $xwiki.ssfx.use('js/xwiki/table/livetable.css', true)
     #end
   #end
 #end
-#set ($guestRights = [])
+#set ($r = [])
 #foreach ($i in [0..$maxlevel])
   #set ($value = 0)
   #if ($allowWins.contains($i))
@@ -145,7 +145,7 @@ $xwiki.ssfx.use('js/xwiki/table/livetable.css', true)
       #set ($value = 1)
     #end
   #end
-  #set ($discard = $guestRights.add($value))
+  #set ($discard = $r.add($value))
 #end
 
 <div id="xwikieditcontent">
@@ -323,10 +323,11 @@ $xwiki.ssfx.use('js/xwiki/table/livetable.css', true)
 
   function startup() {
     if (XWiki && XWiki.widgets && XWiki.widgets.LiveTable) {
-      #if ($isWorkspace)
-        window.groupScopeIndex = 0;
-        hideScopeForUsers() || Event.observe(window, 'load', hideScopeForUsers);
-      #end
+
+    #if ($isWorkspace)
+      window.groupScopeIndex = 0;
+      hideScopeForUsers() || Event.observe(window, 'load', hideScopeForUsers);
+    #end
 
       window.activeRights = [#foreach($i in [0..$maxlevel])#if ($currentAllowed[$i])"$levelsRights.get($i)",#end#end];
       window.saveUrl = "$saveUrl";
@@ -339,11 +340,11 @@ $xwiki.ssfx.use('js/xwiki/table/livetable.css', true)
       // the callback function is called from LiveTable with 3 arguments
       var callback = function(row, i, table, idx) { return displayUsersAndGroups(row, i, table, idx, "$!{services.csrf.getToken()}", targetDocument) };
       var ta = new XWiki.widgets.LiveTable("$url", "usersandgroupstable", callback, {"filtersNode": $('usersandgroupstable')});
-      #foreach($i in [0..$maxlevel])
-        #if ($currentAllowed[$i])
-          var chbx${i} = new MSCheckbox($("td${levelsRights.get($i)}"), "${levelsRights.get($i)}", window.saveUrl, $guestRights.get($i));
-        #end
+    #foreach($i in [0..$maxlevel])
+      #if ($currentAllowed[$i])
+        var chbx${i} = new MSCheckbox($("td${levelsRights.get($i)}"), "${levelsRights.get($i)}", window.saveUrl, "${r.get($i)}");
       #end
+    #end
       Event.observe(window, 'load', function() {
         if($('uorgg').checked && !$('unregistered').hasClassName('hidden')) {
           $('unregistered').addClassName('hidden');
@@ -351,13 +352,13 @@ $xwiki.ssfx.use('js/xwiki/table/livetable.css', true)
           $('unregistered').removeClassName('hidden');
         }
       });
-      #if("$!editor" == 'globaladmin' && $isStandardRights)
-        Event.observe($('authenticate_view'), 'click', setBooleanPropertyFromLiveCheckbox($('authenticate_view'), '$xwiki.getURL('XWiki.XWikiPreferences', 'save', "form_token=$!{services.csrf.getToken()}")', 'XWiki.XWikiPreferences', 0));
-        Event.observe($('authenticate_edit'), 'click', setBooleanPropertyFromLiveCheckbox($('authenticate_edit'), '$xwiki.getURL('XWiki.XWikiPreferences', 'save', "form_token=$!{services.csrf.getToken()}")', 'XWiki.XWikiPreferences', 0));
-      #end
-      #if($guest_comment_captcha_prop && $isStandardRights)
-        Event.observe($('guest_comment_requires_captcha'), 'click', setBooleanPropertyFromLiveCheckbox($('guest_comment_requires_captcha'), '$targetDocument.getURL('save', "form_token=$!{services.csrf.getToken()}")', 'XWiki.XWikiPreferences', 0));
-      #end
+    #if("$!editor" == 'globaladmin' && $isStandardRights)
+      Event.observe($('authenticate_view'), 'click', setBooleanPropertyFromLiveCheckbox($('authenticate_view'), '$xwiki.getURL('XWiki.XWikiPreferences', 'save', "form_token=$!{services.csrf.getToken()}")', 'XWiki.XWikiPreferences', 0));
+      Event.observe($('authenticate_edit'), 'click', setBooleanPropertyFromLiveCheckbox($('authenticate_edit'), '$xwiki.getURL('XWiki.XWikiPreferences', 'save', "form_token=$!{services.csrf.getToken()}")', 'XWiki.XWikiPreferences', 0));
+    #end
+    #if($guest_comment_captcha_prop && $isStandardRights)
+      Event.observe($('guest_comment_requires_captcha'), 'click', setBooleanPropertyFromLiveCheckbox($('guest_comment_requires_captcha'), '$targetDocument.getURL('save', "form_token=$!{services.csrf.getToken()}")', 'XWiki.XWikiPreferences', 0));
+    #end
       return true;
     }
     return false;


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22010

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Renamed the r variable to a more explicit name : guestRights
* Replaced the string value when calling MSCheckbox for guest users with an int value, like it is done for any other user
* Indented blocks with a wrong indentation

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

This regression is caused because the MSCheckbox instantiation is done with a state of "1" (string) instead of 1 (int) for unregistered users.
This is inconsistent with the regular user/group MSCheckbox instantiation that used a numeric value. Beforehand it passed successfully because we used it as a list index. Now the check on the value doesn't pass and it's initialized with the default state : none.

___

I could think of 2 solutions:
1. Fix the state selector to accept int and string as a state.
2. Fix the MSCheckbox call to provide only ints for the state.

2. could be considered as leaving a breaking change in. However the MSCheckbox class is [documented nowhere](https://www.xwiki.org/xwiki/bin/view/Main/Search?text=MSCheckbox&f_type=DOCUMENT&f_locale=en&f_locale=&r=1). Because of that I suppose it's not part of our public API, so as long as we fix all internal uses, it's okay to update it.

I'd rather keep variable's type consistent here, so I'll go with 2.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

https://github.com/xwiki/xwiki-platform/assets/28761965/7a35502b-79e2-4890-97ce-a469b01e862e

We can see on this video that unlike before, the state of the unregistered user checkboxes are correctly initialized after a refresh.
# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Only manual tests, see demo above. No automatic tests were broken by this regression so I suppose fixing it does not break anything. Most of the changes in this PR are codestyle only.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * No backport (same as https://github.com/xwiki/xwiki-platform/pull/2649)