### PR TITLE
XWIKI-13915: $xwiki.getConfiguredSyntaxes() not equals to $services.rendering.getConfiguredSyntaxes()

### DIFF
--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/XWikiCompatibilityAspect.aj
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/XWikiCompatibilityAspect.aj
@@ -30,6 +30,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.net.InetAddress;
 import java.lang.reflect.Method;
 import java.lang.reflect.InvocationTargetException;
@@ -1397,9 +1398,10 @@ public privileged aspect XWikiCompatibilityAspect
         if (this.configuredSyntaxes == null) {
             ExtendedRenderingConfiguration extendedRenderingConfiguration =
                 Utils.getComponent(ExtendedRenderingConfiguration.class);
-            String syntaxes = getConfiguration().getProperty("xwiki.rendering.syntaxes",
-                extendedRenderingConfiguration.getDefaultContentSyntax().toIdString());
-            this.configuredSyntaxes = Arrays.asList(StringUtils.split(syntaxes, " ,"));
+            this.configuredSyntaxes = extendedRenderingConfiguration.getConfiguredSyntaxes()
+              .stream()
+              .map(Syntax::toIdString)
+              .collect(Collectors.toList());
         }
         return this.configuredSyntaxes;
     }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-13915

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

 * Change implementation of legacy XWiki#getConfiguredSyntaxes to rely on ExtendedRenderingConfiguration#getConfiguredSyntaxes

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Ran `mvn clean install -Pquality` on `xwiki-platform-legacy-oldcore`

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None