### PR TITLE
Misc: Accessibility rules update

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/WCAGContext.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/WCAGContext.java
@@ -96,12 +96,9 @@ public class WCAGContext
             entry("definition-list", true),
             entry("dlitem", true),
             entry("document-title", true),
-            // Set to true once the build doesn't fail this rule anymore
-            entry("duplicate-id-active", false),
-            // Set to true once the build doesn't fail this rule anymore
-            entry("duplicate-id-aria", false),
-            // Set to true once the build doesn't fail this rule anymore
-            entry("duplicate-id", false),
+            entry("duplicate-id-active", true),
+            entry("duplicate-id-aria", true),
+            entry("duplicate-id", true),
             entry("form-field-multiple-labels", true),
             entry("frame-focusable-content", true),
             entry("frame-title-unique", true),


### PR DESCRIPTION
Changes to the status of the WCAG rules that are currently not violated. From this point on, all rules set to true will make the build fail when they are violated. The build will only fail on an accessibility regression. See the [XWiki WCAG testing page](https://dev.xwiki.org/xwiki/bin/view/Community/Testing/WCAGTesting#HTesting) for more details about the consequences of these changes.

As of https://ci.xwiki.org/job/XWiki%20Environment%20Tests/job/xwiki-platform/job/master/506/, there are only a few rules that fail through tests:
- aria-allowed-attr 1 violation
- label 76 violations
- image-alt 1 violation
- link-in-text-block 409 violations
- select-name 2 violations
- color-contrast 2 violations
- scrollable-region-focusable 1 violation

Total violations: 492

* duplicate-id fixed
* duplicate-id-active fixed
* duplicate-id-aria fixed


There are no additional failing types in [environment test master build #506](https://ci.xwiki.org/job/XWiki%20Environment%20Tests/job/xwiki-platform/job/master/506/)

|  | Count of warning rules | Count of failing rules |
| ------------- | ------------- | ------------- |
| Before this PR | 10 | 51 |
| After this PR | 7 | 54 |

This is a continuation of the process started in https://github.com/xwiki/xwiki-platform/pull/2152, last step before this one was https://github.com/xwiki/xwiki-platform/pull/2444.

---
As most of those of these errors now only have a couple violations, we can list them with their jira tickets and status at the time of writing this:

- aria-allowed-attr 1 violation https://jira.xwiki.org/browse/XWIKI-21005
- label 76 violations https://jira.xwiki.org/browse/XWIKI-20996 started to look for a solution, not a priority since it's a quite advanced UC, WIP
- image-alt 1 violation https://jira.xwiki.org/browse/XWIKI-22041looks like a dev issue only
- link-in-text-block 409 violations https://jira.xwiki.org/browse/XWIKI-21492 In the roadmap, should be merged soon
- select-name 2 violations https://jira.xwiki.org/browse/XWIKI-22040 Just found out about it, somehow it didn't get reported before...
- color-contrast 2 violations https://jira.xwiki.org/browse/XWIKI-21584 not in the roadmap, but should be merged soon (16.3 or 16.4) && https://jira.xwiki.org/browse/XWIKI-21387 not worked on yet
- scrollable-region-focusable 1 violation https://jira.xwiki.org/browse/XWIKI-20909 blocked, shoudl be fixed on the browser side soon, waiting for Chrome