### PR TITLE
XWIKI-22040: Select tour step order has no name

### DIFF
--- a/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui/src/main/resources/TourCode/StepSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui/src/main/resources/TourCode/StepSheet.xml
@@ -73,7 +73,7 @@
   #foreach($prop in $class.properties)
     #if($prop.getName().equals('order'))
       &lt;dl&gt;
-        &lt;dt&gt;&lt;label&gt;$services.localization.render("${class.name}_${prop.name}")&lt;/label&gt;&lt;/dt&gt;
+        &lt;dt&gt;&lt;label for="stepOrderSelect"&gt;$services.localization.render("${class.name}_${prop.name}")&lt;/label&gt;&lt;/dt&gt;
         &lt;dd&gt;
           &lt;select id="stepOrderSelect"&gt;
             #if ($nbSteps &gt; 0)


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22040

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Paired the label with its select


# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
No visual changes

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Built change with `mvn clean install -f xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui`.
Afterward successfully ran `mvn clean install -f xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-test/ -Pdocker,quality,integration-tests -Dxwiki.test.ui.wcag=true`. There, no WCAG violation of the rule `select-name` were found.
[Here is the content of the resulting wcagWarnings.txt file](https://up1.xwikisas.com/#hvOiI7CpyJ1SyggMhiJyeA)
We can see that the violations for which this issue were reported are not here anymore.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.x , pretty safe changes with a limited scope and coverage tests ran successfully.