### PR TITLE
XWIKI-22041: Image pasted during tests has no alternative

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/ImageIT.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/ImageIT.java
@@ -830,7 +830,7 @@ class ImageIT extends AbstractCKEditorIT
         ViewPage savedPage = wysiwygEditPage.clickSaveAndView();
 
         // Verify that the content matches what we did using CKEditor.
-        assertEquals("a [[image:" + imageURL + "||height=\"100\" width=\"100\"]] b", savedPage.editWiki().getContent());
+        assertEquals("a [[image:" + imageURL + "||alt=\"Test alt\" height=\"100\" width=\"100\"]] b", savedPage.editWiki().getContent());
     }
 
     /**
@@ -846,7 +846,7 @@ class ImageIT extends AbstractCKEditorIT
         wikiEditPage.sendKeys("{{html clean='false'}}\n"
             + "<div contenteditable=\"true\" id=\"copyme\">\n"
             + "  <p>\n"
-            + "    a <img src=\"" + imageURL + "\" > b\n"
+            + "    a <img src=\"" + imageURL + "\" alt=\"Test alt\"> b\n"
             + "  </p>\n"
             + "</div>\n"
             + "{{/html}}");


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22041

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added an alt in the copied content

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The image-alt WCAG violation happened when the viewpage where we copy the image was opened (during test setup). I updated the HTML to add an alt, and updated the result to match this change. 
* Now the assertion will fail if the alt is not kept through the pasting+editing process.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
None, development issue only

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Passed `mvn clean install -f xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test -P docker,integration-tests,quality -Dxwiki.test.ui.wcag=true` successfully. In the wcagWarnings, there is no image-alt rule violation anymore.
With the more specific `mvn clean install -f xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test -P docker,integration-tests,quality -Dxwiki.test.ui.wcag=true -Dit.test=ImageIT#pasteAndEditExternalImage`, there is no WCAG violation reported at all anymore.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.x , development only change, low scope of impact and not dangerous.