### PR TITLE
XCOMMONS-2276: Upgrade to HtmlCleaner 2.29

### DIFF
--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-api/src/test/java/org/xwiki/attachment/MoveStatusPagesTest.java
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-api/src/test/java/org/xwiki/attachment/MoveStatusPagesTest.java
@@ -43,7 +43,6 @@ import org.xwiki.test.annotation.ComponentList;
 import org.xwiki.test.page.HTML50ComponentList;
 import org.xwiki.test.page.PageTest;
 import org.xwiki.test.page.XWikiSyntax21ComponentList;
-import org.xwiki.xml.internal.html.filter.ControlCharactersFilter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -63,7 +62,6 @@ import static org.xwiki.attachment.refactoring.MoveAttachmentRequest.DESTINATION
 @HTML50ComponentList
 @XWikiSyntax21ComponentList
 @ComponentList({
-    ControlCharactersFilter.class,
     TemplateScriptService.class
 })
 class MoveStatusPagesTest extends PageTest

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-api/src/test/java/org/xwiki/attachment/RefactoringMacrosPageTest.java
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-api/src/test/java/org/xwiki/attachment/RefactoringMacrosPageTest.java
@@ -36,7 +36,6 @@ import org.xwiki.test.annotation.ComponentList;
 import org.xwiki.test.page.HTML50ComponentList;
 import org.xwiki.test.page.PageTest;
 import org.xwiki.test.page.XWikiSyntax21ComponentList;
-import org.xwiki.xml.internal.html.filter.ControlCharactersFilter;
 
 import com.xpn.xwiki.doc.XWikiDocument;
 
@@ -54,7 +53,6 @@ import static org.mockito.Mockito.when;
 @HTML50ComponentList
 @XWikiSyntax21ComponentList
 @ComponentList({
-    ControlCharactersFilter.class,
     TemplateScriptService.class
 })
 class RefactoringMacrosPageTest extends PageTest

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/test/java/org/xwiki/attachment/AttachmentSelectorPageTest.java
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/test/java/org/xwiki/attachment/AttachmentSelectorPageTest.java
@@ -53,7 +53,6 @@ import org.xwiki.test.page.IconSetup;
 import org.xwiki.test.page.PageTest;
 import org.xwiki.test.page.TestNoScriptMacro;
 import org.xwiki.test.page.XWikiSyntax21ComponentList;
-import org.xwiki.xml.internal.html.filter.ControlCharactersFilter;
 
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiAttachment;
@@ -86,7 +85,6 @@ import static org.xwiki.test.page.WikiMacroSetup.loadWikiMacro;
 @IconManagerScriptServiceComponentList
 @WikiMacroFactoryComponentClass
 @ComponentList({
-    ControlCharactersFilter.class,
     ModelScriptService.class,
     TestNoScriptMacro.class,
     TemporaryAttachmentsScriptService.class,

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/test/java/org/xwiki/help/XWikiSyntaxMacrosListPageTest.java
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/test/java/org/xwiki/help/XWikiSyntaxMacrosListPageTest.java
@@ -50,7 +50,6 @@ import org.xwiki.test.annotation.ComponentList;
 import org.xwiki.test.page.HTML50ComponentList;
 import org.xwiki.test.page.PageTest;
 import org.xwiki.test.page.XWikiSyntax21ComponentList;
-import org.xwiki.xml.internal.html.filter.ControlCharactersFilter;
 
 import com.xpn.xwiki.DefaultSkinAccessBridge;
 import com.xpn.xwiki.doc.XWikiDocument;
@@ -75,7 +74,6 @@ import static org.xwiki.rendering.wikimacro.internal.WikiMacroConstants.WIKI_MAC
 @RenderingScriptServiceComponentList
 @DefaultRenderingConfigurationComponentList
 @ComponentList({
-    ControlCharactersFilter.class,
     // Start document initializer
     WikiMacroClassDocumentInitializer.class,
     DefaultContextStoreManager.class,

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/xwiki-platform-image-style-ui/src/test/java/org/xwiki/image/style/AdministrationPageTest.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/xwiki-platform-image-style-ui/src/test/java/org/xwiki/image/style/AdministrationPageTest.java
@@ -37,7 +37,6 @@ import org.xwiki.test.page.HTML50ComponentList;
 import org.xwiki.test.page.PageTest;
 import org.xwiki.test.page.XWikiSyntax21ComponentList;
 import org.xwiki.velocity.VelocityManager;
-import org.xwiki.xml.internal.html.filter.ControlCharactersFilter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
@@ -51,7 +50,6 @@ import static org.mockito.Mockito.when;
 @XWikiSyntax21ComponentList
 @HTML50ComponentList
 @ComponentList({
-    ControlCharactersFilter.class,
     ModelScriptService.class,
     TranslationMacro.class
 })

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/test/java/org/xwiki/panels/CreatePanelTest.java
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/test/java/org/xwiki/panels/CreatePanelTest.java
@@ -34,7 +34,6 @@ import org.xwiki.test.page.HTML50ComponentList;
 import org.xwiki.test.page.PageTest;
 import org.xwiki.test.page.XWikiSyntax21ComponentList;
 import org.xwiki.velocity.tools.EscapeTool;
-import org.xwiki.xml.internal.html.filter.ControlCharactersFilter;
 
 import com.xpn.xwiki.doc.XWikiDocument;
 
@@ -52,7 +51,6 @@ import static org.mockito.Mockito.when;
 @XWikiSyntax21ComponentList
 @HTML50ComponentList
 @ComponentList({
-    ControlCharactersFilter.class,
     ModelScriptService.class,
     // ModelValidationScriptService and its dependencies.
     ModelValidationScriptService.class,

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-ui/src/test/java/org/xwiki/ratings/RatingsTest.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-ui/src/test/java/org/xwiki/ratings/RatingsTest.java
@@ -28,11 +28,9 @@ import org.xwiki.model.script.ModelScriptService;
 import org.xwiki.ratings.script.RatingsScriptService;
 import org.xwiki.rendering.syntax.Syntax;
 import org.xwiki.script.service.ScriptService;
-import org.xwiki.test.annotation.ComponentList;
 import org.xwiki.test.page.HTML50ComponentList;
 import org.xwiki.test.page.PageTest;
 import org.xwiki.test.page.XWikiSyntax21ComponentList;
-import org.xwiki.xml.internal.html.filter.ControlCharactersFilter;
 
 import com.xpn.xwiki.doc.XWikiDocument;
 
@@ -51,9 +49,6 @@ import static org.mockito.Mockito.when;
  */
 @XWikiSyntax21ComponentList
 @HTML50ComponentList
-@ComponentList({
-    ControlCharactersFilter.class
-})
 class RatingsTest extends PageTest
 {
     @Test

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-ui/src/test/java/org/xwiki/refactoring/RefactoringConfigurationTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-ui/src/test/java/org/xwiki/refactoring/RefactoringConfigurationTest.java
@@ -22,12 +22,10 @@ package org.xwiki.refactoring;
 import org.junit.jupiter.api.Test;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.rendering.syntax.Syntax;
-import org.xwiki.test.annotation.ComponentList;
 import org.xwiki.test.junit5.mockito.MockComponent;
 import org.xwiki.test.page.HTML50ComponentList;
 import org.xwiki.test.page.PageTest;
 import org.xwiki.test.page.XWikiSyntax21ComponentList;
-import org.xwiki.xml.internal.html.filter.ControlCharactersFilter;
 
 import com.xpn.xwiki.internal.store.StoreConfiguration;
 
@@ -45,9 +43,6 @@ import static org.mockito.Mockito.when;
  */
 @XWikiSyntax21ComponentList
 @HTML50ComponentList
-@ComponentList({
-    ControlCharactersFilter.class
-})
 class RefactoringConfigurationTest extends PageTest
 {
     private static final DocumentReference REFACTORING_CONFIGURATION_REFERENCE =

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-mainwiki/src/test/java/org/xwiki/wiki/WikiManagerPageTest.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-mainwiki/src/test/java/org/xwiki/wiki/WikiManagerPageTest.java
@@ -35,7 +35,6 @@ import org.xwiki.test.annotation.ComponentList;
 import org.xwiki.test.page.HTML50ComponentList;
 import org.xwiki.test.page.PageTest;
 import org.xwiki.test.page.XWikiSyntax21ComponentList;
-import org.xwiki.xml.internal.html.filter.ControlCharactersFilter;
 
 import com.xpn.xwiki.plugin.skinx.SkinExtensionPluginApi;
 
@@ -57,7 +56,6 @@ import static org.mockito.Mockito.when;
 @HTML50ComponentList
 @LiveDataMacroComponentList
 @ComponentList({
-    ControlCharactersFilter.class,
     TemplateScriptService.class
 })
 class WikiManagerPageTest extends PageTest


### PR DESCRIPTION
 # Jira URL

https://jira.xwiki.org/browse/XCOMMONS-2276

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

 * Remove all usages of ControlCharacterFilter as it's been removed in xwiki-commons-xml as part of the upgrade

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* PR to be merged only after https://github.com/xwiki/xwiki-commons/pull/799 as it depends on it

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A