### PR TITLE
XWIKI-14032: The long names of submenus are showing out of the menu box (not wrapped) and the name of the submenus that use plain text and don't have other submenus don't have left margins

### DIFF
--- a/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
@@ -812,6 +812,8 @@ require(['jquery','xwiki-l10n!menu-ui-translation-keys'], function($, l10n) {
         margin-top: 0;
         border-top-right-radius: 0;
         border-top-left-radius: 0;
+        overflow-wrap: break-word;
+        hyphens: auto;
         li {
           /* Text inside menu */
           color: @dropdown-link-color;

--- a/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
@@ -817,16 +817,14 @@ require(['jquery','xwiki-l10n!menu-ui-translation-keys'], function($, l10n) {
         li {
           /* Text inside menu */
           color: @dropdown-link-color;
+          padding: 3px 20px;
           /* Links inside menu */
           a {
             display: block;
-            padding: 3px 20px;
             clear: both;
             font-weight: normal;
             line-height: @line-height-base;
             color: @dropdown-link-color;
-            overflow: hidden;
-            text-overflow: ellipsis; // Displaying ... if the text is too long
             &amp;:hover, &amp;:focus-within {
               /* &amp;:extend(.dropdown-menu&gt;li&gt;a:hover); */
               text-decoration: none;


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-14032

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added overflow wrap in words
* Added padding for all items
* Removed unused styles

## Clarifications
* Used the `hyphens` property to make sure the items are all properly hyphenated when the language needs it.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Those screenshots were taken on a default flavor on Firefox, with a custom menu content to highlight the different issues and fixes.
Before PR vvv
![14032-beforePR](https://github.com/xwiki/xwiki-platform/assets/28761965/711ea56f-2372-4f44-a44d-413824cb87e7)
After PR (added some non link non subcategory items to test a part of the ticket I forgot about at the start) vvv
![14032-afterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/960de3f2-11c2-4b9d-bfcb-aeae145880ff)

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Only manual, see screenshots above style changes only.
Also checked the default menu content, everything looks okay with the changes.
Also checked the menu used on https://www.xwiki.org, looks exactly the same with the changes applied locally.
# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.X, pretty safe to backport this bugfix IMO.