### PR TITLE
XWIKI-22036: Add hasNext check before call next.

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocumentArchive.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocumentArchive.java
@@ -263,6 +263,9 @@ public class XWikiDocumentArchive
             Collection nodes = archive.getNodes(getWikiReference(), getId());
             for (Iterator it = nodes.iterator(); it.hasNext();) {
                 XWikiRCSNodeInfo nodeInfo = (XWikiRCSNodeInfo) it.next();
+                if (!it.hasNext()) {
+                    throw new IllegalStateException("The number of nodes is an odd number.");
+                }
                 XWikiRCSNodeContent nodeContent = (XWikiRCSNodeContent) it.next();
                 updateNode(nodeInfo);
                 this.updatedNodeInfos.add(nodeInfo);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/query/HqlQueryUtils.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/query/HqlQueryUtils.java
@@ -304,6 +304,9 @@ public final class HqlQueryUtils
 
     private static String getTableName(Table table, Map<String, String> tables)
     {
+        if (tables.isEmpty()) {
+            return "";
+        }
         String tableName = tables.values().iterator().next();
 
         if (table != null && StringUtils.isNotEmpty(table.getFullyQualifiedName())) {


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-22036

# Changes

## Description

Add hasNext check before call next.

## Clarifications

Difficulty in determining the evenness of the variable 'nodes' and the non-emptiness of 'tables' based on the code.

# Expected merging strategy

* Prefers squash: Yes