### PR TITLE
XWIKI-18802: Display the whole breadcrumb of the pages in the notification email

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/notification/email/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/notification/email/macros.vm
@@ -97,7 +97,7 @@
   <div>
     <div style="background-color: #f5f5f5; color: #777777; padding: 4px 8px; border-radius: 7px; font-size: 8px;">
       #template('hierarchy_macros.vm')
-      #hierarchy($event.document, {'id': 'hierarchy', 'limit': 5, 'treeNavigation': false, 'plain': true})
+      #hierarchy($event.document, {'id': 'hierarchy', 'treeNavigation': false, 'plain': true})
     </div>
     #set ($document = $xwiki.getDocument($event.document))
     ## See `#displayNotificationEvent()` in `templates/notification/macros.vm` to understand why we don't use escape


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-18802
# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Removed the limit on the size of the breadcrumb displayed in the HTML notification mail.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Before the changes proposed in this PR:
![18802-beforePR](https://github.com/xwiki/xwiki-platform/assets/28761965/372354a8-35d1-4145-8efe-d3288a128ca0)
After the changes proposed in this PR:
![18802-afterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/2b7d4406-358e-4ddf-aae5-c69767f24350)

We can see here that the breadcrumb that had an ellipsis before is no longer ellipsed. Instead, it spans upon multiple lines.

(ignore the slight changes in color in between the two screenshots, they are caused by a change specific to my distribution, related to my work on https://github.com/xwiki/xwiki-platform/pull/3037)

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

It doesn't seem like this limit was covered in tests: https://github.com/search?q=repo%3Axwiki%2Fxwiki-platform+%22padding%3A+4px+8px%3B%22&type=code

Successfully passed `mvn clean install -f xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/ -Pquality,docker,integration-tests`.
# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.X , the one change has a very limited scope (only used in notification emails) and it looks pretty safe.