### PR TITLE
XWIKI-22037 AWM Display as hidden field should not be displayed

### DIFF
--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/Content.xml
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/Content.xml
@@ -37,21 +37,21 @@
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
   <content>{{velocity}}
+#set ($className = $object.getxWikiClass().name)
+#if ($doc.fullName == $className)
+  ## We are editing the class so the content must be read from / written to the template document.
+  #set ($name = 'templateContent')
+  #set ($document = $xwiki.getDocument("$stringtool.removeEnd($className, 'Class')Template"))
+  ## Don't load the WYSIWYG editor when editing the class, because it's too heavy.
+  #set ($useWysiwygEditor = false)
+#else
+  ## We are editing an application entry so the content must be read from / written to the current document.
+  #set ($name = 'content')
+  #set ($document = $tdoc)
+  ## Use the preferred content editor.
+  #set ($useWysiwygEditor = $xwiki.getUserPreference('editor') == 'Wysiwyg')
+#end
 #if ($type == 'edit')
-  #set ($className = $object.getxWikiClass().name)
-  #if ($doc.fullName == $className)
-    ## We are editing the class so the content must be read from / written to the template document.
-    #set ($name = 'templateContent')
-    #set ($editedDocument = $xwiki.getDocument("$stringtool.removeEnd($className, 'Class')Template"))
-    ## Don't load the WYSIWYG editor when editing the class, because it's too heavy.
-    #set ($useWysiwygEditor = false)
-  #else
-    ## We are editing an application entry so the content must be read from / written to the current document.
-    #set ($name = 'content')
-    #set ($editedDocument = $tdoc)
-    ## Use the preferred content editor.
-    #set ($useWysiwygEditor = $xwiki.getUserPreference('editor') == 'Wysiwyg')
-  #end
   {{html clean="false"}}
   ## The "content" id is expected by some JavaScript and CSS code.
   #set ($id = 'content')
@@ -61,20 +61,24 @@
       #set ($toolBar = "#template('simpleedittoolbar.vm')")
       $!toolBar.replace('{{', '&amp;#123;&amp;#123;')
       ## Display a simple textarea.
-      &lt;textarea id="$id" cols="80" rows="25" name="$name"&gt;$escapetool.xml($editedDocument.content)&lt;/textarea&gt;
+      &lt;textarea id="$id" cols="80" rows="25" name="$name"&gt;$escapetool.xml($document.content)&lt;/textarea&gt;
   #end
   #if ($useWysiwygEditor)
-    $!services.edit.syntaxContent.wysiwyg($editedDocument.content, $editedDocument.syntax, {
+    $!services.edit.syntaxContent.wysiwyg($document.content, $document.syntax, {
       'id': "$id",
       'name': "$name",
       'rows': 25,
       'cols': 80,
       'full': true,
-      'restricted': $editedDocument.isRestricted()
+      'restricted': $document.isRestricted()
     })
   #else
     &lt;/div&gt;
   #end
+  {{/html}}
+#elseif ($type == 'hidden')
+  {{html clean="false"}}
+    &lt;input type="hidden" id="$id" name="$name" value="$!escapetool.xml($document.content)"/>
   {{/html}}
 #elseif ("$!type" != '')
   ## Display the content of the current document without using any sheet. We can't use the include macro here (with the

--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/Title.xml
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/Title.xml
@@ -37,26 +37,30 @@
   <syntaxId>xwiki/2.1</syntaxId>
   <hidden>true</hidden>
   <content>{{velocity}}
-#if ($type == 'edit')
-  #set ($className = $object.getxWikiClass().name)
-  #if ($doc.fullName == $className)
-    ## We are editing the class so the title must be read from / written to the template document.
-    #set ($name = 'templateTitle')
-    #set ($value = $xwiki.getDocument("$stringtool.removeEnd($className, 'Class')Template").title)
-  #else
-    ## We are editing an application entry so the title must be read from / written to the current document.
-    #set ($name = 'title')
-    #set ($value = $tdoc.title)
-    #if ("$!value" == '')
-      #set ($value = $tdoc.documentReference.name)
-    #end
+#set ($className = $object.getxWikiClass().name)
+#if ($doc.fullName == $className)
+  ## We are editing the class so the title must be read from / written to the template document.
+  #set ($name = 'templateTitle')
+  #set ($value = $xwiki.getDocument("$stringtool.removeEnd($className, 'Class')Template").title)
+#else
+  ## We are editing an application entry so the title must be read from / written to the current document.
+  #set ($name = 'title')
+  #set ($value = $tdoc.title)
+  #if ("$!value" == '')
+    #set ($value = $tdoc.documentReference.name)
   #end
+#end
+#if ($type == 'edit')
   {{html clean="false"}}
   &lt;input type="text" name="$name" value="$!escapetool.xml($value)"
     ## The default value for an AppWithinMinutes field should be optional so we make only the actual page title
     ## mandatory and not the template title, which holds the default title value.
     #if ($name == 'title' &amp;&amp; $xwiki.getSpacePreference('xwiki.title.mandatory') == 1)required #end
     data-validation-value-missing="$escapetool.xml($services.localization.render('core.validation.required.message'))"/&gt;
+  {{/html}}
+#elseif ("$!type" == 'hidden')
+  {{html clean="false"}}
+  &lt;input type="hidden" name="$name" value="$!escapetool.xml($value)"/>
   {{/html}}
 #elseif ("$!type" != '')
   ## Render the title of the current document.


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-22037

# Changes

## Description

* Add support to hidden type in Content and Title custom display
* Factorise code between edit and hidden mode (by moving out of the `if`)

## Clarifications


# Executed Tests

It's mainly the same process than to reproduce the issue described here: https://jira.xwiki.org/browse/XWIKI-22037

Tested by creating a new App with AWM and edited the `title1` and `content1` field on the generated sheet to show as hidden. Than tested that theses field are correctly hidden.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * Ideally on 15.10.x