### PR TITLE
XWIKI-22024: Strange Behaviour With "/" Completion in Lists

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-filter/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-filter/plugin.js
@@ -261,7 +261,10 @@
           }
           return textNodes;
         };
-        var textNodesBefore = getSiblingTextNodes(node.getChild(offset - 1), 'getPrevious');
+        // When the direction is 'getPrevious', getSiblingTextNodes returns an array of DOM Nodes in reverse order.
+        // The maybeFixNonBreakingSpace method expects both arrays to be in the actual DOM order.
+        // This is why we need to reverse the textNodesBefore array.
+        var textNodesBefore = getSiblingTextNodes(node.getChild(offset - 1), 'getPrevious').reverse();
         var textNodesAfter = getSiblingTextNodes(node.getChild(offset), 'getNext');
         return this.maybeFixNonBreakingSpace(textNodesBefore, textNodesAfter);
       } else if (node.type === CKEDITOR.NODE_TEXT) {

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/FilterIT.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/FilterIT.java
@@ -23,9 +23,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Keys;
 import org.xwiki.test.docker.junit5.TestReference;
 import org.xwiki.test.docker.junit5.UITest;
 import org.xwiki.test.ui.TestUtils;
+import org.xwiki.text.StringUtils;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -87,5 +89,26 @@ class FilterIT extends AbstractCKEditorIT
         this.textArea.sendKeys(" end");
         // Verify that the origial style content is preserved.
         assertSourceContains(source.toString() + " end");
+    }
+
+    @Test
+    @Order(2)
+    void listUnbreakableSpaceMerge()
+    {
+        // See https://jira.xwiki.org/browse/XWIKI-22024.
+        this.editor.getToolBar().clickNumberedList();
+
+        // Write the triggering text: any text between round brackets, followed by more text, a space and more text
+        // again.
+        this.textArea.sendKeys("(test)s test");
+
+        // Move to inside the round brackets and change the content inside the bracket.
+        this.textArea.sendKeys(StringUtils.repeat(Keys.ARROW_LEFT.toString(), 7));
+        this.textArea.sendKeys(Keys.BACK_SPACE);
+
+        // Move back to after the round brackets and erase the text right after the closing bracket.
+        this.textArea.sendKeys(Keys.ARROW_RIGHT, Keys.ARROW_RIGHT, Keys.BACK_SPACE);
+
+        this.assertSourceEquals("1. (tes) test");
     }
 }


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-22024

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Fix a bug where erasing text using backspace would add more text in a list item.
* Add a Functional test for said bug.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* See attachments to the Jira issue: The bug seems to happen on chrome and not on firefox because the two browsers split the text nodes differently. On Firefox, after entering the reported triggering text, there is one text node before the caret, and one text node after the caret. Hence the order of the text nodes before the caret has no incidence. On Chrome, there are multiple text nodes before the caret. They get inserted in the wrong order, on the wrong text node.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

* `mvn clean install -Dxwiki.test.ui.browser=chrome` in `xwiki-platform/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-tests/xwiki-platform-ckeditor-tests-docker`.
* `mvn clean install` in `xwiki-platform/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-tests/xwiki-platform-ckeditor-tests-docker`.

# Expected merging strategy

* Prefers squash: No, there is only one commit.
* Backport on branches:
  * stable-14.10.x
    * The structure of xwiki-platform-ckeditor-plugins is different in that branch, pay attention when backporting.
    * The structure of xwiki-platform-ckeditor-test-docker is different in that branch, the new test needs to be adapted. Tell me if I should open an other PR for this backport.
  * stable-15.10.x
  * master
 
Thanks,
Dorian.