### PR TITLE
XWIKI-22073: Image specific syntax with data-widget causes CKEditor to freeze

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-filter/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-filter/plugin.js
@@ -40,35 +40,15 @@
     __namespace: true
   };
 
-  /**
-   * Remove data-widget attributes on image as they can lead to CKEditor crashing.
-   * @param event a toHtml event
-   */
-  function cleanupImages(event) {
-    const domParser = new DOMParser();
-    let html = event.data.dataValue;
-    // Depending on the editor type (inline or iframe-based) and configuration (fullPage true or false) the HTML
-    // string can be a full HTML document or just a fragment (e.g. the content of the BODY tag).
-    const isFragment = !html.trimEnd().endsWith('</html>');
-    try {
-      const doc = domParser.parseFromString(html, 'text/html');
-      // We want to modify the input HTML string only if there is a style tag that need escaping.
-      let modified = false;
-      doc.querySelectorAll('img').forEach(img => {
-        const dataWidgetAttribute = 'data-widget';
-        const hasDataWidget = img.hasAttribute(dataWidgetAttribute);
-        if(hasDataWidget) {
-          img.removeAttribute(dataWidgetAttribute);
-        }
-        modified = modified || hasDataWidget;
-      });
-      if (modified) {
-        event.data.dataValue = isFragment ? doc.body.innerHTML : doc.documentElement.outerHTML;
+  const removeDataWidgetAttributeFromImage = {
+    elements: {
+      img: function (element) {
+        console.log('removeDataWidgetAttributeFromImage', element);
+        delete element.attributes['data-widget'];
+        return element;
       }
-    } catch (e) {
-      console.warn('Failed to cleanup the image attributes from the given HTML string: ' + html, e);
     }
-  }
+  };
 
   CKEDITOR.plugins.add('xwiki-filter', {
     init: function(editor) {
@@ -180,6 +160,7 @@
       // Filter the editor input.
       var dataFilter = editor.dataProcessor && editor.dataProcessor.dataFilter;
       if (dataFilter) {
+        dataFilter.addRules(removeDataWidgetAttributeFromImage, {priority: 5});
         dataFilter.addRules(replaceEmptyLinesWithEmptyParagraphs, {priority: 5});
         if (editor.config.loadJavaScriptSkinExtensions) {
           dataFilter.addRules(unprotectAllowedScripts, {priority: 5});
@@ -197,7 +178,6 @@
       // parser is called in both cases. Priority 1 is needed to ensure our listener is called before the HTML parser
       // (which has priority 5).
       editor.on('toHtml', escapeStyleContent, null, null, 1);
-      editor.on('toHtml', cleanupImages, null, null, 1);
       editor.on('toDataFormat', escapeStyleContent, null, null, 1);
 
       // Transform <font color="..." face="..."> into <span style="color: ...; font-family: ...">.

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/ImageIT.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/ImageIT.java
@@ -862,6 +862,20 @@ class ImageIT extends AbstractCKEditorIT
             + "1. Item 2 [[image:image.gif]]", savedPage.editWiki().getContent());
     }
 
+    @Test
+    @Order(20)
+    void editImageWithDataWidgetAttribute(TestUtils setup, TestReference testReference) throws Exception
+    {
+        setup.loginAsSuperAdmin();
+        ViewPage page = setup.createPage(testReference, "[[image:image.gif||data-widget='uploadimage']]");
+        WYSIWYGEditPage wysiwygEditPage = page.editWYSIWYG();
+        CKEditor editor = new CKEditor("content").waitToLoad();
+        // Make sure the image can be clicked as a proof that the editor did not crash.
+        editor.executeOnEditedContent(() -> setup.getDriver().findElement(By.cssSelector("img")).click());
+        ViewPage savedPage = wysiwygEditPage.clickSaveAndView();
+        assertEquals("[[image:image.gif]]", savedPage.editWiki().getContent());
+    }
+
     /**
      * Initialize a page with some content and an image. Then, copy its displayed content in the clipboard.
      *


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22073

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* introduce a  `toHtml` event handler removing `data-widget` attributes from images


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
mvn clean install \
  -Pquality,integration-tests,docker \
  -pl :xwiki-platform-ckeditor-plugins,:xwiki-platform-ckeditor-test-docker
```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-15.10.x
  * stable-14.10.x