### PR TITLE
XWIKI-22101: WatchListClass is not properly migrated for subwiki users

### DIFF
--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -138,7 +138,19 @@
 
                  Single justification example:
             -->
-            
+            <revapi.differences>
+              <justification>
+                This should have been internal or at least marked unstable. Also, this class was only moved.
+              </justification>
+              <criticality>allowed</criticality>
+              <differences>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.removed</code>
+                  <old>class org.xwiki.notifications.filters.migration.R160000000XWIKI17243DataMigration</old>
+                </item>
+              </differences>
+            </revapi.differences>
             
             
             

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/checkstyle/checkstyle-suppressions.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/checkstyle/checkstyle-suppressions.xml
@@ -27,6 +27,6 @@
 <suppressions>
   <suppress checks="FanOutComplexity" files="NotificationFilterPreferenceStore.java"/>
   <suppress checks="FanOutComplexity" files="R140401000XWIKI15460DataMigration.java"/>
-  <suppress checks="FanOutComplexity" files="R160000000XWIKI17243DataMigration.java"/>
+  <suppress checks="FanOutComplexity" files="R160300000XWIKI17243DataMigration.java"/>
   <suppress checks="FanOutComplexity" files="NotificationCustomFiltersLiveDataEntryStore.java"/>
 </suppressions>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/migration/R151002000XWIKI21448DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/migration/R151002000XWIKI21448DataMigration.java
@@ -43,6 +43,7 @@ import org.xwiki.query.Query;
 import org.xwiki.query.QueryException;
 import org.xwiki.query.QueryFilter;
 import org.xwiki.query.QueryManager;
+import org.xwiki.stability.Unstable;
 import org.xwiki.wiki.descriptor.WikiDescriptorManager;
 
 import com.xpn.xwiki.XWikiException;
@@ -60,6 +61,7 @@ import com.xpn.xwiki.store.migration.hibernate.AbstractHibernateDataMigration;
 @Component
 @Named("R151002000XWIKI21448")
 @Singleton
+@Unstable
 public class R151002000XWIKI21448DataMigration extends AbstractHibernateDataMigration
 {
     private static final int BATCH_SIZE = 100;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/migration/R160100000XWIKI21738DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/migration/R160100000XWIKI21738DataMigration.java
@@ -43,6 +43,7 @@ import org.xwiki.notifications.filters.internal.NotificationFilterPreferenceStor
 import org.xwiki.query.Query;
 import org.xwiki.query.QueryException;
 import org.xwiki.query.QueryManager;
+import org.xwiki.stability.Unstable;
 import org.xwiki.wiki.descriptor.WikiDescriptorManager;
 import org.xwiki.wiki.manager.WikiManagerException;
 
@@ -60,6 +61,7 @@ import com.xpn.xwiki.store.migration.hibernate.AbstractHibernateDataMigration;
 @Component
 @Named("R160100000XWIKI21738")
 @Singleton
+@Unstable
 public class R160100000XWIKI21738DataMigration extends AbstractHibernateDataMigration
 {
     private static final int BATCH_SIZE = 100;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/migration/R160300000XWIKI17243DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/migration/R160300000XWIKI17243DataMigration.java
@@ -133,7 +133,7 @@ public class R160300000XWIKI17243DataMigration extends AbstractHibernateDataMigr
     protected void hibernateMigrate() throws DataMigrationException, XWikiException
     {
         String statement = "from doc.object(XWiki.WatchListClass) as watchListDoc";
-        Long numberOfEntries = -1L;
+        long numberOfEntries;
         try {
             List<Long> countResult = this.queryManager
                 .createQuery(statement, Query.XWQL)

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/migration/R160300000XWIKI17243DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/migration/R160300000XWIKI17243DataMigration.java
@@ -49,6 +49,7 @@ import org.xwiki.query.Query;
 import org.xwiki.query.QueryException;
 import org.xwiki.query.QueryFilter;
 import org.xwiki.query.QueryManager;
+import org.xwiki.stability.Unstable;
 
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
@@ -70,12 +71,13 @@ import static org.apache.commons.codec.digest.DigestUtils.sha256Hex;
  * remove the xobjects but asks {@link WatchListObjectsRemovalTaskConsumer} to do it.
  *
  * @version $Id$
- * @since 16.0.0RC1
+ * @since 16.3.0RC1
  */
 @Component
-@Named("R160000000XWIKI17243")
+@Named("R160300000XWIKI17243")
 @Singleton
-public class R160000000XWIKI17243DataMigration extends AbstractHibernateDataMigration
+@Unstable
+public class R160300000XWIKI17243DataMigration extends AbstractHibernateDataMigration
 {
     private static final String WATCHLIST_CLASSNAME = "WatchListClass";
 
@@ -100,6 +102,10 @@ public class R160000000XWIKI17243DataMigration extends AbstractHibernateDataMigr
     private QueryFilter uniqueFilter;
 
     @Inject
+    @Named("count")
+    private QueryFilter countFilter;
+
+    @Inject
     private NotificationFilterPreferenceStore notificationFilterPreferenceStore;
 
     @Inject
@@ -120,33 +126,57 @@ public class R160000000XWIKI17243DataMigration extends AbstractHibernateDataMigr
     @Override
     public XWikiDBVersion getVersion()
     {
-        return new XWikiDBVersion(160000000);
+        return new XWikiDBVersion(160300000);
     }
 
     @Override
     protected void hibernateMigrate() throws DataMigrationException, XWikiException
     {
         String statement = "from doc.object(XWiki.WatchListClass) as watchListDoc";
-        int offset = 0;
-        List<String> results;
-        do {
-            try {
-                results = this.queryManager.createQuery(statement, Query.XWQL)
-                    .addFilter(uniqueFilter)
-                    .setOffset(offset)
-                    .setLimit(BATCH_SIZE).execute();
+        Long numberOfEntries = -1L;
+        try {
+            List<Long> countResult = this.queryManager
+                .createQuery(statement, Query.XWQL)
+                .addFilter(countFilter).execute();
+            numberOfEntries = countResult.get(0);
+        } catch (QueryException e) {
+            throw new DataMigrationException("Error while performing query to count users with WatchList objects",
+                e);
+        }
+        if (numberOfEntries > 0) {
+            WikiReference currentWiki = getXWikiContext().getWikiReference();
+            long loops = numberOfEntries / BATCH_SIZE;
+            this.logger.info(
+                "Found a total number of [{}] users with WatchListClass objects. Migration will operate [{}]"
+                    + " loops of [{}] entries.", numberOfEntries, loops, BATCH_SIZE);
 
-                this.logger.info("Found [{}] users with WatchListClass objects... migrating them.", results.size());
-                for (String result : results) {
-                    DocumentReference watchListDoc = this.documentReferenceResolver.resolve(result);
-                    this.migrateWatchListDoc(watchListDoc);
+            int loopIndex = 0;
+            int offset = 0;
+            List<String> results;
+            do {
+                try {
+                    results = this.queryManager.createQuery(statement, Query.XWQL)
+                        .addFilter(uniqueFilter)
+                        .setOffset(offset)
+                        .setLimit(BATCH_SIZE).execute();
+
+                    this.logger.info("(loop [{}] on [{}]) Migrating [{}] users with WatchListClass objects...",
+                        loopIndex, loops, results.size());
+                    for (String result : results) {
+                        DocumentReference watchListDoc = this.documentReferenceResolver.resolve(result, currentWiki);
+                        this.migrateWatchListDoc(watchListDoc);
+                    }
+                    offset += BATCH_SIZE;
+                } catch (QueryException e) {
+                    throw new DataMigrationException(
+                        "Error while performing query to find users with WatchList objects",
+                        e);
                 }
-                offset += BATCH_SIZE;
-            } catch (QueryException e) {
-                throw new DataMigrationException("Error while performing query to find users with WatchList objects",
-                    e);
-            }
-        } while (results.size() == BATCH_SIZE);
+                loopIndex++;
+            } while (results.size() == BATCH_SIZE);
+        } else {
+            this.logger.info("No users have been found with WatchListClass object. Migration skipped.");
+        }
     }
 
     private void migrateWatchListDoc(DocumentReference watchListDocReference)

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/migration/R160300000XWIKI17243DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/migration/R160300000XWIKI17243DataMigration.java
@@ -145,12 +145,15 @@ public class R160300000XWIKI17243DataMigration extends AbstractHibernateDataMigr
         }
         if (numberOfEntries > 0) {
             WikiReference currentWiki = getXWikiContext().getWikiReference();
-            long loops = numberOfEntries / BATCH_SIZE;
+            long loops = (numberOfEntries / BATCH_SIZE);
+            if (numberOfEntries % BATCH_SIZE > 0) {
+                loops += 1;
+            }
             this.logger.info(
                 "Found a total number of [{}] users with WatchListClass objects. Migration will operate [{}]"
                     + " loops of [{}] entries.", numberOfEntries, loops, BATCH_SIZE);
 
-            int loopIndex = 0;
+            int loopIndex = 1;
             int offset = 0;
             List<String> results;
             do {

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/migration/WatchListObjectsRemovalTaskConsumer.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/migration/WatchListObjectsRemovalTaskConsumer.java
@@ -43,7 +43,7 @@ import com.xpn.xwiki.objects.BaseObject;
 
 /**
  * Task for removing WatchListClass xobjects from page. This task should only be triggered when
- * {@link R160000000XWIKI17243DataMigration} has been done.
+ * {@link R160300000XWIKI17243DataMigration} has been done.
  * Note that this task might also create an autowatch xobject to get the new property if it's not defined, as we use
  * to fallback on the autowatch property defined in the WatchListClass xobject.
  *

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/resources/META-INF/components.txt
@@ -24,6 +24,6 @@ org.xwiki.notifications.filters.internal.WikiNotificationFilterDisplayerComponen
 org.xwiki.notifications.filters.internal.WikiNotificationFilterDisplayerDocumentInitializer
 org.xwiki.notifications.filters.migration.R140401000XWIKI15460DataMigration
 org.xwiki.notifications.filters.migration.R151002000XWIKI21448DataMigration
-org.xwiki.notifications.filters.migration.R160000000XWIKI17243DataMigration
+org.xwiki.notifications.filters.migration.R160300000XWIKI17243DataMigration
 org.xwiki.notifications.filters.migration.R160100000XWIKI21738DataMigration
 org.xwiki.notifications.filters.migration.WatchListObjectsRemovalTaskConsumer


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22101

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

  * Ensure to use proper WikiReference when resolving user document reference
  * Provide some more logs to perform migration of users
  * Move the migration so that it's executed in recent version of XS
  * Put forgotten unstable annotations on migrations

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

None

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A