### PR TITLE
Misc: Fix livedata sorting in docker tests

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-pageobjects/src/main/java/org/xwiki/livedata/test/po/TableLayoutElement.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-pageobjects/src/main/java/org/xwiki/livedata/test/po/TableLayoutElement.java
@@ -566,7 +566,7 @@ public class TableLayoutElement extends BaseElement
         int columnIndex = findColumnIndex(columnLabel);
 
         WebElement element = getRoot().findElement(By.cssSelector(String.format(".column-header-names > th:nth-child"
-            + "(%d) .sort-icon", columnIndex)));
+            + "(%d) .handle", columnIndex)));
         element.click();
 
         waitUntilReady();


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
None, development change only, related to https://jira.xwiki.org/browse/XWIKI-21009
This PR aims at fixing [this failure on CI](https://ci.xwiki.org/job/XWiki%20Environment%20Tests/job/xwiki-platform/job/master/525/testReport/junit/org.xwiki.platform.notifications.test.ui/AllIT$NestedNotificationsSettingsIT/PostgreSQL_16__Tomcat_9_jdk17__Chrome___Docker_tests_for_xwiki_platform_notifications___Build_for_PostgreSQL_16__Tomcat_9_jdk17__Chrome___Docker_tests_for_xwiki_platform_notifications___customFiltersAndLiveData_TestUtils_/). 

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Fixed the sorting function to focus the new event handler itself

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* I couldn't reproduce the CI fail locally unfortunately (matter of display size)... however the changes did not break tests so they should be correct.
* This does not pose an issue elsewhere because the clicked element was a child of the new sorting handler. The event propagated upwards and triggered the sort action properly. In the case of the failing test, using a test selector at this higher level allows to not fail when the icon is hidden for whatever reason.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
None, changes only on tests

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Successfully built 
* `mvn clean install -f xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-pageobjects`
* `mvn clean install -f xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker -Pdocker -Dit.test=NotificationsSettingsIT` (did not get a fail even without building the changes...)


# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, this fixes a fail that is only on the master branch.