### PR TITLE
XWIKI-22108: Extra empty paragraph and spacing in the information panel in edit mode

### DIFF
--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/IncludedPagesDocumentInformation.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/IncludedPagesDocumentInformation.xml
@@ -213,7 +213,7 @@
       &lt;dt&gt;$escapetool.html($services.localization.render('panels.documentInformation.includesCount', [$pages.size()]))&lt;/dt&gt;
       #foreach ($page in $pages)
         #set ($alt = $escapetool.xml($services.localization.render('panels.documentInformation.editIncluded', [$page])))
-        &lt;dd&gt;&lt;a href="$xwiki.getURL($page, 'view')"&gt;$escapetool.xml($page)&lt;/a&gt; &lt;a href="$xwiki.getURL($page, 'edit')"&gt;$services.icon.renderHTML('edit')&lt;span class="sr-only"&gt;$alt&lt;/span&gt;&lt;/a&gt;&lt;/dd&gt;
+        &lt;dd&gt;&lt;span class="wikilink"&gt;&lt;a href="$xwiki.getURL($page, 'view')"&gt;$escapetool.xml($page)&lt;/a&gt;&lt;/span&gt; &lt;span class="wikiinternallink"&gt;&lt;a href="$xwiki.getURL($page, 'edit')"&gt;$services.icon.renderHTML('edit')&lt;span class="sr-only"&gt;$alt&lt;/span&gt;&lt;/a&gt;&lt;/span&gt;&lt;/dd&gt;
       #end
     #end
   {{/html}}

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/IncludedPagesDocumentInformation.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/IncludedPagesDocumentInformation.xml
@@ -210,11 +210,11 @@
   {{html clean="false" wiki="true"}}
     #set ($pages = $tdoc.includedPages)
     #if($pages.size() != 0)
-      &lt;dt&gt;$services.localization.render('panels.documentInformation.includesCount', [$pages.size()])&lt;/dt&gt;
+      &lt;dt&gt;$escapetool.html($services.localization.render('panels.documentInformation.includesCount', [$pages.size()]))&lt;/dt&gt;
       #foreach ($page in $pages)
-        #set ($pageLink = $services.rendering.escape($page, 'xwiki/2.1'))
-        #set ($pageName = $services.rendering.escape($services.rendering.escape($page, 'xwiki/2.1'), 'xwiki/2.1'))
-        #set ($alt = $services.rendering.escape($services.localization.render('panels.documentInformation.editIncluded', [$page]), 'xwiki/2.1'))
+        #set ($pageLink = $escapetool.html($services.rendering.escape($page, 'xwiki/2.1')))
+        #set ($pageName = $services.rendering.escape($pageLink, 'xwiki/2.1'))
+        #set ($alt = $escapetool.html($services.rendering.escape($services.localization.render('panels.documentInformation.editIncluded', [$page]), 'xwiki/2.1')))
         &lt;dd&gt;[[$pageName&gt;&gt;$pageLink]] [[[[image:icon:page_white_edit||alt="$alt"]]&gt;&gt;path:$xwiki.getURL($page, 'edit')]]&lt;/dd&gt;
       #end
     #end

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/IncludedPagesDocumentInformation.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/IncludedPagesDocumentInformation.xml
@@ -207,15 +207,14 @@
     <property>
       <content>{{velocity}}
 ##--------------------------------------------------------------------------
-  {{html clean="false" wiki="true"}}
+  {{html clean="false"}}
     #set ($pages = $tdoc.includedPages)
     #if($pages.size() != 0)
       &lt;dt&gt;$escapetool.html($services.localization.render('panels.documentInformation.includesCount', [$pages.size()]))&lt;/dt&gt;
       #foreach ($page in $pages)
-        #set ($pageLink = $escapetool.html($services.rendering.escape($page, 'xwiki/2.1')))
-        #set ($pageName = $services.rendering.escape($pageLink, 'xwiki/2.1'))
-        #set ($alt = $escapetool.html($services.rendering.escape($services.localization.render('panels.documentInformation.editIncluded', [$page]), 'xwiki/2.1')))
-        &lt;dd&gt;[[$pageName&gt;&gt;$pageLink]] [[[[image:icon:page_white_edit||alt="$alt"]]&gt;&gt;path:$xwiki.getURL($page, 'edit')]]&lt;/dd&gt;
+        #set ($pageRef = $escapetool.html($page))
+        #set ($alt = $escapetool.html($services.localization.render('panels.documentInformation.editIncluded', [$page])))
+        &lt;dd&gt;&lt;a href="$xwiki.getURL($pageRef, 'view')"&gt;$pageRef&lt;/a&gt; &lt;a href="$xwiki.getURL($pageRef, 'edit')"&gt;$services.icon.renderHTML('edit')&lt;span class="sr-only"&gt;$alt&lt;/span&gt;&lt;/a&gt;&lt;/dd&gt;
       #end
     #end
   {{/html}}

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/IncludedPagesDocumentInformation.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/IncludedPagesDocumentInformation.xml
@@ -207,16 +207,18 @@
     <property>
       <content>{{velocity}}
 ##--------------------------------------------------------------------------
-#set ($pages = $tdoc.includedPages)
-#if($pages.size() != 0)
-  {{html clean="false"}}&lt;dt&gt;{{/html}}$services.localization.render('panels.documentInformation.includesCount', [$pages.size()]){{html clean="false"}}&lt;/dt&gt;{{/html}}
-  #foreach ($page in $pages)
-    #set ($pageLink = $services.rendering.escape($page, 'xwiki/2.1'))
-    #set ($pageName = $services.rendering.escape($services.rendering.escape($page, 'xwiki/2.1'), 'xwiki/2.1'))
-    #set ($alt = $services.rendering.escape($services.localization.render('panels.documentInformation.editIncluded', [$page]), 'xwiki/2.1'))
-    {{html clean="false"}}&lt;dd&gt;{{/html}}[[$pageName&gt;&gt;$pageLink]] [[[[image:icon:page_white_edit||alt="$alt"]]&gt;&gt;path:$xwiki.getURL($page, 'edit')]]{{html clean="false"}}&lt;/dd&gt;{{/html}}
-  #end
-#end
+  {{html clean="false" wiki="true"}}
+    #set ($pages = $tdoc.includedPages)
+    #if($pages.size() != 0)
+      &lt;dt&gt;$services.localization.render('panels.documentInformation.includesCount', [$pages.size()])&lt;/dt&gt;
+      #foreach ($page in $pages)
+        #set ($pageLink = $services.rendering.escape($page, 'xwiki/2.1'))
+        #set ($pageName = $services.rendering.escape($services.rendering.escape($page, 'xwiki/2.1'), 'xwiki/2.1'))
+        #set ($alt = $services.rendering.escape($services.localization.render('panels.documentInformation.editIncluded', [$page]), 'xwiki/2.1'))
+        &lt;dd&gt;[[$pageName&gt;&gt;$pageLink]] [[[[image:icon:page_white_edit||alt="$alt"]]&gt;&gt;path:$xwiki.getURL($page, 'edit')]]&lt;/dd&gt;
+      #end
+    #end
+  {{/html}}
 ##--------------------------------------------------------------------------
 {{/velocity}}</content>
     </property>

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/IncludedPagesDocumentInformation.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/IncludedPagesDocumentInformation.xml
@@ -212,9 +212,8 @@
     #if($pages.size() != 0)
       &lt;dt&gt;$escapetool.html($services.localization.render('panels.documentInformation.includesCount', [$pages.size()]))&lt;/dt&gt;
       #foreach ($page in $pages)
-        #set ($pageRef = $escapetool.html($page))
-        #set ($alt = $escapetool.html($services.localization.render('panels.documentInformation.editIncluded', [$page])))
-        &lt;dd&gt;&lt;a href="$xwiki.getURL($pageRef, 'view')"&gt;$pageRef&lt;/a&gt; &lt;a href="$xwiki.getURL($pageRef, 'edit')"&gt;$services.icon.renderHTML('edit')&lt;span class="sr-only"&gt;$alt&lt;/span&gt;&lt;/a&gt;&lt;/dd&gt;
+        #set ($alt = $escapetool.xml($services.localization.render('panels.documentInformation.editIncluded', [$page])))
+        &lt;dd&gt;&lt;a href="$xwiki.getURL($page, 'view')"&gt;$escapetool.xml($page)&lt;/a&gt; &lt;a href="$xwiki.getURL($page, 'edit')"&gt;$services.icon.renderHTML('edit')&lt;span class="sr-only"&gt;$alt&lt;/span&gt;&lt;/a&gt;&lt;/dd&gt;
       #end
     #end
   {{/html}}


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22108

Related to the failure https://ci.xwiki.org/job/XWiki%20Environment%20Tests/job/xwiki-platform/job/master/526/testReport/org.xwiki.flamingo.test.docker/AllIT/MySQL_8_3__Tomcat_9_jdk21__Chrome___Docker_tests_for_xwiki_platform_flamingo_skin___Build_for_MySQL_8_3__Tomcat_9_jdk21__Chrome___Docker_tests_for_xwiki_platform_flamingo_skin______/ on CI.
# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added `wiki="true"` to the html macro so that we can use it right under the velocity macro. Therefore all the velocity content is already encapsulated in some blocks (the ones created in the HTML macro ) and velocity does not need to wrap it up any more.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Before the PR:
![Before PR](https://github.com/xwiki/xwiki-platform/assets/28761965/2a994075-b8f8-4c14-b8e9-981f40eb7871)
After the PR:
![After PR](https://github.com/xwiki/xwiki-platform/assets/28761965/8e4b567d-9eb0-441a-a317-3b2e75141146)
We can see that unlike before the PR, the dt and dd are not wrapped in a div and siblings of empty `<p>`s.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests :ok_hand: 
Successfully built changes with `mvn clean install -f xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui -Pquality,integration-tests`. And successfully passed the test that failed on CI with `mvn clean install -f xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker -Pdocker -Dit.test=SectionEditIT#sectionEditInWikiEditorWhenSyntax2x -Dxwiki.test.ui.wcag=true`.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, cannot reproduce this change on the latest 15.10.X snapshot