### PR TITLE
XWIKI-21492: Underline inline links

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/htmlheader.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/htmlheader.vm
@@ -22,102 +22,102 @@
 ## elements.
 ## -------------------------------------------------------------------------------------------------------------------
 #if($isInServletMode)
-  ## TODO this should be more specific
-  #if("$!request.noDoctype" != "true")
-  <!DOCTYPE html>
+## TODO this should be more specific
+#if("$!request.noDoctype" != "true")
+<!DOCTYPE html>
+#end
+#macro(addMetaAttribute $metaAttributes $name $value)
+  #set ($discard = $metaAttributes.add("data-xwiki-${name}=""$escapetool.xml($value)"""))
+#end
+## ---------------------------------------------------------------------------------------------------------------
+## Compute all the meta attributes to add to the HTML tag.
+## ---------------------------------------------------------------------------------------------------------------
+#set ($metaAttributes = [])
+## Target the paper paged media by default when using the print feature provided by the web browser.
+#addMetaAttribute($metaAttributes, 'paged-media', 'paper')
+#if("$!doc" != "" && "$!tdoc" != "")
+  ## NOTE: you should not use these attributes in javascript directly, but via the 'xwiki-meta' module instead:
+  ## http://www.xwiki.org/xwiki/bin/view/Documentation/DevGuide/FrontendResources/JavaScriptAPI/#HGetsomeinformationaboutthecurrentdocument
+  #addMetaAttribute($metaAttributes, 'reference', $services.model.serialize($doc.documentReference, 'default'))
+  #addMetaAttribute($metaAttributes, 'document', $doc.fullName)##deprecated, use 'reference' instead
+  #addMetaAttribute($metaAttributes, 'wiki', $doc.wiki)##deprecated, use 'reference' instead
+  #addMetaAttribute($metaAttributes, 'space', $doc.space)##deprecated, use 'reference' instead
+  #addMetaAttribute($metaAttributes, 'page', $doc.documentReference.name)##deprecated, use 'reference' instead
+  #addMetaAttribute($metaAttributes, 'isnew', $tdoc.isNew())
+  ## If tdoc is a new document, its version when checking for conflict will be the original doc version.
+  ## This fix XWIKI-16299.
+  #if ($tdoc.isNew())
+    #set ($version = $doc.version)
+  #else
+    #set ($version = $tdoc.version)
   #end
-  #macro(addMetaAttribute $metaAttributes $name $value)
-    #set ($discard = $metaAttributes.add("data-xwiki-${name}=""$escapetool.xml($value)"""))
-  #end
-  ## ---------------------------------------------------------------------------------------------------------------
-  ## Compute all the meta attributes to add to the HTML tag.
-  ## ---------------------------------------------------------------------------------------------------------------
-  #set ($metaAttributes = [])
-  ## Target the paper paged media by default when using the print feature provided by the web browser.
-  #addMetaAttribute($metaAttributes, 'paged-media', 'paper')
-  #if("$!doc" != "" && "$!tdoc" != "")
-    ## NOTE: you should not use these attributes in javascript directly, but via the 'xwiki-meta' module instead:
-    ## http://www.xwiki.org/xwiki/bin/view/Documentation/DevGuide/FrontendResources/JavaScriptAPI/#HGetsomeinformationaboutthecurrentdocument
-    #addMetaAttribute($metaAttributes, 'reference', $services.model.serialize($doc.documentReference, 'default'))
-    #addMetaAttribute($metaAttributes, 'document', $doc.fullName)##deprecated, use 'reference' instead
-    #addMetaAttribute($metaAttributes, 'wiki', $doc.wiki)##deprecated, use 'reference' instead
-    #addMetaAttribute($metaAttributes, 'space', $doc.space)##deprecated, use 'reference' instead
-    #addMetaAttribute($metaAttributes, 'page', $doc.documentReference.name)##deprecated, use 'reference' instead
-    #addMetaAttribute($metaAttributes, 'isnew', $tdoc.isNew())
-    ## If tdoc is a new document, its version when checking for conflict will be the original doc version.
-    ## This fix XWIKI-16299.
-    #if ($tdoc.isNew())
-      #set ($version = $doc.version)
-    #else
-      #set ($version = $tdoc.version)
-    #end
-    #addMetaAttribute($metaAttributes, 'version', $version)
-    #addMetaAttribute($metaAttributes, 'rest-url', $services.rest.url($tdoc.documentReferenceWithLocale))
-    #addMetaAttribute($metaAttributes, 'locale', $tdoc.locale)
-  #end
-  #addMetaAttribute($metaAttributes, 'form-token', "$!{services.csrf.token}")
-  ## Don't put any user-reference tag when the user is not logged in
-  #if ("$!xcontext.userReference" != '')
-    #addMetaAttribute($metaAttributes, 'user-reference', $!services.model.serialize($xcontext.userReference, 'default'))
-  #end
+  #addMetaAttribute($metaAttributes, 'version', $version)
+  #addMetaAttribute($metaAttributes, 'rest-url', $services.rest.url($tdoc.documentReferenceWithLocale))
+  #addMetaAttribute($metaAttributes, 'locale', $tdoc.locale)
+#end
+#addMetaAttribute($metaAttributes, 'form-token', "$!{services.csrf.token}")
+## Don't put any user-reference tag when the user is not logged in
+#if ("$!xcontext.userReference" != '')
+  #addMetaAttribute($metaAttributes, 'user-reference', $!services.model.serialize($xcontext.userReference, 'default'))
+#end
 
 <html xmlns="http://www.w3.org/1999/xhtml" lang="$xcontext.locale.toLanguageTag()" xml:lang="$xcontext.locale.toLanguageTag()" $stringtool.join($metaAttributes, ' ')>
-<head>
-  ## ---------------------------------------------------------------------------------------------------------------
-  ## Ensure that the Content-Type meta directive is the first one in the header.
-  ## See http://www.w3.org/International/tutorials/tutorial-char-enc/
-  ## ---------------------------------------------------------------------------------------------------------------
-  <meta http-equiv="Content-Type" content="text/html; charset=$xwiki.encoding" />
-  ## ---------------------------------------------------------------------------------------------------------------
-  ## Compute the title.
-  ## ---------------------------------------------------------------------------------------------------------------
-  #if(!$title)
-    #set($title = $!xwiki.getSpacePreference('title'))
-    #if($title != '')
-      ## Evaluate the title since it can have velocity code.
-      #set($title = "#evaluate($title)")
-      ## Don`t forget to escape it.
-      #set($title = "$escapetool.xml($title)")
+  <head>
+    ## ---------------------------------------------------------------------------------------------------------------
+    ## Ensure that the Content-Type meta directive is the first one in the header.
+    ## See http://www.w3.org/International/tutorials/tutorial-char-enc/
+    ## ---------------------------------------------------------------------------------------------------------------
+    <meta http-equiv="Content-Type" content="text/html; charset=$xwiki.encoding" />
+    ## ---------------------------------------------------------------------------------------------------------------
+    ## Compute the title.
+    ## ---------------------------------------------------------------------------------------------------------------
+    #if(!$title)
+      #set($title = $!xwiki.getSpacePreference('title'))
+      #if($title != '')
+        ## Evaluate the title since it can have velocity code.
+        #set($title = "#evaluate($title)")
+        ## Don`t forget to escape it.
+        #set($title = "$escapetool.xml($title)")
+      #else
+        #set($title = "XWiki - $escapetool.xml($!doc.space) - $escapetool.xml($!tdoc.displayTitle)")
+      #end
     #else
-      #set($title = "XWiki - $escapetool.xml($!doc.space) - $escapetool.xml($!tdoc.displayTitle)")
+      #set($title = $escapetool.xml($title))
     #end
-  #else
-    #set($title = $escapetool.xml($title))
-  #end
-  <title>$title</title>
-  ## ---------------------------------------------------------------------------------------------------------------
-  ## Enable Responsiveness for phones
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  ## ---------------------------------------------------------------------------------------------------------------
-  ## Favicons
-  ## Present, HTML5
-  <link rel="icon" href="$xwiki.getSkinFile('icons/xwiki/favicon16.png')" type="image/png" />
-  ## The future, scalable icons
-  <link rel="icon" href="$xwiki.getSkinFile('icons/xwiki/favicon.svg')" type="image/svg+xml" />
-  ## For smart phones and tablets
-  <link rel="apple-touch-icon" href="$xwiki.getSkinFile('icons/xwiki/favicon144.png')" />
-  ## ---------------------------------------------------------------------------------------------------------------
-  ## Universal edit button. See http://universaleditbutton.org
-  ## ---------------------------------------------------------------------------------------------------------------
-  #if($xcontext.action=="view")
-    <link rel="alternate" type="application/x-wiki" title="Edit" href="$doc.getURL("edit")" />
-  #end
-  ## ---------------------------------------------------------------------------------------------------------------
-  ## Make sure search engine spiders give the plain page instead of ?viewer=comments, ?viewer=code etc.
-  ## ---------------------------------------------------------------------------------------------------------------
-  <link rel="canonical" href="$doc.getURL('view')" />
-  ## ---------------------------------------------------------------------------------------------------------------
-  ## Add user-defined Meta directives.
-  ## ---------------------------------------------------------------------------------------------------------------
-  ## Note: Velocity code, so it needs to be evaluated.
-  #evaluate($!xwiki.getSpacePreference("meta"))
-  ## ---------------------------------------------------------------------------------------------------------------
-  ## Hook for inserting Link extensions. This will be replaced with the pulled link references.
-  ## ---------------------------------------------------------------------------------------------------------------
-  <!-- com.xpn.xwiki.plugin.skinx.LinkExtensionPlugin -->
-  #template("stylesheets.vm")
-  #template("javascript.vm")
-</head>
+    <title>$title</title>
+    ## ---------------------------------------------------------------------------------------------------------------
+    ## Enable Responsiveness for phones
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    ## ---------------------------------------------------------------------------------------------------------------
+    ## Favicons
+    ## Present, HTML5
+    <link rel="icon" href="$xwiki.getSkinFile('icons/xwiki/favicon16.png')" type="image/png" />
+    ## The future, scalable icons
+    <link rel="icon" href="$xwiki.getSkinFile('icons/xwiki/favicon.svg')" type="image/svg+xml" />
+    ## For smart phones and tablets
+    <link rel="apple-touch-icon" href="$xwiki.getSkinFile('icons/xwiki/favicon144.png')" />
+    ## ---------------------------------------------------------------------------------------------------------------
+    ## Universal edit button. See http://universaleditbutton.org
+    ## ---------------------------------------------------------------------------------------------------------------
+    #if($xcontext.action=="view")
+      <link rel="alternate" type="application/x-wiki" title="Edit" href="$doc.getURL("edit")" />
+    #end
+    ## ---------------------------------------------------------------------------------------------------------------
+    ## Make sure search engine spiders give the plain page instead of ?viewer=comments, ?viewer=code etc.
+    ## ---------------------------------------------------------------------------------------------------------------    
+    <link rel="canonical" href="$doc.getURL('view')" />
+    ## ---------------------------------------------------------------------------------------------------------------
+    ## Add user-defined Meta directives.
+    ## ---------------------------------------------------------------------------------------------------------------
+    ## Note: Velocity code, so it needs to be evaluated.
+    #evaluate($!xwiki.getSpacePreference("meta"))
+    ## ---------------------------------------------------------------------------------------------------------------
+    ## Hook for inserting Link extensions. This will be replaced with the pulled link references.
+    ## ---------------------------------------------------------------------------------------------------------------
+    <!-- com.xpn.xwiki.plugin.skinx.LinkExtensionPlugin -->
+    #template("stylesheets.vm")
+    #template("javascript.vm")
+  </head>
   #set($bodyTagName = 'body')
 #else ## Portlet Mode
   #template("stylesheets.vm")
@@ -153,10 +153,10 @@
 ## Note: when showLeftPanels and showRightPanels are both equals to 0, it is intentional of hideleft and hideright to
 ## be concatenated without space.
 <$bodyTagName id="body" class="skin-flamingo wiki-${xcontext.database} ${bodyAction}body panel-left-width-${leftPanelsWidth} panel-right-width-${rightPanelsWidth} drawer drawer--right ${preferenceUnderlining}
-#if("$!doc.space" != "") space-${escapetool.xml($doc.space.replaceAll(' ', '_'))}#end
-#if($showLeftPanels == "0") hideleft#end
-#if($showRightPanels == "0")hideright#end
-#if($hidecolumns && ($!hidecolumns == 1)) hidelefthideright#end
-#if($showLeftPanels != "0" && $showRightPanels != "0" && $!hidecolumns != 1) content#end">
+  #if("$!doc.space" != "") space-${escapetool.xml($doc.space.replaceAll(' ', '_'))}#end
+  #if($showLeftPanels == "0") hideleft#end
+  #if($showRightPanels == "0")hideright#end
+  #if($hidecolumns && ($!hidecolumns == 1)) hidelefthideright#end
+  #if($showLeftPanels != "0" && $showRightPanels != "0" && $!hidecolumns != 1) content#end">
 <div id="xwikimaincontainer">
-  <div id="xwikimaincontainerinner">
+<div id="xwikimaincontainerinner">

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/htmlheader.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/htmlheader.vm
@@ -22,102 +22,102 @@
 ## elements.
 ## -------------------------------------------------------------------------------------------------------------------
 #if($isInServletMode)
-## TODO this should be more specific
-#if("$!request.noDoctype" != "true")
-<!DOCTYPE html>
-#end
-#macro(addMetaAttribute $metaAttributes $name $value)
-  #set ($discard = $metaAttributes.add("data-xwiki-${name}=""$escapetool.xml($value)"""))
-#end
-## ---------------------------------------------------------------------------------------------------------------
-## Compute all the meta attributes to add to the HTML tag.
-## ---------------------------------------------------------------------------------------------------------------
-#set ($metaAttributes = [])
-## Target the paper paged media by default when using the print feature provided by the web browser.
-#addMetaAttribute($metaAttributes, 'paged-media', 'paper')
-#if("$!doc" != "" && "$!tdoc" != "")
-  ## NOTE: you should not use these attributes in javascript directly, but via the 'xwiki-meta' module instead:
-  ## http://www.xwiki.org/xwiki/bin/view/Documentation/DevGuide/FrontendResources/JavaScriptAPI/#HGetsomeinformationaboutthecurrentdocument
-  #addMetaAttribute($metaAttributes, 'reference', $services.model.serialize($doc.documentReference, 'default'))
-  #addMetaAttribute($metaAttributes, 'document', $doc.fullName)##deprecated, use 'reference' instead
-  #addMetaAttribute($metaAttributes, 'wiki', $doc.wiki)##deprecated, use 'reference' instead
-  #addMetaAttribute($metaAttributes, 'space', $doc.space)##deprecated, use 'reference' instead
-  #addMetaAttribute($metaAttributes, 'page', $doc.documentReference.name)##deprecated, use 'reference' instead
-  #addMetaAttribute($metaAttributes, 'isnew', $tdoc.isNew())
-  ## If tdoc is a new document, its version when checking for conflict will be the original doc version.
-  ## This fix XWIKI-16299.
-  #if ($tdoc.isNew())
-    #set ($version = $doc.version)
-  #else
-    #set ($version = $tdoc.version)
+  ## TODO this should be more specific
+  #if("$!request.noDoctype" != "true")
+  <!DOCTYPE html>
   #end
-  #addMetaAttribute($metaAttributes, 'version', $version)
-  #addMetaAttribute($metaAttributes, 'rest-url', $services.rest.url($tdoc.documentReferenceWithLocale))
-  #addMetaAttribute($metaAttributes, 'locale', $tdoc.locale)
-#end
-#addMetaAttribute($metaAttributes, 'form-token', "$!{services.csrf.token}")
-## Don't put any user-reference tag when the user is not logged in
-#if ("$!xcontext.userReference" != '')
-  #addMetaAttribute($metaAttributes, 'user-reference', $!services.model.serialize($xcontext.userReference, 'default'))
-#end
+  #macro(addMetaAttribute $metaAttributes $name $value)
+    #set ($discard = $metaAttributes.add("data-xwiki-${name}=""$escapetool.xml($value)"""))
+  #end
+  ## ---------------------------------------------------------------------------------------------------------------
+  ## Compute all the meta attributes to add to the HTML tag.
+  ## ---------------------------------------------------------------------------------------------------------------
+  #set ($metaAttributes = [])
+  ## Target the paper paged media by default when using the print feature provided by the web browser.
+  #addMetaAttribute($metaAttributes, 'paged-media', 'paper')
+  #if("$!doc" != "" && "$!tdoc" != "")
+    ## NOTE: you should not use these attributes in javascript directly, but via the 'xwiki-meta' module instead:
+    ## http://www.xwiki.org/xwiki/bin/view/Documentation/DevGuide/FrontendResources/JavaScriptAPI/#HGetsomeinformationaboutthecurrentdocument
+    #addMetaAttribute($metaAttributes, 'reference', $services.model.serialize($doc.documentReference, 'default'))
+    #addMetaAttribute($metaAttributes, 'document', $doc.fullName)##deprecated, use 'reference' instead
+    #addMetaAttribute($metaAttributes, 'wiki', $doc.wiki)##deprecated, use 'reference' instead
+    #addMetaAttribute($metaAttributes, 'space', $doc.space)##deprecated, use 'reference' instead
+    #addMetaAttribute($metaAttributes, 'page', $doc.documentReference.name)##deprecated, use 'reference' instead
+    #addMetaAttribute($metaAttributes, 'isnew', $tdoc.isNew())
+    ## If tdoc is a new document, its version when checking for conflict will be the original doc version.
+    ## This fix XWIKI-16299.
+    #if ($tdoc.isNew())
+      #set ($version = $doc.version)
+    #else
+      #set ($version = $tdoc.version)
+    #end
+    #addMetaAttribute($metaAttributes, 'version', $version)
+    #addMetaAttribute($metaAttributes, 'rest-url', $services.rest.url($tdoc.documentReferenceWithLocale))
+    #addMetaAttribute($metaAttributes, 'locale', $tdoc.locale)
+  #end
+  #addMetaAttribute($metaAttributes, 'form-token', "$!{services.csrf.token}")
+  ## Don't put any user-reference tag when the user is not logged in
+  #if ("$!xcontext.userReference" != '')
+    #addMetaAttribute($metaAttributes, 'user-reference', $!services.model.serialize($xcontext.userReference, 'default'))
+  #end
 
 <html xmlns="http://www.w3.org/1999/xhtml" lang="$xcontext.locale.toLanguageTag()" xml:lang="$xcontext.locale.toLanguageTag()" $stringtool.join($metaAttributes, ' ')>
-  <head>
-    ## ---------------------------------------------------------------------------------------------------------------
-    ## Ensure that the Content-Type meta directive is the first one in the header.
-    ## See http://www.w3.org/International/tutorials/tutorial-char-enc/
-    ## ---------------------------------------------------------------------------------------------------------------
-    <meta http-equiv="Content-Type" content="text/html; charset=$xwiki.encoding" />
-    ## ---------------------------------------------------------------------------------------------------------------
-    ## Compute the title.
-    ## ---------------------------------------------------------------------------------------------------------------
-    #if(!$title)
-      #set($title = $!xwiki.getSpacePreference('title'))
-      #if($title != '')
-        ## Evaluate the title since it can have velocity code.
-        #set($title = "#evaluate($title)")
-        ## Don`t forget to escape it.
-        #set($title = "$escapetool.xml($title)")
-      #else
-        #set($title = "XWiki - $escapetool.xml($!doc.space) - $escapetool.xml($!tdoc.displayTitle)")
-      #end
+<head>
+  ## ---------------------------------------------------------------------------------------------------------------
+  ## Ensure that the Content-Type meta directive is the first one in the header.
+  ## See http://www.w3.org/International/tutorials/tutorial-char-enc/
+  ## ---------------------------------------------------------------------------------------------------------------
+  <meta http-equiv="Content-Type" content="text/html; charset=$xwiki.encoding" />
+  ## ---------------------------------------------------------------------------------------------------------------
+  ## Compute the title.
+  ## ---------------------------------------------------------------------------------------------------------------
+  #if(!$title)
+    #set($title = $!xwiki.getSpacePreference('title'))
+    #if($title != '')
+      ## Evaluate the title since it can have velocity code.
+      #set($title = "#evaluate($title)")
+      ## Don`t forget to escape it.
+      #set($title = "$escapetool.xml($title)")
     #else
-      #set($title = $escapetool.xml($title))
+      #set($title = "XWiki - $escapetool.xml($!doc.space) - $escapetool.xml($!tdoc.displayTitle)")
     #end
-    <title>$title</title>
-    ## ---------------------------------------------------------------------------------------------------------------
-    ## Enable Responsiveness for phones
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    ## ---------------------------------------------------------------------------------------------------------------
-    ## Favicons
-    ## Present, HTML5
-    <link rel="icon" href="$xwiki.getSkinFile('icons/xwiki/favicon16.png')" type="image/png" />
-    ## The future, scalable icons
-    <link rel="icon" href="$xwiki.getSkinFile('icons/xwiki/favicon.svg')" type="image/svg+xml" />
-    ## For smart phones and tablets
-    <link rel="apple-touch-icon" href="$xwiki.getSkinFile('icons/xwiki/favicon144.png')" />
-    ## ---------------------------------------------------------------------------------------------------------------
-    ## Universal edit button. See http://universaleditbutton.org
-    ## ---------------------------------------------------------------------------------------------------------------
-    #if($xcontext.action=="view")
-      <link rel="alternate" type="application/x-wiki" title="Edit" href="$doc.getURL("edit")" />
-    #end
-    ## ---------------------------------------------------------------------------------------------------------------
-    ## Make sure search engine spiders give the plain page instead of ?viewer=comments, ?viewer=code etc.
-    ## ---------------------------------------------------------------------------------------------------------------    
-    <link rel="canonical" href="$doc.getURL('view')" />
-    ## ---------------------------------------------------------------------------------------------------------------
-    ## Add user-defined Meta directives.
-    ## ---------------------------------------------------------------------------------------------------------------
-    ## Note: Velocity code, so it needs to be evaluated.
-    #evaluate($!xwiki.getSpacePreference("meta"))
-    ## ---------------------------------------------------------------------------------------------------------------
-    ## Hook for inserting Link extensions. This will be replaced with the pulled link references.
-    ## ---------------------------------------------------------------------------------------------------------------
-    <!-- com.xpn.xwiki.plugin.skinx.LinkExtensionPlugin -->
-    #template("stylesheets.vm")
-    #template("javascript.vm")
-  </head>
+  #else
+    #set($title = $escapetool.xml($title))
+  #end
+  <title>$title</title>
+  ## ---------------------------------------------------------------------------------------------------------------
+  ## Enable Responsiveness for phones
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  ## ---------------------------------------------------------------------------------------------------------------
+  ## Favicons
+  ## Present, HTML5
+  <link rel="icon" href="$xwiki.getSkinFile('icons/xwiki/favicon16.png')" type="image/png" />
+  ## The future, scalable icons
+  <link rel="icon" href="$xwiki.getSkinFile('icons/xwiki/favicon.svg')" type="image/svg+xml" />
+  ## For smart phones and tablets
+  <link rel="apple-touch-icon" href="$xwiki.getSkinFile('icons/xwiki/favicon144.png')" />
+  ## ---------------------------------------------------------------------------------------------------------------
+  ## Universal edit button. See http://universaleditbutton.org
+  ## ---------------------------------------------------------------------------------------------------------------
+  #if($xcontext.action=="view")
+    <link rel="alternate" type="application/x-wiki" title="Edit" href="$doc.getURL("edit")" />
+  #end
+  ## ---------------------------------------------------------------------------------------------------------------
+  ## Make sure search engine spiders give the plain page instead of ?viewer=comments, ?viewer=code etc.
+  ## ---------------------------------------------------------------------------------------------------------------
+  <link rel="canonical" href="$doc.getURL('view')" />
+  ## ---------------------------------------------------------------------------------------------------------------
+  ## Add user-defined Meta directives.
+  ## ---------------------------------------------------------------------------------------------------------------
+  ## Note: Velocity code, so it needs to be evaluated.
+  #evaluate($!xwiki.getSpacePreference("meta"))
+  ## ---------------------------------------------------------------------------------------------------------------
+  ## Hook for inserting Link extensions. This will be replaced with the pulled link references.
+  ## ---------------------------------------------------------------------------------------------------------------
+  <!-- com.xpn.xwiki.plugin.skinx.LinkExtensionPlugin -->
+  #template("stylesheets.vm")
+  #template("javascript.vm")
+</head>
   #set($bodyTagName = 'body')
 #else ## Portlet Mode
   #template("stylesheets.vm")
@@ -148,11 +148,15 @@
 #end
 ## These elements will be closed in the htmlfooter.vm file
 ## We put a space before each class added in #if, to avoid losing them because of velocity line stripping
+## TODO: the classes should be refactored to use a array of classes where individal classes are happened on by one and
+## joined with space at the end
+## Note: when showLeftPanels and showRightPanels are both equals to 0, it is intentional of hideleft and hideright to
+## be concatenated without space.
 <$bodyTagName id="body" class="skin-flamingo wiki-${xcontext.database} ${bodyAction}body panel-left-width-${leftPanelsWidth} panel-right-width-${rightPanelsWidth} drawer drawer--right ${preferenceUnderlining}
-  #if("$!doc.space" != "") space-${escapetool.xml($doc.space.replaceAll(' ', '_'))}#end
-  #if($showLeftPanels == "0") hideleft#end
+#if("$!doc.space" != "") space-${escapetool.xml($doc.space.replaceAll(' ', '_'))}#end
+#if($showLeftPanels == "0") hideleft#end
 #if($showRightPanels == "0")hideright#end
-  #if($hidecolumns && ($!hidecolumns == 1)) hidelefthideright#end
-  #if($showLeftPanels != "0" && $showRightPanels != "0" && $!hidecolumns != 1) content#end">
+#if($hidecolumns && ($!hidecolumns == 1)) hidelefthideright#end
+#if($showLeftPanels != "0" && $showRightPanels != "0" && $!hidecolumns != 1) content#end">
 <div id="xwikimaincontainer">
-<div id="xwikimaincontainerinner">
+  <div id="xwikimaincontainerinner">

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/htmlheader.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/htmlheader.vm
@@ -151,7 +151,7 @@
 <$bodyTagName id="body" class="skin-flamingo wiki-${xcontext.database} ${bodyAction}body panel-left-width-${leftPanelsWidth} panel-right-width-${rightPanelsWidth} drawer drawer--right ${preferenceUnderlining}
   #if("$!doc.space" != "") space-${escapetool.xml($doc.space.replaceAll(' ', '_'))}#end
   #if($showLeftPanels == "0") hideleft#end
-  #if($showRightPanels == "0") hideright#end
+#if($showRightPanels == "0")hideright#end
   #if($hidecolumns && ($!hidecolumns == 1)) hidelefthideright#end
   #if($showLeftPanels != "0" && $showRightPanels != "0" && $!hidecolumns != 1) content#end">
 <div id="xwikimaincontainer">

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/general.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/general.less
@@ -162,10 +162,11 @@ body.content {
     /* UIs in content where we want to not underline by default.
       Those elements usually contain only links that are not inline (and a lot of links). */
     #xwikicontent {
-      &.xwiki-livetable-container,
-      &.xtree,
-      &.xwikitabbar,
-      &.buttonwrapper {
+      & .xwiki-livetable-container,
+      & .xtree,
+      & .xwikitabbar,
+      & .buttonwrapper,
+      & #user-menu-col {
         & a {
           text-decoration: none;
           // Make sure we don't take over the default behaviour on hover with too much specificity.

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-test/xwiki-platform-user-profile-test-pageobjects/src/main/java/org/xwiki/user/test/po/PreferencesUserProfilePage.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-test/xwiki-platform-user-profile-test-pageobjects/src/main/java/org/xwiki/user/test/po/PreferencesUserProfilePage.java
@@ -33,13 +33,13 @@ public class PreferencesUserProfilePage extends AbstractUserProfilePage
     @FindBy(xpath = "//div[@id='preferencesPane']//div[@class='editProfileCategory']/a")
     private WebElement editPreferences;
 
-    @FindBy(xpath = "//div[@id='preferencesPane']/div[1]/div/dl[2]/dd[1]")
+    @FindBy(xpath = "//div[@id='preferencesPane']/div[1]/div/dl[3]/dd[1]")
     private WebElement timezone;
 
-    @FindBy(xpath = "//div[@id='preferencesPane']/div[1]/div/dl[3]/dd[2]")
+    @FindBy(xpath = "//div[@id='preferencesPane']/div[1]/div/dl[4]/dd[2]")
     private WebElement userType;
 
-    @FindBy(xpath = "//div[@id='preferencesPane']/div[1]/div/dl[3]/dd[1]")
+    @FindBy(xpath = "//div[@id='preferencesPane']/div[1]/div/dl[4]/dd[1]")
     private WebElement defaultEditorToUse;
 
     @FindBy(xpath = "//a[@id='changePassword']")

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-test/xwiki-platform-user-profile-test-pageobjects/src/main/java/org/xwiki/user/test/po/PreferencesUserProfilePage.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-test/xwiki-platform-user-profile-test-pageobjects/src/main/java/org/xwiki/user/test/po/PreferencesUserProfilePage.java
@@ -33,13 +33,13 @@ public class PreferencesUserProfilePage extends AbstractUserProfilePage
     @FindBy(xpath = "//div[@id='preferencesPane']//div[@class='editProfileCategory']/a")
     private WebElement editPreferences;
 
-    @FindBy(xpath = "//div[@id='preferencesPane']/div[1]/div/dl[3]/dd[1]")
+    @FindBy(xpath = "//div[@id='preferencesPane']/div[1]/div//dd[@data-user-property = 'timezone']")
     private WebElement timezone;
 
-    @FindBy(xpath = "//div[@id='preferencesPane']/div[1]/div/dl[4]/dd[2]")
+    @FindBy(xpath = "//div[@id='preferencesPane']/div[1]/div//dd[@data-user-property = 'usertype']")
     private WebElement userType;
 
-    @FindBy(xpath = "//div[@id='preferencesPane']/div[1]/div/dl[4]/dd[1]")
+    @FindBy(xpath = "//div[@id='preferencesPane']/div[1]/div//dd[@data-user-property = 'editor']")
     private WebElement defaultEditorToUse;
 
     @FindBy(xpath = "//a[@id='changePassword']")


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-21492
# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Fixed the xpaths to account for the new preference category

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Adding the `accessibility settings` section changed some of the xpaths (that are not very robust, they rely on order only, but unfortunately there's no other easy way)
* The selectors on the `PreferencesEditPage` page are not broken because their definition is more sturdy :)

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
None, development changes only.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
None.
I don't have a build with the changes from XWIKI-21492 yet. However the issue here is quite easy to understand and fix.


Fixes https://ci.xwiki.org/job/XWiki%20Environment%20Tests/job/xwiki-platform/job/master/527/testReport/org.xwiki.user.test.ui/AllIT$NestedUserProfileIT/Oracle_19_3_0_se2__Jetty_10_jdk21__Firefox___Docker_tests_for_xwiki_platform_user_profile___Build_for_Oracle_19_3_0_se2__Jetty_10_jdk21__Firefox___Docker_tests_for_xwiki_platform_user_profile___changeUserProfile/ and https://ci.xwiki.org/job/XWiki%20Environment%20Tests/job/xwiki-platform/job/master/527/testReport/org.xwiki.user.test.ui/AllIT$NestedUserProfileIT/Oracle_19_3_0_se2__Jetty_10_jdk21__Firefox___Docker_tests_for_xwiki_platform_user_profile___Build_for_Oracle_19_3_0_se2__Jetty_10_jdk21__Firefox___Docker_tests_for_xwiki_platform_user_profile___changeDefaultEditor/

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None