### PR TITLE
Typo "an Document"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/reference/DocumentReference.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/reference/DocumentReference.java
@@ -72,7 +72,7 @@ public class DocumentReference extends AbstractLocalizedEntityReference
     }
 
     /**
-     * Clone an DocumentReference, but replace one of the parent in the chain by a new one.
+     * Clone a DocumentReference, but replace one of the parent in the chain by a new one.
      *
      * @param reference the reference that is cloned
      * @param oldReference the old parent that will be replaced
@@ -210,7 +210,7 @@ public class DocumentReference extends AbstractLocalizedEntityReference
     }
 
     /**
-     * Clone an DocumentReference, but use the specified parent for its new parent.
+     * Clone a DocumentReference, but use the specified parent for its new parent.
      *
      * @param reference the reference to clone
      * @param parent the new parent to use

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/reference/LocalPageReference.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/reference/LocalPageReference.java
@@ -104,7 +104,7 @@ public class LocalPageReference extends AbstractLocalizedEntityReference
     }
 
     /**
-     * Clone an DocumentVersionReference, but use the specified parent for its new parent.
+     * Clone a DocumentVersionReference, but use the specified parent for its new parent.
      *
      * @param reference the reference to clone
      * @param parent the new parent to use

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/XWiki.java
@@ -257,7 +257,7 @@ public class XWiki extends Api
     }
 
     /**
-     * Loads an Document from the database. Rights are checked before sending back the document.
+     * Loads a Document from the database. Rights are checked before sending back the document.
      * <p>
      * This is a helper for document reference but you can use {@link #getEntityDocument(String, EntityType)} for any
      * other kind of reference.
@@ -285,7 +285,7 @@ public class XWiki extends Api
     }
 
     /**
-     * Loads an Document from the database. Rights are checked before sending back the document.
+     * Loads a Document from the database. Rights are checked before sending back the document.
      *
      * @param reference the reference of the document to be loaded
      * @param type the type of the reference
@@ -349,7 +349,7 @@ public class XWiki extends Api
     }
 
     /**
-     * Loads an Document from the database. Rights are checked on the author (contentAuthor) of the document containing
+     * Loads a Document from the database. Rights are checked on the author (contentAuthor) of the document containing
      * the currently executing script before sending back the loaded document.
      *
      * @param fullName the full name of the XWiki document to be loaded
@@ -375,7 +375,7 @@ public class XWiki extends Api
     }
 
     /**
-     * Loads an Document from the database. Rights are checked on the author (contentAuthor) of the document containing
+     * Loads a Document from the database. Rights are checked on the author (contentAuthor) of the document containing
      * the currently executing script before sending back the loaded document.
      *
      * @param reference the reference of the XWiki document to be loaded
@@ -606,7 +606,7 @@ public class XWiki extends Api
     }
 
     /**
-     * Loads an Document from the database. Rights are checked before sending back the document.
+     * Loads a Document from the database. Rights are checked before sending back the document.
      *
      * @param space Space to use in case no space is defined in the provided <code>fullname</code>
      * @param fullname the full name or relative name of the document to load
@@ -1928,7 +1928,7 @@ public class XWiki extends Api
     }
 
     /**
-     * API to retrieve the URL of an a Wiki Document in view mode The URL is generated differently depending on the
+     * API to retrieve the URL of a Wiki Document in view mode The URL is generated differently depending on the
      * environment (Servlet, Portlet, PDF, etc..) The URL generation can be modified by implementing a new
      * XWikiURLFactory object For compatibility with any target environment (and especially the portlet environment) It
      * is important to always use the URL functions to generate URL and never hardcode URLs
@@ -1979,7 +1979,7 @@ public class XWiki extends Api
     }
 
     /**
-     * API to retrieve the URL of an a Wiki Document in view mode The URL is generated differently depending on the
+     * API to retrieve the URL of a Wiki Document in view mode The URL is generated differently depending on the
      * environment (Servlet, Portlet, PDF, etc..) The URL generation can be modified by implementing a new
      * XWikiURLFactory object For compatibility with any target environment (and especially the portlet environment) It
      * is important to always use the URL functions to generate URL and never hardcode URLs
@@ -1995,7 +1995,7 @@ public class XWiki extends Api
     }
 
     /**
-     * API to retrieve the URL of an a Wiki Document in any mode. The URL is generated differently depending on the
+     * API to retrieve the URL of a Wiki Document in any mode. The URL is generated differently depending on the
      * environment (Servlet, Portlet, PDF, etc..). The URL generation can be modified by implementing a new
      * XWikiURLFactory object For compatibility with any target environment (and especially the portlet environment). It
      * is important to always use the URL functions to generate URL and never hardcode URLs.
@@ -2050,7 +2050,7 @@ public class XWiki extends Api
     }
 
     /**
-     * API to retrieve the URL of an a Wiki Document in any mode, optionally adding an anchor. The URL is generated
+     * API to retrieve the URL of a Wiki Document in any mode, optionally adding an anchor. The URL is generated
      * differently depending on the environment (Servlet, Portlet, PDF, etc..) The URL generation can be modified by
      * implementing a new XWikiURLFactory object. The anchor will be modified to be added in the way the environment
      * needs it. It is important to not add the anchor parameter manually after a URL. Some environments will not accept

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/events/DocumentUpdatedEventDescriptor.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/events/DocumentUpdatedEventDescriptor.java
@@ -42,7 +42,7 @@ public class DocumentUpdatedEventDescriptor extends AbstractXWikiRecordableEvent
     public static final String EVENT_TYPE = DocumentEventType.UPDATE;
 
     /**
-     * Construct an DocumentUpdatedEventDescriptor.
+     * Construct a DocumentUpdatedEventDescriptor.
      */
     public DocumentUpdatedEventDescriptor()
     {


### PR DESCRIPTION
# Changes

## Description

typo fix: "an Document" -> "a Document"