### PR TITLE
XWIKI-22082: Some LiveData tables flicker on page refresh

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/xwiki.selectize.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/xwiki.selectize.css
@@ -6,11 +6,6 @@
   padding: 6px 12px;
 }
 
-/* The selected value overflows the dropdown caret on single selection. */
-.selectize-control.single > .selectize-input {
-  padding-right: 32px;
-}
-
 /* The selectize widget adds padding around the text input so we need to reduce the height of the text input. */
 .selectize-input > input[type="text"] {
   height: 20px;
@@ -22,8 +17,24 @@
   background-image: url("$xwiki.getSkinFile('icons/xwiki/spinner.gif')");
   background-repeat: no-repeat;
 }
+/*
+Add enough padding to have room to display the spinning loader. That way, the selectize field do not have a brief
+change of width during load.
+The second 'has-items' selector is required to override the one from default bootstrap's selectize css. */
+.selectize-control.multi .selectize-input,
+.selectize-control.multi .selectize-input.has-items {
+  padding-right: 32px;
+}
 .selectize-control.multi.loading .selectize-input {
   background-position: center right 12px;
+}
+/**
+Add enough padding to have room to display the spinning loader. That way, the selectize field do not have a brief
+change of width during load.
+ */
+.selectize-control.single .selectize-input,
+.selectize-control.single .selectize-input.input-active {
+  padding-right: 55px;
 }
 .selectize-control.single.loading .selectize-input,
 .selectize-control.single.loading .selectize-input.input-active {

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/xwiki.selectize.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/xwiki.selectize.css
@@ -24,12 +24,10 @@
 }
 .selectize-control.multi.loading .selectize-input {
   background-position: center right 12px;
-  padding-right: 31px;
 }
 .selectize-control.single.loading .selectize-input,
 .selectize-control.single.loading .selectize-input.input-active {
   background-position: center right 36px;
-  padding-right: 55px;
 }
 
 /* Dropdown styles */


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22082

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* always add enough padding on the selectize fields to avoid a change of width on load

# Screenshots & Video

**Limitation**

Empty
![image](https://github.com/xwiki/xwiki-platform/assets/327856/7d08ae9b-80ad-41d3-be31-205bd020fbee)

With content
![image](https://github.com/xwiki/xwiki-platform/assets/327856/afe55a7b-7229-4766-b0a0-ea145b910d7d)

Vertical space is always reserved for the spinner, even when the field is not loading.
As a consequence, the red square above is always there, preventing the field to get any smaller.
Note: as you can see the reserved space is also visible when some content is selected, making the minimal space between the selected value and the right caret always at least what you can see in the "with content" screenshot above.
I don't think this is an issue in practice as it only noticeable when the field is really constrained in its allowed horizontal space. 

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-15.10.x