### PR TITLE
XWIKI-22108: Extra empty paragraph and spacing in the information panel in edit mode

### DIFF
--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/IncludedPagesDocumentInformation.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/IncludedPagesDocumentInformation.xml
@@ -209,13 +209,18 @@
 ##--------------------------------------------------------------------------
 #set ($pages = $tdoc.includedPages)
 #if($pages.size() != 0)
-  {{html clean="false"}}&lt;dt&gt;{{/html}}$services.localization.render('panels.documentInformation.includesCount', [$pages.size()]){{html clean="false"}}&lt;/dt&gt;{{/html}}
+  {{html clean="false"}}&lt;dt&gt;$escapetool.xml($services.localization.render('panels.documentInformation.includesCount', [$pages.size()]))&lt;/dt&gt;{{/html}}
+
+  {{html clean="false"}}&lt;dd&gt;{{/html}}
+
   #foreach ($page in $pages)
     #set ($pageLink = $services.rendering.escape($page, 'xwiki/2.1'))
     #set ($pageName = $services.rendering.escape($services.rendering.escape($page, 'xwiki/2.1'), 'xwiki/2.1'))
     #set ($alt = $services.rendering.escape($services.localization.render('panels.documentInformation.editIncluded', [$page]), 'xwiki/2.1'))
-    {{html clean="false"}}&lt;dd&gt;{{/html}}[[$pageName&gt;&gt;$pageLink]] [[[[image:icon:page_white_edit||alt="$alt"]]&gt;&gt;path:$xwiki.getURL($page, 'edit')]]{{html clean="false"}}&lt;/dd&gt;{{/html}}
+    * [[$pageName&gt;&gt;$pageLink]] [[[[image:icon:page_white_edit||alt="$alt"]]&gt;&gt;path:$xwiki.getURL($page, 'edit')]]
   #end
+
+  {{html clean="false"}}&lt;/dd&gt;{{/html}}
 #end
 ##--------------------------------------------------------------------------
 {{/velocity}}</content>


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-22108

# Changes

## Description

* Make all HTML macros standalone to avoid wrapping in paragraphs
* Replace multiple dd tags by a single dd with a nested unordered list as otherwise we cannot avoid that the XWiki syntax content is wrapped inside a paragraph

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* An alternative is to just move all HTML macros on their own lines to be standalone and accept that there is now some space between the items. The spacing could also be removed with custom CSS but to me this doesn't seem clean.
* I did not change the edit icon to use the icon theme to not introduce additional changes apart from what's really required to fix this issue.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

![clipboard](https://github.com/xwiki/xwiki-platform/assets/198317/c6a32761-0e4e-4451-a80c-34373209157d)

Alternative with spacing between items:

![rhmozHykEHmDSHwLYYoBpTwV](https://github.com/xwiki/xwiki-platform/assets/198317/a5bbd90c-9a90-436f-8e23-1ea783ba42fa)

Previous state:

![UuigjQkXhNuXYeKmxgxPwWSI](https://github.com/xwiki/xwiki-platform/assets/198317/c609a594-21fd-4776-a97f-b493636559c3)

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
mvn clean install -Pintegration-tests,docker,legacy,standalone,quality -pl :xwiki-platform-panels-ui
```

There do not seem to be any UI tests targeting this element, the [page object](https://github.com/xwiki/xwiki-platform/blob/c7a69d2835f83db1694fbb88dae9a2055dc3309e/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-pageobjects/src/main/java/org/xwiki/panels/test/po/DocumentInformationPanel.java#L31) for this panel doesn't offer access to the included pages, neither do [EditPage](https://github.com/xwiki/xwiki-platform/blob/b646b33583cbb28b134352af4083daefc6588b85/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/editor/EditPage.java#L47) or any of the subclasses for the wiki or WYSIWYG editor.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-15.10.x