### PR TITLE
XWIKI-22118: Application panel "more applications" dropdown display is wrong on Chrome

### DIFF
--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
@@ -599,7 +599,10 @@ require(['scriptaculous/effects'], function() {
 .panel-width-Small .applicationPanelMoreButton {
   flex-direction: column;
   padding: 0;
-  text-align: center;
+}
+
+.panel-width-Small .applicationPanelMoreButton .application-img  {
+  margin: auto;
 }
 
 .panel-width-Small .applicationPanelMoreButton .application-label {

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/Applications.xml
@@ -598,15 +598,8 @@ require(['scriptaculous/effects'], function() {
 
 .panel-width-Small .applicationPanelMoreButton {
   flex-direction: column;
+  align-items: center;
   padding: 0;
-}
-
-.panel-width-Small .applicationPanelMoreButton .application-img  {
-  margin: auto;
-}
-
-.panel-width-Small .applicationPanelMoreButton .application-label {
-  text-align: center;
 }
 
 .panel-width-Small .panel.Applications {


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22118

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Updated the solution to use flex properties

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* This flex property is more robust than what was used, and we can reduce the number of styles :)

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Here is what this UI looks like with the changes proposed here, on Firefox and Chrome respectively:
![22118-FFAfterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/8c8b9749-450b-4fc6-901b-4054e6e8088c)
![22118-ChromeAfterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/a8f27c54-0538-4979-b008-d0c6205cec02)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Only manual (see screenshots) on FF and Chrome. Style change only.
# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.X , to follow the commits for XWIKI-20843 (cause of this regression)