### PR TITLE
XWIKI-22123: Pressing "Enter" key does not validate the image choice in Gallery on Chrome and Edge

### DIFF
--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-picker/xwiki-platform-attachment-picker-ui/src/main/resources/Attachment/Picker/Code/CKEditorImagePlugin.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-picker/xwiki-platform-attachment-picker-ui/src/main/resources/Attachment/Picker/Code/CKEditorImagePlugin.xml
@@ -155,7 +155,7 @@
       }
     });
     // Submit form on Enter key pressed
-    results.on('keypress', 'a', function(event) {
+    results.on('keyup', 'a', function(event) {
       // 13 is the key id of the Enter key
       if (event.which === 13) {
         validateForm(event);


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22123
# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* replace the Javascript event name with the proper JQuery one

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

This is caused by the wrong event being used.
`keypress` is a Javascript event.
`keyup` is its JQuery equivalent.
We used JQuery in the fix for [XWIKI-19965](https://jira.xwiki.org/browse/XWIKI-19965).

When testing with Firefox, I guess the browser fixes things and the event handler is properly run. However it's not the case with Chromium and the feature is broken on these browsers.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
None

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests on Chrome, Edge and Firefox. Everything lines up now

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.3.0