### PR TITLE
XWIKI-22119: Live Data Delete actions from Notifications Custom Filters do not have red icons as other Live Data tables

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersLiveDataConfigurationProvider.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersLiveDataConfigurationProvider.java
@@ -31,9 +31,6 @@ import javax.inject.Singleton;
 
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
-import org.xwiki.icon.IconException;
-import org.xwiki.icon.IconManager;
-import org.xwiki.livedata.LiveDataActionDescriptor;
 import org.xwiki.livedata.LiveDataConfiguration;
 import org.xwiki.livedata.LiveDataEntryDescriptor;
 import org.xwiki.livedata.LiveDataException;
@@ -126,9 +123,6 @@ public class NotificationCustomFiltersLiveDataConfigurationProvider implements P
     private NotificationFilterLiveDataTranslationHelper translationHelper;
 
     @Inject
-    private IconManager iconManager;
-
-    @Inject
     private Logger logger;
 
     @Override
@@ -145,18 +139,6 @@ public class NotificationCustomFiltersLiveDataConfigurationProvider implements P
         LiveDataEntryDescriptor entryDescriptor = new LiveDataEntryDescriptor();
         entryDescriptor.setIdProperty(ID_FIELD);
         meta.setEntryDescriptor(entryDescriptor);
-
-        LiveDataActionDescriptor deleteAction = new LiveDataActionDescriptor();
-        deleteAction.setName(this.l10n.getTranslationPlain("liveData.action.delete"));
-        deleteAction.setId(DELETE);
-        deleteAction.setAllowProperty(DOC_HAS_DELETE_FIELD);
-        try {
-            // FIXME: we should map delete action icon to the cross..
-            deleteAction.setIcon(this.iconManager.getMetaData("cross"));
-        } catch (IconException e) {
-            this.logger.error("Error while getting icon for the remove action", e);
-        }
-        meta.setActions(List.of(deleteAction));
 
         meta.setPropertyDescriptors(List.of(
             getIDDescriptor(),

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersLiveDataConfigurationProvider.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersLiveDataConfigurationProvider.java
@@ -31,6 +31,7 @@ import javax.inject.Singleton;
 
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
+import org.xwiki.livedata.LiveDataActionDescriptor;
 import org.xwiki.livedata.LiveDataConfiguration;
 import org.xwiki.livedata.LiveDataEntryDescriptor;
 import org.xwiki.livedata.LiveDataException;
@@ -139,6 +140,11 @@ public class NotificationCustomFiltersLiveDataConfigurationProvider implements P
         LiveDataEntryDescriptor entryDescriptor = new LiveDataEntryDescriptor();
         entryDescriptor.setIdProperty(ID_FIELD);
         meta.setEntryDescriptor(entryDescriptor);
+
+        LiveDataActionDescriptor deleteAction = new LiveDataActionDescriptor();
+        deleteAction.setId(DELETE);
+        deleteAction.setAllowProperty(DOC_HAS_DELETE_FIELD);
+        meta.setActions(List.of(deleteAction));
 
         meta.setPropertyDescriptors(List.of(
             getIDDescriptor(),


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22119

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* remove a custom definition of the delete icon to let the default one be used instead (therefore, using its default color).

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
![image](https://github.com/xwiki/xwiki-platform/assets/327856/7b60ccdc-89a5-4e42-b560-9f160b0fafbd)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

`mvn clean install -pl :xwiki-platform-notifications-filters-default -Pquality`

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-16.3.x