### PR TITLE
XWIKI-22138: Tips panel does not have underline style for links in subwiki

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/general.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/general.less
@@ -161,7 +161,7 @@ body.content {
 
     // UIs where we want to underline outside of content.
     .xdocLastModification,
-    .panel[class*="HelpTipsPanel"],
+    .panel[class*="HelpTipsPanel "],
     .commentauthor {
       & a {
         text-decoration: underline;

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/general.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/general.less
@@ -161,7 +161,7 @@ body.content {
 
     // UIs where we want to underline outside of content.
     .xdocLastModification,
-    .panel.HelpTipsPanel,
+    .panel[class*="HelpTipsPanel"],
     .commentauthor {
       & a {
         text-decoration: underline;


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22138

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Replaced the classic CSS class selector with a `class contains` selector

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The subwiki add their IDs before all of the panel specific classes. There's no other robust way to select the Tips Panel than using this class. In order to still use it, I decided to go for an attribute selector based on class. This allows to use a `contains` boolean that would not be possible to do with the `.` notation.
* In the new class selector, I added a space after the `HelpTipsPanel`. This makes sure we don't match any panel in a wiki that would have `HelpTipsPanel` for ID. I think the selector as it is now is robust enough. It's not perfect and could still be matched unexpectedly in some very niche situations e.g., using a panel with an ID which contains the string `HelpTipsPanel`.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Before the changes proposed in this PR
![image](https://github.com/xwiki/xwiki-platform/assets/28761965/973a7fb3-041b-46bb-b7ac-5b5ea1ee5dfa)
After the changes proposed in this PR
![image](https://github.com/xwiki/xwiki-platform/assets/28761965/54972f9b-963d-4c7c-8ddb-98136bd2ed5d)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Style changes only, tested manually on a local distribution with:
* the main wiki
* two subwikis

See the screenshots above. After updating the color theme (reloading the LESS content from the updated general.less), we could witness that the anchors are properly hit by the new css selector.


# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None