### PR TITLE
[Misc] Fix missing programming rights for UI tests

### DIFF
--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-test/xwiki-platform-mail-test-docker/src/test/it/org/xwiki/mail/test/ui/MailIT.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-test/xwiki-platform-mail-test-docker/src/test/it/org/xwiki/mail/test/ui/MailIT.java
@@ -70,8 +70,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
         "xwikiDbHbmCommonExtraMappings=mailsender.hbm.xml",
         // Pages created in the tests need to have PR since we ask for PR to send mails so we need to exclude them from
         // the PR checker.
+        // Also, programming rights are required to use scheduling operations.
         // TODO: Mail.MailResender can be removed when XWIKI-20557 is closed
-        "xwikiPropertiesAdditionalProperties=test.prchecker.excludePattern=.*:(MailIT\\..*|Mail\\.MailResender)",
+        "xwikiPropertiesAdditionalProperties=test.prchecker.excludePattern="
+            + ".*:(MailIT\\..*|Mail\\.MailResender|Scheduler.WebHome)",
         // Add the Scheduler plugin used by Mail Resender Scheduler Job
         "xwikiCfgPlugins=com.xpn.xwiki.plugin.scheduler.SchedulerPlugin"
     },

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/src/test/it/org/xwiki/platform/notifications/test/ui/NotificationsSettingsIT.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/src/test/it/org/xwiki/platform/notifications/test/ui/NotificationsSettingsIT.java
@@ -65,6 +65,8 @@ import static org.xwiki.test.ui.po.BootstrapSwitch.State.UNDETERMINED;
 @UITest(
     properties = {
         "xwikiDbHbmCommonExtraMappings=notification-filter-preferences.hbm.xml",
+        // Programming rights are required to use scheduling operations.
+        "xwikiPropertiesAdditionalProperties=test.prchecker.excludePattern=xwiki:Scheduler.WebHome",
     },
     extraJARs = {
         // It's currently not possible to install a JAR contributing a Hibernate mapping file as an Extension. Thus,


### PR DESCRIPTION
# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Add missing programming rights in UI tests, following https://github.com/xwiki/xwiki-platform/commit/54bcc5a7a2e440cc591b91eece9c13dc0c487331.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

N/A

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

The tests now pass locally.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-15.10.x