### PR TITLE
XWIKI-22146: Black square when drag-and-dropping an image in WYSIWYG

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-filter/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-filter/plugin.js
@@ -178,7 +178,7 @@
               const isUploadImageWidget = dataWidgetAttribute === 'uploadimage';
               // Cleanup data-widget attributes on images. Except for 'uploadimage' which is only cleaned up when
               // the image is not currently being uploaded (i.e., has a data-cke-upload-id attribute)
-              if (!isUploadImageWidget || isUploadImageWidget && dataCkeUploadIdAttribute === undefined)
+              if (!isUploadImageWidget || (isUploadImageWidget && dataCkeUploadIdAttribute === undefined))
               {
                 delete element.attributes['data-widget'];
               }

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-filter/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-filter/plugin.js
@@ -178,7 +178,7 @@
               const isUploadImageWidget = dataWidgetAttribute === 'uploadimage';
               // Cleanup data-widget attributes on images. Except for 'uploadimage' which is only cleaned up when
               // the image is not currently being uploaded (i.e., has a data-cke-upload-id attribute)
-              if (!isUploadImageWidget || (isUploadImageWidget && dataCkeUploadIdAttribute === undefined))
+              if (!isUploadImageWidget || dataCkeUploadIdAttribute === undefined)
               {
                 delete element.attributes['data-widget'];
               }

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-filter/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-filter/plugin.js
@@ -173,7 +173,15 @@
         event.data.dataValue.filter(new CKEDITOR.htmlParser.filter({
           elements: {
             img: function (element) {
-              delete element.attributes['data-widget'];
+              const dataWidgetAttribute = element.attributes['data-widget'];
+              const dataCkeUploadIdAttribute = element.attributes['data-cke-upload-id'];
+              const isUploadImageWidget = dataWidgetAttribute === 'uploadimage';
+              // Cleanup data-widget attributes on images. Except for 'uploadimage' which is only cleaned up when
+              // the image is not currently being uploaded (i.e., has a data-cke-upload-id attribute)
+              if (!isUploadImageWidget || isUploadImageWidget && dataCkeUploadIdAttribute === undefined)
+              {
+                delete element.attributes['data-widget'];
+              }
             }
           }
         }));


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22146
# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* It is now possible to paste/drag-n-drop images

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
mvn clean install -Pquality,integration-tests,docker \
  -pl :xwiki-platform-ckeditor-plugins -amd -f xwiki-platform-core/xwiki-platform-ckeditor
````

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches: 
  * stable-16.3.x
  * stable-15.10.x (manually, as part of XWIKI-22073 since not released yet)
  * stable-14.10.x (manually, as part of XWIKI-22073 since not released yet)