### PR TITLE
XWIKI-22148: The search results are not hidden when the focus moves out of the quick search field

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/action-menus.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/action-menus.less
@@ -125,12 +125,6 @@
     width: 200px; // we need to set a width in pixels otherwise the transition is not applied nicely
   }
 
-  // Defines a transition for when the search results get hidden because the focus
-  // moves out of the search field.
-  & .searchSuggest {
-    transition: opacity 300ms ease-out, max-height 300ms ease-out;
-  }
-
   // When the global search is closed
   .btn[aria-expanded='false'] {
     background-color: @navbar-default-bg;

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/action-menus.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/action-menus.less
@@ -125,6 +125,12 @@
     width: 200px; // we need to set a width in pixels otherwise the transition is not applied nicely
   }
 
+  // Defines a transition for when the search results get hidden because the focus
+  // moves out of the search field.
+  & .searchSuggest {
+    transition: opacity 300ms ease-out, max-height 300ms ease-out;
+  }
+
   // When the global search is closed
   .btn[aria-expanded='false'] {
     background-color: @navbar-default-bg;
@@ -145,6 +151,12 @@
     & + #headerglobalsearchinput { // we need to be that specific to be applied
       width: 0;
       padding: 0;
+    }
+
+    // Hides the search result when the focus is not on the search field.
+    & ~ .searchSuggest {
+      opacity: 0;
+      max-height: 0;
     }
   }
 }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22148

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Define a css selector for the search results when the focus is out of the search field
* Define a transition when the search results get hidden (I'm not really satisfied of the result for now, if somebody has a suggestion for improvement, @tkrieck maybe?)

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

[Screencast from 06-05-2024 15:44:39.webm](https://github.com/xwiki/xwiki-platform/assets/327856/b4d385f6-8106-4baf-bed0-88d66d532264)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Manual tests.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-16.3.x
  * stable-15.10.x