### PR TITLE
XWIKI-22152 In velocity, can't use $macro.myVar with setVariable macro

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -1230,6 +1230,9 @@ $html
 ## Only do this if the variable name is really a valid variable name
 #if ($variableName.matches('[a-zA-Z_][a-zA-Z0-9_-]*'))
 #evaluate("${escapetool.h}set(${escapetool.d}${variableName}=${escapetool.d}value)")
+#elseif ($variableName.matches('\$macro\.[a-zA-Z_][a-zA-Z0-9_-]*'))
+#set($macro.varName = $variableName.substring(7))
+#evaluate("${escapetool.h}set(${escapetool.d}macro.parent.parent.$macro.varName=${escapetool.d}value)")
 #elseif ($variableName.matches('\$[a-zA-Z_][a-zA-Z0-9_-]*'))
 #evaluate("${escapetool.h}set(${variableName}=${escapetool.d}value)")
 #end

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/MacrosTest.java
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/MacrosTest.java
@@ -67,7 +67,41 @@ class MacrosTest extends PageTest
     {
         this.velocityManager = this.oldcore.getMocker().getInstance(VelocityManager.class);
     }
+    
+    @Test
+    void setVariableGlobal() throws Exception
+    {
+        StringWriter writer = new StringWriter();
+        this.velocityManager.evaluate(writer, "logtag", new StringReader("\n"
+			+ "#macro(helloMacro $return)\n"
+			+ "  #set($return = $NULL)\n"
+			+ "  #setVariable(\"$return\" \"my new value\")\n"
+			+ "#end\n"
+			+ "#helloMacro($myVarToSet)"));
+        
+        VelocityContext velocityContext = this.velocityManager.getVelocityContext();
+        assertEquals("my new value", velocityContext.get("myVarToSet"));
+    } 
 
+    @Test
+    void setVariableInMacroContext() throws Exception
+    {
+        StringWriter writer = new StringWriter();
+        this.velocityManager.evaluate(writer, "logtag", new StringReader("\n"
+			+ "#macro(childMacro $return)\n"
+			+ "  #set($return = $NULL)\n"
+			+ "  #setVariable(\"$return\" \"value from child macro\")\n"
+			+ "#end\n"  		
+			+ "#macro(parentMacro $return)\n"
+			+ "  #childMacro($macro.childMacroResult)\n"
+			+ "  #setVariable(\"$return\" \"${macro.childMacroResult}/parentValue\")\n"
+			+ "#end\n"
+			+ "#parentMacro($myVarToSet)"));
+        
+        VelocityContext velocityContext = this.velocityManager.getVelocityContext();
+        assertEquals("value from child macro/parentValue", velocityContext.get("myVarToSet"));
+    } 
+    
     @Test
     void addLivetableLocationFilter() throws Exception
     {


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-22152

# Changes

## Description

Add support for variable like `$macro.myvar` in `setVariable` velocity macro.

## Clarifications

So to fix the described issue, the idea is to improve the `setVariable` macro to be able to set correctly the value when the caller pass a parameter to set with something like this `$macro.xxx`.

For this we need the `$macro.parent` which give access to the `$macro` dict of the caller. Note that we need to call `$macro.parent.parent` because `$macro.parent` return the macro which is calling `setVariable` and so we want to call the parent of this one.

# Executed Tests

To test this we can use this small code

```velocity
#macro(myChildMacro $return)
  #set($return = $NULL)
  #setVariable("$return" "my new value")
#end

#macro(myParentMacro)
  #myChildMacro($macro.childResult)
  $macro.childResult
#end

#myParentMacro()
```
Before we have this result

```
$macro.childResult
```

After we have this result:

```
my new value
```
# Expected merging strategy

* Prefers squash: Yes
* Backport on branches: Not needed, as it's a new feature.