### PR TITLE
XWIKI-22151: Impossible to move a page to a space with spaces in the name

### DIFF
--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/tree.js
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/webjar/tree.js
@@ -71,15 +71,7 @@ define([
         urlParams[pair[0]] = pair[1];
       }
     }
-    return $.post(new URL('?', url), $.param($.extend(urlParams, data), true))
-      .then((nodes) => {
-        nodes.forEach((object) => {
-          // Each node will be rendered as an HTML element.
-          // As such, we want to make sure we escape space characters in their ids
-          object.id = object.id.replaceAll('%', '%25').replaceAll(' ', '%20');
-        });
-        return nodes;
-      });
+    return $.post(new URL('?', url), $.param($.extend(urlParams, data), true));
   };
 
   var getChildren = function(node, callback, parameters) {
@@ -111,7 +103,7 @@ define([
       childrenURL = this.element.attr('data-url');
       parameters = $.extend({
         data: 'children',
-        id: node.id.replaceAll('%20', ' ').replaceAll('%25', '%')
+        id: node.id
       }, parameters);
     }
     if (childrenURL) {


### PR DESCRIPTION
This reverts xwiki/xwiki-platform#3015

Jira issue: https://jira.xwiki.org/browse/XWIKI-22151

Our code seems to heavily rely on the broken id values. We first need to decide how to continue from here, if we continue escaping the id values or if we replace the id values by a data attribute which sounds safer in the long run as it also avoids duplicate ids. I propose a simple revert for now until we have more carefully examined all places that are affected by this change.