### PR TITLE
XWIKI-22130: ORA-00932 errors which prevent filtering and sorting Notifications filters by 'Events' column on Oracle

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/src/test/it/org/xwiki/platform/notifications/test/ui/NotificationsSettingsIT.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/src/test/it/org/xwiki/platform/notifications/test/ui/NotificationsSettingsIT.java
@@ -829,6 +829,28 @@ class NotificationsSettingsIT
         assertEquals(CustomNotificationFilterPreference.FilterAction.NOTIFY_EVENT, filterPreference.getFilterAction());
         assertTrue(filterPreference.getEventTypes().isEmpty());
         assertEquals(pageSpaceName + ".Page_12", filterPreference.getLocation());
+
+        customPrefLiveData.clearAllSort();
+        customPrefLiveData.clearAllFilters();
+        customPrefLiveData.filterEventType(DELETE);
+        assertEquals(2, customPrefLiveData.getTableLayout().getTotalEntries());
+        customNotificationFilterPreferences = customPrefLiveData.getCustomNotificationFilterPreferences();
+        filterPreference = customNotificationFilterPreferences.get(1);
+        assertEquals("Page only", filterPreference.getScope());
+        assertEquals(NotificationsSettingsIT.class.getSimpleName() + ".Page2", filterPreference.getLocation());
+        assertEquals(CustomNotificationFilterPreference.FilterAction.NOTIFY_EVENT, filterPreference.getFilterAction());
+        assertEquals(List.of("Alert"), filterPreference.getFormats());
+        // core.events.delete before core.events.update
+        assertEquals(List.of("A page is deleted","A page is modified"), filterPreference.getEventTypes());
+
+        filterPreference = customNotificationFilterPreferences.get(0);
+
+        assertEquals("Page only", filterPreference.getScope());
+        assertEquals(NotificationsSettingsIT.class.getSimpleName() + ".Page1", filterPreference.getLocation());
+        assertEquals(CustomNotificationFilterPreference.FilterAction.NOTIFY_EVENT, filterPreference.getFilterAction());
+        assertEquals(List.of("Alert"), filterPreference.getFormats());
+        // core.events.delete before core.events.update
+        assertEquals(List.of("A page is deleted", "A page is modified"), filterPreference.getEventTypes());
     }
 
     @Test


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-22130

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

Right now this PR only contains an improvment of existing integration tests exposing the problem when executed with Oracle. 
The actual root cause error is: 
>  ORA-00932: inconsistent datatypes: expected CHAR got LONG

and it's happening because we have the following column with a type `text` in our hibernate file:
```
<property name="allEventTypes" type="text" column="nfp_event_types" />
```

The only possibility for fixing this is to provide a dedicated hibernate configuration for Oracle with a different column type. And to also provide a migration for Oracle. 
Now, maybe it would be more interesting to not do that, but instead to entirely refactor the table as proposed in https://forum.xwiki.org/t/change-db-schema-of-notificationfilterpreferences/14261/

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 