### PR TITLE
XWIKI-22166: Contrast of paragraph edit buttons is too low

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/headers.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/headers.less
@@ -38,9 +38,13 @@
   // Leave some space on the left so that we distinguish the section edit link from the heading text.
   margin-left: 1em;
   // We can have many section edit links on a page so they should have a low profile.
-  opacity: .3;
+  // We don't reduce the opacity too much in order to keep a correct contrast at least on the Iceberg colortheme.
+  opacity: .65;
+  // Add some padding so that the focus border is displayed nicely and doesn't cramp down aroundthe icon.
+  padding-right: 4px;
+  padding-left: 4px;
 }
 
-.edit_section:not(.disabled):hover {
+.edit_section:not(.disabled):hover, .edit_section:not(.disabled):focus {
   opacity: 1;
 }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22166

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Increased alpha on the icon, so that it would be visible enough even when not focused or hovered.
* Added a selector for the :focus pseudo class to benefit from the style already implemented for the :hover pseudo class (and improve consistency)
* Added padding around the icon so that the focus border is nice and square, not sticking on the side edges of the icon.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
before changes in this PR, default and focused states:
![22166-beforePR](https://github.com/xwiki/xwiki-platform/assets/28761965/813625e3-b2e6-49ad-aa4b-0cfbf871620e)

after changes in this PR, default and focused states:
![22166-afterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/bf635458-6aa8-4dc9-afe9-7dfff29fb59e)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests, see above. Style change only so no test should be impacted.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.X - pretty safe style changes.