### PR TITLE
XWIKI-22169: Breadcrumb dropdowns for navigation should be keyboard accessible

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/breadcrumbs.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/breadcrumbs.less
@@ -29,6 +29,7 @@
         background: transparent;
         border-color: transparent;
         padding: 0;
+        line-height: .5rem;
 
         &:hover, &:focus {
           color: @breadcrumb-active-color;

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/breadcrumbs.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/breadcrumbs.less
@@ -23,10 +23,17 @@
         color: @breadcrumb-color;
         cursor: pointer;
         /* Match the separator padding */
+        margin: 2px;
         margin-left: 5px;
+        /* Remove default styles for buttons */
+        background: transparent;
+        border-color: transparent;
+        padding: 0;
 
-        :hover {
+        &:hover, &:focus {
           color: @breadcrumb-active-color;
+          /* We want to revert the default from bootstrap where the outline is removed... */
+          outline: revert;
         }
       }
 

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/hierarchy_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/hierarchy_macros.vm
@@ -220,8 +220,8 @@
       'showTranslations': $xwiki.isMultiLingual(),
       'showWikis': $showWikis
     })
-    #set ($treeToggle = "<span class='dropdown-toggle' data-toggle='dropdown'>" +
-      "$services.icon.renderHTML('caret-down')</span>")
+    #set ($treeToggle = "<button class='dropdown-toggle' data-toggle='dropdown'>" +
+      "$services.icon.renderHTML('caret-down')</button>")
     #set ($treeNavigation = "$treeToggle<div class='dropdown-menu'>#documentTree($treeParams)</div>")
   #end
 #end


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22169

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Changed the nature of the dropdown toggler so that it can be keyboard focused
* Updated the style of this toggler so that focus is visible
* Reduced line height to avoid increasing the whole breadcrumb height by adding the 2px of margin (to fit the border) on the buttons.

## Clarifications
* The dropdown togglers already rely on a common logic to handle their behavior (could use it with a mouse). All we had to do here was to make sure the toggler was keyboard accessible. The whole dropdown experience behind that is a regular xwiki tree, we do not need to update anything.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Here is a video illustrating the new behavior of the togglers:

https://github.com/xwiki/xwiki-platform/assets/28761965/160b13c6-8f0a-4fb7-a8f9-c740260b2a3b

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests, see video above. 

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.X, low impact changes. The DOM is changed, but from what I could see, this navigation feature of the breadcrumb is never tested.