### PR TITLE
XWIKI-22176: WrappingQuery's bindValue(s) methods unexpectedly return the wrapped query

### DIFF
--- a/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/Query.java
+++ b/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/Query.java
@@ -79,11 +79,11 @@ public interface Query
     /**
      * Bind named parameter var with value val in query statement.
      *
-     * @param var variable in query statement (:var).
+     * @param variable variable in query statement (:var).
      * @param val value of the variable.
      * @return this query
      */
-    Query bindValue(String var, Object val);
+    Query bindValue(String variable, Object val);
 
     /**
      * Bind a positional parameter present in the statement (?index in XWQL) with a value. It is recommended to use
@@ -122,19 +122,19 @@ public interface Query
     }
 
     /**
-     * Bind named parameter var with a value that will be constructed using calls to
+     * Bind named parameter variable with a value that will be constructed using calls to
      * {@link QueryParameter#literal(String)}, {@link QueryParameter#anychar()} and {@link QueryParameter#anyChars()}.
      * In order to perserve the fluent API, it's also possible to call {@link QueryParameter#query()} to get back the
      * {@link Query}.
      *
-     * @param var the variable in the query statement ({@code :var}).
+     * @param variable the variable in the query statement ({@code :variable}).
      * @return an empty {@link QueryParameter} that needs to be populated by calling
      *         {@link QueryParameter#literal(String)}, {@link QueryParameter#anychar()} and
      *         {@link QueryParameter#anyChars()}
      * @since 8.4.5
      * @since 9.3RC1
      */
-    default QueryParameter bindValue(String var)
+    default QueryParameter bindValue(String variable)
     {
         throw new RuntimeException("Not implemented");
     }

--- a/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/Query.java
+++ b/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/Query.java
@@ -77,9 +77,9 @@ public interface Query
     String getWiki();
 
     /**
-     * Bind named parameter var with value val in query statement.
+     * Bind named parameter variable with value val in query statement.
      *
-     * @param variable variable in query statement (:var).
+     * @param variable variable in query statement (:variable).
      * @param val value of the variable.
      * @return this query
      */

--- a/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/WrappingQuery.java
+++ b/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/WrappingQuery.java
@@ -32,7 +32,7 @@ import java.util.Map;
  */
 public class WrappingQuery implements Query
 {
-    private Query wrappedQuery;
+    private final Query wrappedQuery;
 
     /**
      * @param wrappedQuery the query being wrapped

--- a/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/WrappingQuery.java
+++ b/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/WrappingQuery.java
@@ -83,25 +83,29 @@ public class WrappingQuery implements Query
     @Override
     public Query bindValue(String variable, Object val)
     {
-        return getWrappedQuery().bindValue(variable, val);
+        getWrappedQuery().bindValue(variable, val);
+        return this;
     }
 
     @Override
     public Query bindValue(int index, Object val)
     {
-        return getWrappedQuery().bindValue(index, val);
+        getWrappedQuery().bindValue(index, val);
+        return this;
     }
 
     @Override
     public Query bindValues(List<Object> values)
     {
-        return getWrappedQuery().bindValues(values);
+        getWrappedQuery().bindValues(values);
+        return this;
     }
 
     @Override
     public Query bindValues(Map<String, ?> values)
     {
-        return getWrappedQuery().bindValues(values);
+        getWrappedQuery().bindValues(values);
+        return this;
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/WrappingQuery.java
+++ b/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/WrappingQuery.java
@@ -81,9 +81,9 @@ public class WrappingQuery implements Query
     }
 
     @Override
-    public Query bindValue(String var, Object val)
+    public Query bindValue(String variable, Object val)
     {
-        return getWrappedQuery().bindValue(var, val);
+        return getWrappedQuery().bindValue(variable, val);
     }
 
     @Override
@@ -111,9 +111,9 @@ public class WrappingQuery implements Query
     }
 
     @Override
-    public QueryParameter bindValue(String var)
+    public QueryParameter bindValue(String variable)
     {
-        return getWrappedQuery().bindValue(var);
+        return getWrappedQuery().bindValue(variable);
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/DefaultQuery.java
+++ b/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/DefaultQuery.java
@@ -169,9 +169,9 @@ public class DefaultQuery implements SecureQuery
     }
 
     @Override
-    public Query bindValue(String var, Object val)
+    public Query bindValue(String variable, Object val)
     {
-        this.namedParameters.put(var, val);
+        this.namedParameters.put(variable, val);
         return this;
     }
 
@@ -209,10 +209,10 @@ public class DefaultQuery implements SecureQuery
     }
 
     @Override
-    public QueryParameter bindValue(String var)
+    public QueryParameter bindValue(String variable)
     {
         QueryParameter parameter = new DefaultQueryParameter(this);
-        bindValue(var, parameter);
+        bindValue(variable, parameter);
         return parameter;
     }
 

--- a/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/DefaultQuery.java
+++ b/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/DefaultQuery.java
@@ -57,7 +57,7 @@ public class DefaultQuery implements SecureQuery
     /**
      * field for {@link Query#getStatement()}.
      */
-    private String statement;
+    private final String statement;
 
     /**
      * field for {@link Query#getLanguage()}.
@@ -72,12 +72,12 @@ public class DefaultQuery implements SecureQuery
     /**
      * map from query parameters to values.
      */
-    private Map<String, Object> namedParameters = new HashMap<String, Object>();
+    private final Map<String, Object> namedParameters = new HashMap<String, Object>();
 
     /**
      * map from index to positional parameter value.
      */
-    private Map<Integer, Object> positionalParameters = new HashMap<Integer, Object>();
+    private final Map<Integer, Object> positionalParameters = new HashMap<Integer, Object>();
 
     /**
      * field for {@link Query#setLimit(int)}.
@@ -102,12 +102,12 @@ public class DefaultQuery implements SecureQuery
     /**
      * field for {@link #getFilters()}.
      */
-    private List<QueryFilter> filters = new ArrayList<QueryFilter>();
+    private final List<QueryFilter> filters = new ArrayList<QueryFilter>();
 
     /**
      * field for {@link #getExecuter()}.
      */
-    private transient QueryExecutor executer;
+    private final transient QueryExecutor executer;
 
     /**
      * Create a Query.

--- a/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/ScriptQuery.java
+++ b/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/ScriptQuery.java
@@ -59,12 +59,12 @@ public class ScriptQuery implements SecureQuery
     /**
      * Used to retrieve {@link org.xwiki.query.QueryFilter} implementations.
      */
-    private ComponentManager componentManager;
+    private final ComponentManager componentManager;
 
     /**
      * The wrapped {@link Query}.
      */
-    private Query query;
+    private final Query query;
 
     private boolean switchAuthor;
 

--- a/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/ScriptQuery.java
+++ b/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/ScriptQuery.java
@@ -177,9 +177,9 @@ public class ScriptQuery implements SecureQuery
     }
 
     @Override
-    public Query bindValue(String var, Object val)
+    public Query bindValue(String variable, Object val)
     {
-        this.query.bindValue(var, val);
+        this.query.bindValue(variable, val);
         return this;
     }
 
@@ -205,9 +205,9 @@ public class ScriptQuery implements SecureQuery
     }
 
     @Override
-    public QueryParameter bindValue(String var)
+    public QueryParameter bindValue(String variable)
     {
-        QueryParameter parameter = this.query.bindValue(var);
+        QueryParameter parameter = this.query.bindValue(variable);
         return new ScriptQueryParameter(this, parameter);
     }
 

--- a/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/test/java/org/xwiki/query/internal/WrappingQueryTest.java
+++ b/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/test/java/org/xwiki/query/internal/WrappingQueryTest.java
@@ -1,0 +1,53 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.query.internal;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.query.Query;
+import org.xwiki.query.WrappingQuery;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+
+import static org.mockito.Mockito.mock;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Unit tests for {@link WrappingQuery}.
+ *
+ * @version $Id$
+ * @since 8.4.5
+ * @since 9.3RC1
+ */
+@ComponentTest
+class WrappingQueryTest
+{
+    @Test
+    void bindValueReturnsThisTest()
+    {
+        Query wrappedQuery =  mock(Query.class);
+        Query wrappingQuery = new WrappingQuery(wrappedQuery);
+        assertSame(wrappingQuery, wrappingQuery.bindValue("hello", "world"));
+        assertSame(wrappingQuery, wrappingQuery.bindValue(0, "hello"));
+        assertSame(wrappingQuery, wrappingQuery.bindValues(List.of("hello", "world")));
+        assertSame(wrappingQuery, wrappingQuery.bindValues(Map.of("hello", "world")));
+    }
+}


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-22176

# Changes

## Description

- `bindValue` and `bindValues` families of methods now return `this` in `WrappingQuery` to honor the documented behavior from the JavaDoc of the implemented interface `Query`
- I also renamed parameters called `var` in `Query` and its implemented interfaces
- I also made some fields `final` (but I can remove this commit if not wanted)


# Expected merging strategy

* Prefers squash: No (because there are Misc commits)
* Backport on branches: I'm not sure whether we want to backport this.  Probably.