### PR TITLE
XWIKI-22184: Change the underlining inline links behavior on a minimal install

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/general.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/general.less
@@ -134,7 +134,7 @@ img {
 }
 
 // User preferences ===========================================================
-body.content {
+body {
   /* We apply various user preference related styles to the content of the page.
    We use classes that are added to the body itself in htmlheader.vm */
   // Link underlining preference


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22184

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Reduced the specificity of the underlining preference selector so that it's matched even during docker testing.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The selector for the underlining preference rules was very specific. In this case it was too specific. It relied on the `.content` class, which is somehow related only to the state of the columns. In docker tests, there is no side panels, and the .content class is not on the body. This caused the automated tests to unexpectedly sill fail on all the link that were supposed to be fixed by the new underlining defaults. The fix reduces specificity on the style rule. This should not have any negative impact. AFAIR this rule was not here out of necessity, I just added it to avoid matching too wide. I should have considered the origin of the `.content` class better though.
* This class was introduced in https://github.com/xwiki/xwiki-platform/commit/abcf971d7d52e80cc512f3c4f8eb37623331ff8a . 

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
None, test change only.
# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Ran `mvn clean install -f xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/ -Pdocker -Dit.test=PageTemplatesIT -Dxwiki.test.ui.wcag=true` successfully. The inline links were only reported for the places fixed in this other PR: https://github.com/xwiki/xwiki-platform/pull/3124 .

My expectation is for this change to fix most of the automated tests about link underlining, at least the ~220 occurences of issues that arise with the lastModificationAuthor link (which is the one I checked manually and the one that was overly present in the administration tests) .

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, like https://github.com/xwiki/xwiki-platform/pull/2694