### PR TITLE
XWIKI-22177: Remove the login button for guest users commenting

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/commentsinline.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/commentsinline.vm
@@ -258,12 +258,6 @@ $xwiki.ssfx.use('uicomponents/viewers/comments.css', true)
       $services.localization.render('core.viewers.comments.add.commentAsGuest.label')
     #end
   </button>
-  #if($isGuest)
-    <a id='loginAndComment' class='btn btn-primary'
-      href='$xwiki.getURL('XWiki.XWikiLogin', 'login', "xredirect=$escapetool.url($doc.getURL('view', 'viewer=comments'))")'>
-      $services.localization.render('core.viewers.comments.add.loginAndComment.label')
-    </a>
-  #end
 #end
 ##
 ##


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22177

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Removed the login button from the guest comment UI.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Didn't add any hint to replace this button. It seems to me like the UI is already clear enough about the user being a guest. See screenshots below.
* This button was added after a recent update for https://jira.xwiki.org/browse/XWIKI-12471 .

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
This is what a logged out user commenting on a wiki will see after the changes brought in this PR:
Step 1
![22177-afterPR1](https://github.com/xwiki/xwiki-platform/assets/28761965/cc4f14ff-e5db-4f6b-9f43-d3215588a57c)
Step 2
![22177-afterPR2](https://github.com/xwiki/xwiki-platform/assets/28761965/738f370d-eb75-4d01-91af-5e0ba888cc8a)

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

None, changes only concern content added for XWIKI-12471. We can see that no test goes with it: https://github.com/xwiki/xwiki-platform/commit/92d8ef004554730bb4b0b355f8aa2578f432a1ee

Only manual testing, see screenshot above.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None