### PR TITLE
XWIKI-22183: FilesystemAttachmentVersioningStore#loadArchive leads to a switch of metadata dirty flag

### DIFF
--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/FilesystemAttachmentVersioningStore.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/FilesystemAttachmentVersioningStore.java
@@ -134,7 +134,7 @@ public class FilesystemAttachmentVersioningStore implements AttachmentVersioning
             attach.setAttachment_content(new FilesystemAttachmentContent(contentFile, attach));
             attach.setContentStore(FileSystemStoreUtils.HINT);
             // Pass the document since it will be lost in the serialize/deserialize.
-            attach.setDoc(attachment.getDoc());
+            attach.setDoc(attachment.getDoc(), false);
         }
 
         final ListAttachmentArchive out = new ListAttachmentArchive(attachList);


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22183

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Ensure to not update the dirty flag when setting the attachment doc in #loadArchive
* New integration test to ensure renaming a document with an attachment doesn't mess up history

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

N/A

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

`mvn clean install -Dit.test=RenamePageIT#renamePageWithObjectAndAttachmentsPreserveHistory`

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.4.x
  * Probably 15.10.x, to be confirmed