### PR TITLE
XWIKI-22182: Page history is missing after a page containing attachments is moved

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateVersioningStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateVersioningStore.java
@@ -19,10 +19,14 @@
  */
 package com.xpn.xwiki.store;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -148,11 +152,69 @@ public class XWikiHibernateVersioningStore extends XWikiHibernateBaseStore imple
         XWikiContext inputxcontext) throws XWikiException
     {
         XWikiDocumentArchive archiveDoc = doc.getDocumentArchive();
-        // We only retrieve a cached archive if we want a complete one.
-        if (archiveDoc != null && criteria.isAllInclusive()) {
-            return archiveDoc;
+        if (archiveDoc == null) {
+            archiveDoc = getXWikiDocumentArchiveFromDatabase(doc, criteria, inputxcontext);
+        } else if (!criteria.isAllInclusive()) {
+            archiveDoc = filterArchiveFromCriteria(doc, archiveDoc, criteria);
+        }
+        return archiveDoc;
+    }
+
+    private XWikiDocumentArchive filterArchiveFromCriteria(XWikiDocument doc, XWikiDocumentArchive archiveDoc,
+        RevisionCriteria criteria)
+    {
+        XWikiDocumentArchive result =
+            new XWikiDocumentArchive(doc.getDocumentReference().getWikiReference(), doc.getId());
+        Collection<XWikiRCSNodeInfo> nodes = archiveDoc.getNodes();
+        XWikiRCSNodeInfo nodeinfo = null;
+        List<XWikiRCSNodeInfo> results = new ArrayList<>();
+
+        for (XWikiRCSNodeInfo nextNodeinfo : nodes) {
+            if (nodeinfo != null && (criteria.getIncludeMinorVersions() || !nextNodeinfo.isMinorEdit())) {
+                if (isAuthorMatching(criteria, nodeinfo) && isDateMatching(criteria, nodeinfo)) {
+                    results.add(nodeinfo);
+                }
+            }
+            nodeinfo = nextNodeinfo;
+        }
+        if (nodeinfo != null && isAuthorMatching(criteria, nodeinfo) && isDateMatching(criteria, nodeinfo)) {
+            results.add(nodeinfo);
         }
 
+        List<String> versionList = criteria.getRange().subList(
+            results
+                .stream()
+                .map(XWikiRCSNodeInfo::getVersion)
+                .map(Version::toString)
+                .collect(
+                    Collectors.collectingAndThen(
+                        Collectors.toList(),
+                        l -> {
+                            Collections.reverse(l); return l;
+                        }
+                    )
+                )
+        );
+        result.setNodes(results.stream()
+            .filter(node -> versionList.contains(node.getVersion().toString())).toList());
+        return result;
+    }
+
+    private static boolean isAuthorMatching(RevisionCriteria criteria, XWikiRCSNodeInfo nodeinfo)
+    {
+        return criteria.getAuthor().isEmpty() || criteria.getAuthor().equals(nodeinfo.getAuthor());
+    }
+
+    private static boolean isDateMatching(RevisionCriteria criteria, XWikiRCSNodeInfo nodeinfo)
+    {
+        Date versionDate = nodeinfo.getDate();
+        return (versionDate.after(criteria.getMinDate()) && versionDate.before(criteria.getMaxDate()));
+    }
+
+    private XWikiDocumentArchive getXWikiDocumentArchiveFromDatabase(XWikiDocument doc, RevisionCriteria criteria,
+        XWikiContext inputxcontext) throws XWikiException
+    {
+        XWikiDocumentArchive archiveDoc = null;
         XWikiContext context = getExecutionXContext(inputxcontext, true);
 
         String db = context.getWikiId();


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22182

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

 * apply the criteria over the archive in cache when possible instead of always loading it from database

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.x
  * 16.4.x