### PR TITLE
XWIKI-22187: Cannot get revisions with a criteria on a document not stored in DB

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/VersionIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/VersionIT.java
@@ -32,6 +32,7 @@ import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.rest.model.jaxb.Page;
 import org.xwiki.test.docker.junit5.TestReference;
 import org.xwiki.test.docker.junit5.UITest;
+import org.xwiki.test.integration.junit.LogCaptureConfiguration;
 import org.xwiki.test.ui.TestUtils;
 import org.xwiki.test.ui.po.HistoryPane;
 import org.xwiki.test.ui.po.ViewPage;
@@ -52,7 +53,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 @UITest(properties = {
     // Add the FileUploadPlugin which is needed by the test to upload attachment files
-    "xwikiCfgPlugins=com.xpn.xwiki.plugin.fileupload.FileUploadPlugin"})
+    "xwikiCfgPlugins=com.xpn.xwiki.plugin.fileupload.FileUploadPlugin",
+    // The script needs PR right.
+    "xwikiPropertiesAdditionalProperties=test.prchecker.excludePattern="
+        + ".*:((Nested)?VersionIT\\.getRevisionsWithCriteria\\.Script)"
+})
 class VersionIT
 {
     private static final String TITLE = "Page Title";
@@ -644,5 +649,60 @@ class VersionIT
             historyPane = historyPane.showMinorEdits();
             historyPane.rollbackToVersion(latestVersionBeforeChanges);
         }
+    }
+
+    @Test
+    @Order(10)
+    void getRevisionsWithCriteria(TestUtils testUtils, TestReference testReference,
+        LogCaptureConfiguration logCaptureConfiguration) throws Exception
+    {
+        testUtils.loginAsSuperAdmin();
+        testUtils.rest().delete(testReference);
+        testUtils.rest().savePage(testReference, "Some content", "Title");
+        testUtils.rest().savePage(testReference, "Some content 1", "Title");
+        testUtils.rest().savePage(testReference, "Some content 1 2", "Title");
+        testUtils.rest().savePage(testReference, "Some content 1 2 3", "Title");
+        testUtils.rest().savePage(testReference, "Some content 1 2 3 4", "Title");
+
+        ViewPage viewPage = testUtils.gotoPage(testReference);
+        HistoryPane historyPane = viewPage.openHistoryDocExtraPane();
+        assertEquals("5.1", historyPane.getCurrentVersion());
+        assertEquals(5, historyPane.getNumberOfVersions());
+
+        String currentTestReference = testUtils.serializeReference(testReference);
+        String targetTestReference = "xwiki:Test.getRevisionsWithCriteriaFoo.WebHome";
+        String script = String.format("""
+        {{velocity}}
+        #set ($myTest = "%s")
+        #set ($startAt = 0)
+        #set ($endAt = -1)
+        #set ($criteria = $xwiki.criteriaService.revisionCriteriaFactory.createRevisionCriteria('', $minorVersions))
+        #set ($range = $xwiki.criteriaService.rangeFactory.createRange($startAt, $endAt))
+        #set ($discard = $criteria.setRange($range))
+        #set ($myDoc = $xwiki.getDocument($myTest))
+        #set ($xwikiDoc = $myDoc.document)
+        #set ($discard = $myDoc.document.loadArchive($xcontext.context))
+        XWiki Doc: $xwikiDoc
+        #set ($revisions = $xwikiDoc.getRevisions($criteria, $xcontext.context))
+        Revision: $revisions
+        #set ($newRef = $services.model.resolveDocument("%s"))
+        #set ($discard = $xwikiDoc.setDocumentReference($newRef))
+        XWiki Doc: $xwikiDoc
+        #set ($revisions = $xwikiDoc.getRevisions($criteria, $xcontext.context))
+        Revision: $revisions
+        {{/velocity}}
+        """, currentTestReference, targetTestReference);
+
+        DocumentReference scriptReference = new DocumentReference("Script", testReference.getLastSpaceReference());
+        ViewPage page = testUtils.createPage(scriptReference, script);
+        String expectedResult = String.format("""
+        XWiki Doc: %s
+        Revision: [5.1]
+        XWiki Doc: %s
+        Revision: [5.1]""", currentTestReference.substring("xwiki:".length()), targetTestReference.substring("xwiki:".length()));
+        assertEquals(expectedResult, page.getContent());
+        logCaptureConfiguration.registerExpectedRegexes("^.*\\QDeprecated usage of method "
+            + "[com.xpn.xwiki.doc.XWikiDocument.setDocumentReference] in "
+            + "xwiki:\\E(Nested)?\\QVersionIT.getRevisionsWithCriteria.Script\\E.*$");
     }
 }

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/VersionIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/VersionIT.java
@@ -29,6 +29,7 @@ import org.xwiki.flamingo.skin.test.po.AttachmentsPane;
 import org.xwiki.flamingo.skin.test.po.AttachmentsViewPage;
 import org.xwiki.model.reference.AttachmentReference;
 import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.rendering.syntax.Syntax;
 import org.xwiki.rest.model.jaxb.Page;
 import org.xwiki.test.docker.junit5.TestReference;
 import org.xwiki.test.docker.junit5.UITest;
@@ -56,7 +57,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
     "xwikiCfgPlugins=com.xpn.xwiki.plugin.fileupload.FileUploadPlugin",
     // The script needs PR right.
     "xwikiPropertiesAdditionalProperties=test.prchecker.excludePattern="
-        + ".*:((Nested)?VersionIT\\.getRevisionsWithCriteria\\.Script)"
+        + ".*:Test\\.Execute\\..+"
 })
 class VersionIT
 {
@@ -656,7 +657,6 @@ class VersionIT
     void getRevisionsWithCriteria(TestUtils testUtils, TestReference testReference,
         LogCaptureConfiguration logCaptureConfiguration) throws Exception
     {
-        testUtils.loginAsSuperAdmin();
         testUtils.rest().delete(testReference);
         testUtils.rest().savePage(testReference, "Some content", "Title");
         testUtils.rest().savePage(testReference, "Some content 1", "Title");
@@ -693,16 +693,16 @@ class VersionIT
         {{/velocity}}
         """, currentTestReference, targetTestReference);
 
-        DocumentReference scriptReference = new DocumentReference("Script", testReference.getLastSpaceReference());
-        ViewPage page = testUtils.createPage(scriptReference, script);
+        String obtainedResult = testUtils.executeWikiPlain(script, Syntax.XWIKI_2_1);
         String expectedResult = String.format("""
         XWiki Doc: %s
         Revision: [5.1]
         XWiki Doc: %s
-        Revision: [5.1]""", currentTestReference.substring("xwiki:".length()), targetTestReference.substring("xwiki:".length()));
-        assertEquals(expectedResult, page.getContent());
+        Revision: [5.1]""",
+            currentTestReference.substring("xwiki:".length()),
+            targetTestReference.substring("xwiki:".length()));
+        assertEquals(expectedResult, obtainedResult);
         logCaptureConfiguration.registerExpectedRegexes("^.*\\QDeprecated usage of method "
-            + "[com.xpn.xwiki.doc.XWikiDocument.setDocumentReference] in "
-            + "xwiki:\\E(Nested)?\\QVersionIT.getRevisionsWithCriteria.Script\\E.*$");
+            + "[com.xpn.xwiki.doc.XWikiDocument.setDocumentReference] in xwiki:Test.Execute\\E.*$");
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateVersioningStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateVersioningStore.java
@@ -153,6 +153,7 @@ public class XWikiHibernateVersioningStore extends XWikiHibernateBaseStore imple
         XWikiDocumentArchive archiveDoc = doc.getDocumentArchive();
         if (archiveDoc == null) {
             archiveDoc = getXWikiDocumentArchiveFromDatabase(doc, criteria, inputxcontext);
+        // if there's an archive doc and the criteria is to not return everything then we filter, else we just return
         } else if (!criteria.isAllInclusive()) {
             archiveDoc = filterArchiveFromCriteria(doc, archiveDoc, criteria);
         }
@@ -168,6 +169,7 @@ public class XWikiHibernateVersioningStore extends XWikiHibernateBaseStore imple
         XWikiRCSNodeInfo nodeinfo = null;
         List<XWikiRCSNodeInfo> results = new ArrayList<>();
 
+        // Iterate over all versions and get the ones matching the criteria
         for (XWikiRCSNodeInfo nextNodeinfo : nodes) {
             if (nodeinfo != null && (criteria.getIncludeMinorVersions() || !nextNodeinfo.isMinorEdit())) {
                 if (isAuthorMatching(criteria, nodeinfo) && isDateMatching(criteria, nodeinfo)) {
@@ -180,6 +182,8 @@ public class XWikiHibernateVersioningStore extends XWikiHibernateBaseStore imple
             results.add(nodeinfo);
         }
 
+        // getRange().subList only applies on String: so we apply it on the Version (e.g.: 1.1,2.1,etc) and
+        // we ensure to return them in the ascending order: nodes are returned from the archive in descending order
         List<String> versionList = criteria.getRange().subList(
             results
                 .stream()
@@ -194,6 +198,7 @@ public class XWikiHibernateVersioningStore extends XWikiHibernateBaseStore imple
                     )
                 )
         );
+        // We retrieve the actual nodes from the versions we kept just before
         result.setNodes(results.stream()
             .filter(node -> versionList.contains(node.getVersion().toString())).toList());
         return result;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateVersioningStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateVersioningStore.java
@@ -19,14 +19,10 @@
  */
 package com.xpn.xwiki.store;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Date;
 import java.util.Deque;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import javax.inject.Named;
 import javax.inject.Singleton;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/XWikiVersioningStoreInterfaceTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/XWikiVersioningStoreInterfaceTest.java
@@ -19,6 +19,7 @@
  */
 package com.xpn.xwiki.store;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -56,7 +57,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class XWikiVersioningStoreInterfaceTest
+class XWikiVersioningStoreInterfaceTest
 {
     @Spy
     private XWikiVersioningStoreInterface versioningStore;
@@ -87,19 +88,14 @@ public class XWikiVersioningStoreInterfaceTest
             archiveNodes.put((Version) arguments.get()[0], node);
         });
 
-        when(this.archive.getNode(any(Version.class))).thenAnswer(i -> {
-            Version version = i.getArgument(0);
-            return archiveNodes.getOrDefault(version, null);
-        });
-
-        List<Version> versions = archiveNodes.keySet().stream().sorted().collect(Collectors.toList());
-        Collections.reverse(versions);
-        when(this.versioningStore.getXWikiDocVersions(any(), any())).thenReturn(versions.toArray(new Version[0]));
+        List<XWikiRCSNodeInfo> nodes = new ArrayList<>(archiveNodes.values());
+        Collections.sort(nodes);
+        when(this.archive.getNodes()).thenReturn(nodes);
         when(this.versioningStore.getXWikiDocumentArchive(any(), any())).thenReturn(this.archive);
     }
 
     @Test
-    void testGetVersionsDefaultCriteria() throws XWikiException
+    void getVersionsDefaultCriteria() throws XWikiException
     {
         RevisionCriteria criteria = new RevisionCriteria();
         Collection<Version> versions = this.versioningStore.getXWikiDocVersions(null, criteria, null);
@@ -111,7 +107,7 @@ public class XWikiVersioningStoreInterfaceTest
     }
 
     @Test
-    void testGetVersionsFilterAuthor() throws XWikiException
+    void getVersionsFilterAuthor() throws XWikiException
     {
         RevisionCriteria criteria = new RevisionCriteriaFactory().createRevisionCriteria("Author1", true);
         Collection<Version> versions = this.versioningStore.getXWikiDocVersions(null, criteria, null);
@@ -123,7 +119,7 @@ public class XWikiVersioningStoreInterfaceTest
     }
 
     @Test
-    void testGetVersionsFilterDate() throws XWikiException
+    void getVersionsFilterDate() throws XWikiException
     {
         RevisionCriteria criteria = new RevisionCriteriaFactory().createRevisionCriteria(new Period(1999L, 6001L),
             true);
@@ -136,7 +132,7 @@ public class XWikiVersioningStoreInterfaceTest
     }
 
     @Test
-    void testGetLastVersion() throws XWikiException
+    void getLastVersion() throws XWikiException
     {
         RevisionCriteria criteria = new RevisionCriteriaFactory().createRevisionCriteria();
         criteria.setRange(RangeFactory.getLAST());


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

  * apply the criteria over the archive in cache when possible instead of always loading it from database
  * add an integration test to test that there's no regression on getRevision API even if the document is not stored

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* For the fix I actually took back and improved code that was removed in https://github.com/xwiki/xwiki-platform/pull/2925/files#diff-bb23b7b80163e5c6cac4ba4592802e30d01ac1d463466454d47e8eaa5bf021d9L2678-L2716

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Manually tested with the reproduction steps provided in jira ticket, and then executed `mvn clean install -Dit.test=VersionIT` and `mvn clean install -Pquality` in oldcore and legacy-oldcore. 

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.x
  * 16.4.x