### PR TITLE
XWIKI-22137: Tour button on the bottom right in French doesn't display properly characters with accents 

### DIFF
--- a/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui/src/main/resources/TourCode/TourJS.xml
+++ b/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui/src/main/resources/TourCode/TourJS.xml
@@ -172,10 +172,8 @@ require(['jquery', 'xwiki-meta'], function ($, xm) {
     // Create the popover
     var popover = $('&lt;div class="popover-content"&gt;#tr("tour.popover.show.hint")&lt;/div&gt;').appendTo(buttonContainer);
     // Create the button that will start the tour again
-    var button = $($jsontool.serialize("&lt;button id='tourResume' class='btn btn-default btn-xs'&gt;$services.icon.renderHTML('info')")
-      + "#tr('tour.popover.show')"
-      + $jsontool.serialize("&lt;/button&gt;"))
-      .appendTo(buttonContainer);
+    const button = $('&lt;button id=\'tourResume\' class=\'btn btn-default btn-xs\'&gt;&lt;/button&gt;')
+      .html("$escapetool.javascript($services.icon.renderHTML('info')) #tr('tour.popover.show')")
 
     if (showPopover) {
       buttonContainer.addClass('opened');

--- a/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui/src/main/resources/TourCode/TourJS.xml
+++ b/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui/src/main/resources/TourCode/TourJS.xml
@@ -174,6 +174,7 @@ require(['jquery', 'xwiki-meta'], function ($, xm) {
     // Create the button that will start the tour again
     const button = $('&lt;button id=\'tourResume\' class=\'btn btn-default btn-xs\'&gt;&lt;/button&gt;')
       .html("$escapetool.javascript($services.icon.renderHTML('info')) #tr('tour.popover.show')")
+      .appendTo(buttonContainer);
 
     if (showPopover) {
       buttonContainer.addClass('opened');

--- a/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui/src/main/resources/TourCode/TourJS.xml
+++ b/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui/src/main/resources/TourCode/TourJS.xml
@@ -172,7 +172,10 @@ require(['jquery', 'xwiki-meta'], function ($, xm) {
     // Create the popover
     var popover = $('&lt;div class="popover-content"&gt;#tr("tour.popover.show.hint")&lt;/div&gt;').appendTo(buttonContainer);
     // Create the button that will start the tour again
-    var button = $($jsontool.serialize("&lt;button id='tourResume' class='btn btn-default btn-xs'&gt;$services.icon.renderHTML('info') #tr('tour.popover.show')&lt;/button&gt;")).appendTo(buttonContainer);
+    var button = $($jsontool.serialize("&lt;button id='tourResume' class='btn btn-default btn-xs'&gt;$services.icon.renderHTML('info')")
+      + "#tr('tour.popover.show')"
+      + $jsontool.serialize("&lt;/button&gt;"))
+      .appendTo(buttonContainer);
 
     if (showPopover) {
       buttonContainer.addClass('opened');


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22137

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Removed the json escaping from the button text content

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* AFAIK there's no easy string substitution function in Javascript (no way to easily add the translation after it's been serialized)
* Before the changes brought in XWIKI-21475, this string was not escaped at all. I suppose it's okay to remove escaping from it.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
before PR vvv
![22137-beforePR](https://github.com/xwiki/xwiki-platform/assets/28761965/cf557bfb-1a80-49c5-ab39-01b6741448a9)

after PR vvv
![221137-afterPR](https://github.com/xwiki/xwiki-platform/assets/28761965/c3e39870-853a-4bac-8491-7b965a92aab0)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Manual test only, the changes causing this did not come with any test update: https://github.com/xwiki/xwiki-platform/pull/2585

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.X