### PR TITLE
XWIKI-22056: Inserted icons on each line via Quick Actions are merged into one line in view mode

### DIFF
--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-macro/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-macro/pom.xml
@@ -110,5 +110,11 @@
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>
+    <dependency>
+      <groupId>org.xwiki.rendering</groupId>
+      <artifactId>xwiki-rendering-macro-html</artifactId>
+      <version>${rendering.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-macro/src/test/java/org/xwiki/icon/macro/IntegrationTests.java
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-macro/src/test/java/org/xwiki/icon/macro/IntegrationTests.java
@@ -72,6 +72,8 @@ public class IntegrationTests implements RenderingTests
             componentManager.registerMockComponent(ContextualAuthorizationManager.class);
         // Grant view right on the icon document.
         when(authorizationManager.hasAccess(Right.VIEW, ICON_DOCUMENT_REFERENCE)).thenReturn(true);
+        // Grant script right to disable restricted cleaning in the HTML macro.
+        when(authorizationManager.hasAccess(Right.SCRIPT)).thenReturn(true);
         componentManager.registerMockComponent(AuthorizationManager.class);
 
         // Mock the icon set cache as it fails.
@@ -117,6 +119,13 @@ public class IntegrationTests implements RenderingTests
         documentIconSet.setRenderWiki("document $icon");
         documentIconSet.setSourceDocumentReference(new DocumentReference(ICON_DOCUMENT_REFERENCE));
         when(iconSetManager.getIconSet("document")).thenReturn(documentIconSet);
+
+        // An icon theme that uses the HTML macro to display the icon
+        IconSet htmlSet = new IconSet("html");
+        htmlSet.addIcon("home", new Icon("htmlHome"));
+        htmlSet.setRenderWiki("{{html clean=\"false\"}}<span class=\"fa fa-$icon\" aria-hidden=\"true\"></span>"
+            + "{{/html}}");
+        when(iconSetManager.getIconSet("html")).thenReturn(htmlSet);
 
         // The default icon set to test fallback to the default when the current or specified icon set doesn't
         // contain an icon.

--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-macro/src/test/resources/macrodisplayicon5.test
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-macro/src/test/resources/macrodisplayicon5.test
@@ -1,0 +1,34 @@
+.runTransformations
+.#-----------------------------------------------------
+.input|xwiki/2.1
+.# Verify that icons using HTML are correctly displayed in inline and standalone contexts
+.#-----------------------------------------------------
+{{displayIcon name="home" iconSet="html" /}}
+
+Inline: {{displayIcon name="home" iconSet="html" /}}
+.#-----------------------------------------------------
+.expect|event/1.0
+.#-----------------------------------------------------
+beginDocument
+beginMacroMarkerStandalone [displayIcon] [name=home|iconSet=html]
+beginMetaData [[syntax]=[XWiki 2.1]]
+beginParagraph
+beginMacroMarkerInline [html] [clean=false] [<span class="fa fa-htmlHome" aria-hidden="true"></span>]
+onRawText [<span class="fa fa-htmlHome" aria-hidden="true"></span>] [html/5.0]
+endMacroMarkerInline [html] [clean=false] [<span class="fa fa-htmlHome" aria-hidden="true"></span>]
+endParagraph
+endMetaData [[syntax]=[XWiki 2.1]]
+endMacroMarkerStandalone [displayIcon] [name=home|iconSet=html]
+beginParagraph
+onWord [Inline]
+onSpecialSymbol [:]
+onSpace
+beginMacroMarkerInline [displayIcon] [name=home|iconSet=html]
+beginMetaData [[syntax]=[XWiki 2.1]]
+beginMacroMarkerInline [html] [clean=false] [<span class="fa fa-htmlHome" aria-hidden="true"></span>]
+onRawText [<span class="fa fa-htmlHome" aria-hidden="true"></span>] [html/5.0]
+endMacroMarkerInline [html] [clean=false] [<span class="fa fa-htmlHome" aria-hidden="true"></span>]
+endMetaData [[syntax]=[XWiki 2.1]]
+endMacroMarkerInline [displayIcon] [name=home|iconSet=html]
+endParagraph
+endDocument


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22056

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Ensure that icon themes that output inline HTML are wrapped in a paragraph when the macro is standalone.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* An alternative would be to change the FontAwesome icon theme to enable cleaning in the HTML macro, this would fix the problem, too. But this would fix only this single icon theme.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

The syntax that was provided in the issue now displays correctly:

![image](https://github.com/xwiki/xwiki-platform/assets/198317/19232a7d-244a-41c3-89a7-8c45a799ca63)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
mvn clean install -Pintegration-tests,docker,legacy,standalone,quality -pl :xwiki-platform-icon-macro
```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-15.10.x
  * stable-16.4.x