### PR TITLE
XWIKI-22200: Missing `set` from .bat scripts causes 'XWIKI_OPTS' to not be recognized

### DIFF
--- a/xwiki-platform-tools/xwiki-platform-tool-jetty/xwiki-platform-tool-jetty-resources/src/main/resources/start_xwiki.bat
+++ b/xwiki-platform-tools/xwiki-platform-tool-jetty/xwiki-platform-tool-jetty-resources/src/main/resources/start_xwiki.bat
@@ -76,7 +76,7 @@ set XWIKI_OPTS=%XWIKI_OPTS% -Dxwiki.data.dir="%XWIKI_DATA_DIR%"
 
 REM Make sure the standard Java tmpdir is isolated per instance (by default Jetty provides applications work dir in the Java tmpdir)
 set JAVA_TMP=tmp
-XWIKI_OPTS=%XWIKI_OPTS% -Djava.io.tmpdir=%JAVA_TMP%
+set XWIKI_OPTS=%XWIKI_OPTS% -Djava.io.tmpdir=%JAVA_TMP%
 REM Make sure the Java tmpdir exist since Jenkins does not create it
 if not exist "%JAVA_TMP%" mkdir "%JAVA_TMP%"
 

--- a/xwiki-platform-tools/xwiki-platform-tool-jetty/xwiki-platform-tool-jetty-resources/src/main/resources/start_xwiki_debug.bat
+++ b/xwiki-platform-tools/xwiki-platform-tool-jetty/xwiki-platform-tool-jetty-resources/src/main/resources/start_xwiki_debug.bat
@@ -90,7 +90,7 @@ set XWIKI_OPTS=%XWIKI_OPTS% -Dxwiki.data.dir="%XWIKI_DATA_DIR%"
 
 REM Make sure the standard Java tmpdir is isolated per instance (by default Jetty provides applications work dir in the Java tmpdir)
 set JAVA_TMP=tmp
-XWIKI_OPTS=%XWIKI_OPTS% -Djava.io.tmpdir="%JAVA_TMP%"
+set XWIKI_OPTS=%XWIKI_OPTS% -Djava.io.tmpdir="%JAVA_TMP%"
 REM Make sure the Java tmpdir exist since Jenkins does not create it
 if not exist "%JAVA_TMP%" mkdir "%JAVA_TMP%"
 


### PR DESCRIPTION
# Jira URL
[https://jira.xwiki.org/browse/XWIKI-22200](https://jira.xwiki.org/browse/XWIKI-22200)

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

# Changes

## Description

The files `start_xwiki.bat` and `start_xwiki_debug.bat` are missing a 'set' argument.

# Expected merging strategy

- Prefers squash: Yes
- Backport on branches: `stable-16.4.x`