### PR TITLE
XWIKI-22191: Account disabling and password changing action links should be buttons

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/general.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/general.less
@@ -183,7 +183,8 @@ body {
 
       /* Remove the underlining from links with the btn class.
        Those are already styled differently from their neighboring text. */
-      & a.btn {
+      & a.btn,
+      & a.button {
         .not-inline-link();
       }
 

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserPreferencesSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserPreferencesSheet.xml
@@ -340,8 +340,8 @@
       &lt;div class="passwordManagement"&gt;
         &lt;h2&gt;$escapetool.xml($services.localization.render('platform.core.profile.section.security'))&lt;/h2&gt;
         &lt;span class="buttonwrapper"&gt;
-          &lt;a id="changePassword" href="$doc.getURL('view', 'xpage=passwd')"&gt;$escapetool.xml(
-            $services.localization.render('platform.core.profile.changePassword'))&lt;/a&gt;
+          &lt;button id="changePassword" onclick="location='$doc.getURL('view', 'xpage=passwd')'"&gt;$escapetool.xml(
+            $services.localization.render('platform.core.profile.changePassword'))&lt;/button&gt;
         &lt;/span&gt;
       &lt;/div&gt;
     &lt;/div&gt;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml
@@ -602,8 +602,8 @@ $services.localization.render('platform.core.profile.category.profile.disabled')
         #set ($enableClass = "hidden")
         #set ($disableClass = "")
       #end
-      &lt;a href="#" id="enable" class="btn btn-success $enableClass"&gt;$services.icon.renderHTML('unlock') $services.localization.render('platform.core.profile.category.profile.enableAccount')&lt;/a&gt;
-      &lt;a href="#" id="disable" class="btn btn-warning $disableClass"&gt;$services.icon.renderHTML('lock') $services.localization.render('platform.core.profile.category.profile.disableAccount')&lt;/a&gt;
+      &lt;button id="enable" class="btn btn-success $enableClass"&gt;$services.icon.renderHTML('unlock') $services.localization.render('platform.core.profile.category.profile.enableAccount')&lt;/button&gt;
+      &lt;button id="disable" class="btn btn-warning $disableClass"&gt;$services.icon.renderHTML('lock') $services.localization.render('platform.core.profile.category.profile.disableAccount')&lt;/button&gt;
     #end
     &lt;div class='userInfo'&gt;
     #if($xcontext.action == 'view' &amp;&amp; $hasEdit)


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22191

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Updated the account disabling buttons
* Updated the `Change password` button to be a button instead of an anchor styled like a button
* (Extra - not required by the ticket, but close to its subject) Improved the consistency of the inline-link-only selector to also match `.button` links, which can happen, such as the one for the creation of a new wiki.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Consistency of the inline-link-only selector: we could also just replace the class on https://github.com/xwiki/xwiki-platform/blob/8aa04a3b83f3a7ad5a0659090fbcc9123d08c7be/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-mainwiki/src/main/resources/WikiManager/WebHome.xml#L46 with the bootstrap classes.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

None, abrely any visual change. The link underlining doesn't happen when hovered on both of those buttons anymore.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
* Account enable/disable buttons: There doesn't seem to be a test about this. AFAICS, the selectors for this element rely on the id, and not the anchor nature of them.
https://github.com/xwiki/xwiki-platform/blob/d11ca5d781f8a42a85bc98eb82306c1431e764d4/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/test/java/org/xwiki/user/profile/UserProfilePageTest.java#L65
https://github.com/xwiki/xwiki-platform/blob/7461bac6bbba52befecac6d2c03cc9869b6cef35/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-ui/src/main/resources/XWiki/XWikiUserProfileSheet.xml#L224-L225
* Change of the inline-link-only ruleset: very small scope.

Manual tests for both of the buttons. They both still had the same effect after the DOM changes.
# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-16.4.x (same as https://jira.xwiki.org/browse/XWIKI-21492)