### PR TITLE
[Misc] Accessibility rules update

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/WCAGContext.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/WCAGContext.java
@@ -70,8 +70,7 @@ public class WCAGContext
 
             // WCAG 2.0 Level A & AA Rules
             entry("area-alt", true),
-            // Set to true once the build doesn't fail this rule anymore
-            entry("aria-allowed-attr", false),
+            entry("aria-allowed-attr", true),
             entry("aria-command-name", true),
             entry("aria-hidden-body", true),
             entry("aria-hidden-focus", true),
@@ -106,8 +105,7 @@ public class WCAGContext
             entry("html-has-lang", true),
             entry("html-lang-valid", true),
             entry("html-xml-lang-mismatch", true),
-            // Set to true once the build doesn't fail this rule anymore
-            entry("image-alt", false),
+            entry("image-alt", true),
             entry("input-button-name", true),
             entry("input-image-alt", true),
             // Set to true once the build doesn't fail this rule anymore
@@ -126,8 +124,7 @@ public class WCAGContext
             entry("role-img-alt", true),
             // Set to true once the build doesn't fail this rule anymore
             entry("scrollable-region-focusable", false),
-            // Set to true once the build doesn't fail this rule anymore
-            entry("select-name", false),
+            entry("select-name", true),
             entry("server-side-image-map", true),
             entry("svg-img-alt", true),
             entry("td-headers-attr", true),


### PR DESCRIPTION
Changes to the status of the WCAG rules that are currently not violated. From this point on, all rules set to true will make the build fail when they are violated. The build will only fail on an accessibility regression. See the [XWiki WCAG testing page](https://dev.xwiki.org/xwiki/bin/view/Community/Testing/WCAGTesting#HTesting) for more details about the consequences of these changes.

As of https://ci.xwiki.org/job/XWiki%20Environment%20Tests/job/xwiki-platform/job/master/593/, there are only a few rules that fail through tests:

- label 77 violations
- link-in-text-block 158 violations
- color-contrast 2 violations
- scrollable-region-focusable 1 violation

Total violations: 236

- aria-allowed-attr fixed
- image-alt fixed
- select-name fixed


There are no additional failing types in [environment test master build #593](https://ci.xwiki.org/job/XWiki%20Environment%20Tests/job/xwiki-platform/job/master/593/)

|  | Count of rules triggering warnings| Count of rules triggering fails|
| ------------- | ------------- | ------------- |
| Before this PR | 7 | 54 |
| After this PR | 4 | 57 |

This is a continuation of the process started in https://github.com/xwiki/xwiki-platform/pull/2152, last step before this one was https://github.com/xwiki/xwiki-platform/pull/3022.

---
As most of those of these errors now only have a couple violations, we can list them with their jira tickets and status at the time of writing this:

- label 77 violations https://jira.xwiki.org/browse/XWIKI-20996 no progress since March, should take more time to try and fix them. + livedata filters with selectize do not have labels
- link-in-text-block 154 violations Multiple issues reported recently, expected to drop down in count quickly. I don't expect to reach 0 soon.
- color-contrast 2 violations https://jira.xwiki.org/browse/XWIKI-21584 && https://jira.xwiki.org/browse/XWIKI-21387 PRs waiting for reviews.
- scrollable-region-focusable 1 violation https://jira.xwiki.org/browse/XWIKI-20909 blocked, should be fixed on the browser side soon, still waiting for Chrome


[[EDIT]] Updated the links to the latest build, no large change in the result, things are more or less the same.