### PR TITLE
XWIKI-22209: Deprecate NotificationFilterPreference#isActive

### DIFF
--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-events-hibernate/xwiki-platform-legacy-events-hibernate-api/src/test/java/org/xwiki/notifications/sources/internal/AbstractQueryGeneratorTest.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-events-hibernate/xwiki-platform-legacy-events-hibernate-api/src/test/java/org/xwiki/notifications/sources/internal/AbstractQueryGeneratorTest.java
@@ -92,7 +92,6 @@ public abstract class AbstractQueryGeneratorTest
         when(this.pref1.isNotificationEnabled()).thenReturn(true);
 
         this.fakeFilterPreference = mock(NotificationFilterPreference.class);
-        when(this.fakeFilterPreference.isActive()).thenReturn(true);
 
         when(this.wikiDescriptorManager.getMainWikiId()).thenReturn("xwiki");
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/NotificationFilterPreference.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/NotificationFilterPreference.java
@@ -84,7 +84,10 @@ public interface NotificationFilterPreference
      * retrieving the notifications nowadays.
      */
     @Deprecated(since = "16.5.0RC1")
-    boolean isActive();
+    default boolean isActive()
+    {
+        return true;
+    }
 
     /**
      * @return the type of the filter described by this preference.

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/NotificationFilterPreference.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/NotificationFilterPreference.java
@@ -80,7 +80,10 @@ public interface NotificationFilterPreference
      * notifications.
      *
      * @return true if the filter preference is active.
+     * @deprecated this behaviour doesn't make sense anymore with usage of prefiltering as there's no trigger for
+     * retrieving the notifications nowadays.
      */
+    @Deprecated(since = "16.5.0RC1")
     boolean isActive();
 
     /**

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterPreference.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterPreference.java
@@ -153,12 +153,6 @@ public class ScopeNotificationFilterPreference implements NotificationFilterPref
     }
 
     @Override
-    public boolean isActive()
-    {
-        return true;
-    }
-
-    @Override
     public NotificationFilterType getFilterType()
     {
         return filterPreference.getFilterType();

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterPreference.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterPreference.java
@@ -155,7 +155,7 @@ public class ScopeNotificationFilterPreference implements NotificationFilterPref
     @Override
     public boolean isActive()
     {
-        return filterPreference.isActive();
+        return true;
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/DefaultFilterPreferencesModelBridge.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/DefaultFilterPreferencesModelBridge.java
@@ -253,7 +253,6 @@ public class DefaultFilterPreferencesModelBridge implements FilterPreferencesMod
             preference.setEventTypes(new HashSet<>(eventTypes));
         }
         preference.setEnabled(true);
-        preference.setActive(false);
         preference.setFilterName(ScopeNotificationFilter.FILTER_NAME);
         preference.setStartingDate(new Date());
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/DefaultNotificationFilterPreference.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/DefaultNotificationFilterPreference.java
@@ -274,12 +274,6 @@ public class DefaultNotificationFilterPreference implements NotificationFilterPr
     }
 
     @Override
-    public boolean isActive()
-    {
-        return true;
-    }
-
-    @Override
     public NotificationFilterType getFilterType()
     {
         return filterType;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/DefaultNotificationFilterPreference.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/DefaultNotificationFilterPreference.java
@@ -51,8 +51,6 @@ public class DefaultNotificationFilterPreference implements NotificationFilterPr
 
     private boolean enabled;
 
-    private boolean active;
-
     private NotificationFilterType filterType;
 
     private Set<NotificationFormat> notificationFormats = new HashSet<>();
@@ -104,7 +102,6 @@ public class DefaultNotificationFilterPreference implements NotificationFilterPr
         this.id = notificationFilterPreference.getId();
         this.filterName = notificationFilterPreference.getFilterName();
         this.enabled = notificationFilterPreference.isEnabled();
-        this.active = notificationFilterPreference.isActive();
         this.filterType = notificationFilterPreference.getFilterType();
         this.notificationFormats = notificationFilterPreference.getNotificationFormats();
         this.startingDate = notificationFilterPreference.getStartingDate();
@@ -177,10 +174,11 @@ public class DefaultNotificationFilterPreference implements NotificationFilterPr
 
     /**
      * @param active if the preference is active or not
+     * @deprecated this method is kept only for avoiding issues with hibernate
      */
+    @Deprecated(since = "16.5.0RC1")
     public void setActive(boolean active)
     {
-        this.active = active;
     }
 
     /**
@@ -278,7 +276,7 @@ public class DefaultNotificationFilterPreference implements NotificationFilterPr
     @Override
     public boolean isActive()
     {
-        return active;
+        return true;
     }
 
     @Override
@@ -413,7 +411,6 @@ public class DefaultNotificationFilterPreference implements NotificationFilterPr
                 + ", owner='" + owner + '\''
                 + ", filterName='" + filterName + '\''
                 + ", enabled=" + enabled
-                + ", active=" + active
                 + ", filterType=" + filterType
                 + ", notificationFormats=" + notificationFormats
                 + ", startingDate=" + startingDate
@@ -440,7 +437,6 @@ public class DefaultNotificationFilterPreference implements NotificationFilterPr
         EqualsBuilder equalsBuilder = new EqualsBuilder();
         equalsBuilder.append(internalId, other.internalId)
             .append(enabled, other.enabled)
-            .append(active, other.active)
             .append(id, other.id)
             .append(owner, other.owner)
             .append(filterName, other.filterName)
@@ -461,7 +457,6 @@ public class DefaultNotificationFilterPreference implements NotificationFilterPr
         HashCodeBuilder hashCodeBuilder = new HashCodeBuilder();
         hashCodeBuilder.append(internalId)
             .append(enabled)
-            .append(active)
             .append(id)
             .append(owner)
             .append(filterName)

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/migrators/NotificationFilterPreferencesMigrator.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/migrators/NotificationFilterPreferencesMigrator.java
@@ -208,7 +208,6 @@ public class NotificationFilterPreferencesMigrator extends AbstractEventListener
 
         preference.setFilterName(obj.getStringValue(FIELD_FILTER_NAME));
         preference.setEnabled(obj.getIntValue(FIELD_IS_ENABLED, 1) == 1);
-        preference.setActive(obj.getIntValue(FIELD_IS_ACTIVE, 1) == 1);
         preference.setFilterType(filterType);
         preference.setNotificationFormats(filterFormats);
         preference.setStartingDate(obj.getDateValue(FIELD_STARTING_DATE));

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-watch/src/main/java/org/xwiki/notifications/filters/watch/WatchedLocationReference.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-watch/src/main/java/org/xwiki/notifications/filters/watch/WatchedLocationReference.java
@@ -141,7 +141,6 @@ public class WatchedLocationReference implements WatchedEntityReference
         filterPreference.setFilterType(NotificationFilterType.INCLUSIVE);
         filterPreference.setFilterName(ScopeNotificationFilter.FILTER_NAME);
         filterPreference.setNotificationFormats(ALL_NOTIFICATION_FORMATS);
-        filterPreference.setActive(false);
         filterPreference.setStartingDate(new Date());
 
         // Properties

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-watch/src/main/java/org/xwiki/notifications/filters/watch/WatchedUserReference.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-watch/src/main/java/org/xwiki/notifications/filters/watch/WatchedUserReference.java
@@ -95,7 +95,6 @@ public class WatchedUserReference implements WatchedEntityReference
         filterPreference.setFilterType(NotificationFilterType.INCLUSIVE);
         filterPreference.setFilterName(EventUserFilter.FILTER_NAME);
         filterPreference.setNotificationFormats(Sets.newHashSet(NotificationFormat.values()));
-        filterPreference.setActive(true);
         filterPreference.setStartingDate(new Date());
         filterPreference.setUser(userId);
 
@@ -111,7 +110,6 @@ public class WatchedUserReference implements WatchedEntityReference
         filterPreference.setFilterType(NotificationFilterType.EXCLUSIVE);
         filterPreference.setFilterName(EventUserFilter.FILTER_NAME);
         filterPreference.setNotificationFormats(Sets.newHashSet(NotificationFormat.values()));
-        filterPreference.setActive(false);
         filterPreference.setStartingDate(new Date());
         filterPreference.setUser(userId);
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-watch/src/test/java/org/xwiki/notifications/filters/watch/WatchedLocationReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-watch/src/test/java/org/xwiki/notifications/filters/watch/WatchedLocationReferenceTest.java
@@ -179,7 +179,6 @@ class WatchedLocationReferenceTest
         filterPreference.setFilterType(NotificationFilterType.INCLUSIVE);
         filterPreference.setFilterName(ScopeNotificationFilter.FILTER_NAME);
         filterPreference.setNotificationFormats(Set.of(NotificationFormat.values()));
-        filterPreference.setActive(false);
         filterPreference.setPageOnly(this.serializedReference);
 
         Date now = new Date();
@@ -215,7 +214,6 @@ class WatchedLocationReferenceTest
         filterPreference.setFilterType(NotificationFilterType.EXCLUSIVE);
         filterPreference.setFilterName(ScopeNotificationFilter.FILTER_NAME);
         filterPreference.setNotificationFormats(Set.of(NotificationFormat.values()));
-        filterPreference.setActive(false);
         filterPreference.setPage(this.serializedReference);
 
         Date now = new Date();

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/QueryExpressionGenerator.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/QueryExpressionGenerator.java
@@ -33,7 +33,6 @@ import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.LocalDocumentReference;
 import org.xwiki.notifications.filters.NotificationFilter;
 import org.xwiki.notifications.filters.NotificationFilterManager;
-import org.xwiki.notifications.filters.NotificationFilterPreference;
 import org.xwiki.notifications.filters.NotificationFilterType;
 import org.xwiki.notifications.filters.expression.AndNode;
 import org.xwiki.notifications.filters.expression.BooleanValueNode;
@@ -99,9 +98,8 @@ public class QueryExpressionGenerator
         // First: get the active preferences of the given user
         Collection<NotificationPreference> preferences = parameters.preferences;
 
-        // Ensure that we have at least one filter preference that is active
-        if (preferences.isEmpty()
-            && parameters.filterPreferences.stream().noneMatch(NotificationFilterPreference::isActive)) {
+        // Ensure that we have at least one filter preference
+        if (preferences.isEmpty()) {
             return null;
         }
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/TagNotificationFilterPreference.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/TagNotificationFilterPreference.java
@@ -86,12 +86,6 @@ public class TagNotificationFilterPreference implements NotificationFilterPrefer
     }
 
     @Override
-    public boolean isActive()
-    {
-        return false;
-    }
-
-    @Override
     public NotificationFilterType getFilterType()
     {
         return NotificationFilterType.INCLUSIVE;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/AbstractQueryGeneratorTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/AbstractQueryGeneratorTest.java
@@ -92,8 +92,6 @@ public abstract class AbstractQueryGeneratorTest
         when(this.pref1.isNotificationEnabled()).thenReturn(true);
 
         this.fakeFilterPreference = mock(NotificationFilterPreference.class);
-        when(this.fakeFilterPreference.isActive()).thenReturn(true);
-
         when(this.wikiDescriptorManager.getMainWikiId()).thenReturn("xwiki");
 
         when(this.recordableEventDescriptorHelper.hasDescriptor(anyString(), any(DocumentReference.class)))


### PR DESCRIPTION
 # Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22209

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Ensure to not use anymore isActive and setActive

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

N/A

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
`mvn clean install -Pquality,integration-tests,docker` on module `xwiki-platform-notifications` and on `xwiki-platform-legacy-notifications`

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches: No