### PR TITLE
XWIKI-22214: Inconsistent underlining of the navigation tree

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/general.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/general.less
@@ -175,7 +175,8 @@ body {
       & .xtree,
       & .xwikitabbar,
       & .buttonwrapper,
-      & #user-menu-col {
+      & #user-menu-col,
+      & .jstree-xwiki {
         & a {
           .not-inline-link();
         }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Added a rule to never underline links in jstrees, when the onlyInlineLink preference is picked.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* `jstree-xwiki` is a class that is on any jstree used in xwiki. AFAICS this is the one used in other CSS rulesets to customize jstrees in XWiki. This one seemed appropriate and got the proper results.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
before the PR:
![Screenshot from 2024-06-06 11-08-02](https://github.com/xwiki/xwiki-platform/assets/28761965/d17edea8-00f4-4e49-81c8-41d8e4fb15e8)
after the PR:
![Screenshot from 2024-06-06 11-20-42](https://github.com/xwiki/xwiki-platform/assets/28761965/29920569-7619-4ad6-a4a0-13712901f748)



# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Only manual. This is a style change only, and doesn't change the layout, so it's very safe.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * Stable 16.4.X