### PR TITLE
XWIKI-22204: Underline inline links on the change viewer

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/diff_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/diff_macros.vm
@@ -600,7 +600,7 @@
 #end
 
 #macro (displayDocumentChangesHeader $from $to)
-  <div id="changes-info">
+  <div id="changes-info" class="force-underline">
     <div id="changes-info-boxes">
       #if ("$!from.previousLink" != '' || "$!to.nextLink" != '')
         <div id='changes-arrows-box'>


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22204

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Fixed missing underlining on the inline links in the diff boxes.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Since this is a specific UI and structure around the anchor, I decided to go with the solution that's the least generic and just add the helper class to this element.


# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Before the PR on the ticket report itself.
Here is what it looks like after the PR:
![Screenshot from 2024-06-12 15-06-32](https://github.com/xwiki/xwiki-platform/assets/28761965/aec8c643-398f-4d84-bc6d-d73630d0a8f3)
We can see that all the inline links in the `From version` and `To version` blocks are properly underlined.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests only, see above.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None