### PR TITLE
XWIKI-17218: Text in a table cell gets scrambled when cancelling the add annotation form

### DIFF
--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Script.xml
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Script.xml
@@ -331,10 +331,15 @@ XWiki.Selection = Class.create({
     return descendant;
   },
 
+  // Removes the highligh on selected text (e.g., after pressing when annotating a new piece of text).
   removeSelectionHighlight : function() {
-    // unwrap
+    // We used previously replace from prototype earlier, but it behaves badly when the parent of the wrapper is a td
+    // (moving the selected text at the end of the td).
+    // Also, wrapper is always an element containing only text. If &lt;strong&gt;a&lt;em&gt;b&lt;/em&gt;c&lt;/strong&gt; is
+    // selected for annotation, a, b, and c will each be wrapped in a &lt;span class='selection-highligh' ...&gt;.
+    // Therefore, when unwrapping we know that the spans of this.highlightWrappers contain only text.
     this.highlightWrappers.each(function(wrapper) {
-      wrapper.replace(wrapper.innerHTML);
+      wrapper.replaceWith(wrapper.innerHTML);
     });
   },
 
@@ -623,7 +628,7 @@ XWiki.Annotation = Class.create({
     document.observe('xwiki:docextra:loaded', this.addDeleteListenersInTab.bindAsEventListener(this));
     document.observe('xwiki:docextra:loaded', this.addEditListenersInTab.bindAsEventListener(this));
     document.observe('xwiki:docextra:loaded', this.addValidateListenersInTab.bindAsEventListener(this));
-    // List for clicks on annotated texts on the comments. 
+    // List for clicks on annotated texts on the comments.
     // Takes care to load the annotations and to make them visible before moving
     // the user to the anchor corresponding to the requested annotation.
     require(['jquery'], ($) =&gt; {
@@ -634,7 +639,7 @@ XWiki.Annotation = Class.create({
           this.setAnnotationVisibility(true);
           this.toggleAnnotations(this.displayingAnnotations);
         } else {
-          // In this case we need to fetch the annotations fist. As this is asynchronous we need to wait for 
+          // In this case we need to fetch the annotations fist. As this is asynchronous we need to wait for
           // the annotations to be fetched before moving the user to the anchor.
           this.fetchAnnotations(true);
           event.preventDefault();

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Script.xml
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Script.xml
@@ -333,13 +333,12 @@ XWiki.Selection = Class.create({
 
   // Removes the highligh on selected text (e.g., after pressing when annotating a new piece of text).
   removeSelectionHighlight : function() {
-    // We used previously replace from prototype earlier, but it behaves badly when the parent of the wrapper is a td
-    // (moving the selected text at the end of the td).
-    // Also, wrapper is always an element containing only text. If &lt;strong&gt;a&lt;em&gt;b&lt;/em&gt;c&lt;/strong&gt; is
+    // We used previously replace for prototype, but it behaves badly when the parent of the wrapper is a td.
+    // Also, wrapper is always an element containing only text. In otherword, if &lt;strong&gt;a&lt;em&gt;b&lt;/em&gt;c&lt;/strong&gt; is
     // selected for annotation, a, b, and c will each be wrapped in a &lt;span class='selection-highligh' ...&gt;.
     // Therefore, when unwrapping we know that the spans of this.highlightWrappers contain only text.
     this.highlightWrappers.each(function(wrapper) {
-      wrapper.replaceWith(wrapper.innerHTML);
+      wrapper.replaceWith(...wrapper.childNodes)
     });
   },
 


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-17218

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Selecting a piece of text in a table, annotation it and finally cancelling the annotation simply remove the highlighting. And do not change the html structure of the cell.

<!--
## Clarifications

 Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on


*
-->

<!--
# Screenshots & Video

 If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
mvn clean install -Pquality,integration-tests,docker -pl :xwiki-platform-annotation-ui -amd -f xwiki-platform-core/xwiki-platform-annotation
```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-15.10.x
  * stable-16.4.x