### PR TITLE
Related Tags

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -2213,6 +2213,7 @@ xe.tag.delete=Delete tag {0}
 xe.tag.delete.success=Tag {0} has been successfully deleted.
 xe.tag.delete.failure=Deletion of tag {0} failed.
 xe.tag.delete.link=Delete
+xe.tag.related=Related tags:
 core.tags.list.label=Tags:
 core.tags.add.tooltip=Add tags
 core.tags.add.label=Comma separated tags:

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-ui/src/main/resources/Main/Tags.xml
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-ui/src/main/resources/Main/Tags.xml
@@ -96,6 +96,28 @@ $xwiki.ssx.use('Main.Tags')##
       {{notifications useUserPreferences="false" displayOwnEvents="true" tags="$wikiEscapedTag" displayRSSLink="true" /}}
     )))
   {{/container}}
+
+  {{container}}
+      ## Getting the related tags.
+      #set ($documents = $xwiki.tag.getDocumentsWithTag($tag))
+      #set ($tagsMap = {})
+      #foreach($document in $documents)
+        #set ($tags = $xwiki.tag.getTagsFromDocument($document))
+        #foreach($tag in $tags)
+          #set($discard = $tagsMap.put($tag, 1))
+        #end
+      #end
+      #set ($discard = $tagsMap.remove($tag))
+      ## Displaying the related tags as a list with links to their own page.
+      === $services.localization.render('xe.tag.related') ===
+      #set ($relatedTags = $tagsMap.keySet())
+      #foreach($tag in $relatedTags)##
+        [[$tag>>||queryString="do=viewTag&amp;tag=$tag"]]##
+          #if($foreach.count &lt;$relatedTags.size())##
+          , ##
+          #end##
+        #end##
+  {{/container}}
 #elseif ($do == 'prepareRename')
   ##
   ## Prepare rename tag


### PR DESCRIPTION
* Added the related tags feature, where you can view tags related to the current tag. A tag is considered related to the current one if it is on the same page.

# Jira URL
https://jira.xwiki.org/browse/XWIKI-22174
<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

# Changes
Updated the tags page.
## Description
Added the velocity code needed to get the related tags and displayed them.
<!-- Describe the main changes brought in this PR. -->

*

# Screenshots & Video
![image](https://github.com/xwiki/xwiki-platform/assets/92780090/1b82694c-d6b5-4dcd-8752-8724fab8e7d2)
