### PR TITLE
XWIKI-22269: Update the structure of the User display macro

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -318,10 +318,12 @@ $xwiki.getUserName("xwiki:${username}")
     ## We avoid the whitespace because the users are displayed as inline blocks.
     #set ($discard = $output.addAll([
       "<$userTag class=""$type"" data-reference=""$escapetool.xml($userReference)"">",
+        "<$userNameTag $userNameTagAttributes>",
         $avatarWrapperStart,
-          "<img class=""${type}-avatar"" src=""$escapetool.xml($avatarURL.url)"" alt=""$escapedUserName"" />",
+          "<img class=""${type}-avatar"" src=""$escapetool.xml($avatarURL.url)"" alt="""" />",
         $avatarWrapperEnd,
-        "<$userNameTag $userNameTagAttributes>$escapedUserName</$userNameTag>",
+        $escapedUserName,
+        "</$userNameTag>",
         $userAliasDisplay,
       "</$userTag>"
     ]))


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22269

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Updated the user display macro according to what was discussed and approved in the proposal.

## Details

* This PR is related to the discussion that happened on https://forum.xwiki.org/t/proposal-update-the-structure-of-the-user-display-macro/14723 

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
None.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
None, I could not find any test related to the specific content of this macro. Searching `-avatar-wrapper` in the project only returns a few results in style sheets and templates.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None. This is a DOM change, so this could theorically break some extensions and should not be backported.