### PR TITLE
XWIKI-22271: Custom filters to subwiki remain on the main Wiki after subwiki is deleted

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/NotificationFilterPreferenceStore.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/NotificationFilterPreferenceStore.java
@@ -46,6 +46,8 @@ import org.xwiki.observation.ObservationManager;
 import org.xwiki.query.Query;
 import org.xwiki.query.QueryException;
 import org.xwiki.query.QueryManager;
+import org.xwiki.wiki.descriptor.WikiDescriptorManager;
+import org.xwiki.wiki.manager.WikiManagerException;
 
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
@@ -75,6 +77,9 @@ public class NotificationFilterPreferenceStore
 
     @Inject
     private ObservationManager observation;
+
+    @Inject
+    private WikiDescriptorManager wikiDescriptorManager;
 
     /**
      * Retrieve the notification preference that corresponds to the given id and wiki.
@@ -336,7 +341,7 @@ public class NotificationFilterPreferenceStore
     }
 
     /**
-     * Delete all the filter preferences from a wiki.
+     * Delete all the filter preferences related to a wiki.
      *
      * @param wikiReference the reference of a wiki
      * @throws NotificationException in case of error during the hibernate operations
@@ -346,31 +351,42 @@ public class NotificationFilterPreferenceStore
      */
     public void deleteFilterPreference(WikiReference wikiReference) throws NotificationException
     {
-        configureContextWrapper(wikiReference, () -> {
-            XWikiContext context = this.contextProvider.get();
+        // We iterate over all wiki dbs and we remove the preferences in each of them since they might all contain
+        // filter preferences related to the given wiki.
+        try {
+            for (String wikiId : this.wikiDescriptorManager.getAllIds()) {
+                configureContextWrapper(new WikiReference(wikiId), () -> {
+                    XWikiContext context = this.contextProvider.get();
 
-            XWikiHibernateStore hibernateStore = context.getWiki().getHibernateStore();
+                    XWikiHibernateStore hibernateStore = context.getWiki().getHibernateStore();
 
-            try {
-                hibernateStore.executeWrite(context, session -> {
-                    session
-                        .createQuery("delete from DefaultNotificationFilterPreference "
-                            + "where page like :wikiPrefix "
-                            + "or pageOnly like :wikiPrefix "
-                            + "or user like :wikiPrefix "
-                            + "or wiki = :wikiId")
-                        .setParameter("wikiPrefix", wikiReference.getName() + ":%")
-                        .setParameter("wikiId", wikiReference.getName()).executeUpdate();
+                    try {
+                        hibernateStore.executeWrite(context, session -> {
+                            session
+                                .createQuery("delete from DefaultNotificationFilterPreference "
+                                    + "where page like :wikiPrefix "
+                                    + "or pageOnly like :wikiPrefix "
+                                    + "or user like :wikiPrefix "
+                                    + "or wiki = :wikiId")
+                                .setParameter("wikiPrefix", wikiReference.getName() + ":%")
+                                .setParameter("wikiId", wikiReference.getName()).executeUpdate();
+
+                            return null;
+                        });
+                    } catch (XWikiException e) {
+                        throw new NotificationException(String.format(
+                            "Failed to delete the notification preferences for wiki [%s]",
+                            wikiReference.getName()), e);
+                    }
 
                     return null;
                 });
-            } catch (XWikiException e) {
-                throw new NotificationException(String
-                    .format("Failed to delete the notification preferences for wiki [%s]", wikiReference.getName()), e);
             }
-
-            return null;
-        });
+        } catch (WikiManagerException e) {
+            throw new NotificationException(String
+                .format("Error when trying to get the list of wiki ids preventing to delete filter preferences for "
+                        + "wiki [%s]", wikiReference.getName()), e);
+        }
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/migration/R160500000XWIKI22271DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/migration/R160500000XWIKI22271DataMigration.java
@@ -1,0 +1,172 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.xwiki.notifications.filters.migration;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.slf4j.Logger;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.notifications.filters.internal.DefaultNotificationFilterPreference;
+import org.xwiki.query.Query;
+import org.xwiki.query.QueryException;
+import org.xwiki.query.QueryManager;
+import org.xwiki.wiki.descriptor.WikiDescriptorManager;
+import org.xwiki.wiki.manager.WikiManagerException;
+
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.store.migration.DataMigrationException;
+import com.xpn.xwiki.store.migration.XWikiDBVersion;
+import com.xpn.xwiki.store.migration.hibernate.AbstractHibernateDataMigration;
+
+/**
+ * Ensure to clean up filters related to deleted wikis.
+ *
+ * @version $Id$
+ * @since 16.5.0
+ * @since 16.4.1
+ */
+@Component
+@Named("R160500000XWIKI22271")
+@Singleton
+public class R160500000XWIKI22271DataMigration extends AbstractHibernateDataMigration
+{
+    private static final String SEARCH_FILTERS_STATEMENT = "select nfp "
+        + "from DefaultNotificationFilterPreference nfp "
+        + "where nfp.page not like :wikiPrefix and "
+        + "nfp.pageOnly not like :wikiPrefix and "
+        + "nfp.user not like :wikiPrefix and"
+        + "nfp.wiki <> :wikiId";
+
+    private static final String DELETE_FILTER_STATEMENT = "delete from DefaultNotificationFilterPreference "
+        + "where internalId in (:filterIds)";
+
+    private static final int BATCH_SIZE = 100;
+
+    @Inject
+    private QueryManager queryManager;
+
+    @Inject
+    private WikiDescriptorManager wikiDescriptorManager;
+
+    @Inject
+    private Logger logger;
+
+    @Override
+    public String getDescription()
+    {
+        return "Ensure that filters related to deleted wiki are clean up.";
+    }
+
+    @Override
+    public XWikiDBVersion getVersion()
+    {
+        return new XWikiDBVersion(160500000);
+    }
+
+    @Override
+    public boolean shouldExecute(XWikiDBVersion startupVersion)
+    {
+        boolean shouldExecute = super.shouldExecute(startupVersion);
+
+        if (shouldExecute) {
+            int version = startupVersion.getVersion();
+            // The migration is backported in 16.4.1 so any DB between 16.4.1 and 16.5.0 don't need to execute it again.
+            shouldExecute = !(version >= 160401000 && version < 160500000);
+        }
+        return shouldExecute;
+    }
+
+    @Override
+    protected void hibernateMigrate() throws DataMigrationException, XWikiException
+    {
+        String currentWikiId = getXWikiContext().getWikiId();
+        Set<Long> idsToCleanup = new HashSet<>();
+        int offset = 0;
+        List<DefaultNotificationFilterPreference> results = null;
+        try {
+            Collection<String> allIds = this.wikiDescriptorManager.getAllIds();
+            do {
+                results = this.queryManager
+                    .createQuery(SEARCH_FILTERS_STATEMENT, Query.HQL)
+                    .bindValue("wikiPrefix")
+                    .literal(currentWikiId + ":")
+                    .anyChars()
+                    .query()
+                    .bindValue("wikiId")
+                    .literal(currentWikiId)
+                    .query()
+                    .setOffset(offset)
+                    .setLimit(BATCH_SIZE)
+                    .execute();
+
+                if (!results.isEmpty()) {
+                    this.logger.info("Performing analysis of [{}] filters to find those related to removed wikis",
+                        results.size());
+
+                    results.forEach(filter -> {
+                        if (!isFilterAboutExistingWiki(filter, allIds)) {
+                            idsToCleanup.add(filter.getInternalId());
+                        }
+                    });
+                }
+                offset += results.size();
+            } while (!results.isEmpty());
+        } catch (QueryException e) {
+            throw new DataMigrationException("Error while performing query for finding filters", e);
+        } catch (WikiManagerException e) {
+            throw new DataMigrationException("Error when searching for wiki ids", e);
+        }
+
+        if (!idsToCleanup.isEmpty()) {
+            this.logger.info("Removing [{}] filters related to deleted wikis", idsToCleanup.size());
+            try {
+                getStore().executeWrite(getXWikiContext(), session -> {
+                    session
+                        .createQuery(DELETE_FILTER_STATEMENT)
+                        .setParameter("filterIds", idsToCleanup).executeUpdate();
+
+                    return null;
+                });
+            } catch (XWikiException e) {
+                throw new DataMigrationException("Error when performing the request to clean up filters.", e);
+            }
+        } else {
+            this.logger.info("No filter has been found related to deleted wikis.");
+        }
+    }
+
+    private boolean isFilterAboutExistingWiki(DefaultNotificationFilterPreference filterPreference,
+        Collection<String> wikiIds)
+    {
+        if (filterPreference.getWikiId().isPresent()) {
+            return wikiIds.contains(filterPreference.getWikiId().get());
+        } else {
+            return false;
+        }
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/resources/META-INF/components.txt
@@ -26,4 +26,5 @@ org.xwiki.notifications.filters.migration.R140401000XWIKI15460DataMigration
 org.xwiki.notifications.filters.migration.R151002000XWIKI21448DataMigration
 org.xwiki.notifications.filters.migration.R160300000XWIKI17243DataMigration
 org.xwiki.notifications.filters.migration.R160100000XWIKI21738DataMigration
+org.xwiki.notifications.filters.migration.R160500000XWIKI22271DataMigration
 org.xwiki.notifications.filters.migration.WatchListObjectsRemovalTaskConsumer

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/NotificationFilterPreferenceStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/NotificationFilterPreferenceStoreTest.java
@@ -42,6 +42,7 @@ import org.xwiki.query.QueryManager;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
+import org.xwiki.wiki.descriptor.WikiDescriptorManager;
 
 import com.xpn.xwiki.XWiki;
 import com.xpn.xwiki.XWikiContext;
@@ -56,6 +57,8 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -87,6 +90,9 @@ class NotificationFilterPreferenceStoreTest
 
     @MockComponent
     private QueryManager queryManager;
+
+    @MockComponent
+    private WikiDescriptorManager wikiDescriptorManager;
 
     @Mock
     private XWikiContext context;
@@ -127,21 +133,35 @@ class NotificationFilterPreferenceStoreTest
     @Test
     void deleteWikiFilterPreferences() throws Exception
     {
-        when(this.context.getWikiReference()).thenReturn(CURRENT_WIKI_REFERENCE);
-
         WikiReference wikiReference = new WikiReference("wikiid");
+        when(this.context.getWikiReference()).thenReturn(CURRENT_WIKI_REFERENCE);
+        when(this.wikiDescriptorManager.getAllIds()).thenReturn(List.of(
+            "foo",
+            "bar",
+            CURRENT_WIKI_REFERENCE.getName(),
+            MAIN_WIKI_REFERENCE.getName(),
+            wikiReference.getName()
+        ));
+
         this.notificationFilterPreferenceStore.deleteFilterPreference(wikiReference);
 
+        verify(this.context).setWikiReference(new WikiReference("foo"));
+        verify(this.context).setWikiReference(new WikiReference("bar"));
+        verify(this.context).setWikiReference(MAIN_WIKI_REFERENCE);
         verify(this.context).setWikiReference(wikiReference);
-        verify(this.session).createQuery("delete from DefaultNotificationFilterPreference "
+        // 1 before performing the request and 5 for setting back the current reference
+        verify(this.context, times(6)).setWikiReference(CURRENT_WIKI_REFERENCE);
+        verify(this.session, times(5)).createQuery("delete from DefaultNotificationFilterPreference "
             + "where page like :wikiPrefix "
             + "or pageOnly like :wikiPrefix "
             + "or user like :wikiPrefix "
             + "or wiki = :wikiId");
-        verify(this.query).setParameter("wikiPrefix", "wikiid:%");
-        verify(this.query).setParameter("wikiId", "wikiid");
-        verify(this.query).executeUpdate();
-        verify(this.context).setWikiReference(CURRENT_WIKI_REFERENCE);
+
+        verify(this.query, times(5)).setParameter("wikiPrefix", "wikiid:%");
+        verify(this.query, times(5)).setParameter("wikiId", "wikiid");
+
+        verify(this.query, times(5)).executeUpdate();
+
     }
 
     @Test
@@ -152,6 +172,10 @@ class NotificationFilterPreferenceStoreTest
         when(this.hibernateStore.executeWrite(same(context), any())).thenThrow(XWikiException.class);
 
         WikiReference wikiReference = new WikiReference("wikiid");
+        when(this.wikiDescriptorManager.getAllIds()).thenReturn(List.of(
+            wikiReference.getName(),
+            CURRENT_WIKI_REFERENCE.getName()
+        ));
         NotificationException notificationException = assertThrows(NotificationException.class,
             () -> this.notificationFilterPreferenceStore.deleteFilterPreference(
                 wikiReference));

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/migration/R160500000XWIKI22271DataMigrationTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/migration/R160500000XWIKI22271DataMigrationTest.java
@@ -1,0 +1,261 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.xwiki.notifications.filters.migration;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.hibernate.Session;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.xwiki.context.Execution;
+import org.xwiki.context.ExecutionContext;
+import org.xwiki.notifications.filters.internal.DefaultNotificationFilterPreference;
+import org.xwiki.query.Query;
+import org.xwiki.query.QueryException;
+import org.xwiki.query.QueryManager;
+import org.xwiki.query.QueryParameter;
+import org.xwiki.test.LogLevel;
+import org.xwiki.test.annotation.BeforeComponent;
+import org.xwiki.test.junit5.LogCaptureExtension;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+import org.xwiki.test.mockito.MockitoComponentManager;
+import org.xwiki.wiki.descriptor.WikiDescriptorManager;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.internal.store.hibernate.HibernateStore;
+import com.xpn.xwiki.store.XWikiHibernateBaseStore;
+import com.xpn.xwiki.store.XWikiHibernateStore;
+import com.xpn.xwiki.store.XWikiStoreInterface;
+import com.xpn.xwiki.store.migration.DataMigrationException;
+import com.xpn.xwiki.store.migration.hibernate.HibernateDataMigration;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link R160500000XWIKI22271DataMigration}.
+ *
+ * @version $Id$
+ * @since 16.5.0
+ * @since 16.4.1
+ */
+@ComponentTest
+class R160500000XWIKI22271DataMigrationTest
+{
+    private static final String CURRENT_WIKI = "currentWiki";
+
+    @InjectMockComponents(role = HibernateDataMigration.class)
+    private R160500000XWIKI22271DataMigration dataMigration;
+
+    @MockComponent
+    private WikiDescriptorManager wikiDescriptorManager;
+
+    @MockComponent
+    private QueryManager queryManager;
+
+    @MockComponent
+    private Execution execution;
+
+    private XWikiContext context;
+
+    @RegisterExtension
+    private LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.INFO);
+
+    private HibernateStore hibernateStore;
+    private XWikiHibernateStore hibernateBaseStore;
+
+    @BeforeComponent
+    void beforeComponent(MockitoComponentManager componentManager) throws Exception
+    {
+        this.hibernateStore = componentManager.registerMockComponent(HibernateStore.class);
+        this.hibernateBaseStore = componentManager.registerMockComponent(XWikiStoreInterface.class,
+            XWikiHibernateBaseStore.HINT, XWikiHibernateStore.class, false);
+    }
+
+    @BeforeEach
+    void setUp() throws Exception
+    {
+        when(this.wikiDescriptorManager.getAllIds()).thenReturn(List.of(
+            "wikiA", CURRENT_WIKI, "wikiB"
+        ));
+
+        ExecutionContext executionContext = mock(ExecutionContext.class);
+        when(this.execution.getContext()).thenReturn(executionContext);
+
+        this.context = mock(XWikiContext.class);
+        when(executionContext.getProperty("xwikicontext")).thenReturn(this.context);
+        when(this.context.getWikiId()).thenReturn(CURRENT_WIKI);
+    }
+
+    @Test
+    void hibernateMigrate() throws QueryException, XWikiException, DataMigrationException
+    {
+        // We simulate 2 loops (3rd is just getting empty value)
+        Query query1 = mock(Query.class, "query1");
+        Query query2 = mock(Query.class, "query2");
+        Query query3 = mock(Query.class, "query3");
+
+        when(this.queryManager.createQuery("select nfp "
+            + "from DefaultNotificationFilterPreference nfp "
+            + "where nfp.page not like :wikiPrefix and "
+            + "nfp.pageOnly not like :wikiPrefix and "
+            + "nfp.user not like :wikiPrefix and"
+            + "nfp.wiki <> :wikiId", Query.HQL))
+            .thenReturn(query1)
+            .thenReturn(query2)
+            .thenReturn(query3);
+
+        QueryParameter queryParameter1 = mock(QueryParameter.class);
+        when(query1.bindValue("wikiPrefix")).thenReturn(queryParameter1);
+        when(queryParameter1.literal(CURRENT_WIKI + ":")).thenReturn(queryParameter1);
+        when(queryParameter1.anyChars()).thenReturn(queryParameter1);
+        when(queryParameter1.query()).thenReturn(query1);
+
+        QueryParameter queryParameter1Bis = mock(QueryParameter.class);
+        when(query1.bindValue("wikiId")).thenReturn(queryParameter1Bis);
+        when(queryParameter1Bis.literal(CURRENT_WIKI)).thenReturn(queryParameter1Bis);
+        when(queryParameter1Bis.query()).thenReturn(query1);
+
+        when(query1.setOffset(0)).thenReturn(query1);
+        when(query1.setLimit(100)).thenReturn(query1);
+
+        List resultQuery1 = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            DefaultNotificationFilterPreference pref = mock(DefaultNotificationFilterPreference.class, "pref_" + i);
+            when(pref.getInternalId()).thenReturn(Long.valueOf(i));
+            if (List.of(11, 15, 32).contains(i)) {
+                when(pref.getWikiId()).thenReturn(Optional.of("unknown"));
+            } else if (i % 2 == 0) {
+                when(pref.getWikiId()).thenReturn(Optional.of("wikiA"));
+            } else {
+                when(pref.getWikiId()).thenReturn(Optional.of("wikiB"));
+            }
+            resultQuery1.add(pref);
+        }
+        when(query1.execute()).thenReturn(resultQuery1);
+
+        // query 2
+        QueryParameter queryParameter2 = mock(QueryParameter.class);
+        when(query2.bindValue("wikiPrefix")).thenReturn(queryParameter2);
+        when(queryParameter2.literal(CURRENT_WIKI + ":")).thenReturn(queryParameter2);
+        when(queryParameter2.anyChars()).thenReturn(queryParameter2);
+        when(queryParameter2.query()).thenReturn(query2);
+
+        QueryParameter queryParameter2Bis = mock(QueryParameter.class);
+        when(query2.bindValue("wikiId")).thenReturn(queryParameter2Bis);
+        when(queryParameter2Bis.literal(CURRENT_WIKI)).thenReturn(queryParameter2Bis);
+        when(queryParameter2Bis.query()).thenReturn(query2);
+
+        when(query2.setOffset(100)).thenReturn(query2);
+        when(query2.setLimit(100)).thenReturn(query2);
+
+        List resultQuery2 = new ArrayList<>();
+        for (int i = 0; i < 36; i++) {
+            DefaultNotificationFilterPreference pref = mock(DefaultNotificationFilterPreference.class, "pref2_" + i);
+            when(pref.getInternalId()).thenReturn(100L + i);
+            if (i % 5 == 0) {
+                when(pref.getWikiId()).thenReturn(Optional.of("Subwiki"));
+            } else if (i == 12) {
+                when(pref.getWikiId()).thenReturn(Optional.empty());
+            } else {
+                when(pref.getWikiId()).thenReturn(Optional.of(CURRENT_WIKI));
+            }
+            resultQuery2.add(pref);
+        }
+        when(query2.execute()).thenReturn(resultQuery2);
+
+        // query 3
+        QueryParameter queryParameter3 = mock(QueryParameter.class);
+        when(query3.bindValue("wikiPrefix")).thenReturn(queryParameter3);
+        when(queryParameter3.literal(CURRENT_WIKI + ":")).thenReturn(queryParameter3);
+        when(queryParameter3.anyChars()).thenReturn(queryParameter3);
+        when(queryParameter3.query()).thenReturn(query3);
+
+        QueryParameter queryParameter3Bis = mock(QueryParameter.class);
+        when(query3.bindValue("wikiId")).thenReturn(queryParameter3Bis);
+        when(queryParameter3Bis.literal(CURRENT_WIKI)).thenReturn(queryParameter3Bis);
+        when(queryParameter3Bis.query()).thenReturn(query3);
+
+        when(query3.setOffset(136)).thenReturn(query3);
+        when(query3.setLimit(100)).thenReturn(query3);
+
+        when(query3.execute()).thenReturn(List.of());
+
+        Set<Long> expectedSet = Set.of(
+            11L,
+            15L,
+            32L,
+            100L,
+            105L,
+            110L,
+            112L,
+            115L,
+            120L,
+            125L,
+            130L,
+            135L
+        );
+        Session session = mock(Session.class, "session");
+        when(this.hibernateBaseStore.executeWrite(eq(context), any())).then(invocationOnMock -> {
+            XWikiHibernateBaseStore.HibernateCallback callback = invocationOnMock.getArgument(1);
+            return callback.doInHibernate(session);
+        });
+        org.hibernate.query.Query sessionQuery = mock(org.hibernate.query.Query.class, "sessionQuery");
+        when(session.createQuery("delete from DefaultNotificationFilterPreference "
+            + "where internalId in (:filterIds)")).thenReturn(sessionQuery);
+        when(sessionQuery.setParameter("filterIds", expectedSet)).thenReturn(sessionQuery);
+
+        this.dataMigration.hibernateMigrate();
+        assertEquals(3, logCapture.size());
+
+        assertEquals("Performing analysis of [100] filters to find those related to removed wikis",
+            logCapture.getMessage(0));
+        assertEquals("Performing analysis of [36] filters to find those related to removed wikis",
+            logCapture.getMessage(1));
+        assertEquals("Removing [12] filters related to deleted wikis",
+            logCapture.getMessage(2));
+
+        verify(query1).execute();
+        verify(query2).execute();
+        verify(query3).execute();
+        verify(queryParameter1).literal(CURRENT_WIKI + ":");
+        verify(queryParameter1).anyChars();
+        verify(queryParameter2).literal(CURRENT_WIKI + ":");
+        verify(queryParameter2).anyChars();
+        verify(queryParameter3).literal(CURRENT_WIKI + ":");
+        verify(queryParameter3).anyChars();
+        verify(queryParameter1Bis).literal(CURRENT_WIKI);
+        verify(queryParameter2Bis).literal(CURRENT_WIKI);
+        verify(queryParameter3Bis).literal(CURRENT_WIKI);
+        verify(sessionQuery).executeUpdate();
+    }
+}


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22271

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

  * Iterate over all wikis when deleting filters related to a wiki
  * Fix unit test
  * Provide a migration to clean up filters related to deleted wikis
  * Provide unit test for the migration

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* N/A

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

  - [ ] `mvn clean install -Pquality` on module `xwiki-platform-notifications-filters`
  - [ ]  `mvn clean install -Pquality,integration-tests,docker` on module `xwiki-platform-notifications`
  - [ ] Manual test of steps described in the ticket
  - [ ] Manual test of upgrading a wiki containing some remaining filters

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.4.x
  * 16.5.x