### PR TITLE
XWIKI-20650: Impossible to switch back to 10 entries per page in LiveData after going to 15

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/pom.xml
@@ -31,7 +31,7 @@
   <artifactId>xwiki-platform-livedata-api</artifactId>
   <name>XWiki Platform - Live Data - API</name>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.70</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.69</xwiki.jacoco.instructionRatio>
     <checkstyle.suppressions.location>${basedir}/src/checkstyle/checkstyle-suppressions.xml</checkstyle.suppressions.location>
     <!-- Name to display by the Extension Manager -->
     <xwiki.extension.name>Live Data API</xwiki.extension.name>

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/internal/DefaultLiveDataConfigurationResolver.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/internal/DefaultLiveDataConfigurationResolver.java
@@ -124,7 +124,7 @@ public class DefaultLiveDataConfigurationResolver implements LiveDataConfigurati
     }
 
     /**
-     * If the pagination sizes are missing the limit define in the query, add it to the allowed page limits.
+     * If the pagination sizes are missing the limit defined in the query, add it to the allowed page limits.
      *
      * @param mergedConfiguration the live data configuration
      */

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/internal/DefaultLiveDataConfigurationResolver.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/internal/DefaultLiveDataConfigurationResolver.java
@@ -22,7 +22,10 @@ package org.xwiki.livedata.internal;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -42,6 +45,7 @@ import org.xwiki.livedata.LiveDataConfigurationResolver;
 import org.xwiki.livedata.LiveDataException;
 import org.xwiki.livedata.LiveDataLayoutDescriptor;
 import org.xwiki.livedata.LiveDataMeta;
+import org.xwiki.livedata.LiveDataPaginationConfiguration;
 import org.xwiki.livedata.LiveDataPropertyDescriptor.FilterDescriptor;
 import org.xwiki.livedata.LiveDataPropertyDescriptor.OperatorDescriptor;
 import org.xwiki.livedata.LiveDataQuery.Source;
@@ -113,9 +117,41 @@ public class DefaultLiveDataConfigurationResolver implements LiveDataConfigurati
         mergedConfig.initialize();
 
         handleLayouts(config.getMeta().getLayouts(), mergedConfig.getMeta());
+        handlePageSizes(mergedConfig);
 
         // Translate using the context locale.
         return translate(mergedConfig);
+    }
+
+    /**
+     * If the pagination sizes are missing the limit define in the query, add it to the allowed page limits.
+     *
+     * @param mergedConfiguration the live data configuration
+     */
+    private void handlePageSizes(LiveDataConfiguration mergedConfiguration)
+    {
+        Integer limit = mergedConfiguration.getQuery().getLimit();
+        if (limit != null) {
+            LiveDataMeta meta = mergedConfiguration.getMeta();
+            if (meta == null) {
+                meta = new LiveDataMeta();
+                mergedConfiguration.setMeta(meta);
+            }
+            LiveDataPaginationConfiguration pagination = meta.getPagination();
+            if (pagination == null) {
+                pagination = new LiveDataPaginationConfiguration();
+                meta.setPagination(pagination);
+            }
+            List<Integer> pageSizes = pagination.getPageSizes();
+            if (pageSizes == null) {
+                pageSizes = new ArrayList<>();
+                pagination.setPageSizes(pageSizes);
+            }
+            if (!pageSizes.contains(limit)) {
+                pageSizes.add(limit);
+                Collections.sort(pageSizes);
+            }
+        }
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/internal/LiveDataRendererConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/internal/LiveDataRendererConfiguration.java
@@ -257,15 +257,27 @@ public class LiveDataRendererConfiguration
     private static void addPageSizeToPaginationIfMissing(LiveDataRendererParameters parameters,
         LiveDataConfiguration configuration)
     {
-        if (configuration.getMeta() == null) {
-            configuration.setMeta(new LiveDataMeta());
-        }
-        if (configuration.getMeta().getPagination() == null) {
-            configuration.getMeta().setPagination(new LiveDataPaginationConfiguration());
-        }
-        List<Integer> pageSizes = configuration.getMeta().getPagination().getPageSizes();
-        if (!pageSizes.contains(parameters.getLimit())) {
-            pageSizes.add(parameters.getLimit());
+        Integer limit = parameters.getLimit();
+        if (limit != null) {
+            LiveDataMeta meta = configuration.getMeta();
+            if (meta == null) {
+                meta = new LiveDataMeta();
+                configuration.setMeta(meta);
+            }
+            LiveDataPaginationConfiguration pagination = meta.getPagination();
+            if (pagination == null) {
+                pagination = new LiveDataPaginationConfiguration();
+                meta.setPagination(pagination);
+            }
+            List<Integer> pageSizes = pagination.getPageSizes();
+            if (pageSizes == null) {
+                pageSizes = new ArrayList<>();
+                pagination.setPageSizes(pageSizes);
+            }
+            if (!pageSizes.contains(limit)) {
+                pageSizes.add(limit);
+                Collections.sort(pageSizes);
+            }
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/internal/LiveDataRendererConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/internal/LiveDataRendererConfiguration.java
@@ -86,9 +86,7 @@ public class LiveDataRendererConfiguration
         LiveDataConfiguration basicConfig = getLiveDataConfiguration(parameters);
         // Make sure both configurations have the same id so that they are properly merged.
         advancedConfig.setId(basicConfig.getId());
-        LiveDataConfiguration configuration = this.jsonMerge.merge(advancedConfig, basicConfig);
-        addPageSizeToPaginationIfMissing(parameters, configuration);
-        return configuration;
+        return this.jsonMerge.merge(advancedConfig, basicConfig);
     }
 
     private LiveDataConfiguration getLiveDataConfiguration(LiveDataRendererParameters parameters) throws Exception
@@ -246,38 +244,5 @@ public class LiveDataRendererConfiguration
     private Stream<String> getSplitStringStream(String commaListAsString)
     {
         return Stream.of(commaListAsString.split(",")).map(StringUtils::trim);
-    }
-
-    /**
-     * If the pagination sizes are missing the limit define in the parameters, add it to the allowed page limits.
-     *
-     * @param parameters the live data parameters
-     * @param configuration the computed live data configuration
-     */
-    private static void addPageSizeToPaginationIfMissing(LiveDataRendererParameters parameters,
-        LiveDataConfiguration configuration)
-    {
-        Integer limit = parameters.getLimit();
-        if (limit != null) {
-            LiveDataMeta meta = configuration.getMeta();
-            if (meta == null) {
-                meta = new LiveDataMeta();
-                configuration.setMeta(meta);
-            }
-            LiveDataPaginationConfiguration pagination = meta.getPagination();
-            if (pagination == null) {
-                pagination = new LiveDataPaginationConfiguration();
-                meta.setPagination(pagination);
-            }
-            List<Integer> pageSizes = pagination.getPageSizes();
-            if (pageSizes == null) {
-                pageSizes = new ArrayList<>();
-                pagination.setPageSizes(pageSizes);
-            }
-            if (!pageSizes.contains(limit)) {
-                pageSizes.add(limit);
-                Collections.sort(pageSizes);
-            }
-        }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/test/java/org/xwiki/livedata/internal/LiveDataRendererConfigurationTest.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/test/java/org/xwiki/livedata/internal/LiveDataRendererConfigurationTest.java
@@ -19,8 +19,6 @@
  */
 package org.xwiki.livedata.internal;
 
-import java.util.List;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.xwiki.livedata.LiveDataConfiguration;

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/test/java/org/xwiki/livedata/internal/LiveDataRendererConfigurationTest.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/test/java/org/xwiki/livedata/internal/LiveDataRendererConfigurationTest.java
@@ -71,13 +71,4 @@ class LiveDataRendererConfigurationTest
         LiveDataConfiguration liveDataConfiguration = this.configuration.getLiveDataConfiguration("{}", parameters);
         assertEquals(description, liveDataConfiguration.getMeta().getDescription());
     }
-
-    @Test
-    void getLiveDataConfigurationLimitIsDefined() throws Exception
-    {
-        LiveDataRendererParameters parameters = new LiveDataRendererParameters();
-        parameters.setLimit(2);
-        LiveDataConfiguration liveDataConfiguration = this.configuration.getLiveDataConfiguration("{}", parameters);
-        assertEquals(List.of(2), liveDataConfiguration.getMeta().getPagination().getPageSizes());
-    }
 }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/test/java/org/xwiki/livedata/internal/LiveDataRendererConfigurationTest.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/test/java/org/xwiki/livedata/internal/LiveDataRendererConfigurationTest.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.livedata.internal;
 
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.xwiki.livedata.LiveDataConfiguration;
@@ -68,5 +70,14 @@ class LiveDataRendererConfigurationTest
         parameters.setDescription(description);
         LiveDataConfiguration liveDataConfiguration = this.configuration.getLiveDataConfiguration("{}", parameters);
         assertEquals(description, liveDataConfiguration.getMeta().getDescription());
+    }
+
+    @Test
+    void getLiveDataConfigurationLimitIsDefined() throws Exception
+    {
+        LiveDataRendererParameters parameters = new LiveDataRendererParameters();
+        parameters.setLimit(2);
+        LiveDataConfiguration liveDataConfiguration = this.configuration.getLiveDataConfiguration("{}", parameters);
+        assertEquals(List.of(2), liveDataConfiguration.getMeta().getPagination().getPageSizes());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/test/resources/DefaultLiveDataConfigurationResolver.test
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/test/resources/DefaultLiveDataConfigurationResolver.test
@@ -4,7 +4,8 @@
 {
   "id":"defaultConfigResolverTest",
   "query":{
-    "source":"test"
+    "source":"test",
+    "limit": 17
   },
   "meta":{
     "propertyDescriptors":[
@@ -45,7 +46,7 @@
     "filters":[],
     "sort":[],
     "offset":0,
-    "limit":15
+    "limit":17
   },
   "data":{
     "count":0,
@@ -160,7 +161,7 @@
     "defaultDisplayer":"text",
     "pagination":{
       "maxShownPages":10,
-      "pageSizes":[15,25,50,100],
+      "pageSizes":[15,17,25,50,100],
       "showEntryRange":true,
       "showNextPrevious":true
     },

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-macro/src/test/java/org/xwiki/livedata/internal/macro/LiveDataMacroTest.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-macro/src/test/java/org/xwiki/livedata/internal/macro/LiveDataMacroTest.java
@@ -173,7 +173,7 @@ class LiveDataMacroTest
         expectedConfig.append("    ],".trim());
         expectedConfig.append("    'defaultLayout':'table',".trim());
         expectedConfig.append("    'pagination':{".trim());
-        expectedConfig.append("      'pageSizes':[15,25,50],".trim());
+        expectedConfig.append("      'pageSizes':[10,15,25,50],".trim());
         expectedConfig.append("      'showPageSizeDropdown':true".trim());
         expectedConfig.append("    },'description':'A description'".trim());
         expectedConfig.append("  }".trim());
@@ -235,7 +235,9 @@ class LiveDataMacroTest
         expectedConfig.append("    'limit':10".trim());
         expectedConfig.append("  },".trim());
         expectedConfig.append("  'meta':{".trim());
-        expectedConfig.append("    'pagination':{}".trim());
+        expectedConfig.append("    'pagination':{".trim());
+        expectedConfig.append("        'pageSizes':[10]".trim());
+        expectedConfig.append("     }".trim());
         expectedConfig.append("  }".trim());
         expectedConfig.append("}");
 

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/src/test/it/org/xwiki/livedata/test/ui/LiveDataIT.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/src/test/it/org/xwiki/livedata/test/ui/LiveDataIT.java
@@ -157,6 +157,14 @@ class LiveDataIT
 
         // Test the Live Data content.
         assertEquals(3, tableLayout.countRows());
+
+        assertEquals(List.of(5, 15, 25, 50, 100), liveDataElement.getPaginationPageSizes());
+
+        // Check that the list of page sizes is preserved when we select a standard page size (see XWIKI-20650)
+        liveDataElement = liveDataElement.setPagination(15);
+        assertEquals(3, liveDataElement.getTableLayout().countRows());
+        assertEquals(List.of(5, 15, 25, 50, 100), liveDataElement.getPaginationPageSizes());
+
         tableLayout.assertRow(DOC_TITLE_COLUMN, "O1");
         tableLayout.assertRow(DOC_TITLE_COLUMN, "O2 1");
         tableLayout.assertRow(DOC_TITLE_COLUMN, "O3 1");
@@ -425,6 +433,7 @@ class LiveDataIT
             + "{{liveData\n"
             + "  id=\"test\"\n"
             + "  properties=\"" + String.join(",", properties) + "\"\n"
+            + "  limit=\"5\"\n"
             + "  source=\"liveTable\"\n"
             + "  sourceParameters=\"translationPrefix=&className=" + testUtils.serializeReference(
             testReference.getLocalDocumentReference()) + "\"\n"

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-pageobjects/src/main/java/org/xwiki/livedata/test/po/LiveDataElement.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-pageobjects/src/main/java/org/xwiki/livedata/test/po/LiveDataElement.java
@@ -144,6 +144,22 @@ public class LiveDataElement extends BaseElement
         return this;
     }
 
+    /**
+     *
+     * @return the possible pagination sizes.
+     * @since 16.5.0
+     */
+    public List<Integer> getPaginationPageSizes()
+    {
+        WebElement element = getRootElement().findElement(By.cssSelector(".pagination-page-size select"));
+        return new Select(element)
+            .getOptions()
+            .stream()
+            .map(WebElement::getText)
+            .map(Integer::parseInt)
+            .collect(Collectors.toList());
+    }
+
     public void waitUntilReady()
     {
         getDriver().waitUntilCondition(input -> isVueLoaded());


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-20650

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Change the LiveDataConfigurationResolver so that it adds the limit to the list of page sizes if it's not already there
* Refactor a bit existing LiveDataMacroTest so that it uses the real components for configuration resolver to have a better coverage 

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* N/A

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

`mvn clean install -Pquality,integration-tests,docker` on module `xwiki-platform-livedata`

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * No