### PR TITLE
[Misc] Clean up a bit xwiki.js to move deprecated stuff

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/compatibility.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/compatibility.js
@@ -398,6 +398,101 @@ Object.extend(XWiki.constants, {
           return fileInput.value;
       }
   },
+
+  /**
+   * Watchlist methods.
+   *
+   * @deprecated Since XWiki 7.4, the watchlist UI is implemented in a UI extension. This code is still there to not
+   * break the retro-compatibility but we can consider removing it.
+   */
+  watchlist : {
+
+      /**
+       * Mapping between link IDs and associated actions.
+       */
+      actionsMap : {
+          'tmWatchDocument' : 'adddocument',
+          'tmUnwatchDocument' : 'removedocument',
+          'tmWatchSpace' : 'addspace',
+          'tmUnwatchSpace' : 'removespace',
+          'tmWatchWiki' : 'addwiki',
+          'tmUnwatchWiki' : 'removewiki'
+      },
+
+      /**
+       * Mapping allowing to know which action to display when a previous action has been executed.
+       */
+      flowMap : {
+          'tmWatchDocument' : 'tmUnwatchDocument',
+          'tmUnwatchDocument' : 'tmWatchDocument',
+          'tmWatchSpace' : 'tmUnwatchSpace',
+          'tmUnwatchSpace' : 'tmWatchSpace',
+          'tmWatchWiki' : 'tmUnwatchWiki',
+          'tmUnwatchWiki' : 'tmWatchWiki'
+      },
+
+      /**
+       * Execute a watchlist action (add or remove the given document/space/wiki from watchlist).
+       *
+       * @param element the element that fired the action.
+       */
+      executeAction : function(element) {
+          warn("XWiki.watchlist is deprecated since 7.4.");
+          var surl = window.docgeturl + "?xpage=watch&do=" + this.actionsMap[element.id];
+          new Ajax.Request(
+              surl,
+              {
+                  method: 'get',
+                  onComplete: function() {
+                      if (element.nodeName == 'A') {
+                          element.up().toggleClassName('hidden');
+                          $(XWiki.watchlist.flowMap[element.id]).up().toggleClassName('hidden');
+                      } else {
+                          element.toggleClassName('hidden');
+                          $(XWiki.watchlist.flowMap[element.id]).toggleClassName('hidden');
+                      }
+                  }
+              });
+      },
+
+      /**
+       * Initialize watchlist UI.
+       */
+      initialize: function(container) {
+          container = $(container || 'body');
+          for (var button in XWiki.watchlist.actionsMap) {
+              var element = container.down('#' + button);
+              if (element) {
+                  if (element.nodeName != 'A') {
+                      element = $(button).down('A');
+                  }
+
+                  if (!element) {
+                      // This is supposed to happen every time since the watchlist icons are implemented in the
+                     // notifications
+                      // menu. The watchlist icons are now implemented as a UI extension, and the inputs are handled
+                     // with a
+                      // custom solution (bootstrap-switch).
+                      // For these reasons, we stop the initialization here.
+                      // We keep this function for old skins (like Colibri), that still have the old-fashioned
+                     // watchlist icons.
+                      return;
+                  }
+
+                  // unregister previously registered handler if any
+                  element.stopObserving('click');
+                  element.observe('click', function(event) {
+                      Event.stop(event);
+                      var element = event.element();
+                      while (element.id == '') {
+                          element = element.up();
+                      }
+                      XWiki.watchlist.executeAction(element);
+                  });
+              }
+          }
+      }
+  }
 });
 
 /**
@@ -441,4 +536,15 @@ Object.extend(XWiki.constants, {
  */
 XWiki.blacklistedSpaces = XWiki.blacklistedSpaces || [];
 
+})();
+
+(function () {
+    var initializeWatch = function (container) {
+        container = container || $('body');
+        XWiki.watchlist.initialize(container);
+    }
+    document.observe('xwiki:dom:updated', function(event) {
+        event.memo.elements.each(initializeWatch.bind(this));
+    }.bindAsEventListener(this));
+    initializeWatch();
 })();

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/compatibility.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/compatibility.js
@@ -240,6 +240,8 @@ Object.extend(XWiki.resource, {
    * @deprecated since 4.2M1, use {@code XWiki.resource.get(name).wiki} instead
    */
   getWikiFromResourceName: function(name) {
+    warn("XWiki.resource.getWikiFromResourceName is deprecated since XWiki 4.2M1. " +
+        "Use XWiki.resource.get(name).wiki instead.");
     if (name.include(XWiki.constants.wikiSpaceSeparator)) {
       return name.substring(0, name.indexOf(XWiki.constants.wikiSpaceSeparator));
     }
@@ -253,6 +255,8 @@ Object.extend(XWiki.resource, {
    * @deprecated since 4.2M1, use {@code XWiki.resource.get(name).space} instead
    */
   getSpaceFromResourceName: function(name) {
+    warn("XWiki.resource.getSpaceFromResourceName is deprecated since XWiki 4.2M1. " +
+        "Use XWiki.resource.get(name).space instead.");
     var originalName = name;
     // Remove wiki if any.
     if (name.include(XWiki.constants.wikiSpaceSeparator)) {
@@ -282,6 +286,8 @@ Object.extend(XWiki.resource, {
    * @deprecated since 4.2M1, use {@code XWiki.resource.get(name).name} instead
    */
   getNameFromResourceName: function(name) {
+    warn("XWiki.resource.getNameFromResourceName is deprecated since XWiki 4.2M1. " +
+        "Use XWiki.resource.get(name).name instead.");
     var originalName = name;
     // Remove wiki if any.
     if (name.include(XWiki.constants.wikiSpaceSeparator)) {
@@ -314,6 +320,8 @@ Object.extend(XWiki.resource, {
    * @deprecated since 4.2M1, use {@code XWiki.resource.get(name).attachment} instead
    */
   getAttachmentFromResourceName: function(name) {
+    warn("XWiki.resource.getAttachmentFromResourceName is deprecated since XWiki 4.2M1. " +
+        "Use XWiki.resource.get(name).attachment instead.");
     if (name.include(XWiki.constants.pageAttachmentSeparator)) {
       return name.substring(name.indexOf(XWiki.constants.pageAttachmentSeparator) + 1, name.length);
     }
@@ -327,6 +335,8 @@ Object.extend(XWiki.resource, {
    * @deprecated since 4.2M1, use {@code XWiki.resource.get(name).anchor} instead
    */
   getAnchorFromResourceName: function(name) {
+    warn("XWiki.resource.getAnchorFromResourceName is deprecated since XWiki 4.2M1. " +
+        "Use XWiki.resource.get(name).anchor instead.");
     if (name.include(XWiki.constants.anchorSeparator)) {
       return name.substring(name.indexOf(XWiki.constants.anchorSeparator) + 1, name.length);
     }

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/compatibility.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/compatibility.js
@@ -368,7 +368,36 @@ Object.extend(XWiki.constants, {
    * @deprecated since 4.2M1, your code shouldn't be aware of this separator, use {@code XWiki.Model}
    *             to resolve/serialize entity references
    */
-  pageAttachmentSeparator: "@"
+  pageAttachmentSeparator: "@",
+
+  /**
+   * Extracts the file name from the value of the specified file input.
+   * @deprecated since 16.6.0RC1
+   */
+  extractFileName: function(fileInput) {
+      warn("XWiki.extractFileName is deprecated since 16.6.0RC1.");
+      fileInput = $(fileInput);
+      if (fileInput.files && fileInput.files.length > 0) {
+          // Modern browsers provide additional information about the selected file(s).
+          return fileInput.files[0].name;
+      } else if (fileInput.value.substr(0, 12) == 'C:\\fakepath\\') {
+          // Most browsers hide the real path for security reasons.
+          return fileInput.value.substr(12);
+      } else {
+          var lastPathSeparatorIndex = fileInput.value.lastIndexOf('/');
+          if (lastPathSeparatorIndex >= 0) {
+              // Unix-based path.
+              return fileInput.value.substr(lastPathSeparatorIndex + 1);
+          }
+          lastPathSeparatorIndex = fileInput.value.lastIndexOf('\\');
+          if (lastPathSeparatorIndex >= 0) {
+              // Windows-based path.
+              return fileInput.value.substr(lastPathSeparatorIndex + 1);
+          }
+          // The file input value is just the file name.
+          return fileInput.value;
+      }
+  },
 });
 
 /**

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/xwiki.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/xwiki.js
@@ -596,33 +596,6 @@ Object.extend(XWiki, {
   },
 
   /**
-   * Extracts the file name from the value of the specified file input.
-   */
-  extractFileName: function(fileInput) {
-    fileInput = $(fileInput);
-    if (fileInput.files && fileInput.files.length > 0) {
-      // Modern browsers provide additional information about the selected file(s).
-      return fileInput.files[0].name;
-    } else if (fileInput.value.substr(0, 12) == 'C:\\fakepath\\') {
-      // Most browsers hide the real path for security reasons.
-      return fileInput.value.substr(12);
-    } else {
-      var lastPathSeparatorIndex = fileInput.value.lastIndexOf('/');
-      if (lastPathSeparatorIndex >= 0) {
-        // Unix-based path.
-        return fileInput.value.substr(lastPathSeparatorIndex + 1);
-      }
-      lastPathSeparatorIndex = fileInput.value.lastIndexOf('\\');
-      if (lastPathSeparatorIndex >= 0) {
-        // Windows-based path.
-        return fileInput.value.substr(lastPathSeparatorIndex + 1);
-      }
-      // The file input value is just the file name.
-      return fileInput.value;
-    }
-  },
-
-  /**
    * Initialize method for the XWiki object. This is to be called only once upon dom loading.
    * It makes rendering errors expandable and fixes external links on the body content.
    * Then it fires an custom event to signify the (modified) DOM is now loaded.

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/xwiki.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/xwiki.js
@@ -436,97 +436,6 @@ Object.extend(XWiki, {
       }
   },
 
-  /**
-   * Watchlist methods.
-   * 
-   * @deprecated Since XWiki 7.4, the watchlist UI is implemented in a UI extension. This code is still there to not 
-   * break the retro-compatibility but we can consider removing it.
-   */
-  watchlist : {
-
-    /**
-     * Mapping between link IDs and associated actions.
-     */
-    actionsMap : {
-        'tmWatchDocument' : 'adddocument',
-        'tmUnwatchDocument' : 'removedocument',
-        'tmWatchSpace' : 'addspace',
-        'tmUnwatchSpace' : 'removespace',
-        'tmWatchWiki' : 'addwiki',
-        'tmUnwatchWiki' : 'removewiki'
-    },
-
-    /**
-     * Mapping allowing to know which action to display when a previous action has been executed.
-     */
-    flowMap : {
-        'tmWatchDocument' : 'tmUnwatchDocument',
-        'tmUnwatchDocument' : 'tmWatchDocument',
-        'tmWatchSpace' : 'tmUnwatchSpace',
-        'tmUnwatchSpace' : 'tmWatchSpace',
-        'tmWatchWiki' : 'tmUnwatchWiki',
-        'tmUnwatchWiki' : 'tmWatchWiki'
-    },
-
-    /**
-     * Execute a watchlist action (add or remove the given document/space/wiki from watchlist).
-     *
-     * @param element the element that fired the action.
-     */
-    executeAction : function(element) {
-        var surl = window.docgeturl + "?xpage=watch&do=" + this.actionsMap[element.id];
-        new Ajax.Request(
-          surl,
-          {
-            method: 'get',
-            onComplete: function() {
-              if (element.nodeName == 'A') {
-                element.up().toggleClassName('hidden');
-                $(XWiki.watchlist.flowMap[element.id]).up().toggleClassName('hidden');
-              } else {
-                element.toggleClassName('hidden');
-                $(XWiki.watchlist.flowMap[element.id]).toggleClassName('hidden');
-              }
-            }
-          });
-    },
-
-    /**
-     * Initialize watchlist UI.
-     */
-    initialize: function(container) {
-        container = $(container || 'body');
-        for (var button in XWiki.watchlist.actionsMap) {
-          var element = container.down('#' + button);
-          if (element) {
-            if (element.nodeName != 'A') {
-              element = $(button).down('A');
-            }
-
-            if (!element) {
-              // This is supposed to happen every time since the watchlist icons are implemented in the notifications
-              // menu. The watchlist icons are now implemented as a UI extension, and the inputs are handled with a 
-              // custom solution (bootstrap-switch).
-              // For these reasons, we stop the initialization here.
-              // We keep this function for old skins (like Colibri), that still have the old-fashioned watchlist icons.
-              return;
-            }
-
-            // unregister previously registered handler if any
-            element.stopObserving('click');
-            element.observe('click', function(event) {
-                Event.stop(event);
-                var element = event.element();
-                while (element.id == '') {
-                    element = element.up();
-                }
-                XWiki.watchlist.executeAction(element);
-              });
-          }
-        }
-    }
-  },
-
   cookies: {
     /**
      * Create a cookie, with or without expiration date.
@@ -637,7 +546,6 @@ Object.extend(XWiki, {
     this.makeRenderingErrorsExpandable(container);
     this.fixLinksTargetAttribute(container);
     this.insertSectionEditLinks(container);
-    this.watchlist.initialize(container);
     this.registerPanelToggle(container);
   }
 });


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

None

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Just moving some deprecated stuff from xwiki.js to compatibility.js

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

N/A

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

`mvn clean install -Pquality` on the module of the changes.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * No