### PR TITLE
XWIKI-22106: The comment button doesn't focus the WYSIWYG editor that gets inserted

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/viewers/comments.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/viewers/comments.js
@@ -595,7 +595,6 @@ viewers.Comments = Class.create({
 
     require(['jquery', 'xwiki-events-bridge'], function ($) {
       if ($(".commenteditor").length) {
-        CKEDITOR.config.startupFocus = true;
         $.post(new XWiki.Document().getURL("get") + '?' + $.param({
           xpage: 'xpart',
           vm: 'commentfield.vm',

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/viewers/comments.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/viewers/comments.js
@@ -595,6 +595,7 @@ viewers.Comments = Class.create({
 
     require(['jquery', 'xwiki-events-bridge'], function ($) {
       if ($(".commenteditor").length) {
+        CKEDITOR.config.startupFocus = true;
         $.post(new XWiki.Document().getURL("get") + '?' + $.param({
           xpage: 'xpart',
           vm: 'commentfield.vm',

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/viewers/comments.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/viewers/comments.js
@@ -88,6 +88,10 @@ viewers.Comments = Class.create({
             this.addSubmitListener(this.form);
             this.addCancelListener();
             this.addPreview(this.form);
+            if(typeof CKEDITOR === 'undefined') {
+              // Focus on the textarea.
+              this.form["XWiki.XWikiComments_comment"].focus();
+            }
           }.bind(this)
         });
       }.bind(this));
@@ -595,7 +599,9 @@ viewers.Comments = Class.create({
 
     require(['jquery', 'xwiki-events-bridge'], function ($) {
       if ($(".commenteditor").length) {
-        CKEDITOR.config.startupFocus = true;
+        if(typeof CKEDITOR !== 'undefined') {
+          CKEDITOR.config.startupFocus = true;
+        }
         $.post(new XWiki.Document().getURL("get") + '?' + $.param({
           xpage: 'xpart',
           vm: 'commentfield.vm',


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22106

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added startupFocus for the comment editor

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Properly passed `mvn clean install -f xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker` after building the changes with `mvn clean install -f xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war` :+1: 

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None