### PR TITLE
XWIKI-22304: Do not trigger the lightbox feature for images from the Gallery macro

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-gallery/src/main/java/org/xwiki/rendering/internal/macro/gallery/GalleryMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-gallery/src/main/java/org/xwiki/rendering/internal/macro/gallery/GalleryMacro.java
@@ -118,6 +118,8 @@ public class GalleryMacro extends AbstractMacro<GalleryMacroParameters>
 
             Map<String, String> groupParameters = new HashMap<>();
             groupParameters.put("class", ("gallery " + StringUtils.defaultString(parameters.getClassNames())).trim());
+            // Disable lightbox for the gallery macro since the two features are very similar and it produces confusion.
+            groupParameters.put("data-xwiki-lightbox", "false");
             if (inlineStyle.length() > 0) {
                 groupParameters.put("style", inlineStyle.toString());
             }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-gallery/src/test/resources/macrogallery1.test
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-gallery/src/test/resources/macrogallery1.test
@@ -12,13 +12,13 @@ image:second.png
 beginDocument
 beginMacroMarkerStandalone [gallery] [] [image:first.png
 image:second.png]
-beginGroup [[class]=[gallery]]
+beginGroup [[class]=[gallery][data-xwiki-lightbox]=[false]]
 beginParagraph
 onImage [Typed = [false] Type = [url] Reference = [first.png]] [true] [Ifirst.png]
 onNewLine
 onImage [Typed = [false] Type = [url] Reference = [second.png]] [true] [Isecond.png]
 endParagraph
-endGroup [[class]=[gallery]]
+endGroup [[class]=[gallery][data-xwiki-lightbox]=[false]]
 endMacroMarkerStandalone [gallery] [] [image:first.png
 image:second.png]
 endDocument

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-gallery/src/test/resources/macrogallery2.test
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-gallery/src/test/resources/macrogallery2.test
@@ -12,13 +12,13 @@ image:second.png
 beginDocument
 beginMacroMarkerStandalone [gallery] [class=foo|width=300px|height=200px] [image:first.png
 image:second.png]
-beginGroup [[class]=[gallery foo][style]=[width: 300px;height: 200px;]]
+beginGroup [[class]=[gallery foo][data-xwiki-lightbox]=[false][style]=[width: 300px;height: 200px;]]
 beginParagraph
 onImage [Typed = [false] Type = [url] Reference = [first.png]] [true] [Ifirst.png]
 onNewLine
 onImage [Typed = [false] Type = [url] Reference = [second.png]] [true] [Isecond.png]
 endParagraph
-endGroup [[class]=[gallery foo][style]=[width: 300px;height: 200px;]]
+endGroup [[class]=[gallery foo][data-xwiki-lightbox]=[false][style]=[width: 300px;height: 200px;]]
 endMacroMarkerStandalone [gallery] [class=foo|width=300px|height=200px] [image:first.png
 image:second.png]
 endDocument

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-gallery/src/test/resources/macrogallery3.test
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-gallery/src/test/resources/macrogallery3.test
@@ -12,13 +12,13 @@ image:second.png
 beginDocument
 beginMacroMarkerStandalone [gallery] [width=|height=] [image:first.png
 image:second.png]
-beginGroup [[class]=[gallery]]
+beginGroup [[class]=[gallery][data-xwiki-lightbox]=[false]]
 beginParagraph
 onImage [Typed = [false] Type = [url] Reference = [first.png]] [true] [Ifirst.png]
 onNewLine
 onImage [Typed = [false] Type = [url] Reference = [second.png]] [true] [Isecond.png]
 endParagraph
-endGroup [[class]=[gallery]]
+endGroup [[class]=[gallery][data-xwiki-lightbox]=[false]]
 endMacroMarkerStandalone [gallery] [width=|height=] [image:first.png
 image:second.png]
 endDocument


### PR DESCRIPTION
# Jira URL
https://jira.xwiki.org/browse/XWIKI-22304

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* disable lightbox for the gallery macro

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
[IntegrationTests](https://github.com/xwiki/xwiki-platform/blob/master/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-gallery/src/test/java/org/xwiki/rendering/macro/gallery/IntegrationTests.java)

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * stable-16.5.x
  * stable-16.4.x
  * stable-15.10.x