### PR TITLE
XWIKI-22314: Navigation tree items have an unexpected shadow with a mobile and dark theme.

### DIFF
--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/responsive.less
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/responsive.less
@@ -31,7 +31,7 @@
 	.jstree-checked > .jstree-checkbox:hover { background-position:0 -(@base-height * 2); }
 	.jstree-anchor > .jstree-undetermined, .jstree-anchor > .jstree-undetermined:hover { background-position:0 -(@base-height * 3); }
 
-	.jstree-anchor { font-weight:bold; font-size:1.1em; text-shadow:1px 1px white; }
+	.jstree-anchor { font-weight:bold; font-size:1.1em; }
 
 	> .jstree-striped { background:transparent; }
 	.jstree-wholerow { border-top:1px solid @mobile-wholerow-bordert; border-bottom:1px solid @mobile-wholerow-borderb; background:@mobile-wholerow-bg-color; height:@base-height; }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22314

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Removed the unexpected style taken from jstree.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* This style uses a hard coded color, on mobile only. We can only see this inconsistency when testing on low width screens AND dark color themes. We don't have any automated testing with these conditions.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

before the PR
![Screenshot from 2024-07-04 10-28-27](https://github.com/xwiki/xwiki-platform/assets/28761965/c26d88ca-f7d6-4963-a7ea-6fd92b85987f)
after the PR
![Screenshot from 2024-07-04 11-22-48](https://github.com/xwiki/xwiki-platform/assets/28761965/e13717f4-4b9b-42b5-939d-2e5d6f5ab11f)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

I built `mvn clean install -f xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar` successfully and replaced the jar in my test ditribution to get the screenshot above. Nothing more, since this is a rather specific scope style change.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None