### PR TITLE
XWIKI-15049: NotificationsApplicationsPreferencesMacro stylesheet not using Color Themes variables

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsApplicationsPreferencesMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsApplicationsPreferencesMacro.xml
@@ -712,30 +712,36 @@ require(['jquery', 'xwiki-meta', 'ApplicationWidget', 'xwiki-bootstrap-switch', 
       <code>.notifPreferences tbody {
   margin-top: 2em;
 }
+
 .notifPreferences .appOdd {
-  background: #e5e5e5;
+  background: @breadcrumb-bg;
 }
+
 .notifPreferences .appEven {
-  background: #fafafa;
+  background: @xwiki-page-content-bg;
 }
+
 .notifPreferences .rowApp td, .notifPreferences .rowApp th{
   height: 3em;
 }
+
 .notifPreferences th:nth-child(1) {
   vertical-align: top;
   width: 250px;
 }
+
 .notificationAppCell {
   vertical-align: top;
   width: 33%;
 }
+
 .notificationCollapseButtonCell {
   vertical-align: top;
   text-align: right;
 }</code>
     </property>
     <property>
-      <contentType>CSS</contentType>
+      <contentType>LESS</contentType>
     </property>
     <property>
       <name>NotificationPreferencesTable</name>


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-15049

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Changed the SSX type to LESS
* Replaced the former hard coded colors with values from the colorTheme.
* Added codestyle updates for the SSX - one empty line between adjacent style blocks.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* I decided to use the `@breadcrumb-bg` color here. Even if it's not semantically  exactly what we want,  it's still better than hard coding and should be correct contrast with the base text color.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Before PR (dark theme):

![image](https://github.com/user-attachments/assets/eaa5f48c-77b9-4040-aa9c-4979c0c29e2d)

After PR:
Darkly
![image](https://github.com/user-attachments/assets/f70ece19-fa94-498c-b0ca-05acdef25d97)
Iceberg
![image](https://github.com/user-attachments/assets/0299f568-ef95-4a4d-b4e2-8e6a92e1e6ed)
Kitty
![image](https://github.com/user-attachments/assets/8e152818-0627-4c44-a545-42ab7f1f34e4)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Changes are style only, so I only checked manually. See screenshots above:


# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.X , this change is fairly safe.