### PR TITLE
XWIKI-22336: Updating a page with the REST API makes it non-hidden unless the hidden property is specified

### DIFF
--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -138,10 +138,44 @@
 
                  Single justification example:
             -->
-            
-            
-            
-            
+            <revapi.differences>
+              <justification>To fix XWIKI-22336 and XWIKI-22337, the type of the hidden field of the
+                REST Page model needs to be changed from boolean to Boolean. This class shouldn't be
+                used directly but through ModelFactory. Users of the REST API aren't affected as
+                ModelFactory always sets the hidden attribute and thus the null value will never be in
+                an API response.</justification>
+              <criticality>highlight</criticality>
+              <differences>
+                <item>
+                  <code>java.field.typeChanged</code>
+                  <old>field org.xwiki.rest.model.jaxb.Page.hidden</old>
+                  <new>field org.xwiki.rest.model.jaxb.Page.hidden</new>
+                </item>
+                <item>
+                  <code>java.annotation.removed</code>
+                  <old>field org.xwiki.rest.model.jaxb.Page.hidden</old>
+                  <new>field org.xwiki.rest.model.jaxb.Page.hidden</new>
+                  <annotation>@javax.xml.bind.annotation.XmlElement(defaultValue = "false")</annotation>
+                </item>
+                <item>
+                  <code>java.method.returnTypeChanged</code>
+                  <old>method boolean org.xwiki.rest.model.jaxb.Page::isHidden()</old>
+                  <new>method java.lang.Boolean org.xwiki.rest.model.jaxb.Page::isHidden()</new>
+                </item>
+                <item>
+                  <code>java.method.parameterTypeChanged</code>
+                  <old>parameter void org.xwiki.rest.model.jaxb.Page::setHidden(===boolean===)</old>
+                  <new>parameter void org.xwiki.rest.model.jaxb.Page::setHidden(===java.lang.Boolean===)</new>
+                  <parameterIndex>0</parameterIndex>
+                </item>
+                <item>
+                  <code>java.method.parameterTypeChanged</code>
+                  <old>parameter org.xwiki.rest.model.jaxb.Page org.xwiki.rest.model.jaxb.Page::withHidden(===boolean===)</old>
+                  <new>parameter org.xwiki.rest.model.jaxb.Page org.xwiki.rest.model.jaxb.Page::withHidden(===java.lang.Boolean===)</new>
+                  <parameterIndex>0</parameterIndex>
+                </item>
+              </differences>
+            </revapi.differences>
           </analysisConfiguration>
         </configuration>
       </plugin>

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-model/src/main/resources/xwiki.rest.model.xsd
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-model/src/main/resources/xwiki.rest.model.xsd
@@ -127,7 +127,7 @@
           <element name="language" type="string"></element>
           <element name="majorVersion" type="int"></element>
           <element name="minorVersion" type="int"></element>
-          <element name="hidden" type="boolean" default="false"></element>
+          <element name="hidden" type="boolean" minOccurs="0"></element>
           <element name="created" type="dateTime"></element>
           <element name="creator" type="string"></element>
           <element name="creatorName" type="string"></element>

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/ModelFactory.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/ModelFactory.java
@@ -210,7 +210,10 @@ public class ModelFactory
             modified = true;
         }
 
-        doc.setHidden(restPage.isHidden());
+        if (restPage.isHidden() != null) {
+            doc.setHidden(restPage.isHidden());
+            modified = true;
+        }
 
         // Set objects
         if (restPage.getObjects() != null) {

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/representations/pages/FormUrlEncodedPageReader.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/representations/pages/FormUrlEncodedPageReader.java
@@ -79,7 +79,10 @@ public class FormUrlEncodedPageReader implements MessageBodyReader<Page>, XWikiR
 
         page.setTitle(form.getFirst(TITLE_FIELD_NAME));
         page.setParent(form.getFirst(PARENT_FIELD_NAME));
-        page.setHidden(Boolean.valueOf(form.getFirst(HIDDEN_FIELD_NAME)));
+        String hiddenValue = form.getFirst(HIDDEN_FIELD_NAME);
+        if (hiddenValue != null) {
+            page.setHidden(Boolean.valueOf(hiddenValue));
+        }
         page.setContent(form.getFirst(CONTENT_FIELD_NAME));
 
         return page;

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/PageResourceIT.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-test/xwiki-platform-rest-test-tests/src/test/it/org/xwiki/rest/test/PageResourceIT.java
@@ -577,6 +577,42 @@ public class PageResourceIT extends AbstractHttpIT
     }
 
     @Test
+    public void testPOSTPageFormURLEncodedHidden() throws Exception
+    {
+        Page originalPage = getFirstPage();
+
+        Link link = getFirstLinkByRelation(originalPage, Relations.SELF);
+        Assert.assertNotNull(link);
+
+        // Mark the page as hidden.
+        NameValuePair[] nameValuePairs = new NameValuePair[1];
+        nameValuePairs[0] = new NameValuePair("hidden", "true");
+
+        PostMethod postMethod = executePostForm(String.format("%s?method=PUT", link.getHref()), nameValuePairs,
+            TestUtils.SUPER_ADMIN_CREDENTIALS.getUserName(), TestUtils.SUPER_ADMIN_CREDENTIALS.getPassword());
+        Assert.assertEquals(getHttpMethodInfo(postMethod), HttpStatus.SC_ACCEPTED, postMethod.getStatusCode());
+
+        Page modifiedPage = (Page) this.unmarshaller.unmarshal(postMethod.getResponseBodyAsStream());
+
+        Assert.assertTrue(modifiedPage.isHidden());
+
+        // Set just the title.
+        String title = String.format("Title (%s)", UUID.randomUUID());
+
+        nameValuePairs = new NameValuePair[1];
+        nameValuePairs[0] = new NameValuePair("title", title);
+
+        postMethod = executePostForm(String.format("%s?method=PUT", link.getHref()), nameValuePairs,
+            TestUtils.SUPER_ADMIN_CREDENTIALS.getUserName(), TestUtils.SUPER_ADMIN_CREDENTIALS.getPassword());
+        Assert.assertEquals(getHttpMethodInfo(postMethod), HttpStatus.SC_ACCEPTED, postMethod.getStatusCode());
+
+        modifiedPage = (Page) this.unmarshaller.unmarshal(postMethod.getResponseBodyAsStream());
+
+        Assert.assertEquals(title, modifiedPage.getTitle());
+        Assert.assertTrue(modifiedPage.isHidden());
+    }
+
+    @Test
     public void testPOSTPageFormUrlEncodedNoCSRF() throws Exception
     {
         final String CONTENT = String.format("This is a content (%d)", System.currentTimeMillis());


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22337 and https://jira.xwiki.org/browse/XWIKI-22336

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Make the hidden field a Boolean to allow for a null value.
* Only use the hidden field when it is non-null.
* Add an integration test.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Ideally, we would keep the original getter and setter with the `boolean` type and only add new ones - but I don't know if this is easily possible.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Built `xwiki-platform-rest` with the quality profile.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None (breaking change)