### PR TITLE
XWIKI-22260: WCAG automatic testing for modals

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BasePage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BasePage.java
@@ -695,7 +695,7 @@ public class BasePage extends BaseElement
                 XWikiWebDriver driver = this.getDriver();
                 AxeBuilder axeBuilder = wcagContext.getAxeBuilder();
                 Results axeResult = axeBuilder.analyze(driver);
-                wcagContext.addWCAGResults(driver.getCurrentUrl(), this.getClass().getName(), axeResult);
+                wcagContext.addWCAGResults(this.getPageURL(), this.getClass().getName(), axeResult);
                 long stopTime = System.currentTimeMillis();
                 long deltaTime = stopTime - startTime;
                 LOGGER.debug("[{} : {}] WCAG Validation on this element took [{}] ms.",


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22260

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added wcag validation to modal elements.
* Fixed a code style inconsistency in the BasePage wcag validation

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* I did not run a full build with WCAG testing yet to check if there's any tests failures because of these new checks. So there's two solutions to merge this:
   * Consider there's not that many test suites with modal elements, merge this PR as is, and take care of the state of continuous integration for the docker tests. If fails are found on CI, provide a fix asap (either a real fix or swap the type of the rule from fail to warning until a proper solution is found).
   * Add a safeguard in the WCAG testing to allow tests that never fail. This has the advantage of being reusable if at some point we want to add automated tests on other elements that can be found in multiple places at the level of the project. However as things stand it might not be needed, and on the long term this feature is useless.
* The new code is almost a duplicate of the one in the basePage object. I was not sure how or where I could factorize this. If deemed necessary, I'll factorize this. I could use some help finding out where to keep this function. At first, I thought of `WCAGUtils`, but it doesn't share much scope with the page objects, so I scrapped it. Then I thought of `BaseElement`
, which is the parent of all the elements we would want. This looked pretty good, but I wasn't sure of the impact on performance adding a quite large method and dependencies to all the objects would have (I got a look at the class, it's pretty empty as of now, I'm not sure adding something specific to WCAG testing was correct). At last, I thought of having a new interface for `WCAG analyzable objects`, IMO this is the best alternative, but I don't know in what module I'd include it in... Any of your opinion or help is welcome. I'm certain duplicating code like done now is not good for maintanability and I'd want to avoid it.
* Some of  the modal objects do not extend BaseModal e.g. MacroDialogEditModal . Those will not be tested yet, and should be fixed later on so that they can get their own tests. Some do not call their super() constructor, same effect, they will not be tested.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

None, test changes only. 

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

I ran an emptied out version of flamingo skin docker tests, which only had the `XAR export IT` (few tests with instantiations of modals) with the command:
```
mvn clean install -f xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui; mvn clean install -f xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker -Dxwiki.test.ui.wcag=true;spd-say "DONE"
```
Without the changes in this PR, I had only 306 WCAG rule checks. With the changes in the PR, I have 361. When looking at the logs with the right parameters, I could see that as expected, only two modals got checked. All the other ones did not get checked because already in the cache. 55 rules checked seems like the order of magnitude I'd expect for two checks on a part of a page.

Out of the 55 new rule checks, 2 were marked as incomplete (automated testing alone couldn't deliver a proper answer) and all the others were passed succesfully. These numbers are in line with the repartition of current rule check results. Importantly, no rule check was failed.

I did not test everything to make sure none of the new checks failed. See the first item in the clarifications section above for more info about the strategies we could go with onwards.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, the changes are pretty dangerous for the CI and not needed on more than one branch IMO. Might as well keep it on master.