### PR TITLE
XWIKI-22135: Separations between Live Data entries are not visible enough on mobile`

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/tables.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/tables.less
@@ -62,7 +62,7 @@
 // headers on the left
 .responsive-table-tbody-tr-tdth() {
   border: none;
-  border-bottom: 1px solid @table-border-color;
+  border-bottom: 1px dotted @table-border-color;
   float: left;
   min-height: @input-height-base;
   overflow: hidden;


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22135

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Reduced visibility of the separators between fields

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* This allows to spot out the entry separators more easily. 
* I usually don't like using color theme values with transparency (a dotted line from far away is the same as a semi transparent solid line...). However here
  * We don't have any other color in the theme that would make sense to use here. No variation similar to `@table-border-muted` exists.
  * This is a very specific use case. It's the only place in the UI we want this specific color semantic, and it's only for low width screens.
  * It could be argued that the table displayed like that does not need any separator between the fields. The layout already conveys the structure corrrectly. Even with a bad combination of color, it's not a large issue to have the separators being barely visible.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

On the left : state before the PR;
On the right: state with the changes proposed in this PR
![Difference of visuals between the table before and after the changes proposed here to solve XWIKI-22135](https://github.com/user-attachments/assets/019c97a3-a85a-4a3b-a968-f006bb5f1ac1)

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Manual test only (see above), minor style change. Changing the LESS and forcing LESS recomputation by saving the current color theme do update the style as expected.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.X
  * 16.4.X