### PR TITLE
XWIKI-22131: Update the wand icon used in the Panel Application

### DIFF
--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-fontawesome/src/main/resources/IconThemes/FontAwesome.xml
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-fontawesome/src/main/resources/IconThemes/FontAwesome.xml
@@ -392,6 +392,7 @@ user = user
 user_add=user-plus
 user_delete=user-times
 vcard = vcard-o
+wand = magic
 weather_clouds = cloud
 weather_sun = sun-o
 weather_snow=snowflake-o

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/WebHome.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/Panels/WebHome.xml
@@ -44,7 +44,7 @@
 = $services.localization.render('panels.available') =
 #if ($hasAdmin)
   {{box}}
-    [[image:icon:wand]] $services.localization.render('panels.customize', ["[[$services.localization.render('panelwizard.panelwizard')&gt;&gt;Panels.PanelWizard]]"]).
+    $services.icon.render('wand') $services.localization.render('panels.customize', ["[[$services.localization.render('panelwizard.panelwizard')&gt;&gt;Panels.PanelWizard]]"]).
   {{/box}}
 #end
 #set ($liveDataConfig = {


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22131

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added mapping in FontAwesome for the wand icon
* Replaced the xwiki syntax icon with a call to the icon velocity service.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Since the wand icon is not standard, and not used anywhere else, I figured it didn't need to be added to the icon theme. I just added a mapping in the `Silk backward compatibility` section of the FontAwesome used by wikis by default. On other icon themes, if the wand icon is not defined, it will fall back to Silk, and have the exact same rendering :)


# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

After the changes proposed in this PR: 
![image](https://github.com/user-attachments/assets/32205b69-e879-4852-8d4d-2762d10b7c24)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests only, low scope changes of the DOM structure. The changed element is non interactive, it does not appear at all in the docker tests for the panel module.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.X
  * 16.4.X