### PR TITLE
XWIKI-21766: Notification preferences dropdown carets are not animated

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsApplicationsPreferencesMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsApplicationsPreferencesMacro.xml
@@ -349,8 +349,6 @@ require(['jquery', 'xwiki-meta', 'ApplicationWidget', 'xwiki-bootstrap-switch', 
      * Initialization
      */
     self.init = function () {
-      // Replace the 'hidden' class by a call to jQuery.hide();
-      self.domElement.removeClass('hidden').hide();
       // Enable bootstrap switches
       $([self.switchAlert, self.switchEmail]).bootstrapSwitch({
         size: 'mini',
@@ -392,13 +390,6 @@ require(['jquery', 'xwiki-meta', 'ApplicationWidget', 'xwiki-bootstrap-switch', 
      */
     self.setEmailState = function (state) {
       self.switchEmail.bootstrapSwitch('state', state);
-    };
-
-    /**
-     * Hide/Show the event type widget
-     */
-    self.toggleVisibility = function () {
-      self.domElement.toggle();
     };
 
     // Call init
@@ -539,9 +530,7 @@ require(['jquery', 'xwiki-meta', 'ApplicationWidget', 'xwiki-bootstrap-switch', 
       // Handle collapsing
       // Make sure the click listener is registered only once.
       self.collapseButton.off('click.toggleVisibility').on('click.toggleVisibility', function() {
-        for (var i = 0; i &lt; self.eventTypes.length; ++i) {
-          self.eventTypes[i].toggleVisibility();
-        }
+        this.classList.toggle("collapsed")
       });
 
       // Handle switch change
@@ -728,6 +717,11 @@ require(['jquery', 'xwiki-meta', 'ApplicationWidget', 'xwiki-bootstrap-switch', 
 .notifPreferences th:nth-child(1) {
   vertical-align: top;
   width: 250px;
+}
+
+/* Hide all of the eventType rows that are after a category toggler that is in the collapsed state. */
+.notifPreferences tr:has(> td > button.collapsed) ~ tr {
+  display: none;
 }
 
 .notificationAppCell {
@@ -1050,7 +1044,7 @@ require(['jquery', 'xwiki-meta', 'ApplicationWidget', 'xwiki-bootstrap-switch', 
       #end
       ## Collapse button
       &lt;td class="notificationCollapseButtonCell"&gt;
-        &lt;button type="button" class="btn btn-default btn-sm collapseButton"&gt;
+        &lt;button type="button" class="btn btn-default btn-sm collapseButton collapsed"&gt;
           $services.icon.renderHTML('caret-down')
           &lt;span class='sr-only'&gt;
             $escapetool.xml($services.localization.render('notifications.settings.applications.table.dropdown.toggle.label',[$type.applicationName]))
@@ -1062,7 +1056,7 @@ require(['jquery', 'xwiki-meta', 'ApplicationWidget', 'xwiki-bootstrap-switch', 
     ## Display all events of this application
     ##
     #foreach($type in $app)
-      &lt;tr class="rowEventType hidden" data-eventtype="$type.eventType"&gt;
+      &lt;tr class="rowEventType" data-eventtype="$type.eventType"&gt;
         &lt;td&gt;$escapetool.xml($type.description)&lt;/td&gt;
         #displayPreference($type, 'alert')
         #if ($services.notification.areEmailsEnabled())

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsApplicationsPreferencesMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsApplicationsPreferencesMacro.xml
@@ -720,8 +720,16 @@ require(['jquery', 'xwiki-meta', 'ApplicationWidget', 'xwiki-bootstrap-switch', 
 }
 
 /* Hide all of the eventType rows that are after a category toggler that is in the collapsed state. */
-.notifPreferences tr:has(> td > button.collapsed) ~ tr {
+.notifPreferences tr:has(&gt; td &gt; button.collapsed) ~ tr {
   display: none;
+}
+
+.notifPreferences tr &gt; td &gt; button &gt; *:first-child {
+  transition: transform .2s ease-in-out;
+}
+
+.notifPreferences tr &gt; td &gt; button.collapsed &gt; *:first-child {
+  transform: rotate(90deg);
 }
 
 .notificationAppCell {


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-21766

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Reworked the way hiding sections work to make it easier to handle with CSS (and also avoid inline styling...)
* Added style for the rotation
* Used mvn xar:format to escape properly the new content added in the .xml

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Removing the custom way to hide the categories also simplifies the javascript. Now we can just use CSS `:has` to define the relation between button and dropdown, while before we had to call events on all the eventType events.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Demo of the Notification preference UI with the changes in this PR:
https://github.com/user-attachments/assets/5932733f-8a34-447f-bc9f-c0bc889a1299


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Successfully passed 
```
mvn clean install -f xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker
```
The selector for the button we updated is at https://github.com/xwiki/xwiki-platform/blob/ede10702a03f790d2d17987103801316b3046347/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-pageobjects/src/main/java/org/xwiki/platform/notifications/test/po/preferences/ApplicationPreferences.java#L59  and the collapse action at https://github.com/xwiki/xwiki-platform/blob/ede10702a03f790d2d17987103801316b3046347/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-pageobjects/src/main/java/org/xwiki/platform/notifications/test/po/preferences/ApplicationPreferences.java#L91-L101 does not conflict with the changes proposed.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.X
  * 16.4.X