### PR TITLE
XWIKI-22347: Diff view misplaced button when there's no previous version

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/misc.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/misc.less
@@ -407,6 +407,11 @@ dl.export-tree-legend dt + dd {
   justify-content: space-between;
 }
 
+/* Make sure the right change arrow stays on the right even when the left one is not here. */
+#changes-arrows-box:not(:has(> .changes-arrow-left)) {
+  justify-content: right;
+}
+
 .changes-body > .changes-body-header {
   border-bottom: @border-width solid @xwiki-border-color;
   margin-bottom: (@grid-gutter-width / 2);


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22347

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Added a condition on the style to keep it working even when the state of the UI changes.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* In normal conditions, the right button is pushed to the far right by `justify-content: space-between;`. When it's the only child, this does not push it to the right anymore but keep it on the left by default. The CSS selector just makes sure that we update this style when the left button is not here to push as expected.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Video demonstration of the changes proposed in this PR.
https://github.com/user-attachments/assets/0b8013e8-071a-41b5-b39f-566ea12ce224

We can see that the UI is consistent whatever the number of buttons in the top part.


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
None except for manual (see video above), minimal scope style changes only. Moreover, the elements moved should still always be in a correct position (eg it will not fail a test because it's out of the screen or under something else).

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches: Same as https://github.com/xwiki/xwiki-platform/pull/2323 - which is the cause commit.
  * 15.10.X
  * 16.4.X