### PR TITLE
XWIKI-22348: Underlining of usernames is inconsistent between comment form and displayed comments

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/general.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/general.less
@@ -165,7 +165,7 @@ body {
     // UIs where we want to underline outside of content.
     .xdocLastModification, // Under the title, this link is inline so we want to underline it.
     .panel[class*="HelpTipsPanel "], // This panel, unlike other panels, contains mostly text with underline links.
-    .commentauthor // Similarly to the page last modificator, we want to underline comment authors.
+    .commentauthor, #commentform > label // Similarly to the page last modificator, we want to underline comment authors
     {
       & a {
         .inline-link();


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22348

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added underlining to the author of the comment currently getting written.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
After the changes proposed in this PR: 
![Screenshot from 2024-07-25 15-49-36](https://github.com/user-attachments/assets/22b51986-a821-4f05-ab2a-e8f320f95f8d)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
None, except manual on a local distrib (see screenshot above).

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.4.X - like XWIKI-21492