### PR TITLE
XWIKI-22368: UIExtensionClass imported properties removed after editing and rolling back

### DIFF
--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-data/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-data/pom.xml
@@ -88,22 +88,65 @@
               <artifactId>xwiki-platform-annotation-io</artifactId>
               <version>${project.version}</version>
             </dependency>
-            <!-- WikiMacro classes are automatically generated. -->
+            <!-- Modules containing mandatory document initializers -->
             <dependency>
               <groupId>org.xwiki.platform</groupId>
               <artifactId>xwiki-platform-rendering-wikimacro-store</artifactId>
               <version>${project.version}</version>
             </dependency>
-            <!-- UIExtensionClass is automatically generated -->
             <dependency>
               <groupId>org.xwiki.platform</groupId>
               <artifactId>xwiki-platform-uiextension-api</artifactId>
               <version>${project.version}</version>
             </dependency>
-            <!-- PanelClass is automatically generated -->
             <dependency>
               <groupId>org.xwiki.platform</groupId>
               <artifactId>xwiki-platform-panels-api</artifactId>
+              <version>${project.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.xwiki.platform</groupId>
+              <artifactId>xwiki-platform-crypto-store-wiki</artifactId>
+              <version>${project.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.xwiki.platform</groupId>
+              <artifactId>xwiki-platform-edit-default</artifactId>
+              <version>${project.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.xwiki.platform</groupId>
+              <artifactId>xwiki-platform-feed-api</artifactId>
+              <version>${project.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.xwiki.platform</groupId>
+              <artifactId>xwiki-platform-localization-source-wiki</artifactId>
+              <version>${project.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.xwiki.platform</groupId>
+              <artifactId>xwiki-platform-attachment-api</artifactId>
+              <version>${project.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.xwiki.platform</groupId>
+              <artifactId>xwiki-platform-attachment-validation-default</artifactId>
+              <version>${project.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.xwiki.platform</groupId>
+              <artifactId>xwiki-platform-notifications-filters-watch</artifactId>
+              <version>${project.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.xwiki.platform</groupId>
+              <artifactId>xwiki-platform-index-tree-api</artifactId>
+              <version>${project.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.xwiki.platform</groupId>
+              <artifactId>xwiki-platform-security-authentication-default</artifactId>
               <version>${project.version}</version>
             </dependency>
             <!-- Instance module has its own Hibernate mapping file -->

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/src/test/it/org/xwiki/test/ui/MandatoryDocInitializedTest.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/src/test/it/org/xwiki/test/ui/MandatoryDocInitializedTest.java
@@ -1,30 +1,27 @@
 /*
-
-  * See the NOTICE file distributed with this work for additional
-  * information regarding copyright ownership.
-  *
-  * This is free software; you can redistribute it and/or modify it
-  * under the terms of the GNU Lesser General Public License as
-  * published by the Free Software Foundation; either version 2.1 of
-  * the License, or (at your option) any later version.
-  *
-  * This software is distributed in the hope that it will be useful,
-  * but WITHOUT ANY WARRANTY; without even the implied warranty of
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-  * Lesser General Public License for more details.
-  *
-  * You should have received a copy of the GNU Lesser General Public
-  * License along with this software; if not, write to the Free
-  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
-  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
-
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
 package org.xwiki.test.ui;
 
 import org.junit.Test;
-import org.xwiki.model.reference.DocumentReference;
-import org.xwiki.test.ui.po.ViewPage;
+import org.xwiki.rendering.syntax.Syntax;
 
 import static org.junit.Assert.assertEquals;
 
@@ -35,7 +32,7 @@ import static org.junit.Assert.assertEquals;
  * @version $Id$
  * @since 16.7.0RC1
  */
-public class XClassDeclaredTest extends AbstractTest
+public class MandatoryDocInitializedTest extends AbstractTest
 {
     private static final String GROOVY_CODE =
     """
@@ -86,10 +83,12 @@ public class XClassDeclaredTest extends AbstractTest
     """;
 
     @Test
-    public void testXClassAreDeclaredInPackage()
+    public void docsAreInitialized() throws Exception
     {
         getUtil().loginAsAdmin();
-        ViewPage page = getUtil().createPage(new DocumentReference("xwiki", "Test", "TestXClass"), GROOVY_CODE);
-        assertEquals("", page.getContent());
+        String result = getUtil().executeWikiPlain(GROOVY_CODE, Syntax.XWIKI_2_1);
+
+        // Using equals on purpose to see the output in case of failure.
+        assertEquals("", result);
     }
 }

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/src/test/it/org/xwiki/test/ui/XClassDeclaredTest.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-ui/src/test/it/org/xwiki/test/ui/XClassDeclaredTest.java
@@ -1,0 +1,95 @@
+/*
+
+  * See the NOTICE file distributed with this work for additional
+  * information regarding copyright ownership.
+  *
+  * This is free software; you can redistribute it and/or modify it
+  * under the terms of the GNU Lesser General Public License as
+  * published by the Free Software Foundation; either version 2.1 of
+  * the License, or (at your option) any later version.
+  *
+  * This software is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  * Lesser General Public License for more details.
+  *
+  * You should have received a copy of the GNU Lesser General Public
+  * License along with this software; if not, write to the Free
+  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+
+ */
+
+package org.xwiki.test.ui;
+
+import org.junit.Test;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.test.ui.po.ViewPage;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Check that all mandatory document initializers are properly declared in the demo package build and that the pages
+ * are not created at first start only. See also XWIKI-22368.
+ *
+ * @version $Id$
+ * @since 16.7.0RC1
+ */
+public class XClassDeclaredTest extends AbstractTest
+{
+    private static final String GROOVY_CODE =
+    """
+        {{groovy}}
+        import com.xpn.xwiki.doc.MandatoryDocumentInitializer;
+        import java.time.temporal.ChronoUnit;
+        import java.text.SimpleDateFormat;
+        
+        // define the pages that shouldn't be created during the build.
+        def allowedExceptions = ["XWiki.XWikiServerXwiki"];
+        
+        // Get creation date at build time.
+        def adminRef = services.model.resolveDocument("XWiki.Admin");
+        def adminDoc = xwiki.getDocument(adminRef);
+        def adminCreationDate = adminDoc.getCreationDate();
+        def adminCreationDateDay = adminDoc.getCreationDate().toInstant().truncatedTo(ChronoUnit.DAYS);
+        
+        def allowedExceptionsRef = [];
+        for (exception in allowedExceptions) {
+          allowedExceptionsRef.add(services.model.resolveDocument(exception));
+        }
+        
+        def componentManager = services.component.getContextComponentManager();
+        def documentInitializersList = componentManager.getInstanceList(MandatoryDocumentInitializer.class);
+        
+        def dateFormat = new SimpleDateFormat("dd/MM/YYYY");
+        def foundErrors = [];
+        for (initializer in documentInitializersList) {
+          def ref = initializer.getDocumentReference();
+          if (!allowedExceptionsRef.contains(ref)) {
+            def classDoc = xwiki.getDocument(ref);
+            def creationDate = classDoc.getCreationDate();
+            def creationDateDay = classDoc.getCreationDate().toInstant().truncatedTo(ChronoUnit.DAYS);
+            if (!creationDateDay.equals(adminCreationDateDay)) {
+              foundErrors.add(ref.toString() + " ("+dateFormat.format(creationDateDay.toDate())+")");
+            }
+          }
+        }
+        
+        if (foundErrors.size() > 0) {
+            def adminDateFormat = dateFormat.format(adminCreationDateDay.toDate());
+            println foundErrors.size() + " page found created after the build ("+adminDateFormat+"):\\n";
+            for (error in foundErrors) {
+              println "     * " + error;
+            }
+        }
+        {{/groovy}}        
+    """;
+
+    @Test
+    public void testXClassAreDeclaredInPackage()
+    {
+        getUtil().loginAsAdmin();
+        ViewPage page = getUtil().createPage(new DocumentReference("xwiki", "Test", "TestXClass"), GROOVY_CODE);
+        assertEquals("", page.getContent());
+    }
+}


### PR DESCRIPTION

# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22368

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Provide a test to check that mandatory document initializers are properly declared for the demo package

This PR is only about the test to add. I'm not sure it deserves to be added in other branches even if the actual fix of the ticket was backported.
Note that I put it in flavor-test-ui and not flavor-test-misc because that one apparently doesn't support yet using AbstractTest which is needed to use PO. 


## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

`mvn clean install -Dpattern=XClassDeclaredTest` in `xwiki-platform-distribution-flavor-test-ui` but note that right now it exposes a few problems.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None (check the description)