### PR TITLE
XWIKI-22367: Clicking on Allow Realtime Collaboration in Source mode leads to unexpected result

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-realtime/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-realtime/plugin.js
@@ -79,13 +79,7 @@
       const editor = event.editor;
       const realtimeCheckbox = editor._realtimeInterface.getAllowRealtimeCheckbox();
 
-      if (editor.mode === 'source') {
-        realtimeCheckbox.prop('disabled', true);
-      }
-
-      if (editor.mode === 'wysiwyg') {
-        realtimeCheckbox.prop('disabled', false);
-      }
+      realtimeCheckbox.prop('disabled', editor.mode !== 'wysiwyg');
     },
 
     beforeSetMode: function(event) {

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-realtime/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-realtime/plugin.js
@@ -69,7 +69,23 @@
           previousValue: null
         };
         editor.on('beforeSetMode', this.beforeSetMode.bind(this));
+        editor.on('mode', this.mode.bind(this));
       });
+    },
+
+    mode: function(event) {
+      // The user should not be able to join the realtime editing session while in source mode.
+      // We disable the allow realtime checkbox while in source mode, and enable it when we go back to wysiwyg.
+      const editor = event.editor;
+      const realtimeCheckbox = editor._realtimeInterface.getAllowRealtimeCheckbox();
+
+      if (editor.mode === 'source') {
+        realtimeCheckbox.prop('disabled', true);
+      }
+
+      if (editor.mode === 'wysiwyg') {
+        realtimeCheckbox.prop('disabled', false);
+      }
     },
 
     beforeSetMode: function(event) {

--- a/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wysiwyg/xwiki-platform-realtime-wysiwyg-test/xwiki-platform-realtime-wysiwyg-test-docker/src/test/it/org/xwiki/realtime/wysiwyg/test/ui/RealtimeWYSIWYGEditorIT.java
+++ b/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wysiwyg/xwiki-platform-realtime-wysiwyg-test/xwiki-platform-realtime-wysiwyg-test-docker/src/test/it/org/xwiki/realtime/wysiwyg/test/ui/RealtimeWYSIWYGEditorIT.java
@@ -1427,6 +1427,7 @@ class RealtimeWYSIWYGEditorIT extends AbstractRealtimeWYSIWYGEditorIT
         // Switch to source mode and check that we are not in the realtime session anymore.
         secondEditorToolbar.toggleSourceMode();
         assertFalse(secondEditPage.isRealtimeEditing());
+        assertFalse(secondEditPage.canToggleRealtimeEditing());
 
         // Check that we can still switch back to wysiwyg mode.
         assertTrue(secondEditorToolbar.canToggleSourceMode());
@@ -1456,6 +1457,7 @@ class RealtimeWYSIWYGEditorIT extends AbstractRealtimeWYSIWYGEditorIT
 
         // Check that the second user re-joined the realtime editing session.
         assertTrue(secondEditPage.isRealtimeEditing());
+        assertTrue(secondEditPage.canToggleRealtimeEditing());
         assertTrue(secondEditorToolbar.canToggleSourceMode());
         secondTextArea.waitUntilContentContains("four");
         assertEquals("one\ntwo\nthree\nfour", secondTextArea.getText());
@@ -1470,6 +1472,7 @@ class RealtimeWYSIWYGEditorIT extends AbstractRealtimeWYSIWYGEditorIT
         secondEditorToolbar.toggleSourceMode();
 
         assertFalse(secondEditPage.isRealtimeEditing());
+        assertFalse(secondEditPage.canToggleRealtimeEditing());
         // Check the contents of the source mode.
         assertEquals("one\n\ntwo\n\nthree\n\nfour", secondEditor.getSourceTextArea().getAttribute("value"));
 
@@ -1499,6 +1502,7 @@ class RealtimeWYSIWYGEditorIT extends AbstractRealtimeWYSIWYGEditorIT
         // Check that the second user did not re-join the realtime editing session.
         assertFalse(secondEditPage.isRealtimeEditing());
         assertTrue(secondEditorToolbar.canToggleSourceMode());
+        assertTrue(secondEditPage.canToggleRealtimeEditing());
         assertEquals("one\ntwo\nthree\nfour\nfive", secondTextArea.getText());
 
         // Join the realtime session again and wait to be in sync.
@@ -1515,12 +1519,27 @@ class RealtimeWYSIWYGEditorIT extends AbstractRealtimeWYSIWYGEditorIT
         // Switch to source mode and back to wysiwyg edit mode.
         secondEditorToolbar.toggleSourceMode();
         assertFalse(secondEditPage.isRealtimeEditing());
+        assertFalse(secondEditPage.canToggleRealtimeEditing());
         assertEquals("one\n\ntwo\n\nthree\n\nfour\n\nsix\n\nseven",
             secondEditor.getSourceTextArea().getAttribute("value"));
         secondEditorToolbar.toggleSourceMode();
+        assertTrue(secondEditPage.canToggleRealtimeEditing());
 
         // Check that the second user did not re-join the realtime editing session.
         assertFalse(secondEditPage.isRealtimeEditing());
+        
+        // Switch to source mode and back to wysiwyg again.
+        // We should stay out of the realtime editing session.
+        secondEditorToolbar.toggleSourceMode();
+        assertFalse(secondEditPage.isRealtimeEditing());
+        assertFalse(secondEditPage.canToggleRealtimeEditing());
+        
+        assertEquals("one\n\ntwo\n\nthree\n\nfour\n\nsix\n\nseven",
+            secondEditor.getSourceTextArea().getAttribute("value"));
+        
+        secondEditorToolbar.toggleSourceMode();
+        assertFalse(secondEditPage.isRealtimeEditing());
+        assertTrue(secondEditPage.canToggleRealtimeEditing());
 
         // We keep the second user out of the realtime editing session now
         // and we do more tests with the first user.

--- a/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wysiwyg/xwiki-platform-realtime-wysiwyg-test/xwiki-platform-realtime-wysiwyg-test-pageobjects/src/main/java/org/xwiki/realtime/wysiwyg/test/po/RealtimeWYSIWYGEditPage.java
+++ b/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wysiwyg/xwiki-platform-realtime-wysiwyg-test/xwiki-platform-realtime-wysiwyg-test-pageobjects/src/main/java/org/xwiki/realtime/wysiwyg/test/po/RealtimeWYSIWYGEditPage.java
@@ -78,7 +78,18 @@ public class RealtimeWYSIWYGEditPage extends WYSIWYGEditPage
     {
         return this.allowRealtimeCheckbox.isSelected();
     }
-
+    
+    /**
+     * @return {code true} if it is possible to join or leave the editing session, {@code false} otherwise
+     * @since 15.10.12
+     * @since 16.4.2
+     * @since 16.7.0RC1
+     */
+    public boolean canToggleRealtimeEditing()
+    {
+        return this.allowRealtimeCheckbox.isEnabled();
+    }
+    
     /**
      * Leave the realtime editing session.
      */


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-22367

# Changes

## Description

Disable the "Allow Realtime" checkbox when in source mode.

## Clarifications

Realtime editing is not supported when the user is editing the xwiki syntax source view within the WYSIWYG editor.
Thus, the user should not be able to join the realtime session when in source mode. 

This PR also changes the functional tests related to the source mode to ensure the user can't join the realtime editing session while in source mode.

# Screenshots & Video

![image](https://github.com/user-attachments/assets/8a30b76a-5e8c-4418-a4ed-68ddf95ed9bf)


# Executed Tests

`mvn clean install` in `xwiki-platform-realtime-wysiwyg-test-docker`

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * stable-15.10.x
  * stable-16.4.x
  * stable-16.6.x