### PR TITLE
XWIKI-21227: Gray out the "Select" button when uploading an image through the image modal for the second time

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-image/imageSelector.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-image/imageSelector.js
@@ -157,6 +157,10 @@ define('imageSelector', ['jquery', 'modal', 'resource', 'l10n!imageSelector'],
           modal.find('.modal-dialog').addClass('modal-lg');
 
           modal.on('shown.bs.modal', function () {
+            if (modal.data('initialized') == true) {
+              // If the modal was already use, we make sure it's properly reset
+              updateSelectedImageReferences(null);
+            }
             initialize(modal);
           });
           selectButton.on('click', function () {

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ImageSelectorServiceUIX/Upload.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ImageSelectorServiceUIX/Upload.xml
@@ -175,6 +175,15 @@
     }
 
     init($(document).find('.image-selector'));
+    
+    /* Make sure the input is emptied whenever we reload the image selection modal. */
+    $(document).on('shown.bs.modal', function () {
+      let fileInput = $(document).find('.image-selector').find("input[type='file']");
+      if (fileInput.prop('files').length &gt; 0) { 
+        fileInput.val(''); 
+        $(document).find('.image-selector').find(".upload form input.button").prop("disabled", true);
+      }
+    });
 
     $(document).on('xwiki:dom:updated', (event, data) =&gt; {
       data.elements.forEach(element =&gt; init($(element)));


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-21227

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added a listener to reset the state of the upload input
* Added a reset of the modal state when reloading it.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
This video displays the new behavior of the image selector (specifically the Upload tab) with the changes proposed in this PR:

https://github.com/user-attachments/assets/74653685-fe84-4ab6-846f-1fa88a310027



# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
None excect manual (see video example above), this is specific enough of a use case to not fit any existing test.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None