### PR TITLE
XWIKI-22334: Improve contrast of the CKEditor tables

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/EditSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/EditSheet.xml
@@ -1039,6 +1039,23 @@ body[data-maximized="true"] {
     padding: .5em;
     z-index: 9995;
   }
+}
+
+/*
+ * Override the CKEditor reset for the table border color.
+ * The default border color from CKEditor is quite lacking on contrast.
+ */
+.cke_editable.cke_show_borders table.cke_show_border,
+.cke_editable.cke_show_borders table.cke_show_border > tr > th,
+.cke_editable.cke_show_borders table.cke_show_border > tr > td,
+.cke_editable.cke_show_borders table.cke_show_border > thead > tr > th,
+.cke_editable.cke_show_borders table.cke_show_border > thead > tr > td,
+.cke_editable.cke_show_borders table.cke_show_border > tbody > tr > th,
+.cke_editable.cke_show_borders table.cke_show_border > tbody > tr > td,
+.cke_editable.cke_show_borders table.cke_show_border > tfoot > tr > th,
+.cke_editable.cke_show_borders table.cke_show_border > tfoot > tr > td {
+  border-color: @table-border-color;
+  border-style: solid;
 }</code>
     </property>
     <property>


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22334

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Overrode the inline style added by CKEditor for the tables.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The selector is quite large, but it matches and takes priority over all the ckeditor table styles.
* This new style might decrease contrast with Dark Themes since this is one of the few colors we bring in the editor and it could clash. IMO this PR is good to merge as is, but we should consider the question of getting CKEditor to match the color theme (eg. not having a white background when you edit on a dark colortheme is quite huge for consistency and usability of dark colorthemes).

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
On the left, a default table before the changes proposed here, on the right it's the same table with the style proposed here applied:
![Screenshot from 2024-08-02 18-35-00](https://github.com/user-attachments/assets/a7c06699-ce04-4f58-9b1f-41a0774cbec9)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

None except for manual, see screenshot above.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.4.X - low risk