### PR TITLE
XWIKI-22392: Some Live Data links are still underlined although 'Underline links' setting is set to 'Only Inline Links'

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/general.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/general.less
@@ -180,7 +180,7 @@ body {
       & .xwikitabbar, // Do not underline links in the tab bar. An example of this is the one containing document metadata at the bottom of ny doc.
       & .buttonwrapper, // Do not underline links that are inside buttonwrapper. Those will be styled like buttons and we want to keep their style consistent with buttons.
       & #user-menu-col, // In the user profile, do not underline the menu items.
-      & .jstree-xwiki // Do not underline links in jstrees
+      & .jstree-xwiki, // Do not underline links in jstrees
       & .xwiki-livedata .cell .displayer-link, // Do not underline links that are in their own livedata cell
       & .xwiki-livedata .cell .breadcrumb // Do not underline links that are in breadcrumbs in livedatas
       {


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22392
# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Fixed the typo introduced in the commit for XWIKI-22120 and broke the improvements added for XWIKI-22120 and XWIKI-22214

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* I probably added this typo when moving the changes from my local distribution to the repository on which the PR was based. The screenshots on the PR for XWIKI-22120 looked okay...

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Screenshots of a distribution with the updated content of general.less : 
![image](https://github.com/user-attachments/assets/8a91ff06-cb27-44cc-9434-b50979fc515e)
![image](https://github.com/user-attachments/assets/fa5ac239-1164-4923-a37e-dd155d6d774a)

On both of those, the improvements that should have been added with XWIKI-22120 and XWIKI-22214 were not seen before updating the file. On both of those, we can see that there's no longer useless underlining.


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Manual, see above.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.4.X, same as https://github.com/xwiki/xwiki-platform/pull/3085