### PR TITLE
XWIKI-22399: Load used property values in suggestions, e.g., in Live Data filters even when the filter is empty

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/AbstractClassPropertyValuesProvider.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/classes/AbstractClassPropertyValuesProvider.java
@@ -84,7 +84,7 @@ public abstract class AbstractClassPropertyValuesProvider<T> implements ClassPro
         }
 
         try {
-            if (filter.isEmpty() || limit <= 0) {
+            if (limit <= 0) {
                 return getAllowedValues(propertyDefinition, limit, filter);
             } else {
                 return getMixedValues(propertyDefinition, limit, filter);


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22399

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Also load mixed values when the filter is empty.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The only negative consequence I see is a performance impact, in particular as we preload these filters afaik.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Built `xwiki-platform-rest-server` with the quality profile.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None (improvement)