### PR TITLE
XWIKI-21452: Macros info, success, warning and error are only distinguished by colors

### DIFF
--- a/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wysiwyg/xwiki-platform-realtime-wysiwyg-test/xwiki-platform-realtime-wysiwyg-test-docker/src/test/it/org/xwiki/realtime/wysiwyg/test/ui/RealtimeWYSIWYGEditorIT.java
+++ b/xwiki-platform-core/xwiki-platform-realtime/xwiki-platform-realtime-wysiwyg/xwiki-platform-realtime-wysiwyg-test/xwiki-platform-realtime-wysiwyg-test-docker/src/test/it/org/xwiki/realtime/wysiwyg/test/ui/RealtimeWYSIWYGEditorIT.java
@@ -371,7 +371,7 @@ class RealtimeWYSIWYGEditorIT extends AbstractRealtimeWYSIWYGEditorIT
 
         // Save and check the result.
         ViewPage viewPage = secondEditPage.clickSaveAndView();
-        assertEquals("Information\nmy info message\none two three", viewPage.getContent());
+        assertEquals("Info\nmy info message\none two three", viewPage.getContent());
     }
 
     @Test


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-21452

# Changes

## Description
This PR fixes the realtime WYSIWYG Editor tests.

*

## Clarifications

The changes brought by the info box macro changes the behavior of XWiki, which needs to be taken into account in the tests.

*

# Executed Tests

`mvn clean install -Dxwiki.test.ui.browserTag=128.0` in `xwiki-platform-realtime-wysiwyg-test-docker`

```
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 605.9 s -- in org.xwiki.realtime.wysiwyg.test.ui.AllIT
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 17, Failures: 0, Errors: 0, Skipped: 0

```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None.