### PR TITLE
XWIKI-22448: Batch id link for document restoration does not have any text

### DIFF
--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/XWiki/DeletedDocuments.xml
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/XWiki/DeletedDocuments.xml
@@ -357,8 +357,12 @@ XWiki.index.trash.documents.displayEntry = function (row, i, table) {
   tr.appendChild(new Element('td').update(row.date));
   var deleter = new Element('a', {'href' : row.deleterurl}).update(row.deletername);
   tr.appendChild(new Element('td').update(deleter));
-  var batchId = new Element('a', {'href' : row.batchId_url}).update(row.batchId);
-  tr.appendChild(new Element('td').update(batchId));
+  if (row.batchId != '') {
+    var batchId = new Element('a', {'href' : row.batchId_url}).update(row.batchId);
+    tr.appendChild(new Element('td').update(batchId));
+  } else {
+    tr.appendChild(new Element('td'));
+  }
   var actions = new Element('td', {'class' : 'actions'});
   if(!row.alreadyExists) {
     if(row.canRestore) {

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/recyclebinlist.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/recyclebinlist.vm
@@ -72,7 +72,7 @@
          #end
          </td>
          #if ($canRestore)
-           <td><a href="$xwiki.getURL($dd.fullName, 'undelete', "id=${dd.id}&amp;showBatch=true")">$!{dd.batchId}</a></td>
+           <td>#if("$!{dd.batchId}" != "")<a href="$xwiki.getURL($dd.fullName, 'undelete', "id=${dd.id}&amp;showBatch=true")">$!{dd.batchId}</a>#end</td>
          #end
          <td>
            #if($canRestore)


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22448

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Removed the link if the deleted document batch id is null

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

We can see in the previous code that those links to the batch have an empty text only when the id of the batch is this empty text. In my opinion, having such a link when we don't have a proper batch id is not correct (probably coded with this intention anyways, but the way it was done does not work the best by today's standards).


# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
test on a fresh distribution with the changes proposed in this PR
![Screenshot from 2024-08-26 11-44-03](https://github.com/user-attachments/assets/89e6b101-1e89-4158-973b-c05c1f7e9b69)
![Screenshot from 2024-08-26 11-43-40](https://github.com/user-attachments/assets/5046187b-536e-4a57-b7ad-e7d9eda7deb8)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
After building the changes with `mvn clean install -f xwiki-platform-core/xwiki-platform-web`, the WCAG build `mvn clean install -f xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/ -Dit.test=UsersGroupsRightsManagementIT#createAndDeleteUser -Dxwiki.test.ui.wcag=true` did not return any WCAG fails (as expected it did return the expected ones without building the changes properly). :heavy_check_mark: 


Nothing except the failing WCAG test from xwiki-administration. I could not find any other occurence of `showBatch=true`, which is a parameter quite specific to this link. Moreover, functionnal tests could not rely on this link in these situations, because it did not have any click surface.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.4.X
  * 15.10.X