### PR TITLE
XWIKI-22425: "edit this page" link is still not underlined even if the 'Underline links' setting is set to 'Only Inline Links'

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/general.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/general.less
@@ -213,11 +213,14 @@ body {
     }
 
     // Helper classes for easier content customization. Note that those only work for this preference.
-    #xwikicontent .force-no-underline a {
+    // This class can either be used on a common parent or the links themselves.
+    #xwikicontent .force-no-underline a,
+    #xwikicontent a.force-no-underline {
       text-decoration: none;
     }
 
-    .force-underline a {
+    .force-underline a,
+    a.force-underline {
       text-decoration: underline;
     }
   }


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22425

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Extended the definition of the helper classes to fit the use here, and added a comment to avoid doing the same mistake later on.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Lookking at the screenshots in the previous PR, it seems I did not properly test the PR after the last changes, and it was working because of something that was removed from the PR. I was mistaken in my interpretation of the helper class (assuming that I could use it directly on the link when it was made for the objects above the link). I improved the comment on the LESS to avoid doing a similar mistake again. I extended the definition of the helper class so that it would be easier to use.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

after the PR:
![Screenshot from 2024-08-26 16-54-52](https://github.com/user-attachments/assets/81087a95-2d52-4806-974d-39826e8dcb24)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual, see above

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.4.X, same as https://github.com/xwiki/xwiki-platform/pull/3124 -- the text underlining is not a thing in 15.10.X