### PR TITLE
XWIKI-21878: Various close button modals do not use intended icons

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/utilities/XWikiIcon.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/utilities/XWikiIcon.vue
@@ -86,7 +86,8 @@ export default {
     async fetchRemoteIconDescriptor(iconName) {
       try {
         const parameters = `name=${encodeURIComponent(iconName)}`;
-        const iconURL = `${XWiki.contextPath}/rest/wikis/${encodeURIComponent(XWiki.currentWiki)}/iconThemes/icons?${parameters}`;
+        const iconURL = `${XWiki.contextPath}/rest/wikis/${encodeURIComponent(XWiki.currentWiki)}` +
+        `/iconThemes/icons?${parameters}`;
         const response = await window.fetch(iconURL, {
           headers: {
             'Accept': 'application/json'


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-21878

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Reduced line length to match quality requirement imposed by eslint.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

The build was failing with
`11:53:11,890 [INFO] /root/workspace/XWiki_xwiki-platform_master/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/target/vue/utilities/XWikiIcon.vue
11:53:11,890 [INFO] 89:1 error This line has a length of 130. Maximum allowed is 120 max-len`
This PR goal is to fix this regression introduced in https://github.com/xwiki/xwiki-platform/pull/2888. 

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Successfully ran the quality build that was failing:
`mvn clean install -f xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar -Pquality`

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, which is the same as https://github.com/xwiki/xwiki-platform/pull/2888