### PR TITLE
XWIKI-22269: Update the structure of the User display macro

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/MacrosTest.java
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/MacrosTest.java
@@ -287,36 +287,36 @@ class MacrosTest extends PageTest
         StringWriter out = new StringWriter();
         this.velocityManager.evaluate(out, "displayUser", new StringReader(script));
         assertEquals("<div class=\"user\" data-reference=\"xwiki:XWiki.XWikiGuest\">"
-            + "<img class=\"user-avatar\" src=\"/xwiki/bin/skin/skins/flamingo/icons/xwiki/noavatar.png\" "
-            + "alt=\"XWikiGuest\" />"
-            + "<a class=\"user-name\" href=\"/xwiki/bin/view/XWiki/XWikiGuest\">XWikiGuest</a>"
+            + "<a class=\"user-name\" href=\"/xwiki/bin/view/XWiki/XWikiGuest\">"
+            + "<img class=\"user-avatar\" src=\"/xwiki/bin/skin/skins/flamingo/icons/xwiki/noavatar.png\" alt=\"\" />"
+            + "XWikiGuest</a>"
             + "</div>", out.toString().trim());
 
         script = "#displayUser($NULL)";
         out = new StringWriter();
         this.velocityManager.evaluate(out, "displayUser", new StringReader(script));
         assertEquals("<div class=\"user\" data-reference=\"xwiki:XWiki.XWikiGuest\">"
-            + "<img class=\"user-avatar\" src=\"/xwiki/bin/skin/skins/flamingo/icons/xwiki/noavatar.png\" "
-            + "alt=\"XWikiGuest\" />"
-            + "<a class=\"user-name\" href=\"/xwiki/bin/view/XWiki/XWikiGuest\">XWikiGuest</a>"
+            + "<a class=\"user-name\" href=\"/xwiki/bin/view/XWiki/XWikiGuest\">"
+            + "<img class=\"user-avatar\" src=\"/xwiki/bin/skin/skins/flamingo/icons/xwiki/noavatar.png\" alt=\"\" />"
+            + "XWikiGuest</a>"
             + "</div>", out.toString().trim());
 
         script = "#displayUser(\"\")";
         out = new StringWriter();
         this.velocityManager.evaluate(out, "displayUser", new StringReader(script));
         assertEquals("<div class=\"user\" data-reference=\"xwiki:XWiki.XWikiGuest\">"
-            + "<img class=\"user-avatar\" src=\"/xwiki/bin/skin/skins/flamingo/icons/xwiki/noavatar.png\" "
-            + "alt=\"XWikiGuest\" />"
-            + "<a class=\"user-name\" href=\"/xwiki/bin/view/XWiki/XWikiGuest\">XWikiGuest</a>"
+            + "<a class=\"user-name\" href=\"/xwiki/bin/view/XWiki/XWikiGuest\">"
+            + "<img class=\"user-avatar\" src=\"/xwiki/bin/skin/skins/flamingo/icons/xwiki/noavatar.png\" alt=\"\" />"
+            + "XWikiGuest</a>"
             + "</div>", out.toString().trim());
 
         script = "#displayUser(\"XWiki.Foo\")";
         out = new StringWriter();
         this.velocityManager.evaluate(out, "displayUser", new StringReader(script));
         assertEquals("<div class=\"user\" data-reference=\"xwiki:XWiki.Foo\">"
-            + "<img class=\"user-avatar\" src=\"/xwiki/bin/skin/skins/flamingo/icons/xwiki/noavatar.png\" "
-            + "alt=\"Foo\" />"
-            + "<a class=\"user-name\" href=\"/xwiki/bin/view/XWiki/Foo\">Foo</a>"
+            + "<a class=\"user-name\" href=\"/xwiki/bin/view/XWiki/Foo\">"
+            + "<img class=\"user-avatar\" src=\"/xwiki/bin/skin/skins/flamingo/icons/xwiki/noavatar.png\" alt=\"\" />"
+            + "Foo</a>"
             + "</div>", out.toString().trim());
 
         DocumentReference userFoo = new DocumentReference("xwiki", "XWiki", "Foo");
@@ -326,9 +326,9 @@ class MacrosTest extends PageTest
         out = new StringWriter();
         this.velocityManager.evaluate(out, "displayUser", new StringReader(script));
         assertEquals("<div class=\"user\" data-reference=\"xwiki:XWiki.Foo\">"
-            + "<img class=\"user-avatar\" src=\"/xwiki/bin/skin/skins/flamingo/icons/xwiki/noavatar.png\" "
-            + "alt=\"Foo\" />"
-            + "<a class=\"user-name\" href=\"/xwiki/bin/view/XWiki/Foo\">Foo</a>"
+            + "<a class=\"user-name\" href=\"/xwiki/bin/view/XWiki/Foo\">"
+            + "<img class=\"user-avatar\" src=\"/xwiki/bin/skin/skins/flamingo/icons/xwiki/noavatar.png\" alt=\"\" />"
+            + "Foo</a>"
             + "</div>", out.toString().trim());
     }
 


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22269

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Updated velocity macro integration tests

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* CI fail on MacrosTest#displayUser, caused by https://github.com/xwiki/xwiki-platform/pull/3212
* My search criteria for tests described in the previous PR did not match the test that failed here. 

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

None, test only changes

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Successfully passed `mvn clean install -f xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates -Pquality,integration-tests`

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, same as https://github.com/xwiki/xwiki-platform/pull/3212