### PR TITLE
XWIKI-21878: Various close button modals do not use intended icons

### DIFF
--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-api/src/test/resources/icons/default.iconset
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-api/src/test/resources/icons/default.iconset
@@ -5,4 +5,5 @@ xwiki.iconset.render.html = <img src="$xwiki.getSkinFile("icons/silk/${icon}.png
 xwiki.iconset.icon.url = $xwiki.getSkinFile("icons/silk/${icon}.png")
 
 chart-organisation = chart-organisation
+cross = cross
 home = home


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-21878

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Fixed the iconset used for test
## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The icon was missing from the iconset and would not be resolved to anything at https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/master/7479/testReport/junit/org.xwiki.attachment/MovePageTest/Platform_Builds___quality___Build_for_Quality___submitMoveTargetEditNotAllowed/


# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
None, test change only
# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Fixed the build locally `mvn clean install -f xwiki-platform-core/xwiki-platform-attachment/ -Pquality`.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, same as https://github.com/xwiki/xwiki-platform/pull/2888