### PR TITLE
XWIKI-18816: Useless and somewhat invalid <dt> markup on the login form

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/misc.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/misc.less
@@ -216,10 +216,11 @@ div.suggestItems .hide-button {
     margin-top: .3em;
   }
   .submitSection {
-    margin-top: floor(@font-size-base * 1.4); // Same as `.xform dl dt`
     display: flex;
     flex-flow: row wrap;
     gap: 1em;
+    /* Same as `.xform dl dt` */
+    margin-top: floor(@font-size-base * 1.4);
   }
 }
 

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/misc.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/misc.less
@@ -216,6 +216,7 @@ div.suggestItems .hide-button {
     margin-top: .3em;
   }
   .submitSection {
+    margin-top: floor(@font-size-base * 1.4); // Same as `.xform dl dt`
     display: flex;
     flex-flow: row wrap;
     gap: 1em;

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/login.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/login.vm
@@ -85,19 +85,19 @@
       $supplementaryForm
     </div>
   #end
-  <dt class="submitSection">
-    <input type="submit" class="btn btn-primary col-xs-12" value="$escapetool.xml($services.localization.render('login'))"/>
+  </dl>
+<div class="submitSection">
+  <input type="submit" class="btn btn-primary col-xs-12" value="$escapetool.xml($services.localization.render('login'))"/>
 
-    #set ($forgotUsernameURL = $services.security.authentication.getAuthenticationURL('retrieveusername', $NULL))
-    #if("$!forgotUsernameURL" != "")
-      <span class="xAdditional"><a href="$forgotUsernameURL">$escapetool.xml($services.localization.render('xe.admin.forgotUsername.loginMessage'))</a></span>
-    #end
-    #set ($resetPasswordUrl = $services.security.authentication.getAuthenticationURL('resetpassword', $NULL))
-    #if("$!resetPasswordUrl" != '')
-      <span class="xAdditional recoverPassword"><a href="$resetPasswordUrl" >$escapetool.xml($services.localization.render('xe.admin.passwordReset.loginMessage'))</a></span>
-    #end
-  </dt>
-</dl>
+  #set ($forgotUsernameURL = $services.security.authentication.getAuthenticationURL('retrieveusername', $NULL))
+  #if("$!forgotUsernameURL" != "")
+    <span class="xAdditional"><a href="$forgotUsernameURL">$escapetool.xml($services.localization.render('xe.admin.forgotUsername.loginMessage'))</a></span>
+  #end
+  #set ($resetPasswordUrl = $services.security.authentication.getAuthenticationURL('resetpassword', $NULL))
+  #if("$!resetPasswordUrl" != '')
+    <span class="xAdditional recoverPassword"><a href="$resetPasswordUrl" >$escapetool.xml($services.localization.render('xe.admin.passwordReset.loginMessage'))</a></span>
+  #end
+</div>
 #xwikimessageboxend()
 </form>
 </main>## mainContentArea


### PR DESCRIPTION

# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-18816
# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Updated the DOM of the login form to be valid HTML


# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
after the changes in the PR, manual tests did not show any change in the visual interface:
![Screenshot from 2024-08-29 15-48-25](https://github.com/user-attachments/assets/5457a313-b5c3-4f71-81bd-d8d4de08be43)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
The selector for the submit button is here:
https://github.com/xwiki/xwiki-platform/blob/9ab12902498f0e5fa1e0355f9e57bee576d6803a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/LoginPage.java#L45
It shouldn't stop working with the changes. 

I could not find any element selector for the recovery links in this file or by searching `.xAdditional`.



# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.X, 16.4.X since this is a small bugfix