### PR TITLE
XWIKI-22430: Logging out does not unlock pages that were being edited

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyBasicAuthenticator.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyBasicAuthenticator.java
@@ -35,20 +35,20 @@ import org.xwiki.security.authentication.AuthenticationFailureManager;
 
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
-import com.xpn.xwiki.internal.user.UserAuthenticatedEventNotifier;
+import com.xpn.xwiki.internal.user.UserAuthenticationEventNotifier;
 import com.xpn.xwiki.web.Utils;
 
 public class MyBasicAuthenticator extends BasicAuthenticator implements XWikiAuthenticator
 {
 
-    private UserAuthenticatedEventNotifier userAuthenticatedEventNotifier;
+    private UserAuthenticationEventNotifier userAuthenticationEventNotifier;
 
-    private UserAuthenticatedEventNotifier getUserAuthenticatedEventNotifier()
+    private UserAuthenticationEventNotifier getUserAuthenticatedEventNotifier()
     {
-        if ( this.userAuthenticatedEventNotifier == null ) {
-            this.userAuthenticatedEventNotifier = Utils.getComponent(UserAuthenticatedEventNotifier.class);
+        if ( this.userAuthenticationEventNotifier == null ) {
+            this.userAuthenticationEventNotifier = Utils.getComponent(UserAuthenticationEventNotifier.class);
         }
-        return this.userAuthenticatedEventNotifier;
+        return this.userAuthenticationEventNotifier;
     }
 
     @Override
@@ -89,7 +89,7 @@ public class MyBasicAuthenticator extends BasicAuthenticator implements XWikiAut
 
             request.setUserPrincipal(principal);
 
-            this.getUserAuthenticatedEventNotifier().notify(principal.getName());
+            this.getUserAuthenticatedEventNotifier().notifyUserAuthenticated(principal.getName());
 
             return false;
         } else {
@@ -135,8 +135,8 @@ public class MyBasicAuthenticator extends BasicAuthenticator implements XWikiAut
 
                 // Since this scope is static, no UserAuthenticatedEventNotifier is available
                 // So we create one here
-                UserAuthenticatedEventNotifier notifier = Utils.getComponent(UserAuthenticatedEventNotifier.class);
-                notifier.notify(principal.getName());
+                UserAuthenticationEventNotifier notifier = Utils.getComponent(UserAuthenticationEventNotifier.class);
+                notifier.notifyUserAuthenticated(principal.getName());
 
                 return principal;
             } else {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyFormAuthenticator.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyFormAuthenticator.java
@@ -38,21 +38,21 @@ import org.xwiki.security.authentication.AuthenticationFailureManager;
 
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
-import com.xpn.xwiki.internal.user.UserAuthenticatedEventNotifier;
+import com.xpn.xwiki.internal.user.UserAuthenticationEventNotifier;
 import com.xpn.xwiki.web.Utils;
 
 public class MyFormAuthenticator extends FormAuthenticator implements XWikiAuthenticator
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(MyFormAuthenticator.class);
 
-    private UserAuthenticatedEventNotifier userAuthenticatedEventNotifier;
+    private UserAuthenticationEventNotifier userAuthenticationEventNotifier;
 
-    private UserAuthenticatedEventNotifier getUserAuthenticatedEventNotifier()
+    private UserAuthenticationEventNotifier getUserAuthenticatedEventNotifier()
     {
-        if ( this.userAuthenticatedEventNotifier == null ) {
-            this.userAuthenticatedEventNotifier = Utils.getComponent(UserAuthenticatedEventNotifier.class);
+        if ( this.userAuthenticationEventNotifier == null ) {
+            this.userAuthenticationEventNotifier = Utils.getComponent(UserAuthenticationEventNotifier.class);
         }
-        return this.userAuthenticatedEventNotifier;
+        return this.userAuthenticationEventNotifier;
     }
 
     /**
@@ -168,7 +168,7 @@ public class MyFormAuthenticator extends FormAuthenticator implements XWikiAuthe
 
                     request.setUserPrincipal(principal);
 
-                    this.getUserAuthenticatedEventNotifier().notify(principal.getName());
+                    this.getUserAuthenticatedEventNotifier().notifyUserAuthenticated(principal.getName());
 
                 } else {
                     // Failed to authenticate, better cleanup the user stored in the session
@@ -240,7 +240,7 @@ public class MyFormAuthenticator extends FormAuthenticator implements XWikiAuthe
 
             request.setUserPrincipal(principal);
 
-            this.getUserAuthenticatedEventNotifier().notify(principal.getName());
+            this.getUserAuthenticatedEventNotifier().notifyUserAuthenticated(principal.getName());
 
             Boolean bAjax = (Boolean) context.get("ajax");
             if ((bAjax == null) || (!bAjax.booleanValue())) {
@@ -292,7 +292,8 @@ public class MyFormAuthenticator extends FormAuthenticator implements XWikiAuthe
         HttpServletResponse httpServletResponse, URLPatternMatcher urlPatternMatcher) throws Exception
     {
         boolean result = super.processLogout(securityRequestWrapper, httpServletResponse, urlPatternMatcher);
-        if (result == true) {
+        if (result) {
+            this.getUserAuthenticatedEventNotifier().notifyUserUnauthenticated(securityRequestWrapper.getRemoteUser());
             if (this.persistentLoginManager != null) {
                 this.persistentLoginManager.forgetLogin(securityRequestWrapper, httpServletResponse);
             }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/META-INF/components.txt
@@ -159,7 +159,7 @@ com.xpn.xwiki.internal.render.DefaultOldRendering
 com.xpn.xwiki.internal.render.OldRenderingProvider
 com.xpn.xwiki.internal.render.groovy.ParseGroovyFromString
 com.xpn.xwiki.internal.user.MyPersistentLoginManagerProvider
-com.xpn.xwiki.internal.user.UserAuthenticatedEventNotifier
+com.xpn.xwiki.internal.user.UserAuthenticationEventNotifier
 com.xpn.xwiki.internal.user.UserCreatedEventListener
 com.xpn.xwiki.internal.velocity.DefaultVelocityEvaluator
 org.xwiki.internal.web.EffectiveAuthorSetterListener

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-api/src/main/java/org/xwiki/security/authentication/UserUnauthenticatedEvent.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-api/src/main/java/org/xwiki/security/authentication/UserUnauthenticatedEvent.java
@@ -1,0 +1,75 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.xwiki.security.authentication;
+
+import org.xwiki.observation.event.Event;
+import org.xwiki.stability.Unstable;
+import org.xwiki.user.UserReference;
+
+/**
+ * Event triggered whenever a user is logged out.
+ *
+ * @version $Id$
+ * @since 16.8.0RC1
+ * @since 16.4.3
+ * @since 15.10.13
+ */
+@Unstable
+public class UserUnauthenticatedEvent implements Event
+{
+    /**
+     * The reference related to an authenticated user for whom a {@link UserUnauthenticatedEvent} has been triggered.
+     */
+    private final UserReference userReference;
+
+    /**
+     * Default constructor without user reference for matching.
+     */
+    public UserUnauthenticatedEvent()
+    {
+        this(null);
+    }
+
+    /**
+     * Default constructor.
+     *
+     * @param userReference The reference related to an authenticated user for whom a {@link UserUnauthenticatedEvent}
+     * has been triggered.
+     */
+    public UserUnauthenticatedEvent(UserReference userReference)
+    {
+        this.userReference = userReference;
+    }
+
+    /**
+     * @return the {@link UserReference} of the authenticated user.
+     */
+    public UserReference getUserReference()
+    {
+        return this.userReference;
+    }
+
+    @Override
+    public boolean matches(Object other)
+    {
+        return other instanceof UserUnauthenticatedEvent;
+    }
+}


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22430

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
  * Provide a new UserUnauthenticatedEvent to detect whenever a user logged out, the same way that we have UserAuthenticatedEvent
  * Trigger that new event when processing a logout in MyFormAuthenticator
  * Refactor the code in XWikiHibernateStore to listen for UserUnauthenticatedEvent for cleaning the locks of a user, instead of listening to an action event
  * Rename UserAuthenticatedEventNotifier and use it for both authenticated and unauthenticated events
  * Fix test

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

`mvn clean install -Pquality` on:
  * xwiki-platform-security-authentication-api
  * xwiki-platform-oldcore
  * xwiki-platform-legacy-oldcore

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches: 
  * 15.10.x
  * 16.4.x 
because the original ticket is a backport. Now it contains new stuff (the new event) so it can be discussed.