### PR TITLE
XWIKI-15065: Replace Silk icons with Icon Themes values in attachments Upload component

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.js
@@ -18,7 +18,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 var XWiki = (function(XWiki) {
-  var l10n = {
+  let l10n = {
     "core.widgets.html5upload.status.icon.inprogress" : "$!escapetool.javascript($services.localization.render('core.widgets.html5upload.status.icon.inprogress'))",
     "core.widgets.html5upload.status.icon.done" : "$!escapetool.javascript($services.localization.render('core.widgets.html5upload.status.icon.done'))",
     "core.widgets.html5upload.status.icon.canceled" : "$!escapetool.javascript($services.localization.render('core.widgets.html5upload.status.icon.canceled'))",
@@ -28,7 +28,7 @@ var XWiki = (function(XWiki) {
     "core.widgets.html5upload.cancelAll" : "$!escapetool.javascript($services.localization.render('core.widgets.html5upload.cancelAll'))",
     "core.widgets.html5upload.hideStatus" : "$!escapetool.javascript($services.localization.render('core.widgets.html5upload.hideStatus'))"
   };
-  var icons = {
+  let icons = {
     'check' : "$!escapetool.javascript($services.icon.renderHTML('check'))",
     'remove' : "$!escapetool.javascript($services.icon.renderHTML('remove'))",
     'error' : "$!escapetool.javascript($services.icon.renderHTML('error'))",

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.js
@@ -18,7 +18,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 var XWiki = (function(XWiki) {
-  let l10n = {
+  const l10n = {
     "core.widgets.html5upload.status.icon.inprogress" : "$!escapetool.javascript($services.localization.render('core.widgets.html5upload.status.icon.inprogress'))",
     "core.widgets.html5upload.status.icon.done" : "$!escapetool.javascript($services.localization.render('core.widgets.html5upload.status.icon.done'))",
     "core.widgets.html5upload.status.icon.canceled" : "$!escapetool.javascript($services.localization.render('core.widgets.html5upload.status.icon.canceled'))",
@@ -28,7 +28,7 @@ var XWiki = (function(XWiki) {
     "core.widgets.html5upload.cancelAll" : "$!escapetool.javascript($services.localization.render('core.widgets.html5upload.cancelAll'))",
     "core.widgets.html5upload.hideStatus" : "$!escapetool.javascript($services.localization.render('core.widgets.html5upload.hideStatus'))"
   };
-  let icons = {
+  const icons = {
     'check' : "$!escapetool.javascript($services.icon.renderHTML('check'))",
     'remove' : "$!escapetool.javascript($services.icon.renderHTML('remove'))",
     'error' : "$!escapetool.javascript($services.icon.renderHTML('error'))",


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-15065

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Fixed two high severity recent bad code practices

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
SonarLint doesn't highlight them anymore
![image](https://github.com/user-attachments/assets/b3f473b7-8847-42e3-a9e6-94854a95852a)



# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
See above, sonarLint looks good.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, similar to https://github.com/xwiki/xwiki-platform/pull/2700