### PR TITLE
Avoid bash error in postinst

### DIFF
--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-mysql-common/src/deb/control/postinst
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-mysql-common/src/deb/control/postinst
@@ -20,7 +20,7 @@ if [ -f /usr/share/dbconfig-common/dpkg/postinst.mysql ]; then
   dbc_go xwiki $@
 
   # if they don't want our help, quit
-  if [ "$dbc_install" != "true" ]; then return 0; fi
+  if [ "$dbc_install" != "true" ]; then exit 0; fi
 
   # find out if we're upgrading/reinstalling
   if [ "$dbc_oldversion" ]; then
@@ -35,7 +35,7 @@ if [ -f /usr/share/dbconfig-common/dpkg/postinst.mysql ]; then
         db_get $dbc_package/dbconfig-reinstall && reinstall=$RET
         db_reset $dbc_package/dbconfig-reinstall
         # if they've said they don't want to reinstall stuff...
-        if [ "$reinstall" = "false" ]; then return 0; fi
+        if [ "$reinstall" = "false" ]; then exit 0; fi
     fi
   fi
 


### PR DESCRIPTION
When upgrading the xwiki-mysql-common package, an error in the postinst script can be observed in specific cases:

Unpacking xwiki-mysql-common (16.7.1) over (16.7.1) ... Setting up xwiki-mysql-common (16.7.1) ...
dbconfig-common: writing config to /etc/dbconfig-common/xwiki.conf dbconfig-common: flushing administrative password
/var/lib/dpkg/info/xwiki-mysql-common.postinst: line 23: return: can only `return' from a function or sourced script dpkg: error processing package xwiki-mysql-common (--configure):
 installed xwiki-mysql-common package post-installation script subprocess returned error exit status 2
Errors were encountered while processing:
 xwiki-mysql-common
E: Sub-process /usr/bin/dpkg returned an error code (1)

This commit fixes return to be exit.

# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

*

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 