### PR TITLE
XWIKI-22218: Drag & Drop doesn't successfully create links if the actions are performed in the same time by users

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-realtime/ckeditorRealtimeAdapter.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-realtime/ckeditorRealtimeAdapter.js
@@ -155,10 +155,23 @@ define('xwiki-ckeditor-realtime-adapter', [
 
     /** @inheritdoc */
     getFilters() {
+      /**
+       * Checks if there is a node with a given node name in the given node or its children.
+       */
+      const containsNode = function(node, nodeName) {
+        if (node.nodeName === nodeName) {
+          return true;
+        }
+        if (node.childNodes !== undefined && node.childNodes.some(child => containsNode(child, nodeName))) {
+          return true;
+        }
+        return false;
+      };
       return [
         // Ignore widget id changes.
         change => change.diff.action === 'modifyAttribute' && change.diff.name === 'data-widget-id' &&
-          change.node.classList?.contains('xwiki-widget')
+          change.node.classList?.contains('xwiki-widget'),
+        change => change.diff.action === 'removeElement' && containsNode(change.diff.element, 'XWIKI-WIDGET-UPLOADFILE')
       ];
     }
 


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22218

# Changes

## Description

This is a draft PR.
At the moment, the changes allows an upload widget to remain in the edited content, locally, when in a realtime editing session.

*

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 