### PR TITLE
XWIKI-22508: Creating a link in WYSIWYG by selecting text should follow the name strategy

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-link/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-link/plugin.js
@@ -406,9 +406,23 @@
       },
       setup: function(data) {
         // Create a link to a new page if the resource reference is not provided.
-        var resourceReference = data.resourceReference || this.getDefaultResourceReference();
-        if (resourceReference.type === 'space' && this.resourceTypes.indexOf('space') < 0 &&
-            this.resourceTypes.indexOf('doc') >= 0) {
+        var resourceReference = data.resourceReference;
+        $(this.getResourcePickerInput().$).prop('disabled', true);
+        if (resourceReference) {
+          this.setDefaultValue(this, resourceReference);
+        } else {
+          let self = this;
+
+          this.getDefaultResourceReference()
+              .done(ref => self.setDefaultValue(self, ref))
+              .fail(function () {
+                self.setDefaultValue(self, self.getDefaultResourceReferenceFallback());
+              });
+        }
+      },
+      setDefaultValue: function(self, resourceReference) {
+        if (resourceReference.type === 'space' && self.resourceTypes.indexOf('space') < 0 &&
+            self.resourceTypes.indexOf('doc') >= 0) {
           // Convert the space resource reference to a document resource reference.
           resourceReference = {
             type: 'doc',
@@ -417,7 +431,47 @@
             reference: resourceReference.reference + '.WebHome'
           };
         }
-        this.setValue(resourceReference);
+        self.setValue(resourceReference);
+        $(self.getResourcePickerInput().$).prop('disabled', false);
+      },
+      getDefaultResourceReference: function() {
+        let self = this;
+        // Compute the default reference by cleaning up the link label.
+        // Fall-back on the empty string if there's no text selection (e.g. if an image is selected).
+        var linkLabel = this.getDialog().getParentEditor().getSelection().getSelectedText() || '';
+        // Normalize the white space.
+        var defaultReference = linkLabel.trim().replace(/\s+/g, ' ');
+        var deferred = $.Deferred();
+        $.post(new XWiki.Document('LinkNameStrategyHelper', 'CKEditor').getURL('get'), {
+          outputSyntax: 'plain',
+          input: defaultReference,
+          base: XWiki.Model.serialize(this.base.getBase())
+        }).done(function(data) {
+          deferred.resolve({
+            reference: data[0].reference,
+            location: data[0].location,
+            type: self.resourceTypes[0],
+            // Make sure the picker doesn't try to resolve the link label as a resource reference.
+            isNew: true
+          });
+        }).fail(function(data) {
+          console.error("Error while loading creation link response", data);
+          deferred.resolve(self.getDefaultResourceReferenceFallback());
+        });
+        return deferred.promise();
+      },
+      getDefaultResourceReferenceFallback: function() {
+        // Compute the default reference by cleaning up the link label.
+        // Fall-back on the empty string if there's no text selection (e.g. if an image is selected).
+        var linkLabel = this.getDialog().getParentEditor().getSelection().getSelectedText() || '';
+        // Normalize the white space.
+        var defaultReference = linkLabel.trim().replace(/\s+/g, ' ');
+        return {
+          type: this.resourceTypes[0],
+          reference: defaultReference,
+          // Make sure the picker doesn't try to resolve the link label as a resource reference.
+          isNew: true
+        };
       },
       commit: function(data) {
         var resourceReference = this.getValue();
@@ -460,19 +514,6 @@
         });
         dialog.getContentElement('info', 'optionsToggle').sync();
         dialog.layout();
-      },
-      getDefaultResourceReference: function() {
-        // Compute the default reference by cleaning up the link label.
-        // Fall-back on the empty string if there's no text selection (e.g. if an image is selected).
-        var linkLabel = this.getDialog().getParentEditor().getSelection().getSelectedText() || '';
-        // Normalize the white space.
-        var defaultReference = linkLabel.trim().replace(/\s+/g, ' ');
-        return {
-          type: this.resourceTypes[0],
-          reference: defaultReference,
-          // Make sure the picker doesn't try to resolve the link label as a resource reference.
-          isNew: true
-        };
       }
     });
   };


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22508

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Ensure to use the defined name strategy before providing a link default value when selecting a text

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

Result with the preformatted name strategy: 
![Uploading Capture d’écran du 2024-09-13 17-05-27.png…]()


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

`mvn clean install -Pquality,integration-tests,docker` on `xwiki-platform-ckeditor`

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-16.8.x (once the RC is released)