### PR TITLE
XWIKI-20546: Log CSS exception details

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/java/org/xwiki/rendering/internal/wiki/XWikiWikiModel.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/java/org/xwiki/rendering/internal/wiki/XWikiWikiModel.java
@@ -312,7 +312,7 @@ public class XWikiWikiModel implements WikiModel
                 value = sd.getPropertyValue(dimension);
             } catch (Exception e) {
                 // Ignore the style parameter but log a warning to let the user know.
-                this.logger.warn("Failed to parse CSS style [{}]", style);
+                this.logger.warn("Failed to parse CSS style [{}]", style, e);
             }
         }
         if (StringUtils.isBlank(value)) {

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/java/org/xwiki/rendering/internal/wiki/XWikiWikiModel.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/java/org/xwiki/rendering/internal/wiki/XWikiWikiModel.java
@@ -33,6 +33,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.http.message.BasicNameValuePair;
@@ -312,7 +313,8 @@ public class XWikiWikiModel implements WikiModel
                 value = sd.getPropertyValue(dimension);
             } catch (Exception e) {
                 // Ignore the style parameter but log a warning to let the user know.
-                this.logger.warn("Failed to parse CSS style [{}]", style, e);
+                this.logger.warn("Failed to parse CSS style [{}]. Root cause is: [{}]", style,
+                    ExceptionUtils.getRootCauseMessage(e));
             }
         }
         if (StringUtils.isBlank(value)) {


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-20546

# Changes

## Description

* In XWikiWikiModel, if parsing CSS exception occurs, includes the exception in SLF4J call to get the full stack trace in the logs. This should help investigation of [XWIKI-20546](https://jira.xwiki.org/browse/XWIKI-20546) issue.

## Clarifications

* Root cause of the issue might be related to thread safety issue with `CSSOMParser`.

# Executed Tests

`mvn -f xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/pom.xml clean install` with Java 17 in Linux environment.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches: No