### PR TITLE
[Misc] Fix repository clone error on NTFS filesystems

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/resources/AttachmentIT/<strong>EscapedAttachment.txt
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/resources/AttachmentIT/<strong>EscapedAttachment.txt
@@ -1,1 +1,0 @@
-This is an attachment whose name should be escaped.

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-pageobjects/src/main/java/org/xwiki/flamingo/skin/test/po/AttachmentsPane.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-pageobjects/src/main/java/org/xwiki/flamingo/skin/test/po/AttachmentsPane.java
@@ -28,6 +28,8 @@ import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.LocalFileDetector;
+import org.openqa.selenium.remote.RemoteWebElement;
 import org.openqa.selenium.support.FindBy;
 import org.xwiki.livedata.test.po.LiveDataElement;
 import org.xwiki.livedata.test.po.TableLayoutElement;
@@ -117,8 +119,25 @@ public class AttachmentsPane extends BaseElement
      */
     public void setFileToUpload(final String filePath)
     {
+        setFileToUpload(filePath, false);
+    }
+
+    /**
+     * Fills the URL with the specified file path.
+     *
+     * @param filePath the path to the file to upload in URL form (the file *must* exist in the target directory).
+     * @param local if true, the file will be searched on the local filesystem.
+     * @since 15.10.13
+     * @since 16.4.4
+     * @since 16.9.0RC1
+     */
+    public void setFileToUpload(final String filePath, final boolean local)
+    {
         final List<WebElement> inputs = this.pane.findElements(By.className("uploadFileInput"));
         WebElement input = inputs.get(inputs.size() - 1);
+        if (local) {
+            ((RemoteWebElement) input).setFileDetector(new LocalFileDetector());
+        }
         // Clean the field before setting the value in case of successive uploads.
         input.clear();
         input.sendKeys(filePath);


### PR DESCRIPTION
# Changes

## Description

`<strong>EscapedAttachment.txt` is no longer stored on the repository. Instead, a file containing the `<strong>` tag is created during the test that requires it.

## Clarifications

This change requires adding to the page object an upload method supporting local files, which is done through Selenium's  [LocalFileDetector](https://www.selenium.dev/selenium/docs/api/java/org/openqa/selenium/remote/LocalFileDetector.html).

# Executed Tests

`AttachmentIT` was run locally with the included changes.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-15.10.x
  * stable-16.4.x