### PR TITLE
XWIKI-22458: Message boxes variant style does not match initial design

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/messages.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/messages.less
@@ -10,13 +10,13 @@ span.successmessage, span.errormessage, span.warningmessage, span.infomessage {
 span.box, span.successmessage, span.errormessage, span.warningmessage, span.infomessage {
   padding: 0 floor(@font-size-base * 0.2);
   box-shadow: none;
-  & > img {
+  & > .icon-block > img {
     // Style the silk icons
     margin: 0 .6rem 0 .2rem;
     vertical-align: sub;
   }
 
-  & > span.fa {
+  & > .icon-block > span.fa {
     // Style the font awesome icons
     margin: 0 .6rem 0 .2rem;
   }
@@ -24,19 +24,22 @@ span.box, span.successmessage, span.errormessage, span.warningmessage, span.info
 
 // Used by: message boxes
 div.successmessage, div.errormessage, div.warningmessage, div.infomessage {
+  // In case the structure of the div is not the same as the one from the macro
+  // we do not add those new style rules, in order to not break the looks of the content inside.
+  // The selector below relies on the class introduced in the IconProvider at
+  // the same time as the new style for the message boxes.
+  // This makes it so that this new style will never apply on an older hardcoded box.
+  &:has(>.icon-block) {
+    display: flex;
+    gap: 2rem;
+    justify-content: left;
+    align-items: baseline;
+  }
   padding: 2rem;
   border: none;
   border-left: 4px solid;
   box-shadow: none;
-
-  & > .icon-block {
-    // Ensure to let some space between the icon of the message and the content.
-    padding-right: 2rem;
-    // We want the icon to remain on the left. Note that we don't use display: flex for now since it's causing issues
-    // when the box contains some specific content such as em
-    float: left;
-  }
-
+  
   & > img {
     // Improve alignment for silk icons
     align-self: flex-start;


### PR DESCRIPTION

# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22458

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Updated style to get back the margin next to the icon on inline blocks.
* Updated style of standalone boxes to both:
  * fit the design agreed upon earlier
  * avoid style regression on old hard-coded boxes

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* See comments in the code

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
The style changes on inline messages are quick easy to test. However making sure that we did not break backward compatibility while making the new design was a bit more complicated. The first example shows various uses of the updated macro. The second and third example display some hard coded boxes that we can find in the UI: the second one contains a specific HTML content that did not work well with the style changes (one of the reasons to make the selector for new styles specific) -- the third one contains a hard coded icon.
Before the PR:
![22458-beforePR1](https://github.com/user-attachments/assets/6b50a85a-2dff-4b8e-8e22-ea14474bf9c7)
![22458-beforePR2](https://github.com/user-attachments/assets/95df390a-5088-40e0-a642-3953f85999bb)
![22458-beforePR3](https://github.com/user-attachments/assets/99a8ba31-c3b9-469b-aefa-3a03d6f30f7d)
after the PR:
![22458-afterPR1](https://github.com/user-attachments/assets/c1ce8ade-8a73-405c-9a02-4c4f98816d02)
![22458-afterPR2](https://github.com/user-attachments/assets/aaa7e862-5f6a-4536-9e96-ec2ef57c122e)
![22458-afterPR3](https://github.com/user-attachments/assets/6c752fa6-f531-4d06-9a82-cff249b56993)

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests only, this is a style change.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, same as changes for XWIKI-21452 brought in 16.7.0+