### PR TITLE
Handle MariaDB independently of MySQL

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/DatabaseProduct.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/DatabaseProduct.java
@@ -64,6 +64,11 @@ public final class DatabaseProduct
     public static final DatabaseProduct MYSQL = new DatabaseProduct("MySQL", "mysql");
 
     /**
+     * The Product name and the JDBC scheme to recognize a MariaDB DB.
+     */
+    public static final DatabaseProduct MARIADB = new DatabaseProduct("MariaDB", "mariadb");
+
+    /**
      * The Product name and the JDBC scheme to recognize a PostgreSQL DB.
      */
     public static final DatabaseProduct POSTGRESQL = new DatabaseProduct("PostgreSQL", "postgresql");
@@ -82,13 +87,6 @@ public final class DatabaseProduct
      * Represents an unknown database for which we were not able to find the product name.
      */
     public static final DatabaseProduct UNKNOWN = new DatabaseProduct("Unknown", "unknown");
-
-    /**
-     * The Product name and the JDBC scheme to recognize a MariaDB DB.
-     * <p>
-     * Keeping it private until we think it's different enough from MySQL behavior to justify it's own branches.
-     */
-    private static final DatabaseProduct MARIADB = new DatabaseProduct("MariaDB", "mariadb");
 
     /**
      * @see #getProductName()
@@ -156,8 +154,10 @@ public final class DatabaseProduct
         {
             // See documentation above on why we check starts with for DB2
             product = DB2;
-        } else if (isMySQL(productNameOrJDBCScheme)) {
+        } else if (matches(productNameOrJDBCScheme, MYSQL)) {
             product = MYSQL;
+        } else if (matches(productNameOrJDBCScheme, MARIADB)) {
+            product = MARIADB;
         } else if (matches(productNameOrJDBCScheme, POSTGRESQL)) {
             product = POSTGRESQL;
         } else if (matches(productNameOrJDBCScheme, MSSQL)) {
@@ -167,11 +167,6 @@ public final class DatabaseProduct
         }
 
         return product;
-    }
-
-    private static boolean isMySQL(String productNameOrJDBCScheme)
-    {
-        return matches(productNameOrJDBCScheme, MYSQL) || matches(productNameOrJDBCScheme, MARIADB);
     }
 
     private static boolean matches(String productNameOrJDBCScheme, DatabaseProduct product)

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R130200000XWIKI17200DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R130200000XWIKI17200DataMigration.java
@@ -126,8 +126,10 @@ public class R130200000XWIKI17200DataMigration extends AbstractHibernateDataMigr
     @Override
     public boolean shouldExecute(XWikiDBVersion startupVersion)
     {
-        // Only really required for MySQL since https://jira.xwiki.org/browse/XWIKI-15215 was only affecting MySQL
-        return this.hibernateStore.getDatabaseProductName() == DatabaseProduct.MYSQL;
+        // Only really required for MySQL and MariaDB since https://jira.xwiki.org/browse/XWIKI-15215 was only
+        // affecting MySQL and MariaDB
+        DatabaseProduct databaseProductName = this.hibernateStore.getDatabaseProductName();
+        return databaseProductName == DatabaseProduct.MYSQL || databaseProductName == DatabaseProduct.MARIADB;
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R40000XWIKI6990DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R40000XWIKI6990DataMigration.java
@@ -1242,7 +1242,8 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
 
     /**
      * Detect database products and initialize isMySQLMyISAM and isOracle. isMySQLMyISAM is true if the xwikidoc table
-     * use the MyISAM engine in MySQL, false otherwise or on any failure. isOracle is true if the we access an Oracle
+     * use the MyISAM engine in MySQL or in MariaDB, false otherwise or on any failure. isOracle is true if the we
+     * access an Oracle
      * database.
      *
      * @param store the store to be checked
@@ -1250,7 +1251,7 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
     private void detectDatabaseProducts(XWikiHibernateBaseStore store)
     {
         DatabaseProduct product = store.getDatabaseProductName();
-        if (product != DatabaseProduct.MYSQL) {
+        if (product != DatabaseProduct.MYSQL && product != DatabaseProduct.MARIADB) {
             this.isOracle = (product == DatabaseProduct.ORACLE);
             this.isMSSQL = (product == DatabaseProduct.MSSQL);
             return;
@@ -1283,11 +1284,12 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
             }
             if (this.isMySQL && !this.isMySQLMyISAM) {
                 this.logger
-                    .debug("MySQL innoDB database detected, proceeding to simplified updates with cascaded updates.");
+                    .debug("MySQL or MariaDB innoDB database detected, proceeding to simplified updates with "
+                        + "cascaded updates.");
             }
             if (this.isMySQLMyISAM) {
                 this.logger
-                    .debug("MySQL MyISAM database detected, proceeding to all updates manually without constraints.");
+                    .debug("MySQL or MariaDB MyISAM database detected, proceeding to all updates manually without constraints.");
             }
             if (this.isMSSQL) {
                 this.logger

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/DatabaseProductTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/DatabaseProductTest.java
@@ -50,11 +50,11 @@ class DatabaseProductTest
         assertEquals(DatabaseProduct.MYSQL, product);
         assertSame(DatabaseProduct.MYSQL, product);
         product = DatabaseProduct.toProduct("MariaDB");
-        assertEquals(DatabaseProduct.MYSQL, product);
-        assertSame(DatabaseProduct.MYSQL, product);
+        assertEquals(DatabaseProduct.MARIADB, product);
+        assertSame(DatabaseProduct.MARIADB, product);
         product = DatabaseProduct.toProduct("mariadb");
-        assertEquals(DatabaseProduct.MYSQL, product);
-        assertSame(DatabaseProduct.MYSQL, product);
+        assertEquals(DatabaseProduct.MARIADB, product);
+        assertSame(DatabaseProduct.MARIADB, product);
 
         product = DatabaseProduct.toProduct("Apache Derby");
         assertEquals(DatabaseProduct.DERBY, product);


### PR DESCRIPTION
# Jira URL

This is a partially fix to https://jira.xwiki.org/browse/ADMINTOOL-64

# Changes

## Description

`toProduct` method in `DatabaseProduct` class now returns `DatabaseProduct.MARIADB` when XWiki is relying on MariaDB instead of returning `DatabaseProduct.MYSQL`.

## Clarifications

So far `toProduct` method in `DatabaseProduct` class would reports that a MariaDB database is actually MySQL. This was done on purpose according to [XWIKI-17912](https://jira.xwiki.org/browse/XWIKI-17912) description and also according to comments in the code. This decision has some (minors) side effects such as incorrect database type reported to the user in Admin Tools application (cf https://jira.xwiki.org/browse/ADMINTOOL-64). This commit is an attempt to handle MariaDB independently of MySQL.

The single existing test impact by this change has been update but some additional tests are probably required to increase the confidence in those changes.

# Executed Tests

All unit tests of `xwiki-platform` project were executed.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches: No 