### PR TITLE
XWIKI-22501: Attachment progress info is lacking contrast

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.css
@@ -6,6 +6,7 @@
   position: relative;
   padding: .3em 1em .3em 22px;
   background: $theme.highlightColor none 2px .8em no-repeat;
+  border-radius: 7px; /* Same value as @border-radius-base from Flamingo. */
   margin: .5em 0;
   clear: both;
   display: flex;
@@ -46,7 +47,6 @@
 }
 .progress-info {
   flex-basis: 100%;
-  opacity: 0.5;
 }
 .upload-inprogress .progress-info {
   opacity: 1;


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22501

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Removed the opacity that was here without a specific good reason. This solves the contrast issue and AFAIK wasn't necessary for anything
* Added a border radius to improve consistency of the skin style since `XWIKI-21334: Uniformize the rounded edges of visual elements`

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

Before the PR:
![Screenshot from 2024-10-03 13-49-48](https://github.com/user-attachments/assets/ab157595-7fb0-4b6b-b3e2-29bf545855d5)
After the PR:
![Screenshot from 2024-10-03 13-49-26](https://github.com/user-attachments/assets/2162cb19-897d-48b3-94a0-13100100d191)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

I tried to execute tests with `mvn clean install -f xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-test/xwiki-platform-attachment-test-docker -Pdocker -Dxwiki.test.ui.wcag=true` in order to check that the cotnrast issues reported by auto test are solved. It always failed halfway through though. It failed with the error message :
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.5.0:enforce (enforce-jakarta.xml.bind-api) on project xwiki-platform-attachment-test-docker: 
[ERROR] Rule 0: org.apache.maven.enforcer.rules.dependency.BannedDependencies failed with message:
[ERROR] XWiki uses jakarta.xml.bind:jakarta.xml.bind-api instead
[ERROR] org.xwiki.platform:xwiki-platform-attachment-test-docker:jar:16.9.0-SNAPSHOT
[ERROR]    org.xwiki.platform:xwiki-platform-test-docker:jar:16.9.0-SNAPSHOT
[ERROR]       org.xwiki.platform:xwiki-platform-rest-jersey:jar:16.9.0-SNAPSHOT
[ERROR]          org.glassfish.jersey.media:jersey-media-json-jackson:jar:2.42
[ERROR]             com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:2.18.0
[ERROR]                javax.xml.bind:jaxb-api:jar:2.2.12 <--- banned via the exclude/include list
```

This seems unrelated to the changes proposed here, and I could not find a way to go around it. My guess is that the `extensionOverride` defined in the xwiki-platform POM is not applied and we rely on an old banned dependency that should have been overridden.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.X
  * 16.4.X