### PR TITLE
XWIKI-21116: `@dropdown-link-color` doesn't apply to breadcrumb's dropdown links

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/breadcrumbs.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/breadcrumbs.less
@@ -46,7 +46,7 @@
 
         a {
           /* Reset the link color inside the tree. */
-          color: @link-color;
+          color: @dropdown-link-color;
         }
       }
     }


### PR DESCRIPTION




# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-21116
# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Updated the color used by the links in the breadcrumb dropdown.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Screenshot of the sandbox breadcrumb dropdown after the changes proposed in this PR. The color `@dropdown-link-color` has been set to pink. We can see that the links inside of the breadcrumb dropdown have the same color as the ones in the action buttons on the right. This color is different from the color of other "regular" links on the page.
![Screenshot from 2024-10-03 16-41-57](https://github.com/user-attachments/assets/1008d6b4-79be-423b-8e02-cc76c230b821)
 

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Manual test only, see above. This is a style change that should not impact at all the UI for automated tests.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.X
  * 16.4.X
