### PR TITLE
XWIKI-22547: Make websocket work with root servlet context

### DIFF
--- a/xwiki-platform-core/xwiki-platform-websocket/src/main/java/org/xwiki/websocket/script/WebSocketScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-websocket/src/main/java/org/xwiki/websocket/script/WebSocketScriptService.java
@@ -84,9 +84,14 @@ public class WebSocketScriptService implements ScriptService
             XWikiContext xcontext = this.xcontextProvider.get();
 
             StringBuilder path = new StringBuilder("/");
-            path.append(xcontext.getWiki().getWebAppPath(xcontext));
-            path.append("websocket").append(path(pathOrRoleHint));
 
+            // Test if installed with ROOT servlet context and avoid double slash.
+            String webAppPath = xcontext.getWiki().getWebAppPath(xcontext);
+            if (!"/".equals(webAppPath)) {
+                path.append(webAppPath);
+            }
+
+            path.append("websocket").append(path(pathOrRoleHint));
             URL serverURL = xcontext.getURLFactory().getServerURL(xcontext);
             String scheme = "https".equals(serverURL.getProtocol()) ? "wss" : "ws";
             // We have to add the path afterwards because the URI constructor double encodes it.

--- a/xwiki-platform-core/xwiki-platform-websocket/src/test/java/org/xwiki/websocket/script/WebSocketScriptServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-websocket/src/test/java/org/xwiki/websocket/script/WebSocketScriptServiceTest.java
@@ -109,4 +109,11 @@ class WebSocketScriptServiceTest
             "Failed to create WebSocket URL for [test]. Root cause is [MalformedURLException: Invalid server URL!].",
             this.logCapture.getMessage(0));
     }
+
+    @Test
+    void urlWithRootServletContext() {
+        when(this.xcontext.getWiki().getWebAppPath(xcontext)).thenReturn("/");
+        assertEquals("ws://www.xwiki.org:80/websocket/one/two", this.service.url("/one/two"));
+    }
+
 }


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/projects/XWIKI/issues/XWIKI-22547

# Changes

## Description


* Add a check if the webapppath
is empty, as in set to `/` and exclude it from the URL building.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Exclude the edge-case
and keep the generic code.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

New test case was added.
✅ Checked with upstream code without fix to detect this issue.
✅ Run test locally
✅ Deploy fixed module to formerly faulty XWiki instance and observe the issue being fixed.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 