### PR TITLE
XWIKI-22552: The minimum supported Java version is not accurate in the XJetty startup script

### DIFF
--- a/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-common/src/deb/resources/lib/systemd/system/xwiki.service
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-debian/xwiki-platform-distribution-debian-xjetty/xwiki-platform-distribution-debian-xjetty-common/src/deb/resources/lib/systemd/system/xwiki.service
@@ -13,7 +13,7 @@ WorkingDirectory=/var/lib/xwiki/
 
 # Lifecycle
 Type=simple
-ExecStart=/bin/bash /usr/lib/xwiki-jetty/start_xwiki.sh
+ExecStart=/bin/bash /usr/lib/xwiki-jetty/start_xwiki.sh --noninteractive
 ExecStop=/bin/bash /usr/lib/xwiki-jetty/stop_xwiki.sh
 Restart=on-abort
 

--- a/xwiki-platform-tools/xwiki-platform-tool-jetty/xwiki-platform-tool-jetty-resources/src/main/resources/start_xwiki.sh
+++ b/xwiki-platform-tools/xwiki-platform-tool-jetty/xwiki-platform-tool-jetty-resources/src/main/resources/start_xwiki.sh
@@ -204,20 +204,24 @@ java_version() {
 
 # Check version of Java (when in non-interactive mode)
 JAVA_VERSION="$(java_version)"
-if [ ! "$XWIKI_NONINTERACTIVE" = true ] ; then
-  if [[ "$JAVA_VERSION" -eq "no_java" ]]; then
-    echo "No Java found. You need Java installed for XWiki to work."
-    exit 0
-  fi
-  if [ "$JAVA_VERSION" -lt 11 ]; then
-    echo This version of XWiki requires Java 11 or greater.
-    exit 0
-  fi
-  if [ "$JAVA_VERSION" -gt 17 ]; then
+
+if [[ "$JAVA_VERSION" -eq "no_java" ]]; then
+  echo "No Java found. You need Java installed for XWiki to work."
+  exit 1
+fi
+if [ "$JAVA_VERSION" -lt 17 ]; then
+  echo This version of XWiki requires Java 17 or greater.
+  exit 1
+fi
+if [ "$JAVA_VERSION" -gt 17 ]; then
+  if [ ! "$XWIKI_NONINTERACTIVE" = true ] ; then
     read -p "You're using Java $JAVA_VERSION which XWiki doesn't fully support yet. Continue (y/N)? " -n 1 -r
     if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-      exit 0
+      exit 1
     fi
+  else
+    echo "You're using Java $JAVA_VERSION which XWiki doesn't fully support yet. Exiting"
+    exit 1
   fi
 fi
 

--- a/xwiki-platform-tools/xwiki-platform-tool-jetty/xwiki-platform-tool-jetty-resources/src/main/resources/start_xwiki.sh
+++ b/xwiki-platform-tools/xwiki-platform-tool-jetty/xwiki-platform-tool-jetty-resources/src/main/resources/start_xwiki.sh
@@ -213,7 +213,7 @@ if [ "$JAVA_VERSION" -lt 17 ]; then
   echo This version of XWiki requires Java 17 or greater.
   exit 1
 fi
-if [ "$JAVA_VERSION" -gt 17 ]; then
+if [ "$JAVA_VERSION" -gt 21 ]; then
   if [ ! "$XWIKI_NONINTERACTIVE" = true ] ; then
     read -p "You're using Java $JAVA_VERSION which XWiki doesn't fully support yet. Continue (y/N)? " -n 1 -r
     if [[ ! $REPLY =~ ^[Yy]$ ]]; then

--- a/xwiki-platform-tools/xwiki-platform-tool-jetty/xwiki-platform-tool-jetty-resources/src/main/resources/start_xwiki.sh
+++ b/xwiki-platform-tools/xwiki-platform-tool-jetty/xwiki-platform-tool-jetty-resources/src/main/resources/start_xwiki.sh
@@ -220,8 +220,7 @@ if [ "$JAVA_VERSION" -gt 17 ]; then
       exit 1
     fi
   else
-    echo "You're using Java $JAVA_VERSION which XWiki doesn't fully support yet. Exiting"
-    exit 1
+    echo "Warning: you're using Java $JAVA_VERSION which XWiki doesn't fully support yet."
   fi
 fi
 


### PR DESCRIPTION
# Jira URL

This is related to [XWIKI-21211](https://jira.xwiki.org/browse/XWIKI-21211).

I have installed `xwiki-xjetty-mariadb` and it was failing "silently" at startup because I was using Java 8 by default (systemd was happy due to exit code being `0`).

Fixes:
- https://jira.xwiki.org/browse/XWIKI-22554
- https://jira.xwiki.org/browse/XWIKI-22555
- https://jira.xwiki.org/browse/XWIKI-22556
- https://jira.xwiki.org/browse/XWIKI-22552

# Changes

## Description

- `start_xwiki.sh` wasn't performing any test regarding Java version available when running in non interactive mode. Now Java version verification is performed even in non interactive mode.
- `start_xwiki.sh` exit code is now `1` when:
  - Java version is not found
  - when Java version is lower then the minimal requirement
  - when Java version is not yet fully supported and user cancel the execution
- Since the upgrade to Jetty `12` (included in XWiki `16.7.0` see [XWIKI-21211](https://jira.xwiki.org/browse/XWIKI-21211)) Jetty requires Java 17 (cf https://jetty.org/docs/jetty/12/index.html). `start_xwiki.sh` has been upgrade accordingly.
- `xwiki.service` is now running `start_xwiki.sh` with the `--noninteractive` option.

⚠ Important, breaking changes:
- Exit code have been change from `0` (successful) to `1` (error) if Java requirement are not met so that Systemd correctly reports failure to start the xwiki service.

# Executed Tests

Tested on Debian Bookworm 12.7
Build with Java 17.
`*.deb` packages installed locally and attempt to start `xwiki.service` with Java 11, 17 and 21.
Execution of `sudo -u xwiki /bin/bash /usr/lib/xwiki-jetty/start_xwiki.sh` with Java 21.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches: No