### PR TITLE
Fix the redirect URL growing indefinitely

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/drawer.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/drawer.vm
@@ -42,9 +42,19 @@ aria-label="$escapetool.xml($services.localization.render('core.menu.drawer.labe
           <a href="$xwiki.getURL($xcontext.inactiveUserReference, 'view')" class="brand-user" id="tmUser">$!xwiki.getUserName($xcontext.inactiveUserReference, false)</a>
           $logoutLink
         #else
-          <a href="$xwiki.getURL('XWiki.XWikiLogin', 'login', "xredirect=$escapetool.url($xwiki.relativeRequestURL)&loginLink=1")" id="tmLogin" rel="nofollow">$services.icon.renderHTML('log-in') $escapetool.xml($services.localization.render('login'))</a>
+          ## If xredirect is not set
+          #if (!$request.xredirect)
+            ## Define redirect URL value using current document relative request URL
+            #set($redirectURL = $escapetool.url($xwiki.relativeRequestURL))
+          ## If xredirect is already set
+          #else
+            ## Reuse the current value in the login link
+            #set($redirectURL = $escapetool.url($request.xredirect))
+          #end
+
+          <a href="$xwiki.getURL('XWiki.XWikiLogin', 'login', "xredirect=$redirectURL&loginLink=1")" id="tmLogin" rel="nofollow">$services.icon.renderHTML('log-in') $escapetool.xml($services.localization.render('login'))</a>
           #if ($xwiki.hasAccessLevel('register', 'XWiki.XWikiPreferences'))
-            <a href="$xwiki.getURL('XWiki.XWikiRegister', 'register', "xredirect=$escapetool.url($xwiki.relativeRequestURL)")" id="tmRegister" rel="nofollow">$services.icon.renderHTML('log-in') $escapetool.xml($services.localization.render('register'))</a>
+            <a href="$xwiki.getURL('XWiki.XWikiRegister', 'register', "xredirect=$redirectURL")" id="tmRegister" rel="nofollow">$services.icon.renderHTML('log-in') $escapetool.xml($services.localization.render('register'))</a>
           #end
         #end
         ##


### PR DESCRIPTION
# Jira URL

[XWIKI-17873](https://jira.xwiki.org/browse/XWIKI-17873)

# Changes

## Description

* Reuse URL `xredirect` parameter value if already set.

## Clarifications

Currently, being, for example, on http://localhost:8080/xwiki/bin/view/Help/ and clicking on `Log-in` in the drawer load http://localhost:8080/xwiki/bin/login/XWiki/XWikiLogin?xredirect=%2Fxwiki%2Fbin%2Fview%2FHelp%2F&loginLink=1
Going again in the drawer and clicking on `Log-in` will load http://localhost:8080/xwiki/bin/login/XWiki/XWikiLogin?xredirect=%2Fxwiki%2Fbin%2Flogin%2FXWiki%2FXWikiLogin%3Fxredirect%3D%252Fxwiki%252Fbin%252Fview%252FHelp%252F%26loginLink%3D1&loginLink=1 and so on.
URL will indefinitely grow. That can be an issue when using crawler or when bots visit the wiki.
Same issue exists with register link.

This pull request will reuse value of `xredirect` if exists to avoid this issue.

# Executed Tests

Manual testing locally with Firefox.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches: No