### PR TITLE
XWIKI-22552: The minimum supported Java version is not accurate in the XJetty startup script

### DIFF
--- a/xwiki-platform-tools/xwiki-platform-tool-jetty/xwiki-platform-tool-jetty-resources/src/main/resources/start_xwiki_debug.sh
+++ b/xwiki-platform-tools/xwiki-platform-tool-jetty/xwiki-platform-tool-jetty-resources/src/main/resources/start_xwiki_debug.sh
@@ -240,20 +240,23 @@ java_version() {
 
 # Check version of Java (when in non-interactive mode)
 JAVA_VERSION="$(java_version)"
-if [ ! "$XWIKI_NONINTERACTIVE" = true ] ; then
-  if [[ "$JAVA_VERSION" -eq "no_java" ]]; then
-    echo "No Java found. You need Java installed for XWiki to work."
-    exit 0
-  fi
-  if [ "$JAVA_VERSION" -lt 11 ]; then
-    echo This version of XWiki requires Java 11 or greater.
-    exit 0
-  fi
-  if [ "$JAVA_VERSION" -gt 17 ]; then
+
+if [[ "$JAVA_VERSION" -eq "no_java" ]]; then
+  echo "No Java found. You need Java installed for XWiki to work."
+  exit 1
+fi
+if [ "$JAVA_VERSION" -lt 17 ]; then
+  echo This version of XWiki requires Java 17 or greater.
+  exit 1
+fi
+if [ "$JAVA_VERSION" -gt 21 ]; then
+  if [ ! "$XWIKI_NONINTERACTIVE" = true ] ; then
     read -p "You're using Java $JAVA_VERSION which XWiki doesn't fully support yet. Continue (y/N)? " -n 1 -r
     if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-      exit 0
+      exit 1
     fi
+  else
+    echo "Warning: you're using Java $JAVA_VERSION which XWiki doesn't fully support yet."
   fi
 fi
 


### PR DESCRIPTION
# Jira URL

Fixes:
- https://jira.xwiki.org/browse/XWIKI-22554
- https://jira.xwiki.org/browse/XWIKI-22555
- https://jira.xwiki.org/browse/XWIKI-22556
- https://jira.xwiki.org/browse/XWIKI-22552

# Changes

## Description

Same as https://github.com/xwiki/xwiki-platform/pull/3544

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches: 