### PR TITLE
XWIKI-22523: Hitting the Enter key in fields on XWiki pages opens the hamburger content menu

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_content.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_content.vm
@@ -149,7 +149,7 @@
  *#
 #macro(displayMenu $id $icon $menuContent $titleKey $titleAsLabel $actionUrl $extraAttribute)
   <div class="btn-group" id="$id">
-    <#if ("$!actionUrl" == '')button#{else}a#end class="btn btn-default#if ("$!actionUrl" == '') dropdown-toggle#end" title="$services.localization.render($titleKey)"##
+    <#if ("$!actionUrl" == '')button type="button"#{else}a#end class="btn btn-default#if ("$!actionUrl" == '') dropdown-toggle#end" title="$services.localization.render($titleKey)"##
     #if ("$!actionUrl" != '')
       href="$actionUrl"
     #else

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/hierarchy_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/hierarchy_macros.vm
@@ -227,9 +227,10 @@
       ## If the rootId is null, this means that the root is the home. Which means that we're on the first tree, which doesn't show exactly the same thing as the others.
       #set ($togglerTextAlternative = "<span class='sr-only'>$escapetool.xml($services.localization.render('web.hierarchy.toggler.label.parents', [$pathData.get($openToIndex).label])) </span>")
     #end
-    #set ($treeToggle = "<button class='dropdown-toggle' data-toggle='dropdown'>" +
+    #set ($treeToggle = "<button class='dropdown-toggle' type='button' data-toggle='dropdown'>" +
       $togglerTextAlternative +
-      "$services.icon.renderHTML('caret-down')</button>")
+      $services.icon.renderHTML('caret-down') +
+      "</button>")
     #set ($treeNavigation = "$treeToggle<div class='dropdown-menu'>#documentTree($treeParams)</div>")
   #end
 #end


### PR DESCRIPTION

# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added type=`button` on the edit form buttons

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Those buttons were added recently for semantics.
  * The breadcrumb caret was non semantic, it became a button when reworking the accessibility of the breadcrumb.
  * The moreAction was a link, it got modified to a button in https://github.com/xwiki/xwiki-platform/commit/d5bc04d328a870ec14a3e35d6e48034f05b40be9
* Those butttons without a type were triggered instead of the default form action. Adding a type on both of them ensured that pressing enter on a form input would correctly submit the form.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
None, no visual change.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests to reproduce the bug reported. With the changes, pressing enter properly started the preview mode.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.X
  * 16.4.X
Both of the causes got merged on both of those branches.