### PR TITLE
XWIKI-12987: Relative links are made absolute or even broken after moving a page

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/RenamePageIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/RenamePageIT.java
@@ -366,15 +366,16 @@ class RenamePageIT
 
         setup.rest().delete(testReference);
 
-        setup.createPage(sourcePageReference1, "Some content to be linked. number 1");
-        setup.createPage(sourcePageReference2, "Some content to be linked in macro. number 2");
-        setup.createPage(sourcePageReference3, "Some content to be linked in nested macro. number 3");
-        setup.createPage(sourcePageReference4, "A page with image to be linked. number 4");
+        setup.rest().savePage(sourcePageReference1, "Some content to be linked. number 1", "sourcePage1");
+        setup.rest().savePage(sourcePageReference2, "Some content to be linked in macro. number 2", "sourcePage2");
+        setup.rest().savePage(sourcePageReference3, "Some content to be linked in nested macro. number 3",
+            "sourcePage3");
+        setup.rest().savePage(sourcePageReference4, "A page with image to be linked. number 4", "sourcePage4");
         AttachmentsPane attachmentsPane = new AttachmentsViewPage().openAttachmentsDocExtraPane();
         File image = new File(testConfiguration.getBrowser().getTestResourcesPath(), "AttachmentIT/image.gif");
         attachmentsPane.setFileToUpload(image.getAbsolutePath());
         attachmentsPane.waitForUploadToFinish("image.gif");
-        setup.createPage(sourcePageReference5, "A page to be included. number 5");
+        setup.rest().savePage(sourcePageReference5, "A page to be included. number 5", "sourcePage5");
 
         String testPageContent = "Check out this page: [[type the link label>>doc:%1$s]]\n" + "\n" + "{{warning}}\n"
             + "Withing a macro: Check out this page: [[type the link label>>doc:%2$s]]\n" + "\n" + "{{error}}\n"
@@ -387,8 +388,9 @@ class RenamePageIT
             + "Withing a macro: Check out this page: [[type the link label>>doc:%1$s]]\n"
             + "{{/warning}}\n\n"
             + "Final line.";
-        setup.createPage(testReference,
-            String.format(testPageContent, sourcePage1, sourcePage2, sourcePage3, sourcePage4, sourcePage5));
+        setup.rest().savePage(testReference,
+            String.format(testPageContent, sourcePage1, sourcePage2, sourcePage3, sourcePage4, sourcePage5),
+            "testPage");
 
         // Wait for the solr indexing to be completed before doing any rename
         new SolrTestUtils(setup, testConfiguration.getServletEngine()).waitEmptyQueue();
@@ -671,14 +673,12 @@ class RenamePageIT
     void renameWithRelativeLinks(TestUtils testUtils, TestReference testReference, TestConfiguration testConfiguration)
         throws Exception
     {
-        testUtils.createPage(testReference, "[[Alice]]\n[[Bob]]\n[[Eve]]", "Test relative links");
+        testUtils.rest().savePage(testReference, "[[Alice]]\n[[Bob]]\n[[Eve]]", "Test relative links");
         SpaceReference rootSpaceReference = testReference.getLastSpaceReference();
         SpaceReference aliceSpace = new SpaceReference("Alice", rootSpaceReference);
-        testUtils.createPage(new DocumentReference("WebHome", aliceSpace), "Alice page",
-            "Alice");
+        testUtils.rest().savePage(new DocumentReference("WebHome", aliceSpace), "Alice page", "Alice");
         SpaceReference bobSpace = new SpaceReference("Bob", rootSpaceReference);
-        testUtils.createPage(new DocumentReference("WebHome", bobSpace), "[[Alice]]",
-            "Alice");
+        testUtils.rest().savePage(new DocumentReference("WebHome", bobSpace), "[[Alice]]", "Bob");
 
         // Wait for an empty queue here to ensure that the deleted page has been removed from the index and links
         // won't be updated just because the page is still in the index.
@@ -707,10 +707,10 @@ class RenamePageIT
         statusPage = rename.clickRenameButton().waitUntilFinished();
         assertEquals("Done.", statusPage.getInfoMessage());
 
-        SpaceReference Alice2Space = new SpaceReference("Alice2", newRootSpace);
-        DocumentReference Alice2Reference = new DocumentReference("WebHome", Alice2Space);
+        SpaceReference alice2Space = new SpaceReference("Alice2", newRootSpace);
+        DocumentReference alice2Reference = new DocumentReference("WebHome", alice2Space);
         wikiEditPage = WikiEditPage.gotoPage(new DocumentReference("WebHome", newRootSpace));
-        String serializedAlice2Reference = testUtils.serializeLocalReference(Alice2Reference);
+        String serializedAlice2Reference = testUtils.serializeLocalReference(alice2Reference);
         assertEquals(String.format("[[%s]]%n[[Bob]]%n[[Eve]]", serializedAlice2Reference), wikiEditPage.getContent());
 
         // FIXME: ideally this one should be refactored too, however it's not a regression.

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/RenamePageIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/RenamePageIT.java
@@ -668,4 +668,24 @@ class RenamePageIT
             setup.rest().delete(otherReference);
         }
     }
+
+    @Order(9)
+    @Test
+    void renameWithRelativeLinks(TestUtils testUtils, TestReference testReference)
+    {
+        testUtils.createPage(testReference, "[[Alice]]\n[[Bob]]\n[[Eve]]", "Test relative links");
+        testUtils.createPage(new DocumentReference("Alice", testReference.getLastSpaceReference()), "Alice page",
+            "Alice");
+        testUtils.createPage(new DocumentReference("Bob", testReference.getLastSpaceReference()), "[[Alice]]",
+            "Alice");
+
+        ViewPage viewPage = testUtils.gotoPage(testReference);
+        RenamePage rename = viewPage.rename();
+        rename.getDocumentPicker().setName("Foo");
+        CopyOrRenameOrDeleteStatusPage statusPage = rename.clickRenameButton().waitUntilFinished();
+        assertEquals("Done.", statusPage.getInfoMessage());
+
+        WikiEditPage wikiEditPage = statusPage.gotoNewPage().editWiki();
+        assertEquals("[[Alice]]\n[[Bob]]\n[[Eve]]", wikiEditPage.getContent());
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/RenamePageIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/RenamePageIT.java
@@ -711,7 +711,7 @@ class RenamePageIT
         DocumentReference Alice2Reference = new DocumentReference("WebHome", Alice2Space);
         wikiEditPage = WikiEditPage.gotoPage(new DocumentReference("WebHome", newRootSpace));
         String serializedAlice2Reference = testUtils.serializeLocalReference(Alice2Reference);
-        assertEquals(String.format("[[%s]]\n[[Bob]]\n[[Eve]]", serializedAlice2Reference), wikiEditPage.getContent());
+        assertEquals(String.format("[[%s]]%n[[Bob]]%n[[Eve]]", serializedAlice2Reference), wikiEditPage.getContent());
 
         // FIXME: ideally this one should be refactored too, however it's not a regression.
         //wikiEditPage = WikiEditPage.gotoPage(new DocumentReference("WebHome", newBobSpace));

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/RenamePageIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/RenamePageIT.java
@@ -698,5 +698,23 @@ class RenamePageIT
         SpaceReference newBobSpace = new SpaceReference("Bob", newRootSpace);
         wikiEditPage = WikiEditPage.gotoPage(new DocumentReference("WebHome", newBobSpace));
         assertEquals("[[Alice]]", wikiEditPage.getContent());
+
+        SpaceReference newAliceSpace = new SpaceReference("Alice", newRootSpace);
+        DocumentReference newAliceReference = new DocumentReference("WebHome", newAliceSpace);
+        viewPage = testUtils.gotoPage(newAliceReference);
+        rename = viewPage.rename();
+        rename.getDocumentPicker().setName("Alice2");
+        statusPage = rename.clickRenameButton().waitUntilFinished();
+        assertEquals("Done.", statusPage.getInfoMessage());
+
+        SpaceReference Alice2Space = new SpaceReference("Alice2", newRootSpace);
+        DocumentReference Alice2Reference = new DocumentReference("WebHome", Alice2Space);
+        wikiEditPage = WikiEditPage.gotoPage(new DocumentReference("WebHome", newRootSpace));
+        String serializedAlice2Reference = testUtils.serializeLocalReference(Alice2Reference);
+        assertEquals(String.format("[[%s]]\n[[Bob]]\n[[Eve]]", serializedAlice2Reference), wikiEditPage.getContent());
+
+        // FIXME: ideally this one should be refactored too, however it's not a regression.
+        //wikiEditPage = WikiEditPage.gotoPage(new DocumentReference("WebHome", newBobSpace));
+        //assertEquals(String.format("[[%s]]", serializedAlice2Reference), wikiEditPage.getContent());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
@@ -4974,7 +4974,8 @@ public class XWiki implements EventListener
         JobContext jobContext = Utils.getComponent(JobContext.class);
         Job currentJob = jobContext.getCurrentJob();
 
-        Set<DocumentReference> updatedReferences = Set.of();
+        Map<EntityReference, EntityReference> updatedReferences =
+            Map.of(sourceDoc.getDocumentReference(), newDocumentReference);
         if (currentJob instanceof AbstractCopyOrMoveJob) {
             updatedReferences = ((AbstractCopyOrMoveJob) currentJob).getSelectedEntities();
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/render/DefaultOldRendering.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/render/DefaultOldRendering.java
@@ -20,6 +20,7 @@
 package com.xpn.xwiki.internal.render;
 
 import java.io.StringWriter;
+import java.util.Map;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -117,7 +118,8 @@ public class DefaultOldRendering implements OldRendering
         DocumentReference newDocumentReference, XWikiContext context) throws XWikiException
     {
         this.referenceRenamer.renameReferences(document.getXDOM(), document.getDocumentReference(),
-            oldDocumentReference, newDocumentReference, false, Set.of());
+            oldDocumentReference, newDocumentReference, false,
+            Map.of(oldDocumentReference, newDocumentReference));
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/render/DefaultOldRendering.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/render/DefaultOldRendering.java
@@ -117,7 +117,7 @@ public class DefaultOldRendering implements OldRendering
         DocumentReference newDocumentReference, XWikiContext context) throws XWikiException
     {
         this.referenceRenamer.renameReferences(document.getXDOM(), document.getDocumentReference(),
-            oldDocumentReference, newDocumentReference, false);
+            oldDocumentReference, newDocumentReference, false, Set.of());
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/XWikiTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/XWikiTest.java
@@ -29,7 +29,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 
 import javax.inject.Provider;
 import javax.servlet.http.Cookie;
@@ -1094,13 +1093,14 @@ class XWikiTest
             new DocumentReference(targetReference, Locale.GERMAN), xWikiContext);
 
         // Test links
-        verify(this.referenceUpdater).update(targetReference, sourceReference, targetReference, Set.of());
+        verify(this.referenceUpdater).update(targetReference, sourceReference, targetReference,
+            Map.of(sourceReference, targetReference));
         verify(this.referenceRenamer).renameReferences(doc1.getXDOM(), reference1, sourceReference,
-            targetReference, false, Set.of());
+            targetReference, false, Map.of(sourceReference, targetReference));
         verify(this.referenceRenamer).renameReferences(doc2.getXDOM(), reference2, sourceReference,
-            targetReference, false, Set.of());
+            targetReference, false, Map.of(sourceReference, targetReference));
         verify(this.referenceRenamer).renameReferences(doc3.getXDOM(), reference3, sourceReference,
-            targetReference, false, Set.of());
+            targetReference, false, Map.of(sourceReference, targetReference));
 
         assertTrue(this.xwiki
             .getDocument(new DocumentReference(DOCWIKI, DOCSPACE, DOCNAME), this.oldcore.getXWikiContext()).isNew());

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/XWikiTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/XWikiTest.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import javax.inject.Provider;
 import javax.servlet.http.Cookie;
@@ -1095,11 +1096,11 @@ class XWikiTest
         // Test links
         verify(this.referenceUpdater).update(targetReference, sourceReference, targetReference);
         verify(this.referenceRenamer).renameReferences(doc1.getXDOM(), reference1, sourceReference,
-            targetReference, false);
+            targetReference, false, Set.of());
         verify(this.referenceRenamer).renameReferences(doc2.getXDOM(), reference2, sourceReference,
-            targetReference, false);
+            targetReference, false, Set.of());
         verify(this.referenceRenamer).renameReferences(doc3.getXDOM(), reference3, sourceReference,
-            targetReference, false);
+            targetReference, false, Set.of());
 
         assertTrue(this.xwiki
             .getDocument(new DocumentReference(DOCWIKI, DOCSPACE, DOCNAME), this.oldcore.getXWikiContext()).isNew());

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/XWikiTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/XWikiTest.java
@@ -1094,7 +1094,7 @@ class XWikiTest
             new DocumentReference(targetReference, Locale.GERMAN), xWikiContext);
 
         // Test links
-        verify(this.referenceUpdater).update(targetReference, sourceReference, targetReference);
+        verify(this.referenceUpdater).update(targetReference, sourceReference, targetReference, Set.of());
         verify(this.referenceRenamer).renameReferences(doc1.getXDOM(), reference1, sourceReference,
             targetReference, false, Set.of());
         verify(this.referenceRenamer).renameReferences(doc2.getXDOM(), reference2, sourceReference,

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/checkstyle/checkstyle-suppressions.xml
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/checkstyle/checkstyle-suppressions.xml
@@ -25,5 +25,6 @@
     "http://www.puppycrawl.com/dtds/suppressions_1_0.dtd">
 
 <suppressions>
+  <!-- Fan out of 22 on a max of 20 -->
   <suppress checks="ClassFanOutComplexity" files="DefaultDocumentSplitter.java"/>
 </suppressions>

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/ReferenceRenamer.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/ReferenceRenamer.java
@@ -25,6 +25,7 @@ import org.xwiki.component.annotation.Role;
 import org.xwiki.model.reference.AttachmentReference;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.rendering.block.Block;
+import org.xwiki.stability.Unstable;
 
 /**
  * Allow to replace references during rename/move refactoring operations.
@@ -46,7 +47,28 @@ public interface ReferenceRenamer
      * @return {@code true} if the given {@link Block} was modified
      */
     boolean renameReferences(Block block, DocumentReference currentDocumentReference, DocumentReference oldTarget,
-        DocumentReference newTarget, boolean relative, Set<DocumentReference> updatedDocuments);
+        DocumentReference newTarget, boolean relative);
+
+    /**
+     * Change references of the given block so that the references pointing to the old target points to the new target.
+     *
+     * @param block the {@link Block} to modify
+     * @param currentDocumentReference the current document reference
+     * @param oldTarget the previous reference of the renamed entity (attachment or document)
+     * @param newTarget the new reference of the renamed entity (attachment or document)
+     * @param relative {@code true} if the link should be serialized relatively to the current document
+     * @param updatedDocuments the list of documents that have been renamed in the same job: this list contains the
+     *                          old references before the rename
+     * @return {@code true} if the given {@link Block} was modified
+     * @since 16.10.0RC1
+     */
+    @Unstable
+    default boolean renameReferences(Block block, DocumentReference currentDocumentReference,
+        DocumentReference oldTarget,
+        DocumentReference newTarget, boolean relative, Set<DocumentReference> updatedDocuments)
+    {
+        return renameReferences(block, currentDocumentReference, oldTarget, newTarget, relative);
+    }
 
     /**
      * Change references of the given block so that the references pointing to the old target points to the new target.
@@ -60,10 +82,30 @@ public interface ReferenceRenamer
      * @since 14.2RC1
      */
     default boolean renameReferences(Block block, DocumentReference currentDocumentReference,
+        AttachmentReference oldTarget, AttachmentReference newTarget, boolean relative)
+    {
+        return false;
+    }
+
+    /**
+     * Change references of the given block so that the references pointing to the old target points to the new target.
+     *
+     * @param block the {@link Block} to modify
+     * @param currentDocumentReference the current document reference
+     * @param oldTarget the previous reference of the renamed entity (attachment or document)
+     * @param newTarget the new reference of the renamed entity (attachment or document)
+     * @param relative {@code true} if the link should be serialized relatively to the current document
+     * @param updatedDocuments the list of documents that have been renamed in the same job: this list contains the
+     *     old references before the rename
+     * @return {@code true} if the given {@link Block} was modified
+     * @since 16.10.0RC1
+     */
+    @Unstable
+    default boolean renameReferences(Block block, DocumentReference currentDocumentReference,
         AttachmentReference oldTarget, AttachmentReference newTarget, boolean relative,
         Set<DocumentReference> updatedDocuments)
     {
-        return false;
+        return renameReferences(block, currentDocumentReference, oldTarget, newTarget, relative);
     }
 
 }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/ReferenceRenamer.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/ReferenceRenamer.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.refactoring;
 
+import java.util.Set;
+
 import org.xwiki.component.annotation.Role;
 import org.xwiki.model.reference.AttachmentReference;
 import org.xwiki.model.reference.DocumentReference;
@@ -44,7 +46,7 @@ public interface ReferenceRenamer
      * @return {@code true} if the given {@link Block} was modified
      */
     boolean renameReferences(Block block, DocumentReference currentDocumentReference, DocumentReference oldTarget,
-        DocumentReference newTarget, boolean relative);
+        DocumentReference newTarget, boolean relative, Set<DocumentReference> updatedDocuments);
 
     /**
      * Change references of the given block so that the references pointing to the old target points to the new target.
@@ -58,7 +60,8 @@ public interface ReferenceRenamer
      * @since 14.2RC1
      */
     default boolean renameReferences(Block block, DocumentReference currentDocumentReference,
-        AttachmentReference oldTarget, AttachmentReference newTarget, boolean relative)
+        AttachmentReference oldTarget, AttachmentReference newTarget, boolean relative,
+        Set<DocumentReference> updatedDocuments)
     {
         return false;
     }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/ReferenceRenamer.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/ReferenceRenamer.java
@@ -19,11 +19,12 @@
  */
 package org.xwiki.refactoring;
 
-import java.util.Set;
+import java.util.Map;
 
 import org.xwiki.component.annotation.Role;
 import org.xwiki.model.reference.AttachmentReference;
 import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.EntityReference;
 import org.xwiki.rendering.block.Block;
 import org.xwiki.stability.Unstable;
 
@@ -57,15 +58,15 @@ public interface ReferenceRenamer
      * @param oldTarget the previous reference of the renamed entity (attachment or document)
      * @param newTarget the new reference of the renamed entity (attachment or document)
      * @param relative {@code true} if the link should be serialized relatively to the current document
-     * @param updatedDocuments the list of documents that have been renamed in the same job: this list contains the
-     *                          old references before the rename
+     * @param updatedEntities the map of entities that are or are going to be updated: the map contains the source
+     *      and target destination.
      * @return {@code true} if the given {@link Block} was modified
      * @since 16.10.0RC1
      */
     @Unstable
     default boolean renameReferences(Block block, DocumentReference currentDocumentReference,
-        DocumentReference oldTarget,
-        DocumentReference newTarget, boolean relative, Set<DocumentReference> updatedDocuments)
+        DocumentReference oldTarget, DocumentReference newTarget, boolean relative,
+        Map<EntityReference, EntityReference> updatedEntities)
     {
         return renameReferences(block, currentDocumentReference, oldTarget, newTarget, relative);
     }
@@ -95,15 +96,15 @@ public interface ReferenceRenamer
      * @param oldTarget the previous reference of the renamed entity (attachment or document)
      * @param newTarget the new reference of the renamed entity (attachment or document)
      * @param relative {@code true} if the link should be serialized relatively to the current document
-     * @param updatedDocuments the list of documents that have been renamed in the same job: this list contains the
-     *     old references before the rename
+     * @param updatedEntities the map of entities that are or are going to be updated: the map contains the source
+     *      and target destination.
      * @return {@code true} if the given {@link Block} was modified
      * @since 16.10.0RC1
      */
     @Unstable
     default boolean renameReferences(Block block, DocumentReference currentDocumentReference,
         AttachmentReference oldTarget, AttachmentReference newTarget, boolean relative,
-        Set<DocumentReference> updatedDocuments)
+        Map<EntityReference, EntityReference> updatedEntities)
     {
         return renameReferences(block, currentDocumentReference, oldTarget, newTarget, relative);
     }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/ReferenceUpdater.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/ReferenceUpdater.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.refactoring.internal;
 
+import java.util.Set;
+
 import org.xwiki.component.annotation.Role;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
@@ -36,7 +38,14 @@ public interface ReferenceUpdater
      * @param documentReference the reference of the document in which to update the references
      * @param oldTargetReference the previous reference of the renamed entity
      * @param newTargetReference the new reference of the renamed entity
+     * @param updatedEntities the set of entities that might have been updated.
      */
+    default void update(DocumentReference documentReference, EntityReference oldTargetReference,
+        EntityReference newTargetReference, Set<DocumentReference> updatedEntities)
+    {
+        update(documentReference, oldTargetReference, newTargetReference);
+    }
+
     void update(DocumentReference documentReference, EntityReference oldTargetReference,
         EntityReference newTargetReference);
 }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/ReferenceUpdater.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/ReferenceUpdater.java
@@ -39,6 +39,7 @@ public interface ReferenceUpdater
      * @param oldTargetReference the previous reference of the renamed entity
      * @param newTargetReference the new reference of the renamed entity
      * @param updatedEntities the set of entities that might have been updated.
+     * @since 16.10.0RC1
      */
     default void update(DocumentReference documentReference, EntityReference oldTargetReference,
         EntityReference newTargetReference, Set<DocumentReference> updatedEntities)
@@ -46,6 +47,11 @@ public interface ReferenceUpdater
         update(documentReference, oldTargetReference, newTargetReference);
     }
 
+    /**
+     * @param documentReference the reference of the document in which to update the references
+     * @param oldTargetReference the previous reference of the renamed entity
+     * @param newTargetReference the new reference of the renamed entity
+     */
     void update(DocumentReference documentReference, EntityReference oldTargetReference,
         EntityReference newTargetReference);
 }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/ReferenceUpdater.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/ReferenceUpdater.java
@@ -19,7 +19,7 @@
  */
 package org.xwiki.refactoring.internal;
 
-import java.util.Set;
+import java.util.Map;
 
 import org.xwiki.component.annotation.Role;
 import org.xwiki.model.reference.DocumentReference;
@@ -38,11 +38,12 @@ public interface ReferenceUpdater
      * @param documentReference the reference of the document in which to update the references
      * @param oldTargetReference the previous reference of the renamed entity
      * @param newTargetReference the new reference of the renamed entity
-     * @param updatedEntities the set of entities that might have been updated.
+     * @param updatedEntities the map of entities that are or are going to be updated: the map contains the source
+     * and target destination.
      * @since 16.10.0RC1
      */
     default void update(DocumentReference documentReference, EntityReference oldTargetReference,
-        EntityReference newTargetReference, Set<DocumentReference> updatedEntities)
+        EntityReference newTargetReference, Map<EntityReference, EntityReference> updatedEntities)
     {
         update(documentReference, oldTargetReference, newTargetReference);
     }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/AbstractCopyOrMoveJob.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/AbstractCopyOrMoveJob.java
@@ -60,9 +60,9 @@ public abstract class AbstractCopyOrMoveJob<T extends AbstractCopyOrMoveRequest>
 
         try {
             this.progressManager.startStep(this);
-            BeginFoldEvent beginEvent = getBeginEvent();
+            BeginFoldEvent beginEvent = createBeginEvent();
             this.observationManager.notify(beginEvent, this, this.getRequest());
-            if (((CancelableEvent) beginEvent).isCanceled()) {
+            if (beginEvent instanceof CancelableEvent && ((CancelableEvent) beginEvent).isCanceled()) {
                 return;
             }
             this.progressManager.endStep(this);
@@ -74,7 +74,7 @@ public abstract class AbstractCopyOrMoveJob<T extends AbstractCopyOrMoveRequest>
             this.progressManager.endStep(this);
 
             this.progressManager.startStep(this);
-            EndFoldEvent endEvent = getEndEvent();
+            EndFoldEvent endEvent = createEndEvent();
             this.observationManager.notify(endEvent, this, this.getRequest());
             this.progressManager.endStep(this);
         } finally {
@@ -337,7 +337,6 @@ public abstract class AbstractCopyOrMoveJob<T extends AbstractCopyOrMoveRequest>
      * @return {@code true} if the operation worked well.
      */
     protected abstract boolean atomicOperation(DocumentReference source, DocumentReference target);
-    protected abstract <B extends BeginFoldEvent & CancelableEvent> B getBeginEvent();
-
-    protected abstract EndFoldEvent getEndEvent();
+    protected abstract BeginFoldEvent createBeginEvent();
+    protected abstract EndFoldEvent createEndEvent();
 }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/AbstractCopyOrMoveJob.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/AbstractCopyOrMoveJob.java
@@ -21,6 +21,9 @@ package org.xwiki.refactoring.internal.job;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
 
 import org.xwiki.model.EntityType;
 import org.xwiki.model.reference.DocumentReference;
@@ -100,26 +103,14 @@ public abstract class AbstractCopyOrMoveJob<T extends AbstractCopyOrMoveRequest>
 
         EntityReference destination = this.request.getDestination();
 
-        if (processOnlySameSourceDestinationTypes()) {
-            if (source.getType() != destination.getType()) {
-                this.logger.error("You cannot change the entity type (from [{}] to [{}]).", source.getType(),
-                    destination.getType());
-                return;
-            }
-        }
-
-        if (isDescendantOrSelf(destination, source)) {
-            this.logger.error("Cannot make [{}] a descendant of itself.", source);
-            return;
-        }
-
-        if (source.getParent() != null && source.getParent().equals(destination)) {
-            this.logger.error("Cannot move [{}] into [{}], it's already there.", source, destination);
+        try {
+            checkSourceDestination(source, destination);
+        } catch (InternalCopyOrMoveJobException e) {
+            this.logger.error(e.getMessage());
             return;
         }
 
         // Dispatch the move operation based on the source entity type.
-
         switch (source.getType()) {
             case DOCUMENT:
                 try {
@@ -129,10 +120,31 @@ public abstract class AbstractCopyOrMoveJob<T extends AbstractCopyOrMoveRequest>
                 }
                 break;
             case SPACE:
-                process(new SpaceReference(source), destination);
+                visitSpace(new SpaceReference(source), destination, this::maybePerformRefactoring);
                 break;
             default:
                 this.logger.error("Unsupported source entity type [{}].", source.getType());
+        }
+    }
+
+    private void checkSourceDestination(EntityReference source, EntityReference destination)
+        throws InternalCopyOrMoveJobException
+    {
+        if (processOnlySameSourceDestinationTypes() && source.getType() != destination.getType()) {
+            throw new InternalCopyOrMoveJobException(
+                String.format("You cannot change the entity type (from [%s] to [%s]).",
+                    source.getType(),
+                    destination.getType()));
+        }
+
+        if (isDescendantOrSelf(destination, source)) {
+            throw new InternalCopyOrMoveJobException(
+                String.format("Cannot make [%s] a descendant of itself.", source));
+        }
+
+        if (source.getParent() != null && source.getParent().equals(destination)) {
+            throw new InternalCopyOrMoveJobException(
+                String.format("Cannot move [%s] into [%s], it's already there.", source, destination));
         }
     }
 
@@ -145,6 +157,71 @@ public abstract class AbstractCopyOrMoveJob<T extends AbstractCopyOrMoveRequest>
         return parent != null;
     }
 
+    @Override
+    protected void getEntities(DocumentReference documentReference)
+    {
+        this.putInConcernedEntities(documentReference);
+    }
+
+    @Override
+    protected void putInConcernedEntities(DocumentReference documentReference)
+    {
+        DocumentReference source = cleanLocale(documentReference);
+        try {
+            EntityReference destination = this.request.getDestination();
+            checkSourceDestination(source, destination);
+            DocumentReference destinationDocumentReference;
+            if (processOnlySameSourceDestinationTypes()) {
+                putInConcernedEntitiesOnlySameSource(source, destination);
+            } else {
+                if (this.request.isDeep() && isSpaceHomeReference(source)) {
+                    visitSpace(source.getLastSpaceReference(), destination, this::putInConcernedEntities);
+                } else if (destination.getType() == EntityType.SPACE) {
+                    destinationDocumentReference =
+                        new DocumentReference(source.getName(), new SpaceReference(destination));
+                    this.putInConcernedEntities(source, destinationDocumentReference);
+                } else if (destination.getType() == EntityType.DOCUMENT
+                    && isSpaceHomeReference(new DocumentReference(destination))) {
+                    destinationDocumentReference =
+                        new DocumentReference(source.getName(), new SpaceReference(destination.getParent()));
+                    this.putInConcernedEntities(source, destinationDocumentReference);
+                } else if (destination.getType() == EntityType.WIKI) {
+                    visitSpace(source.getLastSpaceReference(), destination, this::putInConcernedEntities);
+                }
+            }
+        } catch (InternalCopyOrMoveJobException e) {
+            this.logger.debug(e.getMessage());
+        }
+    }
+
+    private void putInConcernedEntitiesOnlySameSource(DocumentReference source, EntityReference destination)
+    {
+        DocumentReference destinationDocumentReference = new DocumentReference(destination);
+        if (this.request.isDeep() && isSpaceHomeReference(source)) {
+            if (isSpaceHomeReference(destinationDocumentReference)) {
+                visitSpace(source.getLastSpaceReference(), destinationDocumentReference.getLastSpaceReference(),
+                    this::putInConcernedEntities);
+            }
+        } else {
+            this.putInConcernedEntities(source, destinationDocumentReference);
+        }
+    }
+
+    private void putInConcernedEntities(DocumentReference sourceDocument, DocumentReference destination)
+    {
+        try {
+            if (!this.modelBridge.exists(sourceDocument)) {
+                this.logger.warn("Skipping [{}] because it doesn't exist.", sourceDocument);
+            } else if (this.checkAllRights(sourceDocument, destination)) {
+                this.concernedEntities.put(sourceDocument, new EntitySelection(sourceDocument, destination));
+            }
+        } catch (Exception e) {
+            logger.error("Failed to perform the refactoring from document with reference [{}] to [{}]",
+                sourceDocument, destination, e);
+        }
+    }
+
+    // FIXME: this should be factorized with the code from getTargetReference
     protected void process(DocumentReference source, EntityReference destination) throws Exception
     {
         if (processOnlySameSourceDestinationTypes()) {
@@ -153,7 +230,7 @@ public abstract class AbstractCopyOrMoveJob<T extends AbstractCopyOrMoveRequest>
             this.process(source, destinationDocumentReference);
         } else {
             if (this.request.isDeep() && isSpaceHomeReference(source)) {
-                process(source.getLastSpaceReference(), destination);
+                visitSpace(source.getLastSpaceReference(), destination, this::maybePerformRefactoring);
             } else if (destination.getType() == EntityType.SPACE) {
                 maybePerformRefactoring(source,
                     new DocumentReference(source.getName(), new SpaceReference(destination)));
@@ -182,39 +259,35 @@ public abstract class AbstractCopyOrMoveJob<T extends AbstractCopyOrMoveRequest>
         }
     }
 
-    protected void process(SpaceReference source, EntityReference destination)
+    private void visitSpace(final SpaceReference source, final EntityReference destination,
+        BiConsumer<DocumentReference, DocumentReference> callback)
     {
+        SpaceReference spaceDestination;
         if (processOnlySameSourceDestinationTypes()) {
             // We know the destination is a space (see above).
-            process(source, new SpaceReference(destination));
+            spaceDestination = new SpaceReference(destination);
         } else {
             if (destination.getType() == EntityType.SPACE || destination.getType() == EntityType.WIKI) {
-                process(source, new SpaceReference(source.getName(), destination));
+                spaceDestination = new SpaceReference(source.getName(), destination);
             } else if (destination.getType() == EntityType.DOCUMENT
                 && isSpaceHomeReference(new DocumentReference(destination))) {
-                process(source, new SpaceReference(source.getName(), destination.getParent()));
+                spaceDestination = new SpaceReference(source.getName(), destination.getParent());
             } else {
+                spaceDestination = null;
                 this.logger.error("Unsupported destination entity type [{}] for a space.", destination.getType());
             }
+        }
+        if (spaceDestination != null) {
+            visitDocuments(source, oldChildReference -> {
+                DocumentReference newChildReference = oldChildReference.replaceParent(source, spaceDestination);
+                callback.accept(oldChildReference, newChildReference);
+            });
         }
     }
 
     protected void process(final SpaceReference source, final SpaceReference destination)
     {
-        visitDocuments(source, new Visitor<DocumentReference>()
-        {
-            @Override
-            public void visit(DocumentReference oldChildReference)
-            {
-                DocumentReference newChildReference = oldChildReference.replaceParent(source, destination);
-                try {
-                    maybePerformRefactoring(oldChildReference, newChildReference);
-                } catch (Exception e) {
-                    logger.error("Failed to perform the refactoring from document with reference [{}] to [{}]",
-                        oldChildReference, newChildReference, e);
-                }
-            }
-        });
+        visitSpace(source, destination, this::maybePerformRefactoring);
     }
 
     protected boolean checkAllRights(DocumentReference oldReference, DocumentReference newReference) throws Exception
@@ -232,18 +305,14 @@ public abstract class AbstractCopyOrMoveJob<T extends AbstractCopyOrMoveRequest>
     }
 
     protected void maybePerformRefactoring(DocumentReference oldReference, DocumentReference newReference)
-        throws Exception
     {
         // Perform checks that are specific to the document source/destination type.
-
         EntitySelection entitySelection = this.getConcernedEntitiesEntitySelection(oldReference);
         if (entitySelection == null) {
             this.logger.info("Skipping [{}] because it does not match any entity selection.", oldReference);
         } else if (!entitySelection.isSelected()) {
             this.logger.info("Skipping [{}] because it has been unselected.", oldReference);
-        } else if (!this.modelBridge.exists(oldReference)) {
-            this.logger.warn("Skipping [{}] because it doesn't exist.", oldReference);
-        } else if (this.checkAllRights(oldReference, newReference)) {
+        } else {
             performRefactoring(oldReference, newReference);
         }
     }
@@ -328,6 +397,19 @@ public abstract class AbstractCopyOrMoveJob<T extends AbstractCopyOrMoveRequest>
         List<EntityReference> entityReferences = new LinkedList<>(this.request.getEntityReferences());
         entityReferences.add(this.request.getDestination());
         return getCommonParent(entityReferences);
+    }
+
+    /**
+     * @return the list of references that have been selected to be refactored.
+     * @since 16.10.0RC1
+     */
+    public Map<EntityReference, EntityReference> getSelectedEntities()
+    {
+        return this.concernedEntities.values().stream()
+            .filter(EntitySelection::isSelected)
+            .filter(entity -> entity.getTargetEntityReference().isPresent())
+            .collect(Collectors.toMap(EntitySelection::getEntityReference,
+                entity -> entity.getTargetEntityReference().get()));
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/AbstractEntityJobWithChecks.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/AbstractEntityJobWithChecks.java
@@ -21,7 +21,6 @@ package org.xwiki.refactoring.internal.job;
 
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -169,6 +168,10 @@ public abstract class AbstractEntityJobWithChecks<R extends EntityRequest, S ext
         return entitySelection;
     }
 
+    /**
+     * @return the list of references that have been selected to be refactored.
+     * @since 16.10.0RC1
+     */
     public Set<EntityReference> getSelectedEntities()
     {
         return this.concernedEntities.values().stream()

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/AbstractEntityJobWithChecks.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/AbstractEntityJobWithChecks.java
@@ -21,8 +21,11 @@ package org.xwiki.refactoring.internal.job;
 
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.xwiki.bridge.event.DocumentsDeletingEvent;
 import org.xwiki.model.reference.DocumentReference;
@@ -164,5 +167,13 @@ public abstract class AbstractEntityJobWithChecks<R extends EntityRequest, S ext
             }
         }
         return entitySelection;
+    }
+
+    public Set<EntityReference> getSelectedEntities()
+    {
+        return this.concernedEntities.values().stream()
+            .filter(EntitySelection::isSelected)
+            .map(EntitySelection::getEntityReference)
+            .collect(Collectors.toSet());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/AbstractEntityJobWithChecks.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/AbstractEntityJobWithChecks.java
@@ -23,8 +23,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.xwiki.bridge.event.DocumentsDeletingEvent;
 import org.xwiki.model.reference.DocumentReference;
@@ -49,7 +47,7 @@ public abstract class AbstractEntityJobWithChecks<R extends EntityRequest, S ext
      * Map that will contain all entities that are concerned by the refactoring.
      * Note that the EntityReference key locale is automatically set to null if it's the Locale.ROOT.
      */
-    private final Map<EntityReference, EntitySelection> concernedEntities = new HashMap<>();
+    protected final Map<EntityReference, EntitySelection> concernedEntities = new HashMap<>();
 
     @Override
     protected void runInternal() throws Exception
@@ -106,7 +104,7 @@ public abstract class AbstractEntityJobWithChecks<R extends EntityRequest, S ext
         }
     }
 
-    private DocumentReference cleanLocale(DocumentReference documentReference)
+    protected DocumentReference cleanLocale(DocumentReference documentReference)
     {
         // We don't want to have locale information for root locale in the reference to not have problems with
         // the questions.
@@ -123,13 +121,13 @@ public abstract class AbstractEntityJobWithChecks<R extends EntityRequest, S ext
         }
     }
 
-    private void putInConcernedEntities(DocumentReference documentReference)
+    protected void putInConcernedEntities(DocumentReference documentReference)
     {
         DocumentReference cleanDocumentReference = cleanLocale(documentReference);
         this.concernedEntities.put(cleanDocumentReference, new EntitySelection(cleanDocumentReference));
     }
 
-    private void getEntities(DocumentReference documentReference)
+    protected void getEntities(DocumentReference documentReference)
     {
         if (this.request.isDeep() && isSpaceHomeReference(documentReference)) {
             getEntities(documentReference.getLastSpaceReference());
@@ -138,7 +136,7 @@ public abstract class AbstractEntityJobWithChecks<R extends EntityRequest, S ext
         }
     }
 
-    private void getEntities(SpaceReference spaceReference)
+    protected void getEntities(SpaceReference spaceReference)
     {
         visitDocuments(spaceReference, this::putInConcernedEntities);
     }
@@ -166,17 +164,5 @@ public abstract class AbstractEntityJobWithChecks<R extends EntityRequest, S ext
             }
         }
         return entitySelection;
-    }
-
-    /**
-     * @return the list of references that have been selected to be refactored.
-     * @since 16.10.0RC1
-     */
-    public Set<EntityReference> getSelectedEntities()
-    {
-        return this.concernedEntities.values().stream()
-            .filter(EntitySelection::isSelected)
-            .map(EntitySelection::getEntityReference)
-            .collect(Collectors.toSet());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/CopyJob.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/CopyJob.java
@@ -23,6 +23,9 @@ import javax.inject.Named;
 
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.observation.event.BeginFoldEvent;
+import org.xwiki.observation.event.CancelableEvent;
+import org.xwiki.observation.event.EndFoldEvent;
 import org.xwiki.refactoring.event.DocumentCopiedEvent;
 import org.xwiki.refactoring.event.DocumentCopyingEvent;
 import org.xwiki.refactoring.event.EntitiesCopiedEvent;
@@ -47,33 +50,6 @@ public class CopyJob extends AbstractCopyOrMoveJob<CopyRequest>
     }
 
     @Override
-    protected void runInternal() throws Exception
-    {
-        this.progressManager.pushLevelProgress(3, this);
-
-        try {
-            this.progressManager.startStep(this);
-            EntitiesCopyingEvent entitiesCopyingEvent = new EntitiesCopyingEvent();
-            this.observationManager.notify(entitiesCopyingEvent, this, this.getRequest());
-            if (entitiesCopyingEvent.isCanceled()) {
-                return;
-            }
-            this.progressManager.endStep(this);
-
-            this.progressManager.startStep(this);
-            super.runInternal();
-            this.progressManager.endStep(this);
-
-            this.progressManager.startStep(this);
-            EntitiesCopiedEvent entitiesCopiedEvent = new EntitiesCopiedEvent();
-            this.observationManager.notify(entitiesCopiedEvent, this, this.getRequest());
-            this.progressManager.endStep(this);
-        } finally {
-            this.progressManager.popLevelProgress(this);
-        }
-    }
-
-    @Override
     protected void performRefactoring(DocumentReference sourceReference, DocumentReference targetReference)
     {
         DocumentCopyingEvent documentCopyingEvent = new DocumentCopyingEvent(sourceReference, targetReference);
@@ -89,5 +65,17 @@ public class CopyJob extends AbstractCopyOrMoveJob<CopyRequest>
     protected boolean atomicOperation(DocumentReference source, DocumentReference target)
     {
         return this.modelBridge.copy(source, target);
+    }
+
+    @Override
+    protected <T extends BeginFoldEvent & CancelableEvent> T getBeginEvent()
+    {
+        return (T) new EntitiesCopyingEvent();
+    }
+
+    @Override
+    protected EndFoldEvent getEndEvent()
+    {
+        return new EntitiesCopiedEvent();
     }
 }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/CopyJob.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/CopyJob.java
@@ -24,7 +24,6 @@ import javax.inject.Named;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.observation.event.BeginFoldEvent;
-import org.xwiki.observation.event.CancelableEvent;
 import org.xwiki.observation.event.EndFoldEvent;
 import org.xwiki.refactoring.event.DocumentCopiedEvent;
 import org.xwiki.refactoring.event.DocumentCopyingEvent;
@@ -68,13 +67,13 @@ public class CopyJob extends AbstractCopyOrMoveJob<CopyRequest>
     }
 
     @Override
-    protected <T extends BeginFoldEvent & CancelableEvent> T getBeginEvent()
+    protected BeginFoldEvent createBeginEvent()
     {
-        return (T) new EntitiesCopyingEvent();
+        return new EntitiesCopyingEvent();
     }
 
     @Override
-    protected EndFoldEvent getEndEvent()
+    protected EndFoldEvent createEndEvent()
     {
         return new EntitiesCopiedEvent();
     }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/InternalCopyOrMoveJobException.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/InternalCopyOrMoveJobException.java
@@ -19,44 +19,20 @@
  */
 package org.xwiki.refactoring.internal.job;
 
-import java.util.Collection;
-
-import javax.inject.Named;
-
-import org.xwiki.component.annotation.Component;
-import org.xwiki.model.reference.EntityReference;
-import org.xwiki.refactoring.job.RefactoringJobs;
-
 /**
- * A job that can rename entities.
- * 
+ * Internal exception to be used in {@link AbstractCopyOrMoveJob}.
+ *
  * @version $Id$
- * @since 7.2M1
+ * @since 16.10.0RC1
  */
-@Component
-@Named(RefactoringJobs.RENAME)
-public class RenameJob extends MoveJob
+public class InternalCopyOrMoveJobException extends Exception
 {
-    @Override
-    public String getType()
+    /**
+     * Default constructor.
+     * @param message the message of the exception.
+     */
+    public InternalCopyOrMoveJobException(String message)
     {
-        return RefactoringJobs.RENAME;
-    }
-
-    @Override
-    protected void process(Collection<EntityReference> entityReferences)
-    {
-        if (entityReferences.size() == 1) {
-            process(entityReferences.iterator().next());
-        } else {
-            this.logger.warn("Cannot rename multiple entities.");
-        }
-    }
-
-    @Override
-    protected boolean processOnlySameSourceDestinationTypes()
-    {
-        // rename always process same destination types
-        return true;
+        super(message);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/MoveJob.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/MoveJob.java
@@ -26,6 +26,9 @@ import javax.inject.Named;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
+import org.xwiki.observation.event.BeginFoldEvent;
+import org.xwiki.observation.event.CancelableEvent;
+import org.xwiki.observation.event.EndFoldEvent;
 import org.xwiki.refactoring.event.DocumentRenamedEvent;
 import org.xwiki.refactoring.event.DocumentRenamingEvent;
 import org.xwiki.refactoring.event.EntitiesRenamedEvent;
@@ -51,30 +54,15 @@ public class MoveJob extends AbstractCopyOrMoveJob<MoveRequest>
     }
 
     @Override
-    protected void runInternal() throws Exception
+    protected <T extends BeginFoldEvent & CancelableEvent> T getBeginEvent()
     {
-        this.progressManager.pushLevelProgress(3, this);
+        return (T) new EntitiesRenamingEvent();
+    }
 
-        try {
-            this.progressManager.startStep(this);
-            EntitiesRenamingEvent entitiesRenamingEvent = new EntitiesRenamingEvent();
-            this.observationManager.notify(entitiesRenamingEvent, this, this.getRequest());
-            if (entitiesRenamingEvent.isCanceled()) {
-                return;
-            }
-            this.progressManager.endStep(this);
-
-            this.progressManager.startStep(this);
-            super.runInternal();
-            this.progressManager.endStep(this);
-
-            this.progressManager.startStep(this);
-            EntitiesRenamedEvent entitiesRenamedEvent = new EntitiesRenamedEvent();
-            this.observationManager.notify(entitiesRenamedEvent, this, this.getRequest());
-            this.progressManager.endStep(this);
-        } finally {
-            this.progressManager.popLevelProgress(this);
-        }
+    @Override
+    protected EndFoldEvent getEndEvent()
+    {
+        return new EntitiesRenamedEvent();
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/MoveJob.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/MoveJob.java
@@ -27,7 +27,6 @@ import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
 import org.xwiki.observation.event.BeginFoldEvent;
-import org.xwiki.observation.event.CancelableEvent;
 import org.xwiki.observation.event.EndFoldEvent;
 import org.xwiki.refactoring.event.DocumentRenamedEvent;
 import org.xwiki.refactoring.event.DocumentRenamingEvent;
@@ -54,13 +53,13 @@ public class MoveJob extends AbstractCopyOrMoveJob<MoveRequest>
     }
 
     @Override
-    protected <T extends BeginFoldEvent & CancelableEvent> T getBeginEvent()
+    protected BeginFoldEvent createBeginEvent()
     {
-        return (T) new EntitiesRenamingEvent();
+        return new EntitiesRenamingEvent();
     }
 
     @Override
-    protected EndFoldEvent getEndEvent()
+    protected EndFoldEvent createEndEvent()
     {
         return new EntitiesRenamedEvent();
     }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/listener/BackLinkUpdaterListener.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/listener/BackLinkUpdaterListener.java
@@ -45,8 +45,6 @@ import org.xwiki.refactoring.internal.job.AbstractEntityJobWithChecks;
 import org.xwiki.refactoring.internal.job.DeleteJob;
 import org.xwiki.refactoring.internal.job.MoveJob;
 import org.xwiki.refactoring.job.DeleteRequest;
-import org.xwiki.refactoring.job.EntityJobStatus;
-import org.xwiki.refactoring.job.EntityRequest;
 import org.xwiki.refactoring.job.MoveRequest;
 import org.xwiki.security.authorization.ContextualAuthorizationManager;
 import org.xwiki.security.authorization.Right;

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/job/question/EntitySelection.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/job/question/EntitySelection.java
@@ -19,9 +19,13 @@
  */
 package org.xwiki.refactoring.job.question;
 
+import java.util.Optional;
+
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.xwiki.model.reference.EntityReference;
+import org.xwiki.stability.Unstable;
 
 /**
  * Represent an entity with an information about either or not the entity is selected to perform some refactoring.
@@ -55,7 +59,8 @@ public class EntitySelection implements Comparable<EntitySelection>
     /**
      * Reference to the entity to select for the refactoring.
      */
-    private EntityReference entityReference;
+    private final EntityReference sourceEntityReference;
+    private final EntityReference targetEntityReference;
 
     /**
      * Indicate if the entity is selected or not by the user.
@@ -68,7 +73,20 @@ public class EntitySelection implements Comparable<EntitySelection>
      */
     public EntitySelection(EntityReference entityReference)
     {
-        this.entityReference = entityReference;
+        this(entityReference, null);
+    }
+
+    /**
+     * Constructor of an EntitySelection when there is a target destination.
+     * @param sourceEntityReference the original reference
+     * @param targetEntityReference the target reference of the refactoring
+     * @since 16.10.0RC1
+     */
+    @Unstable
+    public EntitySelection(EntityReference sourceEntityReference, EntityReference targetEntityReference)
+    {
+        this.sourceEntityReference = sourceEntityReference;
+        this.targetEntityReference = targetEntityReference;
     }
 
     /**
@@ -76,7 +94,17 @@ public class EntitySelection implements Comparable<EntitySelection>
      */
     public EntityReference getEntityReference()
     {
-        return entityReference;
+        return sourceEntityReference;
+    }
+
+    /**
+     * @return the target reference of the refactoring if any.
+     * @since 16.10.0RC1
+     */
+    @Unstable
+    public Optional<EntityReference> getTargetEntityReference()
+    {
+        return (targetEntityReference != null) ? Optional.of(targetEntityReference) : Optional.empty();
     }
 
     /**
@@ -111,7 +139,11 @@ public class EntitySelection implements Comparable<EntitySelection>
     @Override
     public int hashCode()
     {
-        return new HashCodeBuilder(3, 13).append(getEntityReference()).append(isSelected).toHashCode();
+        return new HashCodeBuilder(3, 13)
+            .append(getEntityReference())
+            .append(getTargetEntityReference())
+            .append(isSelected)
+            .toHashCode();
     }
 
     @Override
@@ -127,8 +159,21 @@ public class EntitySelection implements Comparable<EntitySelection>
             return false;
         }
         EntitySelection entitySelection = (EntitySelection) object;
-        return new EqualsBuilder().append(getEntityReference(), entitySelection.getEntityReference())
-            .append(isSelected(), entitySelection.isSelected()).isEquals();
+        return new EqualsBuilder()
+            .append(getEntityReference(), entitySelection.getEntityReference())
+            .append(getTargetEntityReference(), entitySelection.getTargetEntityReference())
+            .append(isSelected(), entitySelection.isSelected())
+            .isEquals();
+    }
+
+    @Override
+    public String toString()
+    {
+        return new ToStringBuilder(this)
+            .append("sourceEntityReference", sourceEntityReference)
+            .append("targetEntityReference", targetEntityReference)
+            .append("isSelected", isSelected)
+            .toString();
     }
 
     @Override
@@ -142,15 +187,15 @@ public class EntitySelection implements Comparable<EntitySelection>
             return 0;
         }
 
-        if (entityReference == null) {
+        if (sourceEntityReference == null) {
             return -1;
         }
 
-        if (entitySelection.entityReference == null) {
+        if (entitySelection.sourceEntityReference == null) {
             return 1;
         }
 
-        int result = entityReference.compareTo(entitySelection.entityReference);
+        int result = sourceEntityReference.compareTo(entitySelection.sourceEntityReference);
 
         if (result == 0) {
             return isSelected.compareTo(entitySelection.isSelected);

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/job/RenameJobTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/job/RenameJobTest.java
@@ -61,12 +61,19 @@ class RenameJobTest extends AbstractMoveJobTest
         DocumentReference whiteReference = new DocumentReference("wiki", "Color", "White");
         DocumentReference orangeReference = new DocumentReference("wiki", "Color", "Orange");
 
+        when(this.modelBridge.exists(blackReference)).thenReturn(true);
+        when(this.modelBridge.exists(whiteReference)).thenReturn(true);
+
         MoveRequest request = new MoveRequest();
         request.setEntityReferences(List.of(blackReference, whiteReference));
         request.setDestination(orangeReference);
+        request.setCheckAuthorRights(false);
+        request.setCheckRights(false);
         run(request);
 
         verifyNoMove();
+        assertEquals(1, getLogCapture().size());
+        assertEquals("Cannot rename multiple entities.", getLogCapture().getMessage(0));
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/listener/BackLinkUpdaterListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/listener/BackLinkUpdaterListenerTest.java
@@ -20,6 +20,7 @@
 package org.xwiki.refactoring.internal.listener;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -129,8 +130,8 @@ class BackLinkUpdaterListenerTest
 
         this.listener.onEvent(documentRenamedEvent, renameJob, renameRequest);
 
-        verify(this.updater).update(carolReference, aliceReference, bobReference, Set.of());
-        verify(this.updater).update(denisReference, aliceReference, bobReference, Set.of());
+        verify(this.updater).update(carolReference, aliceReference, bobReference, Map.of());
+        verify(this.updater).update(denisReference, aliceReference, bobReference, Map.of());
 
         assertEquals("Updating the back-links for document [foo:Users.Alice].", logCapture.getMessage(0));
     }
@@ -147,7 +148,7 @@ class BackLinkUpdaterListenerTest
 
         this.listener.onEvent(documentRenamedEvent, renameJob, renameRequest);
 
-        verify(this.updater).update(carolReference, aliceReference, bobReference, Set.of());
+        verify(this.updater).update(carolReference, aliceReference, bobReference, Map.of());
         verify(this.updater, never()).update(eq(denisReference), any(DocumentReference.class), any());
 
         assertEquals("Updating the back-links for document [foo:Users.Alice].", logCapture.getMessage(0));
@@ -163,7 +164,7 @@ class BackLinkUpdaterListenerTest
 
         this.listener.onEvent(documentRenamedEvent, renameJob, renameRequest);
 
-        verify(this.updater).update(carolReference, aliceReference, bobReference, Set.of());
+        verify(this.updater).update(carolReference, aliceReference, bobReference, Map.of());
         verify(this.updater, never()).update(eq(denisReference), any(DocumentReference.class), any());
 
         assertEquals("Updating the back-links for document [foo:Users.Alice].", logCapture.getMessage(0));
@@ -189,8 +190,8 @@ class BackLinkUpdaterListenerTest
 
         this.listener.onEvent(documentRenamedEvent, null, null);
 
-        verify(this.updater).update(carolReference, aliceReference, bobReference, Set.of());
-        verify(this.updater).update(denisReference, aliceReference, bobReference, Set.of());
+        verify(this.updater).update(carolReference, aliceReference, bobReference, Map.of());
+        verify(this.updater).update(denisReference, aliceReference, bobReference, Map.of());
 
         assertEquals("Updating the back-links for document [foo:Users.Alice].", logCapture.getMessage(0));
     }
@@ -205,7 +206,7 @@ class BackLinkUpdaterListenerTest
         this.listener.onEvent(documentRenamedEvent, null, null);
 
         verify(this.updater, never()).update(eq(carolReference), any(DocumentReference.class), any());
-        verify(this.updater).update(denisReference, aliceReference, bobReference, Set.of());
+        verify(this.updater).update(denisReference, aliceReference, bobReference, Map.of());
 
         assertEquals("Updating the back-links for document [foo:Users.Alice].", logCapture.getMessage(0));
     }
@@ -220,8 +221,8 @@ class BackLinkUpdaterListenerTest
 
         this.listener.onEvent(documentDeletedEvent, null, null);
 
-        verify(this.updater).update(carolReference, aliceReference, bobReference, Set.of());
-        verify(this.updater).update(denisReference, aliceReference, bobReference, Set.of());
+        verify(this.updater).update(carolReference, aliceReference, bobReference, Map.of());
+        verify(this.updater).update(denisReference, aliceReference, bobReference, Map.of());
 
         assertEquals("Updating the back-links for document [foo:Users.Alice].", logCapture.getMessage(0));
     }
@@ -252,7 +253,7 @@ class BackLinkUpdaterListenerTest
 
         this.listener.onEvent(documentDeletedEvent, null, null);
 
-        verify(this.updater).update(carolReference, aliceReference, bobReference, Set.of());
+        verify(this.updater).update(carolReference, aliceReference, bobReference, Map.of());
         verify(this.updater, never()).update(eq(denisReference), any(DocumentReference.class), any());
 
         assertEquals("Updating the back-links for document [foo:Users.Alice].", this.logCapture.getMessage(0));

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/listener/BackLinkUpdaterListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/listener/BackLinkUpdaterListenerTest.java
@@ -129,8 +129,8 @@ class BackLinkUpdaterListenerTest
 
         this.listener.onEvent(documentRenamedEvent, renameJob, renameRequest);
 
-        verify(this.updater).update(carolReference, aliceReference, bobReference);
-        verify(this.updater).update(denisReference, aliceReference, bobReference);
+        verify(this.updater).update(carolReference, aliceReference, bobReference, Set.of());
+        verify(this.updater).update(denisReference, aliceReference, bobReference, Set.of());
 
         assertEquals("Updating the back-links for document [foo:Users.Alice].", logCapture.getMessage(0));
     }
@@ -147,7 +147,7 @@ class BackLinkUpdaterListenerTest
 
         this.listener.onEvent(documentRenamedEvent, renameJob, renameRequest);
 
-        verify(this.updater).update(carolReference, aliceReference, bobReference);
+        verify(this.updater).update(carolReference, aliceReference, bobReference, Set.of());
         verify(this.updater, never()).update(eq(denisReference), any(DocumentReference.class), any());
 
         assertEquals("Updating the back-links for document [foo:Users.Alice].", logCapture.getMessage(0));
@@ -163,7 +163,7 @@ class BackLinkUpdaterListenerTest
 
         this.listener.onEvent(documentRenamedEvent, renameJob, renameRequest);
 
-        verify(this.updater).update(carolReference, aliceReference, bobReference);
+        verify(this.updater).update(carolReference, aliceReference, bobReference, Set.of());
         verify(this.updater, never()).update(eq(denisReference), any(DocumentReference.class), any());
 
         assertEquals("Updating the back-links for document [foo:Users.Alice].", logCapture.getMessage(0));
@@ -189,8 +189,8 @@ class BackLinkUpdaterListenerTest
 
         this.listener.onEvent(documentRenamedEvent, null, null);
 
-        verify(this.updater).update(carolReference, aliceReference, bobReference);
-        verify(this.updater).update(denisReference, aliceReference, bobReference);
+        verify(this.updater).update(carolReference, aliceReference, bobReference, Set.of());
+        verify(this.updater).update(denisReference, aliceReference, bobReference, Set.of());
 
         assertEquals("Updating the back-links for document [foo:Users.Alice].", logCapture.getMessage(0));
     }
@@ -205,7 +205,7 @@ class BackLinkUpdaterListenerTest
         this.listener.onEvent(documentRenamedEvent, null, null);
 
         verify(this.updater, never()).update(eq(carolReference), any(DocumentReference.class), any());
-        verify(this.updater).update(denisReference, aliceReference, bobReference);
+        verify(this.updater).update(denisReference, aliceReference, bobReference, Set.of());
 
         assertEquals("Updating the back-links for document [foo:Users.Alice].", logCapture.getMessage(0));
     }
@@ -220,8 +220,8 @@ class BackLinkUpdaterListenerTest
 
         this.listener.onEvent(documentDeletedEvent, null, null);
 
-        verify(this.updater).update(carolReference, aliceReference, bobReference);
-        verify(this.updater).update(denisReference, aliceReference, bobReference);
+        verify(this.updater).update(carolReference, aliceReference, bobReference, Set.of());
+        verify(this.updater).update(denisReference, aliceReference, bobReference, Set.of());
 
         assertEquals("Updating the back-links for document [foo:Users.Alice].", logCapture.getMessage(0));
     }
@@ -252,7 +252,7 @@ class BackLinkUpdaterListenerTest
 
         this.listener.onEvent(documentDeletedEvent, null, null);
 
-        verify(this.updater).update(carolReference, aliceReference, bobReference);
+        verify(this.updater).update(carolReference, aliceReference, bobReference, Set.of());
         verify(this.updater, never()).update(eq(denisReference), any(DocumentReference.class), any());
 
         assertEquals("Updating the back-links for document [foo:Users.Alice].", this.logCapture.getMessage(0));

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultMacroRefactoring.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultMacroRefactoring.java
@@ -169,6 +169,24 @@ public class DefaultMacroRefactoring implements MacroRefactoring
             sourceReference, targetReference, relative, updatedDocuments));
     }
 
+    @Override
+    public Optional<MacroBlock> replaceReference(MacroBlock macroBlock, DocumentReference currentDocumentReference,
+        DocumentReference sourceReference, DocumentReference targetReference, boolean relative)
+        throws MacroRefactoringException
+    {
+        return replaceReference(macroBlock, currentDocumentReference, sourceReference, targetReference, relative,
+            Set.of(sourceReference));
+    }
+
+    @Override
+    public Optional<MacroBlock> replaceReference(MacroBlock macroBlock, DocumentReference currentDocumentReference,
+        AttachmentReference sourceReference, AttachmentReference targetReference, boolean relative)
+        throws MacroRefactoringException
+    {
+        return replaceReference(macroBlock, currentDocumentReference, sourceReference, targetReference, relative,
+            Set.of());
+    }
+
     private Optional<MacroBlock> innerReplaceReference(MacroBlock macroBlock, Predicate<Block> lambda)
         throws MacroRefactoringException
     {

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultMacroRefactoring.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultMacroRefactoring.java
@@ -149,22 +149,24 @@ public class DefaultMacroRefactoring implements MacroRefactoring
 
     @Override
     public Optional<MacroBlock> replaceReference(MacroBlock macroBlock, DocumentReference currentDocumentReference,
-        DocumentReference sourceReference, DocumentReference targetReference, boolean relative)
+        DocumentReference sourceReference, DocumentReference targetReference, boolean relative,
+        Set<DocumentReference> updatedDocuments)
         throws MacroRefactoringException
     {
         return innerReplaceReference(macroBlock,
             xdom -> this.referenceRenamerProvider.get().renameReferences(xdom, currentDocumentReference,
-            sourceReference, targetReference, relative));
+            sourceReference, targetReference, relative, updatedDocuments));
     }
 
     @Override
     public Optional<MacroBlock> replaceReference(MacroBlock macroBlock, DocumentReference currentDocumentReference,
-        AttachmentReference sourceReference, AttachmentReference targetReference, boolean relative)
+        AttachmentReference sourceReference, AttachmentReference targetReference, boolean relative,
+        Set<DocumentReference> updatedDocuments)
         throws MacroRefactoringException
     {
         return innerReplaceReference(macroBlock,
             xdom -> this.referenceRenamerProvider.get().renameReferences(xdom, currentDocumentReference,
-            sourceReference, targetReference, relative));
+            sourceReference, targetReference, relative, updatedDocuments));
     }
 
     private Optional<MacroBlock> innerReplaceReference(MacroBlock macroBlock, Predicate<Block> lambda)

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultMacroRefactoring.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultMacroRefactoring.java
@@ -20,6 +20,7 @@
 package org.xwiki.refactoring.internal;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -36,6 +37,7 @@ import org.xwiki.component.manager.ComponentLookupException;
 import org.xwiki.component.manager.ComponentManager;
 import org.xwiki.model.reference.AttachmentReference;
 import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.EntityReference;
 import org.xwiki.refactoring.ReferenceRenamer;
 import org.xwiki.rendering.block.Block;
 import org.xwiki.rendering.block.MacroBlock;
@@ -150,23 +152,23 @@ public class DefaultMacroRefactoring implements MacroRefactoring
     @Override
     public Optional<MacroBlock> replaceReference(MacroBlock macroBlock, DocumentReference currentDocumentReference,
         DocumentReference sourceReference, DocumentReference targetReference, boolean relative,
-        Set<DocumentReference> updatedDocuments)
+        Map<EntityReference, EntityReference> updatedEntities)
         throws MacroRefactoringException
     {
         return innerReplaceReference(macroBlock,
             xdom -> this.referenceRenamerProvider.get().renameReferences(xdom, currentDocumentReference,
-            sourceReference, targetReference, relative, updatedDocuments));
+            sourceReference, targetReference, relative, updatedEntities));
     }
 
     @Override
     public Optional<MacroBlock> replaceReference(MacroBlock macroBlock, DocumentReference currentDocumentReference,
         AttachmentReference sourceReference, AttachmentReference targetReference, boolean relative,
-        Set<DocumentReference> updatedDocuments)
+        Map<EntityReference, EntityReference> updatedEntities)
         throws MacroRefactoringException
     {
         return innerReplaceReference(macroBlock,
             xdom -> this.referenceRenamerProvider.get().renameReferences(xdom, currentDocumentReference,
-            sourceReference, targetReference, relative, updatedDocuments));
+            sourceReference, targetReference, relative, updatedEntities));
     }
 
     @Override
@@ -175,7 +177,7 @@ public class DefaultMacroRefactoring implements MacroRefactoring
         throws MacroRefactoringException
     {
         return replaceReference(macroBlock, currentDocumentReference, sourceReference, targetReference, relative,
-            Set.of(sourceReference));
+            Map.of(sourceReference, targetReference));
     }
 
     @Override
@@ -184,7 +186,7 @@ public class DefaultMacroRefactoring implements MacroRefactoring
         throws MacroRefactoringException
     {
         return replaceReference(macroBlock, currentDocumentReference, sourceReference, targetReference, relative,
-            Set.of());
+            Map.of(sourceReference.getDocumentReference(), targetReference.getDocumentReference()));
     }
 
     private Optional<MacroBlock> innerReplaceReference(MacroBlock macroBlock, Predicate<Block> lambda)

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultReferenceRenamer.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultReferenceRenamer.java
@@ -114,26 +114,28 @@ public class DefaultReferenceRenamer implements ReferenceRenamer
 
     @Override
     public boolean renameReferences(Block block, DocumentReference currentDocumentReference,
-        DocumentReference oldTarget, DocumentReference newTarget, boolean relative)
+        DocumentReference oldTarget, DocumentReference newTarget, boolean relative,
+        Set<DocumentReference> updatedDocuments)
     {
         return innerRenameReferences(block, currentDocumentReference, oldTarget, newTarget,
             SUPPORTED_RESOURCE_TYPES_FOR_DOCUMENTS,
             (MacroRefactoring macroRefactoring, MacroBlock macroBlock) -> macroRefactoring.replaceReference(macroBlock,
-                currentDocumentReference, oldTarget, newTarget, relative),
-            reference -> this.resourceReferenceRenamer.updateResourceReference(reference, oldTarget, newTarget,
-                currentDocumentReference, relative));
+                currentDocumentReference, oldTarget, newTarget, relative, updatedDocuments),
+            reference -> this.resourceReferenceRenamer.updateResourceReference(reference, oldTarget,
+                newTarget, currentDocumentReference, relative, updatedDocuments));
     }
 
     @Override
     public boolean renameReferences(Block block, DocumentReference currentDocumentReference,
-        AttachmentReference oldTarget, AttachmentReference newTarget, boolean relative)
+        AttachmentReference oldTarget, AttachmentReference newTarget, boolean relative,
+        Set<DocumentReference> updatedDocuments)
     {
         return innerRenameReferences(block, currentDocumentReference, oldTarget, newTarget,
             SUPPORTED_RESOURCE_TYPES_FOR_ATTACHMENTS,
             (MacroRefactoring macroRefactoring, MacroBlock macroBlock) -> macroRefactoring.replaceReference(macroBlock,
-                currentDocumentReference, oldTarget, newTarget, relative),
-            reference -> this.resourceReferenceRenamer.updateResourceReference(reference, oldTarget, newTarget,
-                currentDocumentReference, relative));
+                currentDocumentReference, oldTarget, newTarget, relative, updatedDocuments),
+            reference -> this.resourceReferenceRenamer.updateResourceReference(reference,
+                oldTarget, newTarget, currentDocumentReference, relative, updatedDocuments));
     }
 
     private boolean innerRenameReferences(Block block, DocumentReference currentDocumentReference,

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultReferenceRenamer.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultReferenceRenamer.java
@@ -127,6 +127,13 @@ public class DefaultReferenceRenamer implements ReferenceRenamer
 
     @Override
     public boolean renameReferences(Block block, DocumentReference currentDocumentReference,
+        DocumentReference oldTarget, DocumentReference newTarget, boolean relative)
+    {
+        return renameReferences(block, currentDocumentReference, oldTarget, newTarget, relative, Set.of(oldTarget));
+    }
+
+    @Override
+    public boolean renameReferences(Block block, DocumentReference currentDocumentReference,
         AttachmentReference oldTarget, AttachmentReference newTarget, boolean relative,
         Set<DocumentReference> updatedDocuments)
     {
@@ -136,6 +143,13 @@ public class DefaultReferenceRenamer implements ReferenceRenamer
                 currentDocumentReference, oldTarget, newTarget, relative, updatedDocuments),
             reference -> this.resourceReferenceRenamer.updateResourceReference(reference,
                 oldTarget, newTarget, currentDocumentReference, relative, updatedDocuments));
+    }
+
+    @Override
+    public boolean renameReferences(Block block, DocumentReference currentDocumentReference,
+        AttachmentReference oldTarget, AttachmentReference newTarget, boolean relative)
+    {
+        return renameReferences(block, currentDocumentReference, oldTarget, newTarget, relative, Set.of());
     }
 
     private boolean innerRenameReferences(Block block, DocumentReference currentDocumentReference,

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultReferenceRenamer.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultReferenceRenamer.java
@@ -21,6 +21,7 @@ package org.xwiki.refactoring.internal;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -115,41 +116,42 @@ public class DefaultReferenceRenamer implements ReferenceRenamer
     @Override
     public boolean renameReferences(Block block, DocumentReference currentDocumentReference,
         DocumentReference oldTarget, DocumentReference newTarget, boolean relative,
-        Set<DocumentReference> updatedDocuments)
+        Map<EntityReference, EntityReference> updatedEntities)
     {
         return innerRenameReferences(block, currentDocumentReference, oldTarget, newTarget,
             SUPPORTED_RESOURCE_TYPES_FOR_DOCUMENTS,
             (MacroRefactoring macroRefactoring, MacroBlock macroBlock) -> macroRefactoring.replaceReference(macroBlock,
-                currentDocumentReference, oldTarget, newTarget, relative, updatedDocuments),
+                currentDocumentReference, oldTarget, newTarget, relative, updatedEntities),
             reference -> this.resourceReferenceRenamer.updateResourceReference(reference, oldTarget,
-                newTarget, currentDocumentReference, relative, updatedDocuments));
+                newTarget, currentDocumentReference, relative, updatedEntities));
     }
 
     @Override
     public boolean renameReferences(Block block, DocumentReference currentDocumentReference,
         DocumentReference oldTarget, DocumentReference newTarget, boolean relative)
     {
-        return renameReferences(block, currentDocumentReference, oldTarget, newTarget, relative, Set.of(oldTarget));
+        return renameReferences(block, currentDocumentReference, oldTarget, newTarget, relative,
+            Map.of(oldTarget, newTarget));
     }
 
     @Override
     public boolean renameReferences(Block block, DocumentReference currentDocumentReference,
         AttachmentReference oldTarget, AttachmentReference newTarget, boolean relative,
-        Set<DocumentReference> updatedDocuments)
+        Map<EntityReference, EntityReference> updatedEntities)
     {
         return innerRenameReferences(block, currentDocumentReference, oldTarget, newTarget,
             SUPPORTED_RESOURCE_TYPES_FOR_ATTACHMENTS,
             (MacroRefactoring macroRefactoring, MacroBlock macroBlock) -> macroRefactoring.replaceReference(macroBlock,
-                currentDocumentReference, oldTarget, newTarget, relative, updatedDocuments),
+                currentDocumentReference, oldTarget, newTarget, relative, updatedEntities),
             reference -> this.resourceReferenceRenamer.updateResourceReference(reference,
-                oldTarget, newTarget, currentDocumentReference, relative, updatedDocuments));
+                oldTarget, newTarget, currentDocumentReference, relative, updatedEntities));
     }
 
     @Override
     public boolean renameReferences(Block block, DocumentReference currentDocumentReference,
         AttachmentReference oldTarget, AttachmentReference newTarget, boolean relative)
     {
-        return renameReferences(block, currentDocumentReference, oldTarget, newTarget, relative, Set.of());
+        return renameReferences(block, currentDocumentReference, oldTarget, newTarget, relative, Map.of());
     }
 
     private boolean innerRenameReferences(Block block, DocumentReference currentDocumentReference,

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultReferenceUpdater.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultReferenceUpdater.java
@@ -21,6 +21,7 @@ package org.xwiki.refactoring.internal;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -265,17 +266,20 @@ public class DefaultReferenceUpdater implements ReferenceUpdater
     }
 
     private void renameLinks(DocumentReference documentReference, DocumentReference oldLinkTarget,
-        DocumentReference newLinkTarget, boolean relative)
+        DocumentReference newLinkTarget, boolean relative, Set<DocumentReference> updatedDocuments)
     {
         internalRenameLinks(documentReference, oldLinkTarget, newLinkTarget, relative, (xdom, currentDocumentReference,
-            r) -> this.renamer.renameReferences(xdom, currentDocumentReference, oldLinkTarget, newLinkTarget, r));
+            r) -> this.renamer.renameReferences(xdom, currentDocumentReference, oldLinkTarget, newLinkTarget, r,
+            updatedDocuments));
     }
 
     private void renameLinks(DocumentReference documentReference, AttachmentReference oldLinkTarget,
-        AttachmentReference newLinkTarget, boolean relative)
+        AttachmentReference newLinkTarget, boolean relative, Set<DocumentReference> updatedDocuments)
     {
         internalRenameLinks(documentReference, oldLinkTarget, newLinkTarget, relative, (xdom, currentDocumentReference,
-            r) -> this.renamer.renameReferences(xdom, currentDocumentReference, oldLinkTarget, newLinkTarget, r));
+            r) ->
+            this.renamer.renameReferences(xdom, currentDocumentReference, oldLinkTarget, newLinkTarget, r,
+                updatedDocuments));
     }
 
     private void internalRenameLinks(DocumentReference documentReference, EntityReference oldLinkTarget,
@@ -331,7 +335,7 @@ public class DefaultReferenceUpdater implements ReferenceUpdater
 
     @Override
     public void update(DocumentReference documentReference, EntityReference oldTargetReference,
-        EntityReference newTargetReference)
+        EntityReference newTargetReference, Set<DocumentReference> updatedDocuments)
     {
         // If the current document is the moved entity the links should be serialized relative to it
         boolean relative = newTargetReference.equals(documentReference);
@@ -344,10 +348,17 @@ public class DefaultReferenceUpdater implements ReferenceUpdater
         // Only support documents and attachments targets
         if (oldTargetReference.getType() == EntityType.ATTACHMENT) {
             renameLinks(documentReference, toAttachmentReference(oldTargetReference),
-                toAttachmentReference(newTargetReference), relative);
+                toAttachmentReference(newTargetReference), relative, updatedDocuments);
         } else if (oldTargetReference.getType() == EntityType.DOCUMENT) {
             renameLinks(documentReference, toDocumentReference(oldTargetReference),
-                toDocumentReference(newTargetReference), relative);
+                toDocumentReference(newTargetReference), relative, updatedDocuments);
         }
+    }
+
+    @Override
+    public void update(DocumentReference documentReference, EntityReference oldTargetReference,
+        EntityReference newTargetReference)
+    {
+        update(documentReference, oldTargetReference, newTargetReference, Set.of());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultReferenceUpdater.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultReferenceUpdater.java
@@ -21,7 +21,7 @@ package org.xwiki.refactoring.internal;
 
 import java.util.List;
 import java.util.Locale;
-import java.util.Set;
+import java.util.Map;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -266,20 +266,20 @@ public class DefaultReferenceUpdater implements ReferenceUpdater
     }
 
     private void renameLinks(DocumentReference documentReference, DocumentReference oldLinkTarget,
-        DocumentReference newLinkTarget, boolean relative, Set<DocumentReference> updatedDocuments)
+        DocumentReference newLinkTarget, boolean relative, Map<EntityReference, EntityReference> updatedEntities)
     {
         internalRenameLinks(documentReference, oldLinkTarget, newLinkTarget, relative, (xdom, currentDocumentReference,
             r) -> this.renamer.renameReferences(xdom, currentDocumentReference, oldLinkTarget, newLinkTarget, r,
-            updatedDocuments));
+            updatedEntities));
     }
 
     private void renameLinks(DocumentReference documentReference, AttachmentReference oldLinkTarget,
-        AttachmentReference newLinkTarget, boolean relative, Set<DocumentReference> updatedDocuments)
+        AttachmentReference newLinkTarget, boolean relative, Map<EntityReference, EntityReference> updatedEntities)
     {
         internalRenameLinks(documentReference, oldLinkTarget, newLinkTarget, relative, (xdom, currentDocumentReference,
             r) ->
             this.renamer.renameReferences(xdom, currentDocumentReference, oldLinkTarget, newLinkTarget, r,
-                updatedDocuments));
+                updatedEntities));
     }
 
     private void internalRenameLinks(DocumentReference documentReference, EntityReference oldLinkTarget,
@@ -335,7 +335,7 @@ public class DefaultReferenceUpdater implements ReferenceUpdater
 
     @Override
     public void update(DocumentReference documentReference, EntityReference oldTargetReference,
-        EntityReference newTargetReference, Set<DocumentReference> updatedDocuments)
+        EntityReference newTargetReference, Map<EntityReference, EntityReference> updatedEntities)
     {
         // If the current document is the moved entity the links should be serialized relative to it
         boolean relative = newTargetReference.equals(documentReference);
@@ -348,10 +348,10 @@ public class DefaultReferenceUpdater implements ReferenceUpdater
         // Only support documents and attachments targets
         if (oldTargetReference.getType() == EntityType.ATTACHMENT) {
             renameLinks(documentReference, toAttachmentReference(oldTargetReference),
-                toAttachmentReference(newTargetReference), relative, updatedDocuments);
+                toAttachmentReference(newTargetReference), relative, updatedEntities);
         } else if (oldTargetReference.getType() == EntityType.DOCUMENT) {
             renameLinks(documentReference, toDocumentReference(oldTargetReference),
-                toDocumentReference(newTargetReference), relative, updatedDocuments);
+                toDocumentReference(newTargetReference), relative, updatedEntities);
         }
     }
 
@@ -359,6 +359,7 @@ public class DefaultReferenceUpdater implements ReferenceUpdater
     public void update(DocumentReference documentReference, EntityReference oldTargetReference,
         EntityReference newTargetReference)
     {
-        update(documentReference, oldTargetReference, newTargetReference, Set.of());
+        update(documentReference, oldTargetReference, newTargetReference,
+            Map.of(oldTargetReference, newTargetReference));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/ResourceReferenceRenamer.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/ResourceReferenceRenamer.java
@@ -146,14 +146,16 @@ public class ResourceReferenceRenamer
             this.defaultReferenceDocumentReferenceResolver.resolve(linkEntityReference);
         EntityReference newTargetReference = newReference;
         ResourceType newResourceType = resourceReference.getType();
-        // TODO: test in subwiki
         EntityReference absoluteResolvedReference = this.entityReferenceResolver.resolve(resourceReference, null);
 
         // If the link targets the old (renamed) document reference and it's an absolute reference
         // (i.e. its resolution without any given parameter gives same result than its resolution with the
         // currentDocument) then we must update it
-        boolean shouldBeUpdated =
-            linkTargetDocumentReference.equals(oldReference) && absoluteResolvedReference.equals(linkEntityReference);
+        // We also update the link if it's not an absolute link but the current document is not part of the move job,
+        // as in this case there won't be any other call to perform the link refactoring.
+        boolean shouldBeUpdated = linkTargetDocumentReference.equals(oldReference)
+            && (absoluteResolvedReference.equals(linkEntityReference)
+            || !movedReferences.contains(currentDocumentReference));
 
         if (shouldBeUpdated) {
             // If the link was resolved to a space...

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultMacroRefactoringTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultMacroRefactoringTest.java
@@ -22,6 +22,7 @@ package org.xwiki.refactoring.internal;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import javax.inject.Provider;
 
@@ -152,11 +153,12 @@ class DefaultMacroRefactoringTest
         });
         assertEquals(Optional.empty(),
             this.macroRefactoring.replaceReference(this.macroBlock, this.currentDocumentReference,
-                this.sourceReference, this.targetReference, true));
+                this.sourceReference, this.targetReference, true, Set.of()));
         assertEquals(Optional.empty(),
             this.macroRefactoring.replaceReference(this.macroBlock, this.currentDocumentReference,
-                this.sourceReference, this.targetReference, false));
-        verify(this.referenceRenamer, never()).renameReferences(any(), any(), any(DocumentReference.class), any(), anyBoolean());
+                this.sourceReference, this.targetReference, false, Set.of()));
+        verify(this.referenceRenamer, never()).renameReferences(any(), any(), any(DocumentReference.class), any(),
+            anyBoolean(), any());
     }
 
     @Test
@@ -186,10 +188,10 @@ class DefaultMacroRefactoringTest
             return xdom;
         });
         when(this.referenceRenamer.renameReferences(xdom, this.currentDocumentReference, this.sourceReference,
-            this.targetReference, true)).thenReturn(false);
+            this.targetReference, true, Set.of())).thenReturn(false);
         assertEquals(Optional.empty(),
             this.macroRefactoring.replaceReference(this.macroBlock, this.currentDocumentReference, this.sourceReference,
-                this.targetReference, true));
+                this.targetReference, true, Set.of()));
         verify(this.blockRenderer, never()).render(any(Block.class), any());
     }
 
@@ -211,7 +213,7 @@ class DefaultMacroRefactoringTest
             return xdom;
         });
         when(this.referenceRenamer.renameReferences(xdom, this.currentDocumentReference, this.sourceReference,
-            this.targetReference, true)).thenReturn(true);
+            this.targetReference, true, Set.of())).thenReturn(true);
         String expectedContent = "the expected content";
         doAnswer(invocationOnMock -> {
             WikiPrinter printer = invocationOnMock.getArgument(1);
@@ -232,7 +234,7 @@ class DefaultMacroRefactoringTest
         MacroBlock expectedBlock = new MacroBlock(this.macroId, parameters, expectedContent, false);
         assertEquals(Optional.of(expectedBlock),
             this.macroRefactoring.replaceReference(this.macroBlock, this.currentDocumentReference, this.sourceReference,
-                this.targetReference, true));
+                this.targetReference, true, Set.of()));
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultMacroRefactoringTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultMacroRefactoringTest.java
@@ -22,7 +22,6 @@ package org.xwiki.refactoring.internal;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import javax.inject.Provider;
 
@@ -153,10 +152,10 @@ class DefaultMacroRefactoringTest
         });
         assertEquals(Optional.empty(),
             this.macroRefactoring.replaceReference(this.macroBlock, this.currentDocumentReference,
-                this.sourceReference, this.targetReference, true, Set.of()));
+                this.sourceReference, this.targetReference, true, Map.of()));
         assertEquals(Optional.empty(),
             this.macroRefactoring.replaceReference(this.macroBlock, this.currentDocumentReference,
-                this.sourceReference, this.targetReference, false, Set.of()));
+                this.sourceReference, this.targetReference, false, Map.of()));
         verify(this.referenceRenamer, never()).renameReferences(any(), any(), any(DocumentReference.class), any(),
             anyBoolean(), any());
     }
@@ -188,10 +187,10 @@ class DefaultMacroRefactoringTest
             return xdom;
         });
         when(this.referenceRenamer.renameReferences(xdom, this.currentDocumentReference, this.sourceReference,
-            this.targetReference, true, Set.of())).thenReturn(false);
+            this.targetReference, true, Map.of())).thenReturn(false);
         assertEquals(Optional.empty(),
             this.macroRefactoring.replaceReference(this.macroBlock, this.currentDocumentReference, this.sourceReference,
-                this.targetReference, true, Set.of()));
+                this.targetReference, true, Map.of()));
         verify(this.blockRenderer, never()).render(any(Block.class), any());
     }
 
@@ -213,7 +212,7 @@ class DefaultMacroRefactoringTest
             return xdom;
         });
         when(this.referenceRenamer.renameReferences(xdom, this.currentDocumentReference, this.sourceReference,
-            this.targetReference, true, Set.of())).thenReturn(true);
+            this.targetReference, true, Map.of())).thenReturn(true);
         String expectedContent = "the expected content";
         doAnswer(invocationOnMock -> {
             WikiPrinter printer = invocationOnMock.getArgument(1);
@@ -234,7 +233,7 @@ class DefaultMacroRefactoringTest
         MacroBlock expectedBlock = new MacroBlock(this.macroId, parameters, expectedContent, false);
         assertEquals(Optional.of(expectedBlock),
             this.macroRefactoring.replaceReference(this.macroBlock, this.currentDocumentReference, this.sourceReference,
-                this.targetReference, true, Set.of()));
+                this.targetReference, true, Map.of()));
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultModelBridgeTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultModelBridgeTest.java
@@ -881,5 +881,15 @@ class DefaultModelBridgeTest
         }
     }
     
-    
+    @Test
+    void rename() throws Exception
+    {
+        DocumentReference source = new DocumentReference("wiki", "space", "sourcePage");
+        DocumentReference target = new DocumentReference("wiki", "space", "targetPage");
+
+        when(this.xwiki.renameDocument(source, target, true, List.of(), List.of(), this.xcontext)).thenReturn(true);
+        assertTrue(this.modelBridge.rename(source, target));
+
+        verify(this.xwiki).renameDocument(source, target, true, List.of(), List.of(), this.xcontext);
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
@@ -233,6 +233,8 @@ class DefaultReferenceUpdaterTest
         AttachmentReference oldImageTargetAttachment = new AttachmentReference("attachment.txt", oldReference);
         DocumentReference newReference = new DocumentReference("wiki", "X", "Y");
         AttachmentReference newImageTargetAttachment = new AttachmentReference("attachment.txt", newReference);
+        AttachmentReference absoluteTargetAttachment = new AttachmentReference("attachment.txt",
+            new DocumentReference("wiki", "Main", "WebHome"));
 
         XWikiDocument newDocument = mock(XWikiDocument.class);
         when(this.xcontext.getWiki().getDocument(newReference, this.xcontext)).thenReturn(newDocument);
@@ -260,14 +262,23 @@ class DefaultReferenceUpdaterTest
         setTextarea(newDocument,
             new XDOM(Arrays.asList(xobjectDocLinkBlock, xobjectSpaceLinkBlock, xobjectImageBlock)));
 
-        DocumentReference originalDocLinkReference = new DocumentReference("C", oldReference.getLastSpaceReference());
+        DocumentReference originalDocLinkReference = new DocumentReference("WebHome",
+            new SpaceReference("C", oldReference.getLastSpaceReference()));
+        DocumentReference absoluteDocLinkReference = new DocumentReference("WebHome", new SpaceReference("wiki", "C"));
+        when(this.resourceReferenceResolver.resolve(docLinkReference, null))
+            .thenReturn(absoluteDocLinkReference);
         when(this.resourceReferenceResolver.resolve(docLinkReference, null, oldReference))
             .thenReturn(originalDocLinkReference);
+        when(this.resourceReferenceResolver.resolve(xobjectDocLinkReference, null))
+            .thenReturn(absoluteDocLinkReference);
         when(this.resourceReferenceResolver.resolve(xobjectDocLinkReference, null, oldReference))
             .thenReturn(originalDocLinkReference);
+        when(this.resourceReferenceResolver.resolve(imageReference, null))
+            .thenReturn(absoluteTargetAttachment);
         when(this.resourceReferenceResolver.resolve(imageReference, null, oldReference))
             .thenReturn(oldImageTargetAttachment);
-        DocumentReference newDocLinkReference = new DocumentReference("C", newReference.getLastSpaceReference());
+        DocumentReference newDocLinkReference = new DocumentReference("WebHome",
+            new SpaceReference("C", newReference.getLastSpaceReference()));
         when(this.resourceReferenceResolver.resolve(docLinkReference, null, newReference))
             .thenReturn(newDocLinkReference);
         when(this.resourceReferenceResolver.resolve(xobjectDocLinkReference, null, newReference))
@@ -276,7 +287,11 @@ class DefaultReferenceUpdaterTest
             .thenReturn(newImageTargetAttachment);
 
         SpaceReference originalSpaceReference = new SpaceReference("wiki", "Z");
+        when(this.resourceReferenceResolver.resolve(spaceLinkReference, null))
+            .thenReturn(originalSpaceReference);
         when(this.resourceReferenceResolver.resolve(spaceLinkReference, null, oldReference))
+            .thenReturn(originalSpaceReference);
+        when(this.resourceReferenceResolver.resolve(xobjectSpaceLinkReference, null))
             .thenReturn(originalSpaceReference);
         when(this.resourceReferenceResolver.resolve(xobjectSpaceLinkReference, null, oldReference))
             .thenReturn(originalSpaceReference);
@@ -334,6 +349,8 @@ class DefaultReferenceUpdaterTest
             .thenReturn(Arrays.asList(docLinkBlock, spaceLinkBlock));
 
         DocumentReference originalDocLinkReference = new DocumentReference("C", oldReference.getLastSpaceReference());
+        DocumentReference absoluteDocLinkReference = new DocumentReference("C", new SpaceReference("xwiki", "Main"));
+        when(this.resourceReferenceResolver.resolve(docLinkReference, null)).thenReturn(absoluteDocLinkReference);
         when(this.resourceReferenceResolver.resolve(docLinkReference, null, oldReference))
             .thenReturn(originalDocLinkReference);
         DocumentReference newDocLinkReference = new DocumentReference("C", newReference.getLastSpaceReference());
@@ -341,6 +358,8 @@ class DefaultReferenceUpdaterTest
             .thenReturn(newDocLinkReference);
 
         SpaceReference originalSpaceReference = new SpaceReference("wiki1", "Z");
+        SpaceReference absoluteSpaceReference = new SpaceReference("xwiki", "Z");
+        when(this.resourceReferenceResolver.resolve(spaceLinkReference, null)).thenReturn(absoluteSpaceReference);
         when(this.resourceReferenceResolver.resolve(spaceLinkReference, null, oldReference))
             .thenReturn(originalSpaceReference);
         SpaceReference newSpaceReference = new SpaceReference("wiki2", "Z");
@@ -388,7 +407,10 @@ class DefaultReferenceUpdaterTest
         XDOM xobjectXDOM = new XDOM(Collections.singletonList(xobjectLinkBlock));
         setTextarea(document, xobjectXDOM);
 
+        when(this.resourceReferenceResolver.resolve(linkReference, null)).thenReturn(oldLinkTarget);
         when(this.resourceReferenceResolver.resolve(linkReference, null, documentReference)).thenReturn(oldLinkTarget);
+        when(this.resourceReferenceResolver.resolve(xobjectLinkReference, null))
+            .thenReturn(oldLinkTarget);
         when(this.resourceReferenceResolver.resolve(xobjectLinkReference, null, documentReference))
             .thenReturn(oldLinkTarget);
         when(this.defaultReferenceDocumentReferenceResolver.resolve(oldLinkTarget)).thenReturn(oldLinkTarget);
@@ -425,6 +447,7 @@ class DefaultReferenceUpdaterTest
         ImageBlock imageBlock = new ImageBlock(imageReference, false);
         when(xdom.getBlocks(any(), eq(Block.Axes.DESCENDANT))).thenReturn(Arrays.asList(imageBlock));
 
+        when(this.resourceReferenceResolver.resolve(imageReference, null)).thenReturn(oldImageTargetAttachment);
         when(this.resourceReferenceResolver.resolve(imageReference, null, documentReference))
             .thenReturn(oldImageTargetAttachment);
         when(this.defaultReferenceDocumentReferenceResolver.resolve(oldImageTargetAttachment))
@@ -462,6 +485,8 @@ class DefaultReferenceUpdaterTest
         LinkBlock linkBlock = new LinkBlock(Collections.emptyList(), linkReference, false);
         when(xdom.getBlocks(any(), eq(Block.Axes.DESCENDANT))).thenReturn(Arrays.asList(linkBlock));
 
+        when(this.resourceReferenceResolver.resolve(linkReference, null))
+            .thenReturn(oldLinkTargetAttachment);
         when(this.resourceReferenceResolver.resolve(linkReference, null, documentReference))
             .thenReturn(oldLinkTargetAttachment);
         when(this.defaultReferenceDocumentReferenceResolver.resolve(oldLinkTargetAttachment)).thenReturn(oldLinkTarget);
@@ -502,6 +527,8 @@ class DefaultReferenceUpdaterTest
             .thenReturn(Arrays.asList(documentLinkBlock, spaceLinkBlock));
 
         // Doc link
+        when(this.resourceReferenceResolver.resolve(docLinkReference, null))
+            .thenReturn(oldLinkTarget);
         when(this.resourceReferenceResolver.resolve(docLinkReference, null, documentReference))
             .thenReturn(oldLinkTarget);
         when(this.defaultReferenceDocumentReferenceResolver.resolve(oldLinkTarget)).thenReturn(oldLinkTarget);
@@ -509,6 +536,8 @@ class DefaultReferenceUpdaterTest
 
         // Space link
         SpaceReference spaceReference = oldLinkTarget.getLastSpaceReference();
+        when(this.resourceReferenceResolver.resolve(spaceLinkReference, null))
+            .thenReturn(spaceReference);
         when(this.resourceReferenceResolver.resolve(spaceLinkReference, null, documentReference))
             .thenReturn(spaceReference);
         when(this.defaultReferenceDocumentReferenceResolver.resolve(spaceReference)).thenReturn(oldLinkTarget);
@@ -550,6 +579,8 @@ class DefaultReferenceUpdaterTest
             .thenReturn(Arrays.asList(documentLinkBlock, spaceLinkBlock));
 
         // Doc link
+        when(this.resourceReferenceResolver.resolve(docLinkReference, null))
+            .thenReturn(oldLinkTarget);
         when(this.resourceReferenceResolver.resolve(docLinkReference, null, documentReference))
             .thenReturn(oldLinkTarget);
         when(this.defaultReferenceDocumentReferenceResolver.resolve(oldLinkTarget)).thenReturn(oldLinkTarget);
@@ -557,6 +588,8 @@ class DefaultReferenceUpdaterTest
 
         // Space link
         SpaceReference spaceReference = oldLinkTarget.getLastSpaceReference();
+        when(this.resourceReferenceResolver.resolve(spaceLinkReference, null))
+            .thenReturn(spaceReference);
         when(this.resourceReferenceResolver.resolve(spaceLinkReference, null, documentReference))
             .thenReturn(spaceReference);
         when(this.defaultReferenceDocumentReferenceResolver.resolve(spaceReference)).thenReturn(oldLinkTarget);
@@ -610,6 +643,8 @@ class DefaultReferenceUpdaterTest
 
         ResourceReference macroResourceReference = new ResourceReference("A.B", ResourceType.DOCUMENT);
 
+        when(this.resourceReferenceResolver.resolve(macroResourceReference, null))
+            .thenReturn(oldLinkTarget);
         when(this.resourceReferenceResolver.resolve(macroResourceReference, null, documentReference))
             .thenReturn(oldLinkTarget);
         when(this.defaultReferenceDocumentReferenceResolver.resolve(oldLinkTarget)).thenReturn(oldLinkTarget);
@@ -657,6 +692,8 @@ class DefaultReferenceUpdaterTest
         when(document.getSyntax()).thenReturn(Syntax.XWIKI_2_1);
         when(document.getXDOM()).thenReturn(xdom);
         when(xdom.getBlocks(any(), eq(Block.Axes.DESCENDANT))).thenReturn(List.of(documentLinkBlock));
+        when(this.resourceReferenceResolver.resolve(resourceReference, null)).thenReturn(
+            new AttachmentReference("oldname.txt", new DocumentReference("wiki", "Main", "WebHome")));
         when(this.resourceReferenceResolver.resolve(resourceReference, null, documentReference)).thenReturn(
             oldLinkTarget);
         when(this.compactEntityReferenceSerializer.serialize(newLinkTarget, documentReference)).thenReturn(
@@ -693,7 +730,7 @@ class DefaultReferenceUpdaterTest
         XDOM xdom = mock(XDOM.class);
         when(document.getXDOM()).thenReturn(xdom);
 
-        Map<String, String> includeParameters = new HashMap<String, String>();
+        Map<String, String> includeParameters = new HashMap<>();
         includeParameters.put("reference", "A.B");
         MacroBlock includeMacroBlock = new MacroBlock("include", includeParameters, false);
 
@@ -703,6 +740,8 @@ class DefaultReferenceUpdaterTest
         when(xdom.getBlocks(any(), eq(Block.Axes.DESCENDANT)))
             .thenReturn(Arrays.asList(includeMacroBlock, documentLinkBlock));
 
+        when(this.resourceReferenceResolver.resolve(resourceReference, null))
+            .thenReturn(oldLinkTarget);
         when(this.resourceReferenceResolver.resolve(resourceReference, null, documentReference))
             .thenReturn(oldLinkTarget);
         when(this.defaultReferenceDocumentReferenceResolver.resolve(oldLinkTarget)).thenReturn(oldLinkTarget);
@@ -771,8 +810,10 @@ class DefaultReferenceUpdaterTest
 
             ResourceReference linkReference = new ResourceReference("A.B", ResourceType.DOCUMENT);
             LinkBlock linkBlock = new LinkBlock(Collections.emptyList(), linkReference, false);
-            when(xdom.getBlocks(any(), eq(Block.Axes.DESCENDANT))).thenReturn(Arrays.asList(linkBlock));
+            when(xdom.getBlocks(any(), eq(Block.Axes.DESCENDANT))).thenReturn(List.of(linkBlock));
 
+            when(this.resourceReferenceResolver.resolve(linkReference, null))
+                .thenReturn(oldLinkTarget);
             when(this.resourceReferenceResolver.resolve(linkReference, null, documentReference))
                 .thenReturn(oldLinkTarget);
             when(this.defaultReferenceDocumentReferenceResolver.resolve(oldLinkTarget)).thenReturn(oldLinkTarget);

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import javax.inject.Named;
 import javax.inject.Provider;
@@ -617,17 +618,18 @@ class DefaultReferenceUpdaterTest
             componentManager.registerMockComponent(MacroRefactoring.class, "include");
         MacroRefactoring displayMacroRefactoring =
             componentManager.registerMockComponent(MacroRefactoring.class, "display");
-        when(displayMacroRefactoring.replaceReference(any(), any(), any(DocumentReference.class), any(), anyBoolean()))
+        when(displayMacroRefactoring.replaceReference(any(), any(), any(DocumentReference.class), any(), anyBoolean()
+            , any()))
             .thenReturn(Optional.of(displayMacroBlock));
         when(this.documentAccessBridge.getDocumentInstance(documentReference)).thenReturn(document);
         updater.update(documentReference, oldLinkTarget, newLinkTarget);
 
         verify(includeMacroRefactoring).replaceReference(includeMacroBlock1, documentReference, oldLinkTarget,
-            newLinkTarget, false);
+            newLinkTarget, false, Set.of());
         verify(includeMacroRefactoring).replaceReference(includeMacroBlock2, documentReference, oldLinkTarget,
-            newLinkTarget, false);
+            newLinkTarget, false, Set.of());
         verify(displayMacroRefactoring).replaceReference(displayMacroBlock, documentReference, oldLinkTarget,
-            newLinkTarget, false);
+            newLinkTarget, false, Set.of());
         verify(this.mutableRenderingContext, times(3)).push(any(), any(), eq(Syntax.XWIKI_2_1), any(), anyBoolean(),
             any());
         verify(this.mutableRenderingContext, times(3)).pop();
@@ -711,7 +713,7 @@ class DefaultReferenceUpdaterTest
         updater.update(documentReference, oldLinkTarget, newLinkTarget);
 
         verify(includeMacroRefactoring).replaceReference(includeMacroBlock, documentReference, oldLinkTarget,
-            newLinkTarget, false);
+            newLinkTarget, false, Set.of());
         assertEquals("X.Y", documentLinkBlock.getReference().getReference());
         assertEquals(ResourceType.DOCUMENT, documentLinkBlock.getReference().getType());
         verifyDocumentSave(document, "Renamed back-links.", false, false);

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
@@ -190,6 +190,7 @@ class DefaultReferenceUpdaterTest
     {
         XWiki xwiki = mock(XWiki.class);
         when(this.xcontext.getWiki()).thenReturn(xwiki);
+        when(xwiki.exists(any(DocumentReference.class), eq(this.xcontext))).thenReturn(true);
 
         when(this.xcontextProvider.get()).thenReturn(this.xcontext);
         when(this.componentManagerProvider.get()).thenReturn(this.componentManager);
@@ -255,7 +256,7 @@ class DefaultReferenceUpdaterTest
         LinkBlock xobjectSpaceLinkBlock =
             new LinkBlock(Collections.emptyList(), xobjectSpaceLinkReference, false);
         ResourceReference xobjectImageReference = new AttachmentResourceReference("attachment.txt");
-        ImageBlock xobjectImageBlock = new ImageBlock(imageReference, false);
+        ImageBlock xobjectImageBlock = new ImageBlock(xobjectImageReference, false);
         setTextarea(newDocument,
             new XDOM(Arrays.asList(xobjectDocLinkBlock, xobjectSpaceLinkBlock, xobjectImageBlock)));
 

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import javax.inject.Named;
 import javax.inject.Provider;
@@ -661,11 +660,11 @@ class DefaultReferenceUpdaterTest
         updater.update(documentReference, oldLinkTarget, newLinkTarget);
 
         verify(includeMacroRefactoring).replaceReference(includeMacroBlock1, documentReference, oldLinkTarget,
-            newLinkTarget, false, Set.of());
+            newLinkTarget, false, Map.of(oldLinkTarget, newLinkTarget));
         verify(includeMacroRefactoring).replaceReference(includeMacroBlock2, documentReference, oldLinkTarget,
-            newLinkTarget, false, Set.of());
+            newLinkTarget, false, Map.of(oldLinkTarget, newLinkTarget));
         verify(displayMacroRefactoring).replaceReference(displayMacroBlock, documentReference, oldLinkTarget,
-            newLinkTarget, false, Set.of());
+            newLinkTarget, false, Map.of(oldLinkTarget, newLinkTarget));
         verify(this.mutableRenderingContext, times(3)).push(any(), any(), eq(Syntax.XWIKI_2_1), any(), anyBoolean(),
             any());
         verify(this.mutableRenderingContext, times(3)).pop();
@@ -753,7 +752,7 @@ class DefaultReferenceUpdaterTest
         updater.update(documentReference, oldLinkTarget, newLinkTarget);
 
         verify(includeMacroRefactoring).replaceReference(includeMacroBlock, documentReference, oldLinkTarget,
-            newLinkTarget, false, Set.of());
+            newLinkTarget, false, Map.of(oldLinkTarget, newLinkTarget));
         assertEquals("X.Y", documentLinkBlock.getReference().getReference());
         assertEquals(ResourceType.DOCUMENT, documentLinkBlock.getReference().getType());
         verifyDocumentSave(document, "Renamed back-links.", false, false);

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/ResourceReferenceRenamerTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/ResourceReferenceRenamerTest.java
@@ -22,7 +22,9 @@ package org.xwiki.refactoring.internal;
 import java.util.Set;
 
 import javax.inject.Named;
+import javax.inject.Provider;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.xwiki.model.reference.AttachmentReference;
 import org.xwiki.model.reference.DocumentReference;
@@ -38,8 +40,15 @@ import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
 
+import com.xpn.xwiki.XWiki;
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -67,6 +76,20 @@ class ResourceReferenceRenamerTest
 
     @MockComponent
     private PageReferenceResolver<EntityReference> defaultReferencePageReferenceResolver;
+
+    @MockComponent
+    private Provider<XWikiContext> contextProvider;
+
+    @BeforeEach
+    void setup() throws XWikiException
+    {
+        XWikiContext context = mock(XWikiContext.class);
+        when(this.contextProvider.get()).thenReturn(context);
+
+        XWiki xWiki = mock(XWiki.class);
+        when(context.getWiki()).thenReturn(xWiki);
+        when(xWiki.exists(any(DocumentReference.class), eq(context))).thenReturn(true);
+    }
 
     @Test
     void updateResourceReferenceRelative()

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/ResourceReferenceRenamerTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/ResourceReferenceRenamerTest.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.refactoring.internal;
 
+import java.util.Set;
+
 import javax.inject.Named;
 
 import org.junit.jupiter.api.Test;
@@ -81,7 +83,7 @@ class ResourceReferenceRenamerTest
         assertTrue(this.renamer.updateResourceReference(resourceReference,
             oldReference,
             newReference,
-            new DocumentReference("xwiki", "Space", "Page"), true));
+            new DocumentReference("xwiki", "Space", "Page"), true, Set.of()));
 
         verify(this.compactEntityReferenceSerializer).serialize(oldReference, newReference);
     }
@@ -103,7 +105,7 @@ class ResourceReferenceRenamerTest
 
         assertTrue(this.renamer.updateResourceReference(resourceReference, oldReference, newReference,
             currentDocumentReference,
-            false));
+            false, Set.of()));
         assertEquals(new AttachmentResourceReference("xwiki:Space.Page.file2.txt"), resourceReference);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/ResourceReferenceRenamerTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/ResourceReferenceRenamerTest.java
@@ -99,6 +99,7 @@ class ResourceReferenceRenamerTest
             new AttachmentReference("file.txt", new DocumentReference("wiki", "space", "page"));
         AttachmentReference newReference =
             new AttachmentReference("file2.txt", new DocumentReference("wiki", "space", "page"));
+        when(this.entityReferenceResolver.resolve(resourceReference, null)).thenReturn(oldReference);
         when(this.entityReferenceResolver.resolve(resourceReference, null, newReference)).thenReturn(newReference);
         when(this.entityReferenceResolver.resolve(resourceReference, null, oldReference)).thenReturn(oldReference);
         when(this.compactEntityReferenceSerializer.serialize(oldReference, newReference)).thenReturn("file2.txt");
@@ -119,8 +120,12 @@ class ResourceReferenceRenamerTest
             new AttachmentReference("file.txt", new DocumentReference("wiki", "space", "page"));
         AttachmentReference newReference =
             new AttachmentReference("file2.txt", new DocumentReference("wiki", "space", "page"));
+        AttachmentReference absoluteReference =
+            new AttachmentReference("image.png", new DocumentReference("xwiki", "Main", "WebHome"));
         DocumentReference currentDocumentReference = new DocumentReference("xwiki", "Space", "Page");
 
+        when(this.entityReferenceResolver.resolve(resourceReference, null))
+            .thenReturn(absoluteReference);
         when(this.entityReferenceResolver.resolve(resourceReference, null, currentDocumentReference))
             .thenReturn(oldReference);
         when(this.compactEntityReferenceSerializer.serialize(newReference, currentDocumentReference))

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/ResourceReferenceRenamerTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/ResourceReferenceRenamerTest.java
@@ -19,7 +19,7 @@
  */
 package org.xwiki.refactoring.internal;
 
-import java.util.Set;
+import java.util.Map;
 
 import javax.inject.Named;
 import javax.inject.Provider;
@@ -107,7 +107,7 @@ class ResourceReferenceRenamerTest
         assertTrue(this.renamer.updateResourceReference(resourceReference,
             oldReference,
             newReference,
-            new DocumentReference("xwiki", "Space", "Page"), true, Set.of()));
+            new DocumentReference("xwiki", "Space", "Page"), true, Map.of()));
 
         verify(this.compactEntityReferenceSerializer).serialize(oldReference, newReference);
     }
@@ -133,7 +133,7 @@ class ResourceReferenceRenamerTest
 
         assertTrue(this.renamer.updateResourceReference(resourceReference, oldReference, newReference,
             currentDocumentReference,
-            false, Set.of()));
+            false, Map.of()));
         assertEquals(new AttachmentResourceReference("xwiki:Space.Page.file2.txt"), resourceReference);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacroRefactoring.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacroRefactoring.java
@@ -85,22 +85,27 @@ public class IncludeMacroRefactoring implements MacroRefactoring
 
     @Override
     public Optional<MacroBlock> replaceReference(MacroBlock macroBlock, DocumentReference currentDocumentReference,
-        DocumentReference sourceReference, DocumentReference targetReference, boolean relative)
+        DocumentReference sourceReference, DocumentReference targetReference, boolean relative,
+        Set<DocumentReference> updatedDocuments)
         throws MacroRefactoringException
     {
-        return getMacroBlock(macroBlock, currentDocumentReference, sourceReference, targetReference, relative);
+        return getMacroBlock(macroBlock, currentDocumentReference, sourceReference, targetReference, relative,
+            updatedDocuments);
     }
 
     @Override
     public Optional<MacroBlock> replaceReference(MacroBlock macroBlock, DocumentReference currentDocumentReference,
-        AttachmentReference sourceReference, AttachmentReference targetReference, boolean relative)
+        AttachmentReference sourceReference, AttachmentReference targetReference, boolean relative,
+        Set<DocumentReference> updatedDocuments)
         throws MacroRefactoringException
     {
-        return getMacroBlock(macroBlock, currentDocumentReference, sourceReference, targetReference, relative);
+        return getMacroBlock(macroBlock, currentDocumentReference, sourceReference, targetReference, relative,
+            updatedDocuments);
     }
 
     private <T extends EntityReference> Optional<MacroBlock> getMacroBlock(MacroBlock macroBlock,
-        DocumentReference currentDocumentReference, T sourceReference, T targetReference, boolean relative)
+        DocumentReference currentDocumentReference, T sourceReference, T targetReference, boolean relative,
+        Set<DocumentReference> updatedDocuments)
         throws MacroRefactoringException
     {
         Optional<MacroBlock> result;

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacroRefactoring.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacroRefactoring.java
@@ -103,6 +103,24 @@ public class IncludeMacroRefactoring implements MacroRefactoring
             updatedDocuments);
     }
 
+    @Override
+    public Optional<MacroBlock> replaceReference(MacroBlock macroBlock, DocumentReference currentDocumentReference,
+        DocumentReference sourceReference, DocumentReference targetReference, boolean relative)
+        throws MacroRefactoringException
+    {
+        return getMacroBlock(macroBlock, currentDocumentReference, sourceReference, targetReference, relative,
+            Set.of());
+    }
+
+    @Override
+    public Optional<MacroBlock> replaceReference(MacroBlock macroBlock, DocumentReference currentDocumentReference,
+        AttachmentReference sourceReference, AttachmentReference targetReference, boolean relative)
+        throws MacroRefactoringException
+    {
+        return getMacroBlock(macroBlock, currentDocumentReference, sourceReference, targetReference, relative,
+            Set.of());
+    }
+
     private <T extends EntityReference> Optional<MacroBlock> getMacroBlock(MacroBlock macroBlock,
         DocumentReference currentDocumentReference, T sourceReference, T targetReference, boolean relative,
         Set<DocumentReference> updatedDocuments)

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacroRefactoring.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/IncludeMacroRefactoring.java
@@ -20,6 +20,7 @@
 package org.xwiki.rendering.internal.macro.include;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -86,21 +87,21 @@ public class IncludeMacroRefactoring implements MacroRefactoring
     @Override
     public Optional<MacroBlock> replaceReference(MacroBlock macroBlock, DocumentReference currentDocumentReference,
         DocumentReference sourceReference, DocumentReference targetReference, boolean relative,
-        Set<DocumentReference> updatedDocuments)
+        Map<EntityReference, EntityReference> updatedEntities)
         throws MacroRefactoringException
     {
         return getMacroBlock(macroBlock, currentDocumentReference, sourceReference, targetReference, relative,
-            updatedDocuments);
+            updatedEntities);
     }
 
     @Override
     public Optional<MacroBlock> replaceReference(MacroBlock macroBlock, DocumentReference currentDocumentReference,
         AttachmentReference sourceReference, AttachmentReference targetReference, boolean relative,
-        Set<DocumentReference> updatedDocuments)
+        Map<EntityReference, EntityReference> updatedEntities)
         throws MacroRefactoringException
     {
         return getMacroBlock(macroBlock, currentDocumentReference, sourceReference, targetReference, relative,
-            updatedDocuments);
+            updatedEntities);
     }
 
     @Override
@@ -109,7 +110,7 @@ public class IncludeMacroRefactoring implements MacroRefactoring
         throws MacroRefactoringException
     {
         return getMacroBlock(macroBlock, currentDocumentReference, sourceReference, targetReference, relative,
-            Set.of());
+            Map.of(sourceReference, targetReference));
     }
 
     @Override
@@ -118,12 +119,13 @@ public class IncludeMacroRefactoring implements MacroRefactoring
         throws MacroRefactoringException
     {
         return getMacroBlock(macroBlock, currentDocumentReference, sourceReference, targetReference, relative,
-            Set.of());
+            Map.of(sourceReference.getDocumentReference(), targetReference.getDocumentReference()));
     }
 
+    // FIXME: double check we don't need to use updated documents parameters here.
     private <T extends EntityReference> Optional<MacroBlock> getMacroBlock(MacroBlock macroBlock,
         DocumentReference currentDocumentReference, T sourceReference, T targetReference, boolean relative,
-        Set<DocumentReference> updatedDocuments)
+        Map<EntityReference, EntityReference> updatedEntities)
         throws MacroRefactoringException
     {
         Optional<MacroBlock> result;

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/include/IncludeMacroRefactoringTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/include/IncludeMacroRefactoringTest.java
@@ -226,7 +226,7 @@ class IncludeMacroRefactoringTest
             new EntityReference("sourcewiki", EntityType.WIKI))).thenReturn("sourcespace/foo");
 
         Optional<MacroBlock> result = this.includeMacroRefactoring.replaceReference(block, null,
-            sourceReference, targetReference, false, Map.of());
+            sourceReference, targetReference, false);
         assertFalse(result.isEmpty());
         assertEquals("sourcewiki:sourcespace.foo", result.get().getParameter("page"));
     }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/include/IncludeMacroRefactoringTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/include/IncludeMacroRefactoringTest.java
@@ -20,6 +20,7 @@
 package org.xwiki.rendering.internal.macro.include;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -110,7 +111,7 @@ class IncludeMacroRefactoringTest
     {
         MacroBlock block = new MacroBlock("include", Collections.emptyMap(), false);
         assertEquals(Optional.empty(), this.includeMacroRefactoring.replaceReference(block, null, null,
-            (DocumentReference) null, false, Set.of()));
+            (DocumentReference) null, false, Map.of()));
     }
 
     @Test
@@ -119,7 +120,7 @@ class IncludeMacroRefactoringTest
         MacroBlock block = new MacroBlock("include", Collections.emptyMap(), false);
         block.setParameter("reference", "");
         assertEquals(Optional.empty(), this.includeMacroRefactoring.replaceReference(block, null, null,
-            (DocumentReference) null, false, Set.of()));
+            (DocumentReference) null, false, Map.of()));
     }
 
     @Test
@@ -128,7 +129,7 @@ class IncludeMacroRefactoringTest
         MacroBlock block = new MacroBlock("include", Collections.emptyMap(), false);
         block.setParameter("page", "");
         assertEquals(Optional.empty(), this.includeMacroRefactoring.replaceReference(block, null, null,
-            (DocumentReference) null, false, Set.of()));
+            (DocumentReference) null, false, Map.of()));
     }
 
     @Test
@@ -153,7 +154,7 @@ class IncludeMacroRefactoringTest
             new EntityReference("sourcewiki", EntityType.WIKI))).thenReturn("sourcespace.foo");
 
         Optional<MacroBlock> result = this.includeMacroRefactoring.replaceReference(block, currentReference,
-            sourceReference, targetReference, false, Set.of());
+            sourceReference, targetReference, false, Map.of());
         assertFalse(result.isEmpty());
         assertEquals("targetwiki:targetspace.targetfoo", result.get().getParameter("reference"));
     }
@@ -189,7 +190,7 @@ class IncludeMacroRefactoringTest
             new EntityReference("sourcewiki", EntityType.WIKI))).thenReturn("sourcespace.foo");
 
         Optional<MacroBlock> result = this.includeMacroRefactoring.replaceReference(block, null,
-            sourceReference, targetReference, false, Set.of());
+            sourceReference, targetReference, false, Map.of());
         assertFalse(result.isEmpty());
         assertEquals("sourcewiki:sourcespace.foo", result.get().getParameter("reference"));
     }
@@ -225,7 +226,7 @@ class IncludeMacroRefactoringTest
             new EntityReference("sourcewiki", EntityType.WIKI))).thenReturn("sourcespace/foo");
 
         Optional<MacroBlock> result = this.includeMacroRefactoring.replaceReference(block, null,
-            sourceReference, targetReference, false, Set.of());
+            sourceReference, targetReference, false, Map.of());
         assertFalse(result.isEmpty());
         assertEquals("sourcewiki:sourcespace.foo", result.get().getParameter("page"));
     }
@@ -254,7 +255,7 @@ class IncludeMacroRefactoringTest
             new EntityReference("sourcewiki", EntityType.WIKI))).thenReturn("sourcespace/foo");
 
         Optional<MacroBlock> result = this.includeMacroRefactoring.replaceReference(block, currentReference,
-            sourceReference, targetReference, false, Set.of());
+            sourceReference, targetReference, false, Map.of());
         assertFalse(result.isEmpty());
         assertEquals("targetwiki:targetspace.targetfoo", result.get().getParameter("page"));
     }
@@ -282,7 +283,7 @@ class IncludeMacroRefactoringTest
             new EntityReference("sourcewiki", EntityType.WIKI))).thenReturn("sourcespace.foo");
 
         Optional<MacroBlock> result = this.includeMacroRefactoring.replaceReference(block, null, sourceReference,
-            targetReference, false, Set.of());
+            targetReference, false, Map.of());
         assertTrue(result.isEmpty());
     }
 
@@ -312,7 +313,7 @@ class IncludeMacroRefactoringTest
             new EntityReference("sourcewiki", EntityType.WIKI))).thenReturn("sourcespace.foo");
 
         Optional<MacroBlock> result = this.includeMacroRefactoring.replaceReference(block, currentReference,
-            sourceReference, targetAttachmentReference, false, Set.of());
+            sourceReference, targetAttachmentReference, false, Map.of());
         assertFalse(result.isEmpty());
         assertEquals("targetwiki:targetspace.targetfoo@targetfile", result.get().getParameter("reference"));
     }
@@ -355,7 +356,7 @@ class IncludeMacroRefactoringTest
             new EntityReference("sourcewiki", EntityType.WIKI))).thenReturn("sourcespace.foopage@foofile");
 
         Optional<MacroBlock> result = this.includeMacroRefactoring.replaceReference(block, null,
-            sourceReference, targetReference, false, Set.of());
+            sourceReference, targetReference, false, Map.of());
         assertFalse(result.isEmpty());
         assertEquals("sourcewiki:sourcespace.foopage@foofile", result.get().getParameter("reference"));
     }
@@ -370,7 +371,7 @@ class IncludeMacroRefactoringTest
 
         Throwable exception = assertThrows(MacroRefactoringException.class,
             () -> this.includeMacroRefactoring.replaceReference(block, null, null, (DocumentReference) null, false,
-                Set.of()));
+                Map.of()));
         assertEquals("There's one or several invalid parameters for an [include] macro with parameters "
             + "[{type=invalid}]", exception.getMessage());
     }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/include/IncludeMacroRefactoringTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/include/IncludeMacroRefactoringTest.java
@@ -110,7 +110,7 @@ class IncludeMacroRefactoringTest
     {
         MacroBlock block = new MacroBlock("include", Collections.emptyMap(), false);
         assertEquals(Optional.empty(), this.includeMacroRefactoring.replaceReference(block, null, null,
-            (DocumentReference) null, false));
+            (DocumentReference) null, false, Set.of()));
     }
 
     @Test
@@ -119,7 +119,7 @@ class IncludeMacroRefactoringTest
         MacroBlock block = new MacroBlock("include", Collections.emptyMap(), false);
         block.setParameter("reference", "");
         assertEquals(Optional.empty(), this.includeMacroRefactoring.replaceReference(block, null, null,
-            (DocumentReference) null, false));
+            (DocumentReference) null, false, Set.of()));
     }
 
     @Test
@@ -128,7 +128,7 @@ class IncludeMacroRefactoringTest
         MacroBlock block = new MacroBlock("include", Collections.emptyMap(), false);
         block.setParameter("page", "");
         assertEquals(Optional.empty(), this.includeMacroRefactoring.replaceReference(block, null, null,
-            (DocumentReference) null, false));
+            (DocumentReference) null, false, Set.of()));
     }
 
     @Test
@@ -153,7 +153,7 @@ class IncludeMacroRefactoringTest
             new EntityReference("sourcewiki", EntityType.WIKI))).thenReturn("sourcespace.foo");
 
         Optional<MacroBlock> result = this.includeMacroRefactoring.replaceReference(block, currentReference,
-            sourceReference, targetReference, false);
+            sourceReference, targetReference, false, Set.of());
         assertFalse(result.isEmpty());
         assertEquals("targetwiki:targetspace.targetfoo", result.get().getParameter("reference"));
     }
@@ -189,7 +189,7 @@ class IncludeMacroRefactoringTest
             new EntityReference("sourcewiki", EntityType.WIKI))).thenReturn("sourcespace.foo");
 
         Optional<MacroBlock> result = this.includeMacroRefactoring.replaceReference(block, null,
-            sourceReference, targetReference, false);
+            sourceReference, targetReference, false, Set.of());
         assertFalse(result.isEmpty());
         assertEquals("sourcewiki:sourcespace.foo", result.get().getParameter("reference"));
     }
@@ -225,7 +225,7 @@ class IncludeMacroRefactoringTest
             new EntityReference("sourcewiki", EntityType.WIKI))).thenReturn("sourcespace/foo");
 
         Optional<MacroBlock> result = this.includeMacroRefactoring.replaceReference(block, null,
-            sourceReference, targetReference, false);
+            sourceReference, targetReference, false, Set.of());
         assertFalse(result.isEmpty());
         assertEquals("sourcewiki:sourcespace.foo", result.get().getParameter("page"));
     }
@@ -254,7 +254,7 @@ class IncludeMacroRefactoringTest
             new EntityReference("sourcewiki", EntityType.WIKI))).thenReturn("sourcespace/foo");
 
         Optional<MacroBlock> result = this.includeMacroRefactoring.replaceReference(block, currentReference,
-            sourceReference, targetReference, false);
+            sourceReference, targetReference, false, Set.of());
         assertFalse(result.isEmpty());
         assertEquals("targetwiki:targetspace.targetfoo", result.get().getParameter("page"));
     }
@@ -282,7 +282,7 @@ class IncludeMacroRefactoringTest
             new EntityReference("sourcewiki", EntityType.WIKI))).thenReturn("sourcespace.foo");
 
         Optional<MacroBlock> result = this.includeMacroRefactoring.replaceReference(block, null, sourceReference,
-            targetReference, false);
+            targetReference, false, Set.of());
         assertTrue(result.isEmpty());
     }
 
@@ -312,7 +312,7 @@ class IncludeMacroRefactoringTest
             new EntityReference("sourcewiki", EntityType.WIKI))).thenReturn("sourcespace.foo");
 
         Optional<MacroBlock> result = this.includeMacroRefactoring.replaceReference(block, currentReference,
-            sourceReference, targetAttachmentReference, false);
+            sourceReference, targetAttachmentReference, false, Set.of());
         assertFalse(result.isEmpty());
         assertEquals("targetwiki:targetspace.targetfoo@targetfile", result.get().getParameter("reference"));
     }
@@ -355,7 +355,7 @@ class IncludeMacroRefactoringTest
             new EntityReference("sourcewiki", EntityType.WIKI))).thenReturn("sourcespace.foopage@foofile");
 
         Optional<MacroBlock> result = this.includeMacroRefactoring.replaceReference(block, null,
-            sourceReference, targetReference, false);
+            sourceReference, targetReference, false, Set.of());
         assertFalse(result.isEmpty());
         assertEquals("sourcewiki:sourcespace.foopage@foofile", result.get().getParameter("reference"));
     }
@@ -369,7 +369,8 @@ class IncludeMacroRefactoringTest
         block.setParameter("type", "invalid");
 
         Throwable exception = assertThrows(MacroRefactoringException.class,
-            () -> this.includeMacroRefactoring.replaceReference(block, null, null, (DocumentReference) null, false));
+            () -> this.includeMacroRefactoring.replaceReference(block, null, null, (DocumentReference) null, false,
+                Set.of()));
         assertEquals("There's one or several invalid parameters for an [include] macro with parameters "
             + "[{type=invalid}]", exception.getMessage());
     }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/java/org/xwiki/rendering/macro/MacroRefactoring.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/java/org/xwiki/rendering/macro/MacroRefactoring.java
@@ -28,6 +28,7 @@ import org.xwiki.model.reference.AttachmentReference;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.rendering.block.MacroBlock;
 import org.xwiki.rendering.listener.reference.ResourceReference;
+import org.xwiki.stability.Unstable;
 
 /**
  * Component dedicated to perform refactoring of existing macros.
@@ -54,9 +55,36 @@ public interface MacroRefactoring
      * @throws MacroRefactoringException in case of problem to parse or render the macro content.
      */
     Optional<MacroBlock> replaceReference(MacroBlock macroBlock, DocumentReference currentDocumentReference,
+        DocumentReference sourceReference, DocumentReference targetReference, boolean relative)
+        throws MacroRefactoringException;
+
+    /**
+     * Replace the given source reference by the given entity reference in the macro block. The method returns an
+     * optional containing a modified macro block if it needs to be updated, else it returns an empty optional.
+     * Depending on the macro implementation, this method might lead to parsing the macro content for finding the
+     * reference, or might just modify the macro parameters.
+     *
+     * @param macroBlock the macro block in which to replace the reference.
+     * @param currentDocumentReference the reference of the document in which the block is located
+     * @param sourceReference the reference to replace.
+     * @param targetReference the reference to use as replacement.
+     * @param relative if {@code true} indicate that the reference should be resolved relatively to the current
+     *     document
+     * @param updatedDocuments the list of documents that have been renamed in the same job: this list contains the
+     *                         old references before the rename
+     * @return an optional containing the new macro block with proper information if it needs to be updated, else an
+     *     empty optional.
+     * @throws MacroRefactoringException in case of problem to parse or render the macro content.
+     * @since 16.10.0RC1
+     */
+    @Unstable
+    default Optional<MacroBlock> replaceReference(MacroBlock macroBlock, DocumentReference currentDocumentReference,
         DocumentReference sourceReference, DocumentReference targetReference, boolean relative,
         Set<DocumentReference> updatedDocuments)
-        throws MacroRefactoringException;
+        throws MacroRefactoringException
+    {
+        return replaceReference(macroBlock, currentDocumentReference, sourceReference, targetReference, relative);
+    }
 
     /**
      * Replace the given source reference by the given entity reference in the macro block. The method returns an
@@ -75,9 +103,36 @@ public interface MacroRefactoring
      * @since 14.2RC1
      */
     Optional<MacroBlock> replaceReference(MacroBlock macroBlock, DocumentReference currentDocumentReference,
+        AttachmentReference sourceReference, AttachmentReference targetReference, boolean relative)
+        throws MacroRefactoringException;
+
+    /**
+     * Replace the given source reference by the given entity reference in the macro block. The method returns an
+     * optional containing a modified macro block if it needs to be updated, else it returns an empty optional.
+     * Depending on the macro implementation, this method might lead to parsing the macro content for finding the
+     * reference, or might just modify the macro parameters.
+     *
+     * @param macroBlock the macro block in which to replace the reference.
+     * @param currentDocumentReference the reference of the document in which the block is located
+     * @param sourceReference the reference to replace.
+     * @param targetReference the reference to use as replacement
+     * @param relative if {@code true} indicate that the reference should be resolved relatively to the current
+     *     document
+     * @param updatedDocuments the list of documents that have been renamed in the same job: this list contains the
+     *                         old references before the rename
+     * @return an optional containing the new macro block with proper information if it needs to be updated, else an
+     *     empty optional.
+     * @throws MacroRefactoringException in case of problem to parse or render the macro content.
+     * @since 16.10.0RC1
+     */
+    @Unstable
+    default Optional<MacroBlock> replaceReference(MacroBlock macroBlock, DocumentReference currentDocumentReference,
         AttachmentReference sourceReference, AttachmentReference targetReference, boolean relative,
         Set<DocumentReference> updatedDocuments)
-        throws MacroRefactoringException;
+        throws MacroRefactoringException
+    {
+        return replaceReference(macroBlock, currentDocumentReference, sourceReference, targetReference, relative);
+    }
 
     /**
      * Extract references used in the macro so that they can be used for example for creating backlinks.

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/java/org/xwiki/rendering/macro/MacroRefactoring.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/java/org/xwiki/rendering/macro/MacroRefactoring.java
@@ -54,7 +54,8 @@ public interface MacroRefactoring
      * @throws MacroRefactoringException in case of problem to parse or render the macro content.
      */
     Optional<MacroBlock> replaceReference(MacroBlock macroBlock, DocumentReference currentDocumentReference,
-        DocumentReference sourceReference, DocumentReference targetReference, boolean relative)
+        DocumentReference sourceReference, DocumentReference targetReference, boolean relative,
+        Set<DocumentReference> updatedDocuments)
         throws MacroRefactoringException;
 
     /**
@@ -74,7 +75,8 @@ public interface MacroRefactoring
      * @since 14.2RC1
      */
     Optional<MacroBlock> replaceReference(MacroBlock macroBlock, DocumentReference currentDocumentReference,
-        AttachmentReference sourceReference, AttachmentReference targetReference, boolean relative)
+        AttachmentReference sourceReference, AttachmentReference targetReference, boolean relative,
+        Set<DocumentReference> updatedDocuments)
         throws MacroRefactoringException;
 
     /**

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/java/org/xwiki/rendering/macro/MacroRefactoring.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-xwiki/src/main/java/org/xwiki/rendering/macro/MacroRefactoring.java
@@ -20,12 +20,14 @@
 package org.xwiki.rendering.macro;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
 import org.xwiki.component.annotation.Role;
 import org.xwiki.model.reference.AttachmentReference;
 import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.EntityReference;
 import org.xwiki.rendering.block.MacroBlock;
 import org.xwiki.rendering.listener.reference.ResourceReference;
 import org.xwiki.stability.Unstable;
@@ -70,8 +72,8 @@ public interface MacroRefactoring
      * @param targetReference the reference to use as replacement.
      * @param relative if {@code true} indicate that the reference should be resolved relatively to the current
      *     document
-     * @param updatedDocuments the list of documents that have been renamed in the same job: this list contains the
-     *                         old references before the rename
+     * @param updatedEntities the map of entities that are or are going to be updated: the map contains the source
+     *      and target destination.
      * @return an optional containing the new macro block with proper information if it needs to be updated, else an
      *     empty optional.
      * @throws MacroRefactoringException in case of problem to parse or render the macro content.
@@ -80,7 +82,7 @@ public interface MacroRefactoring
     @Unstable
     default Optional<MacroBlock> replaceReference(MacroBlock macroBlock, DocumentReference currentDocumentReference,
         DocumentReference sourceReference, DocumentReference targetReference, boolean relative,
-        Set<DocumentReference> updatedDocuments)
+        Map<EntityReference, EntityReference> updatedEntities)
         throws MacroRefactoringException
     {
         return replaceReference(macroBlock, currentDocumentReference, sourceReference, targetReference, relative);
@@ -118,8 +120,8 @@ public interface MacroRefactoring
      * @param targetReference the reference to use as replacement
      * @param relative if {@code true} indicate that the reference should be resolved relatively to the current
      *     document
-     * @param updatedDocuments the list of documents that have been renamed in the same job: this list contains the
-     *                         old references before the rename
+     * @param updatedEntities the map of entities that are or are going to be updated: the map contains the source
+     *      and target destination.
      * @return an optional containing the new macro block with proper information if it needs to be updated, else an
      *     empty optional.
      * @throws MacroRefactoringException in case of problem to parse or render the macro content.
@@ -128,7 +130,7 @@ public interface MacroRefactoring
     @Unstable
     default Optional<MacroBlock> replaceReference(MacroBlock macroBlock, DocumentReference currentDocumentReference,
         AttachmentReference sourceReference, AttachmentReference targetReference, boolean relative,
-        Set<DocumentReference> updatedDocuments)
+        Map<EntityReference, EntityReference> updatedEntities)
         throws MacroRefactoringException
     {
         return replaceReference(macroBlock, currentDocumentReference, sourceReference, targetReference, relative);

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-docker/src/test/it/org/xwiki/wiki/test/ui/SubWikiIT.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-test/xwiki-platform-wiki-test-docker/src/test/it/org/xwiki/wiki/test/ui/SubWikiIT.java
@@ -19,8 +19,6 @@
  */
 package org.xwiki.wiki.test.ui;
 
-import java.util.stream.Collectors;
-
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.xwiki.livedata.test.po.TableLayoutElement;
@@ -180,11 +178,14 @@ class SubWikiIT
         assertEquals("Done.", renameStatusPage.getInfoMessage());
 
         SpaceReference Alice2Space = new SpaceReference("Alice2", newRootSpace);
+        DocumentReference newrootPage = new DocumentReference("WebHome", newRootSpace);
         DocumentReference Alice2Reference = new DocumentReference("WebHome", Alice2Space);
-        wikiEditPage = WikiEditPage.gotoPage(new DocumentReference("WebHome", newRootSpace));
+        wikiEditPage = WikiEditPage.gotoPage(newrootPage);
         String serializedlocalAlice2Reference = setup.serializeLocalReference(Alice2Reference);
         assertEquals(String.format("[[%s]]%n[[Bob]]%n[[Eve]]", serializedlocalAlice2Reference),
             wikiEditPage.getContent());
+        wikiEditPage.setContent(String.format("[[Alice2]]%n[[%s]]%n[[Bob]]%n[[Eve]]",serializedlocalAlice2Reference));
+        wikiEditPage.clickSaveAndView();
 
         viewPage = setup.gotoPage(mainWikiLinkPage);
         wikiEditPage = viewPage.editWiki();
@@ -192,6 +193,25 @@ class SubWikiIT
             String.format("[[%s]]%n[[%s]]%n[[%s]]",
                 setup.serializeReference(movedPageReference),
                 setup.serializeReference(Alice2Reference),
+                setup.serializeReference(newBobPage)), wikiEditPage.getContent());
+
+        viewPage = setup.gotoPage(Alice2Reference);
+        renamePage = viewPage.rename();
+        renamePage.getDocumentPicker().setWiki("xwiki");
+        renameStatusPage = renamePage.clickRenameButton().waitUntilFinished();
+        assertEquals("Done.", renameStatusPage.getInfoMessage());
+
+        Alice2Reference = Alice2Reference.setWikiReference(new WikiReference("xwiki"));
+        String serializedAliceReference = setup.serializeReference(Alice2Reference);
+        wikiEditPage = WikiEditPage.gotoPage(newrootPage);
+        assertEquals(String.format("[[%1$s]]%n[[%1$s]]%n[[Bob]]%n[[Eve]]", serializedAliceReference),
+            wikiEditPage.getContent());
+        viewPage = setup.gotoPage(mainWikiLinkPage);
+        wikiEditPage = viewPage.editWiki();
+        assertEquals(
+            String.format("[[%s]]%n[[%s]]%n[[%s]]",
+                setup.serializeReference(movedPageReference),
+                setup.serializeLocalReference(Alice2Reference),
                 setup.serializeReference(newBobPage)), wikiEditPage.getContent());
 
         deleteSubWiki(setup);


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-12987

# TODO

- [] Document properly abstract methods in AbstractCopyOrMoveJob
- [x] Improve SubWikiIT#movePageToSubwiki
- [ ] Why not checking if the doc exists in updateResourceReferenceAbsolute conditions?
- [x] Verify all new FIXME in the code

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

The idea of this work is to:
  1. Change the way `AbstractCopyOrMoveJob` works to perform computation of couple source/target documents before processing them
  2. Provide a way to access that map source/target documents
  3. Use that information when performing a call to `ReferenceRenamer` to define if a relative untyped link should be handled or not

The PR provides mainly:
  - new APIs in `ReferenceRenamer` and `MacroRefactoring` to integrate the map of references that have been moved as part of same job
  - refactorings of `AbstractCopyOrMoveJob`:
     * specific computation of `getEntities` to actually visit the hierarchy and populate the entities with the couple of source/target documents
     * new abstract methods to avoid duplications (not strictly needed for this work)
     * new method to retrieve the map of source/target documents
  - new conditions in `ResourceReferenceRenamer` to decide if a link should be renamed or not: most of the logic of the fix is encoded there (see also clarifications)
  - new calls in `XWiki#updateLinksForRename` and `BackLinkUpdaterListener#updateBackLinks` to give the map of source/target when calling the rename of references
  - new integration test simulating the scenario indicated in the ticket and also performing a supplementary check related to a regression found afterwards
  - same integration test also performed on a subwiki in `SubWikiIT`

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

The refactoring of references is currently called at two places: 
  1. by the `BackLinkUpdaterListener` for all backlinks after a document has been renamed (triggered by a document event)
  2. by `XWiki#updateLinksForRename` to rename the internal links of the current document (which is always a call to updateResourceReferenceRelative, see below)

The problem of XWIKI-12987 is that `XWiki#updateLinksForRename` is called first and does perform an absolute rename of the relative links. 
Now `ResourceReferenceRenamer` APIs names might be misleading: `updateResourceReferenceRelative` and `updateResourceReferenceAbsolute` are **not** about the references being absolute or relative: it's about the renamed references being absolute or relative respectively to the current document. It took me a while to integrate this, and I'm still struggling a bit with it. 

So the problem was to find a proper condition to decide when to not refactor links, for this I'm performing a check for assessing if a link is absolute or not, by trying to resolve the `ResourceReference` without any parameter: if the result equals the reference with parameter then it was absolute. 

Then for the `updateResourceReferenceAbsolute` the idea is to only perform update of the links, if the provided link is absolute, or if it's relative but the current document hasn't been moved as part of same job: in such case we do need to update the relative link, because there won't be a call to `XWiki#updateLinksForRename` on that document to update the link, we only get the call from `BackLinkUpdaterListener`. 

For the `updateResourceReferenceRelative` the check is a bit more complex. 
We only update links that are relative here, we don't want to update absolute references (is that correct? Can't find a counter example right now). 
Then since we only perform refactoring of links relative to current document, we also check that the link about to be refactored is not related to pages that are part of the moved document in the same job: if those are also moved in the same job, then they're moved using same "direction", they're part of same hierarchy and we don't want to change the relative links wrt to them. This check is the main part of avoiding to update the relative links. 

And finally we perform the update of the link only if the doc actually exists: we would create absolute links for those not existing doc, which doesn't make sense, we should keep the relative link we don't really know what the user wanted to do with those. Note that we could do the same check in `updateResourceReferenceAbsolute` but we don't really have the need since this is only called from the BackLinkUpdaterListener and if I'm correct we'll never have registered backlinks for a not existing doc.

Note that initially we discussed about using untyped link as a condition to perform or not the refactoring: I dropped the idea because we currently always create image resource references as untyped references from the WYSIWYG editor.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Tested and supported UCs 

In RenamePageIT:
* Rename of links outside moved hierarchy: My.Page contains link to `[[1.2.WebHome]]` and `1.2.WebHome` full hierarchy is renamed to `A.B`.
* Rename of absolute links in content, macros and images inside a hierarchy: X.WebHome contains content with absolute links to sub pages in X space. X is renamed, we check that all absolute links / images are properly updated.
* Rename of relative links inside hierarchy: case of a hierarchy of pages containing Alice and Bob, WebHome contains simplest relative links (e.g. `[[Alice]]`) we check that those links are not updated if the whole hierarchy is moved. Test also performed when moving on a subwiki.

TODO:
  - [ ] Check refactoring of relative / absolute links in translations

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Run of tests on following modules / integration test:
  - [x] xwiki-platform-refactoring
  - [x] xwiki-platform-flamingo-skin-test-docker
  - [x] xwiki-platform-attachment-test-docker and specifically AttachmentMoveIT
  - [x] xwiki-platform-index-test-docker and specifically AllDocsIT
  - [x] xwiki-platform-wiki-test-docker and specifically SubWikiIT

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 