### PR TITLE
XWIKI-20782: Display the breadcrumb on access denied pages

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/accessdenied.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/accessdenied.vm
@@ -30,6 +30,7 @@ $services.localization.render('notallowed')
 #else
 #template("startpage.vm")
 <div class="main layoutsubsection">
+#template("hierarchy.vm")
 ## Set as an HTML main for better DOM tree semantics to facilitate navigation with assistive technologies.
 <main id="mainContentArea">
 #if ($xwiki.exists("XWiki.AccessDenied"))


### PR DESCRIPTION

# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-20782

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added the hierarchy template at the usual place.

## Clarification
* The position of the breadcrumb is the same as [the one from view.vm](https://github.com/xwiki/xwiki-platform/blob/8ea02b48f840f0c0ec3174daa38b48ac638427aa/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/view.vm#L40)

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
before the PR:
![Screenshot from 2024-10-10 17-55-25](https://github.com/user-attachments/assets/d8d3a5a2-eae6-453c-a5da-8e7d20f6e04a)
after the changes proposed in this PR:
![Screenshot from 2024-10-10 17-55-39](https://github.com/user-attachments/assets/bf707d9a-c07d-44ef-bcb4-5c705efb09c9)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
None

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, low priority improvement.