### PR TITLE
XWIKI-22501: Attachment progress info is lacking contrast -- 15.10.x cherry pick

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.css
@@ -40,7 +40,6 @@
 }
 .progress-info {
   clear: right;
-  opacity: 0.5;
 }
 .upload-inprogress .progress-info {
   opacity: 1;

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.css
@@ -6,6 +6,7 @@
   position: relative;
   padding: .3em 1em .3em 22px;
   background: $theme.highlightColor none 2px .8em no-repeat;
+  border-radius: 7px; /* Same value as @border-radius-base from Flamingo. */
   margin: .5em 0;
   clear: both;
 }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22501


____
Cherry pick with merge conflict resolution for https://github.com/xwiki/xwiki-platform/pull/3534
