### PR TITLE
XCOMMONS-3174: Move org.xwiki.cache.util.AbstractCache#AbstractCache() to legacy

### DIFF
--- a/xwiki-platform-distribution/xwiki-platform-distribution-war-legacydependencies/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-war-legacydependencies/pom.xml
@@ -88,6 +88,10 @@
       <exclusions>
         <exclusion>
           <groupId>org.xwiki.commons</groupId>
+          <artifactId>xwiki-commons-cache-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.xwiki.commons</groupId>
           <artifactId>xwiki-commons-component-api</artifactId>
         </exclusion>
         <exclusion>
@@ -165,6 +169,11 @@
     </dependency>
     <dependency>
       <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-legacy-cache-api</artifactId>
+      <version>${commons.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
       <artifactId>xwiki-commons-legacy-component-api</artifactId>
       <version>${commons.version}</version>
     </dependency>
@@ -194,6 +203,10 @@
       <version>${project.version}</version>
       <!-- Exclude transitive dependencies which are conflicting with legacy dependencies -->
       <exclusions>
+        <exclusion>
+          <groupId>org.xwiki.commons</groupId>
+          <artifactId>xwiki-commons-cache-api</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>org.xwiki.commons</groupId>
           <artifactId>xwiki-commons-component-api</artifactId>

--- a/xwiki-platform-distribution/xwiki-platform-distribution-war-legacydependencies/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-war-legacydependencies/pom.xml
@@ -54,6 +54,7 @@
                     <exclude>org.xwiki.commons:xwiki-commons-component-default:*:jar:*</exclude>
                     <exclude>org.xwiki.commons:xwiki-platform-distribution-war-dependencies:*:jar:*</exclude>
                     <exclude>org.xwiki.commons:xwiki-commons-component-api:*:jar:*</exclude>
+                    <exclude>org.xwiki.commons:xwiki-commons-cache-api:*:jar:*</exclude>
                     <exclude>org.xwiki.rendering:xwiki-rendering-api:*:jar:*</exclude>
                     <exclude>org.xwiki.rendering:xwiki-rendering-transformation-macro:*:jar:*</exclude>
                     <exclude>org.xwiki.platform:xwiki-platform-extension-handler-xar:*:jar:*</exclude>


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XCOMMONS-3174


# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Move org.xwiki.cache.util.AbstractCache#AbstractCache() to legacy

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*    introduce the cache-api legacy module (in a separate PR https://github.com/xwiki/xwiki-commons/pull/1128 on xwiki-commons)
*    add the new module to the legacy-war dependencies


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Built the distribution module with the legacy profile.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A