### PR TITLE
XCOMMONS-3175: Move LocalInfinispanCacheFactory to legacy

### DIFF
--- a/xwiki-platform-distribution/xwiki-platform-distribution-war-legacydependencies/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-war-legacydependencies/pom.xml
@@ -160,6 +160,11 @@
     <!-- Legacy dependencies -->
     <dependency>
       <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-legacy-cache-infinispan</artifactId>
+      <version>${commons.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
       <artifactId>xwiki-commons-legacy-component-default</artifactId>
       <version>${commons.version}</version>
     </dependency>


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XCOMMONS-3175

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Move LocalInfinispanCacheFactory to legacy

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Introduce xwiki-commons-legacy-cache-infinispan and move LocalInfinispanCacheFactory (in a separate commons PR https://github.com/xwiki/xwiki-commons/pull/1129)
* add xwiki-commons-legacy-cache-infinispan to legacy war dependencies 

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Build commons with profile legacy

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A