### PR TITLE
XWIKI-22579: Livedata filter selectize input for lists does not have a label

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/xwiki.selectize.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/xwiki.selectize.js
@@ -209,6 +209,8 @@ define('xwiki-selectize', [
     }
     // Set the title of the input field.
     this.selectize.get$('control_input').attr('title', $(this).attr('title'));
+    // Set the text alternative of the input field
+    this.selectize.get$('control_input').attr('aria-label', $(this).attr('aria-label'));
   };
 
   var setDropDownAlignment = function(selectize) {


### PR DESCRIPTION



# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Added a way to retrieve the aria-label of the input to complete the selectize control-input

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Very similar needs happened for the title attribute for [XWIKI-16147](https://jira.xwiki.org/browse/XWIKI-16147). This solution uses the same implementation.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Here, we look at the liveData from the menu application, which caused a lot of fails in test suites:
Before the changes proposed in this PR:
![Screenshot from 2024-10-17 13-34-53](https://github.com/user-attachments/assets/52ed87e0-c645-491e-97fd-e61583c4b8b6)
We can see that the LD List filter control-input does not have any text alternative.
After the changes proposed in this PR:
![Screenshot from 2024-10-17 13-43-18](https://github.com/user-attachments/assets/40afd186-a331-41bb-a1f2-e6c16010467f)
We can see that the text alternative is retrieve from the augmented input.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
First, I built the changes locally with `mvn clean install -f xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war -Pquality`. Then I started a test suite where some of those Livedata List filters prompted errors on the CI. Namely, `mvn clean install -f xwiki-platform-core/xwiki-platform-release/xwiki-platform-release-test/xwiki-platform-release-test-docker/ -Pdocker -Dxwiki.test.ui.wcag=true`. The wcagWarning file generated from these tests still reported the errors from https://jira.xwiki.org/browse/XWIKI-22580, but none from XWIKI-22579.

I did not test all the other modules where the errors at the origin of this ticket happened, but from this limited testing I can assess that this PR does not create new WCAG issues and passes quality tests.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.x
  * 16.4.x