### PR TITLE
XWIKI-22581: FocusCatcher input has no label

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -1396,6 +1396,7 @@ core.widgets.gallery.previousImage=Show previous image
 core.widgets.gallery.nextImage=Show next image
 core.widgets.gallery.maximize=Maximize
 core.widgets.gallery.minimize=Minimize
+core.widgets.gallery.index.description=Press the right and left arrow keys to quickly navigate through the images.
 
 core.widgets.suggest.noResults=No results!
 core.widgets.suggest.showResults=Go to search page\u2026

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/gallery/gallery.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/gallery/gallery.css
@@ -33,9 +33,6 @@
   object-fit: scale-down;
   max-width: 100%;
   max-height: 100%;
-  /* Address an issue with the CSS Grid blowing out with large pictures */
-  height: auto;  
-  width: 100%;
 }
 
 /* Transparent buttons that should fill the space they've been given on the grid*/

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/gallery/gallery.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/gallery/gallery.css
@@ -2,6 +2,7 @@
   background-color: black;
   max-width: 100%;
   padding: 10px;
+  border-radius: 7px; /* Same value as @border-radius-base from Flamingo. */
   /* Position relative is required because some of the inner elements have position absolute and the gallery container
   must be their offset parent. */
   position: relative;
@@ -22,16 +23,19 @@
   top: 0;
   z-index: 1001;
   width: 100% !important;
+  border-radius: 0;
 }
 
-.xGallery .image-container {
+.xGallery .currentImage {
   grid-area: 2 / 2 / 3 / 3;
-  display: inline-flex;
-  align-content: center;
-  justify-content: center;
-}
-.xGallery .image-container .currentImage {
+  align-self: center;
+  justify-self: center;
   object-fit: scale-down;
+  max-width: 100%;
+  max-height: 100%;
+  /* Address an issue with the CSS Grid blowing out with large pictures */
+  height: auto;  
+  width: 100%;
 }
 
 /* Transparent buttons that should fill the space they've been given on the grid*/
@@ -48,7 +52,6 @@
   font-family: courier,monospace;
   font-size: 32px;
   font-weight: 100;
-  line-height: 124px;
   text-align: center;
 }
 
@@ -70,7 +73,7 @@
   font-size: smaller;
   line-height: 1;
   grid-area: 3 / 1 / 4 / 2;
-  align-content: end;
+  align-self: end;
 }
 
 .xGallery .loading {

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/gallery/gallery.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/gallery/gallery.css
@@ -35,7 +35,7 @@
   max-height: 100%;
 }
 
-/* Transparent buttons that should fill the space they've been given on the grid*/
+/* Transparent buttons that should fill the space they've been given on the grid */
 .xGallery .previous, .xGallery .next,
 .xGallery .maximize, .xGallery .minimize {
   background-color: transparent;
@@ -89,12 +89,12 @@
   opacity: 1;
 }
 
-/* Elements on the left of the grid are left aligned*/
+/* Elements on the left of the grid are left aligned */
 .xGallery .index, .xGallery .previous {
   text-align: start;
 }
 
-/* Elements on the right of the grid are right aligned*/
+/* Elements on the right of the grid are right aligned */
 .xGallery .maximize, .xGallery .minimize, .xGallery .next {
   text-align: end;
 }

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/gallery/gallery.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/gallery/gallery.css
@@ -10,13 +10,9 @@
   /* Those width/height values can be overridden by the inline styling added with the macro parameters */
   width: 620px;
   height: 349px;
-}
-
-.xGallery:before {
-  content: "";
-  display: inline-block;
-  height: 100%;
-  vertical-align: middle;
+  display: grid;
+  grid-template-columns: 1fr 10fr 1fr;
+  grid-template-rows: 1fr 10fr 1fr;
 }
 
 .xGallery.maximized {
@@ -28,26 +24,32 @@
   width: 100% !important;
 }
 
-.xGallery .currentImage {
-  max-height: 100%;
-  max-width: 100%;
-  padding: 22px;
-  vertical-align: middle;
+.xGallery .image-container {
+  grid-area: 2 / 2 / 3 / 3;
+  display: inline-flex;
+  align-content: center;
+  justify-content: center;
+}
+.xGallery .image-container .currentImage {
+  object-fit: scale-down;
+}
+
+/* Transparent buttons that should fill the space they've been given on the grid*/
+.xGallery .previous, .xGallery .next,
+.xGallery .maximize, .xGallery .minimize {
+  background-color: transparent;
+  border-color: transparent;
+  width: 100%;
+  height: 100%;
 }
 
 .xGallery .previous, .xGallery .next {
   color: #A0A0A0;
-  cursor: pointer;
   font-family: courier,monospace;
   font-size: 32px;
   font-weight: 100;
-  height: 124px;
   line-height: 124px;
-  margin-top: -64px;
-  position: absolute;
   text-align: center;
-  top: 50%;
-  width: 32px;
 }
 
 .xGallery .previous:hover, .xGallery .next:hover {
@@ -55,52 +57,46 @@
 }
 
 .xGallery .previous {
-  left: 0;
+  grid-area: 2 / 1 / 3 / 2;
 }
 
 .xGallery .next {
-  right: 0;
+  grid-area: 2 / 3 / 3 / 4;
 }
 
 .xGallery .index {
-  bottom: 10px;
   color: #C0C0C0;
   font-family: sans-serif;
   font-size: smaller;
-  left: 10px;
   line-height: 1;
-  position: absolute;
+  grid-area: 3 / 1 / 4 / 2;
+  align-content: end;
 }
 
 .xGallery .loading {
   background-image: url('loading.gif') !important;
 }
 
-.xGallery .focusCatcher {
-  background-color: black;
-  border: 0 none;
-  color: black;
-  height: 1px;
-  left: 0;
-  overflow: hidden;
-  position: absolute;
-  top: 0;
-  width: 1px;
-  z-index: -1;
-}
-
 .xGallery .maximize, .xGallery .minimize {
-  cursor: pointer;
   height: 16px;
   opacity: .5;
-  position: absolute;
-  right: 10px;
-  top: 10px;
   width: 16px;
+  grid-area: 1 / 3 / 2 / 4;
+  justify-self: end;
 }
 
 .xGallery .maximize:hover, .xGallery .minimize:hover {
   opacity: 1;
+}
+
+/* Elements on the left of the grid are left aligned*/
+.xGallery .index, .xGallery .previous {
+  text-align: start;
+}
+
+/* Elements on the right of the grid are right aligned*/
+.xGallery .maximize, .xGallery .minimize, .xGallery .next {
+  text-align: end;
 }
 
 .xGallery .maximize {

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/gallery/gallery.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/gallery/gallery.js
@@ -24,25 +24,23 @@ XWiki.Gallery = Class.create({
     this.images = this._collectImages(container);
 
     this.container = container.update(
-      '<input type="text" tabindex="-1" class="focusCatcher"/>' +
+      '<button class="maximize" title="${escapetool.xml($services.localization.render("core.widgets.gallery.maximize"))}"></button>' +
+      '<button class="previous" title="${escapetool.xml($services.localization.render("core.widgets.gallery.previousImage"))}">&lt;</button>' +
+      '<span class="focusCatcher image-container" role="group" aria-roledescription="slide" tabindex="0">' +
       '<img class="currentImage" alt="${escapetool.xml($services.localization.render("core.widgets.gallery.currentImage"))}"/>' +
-      '<div class="previous" title="${escapetool.xml($services.localization.render("core.widgets.gallery.previousImage"))}">&lt;</div>' +
-      '<div class="next" title="${escapetool.xml($services.localization.render("core.widgets.gallery.nextImage"))}">&gt;</div>' +
-      '<div class="index">0 / 0</div>' +
-      '<div class="maximize" title="${escapetool.xml($services.localization.render("core.widgets.gallery.maximize"))}"></div>'
+      '</span>' +
+      '<button class="next" title="${escapetool.xml($services.localization.render("core.widgets.gallery.nextImage"))}">&gt;</button>' +
+      '<div class="index">0 / 0</div>'
     );
-    this.container.addClassName('xGallery');
+    this.container.addClassName('xGallery');    
 
     this.focusCatcher = this.container.down('.focusCatcher');
     this.focusCatcher.observe('keydown', this._onKeyDown.bindAsEventListener(this));
-    this.container.observe('click', function() {
-      this.focusCatcher.focus();
-    }.bind(this));
 
     this.container.down('.previous').observe('click', this._onPreviousImage.bind(this));
     this.container.down('.next').observe('click', this._onNextImage.bind(this));
 
-    this.currentImage = this.container.down('.currentImage');
+    this.currentImage = this.focusCatcher.down('.currentImage');
     this.currentImage.observe('load', this._onLoadImage.bind(this));
     this.currentImage.observe('error', this._onErrorImage.bind(this));
     this.currentImage.observe('abort', this._onAbortImage.bind(this));

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/gallery/gallery.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/gallery/gallery.js
@@ -31,12 +31,12 @@ XWiki.Gallery = Class.create({
     );
     this.container.addClassName('xGallery');    
     
-    /* Instead of an arbitrary element to catch focus, we use the index.
-    * This index already stores the current image state, might as well be responsible for providing quick controls and
-    * explanations about these quick controls.
-    * Note that wrapping the image in an interactive container to handle this would have been a good solution too.
-    * However, this wrapping caused the image to overflow the CSS grid vertically when in maximized mode. 
-    * Technically I couldn't find a CSS solution to prevent this, so I decided to make do without wrapping. */
+    // Instead of an arbitrary element to catch focus, we use the index.
+    // This index already stores the current image state, might as well be responsible for providing quick controls and
+    // explanations about these quick controls.
+    // Note that wrapping the image in an interactive container to handle this would have been a good solution too.
+    // However, this wrapping caused the image to overflow the CSS grid vertically when in maximized mode. 
+    // Technically I couldn't find a CSS solution to prevent this, so I decided to make do without wrapping.
     this.focusCatcher = this.container.down('.index');
     this.focusCatcher.observe('keydown', this._onKeyDown.bindAsEventListener(this));
 

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/gallery/gallery.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/gallery/gallery.js
@@ -22,25 +22,31 @@ var XWiki = (function (XWiki) {
 XWiki.Gallery = Class.create({
   initialize : function(container) {
     this.images = this._collectImages(container);
-
     this.container = container.update(
       '<button class="maximize" title="${escapetool.xml($services.localization.render("core.widgets.gallery.maximize"))}"></button>' +
       '<button class="previous" title="${escapetool.xml($services.localization.render("core.widgets.gallery.previousImage"))}">&lt;</button>' +
-      '<span class="focusCatcher image-container" role="group" aria-roledescription="slide" tabindex="0">' +
       '<img class="currentImage" alt="${escapetool.xml($services.localization.render("core.widgets.gallery.currentImage"))}"/>' +
-      '</span>' +
       '<button class="next" title="${escapetool.xml($services.localization.render("core.widgets.gallery.nextImage"))}">&gt;</button>' +
-      '<div class="index">0 / 0</div>'
+      '<div class="index" tabindex="0" title="${escapetool.xml($services.localization.render("core.widgets.gallery.index.description"))}" aria-description="${escapetool.xml($services.localization.render("core.widgets.gallery.index.description"))}">0 / 0</div>'
     );
     this.container.addClassName('xGallery');    
-
-    this.focusCatcher = this.container.down('.focusCatcher');
+    
+    /* Instead of an arbitrary element to catch focus, we use the index.
+    * This index already stores the current image state, might as well be responsible for providing quick controls and
+    * explanations about these quick controls.
+    * Note that wrapping the image in an interactive container to handle this would have been a good solution too.
+    * However, this wrapping caused the image to overflow the CSS grid vertically when in maximized mode. 
+    * Technically I couldn't find a CSS solution to prevent this, so I decided to make do without wrapping. */
+    this.focusCatcher = this.container.down('.index');
     this.focusCatcher.observe('keydown', this._onKeyDown.bindAsEventListener(this));
 
     this.container.down('.previous').observe('click', this._onPreviousImage.bind(this));
     this.container.down('.next').observe('click', this._onNextImage.bind(this));
+    this.container.observe('click', function() {
+      this.focusCatcher.focus();
+    }.bind(this));
 
-    this.currentImage = this.focusCatcher.down('.currentImage');
+    this.currentImage = this.container.down('.currentImage');;
     this.currentImage.observe('load', this._onLoadImage.bind(this));
     this.currentImage.observe('error', this._onErrorImage.bind(this));
     this.currentImage.observe('abort', this._onAbortImage.bind(this));

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/gallery/gallery.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/gallery/gallery.js
@@ -46,7 +46,7 @@ XWiki.Gallery = Class.create({
       this.focusCatcher.focus();
     }.bind(this));
 
-    this.currentImage = this.container.down('.currentImage');;
+    this.currentImage = this.container.down('.currentImage');
     this.currentImage.observe('load', this._onLoadImage.bind(this));
     this.currentImage.observe('error', this._onErrorImage.bind(this));
     this.currentImage.observe('abort', this._onAbortImage.bind(this));


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22581

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Replaced the FocusCatcher artificial input.
* Updated the style of the gallery to use css grid instead of hackish solutions all around.
* Improved accessibility by changing the div interactive controllers with buttons.
* Improved consistency of the UI by adding standard round corners to the component.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The solution picked had to go around a layout issue with the picture overflowing off the grid when wrapped and in full screen See the comment for more details on this issue.


# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Video demo:

https://github.com/user-attachments/assets/9e352d7c-f303-42fa-8830-5e1b0c9fd606

The gallery controls are tested both with the mouse and the keyboard.

Before:
![image](https://github.com/user-attachments/assets/20ef8053-7b63-4ca0-bab3-99b02ae7e16b)
After:
![image](https://github.com/user-attachments/assets/2518967d-584e-48f6-9c59-2b80e135dbbd)

I tried to keep the visuals as close as possible as what was here before. The only differences I can spot are:
* Round corners
* Slightly more space between the side of the component and the `previous`/`next` buttons. This happens because of the default padding that was added when transforming this element in a button. IMO this change is not a problem.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Manual tests: see above + tests with different screen sizes.
Built changes with `mvn clean install -f xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war -Pquality` and tested `mvn clean install -f xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-test/xwiki-platform-office-test-docker -Pdocker -Dxwiki.test.ui.wcag=true`. The WCAG violations reported did not highlight any issue with the gallery anymore.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None