### PR TITLE
XWIKI-12629: Page Right is shown when administering inexistent WebHome page

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminPageUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminPageUIX.xml
@@ -108,7 +108,7 @@
     </class>
     <property>
       <content>{{velocity}}{{html clean="false"}} ## we need clean="false" because we want to display the raw content of #submenuitem()
-#if ($hasSpaceAdmin &amp;&amp; $isAdminAppInstalled)
+#if ($hasSpaceAdmin &amp;&amp; $isAdminAppInstalled &amp;&amp; !$doc.isNew())
   #template('menus_macros.vm')
   #set ($adminspaceaction = $xwiki.getURL($spacePreferencesDocumentReference, 'admin'))
   #if ($doc.documentReference.name == 'WebHome')

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_content.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_content.vm
@@ -450,7 +450,9 @@
         #end
         <dd>
           <ul>
-            #submenuitem($doc.getURL('view', "viewer=code$!{revisionParameter}") $services.localization.render('core.menu.view.source') 'tmViewSource', '', 'search', $extraAttributes)
+            #if ($canView)
+              #submenuitem($doc.getURL('view', "viewer=code$!{revisionParameter}") $services.localization.render('core.menu.view.source') 'tmViewSource', '', 'search', $extraAttributes)
+            #end
             $viewersContent
             ## Display Viewers menu UIX..
             #displaySecureUIX('org.xwiki.platform.template.menu.viewers', [])

--- a/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-ui/src/main/resources/XWiki/Like/LikeViewersMenuUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-ui/src/main/resources/XWiki/Like/LikeViewersMenuUIX.xml
@@ -164,7 +164,7 @@
     </property>
     <property>
       <content>{{velocity}}
-        #if ($services.like.isEnabled())
+        #if ($services.like.isEnabled() &amp;&amp; !$doc.isNew())
         {{html clean="false"}}
         #template('menus_macros.vm')
         #submenuitem($doc.getURL('view','viewer=likers'), $services.localization.render('like.unlike.modal.viewLikersButton'), 'likers', '', 'heart')


### PR DESCRIPTION



# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-12629

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Removed all items from the tmMoreActions menu when the page is not created yet, except for the `Children` view which actually does something (see XWIKI-12628)

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The `Page Rights` did have an unexpected side effect.
* The two other view displays were not included in the ticket initially, but I figured it'd be better to remove them in the same way when the page is not created. They would just display the same template as the view action.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Before the PR vvv
![Screenshot from 2024-10-24 10-44-54](https://github.com/user-attachments/assets/18e2281c-bd5f-4119-b5f3-b16c0a18479d)
After the PR vvv
![Screenshot from 2024-10-24 11-47-53](https://github.com/user-attachments/assets/02e7d798-61e6-431a-87ec-3227e1183f9f)

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

None except for manual tests. This is purely templating and I doubt any integration test tried to use those actions in this specific context.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.4.X
  * 15.10.X