### PR TITLE
XWIKI-22293: HTML error and non-rendered Velocity in export modal

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/export_modal.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/export_modal.vm
@@ -83,7 +83,7 @@
         $uix.parameters.excludeNestedPagesByDefault == 'true'))
       #set ($discard = $exportFormatsForCategory.add($exportFormat))
       ## Include the resources and configuration required by this export format.
-      $services.rendering.render($uix.execute(), 'html/5.0')
+      $!services.rendering.render($uix.execute(), 'html/5.0')
     #end
   #end
   #addLegacyExportFormats($exportFormatsByCategory)


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-22293

# Changes

## Description

Use the `!` silencer on the velocity variable to prevent displaying the code in the resulting HTML.

## Clarifications

* In the list of `$exportFormatsUIXs`, there are 2 types of data: `java.util.LinkedHashMap` and `org.xwiki.uiextension.internal.WikiUIExtension`. 
* Calling `java.util.LinkedHashMap#execute()` will not produce any result and `$services.rendering.render($uix.execute(), 'html/5.0')` will be displayed in the resulting HTML.

# Screenshots & Video

Before:
![image](https://github.com/user-attachments/assets/f5c59d92-23d1-4f43-84e5-62f40699f62d)
After:
![image](https://github.com/user-attachments/assets/0a9044a8-721f-43d2-8faf-8bba5f218fa1)


# Executed Tests

N/A

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.4.x
  * 15.10.x