### PR TITLE
XWIKI-14073: Hide the Copy action when the wiki is in readonly mode

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_content.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_content.vm
@@ -27,7 +27,9 @@
 ## copy menu action. Checking if the user (or guest) doesn't have edit
 ## permissions on the whole wiki (including subwiki) is costly. Thus FTM we
 ## only check for view permissions.
-#set ($canCopy = $canView)
+## When the wiki server is in readonly mode, edit permissions are OFF everywhere. We can safely assume that the copy
+## action is not allowed.
+#set ($canCopy = $canView && !$xwiki.isReadOnly())
 
 #set ($nbUsers = $doc.getObjectNumbers("XWiki.XWikiUsers"))
 #set ($nbGroups = $doc.getObjectNumbers("XWiki.XWikiGroups"))


### PR DESCRIPTION

# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-14073

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Disabled the display of the copy action when the wiki server is in readonly mode.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* We cannot use directly the edit right here, because it might be allowed to edit onto the target space (and it'd be costly to check every possible target). However the readOnly mode would disable this feature in all cases (all possible targets are also readOnly because it's a wiki server parameter and not a wiki parameter). 

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
After the PR:
![Screenshot from 2024-10-24 17-38-02](https://github.com/user-attachments/assets/caa763ef-6c16-4496-bcd0-bc653189deca)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Quick manual test only (see screenshot above). The changes are minimal and I doubt a functional test tries out functionalities in the readonly mode.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.4.x
  * 15.10.x