### PR TITLE
XWIKI-22577: Cloning documents with many XObjects and high object numbers is slow

### DIFF
--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/reference/EntityReference.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/reference/EntityReference.java
@@ -22,6 +22,7 @@ package org.xwiki.model.reference;
 import java.beans.Transient;
 import java.io.Serializable;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -687,16 +688,6 @@ public class EntityReference implements Serializable, Cloneable, Comparable<Enti
             .append(this.parameters).toHashCode();
     }
 
-    /**
-     * {@inheritDoc}
-     * <p>
-     * Note: The default implementation relies on comparing the string serialization of the 2 entities. It is the
-     * caller's responsibility to make sure that the entities are either first resolved or at least of the same type, in
-     * order for the comparison to actually make sense.
-     * </p>
-     * 
-     * @see java.lang.Comparable#compareTo(java.lang.Object)
-     */
     @Override
     public int compareTo(EntityReference reference)
     {
@@ -708,47 +699,71 @@ public class EntityReference implements Serializable, Cloneable, Comparable<Enti
             return 0;
         }
 
-        // Generically compare the string serializations of the 2 references.
-        int stringCompareResult = toString().compareTo(reference.toString());
-        if (stringCompareResult != 0) {
-            return stringCompareResult;
-        }
+        List<EntityReference> references = getReversedReferenceChain();
+        Iterator<EntityReference> it = references.iterator();
+        List<EntityReference> otherReferences = reference.getReversedReferenceChain();
+        Iterator<EntityReference> otherIt = otherReferences.iterator();
+        while (it.hasNext() && otherIt.hasNext()) {
+            EntityReference element = it.next();
+            EntityReference otherElement = otherIt.next();
 
-        // If the string serializations are the same, compare the parameters.
-        return compareParameters(reference);
-    }
+            // Compare the names
+            int result = element.getName().compareTo(otherElement.getName());
+            if (result != 0) {
+                return result;
+            }
 
-    /**
-     * Compare parameters of this reference and another reference.
-     *
-     * @param reference the other reference to be compare with
-     * @return 0 if parameters are equals, -1 if this reference has lower parameters, +1 otherwise
-     */
-    @SuppressWarnings("unchecked")
-    private int compareParameters(EntityReference reference)
-    {
-        if (parameters != null && reference.parameters == null) {
-            return 1;
-        }
-
-        if (parameters != null) {
-            for (Map.Entry<String, Serializable> entry : parameters.entrySet()) {
-                Object obj = reference.parameters.get(entry.getKey());
-                Object myobj = entry.getValue();
-                if (myobj instanceof Comparable) {
-                    if (obj == null) {
-                        return 1;
-                    }
-
-                    int number = ((Comparable) myobj).compareTo(obj);
-
-                    if (number != 0) {
-                        return number;
-                    }
-                }
+            // Compare the parameters
+            result = compareParameters(element.getParameters(), otherElement.getParameters());
+            if (result != 0) {
+                return result;
             }
         }
 
-        return (reference.parameters == null) ? 0 : -1;
+        return references.size() - otherReferences.size();
+    }
+
+    /**
+     * Compare parameters of two references.
+     *
+     * @param parameters the first parameters to compare
+     * @param otherParameters the other parameters to compare
+     * @return 0 if parameters are equals, -1 if the first parameters are lower, +1 otherwise
+     */
+    private int compareParameters(Map<String, Serializable> parameters, Map<String, Serializable> otherParameters)
+    {
+        for (Map.Entry<String, Serializable> entry : parameters.entrySet()) {
+            Object value = entry.getValue();
+            Object otherValue = otherParameters.get(entry.getKey());
+            int result = compareTo(value, otherValue);
+            if (result != 0) {
+                return result;
+            }
+        }
+
+        return parameters.size() - otherParameters.size();
+    }
+
+    private int compareTo(Object value, Object otherValue)
+    {
+        if (value != otherValue) {
+            if (value == null) {
+                return -1;
+            }
+
+            if (otherValue == null) {
+                return 1;
+            }
+
+            if (value.getClass() == otherValue.getClass() && value instanceof Comparable) {
+                return ((Comparable) value).compareTo(otherValue);
+            }
+
+            if (!value.equals(otherValue)) {
+                return 1;
+            }
+        }
+
+        return 0;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -60,6 +60,7 @@ import java.util.zip.ZipOutputStream;
 import javax.inject.Provider;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -3306,7 +3307,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
     {
         object.setOwnerDocument(this);
 
-        List<BaseObject> vobj = this.xObjects.get(object.getXClassReference());
+        BaseObjects vobj = this.xObjects.get(object.getXClassReference());
         if (vobj == null) {
             setXObject(0, object);
         } else {
@@ -3335,15 +3336,9 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
             object.setNumber(nb);
         }
 
-        BaseObjects objects = this.xObjects.get(classReference);
-        if (objects == null) {
-            objects = new BaseObjects();
-            this.xObjects.put(classReference, objects);
-        }
-        while (nb >= objects.size()) {
-            objects.add(null);
-        }
-        objects.set(nb, object);
+        BaseObjects objects = this.xObjects.computeIfAbsent(classReference, k -> new BaseObjects());
+        objects.put(nb, object);
+
         setMetaDataDirty(true);
     }
 
@@ -3361,15 +3356,9 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
         object.setOwnerDocument(this);
         object.setNumber(nb);
 
-        BaseObjects objects = this.xObjects.get(object.getXClassReference());
-        if (objects == null) {
-            objects = new BaseObjects();
-            this.xObjects.put(object.getXClassReference(), objects);
-        }
-        while (nb >= objects.size()) {
-            objects.add(null);
-        }
-        objects.set(nb, object);
+        BaseObjects objects = this.xObjects.computeIfAbsent(object.getXClassReference(), k -> new BaseObjects());
+        objects.put(nb, object);
+
         setMetaDataDirty(true);
     }
 
@@ -3473,31 +3462,32 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
     /**
      * Copy specified document objects into current document.
      *
-     * @param templatedoc the document to copy
-     * @param keepsIdentity if true it does an exact java copy, otherwise it duplicate objects with the new document
-     *            name (and new class names)
+     * @param templateDocument the document to copy
+     * @param keepsIdentity if true it does an exact copy (same guid), otherwise it create a new object with the same
+     *            values
      */
-    private void cloneXObjects(XWikiDocument templatedoc, boolean keepsIdentity)
+    private void cloneXObjects(XWikiDocument templateDocument, boolean keepsIdentity)
     {
         // clean map
         this.xObjects.clear();
 
         // fill map
-        for (Map.Entry<DocumentReference, List<BaseObject>> entry : templatedoc.getXObjects().entrySet()) {
-            List<BaseObject> tobjects = entry.getValue();
+        for (Map.Entry<DocumentReference, BaseObjects> entry : templateDocument.xObjects.entrySet()) {
+            BaseObjects tobjects = entry.getValue();
 
-            // clone and insert xobjects
-            for (BaseObject otherObject : tobjects) {
-                if (otherObject != null) {
-                    if (keepsIdentity) {
-                        addXObject(otherObject.clone());
-                    } else {
-                        BaseObject newObject = otherObject.duplicate(getDocumentReference());
-                        setXObject(newObject.getNumber(), newObject);
+            if (CollectionUtils.isNotEmpty(tobjects)) {
+                BaseObjects objects = new BaseObjects(this, tobjects, keepsIdentity);
+
+                if (!objects.isEmpty()) {
+                    DocumentReference xclassReference = entry.getKey();
+                    WikiReference wikiReference = getDocumentReference().getWikiReference();
+                    if (!wikiReference.equals(xclassReference.getWikiReference())) {
+                        // Make sure the class reference is in the same wiki as the document in which the object is
+                        // stored
+                        xclassReference = xclassReference.setWikiReference(wikiReference);
                     }
-                } else if (keepsIdentity) {
-                    // set null object to make sure to have exactly the same thing when cloning a document
-                    addXObject(entry.getKey(), null);
+
+                    this.xObjects.put(xclassReference, objects);
                 }
             }
         }
@@ -4597,13 +4587,12 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable
 
             if (keepsIdentity) {
                 doc.setXClassXML(getXClassXML());
-                doc.cloneXObjects(this);
                 doc.cloneAttachments(this);
             } else {
                 doc.getXClass().setCustomMapping(null);
-                doc.duplicateXObjects(this);
                 doc.copyAttachments(this);
             }
+            doc.cloneXObjects(this, keepsIdentity);
 
             doc.setContentDirty(isContentDirty());
             doc.setMetaDataDirty(isMetaDataDirty());


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-22577

# Changes

## Description

Trying to speed up the xobjects part of the document cloning.

## Clarifications

* speed up DocumentReference#compareTo implementation, which is used when accessing xobjects
* optimize xobject cloning to avoid going through public add for each xobject and especially skip the manipulation of "null entries"

# Executed Tests

Not really any new test, since xobject cloning is well covered already, and it's not easy to test performances through automated testing.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches: 15.10.x, 16.10.x