### PR TITLE
XWIKI-12629: Page Right is shown when administering inexistent WebHome page

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/AdministrationIT.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/AdministrationIT.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import org.xwiki.administration.test.po.AdministrablePage;
 import org.xwiki.administration.test.po.AdministrationPage;
+import org.xwiki.test.docker.junit5.TestReference;
 import org.xwiki.test.docker.junit5.UITest;
 import org.xwiki.test.ui.TestUtils;
 
@@ -43,12 +44,12 @@ class AdministrationIT
      * Validate presence of default sections for Administration UIs (Global, Page).
      */
     @Test
-    void verifyAdministrationSections(TestUtils setup)
+    void verifyAdministrationSections(TestUtils setup, TestReference testReference)
     {
         setup.loginAsSuperAdmin();
 
-        // Navigate to a (non existent for test performance reasons) page in view mode.
-        setup.gotoPage("NonExistentSpace", "NonExistentPage");
+        // Navigate to a page in view mode.
+        setup.createPage(testReference, "");
 
         // Verify that pages have an Admin menu and navigate to the wiki admin UI (which happens to be the global
         // admin UI too since we're on the main wiki).
@@ -71,11 +72,11 @@ class AdministrationIT
         assertTrue(wikiAdministrationPage.hasNotSection("PageRights"));
 
         // Select XWiki page administration.
-        setup.gotoPage("NonExistentSpace", "WebHome");
+        setup.gotoPage(testReference);
         page = new AdministrablePage();
         AdministrationPage pageAdministrationPage = page.clickAdministerPage();
 
-        assertEquals("Page Administration: NonExistentSpace", pageAdministrationPage.getDocumentTitle());
+        assertEquals("Page Administration: AdministrationIT.verifyAdministrationSections", pageAdministrationPage.getDocumentTitle());
         assertTrue(pageAdministrationPage.getBreadcrumbContent().endsWith("/Page Administration"));
 
         assertTrue(pageAdministrationPage.hasSection("Themes"));

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/AdministrationIT.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/AdministrationIT.java
@@ -75,8 +75,9 @@ class AdministrationIT
         setup.gotoPage(testReference);
         page = new AdministrablePage();
         AdministrationPage pageAdministrationPage = page.clickAdministerPage();
-
-        assertEquals("Page Administration: AdministrationIT.verifyAdministrationSections", pageAdministrationPage.getDocumentTitle());
+        String fullName = setup.serializeReference(testReference.getParent()).split(":")[1];
+        assertEquals("Page Administration: " + fullName, 
+            pageAdministrationPage.getDocumentTitle());
         assertTrue(pageAdministrationPage.getBreadcrumbContent().endsWith("/Page Administration"));
 
         assertTrue(pageAdministrationPage.hasSection("Themes"));

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/AdministrationIT.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/AdministrationIT.java
@@ -75,7 +75,7 @@ class AdministrationIT
         setup.gotoPage(testReference);
         page = new AdministrablePage();
         AdministrationPage pageAdministrationPage = page.clickAdministerPage();
-        String fullName = setup.serializeReference(testReference.getParent()).split(":")[1];
+        String fullName = setup.serializeLocalReference(testReference.getParent());
         assertEquals("Page Administration: " + fullName, 
             pageAdministrationPage.getDocumentTitle());
         assertTrue(pageAdministrationPage.getBreadcrumbContent().endsWith("/Page Administration"));


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-12629

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Fixed test that relied on an uncreated page's administration section

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* This is a fix for a regression introduced in https://github.com/xwiki/xwiki-platform/pull/3590 : https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/master/7578/testReport/org.xwiki.administration.test.ui/AllIT$NestedAdministrationIT/Platform_Builds___main___integration_tests___IT_for_xwiki_platform_core_xwiki_platform_administration_xwiki_platform_administration_test_xwiki_platform_administration_test_docker___Build_for_IT_for_xwiki_platform_core_xwiki_platform_administration_xwiki_platform_administration_test_xwiki_platform_administration_test_docker___verifyAdministrationSections_TestUtils_/ 
* There was a comment about not creating the page for performance. Since editing the administration section creates the page in the background, I'm pretty sure there is close to none performance improvement. 
* This behaviour of the administration section was considered a bug, so I updated the test to create a page and then use its administration section regularly.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
None, test only change

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Successfully ran `mvn clean install -f xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker -Pdocker`

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.4.X
  * 15.10.X
Similar to https://github.com/xwiki/xwiki-platform/pull/3590 