### PR TITLE
XWIKI-22590: Links in message boxes lack contrast

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/messages.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/messages.less
@@ -76,25 +76,21 @@ fieldset.xwikimessage { // Used by: Login form, Delete messages
 
 .successmessage {
   .alert-success;
-  background-color: @state-success-bg;
   border-color: @brand-success;
 }
 
 .errormessage {
   .alert-danger;
-  background-color: @state-danger-bg;
   border-color: @brand-danger;
 }
 
 .warningmessage {
   .alert-warning;
-  background-color: @state-warning-bg;
   border-color: @brand-warning;
 }
 
 .infomessage {
   .alert-info;
-  background-color: @state-info-bg;
   border-color: @brand-primary;
 }
 


### PR DESCRIPTION

# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22590

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Removed the overwrite of the default value for the messageBox colors. Usually those values are equal or very close. Without a colorTheme, one set of those values was not properly initialized.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* This change was added initially in https://github.com/xwiki/xwiki-platform/commit/beaeb18d3aaf1028f40cbfcf2a958f0c1c459b8d#diff-4c3b8ac56f692179aec4802811ccc197ac6055484d096a0570e808f7472d3d8c 
* This was squashed from the commit https://github.com/xwiki/xwiki-platform/pull/3023/commits/6c0b9e2701f805fa2b809982a259c7237f446e18 on the PR branch. I failed to see that this extra definition of the background-color was 1. superfluous because already defined in the mixin 2. incorrect in some situations.
* Bootstrap natively uses `@alert-<type>-bg` instead of `@status-<type>-bg`. The alert bg is more of a background, while the status bg is more of a border color.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

https://github.com/user-attachments/assets/35b978d6-6bc0-4d23-9c4b-35a0732a112f

The color variation is minimal, and can only be seen on the noColorTheme situation AFAIK.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests. Note that I didn't find a way to clear the `noTheme` cache, so I had to use a fresh instance with the messages.less file updated before the first boot to get the expected results.

Running `mvn clean install -f xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker -Pdocker -Dxwiki.enforcer.skip=true -Dxwiki.test.ui.wcag=true -Dit.test=RenamePageIT#renamePageUsedInMacroContentAndParameters -Dgradle.cache.local.enabled=false -Dgradle.cache.remote.enabled=false` before the changes successfully returned the WCAG violation, while after building the changes with `mvn clean install -f xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources`, the contrast violation was not reported anymore.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, like https://github.com/xwiki/xwiki-platform/pull/2590