### PR TITLE
XWIKI-21387: The syntax highlighting done by the Code Macro lacks contrast

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/main/java/org/xwiki/rendering/internal/parser/pygments/DefaultPygmentsParserConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/main/java/org/xwiki/rendering/internal/parser/pygments/DefaultPygmentsParserConfiguration.java
@@ -41,10 +41,10 @@ public class DefaultPygmentsParserConfiguration implements PygmentsParserConfigu
     private static final String PREFIX = "rendering.macro.code.pygments.";
 
     /**
-     * Default style name to use.
+     * Default value of style provided to code.py
      * @since 16.10.0RC1
      */
-    private static final String DEFAULT_STYLE = "xwiki";
+    private static final String DEFAULT_STYLE = "default";
 
     /**
      * Defines from where to read the Pygments configuration data.

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/main/resources/pygments/code.py
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/main/resources/pygments/code.py
@@ -40,7 +40,7 @@ else:
 if pygmentLexer:
   pygmentStyle = None
   if style:
-    if style == "xwiki":
+    if style == "default":
       pygmentStyle = XWikiStyle
     else:
       try:


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-21387

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Updated the default style value for easier understanding
* Updated the documentation to be more precise


# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
None, code quality change only.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
None.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, similarly to https://github.com/xwiki/xwiki-platform/pull/3052