### PR TITLE
XWIKI-22481: Add the ability to use a LibreOffice binary from another server

### DIFF
--- a/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/internal/server/DefaultOfficeServer.java
+++ b/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/internal/server/DefaultOfficeServer.java
@@ -39,6 +39,7 @@ import org.xwiki.officeimporter.internal.converter.DefaultOfficeConverter;
 import org.xwiki.officeimporter.server.OfficeServer;
 import org.xwiki.officeimporter.server.OfficeServerConfiguration;
 import org.xwiki.officeimporter.server.OfficeServerException;
+import org.xwiki.text.StringUtils;
 
 /**
  * Default {@link OfficeServer} implementation.
@@ -137,6 +138,7 @@ public class DefaultOfficeServer implements OfficeServer
             ExternalOfficeManager.Builder externalProcessOfficeManager = ExternalOfficeManager.builder();
             externalProcessOfficeManager.portNumbers(this.config.getServerPorts());
             externalProcessOfficeManager.connectOnStart(true);
+            externalProcessOfficeManager.hostName(config.getServerHost());
             this.jodManager = externalProcessOfficeManager.build();
         } else {
             setState(ServerState.CONF_ERROR);
@@ -167,6 +169,9 @@ public class DefaultOfficeServer implements OfficeServer
         }
 
         File workDir = this.environment.getTemporaryDirectory();
+        if (StringUtils.isNotBlank(this.config.getWorkDir())) {
+            workDir = new File(this.config.getWorkDir());
+        }
         this.converter = new DefaultOfficeConverter(this.jodConverter, workDir);
     }
 

--- a/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/internal/server/DefaultOfficeServer.java
+++ b/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/internal/server/DefaultOfficeServer.java
@@ -168,11 +168,16 @@ public class DefaultOfficeServer implements OfficeServer
                 .filterChain(new LinkedImagesEmbedderFilter()).build();
         }
 
+        this.converter = new DefaultOfficeConverter(this.jodConverter, getWorkDir());
+    }
+
+    private File getWorkDir()
+    {
         File workDir = this.environment.getTemporaryDirectory();
         if (StringUtils.isNotBlank(this.config.getWorkDir())) {
             workDir = new File(this.config.getWorkDir());
         }
-        this.converter = new DefaultOfficeConverter(this.jodConverter, workDir);
+        return workDir;
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/internal/server/DefaultOfficeServerConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/internal/server/DefaultOfficeServerConfiguration.java
@@ -53,6 +53,11 @@ public class DefaultOfficeServerConfiguration implements OfficeServerConfigurati
     private static final int DEFAULT_SERVER_TYPE = SERVER_TYPE_INTERNAL;
 
     /**
+     * @see OfficeServerConfiguration#getServerHost()
+     */
+    private static final String DEFAULT_SERVER_HOST = "127.0.0.1";
+
+    /**
      * @see OfficeServerConfiguration#getServerPorts()
      */
     private static final int DEFAULT_SERVER_PORT = 8100;
@@ -87,6 +92,12 @@ public class DefaultOfficeServerConfiguration implements OfficeServerConfigurati
     public int getServerType()
     {
         return this.configuration.getProperty(PREFIX + "serverType", DEFAULT_SERVER_TYPE);
+    }
+
+    @Override
+    public String getServerHost()
+    {
+        return this.configuration.getProperty(PREFIX + "host", DEFAULT_SERVER_HOST);
     }
 
     @Override
@@ -132,6 +143,12 @@ public class DefaultOfficeServerConfiguration implements OfficeServerConfigurati
         }
         
         return homePath;
+    }
+
+    @Override
+    public String getWorkDir()
+    {
+        return this.configuration.getProperty(PREFIX + "workDir");
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/server/OfficeServerConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/server/OfficeServerConfiguration.java
@@ -59,6 +59,16 @@ public interface OfficeServerConfiguration
     int getServerType();
 
     /**
+     * @return the hostname of the office server instance
+     * @since 16.10.0RC1
+     */
+    default String getServerHost()
+    {
+        // Coming from org.jodconverter.local.office.ExternalOfficeManager.DEFAULT_HOSTNAME
+        return "127.0.0.1";
+    }
+
+    /**
      * @return the port number used for connecting to the office server instance
      * @deprecated Since 12.1RC1. Now use {@link #getServerPorts()}.
      */
@@ -90,6 +100,16 @@ public interface OfficeServerConfiguration
      * @return the path to office server execution profile, {@code null} by default
      */
     String getProfilePath();
+
+    /**
+     * @return the path where the files are exchanged between XWiki and the office server (null means: use the default
+     * environment temporary directory)
+     * @see 16.10.0RC1
+     */
+    default String getWorkDir()
+    {
+        return null;
+    }
 
     /**
      * @return the maximum number of simultaneous conversion tasks to be handled by a single office process instance

--- a/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.properties.vm
+++ b/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.properties.vm
@@ -350,6 +350,10 @@ rendering.transformations = $xwikiRenderingTransformations
 #-# 1 - Externally managed (local) server instance.
 # openoffice.serverType = 0
 
+#-# [Since 16.10RC1]
+#-# Hostname used for connecting to the openoffice server instance.
+# openoffice.host = localhost
+
 #-# [Since 12.1RC1]
 #-# Port numbers used for connecting to the openoffice server instance.
 #-# For an internally managed server instance, it will create the process for all ports.
@@ -370,6 +374,11 @@ rendering.transformations = $xwikiRenderingTransformations
 #-# Path to openoffice execution profile (serverType:0 only).
 #-# If no path is provided, a default value will be calculated based on the operating environment.
 # openoffice.profilePath = /home/user/.openoffice.org/3
+
+#-# [Since 16.10RC1]
+#-# Path to a folder where XWiki could exchange temporary files with the openoffice server.
+#-# If no path is provided, the temporary folder set for XWiki will be used.
+# openoffice.workDir = /tmp
 
 #-# [Since 1.8RC3]
 #-# Maximum number of simultaneous conversion tasks to be handled by a single openoffice process (serverType:0 only).


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-22481

# Changes

## Description

I have introduced 2 new properties in xwiki.properties:
- `openoffice.host` to set the hostname of the openoffice server (in case it not reachable at "localhost")
- `openoffice.workDir` to set the folder where the files are exchanged, temporary, between XWiki and the openoffice server (same: useful in a kubernetes environment where we need to mount a common volume between the 2 containers).


## Clarifications

I have not made commit on xwiki-platform for a while, so I prefer asking for a quick confirmation before merging. Thank you!

I have not built on the current master branch, but it built successfully against the 16.4.4 tag.