### PR TITLE
XWIKI-22495: Missing text content in the resource picker dropdown

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-resource/resourcePicker.css
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-resource/resourcePicker.css
@@ -19,6 +19,18 @@
  */
 #template('colorThemeInit.vm')
 
+/* We need to redefine this class to have better priority than the CKEditor CSS reset. */
+.resourcePicker .sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
 .resourcePicker .dropdown-menu > .active > a,
 .resourcePicker .dropdown-menu > .active > a:hover,
 .resourcePicker .dropdown-menu > .active > a:focus {

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-resource/resourcePicker.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-resource/resourcePicker.js
@@ -19,7 +19,8 @@
  */
 define('resourcePickerTranslationKeys', [], [
   'attach.hint',
-  'doc.hint'
+  'doc.hint',
+  'dropdown.toggle.title'
 ]);
 
 define('resourcePicker', [
@@ -35,7 +36,9 @@ define('resourcePicker', [
           '<button type="button" class="resourceType btn btn-default">' +
             '<span class="icon">' +
           '</button>' +
-          '<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">' +
+          '<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" ' +
+            'title="' + translations.get('dropdown.toggle.title') + '">' +
+            '<span class="sr-only">' + translations.get('dropdown.toggle.title') + '</span>' +
             '<span class="caret"></span>' +
           '</button>' +
           '<ul class="resourceTypes dropdown-menu dropdown-menu-right"></ul>' +

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/Translations.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/Translations.xml
@@ -300,6 +300,7 @@ resource.user.placeholder=alias
 
 resourcePicker.attach.hint=Select an attachment
 resourcePicker.doc.hint=Select a page
+resourcePicker.dropdown.toggle.title=Toggle the display of resource types.
 
 entityResourceSuggester.doc.placeholder=Find a page...
 entityResourceSuggester.attach.placeholder=Find an attachment...


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22495

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added a translated title/content to the dropdown toggle
* Updated the style to allow for the use of .sr-only in this specific context (overriding CKEditor CSS reset)

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The CKEditor CSS reset works on `.cke_reset_all *`. Pretty much anything more specific than `.sr-only` is enough to take priority over it. I decided to go with a local definition (only useful for this specific element). If any other sr-only elements are needed in our CKEditor UI, we might want to write a style rule for all of them with `.cke_reset_all .sr-only`.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No visual changes in between before and after the PR, except for the title tooltip appearing when hovering the button.
Here is what the UI would look like after the changes proposed in this PR:
![Screenshot from 2024-10-30 16-43-29](https://github.com/user-attachments/assets/10395c6b-ed88-4d59-9236-33578bb5470d)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests on a local instance, see screenshot above.
As far as I can see, [integration-tests](https://github.com/xwiki/xwiki-platform/blob/b043b5021ce559aa816d3f285ba1b23d8e9ee440/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-pageobjects/src/main/java/org/xwiki/ckeditor/test/po/LinkDialog.java#L138) should not be impacted by this change.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.x
  * 16.4.x