### PR TITLE
XWIKI-22625: TestUtils#getURL doesn't take the wiki into account

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/pom.xml
@@ -31,6 +31,9 @@
   <name>XWiki Platform - Test - UI Tests Framework</name>
   <packaging>jar</packaging>
   <description>XWiki Platform - UI Tests Framework</description>
+  <properties>
+    <xwiki.jacoco.instructionRatio>0.05</xwiki.jacoco.instructionRatio>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>org.xwiki.commons</groupId>

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/TestUtils.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/TestUtils.java
@@ -1202,8 +1202,10 @@ public class TestUtils
         if (locale != null) {
             queryString += "&language=" + locale;
         }
-        return getURL(action, extractListFromReference(reference).toArray(new String[] {}), queryString, fragment,
-            reference.extractReference(EntityType.WIKI).getName());
+        EntityReference wikiReference = reference.extractReference(EntityType.WIKI);
+        String wikiName = (wikiReference != null) ? wikiReference.getName() : "";
+        return getURL(wikiName, action, extractListFromReference(reference).toArray(new String[] {}), queryString,
+        fragment);
     }
 
     /**
@@ -1368,7 +1370,7 @@ public class TestUtils
      */
     public String getURL(String action, String[] path, String queryString)
     {
-        return getURL(action, path, queryString, null, null);
+        return getURL(null, action, path, queryString, null);
     }
 
     /**
@@ -1376,7 +1378,7 @@ public class TestUtils
      */
     public String getURL(String action, String[] path, String queryString, String fragment)
     {
-        return getURL(action, path, queryString, fragment, null);
+        return getURL(null, action, path, queryString, fragment);
     }
 
     /**
@@ -1385,7 +1387,7 @@ public class TestUtils
      * @since 16.4.6
      */
     @Unstable
-    public String getURL(String action, String[] path, String queryString, String fragment, String wikiName)
+    public String getURL(String wikiName, String action, String[] path, String queryString, String fragment)
     {
         StringBuilder builder = new StringBuilder(getBaseBinURL(wikiName));
 

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/TestUtils.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/TestUtils.java
@@ -1202,7 +1202,7 @@ public class TestUtils
             queryString += "&language=" + locale;
         }
         EntityReference wikiReference = reference.extractReference(EntityType.WIKI);
-        String wikiName = (wikiReference != null) ? wikiReference.getName() : "";
+        String wikiName = (wikiReference != null) ? wikiReference.getName() : null;
         return getURL(wikiName, action, extractListFromReference(reference).toArray(new String[] {}), queryString,
         fragment);
     }

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/TestUtils.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/TestUtils.java
@@ -100,6 +100,7 @@ import org.xwiki.rest.resources.objects.ObjectResource;
 import org.xwiki.rest.resources.objects.ObjectsResource;
 import org.xwiki.rest.resources.pages.PageResource;
 import org.xwiki.rest.resources.pages.PageTranslationResource;
+import org.xwiki.stability.Unstable;
 import org.xwiki.test.integration.XWikiExecutor;
 import org.xwiki.test.ui.po.BasePage;
 import org.xwiki.test.ui.po.ViewPage;
@@ -188,6 +189,8 @@ public class TestUtils
      * @since 9.5RC1
      */
     public static final int[] STATUS_ACCEPTED = new int[] { Status.ACCEPTED.getStatusCode() };
+
+    private static final String MAIN_WIKI_NAME = "xwiki";
 
     private static PersistentTestContext context;
 
@@ -1199,7 +1202,8 @@ public class TestUtils
         if (locale != null) {
             queryString += "&language=" + locale;
         }
-        return getURL(action, extractListFromReference(reference).toArray(new String[] {}), queryString, fragment);
+        return getURL(action, extractListFromReference(reference).toArray(new String[] {}), queryString, fragment,
+            reference.extractReference(EntityType.WIKI).getName());
     }
 
     /**
@@ -1350,7 +1354,13 @@ public class TestUtils
      */
     public String getBaseBinURL(String wiki)
     {
-        return getBaseURL() + ((StringUtils.isEmpty(wiki) || wiki.equals("xwiki")) ? "bin/" : "wiki/" + wiki + '/');
+        String wikiName = MAIN_WIKI_NAME;
+        if (!StringUtils.isEmpty(wiki)) {
+            wikiName = wiki;
+        } else if (!StringUtils.isEmpty(this.currentWiki)) {
+            wikiName = this.currentWiki;
+        }
+        return getBaseURL() + (wikiName.equals(MAIN_WIKI_NAME) ? "bin/" : "wiki/" + wikiName + '/');
     }
 
     /**
@@ -1358,7 +1368,7 @@ public class TestUtils
      */
     public String getURL(String action, String[] path, String queryString)
     {
-        return getURL(action, path, queryString, null);
+        return getURL(action, path, queryString, null, null);
     }
 
     /**
@@ -1366,7 +1376,18 @@ public class TestUtils
      */
     public String getURL(String action, String[] path, String queryString, String fragment)
     {
-        StringBuilder builder = new StringBuilder(getBaseBinURL());
+        return getURL(action, path, queryString, fragment, null);
+    }
+
+    /**
+     * @since 16.10.0RC1
+     * @since 15.10.14
+     * @since 16.4.6
+     */
+    @Unstable
+    public String getURL(String action, String[] path, String queryString, String fragment, String wikiName)
+    {
+        StringBuilder builder = new StringBuilder(getBaseBinURL(wikiName));
 
         if (!StringUtils.isEmpty(action)) {
             builder.append(action).append('/');

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/TestUtils.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/TestUtils.java
@@ -100,7 +100,6 @@ import org.xwiki.rest.resources.objects.ObjectResource;
 import org.xwiki.rest.resources.objects.ObjectsResource;
 import org.xwiki.rest.resources.pages.PageResource;
 import org.xwiki.rest.resources.pages.PageTranslationResource;
-import org.xwiki.stability.Unstable;
 import org.xwiki.test.integration.XWikiExecutor;
 import org.xwiki.test.ui.po.BasePage;
 import org.xwiki.test.ui.po.ViewPage;
@@ -1386,7 +1385,6 @@ public class TestUtils
      * @since 15.10.14
      * @since 16.4.6
      */
-    @Unstable
     public String getURL(String wikiName, String action, String[] path, String queryString, String fragment)
     {
         StringBuilder builder = new StringBuilder(getBaseBinURL(wikiName));

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/test/java/org/xwiki/test/ui/TestUtilsTest.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/test/java/org/xwiki/test/ui/TestUtilsTest.java
@@ -1,0 +1,73 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.xwiki.test.ui;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.EntityReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link TestUtils}.
+ *
+ * @version $Id$
+ * @since 16.10.0RC1
+ * @since 16.4.6
+ */
+class TestUtilsTest
+{
+    @Test
+    void getBaseBinURL()
+    {
+        TestUtils testUtils = new TestUtils();
+        assertEquals("http://localhost:8080/xwiki/bin/", testUtils.getBaseBinURL(""));
+        assertEquals("http://localhost:8080/xwiki/bin/", testUtils.getBaseBinURL(null));
+        assertEquals("http://localhost:8080/xwiki/wiki/foo/", testUtils.getBaseBinURL("foo"));
+        testUtils.setCurrentWiki("myWiki");
+        assertEquals("http://localhost:8080/xwiki/wiki/myWiki/", testUtils.getBaseBinURL(""));
+        assertEquals("http://localhost:8080/xwiki/wiki/myWiki/", testUtils.getBaseBinURL(null));
+        assertEquals("http://localhost:8080/xwiki/wiki/foo/", testUtils.getBaseBinURL("foo"));
+        testUtils.setCurrentWiki("");
+        assertEquals("http://localhost:8080/xwiki/bin/", testUtils.getBaseBinURL(""));
+        assertEquals("http://localhost:8080/xwiki/bin/", testUtils.getBaseBinURL(null));
+        assertEquals("http://localhost:8080/xwiki/wiki/foo/", testUtils.getBaseBinURL("foo"));
+    }
+
+    @Test
+    void getURL()
+    {
+        TestUtils testUtils = new TestUtils();
+        EntityReference myReference = new DocumentReference("fooWiki", "MySpace", "MyPage");
+        assertEquals("http://localhost:8080/xwiki/wiki/fooWiki/view/MySpace/MyPage", testUtils.getURL(myReference));
+
+        myReference = new DocumentReference("xwiki", List.of("Space1", "Space2", "Foo"), "WebHome");
+        assertEquals("http://localhost:8080/xwiki/bin/view/Space1/Space2/Foo/WebHome", testUtils.getURL(myReference));
+
+        testUtils.setSecretToken("myToken");
+
+        assertEquals("http://localhost:8080/xwiki/bin/edit/Space1/Space2/Foo/WebHome?form_token=myToken&editor=wiki",
+            testUtils.getURL(myReference, "edit", "editor=wiki"));
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/test/java/org/xwiki/test/ui/TestUtilsTest.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/test/java/org/xwiki/test/ui/TestUtilsTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
+import org.xwiki.model.reference.LocalDocumentReference;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
@@ -69,5 +70,8 @@ class TestUtilsTest
 
         assertEquals("http://localhost:8080/xwiki/bin/edit/Space1/Space2/Foo/WebHome?form_token=myToken&editor=wiki",
             testUtils.getURL(myReference, "edit", "editor=wiki"));
+
+        myReference = new LocalDocumentReference("MySpace", "MyPage");
+        assertEquals("http://localhost:8080/xwiki/bin/view/MySpace/MyPage", testUtils.getURL(myReference));
     }
 }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22625

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
  * Improve getBaseBinURL so that it fallbacks on currentWiki if this one is provided
  * Add a new getURL API taking into account the wiki name
  * Extract the wiki from the entityReference when using getURL with a reference
  * Provide new unit test for TestUtils

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

`mvn clean install -Pquality` on  the module

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-15.10.x
  * stable-16.4.x