### PR TITLE
XWIKI-21631: Tour generates a bottom scroll-bar, when items are created near the margins

### DIFF
--- a/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui/src/main/resources/TourCode/TourJS.xml
+++ b/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui/src/main/resources/TourCode/TourJS.xml
@@ -214,7 +214,7 @@ require(['jquery', 'xwiki-meta'], function ($, xm) {
                  + '  &lt;div class="arrow"&gt;&lt;/div&gt;\n'
                  + '  &lt;h2 class="popover-title"&gt;&lt;/h2&gt;\n'
                  + '  &lt;div class="popover-content"&gt;&lt;/div&gt;\n'
-                 + '  &lt;div class="popover-navigation row"&gt;\n'
+                 + '  &lt;div class="popover-navigation"&gt;\n'
                  + '    &lt;div class="col-xs-6 text-left"&gt;\n';
     if (step.prev &gt; -1) {
       template  += '      &lt;a class="btn btn-default btn-sm" href="#" id="'+idPrefix+'_prev"&gt;#tr("tour.popover.previous")&lt;/a&gt;\n';
@@ -605,6 +605,11 @@ require(['jquery', 'xwiki-meta'], function ($, xm) {
   position: absolute;
   top: 3px;
   right: 5px;
+}
+
+.popover[class*="tour-"] .popover-navigation:not(.row) {
+  padding-right: 0;
+  padding-left: 0;
 }
 </code>
     </property>


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-21631

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Removed a useless class from the popover-navigation
* Overwrote a style from bootstrap-tour with a precise selector

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The combinaison of negative margin with positive padding was the cause of the bug. 
* I removed the `.row` class from bootstrap that brought the negative margin.
* I overwrote the `.popover-navigation` class from bootstrap-tour that brought the padding.
* The selector I used to overwrite is very specific, this new style rules should not collide and break any other components or customization.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Before the PR, it looked the same, but on Firefox 128, I could see a horizontal scrollbar trying to scroll would twitch with a blank line on the right and end up as non scrolled.
After the changes proposed in this PR were applied on my local instance, here are the results:
![Screenshot from 2024-10-31 11-06-51](https://github.com/user-attachments/assets/f8b0df0c-5429-4457-bd36-c44c6a94acb5)
There is no more scrollbar. The style of the box did not change.
# Executed Tests
<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Only manual tests, see above.
From what I can see, the pageObject used in tests is not broken: https://github.com/xwiki/xwiki-platform/blob/330657a5de1b72dc9b68fbc208fcdd0da71b55c0/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-test/xwiki-platform-tour-test-pageobjects/src/main/java/org/xwiki/tour/test/po/PageWithTour.java#L122-L123
The xpath selectors do not rely on the "style only" `.row` class but only on `.popover-navigation`, which is kept the same.
I did not run any automated tests.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.4.X
  * 15.10.X