### PR TITLE
XWIKI-22121: Improve the registration experience

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/Registration.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/Registration.xml
@@ -284,7 +284,7 @@
     ## Also, not filled back in if there is an error ('noReturn').
     #set($field =
       {'name' : 'captcha_placeholder',
-        'label' : $services.localization.render('core.captcha.label')
+        'label' : $services.localization.render('core.captcha.label'),
         'skipLabelFor' : true,
         'type'  : 'html',
         'html'  : "&lt;span class='xHint'&gt;$escapetool.xml($services.localization.render('core.captcha.instruction'))

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/validation/livevalidation_prototype.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/validation/livevalidation_prototype.js
@@ -457,8 +457,8 @@ LiveValidation.prototype = {
    *	Empties out the message elements if they exist
    */
   removeMessage: function(){
-    for (let i = 0; i < this.validations.length; i++) {
-      let messageHolder = this.validations[i].messageHolder;
+    for (let validation of validations) {
+      let messageHolder = validation.messageHolder;
       this.removeMessageClass(messageHolder);
       messageHolder.lastChild.textContent = '';
     }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22121

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Improved maintainability reported by SonarCloud, see https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&assignees=Sereza7%40github&createdAt=2024-11-06T20%3A17%3A57%2B0000
* Fixed a regression caused by a typo in `Registration.xml`

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
None

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Tested the regression fix manually locally. I do not expect any test suite to fail because of these changes. 
# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, like https://github.com/xwiki/xwiki-platform/pull/3155