### PR TITLE
XWIKI-22409: Add automated test for "Show Page Information Tab (No)"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/AdministrationIT.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/AdministrationIT.java
@@ -24,9 +24,11 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import org.xwiki.administration.test.po.AdministrablePage;
 import org.xwiki.administration.test.po.AdministrationPage;
+import org.xwiki.administration.test.po.PresentationAdministrationPage;
 import org.xwiki.test.docker.junit5.TestReference;
 import org.xwiki.test.docker.junit5.UITest;
 import org.xwiki.test.ui.TestUtils;
+import org.xwiki.test.ui.po.InformationPane;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -90,5 +92,28 @@ class AdministrationIT
             "Editing", "emailSend", "emailStatus", "emailGeneral")
             .stream().forEach(sectionId -> assertTrue(pageAdministrationPage.hasNotSection(sectionId),
                 String.format("Menu section [%s] shouldn't be present.", sectionId)));
+    }
+
+    /**
+     * Validate that the show information setting of the Presentation section of the administration has an effect.
+     *
+     * @since 15.10.14
+     * @since 16.4.6
+     * @since 16.10.0RC1
+     */
+    @Test
+    void showPageInformationTabSettings(TestUtils setup, TestReference testReference)
+    {
+        setup.loginAsSuperAdmin();
+        setup.createPage(testReference, "");
+        // Check that the information tab is displayed by default.
+        assertTrue(new InformationPane().exists());
+        PresentationAdministrationPage adminPage = PresentationAdministrationPage.goToAdminSection();
+        adminPage.setShowInformation("No");
+        adminPage.save();
+        assertEquals("No", adminPage.getShowInformation());
+
+        setup.gotoPage(testReference);
+        assertTrue(new InformationPane().doesNotExist());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/AdministrationIT.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/AdministrationIT.java
@@ -78,7 +78,7 @@ class AdministrationIT
         page = new AdministrablePage();
         AdministrationPage pageAdministrationPage = page.clickAdministerPage();
         String fullName = setup.serializeLocalReference(testReference.getParent());
-        assertEquals("Page Administration: " + fullName, 
+        assertEquals("Page Administration: " + fullName,
             pageAdministrationPage.getDocumentTitle());
         assertTrue(pageAdministrationPage.getBreadcrumbContent().endsWith("/Page Administration"));
 
@@ -97,9 +97,9 @@ class AdministrationIT
     /**
      * Validate that the show information setting of the Presentation section of the administration has an effect.
      *
-     * @since 15.10.14
-     * @since 16.4.6
-     * @since 16.10.0RC1
+     * @since 16.4.7
+     * @since 16.10.4
+     * @since 17.1.0RC1
      */
     @Test
     void showPageInformationTabSettings(TestUtils setup, TestReference testReference)

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/PresentationAdministrationPage.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/PresentationAdministrationPage.java
@@ -1,0 +1,85 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.administration.test.po;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.openqa.selenium.By;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.test.ui.po.Select;
+import org.xwiki.test.ui.po.ViewPage;
+
+/**
+ * Page object for the Presentation section of the administration.
+ *
+ * @version $Id$
+ * @since 15.10.14
+ * @since 16.4.6
+ * @since 16.10.0RC1
+ */
+public class PresentationAdministrationPage extends ViewPage
+{
+    /**
+     * Go to the Presentation section of the administration.
+     *
+     * @return a {@link PresentationAdministrationPage} instance
+     */
+    public static PresentationAdministrationPage goToAdminSection()
+    {
+        Map<String, Object> queryParameters = new HashMap<>();
+        queryParameters.put("editor", "globaladmin");
+        queryParameters.put("section", "Presentation");
+        DocumentReference reference = new DocumentReference("xwiki", "XWiki", "XWikiPreferences");
+        getUtil().gotoPage(reference, "admin", queryParameters);
+        return new PresentationAdministrationPage();
+    }
+
+    /**
+     * Set the value of the show information field.
+     *
+     * @param value {@code No}, {@code Yes} or {@code ---}
+     */
+    public void setShowInformation(String value)
+    {
+        getShowInformationSelect().selectByVisibleText(value);
+    }
+
+    /**
+     * Save the administration page.
+     */
+    public void save()
+    {
+        getDriver().findElement(By.cssSelector("#presentation input[value='Save']")).click();
+    }
+
+    /**
+     * @return the text of the currently selected show information option
+     */
+    public String getShowInformation()
+    {
+        return getShowInformationSelect().getFirstSelectedOption().getText();
+    }
+
+    private Select getShowInformationSelect()
+    {
+        return new Select(getDriver().findElement(By.id("XWiki.XWikiPreferences_0_showinformation")));
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/PresentationAdministrationPage.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/PresentationAdministrationPage.java
@@ -31,9 +31,9 @@ import org.xwiki.test.ui.po.ViewPage;
  * Page object for the Presentation section of the administration.
  *
  * @version $Id$
- * @since 15.10.14
- * @since 16.4.6
- * @since 16.10.0RC1
+ * @since 16.4.7
+ * @since 16.10.4
+ * @since 17.1.0RC1
  */
 public class PresentationAdministrationPage extends ViewPage
 {

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/InformationPane.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/InformationPane.java
@@ -36,6 +36,8 @@ public class InformationPane extends BaseElement
 {
     private static final By ORIGINAL_LOCALE_SELECTOR = By.cssSelector("dd[data-key='originalLocale']");
 
+    private static final String INFORMATION_TAB_ID = "Informationtab";
+
     @FindBy(id = "informationcontent")
     private WebElement pane;
 
@@ -130,5 +132,27 @@ public class InformationPane extends BaseElement
     public DocumentSyntaxPropertyPane editSyntax()
     {
         return new DocumentSyntaxPropertyPane().clickEdit();
+    }
+
+    /**
+     * @return {@code true} if the information tab is found, {@code false} otherwise
+     * @since 15.10.14
+     * @since 16.4.6
+     * @since 16.10.0RC1
+     */
+    public boolean exists()
+    {
+        return getDriver().findElements(By.id(INFORMATION_TAB_ID)).size() == 1;
+    }
+
+    /**
+     * @return {@code true} if the information tab is not found, {@code false} otherwise
+     * @since 15.10.14
+     * @since 16.4.6
+     * @since 16.10.0RC1
+     */
+    public boolean doesNotExist()
+    {
+        return getDriver().findElements(By.id(INFORMATION_TAB_ID)).isEmpty();
     }
 }

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/InformationPane.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/InformationPane.java
@@ -102,7 +102,7 @@ public class InformationPane extends BaseElement
 
     /**
      * Clicks on the translation link that corresponds to the given locale.
-     * 
+     *
      * @param locale the locale to click on
      * @since 12.10.6
      * @since 13.2RC1
@@ -114,7 +114,7 @@ public class InformationPane extends BaseElement
 
     /**
      * Clicks on the translation link with the specified label (locale pretty name).
-     * 
+     *
      * @param label the locale pretty name
      * @since 12.10.6
      * @since 13.2RC1
@@ -136,9 +136,9 @@ public class InformationPane extends BaseElement
 
     /**
      * @return {@code true} if the information tab is found, {@code false} otherwise
-     * @since 15.10.14
-     * @since 16.4.6
-     * @since 16.10.0RC1
+     * @since 16.4.7
+     * @since 16.10.4
+     * @since 17.1.0RC1
      */
     public boolean exists()
     {
@@ -147,9 +147,9 @@ public class InformationPane extends BaseElement
 
     /**
      * @return {@code true} if the information tab is not found, {@code false} otherwise
-     * @since 15.10.14
-     * @since 16.4.6
-     * @since 16.10.0RC1
+     * @since 16.4.7
+     * @since 16.10.4
+     * @since 17.1.0RC1
      */
     public boolean doesNotExist()
     {


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22409

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* add a functional test for the "show information" setting in the Presentation section of the administration

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* add a new test in `AdministrationIT`
* Introduce `PresentationAdministrationPage` in xwiki-platform-administration-test-pageobjects
* Add new methods in `InformationPane` (`xwiki-platform-test-ui`) to check whether the panel exists or does not

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Execution of `xwiki-platform-administration-test-docker`

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.4.x
  * 15.10.x