### PR TITLE
XWIKI-22121: Improve the registration experience

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/RegisterIT.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/RegisterIT.java
@@ -349,7 +349,9 @@ class RegisterIT
             // TODO: looks like a pretty strange behavior, there might be a message box title missing somewhere
             String messagePrefix = closedWiki ? "" : "Information ";
             messagePrefix = !closedWiki&&withRegistrationConfig ? "Welcome ": messagePrefix;
-
+            // TODO: clean up this test with a better final assertion. 
+            //  As of now, the string retrieved changes a lot depending on the test parameters
+            // The assertion should be less strong so that we can clearly show these differences.
             assertEquals(String.format("%s%s %s (%s)%s", messagePrefix, firstName, lastName,
                     AbstractRegistrationPage.JOHN_SMITH_USERNAME, 
                     !closedWiki&&withRegistrationConfig ? "" : ": Registration successful."),

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/RegisterIT.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/RegisterIT.java
@@ -348,9 +348,11 @@ class RegisterIT
                 + "wiki: %s withRegistrationConfig: %s", isModal, closedWiki, withRegistrationConfig));
             // TODO: looks like a pretty strange behavior, there might be a message box title missing somewhere
             String messagePrefix = closedWiki ? "" : "Information ";
+            messagePrefix = !closedWiki&&withRegistrationConfig ? "Welcome ": messagePrefix;
 
-            assertEquals(String.format("%s%s %s (%s): Registration successful.", messagePrefix, firstName, lastName,
-                    AbstractRegistrationPage.JOHN_SMITH_USERNAME),
+            assertEquals(String.format("%s%s %s (%s)%s", messagePrefix, firstName, lastName,
+                    AbstractRegistrationPage.JOHN_SMITH_USERNAME, 
+                    !closedWiki&&withRegistrationConfig ? "" : ": Registration successful."),
                 ((RegistrationPage) registrationPage).getRegistrationSuccessMessage().orElseThrow());
         }
     }

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/Registration.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/Registration.xml
@@ -462,8 +462,8 @@
     #end
     ## Display a "registration successful" message
     ## Define some strings which may be used by the welcome message
-    #set($firstName = $escapetool.xml($!request.get('register_first_name')))
-    #set($lastName = $escapetool.xml($!request.get('register_last_name')))
+    #set($firstName = $!request.get('register_first_name'))
+    #set($lastName = $!request.get('register_last_name'))
     #evaluate($registrationConfig.registrationSuccessMessage)
 
     ## Empty line prevents message from being forced into a &lt;p&gt; block.

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/AbstractRegistrationPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/AbstractRegistrationPage.java
@@ -116,7 +116,9 @@ public abstract class AbstractRegistrationPage extends BasePage
     public boolean validationFailureMessagesInclude(String message)
     {
         return !getDriver().findElementsWithoutWaiting(
-            By.xpath("//dd/span[contains(@class,'LV_validation_message LV_invalid') and . = '" + message + "']"))
+            By.xpath("//dd/span[contains(@class, 'LV_validation_message') and " + 
+                "contains(@class, 'LV_invalid') and " +
+                "contains(., '" + message + "')]"))
             .isEmpty();
     }
 


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22121

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Removed an escaping that wasn't needed and caused a test to not pass.
* Updated the test to work with the updated Registration template
* Fixed a XPath on AbstractRegistrationPage.java to be more permissive and work with the latest changes.## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* RegisterIT was broken on master. Those fixes allow the test to pass.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
None, mostly test changes
# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Successfully passed `mvn clean install -f xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker -Dit.test=RegisterIT`. Before the changes proposed in this PR I could reproduce locally the fails found on CI with this command.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  *  None, same as https://github.com/xwiki/xwiki-platform/pull/3155