### PR TITLE
XWIKI-22121: Improve the registration experience

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/TemplatesAdministrationSectionPage.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/TemplatesAdministrationSectionPage.java
@@ -97,7 +97,9 @@ public class TemplatesAdministrationSectionPage extends AdministrationSectionPag
         // To be sure that the form is validated before clicking, wait for the two fields validation messages to be
         // displayed before clicking.
         getDriver().waitUntilCondition(input ->
-            getDriver().findElementsWithoutWaiting(By.cssSelector("form .LV_validation_message.LV_valid")).size() == 2);
+            getDriver().findElementsWithoutWaiting(By.cssSelector("form .LV_validation_message.LV_valid"))
+                .size() == 1 &&
+            getDriver().findElementsWithoutWaiting(By.cssSelector("form .LV_validation_message.LV_invalid")).isEmpty());
 
         // FIXME: workaround for https://github.com/mozilla/geckodriver/issues/1026
         getDriver().addPageNotYetReloadedMarker();

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-test/xwiki-platform-user-profile-test-pageobjects/src/main/java/org/xwiki/user/test/po/ChangePasswordPage.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-test/xwiki-platform-user-profile-test-pageobjects/src/main/java/org/xwiki/user/test/po/ChangePasswordPage.java
@@ -97,6 +97,7 @@ public class ChangePasswordPage extends BasePage
         this.password1.sendKeys(password);
         this.password2.clear();
         this.password2.sendKeys(password2);
+        getDriver().waitUntilElementHasNonEmptyAttributeValue(By.xpath("//input[@id='xwikipassword2']"),"class");
     }
 
     /**


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22121

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
1. Added a wait on the changePasswordAsAdmin.
2. Updated the wait condition when validating the form for a new template

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

1. When leaving the field, validation on the field is done almost instantly. Once this individual validation is finished, we add a class on the field to show its current status. We wait for this status, and then the form validation will have all the individual field validations updated when trying to submit the form. This fixes changePasswordWhenPolicyIsLength8AndNumberMandatory .
2. With the new validation script, we do not show a message for some fields when it's just `ok`. Instead of checking the number of valid fields, we check that there's one validation (since there's still one as of now) and no invalid field message. I kept the waitCondition as close as possible to what was before. It could probably be improved but I went with the safer changes. This fixes PageTemplatesIT tests.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

None, test changes only.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
I could reproduce the CI fails locally. 

Then I built the changes with `mvn clean install -f xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-test/xwiki-platform-user-profile-test-pageobjects` and `mvn clean install -f xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects -Pquality` .

Then I ran the failing tests locally with `mvn clean install -f xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-test/xwiki-platform-user-profile-test-docker -Dit.test=UserChangePasswordIT#changePasswordWhenPolicyIsLength8AndNumberMandatory` and `mvn clean install -f xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker -Dit.test=PageTemplatesIT` . Both of the builds passed successfully. I quickly tested other uses of `changePasswordAsAdmin` and the wait did work as expected in those other contexts.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, same as all [XWIKI-22121](https://jira.xwiki.org/browse/XWIKI-22121) changes.