### PR TITLE
XWIKI-21629: The step order displayed in inline edit is not consistent with the order from objects editor

### DIFF
--- a/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui/src/main/resources/TourCode/StepSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui/src/main/resources/TourCode/StepSheet.xml
@@ -78,11 +78,11 @@
           &lt;select id="stepOrderSelect"&gt;
             #if ($nbSteps &gt; 0)
               #foreach($i in [0..$mathtool.sub($nbSteps, 1)])
-                &lt;option value="$i" #if ($vobj.getProperty('order').value == $i) selected #end &gt;$mathtool.add($i, 1)&lt;/option&gt;
+                &lt;option value="$i" #if ($vobj.getProperty('order').value == $i) selected #end &gt;$i&lt;/option&gt;
               #end
             #end
             #if ($isNewStep)
-              &lt;option value="$nbSteps" selected &gt;$mathtool.add($nbSteps, 1)&lt;/option&gt;
+              &lt;option value="$nbSteps" selected &gt;$nbSteps&lt;/option&gt;
             #end
           &lt;/select&gt;
         &lt;/dd&gt;

--- a/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui/src/main/resources/TourCode/StepsListing.xml
+++ b/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui/src/main/resources/TourCode/StepsListing.xml
@@ -85,7 +85,7 @@
                #set($reflex      = $step.getValue('reflex'))
                #set($stepID      = $step.getNumber())
                &lt;tr&gt;
-                  &lt;td&gt;$!mathtool.add($order, 1)&lt;/td&gt;
+                  &lt;td&gt;$!order&lt;/td&gt;
                   &lt;td&gt;$!element&lt;/td&gt;
                   &lt;td&gt;$services.localization.render($!title)&lt;/td&gt;
                   &lt;td&gt;


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-21629

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Removed the operation on the order number that caused confusion
* Removed similar operations, I searched in the module all uses of `mathtool`.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
On this first screenshot, we can see that the list displayed now starts as expected with the order 0.
![Screenshot from 2024-11-14 10-26-07](https://github.com/user-attachments/assets/4791ed0d-9790-44f7-be83-1c1f3e101d02)
One of the annex changes is to make sure the options when creating and editing a step are displayed from 0 too. Just changing the displayed order does not break anything, those options had a non visible order that was used programatically and contained the correct value already.
![Screenshot from 2024-11-14 10-36-37](https://github.com/user-attachments/assets/12635225-042d-4737-841e-04184e86d50a)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
After building the changes, successfully built the docker tests `mvn clean install -f xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-test/xwiki-platform-tour-test-docker`

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None