### PR TITLE
XWIKI-22659: createinline template error when clicking on a link to missing top level page

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/PageTemplatesIT.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/PageTemplatesIT.java
@@ -36,7 +36,6 @@ import org.xwiki.test.docker.junit5.UITest;
 import org.xwiki.test.ui.TestUtils;
 import org.xwiki.test.ui.po.CreatePagePage;
 import org.xwiki.test.ui.po.DocumentDoesNotExistPage;
-import org.xwiki.test.ui.po.PageTypePicker;
 import org.xwiki.test.ui.po.ViewPage;
 import org.xwiki.test.ui.po.editor.EditPage;
 import org.xwiki.test.ui.po.editor.WikiEditPage;
@@ -116,10 +115,9 @@ class PageTemplatesIT
         // Verify that clicking on the wanted link pops up a box to choose the template.
         EntityReference wantedLinkReference =
             setup.resolveDocumentReference(testSpace + "." + TEMPLATE_NAME + "Instance" + ".NewPage");
-        vp.clickWantedLink(wantedLinkReference, true);
-        PageTypePicker pageTypePicker = new PageTypePicker();
-        assertEquals(availableTemplateSize, pageTypePicker.countAvailableTemplates());
-        assertTrue(pageTypePicker.getAvailableTemplates().contains(templateProviderFullName));
+        createPagePage = vp.clickWantedLink(wantedLinkReference);
+        assertEquals(availableTemplateSize, createPagePage.getAvailableTemplateSize());
+        assertTrue(createPagePage.getAvailableTemplates().contains(templateProviderFullName));
 
         // Step 3: Create a new page when located on a non-existing page
 

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/CreatePageAndSpaceIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/CreatePageAndSpaceIT.java
@@ -30,8 +30,10 @@ import org.xwiki.test.ui.TestUtils;
 import org.xwiki.test.ui.po.CreatePagePage;
 import org.xwiki.test.ui.po.ViewPage;
 import org.xwiki.test.ui.po.editor.EditPage;
+import org.xwiki.test.ui.po.editor.WikiEditPage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests basic page and space creation.
@@ -198,6 +200,22 @@ class CreatePageAndSpaceIT
         EditPage editPage = new EditPage();
 
         assertEquals("${escapetool.h}if()", editPage.getDocumentTitle());
+    }
+
+    @Test
+    @Order(4)
+    void createTopLevelPageFromWantedLink(TestUtils setup, TestReference reference) throws Exception
+    {
+        DocumentReference topLevelDoc = new DocumentReference("xwiki", "TopLevelWantedLink", "WebHome");
+        setup.rest().delete(topLevelDoc);
+        ViewPage page = setup.createPage(reference, "[[TopLevelWantedLink>>xwiki:TopLevelWantedLink.WebHome]]");
+        CreatePagePage createPagePage = page.clickWantedLink(topLevelDoc);
+        createPagePage.clickCreate();
+        WikiEditPage editPage = new WikiEditPage();
+        editPage.sendKeys("Some new content");
+        page = editPage.clickSaveAndView();
+        assertEquals("Some new content", page.getContent());
+        assertTrue(page.getBreadcrumb().hasPathElement("TopLevelWantedLink", true, true));
     }
 
     // TODO: Add a test for the input validation.

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/CreatePagePage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/CreatePagePage.java
@@ -36,7 +36,7 @@ import org.xwiki.test.ui.po.editor.EditPage;
  * @version $Id$
  * @since 3.2M3
  */
-public class CreatePagePage extends ViewPage
+public class CreatePagePage extends BaseElement
 {
     private static final By errorMessageLocator = By.className("errormessage");
 
@@ -53,7 +53,7 @@ public class CreatePagePage extends ViewPage
     @FindBy(id = "terminal")
     private WebElement isTerminalCheckbox;
 
-    @FindBy(css = "form#create input[type='submit']")
+    @FindBy(css = "form#create input[type='submit'],form#create button[type='submit']")
     private WebElement createButton;
 
     public static CreatePagePage gotoPage()

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/ViewPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/ViewPage.java
@@ -20,6 +20,7 @@
 package org.xwiki.test.ui.po;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.regex.Pattern;
 
 import org.openqa.selenium.By;
@@ -135,12 +136,17 @@ public class ViewPage extends BasePage
         clickWantedLink(new DocumentReference("xwiki", spaceName, pageName), waitForTemplateDisplay);
     }
 
+    public CreatePagePage clickWantedLink(EntityReference reference)
+    {
+        return clickWantedLink(reference, true).get();
+    }
+
     /**
      * Clicks on a wanted link in the page.
      *
      * @since 7.2M2
      */
-    public void clickWantedLink(EntityReference reference, boolean waitForTemplateDisplay)
+    public Optional<CreatePagePage> clickWantedLink(EntityReference reference, boolean waitForTemplateDisplay)
     {
         WebElement brokenLink = getDriver().findElement(
             By.xpath("//span[@class='wikicreatelink']/a[contains(@href,'/create/" + getUtil().getURLFragment(reference)
@@ -152,7 +158,9 @@ public class ViewPage extends BasePage
             // will all have been displayed.
             getDriver().waitUntilElementIsVisible(
                 By.xpath("//div[@class='modal-dialog']//form[@id='create']//button[@type='submit']"));
+            return Optional.of(new CreatePagePage());
         }
+        return Optional.empty();
     }
 
     public BreadcrumbElement getBreadcrumb()

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/createinline.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/createinline.vm
@@ -397,7 +397,12 @@
             <span class='label'>$escapetool.xml($services.localization.render('core.create.pageTitle'))</span>
           </dt>
           <dl>
-            #set ($targetDocumentReference = $services.model.createDocumentReference($name, $spaceReference))
+            ## We are creating a top level space.
+            #if ("$!spaceReference" == '' && $isSpace)
+              #set ($targetDocumentReference = $services.model.createDocumentReference('WebHome', $name))
+            #else
+              #set ($targetDocumentReference = $services.model.createDocumentReference($name, $spaceReference))
+            #end
             #hierarchy($targetDocumentReference)
           </dl>
         #end


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22659

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Compute proper reference in case of top level page
* Provide a new integration test covering the bug
* Change a bit existing PO for CreatePagePage to allow using it also
    for the modal

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

N/A

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Ran integration tests on flamingo-skin, administration and panel modules.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 15.10.x
  * 16.4.x
  * 16.10.x