### PR TITLE
XWIKI-22571: Backlinks update changes an absolute reference to the moved page into one relative to the current wiki

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/DeletePageIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/DeletePageIT.java
@@ -773,7 +773,7 @@ class DeletePageIT
         // Verify that a redirect was added and the link was updated.
         viewPage = testUtils.gotoPage(reference);
         assertEquals("New target", this.viewPage.getDocumentTitle());
-        assertEquals("[[Link>>doc:NewTarget.WebHome]]",
+        assertEquals("[[Link>>doc:xwiki:NewTarget.WebHome]]",
             testUtils.rest().<Page>get(backlinkDocumentReference).getContent());
     }
 
@@ -826,7 +826,7 @@ class DeletePageIT
         TestConfiguration testConfiguration) throws Exception
     {
         DocumentReference childReference = new DocumentReference("Child", parentReference.getLastSpaceReference());
-        String childFullName = testUtils.serializeReference(childReference).split(":")[1];
+        String childFullName = testUtils.serializeLocalReference(childReference);
         DocumentReference backlinkDocReference = new DocumentReference("xwiki", "Backlink", "WebHome");
         DocumentReference newTargetReference = new DocumentReference("xwiki", "NewTarget", "WebHome");
 
@@ -836,7 +836,7 @@ class DeletePageIT
         // Create backlinks to the parent and the child page.
         String format = "[[Parent>>doc:%s]] [[Child>>doc:%s]]";
         testUtils.createPage(backlinkDocReference,
-            String.format(format, testUtils.serializeReference(parentReference), childFullName), "Backlink document");
+            String.format(format, testUtils.serializeLocalReference(parentReference), childFullName), "Backlink document");
 
         // Wait for Solr indexing to complete as backlink information from Solr is needed
         new SolrTestUtils(testUtils, testConfiguration.getServletEngine()).waitEmptyQueue();
@@ -855,7 +855,7 @@ class DeletePageIT
         // Verify that there is no redirect on the child page and backlink was not altered.
         assertEquals(DELETE_SUCCESSFUL, deletingPage.getInfoMessage());
         String newContent =
-            String.format(format, testUtils.serializeReference(newTargetReference).split(":")[1], childFullName);
+            String.format(format, testUtils.serializeLocalReference(newTargetReference), childFullName);
         assertEquals(newContent, testUtils.rest().<Page>get(backlinkDocReference).getContent());
         parentPage = testUtils.gotoPage(parentReference);
         assertEquals("New target", parentPage.getDocumentTitle());

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/RenamePageIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/RenamePageIT.java
@@ -723,4 +723,24 @@ class RenamePageIT
         //wikiEditPage = WikiEditPage.gotoPage(new DocumentReference("WebHome", newBobSpace));
         //assertEquals(String.format("[[%s]]", serializedAlice2Reference), wikiEditPage.getContent());
     }
+
+    @Order(10)
+    @Test
+    void renameLinkContainingWiki(TestUtils testUtils, TestReference testReference, TestConfiguration testConfiguration)
+        throws Exception
+    {
+        DocumentReference documentReference = new DocumentReference("xwiki", "TestLinkWithWiki", "WebHome");
+        testUtils.rest().delete(documentReference);
+        testUtils.rest().savePage(documentReference, "Some content", "TestLinkWithWiki");
+        testUtils.rest().savePage(testReference, "[[MyPage>>xwiki:TestLinkWithWiki.WebHome]]",
+            "renameLinkContainingWiki");
+        new SolrTestUtils(testUtils, testConfiguration.getServletEngine()).waitEmptyQueue();
+        RenamePage renamePage = testUtils.gotoPage(documentReference).rename();
+        renamePage.getDocumentPicker().setName("TestLinkWithWikiNew");
+        CopyOrRenameOrDeleteStatusPage statusPage =
+            renamePage.clickRenameButton().waitUntilFinished();
+        assertEquals("Done.", statusPage.getInfoMessage());
+        WikiEditPage wikiEditPage = WikiEditPage.gotoPage(testReference);
+        assertEquals("[[MyPage>>xwiki:TestLinkWithWikiNew.WebHome]]", wikiEditPage.getContent());
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/ResourceReferenceRenamer.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/ResourceReferenceRenamer.java
@@ -64,6 +64,9 @@ public class ResourceReferenceRenamer
     private EntityReferenceSerializer<String> compactEntityReferenceSerializer;
 
     @Inject
+    private EntityReferenceSerializer<String> defaultEntityReferenceSerializer;
+
+    @Inject
     private DocumentReferenceResolver<EntityReference> defaultReferenceDocumentReferenceResolver;
 
     @Inject
@@ -152,8 +155,6 @@ public class ResourceReferenceRenamer
         DocumentReference absoluteResolvedDocumentReference =
             this.defaultReferenceDocumentReferenceResolver.resolve(absoluteResolvedEntityReference);
 
-        boolean isRelativePageReferenceOutsideOfParent = false;
-
         // If the link targets the old (renamed) document reference and it's an absolute reference
         // (i.e. its resolution without any given parameter gives same result than its resolution with the
         // currentDocument) then we must update it
@@ -193,14 +194,25 @@ public class ResourceReferenceRenamer
                 newTargetReference = new AttachmentReference(linkEntityReference.getName(), newReference);
             }
 
-            String newReferenceString =
-                this.compactEntityReferenceSerializer.serialize(newTargetReference, currentDocumentReference);
-
+            String newReferenceString = getNewTargetReference(resourceReference, newTargetReference,
+                currentDocumentReference);
             resourceReference.setReference(newReferenceString);
             resourceReference.setType(newResourceType);
             result = true;
         }
         return result;
+    }
+
+    private String getNewTargetReference(ResourceReference resourceReference, EntityReference newTargetReference,
+        EntityReference currentReference)
+    {
+        // If the reference contains the wiki name, then we should keep the absolute serialization.
+        // TODO: This regex feels really fragile, I'm not sure how we should check presence of a wiki here.
+        if (resourceReference.getReference().matches("^\\w+:\\w.*$")) {
+            return this.defaultEntityReferenceSerializer.serialize(newTargetReference, currentReference);
+        } else {
+            return this.compactEntityReferenceSerializer.serialize(newTargetReference, currentReference);
+        }
     }
 
     private boolean isPageReferenceOutOfParent(ResourceReference resourceReference,
@@ -266,8 +278,7 @@ public class ResourceReferenceRenamer
 
         if (shouldBeUpdated) {
             // Serialize the old (original) link relative to the new document's location, in compact form.
-            String serializedLinkReference =
-                this.compactEntityReferenceSerializer.serialize(oldLinkReference, newReference);
+            String serializedLinkReference = getNewTargetReference(resourceReference, oldLinkReference, newReference);
             resourceReference.setReference(serializedLinkReference);
             result = true;
         }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/ResourceReferenceRenamer.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/ResourceReferenceRenamer.java
@@ -60,6 +60,10 @@ public class ResourceReferenceRenamer
     private EntityReferenceResolver<ResourceReference> entityReferenceResolver;
 
     @Inject
+    @Named("relative")
+    private EntityReferenceResolver<ResourceReference> relativeEntityReferenceResolver;
+
+    @Inject
     @Named("compact")
     private EntityReferenceSerializer<String> compactEntityReferenceSerializer;
 
@@ -206,9 +210,10 @@ public class ResourceReferenceRenamer
     private String getNewTargetReference(ResourceReference resourceReference, EntityReference newTargetReference,
         EntityReference currentReference)
     {
+        EntityReference entityReference =
+            this.relativeEntityReferenceResolver.resolve(resourceReference, null, (Object) null);
         // If the reference contains the wiki name, then we should keep the absolute serialization.
-        // TODO: This regex feels really fragile, I'm not sure how we should check presence of a wiki here.
-        if (resourceReference.getReference().matches("^\\w+:\\w.*$")) {
+        if (entityReference.extractReference(EntityType.WIKI) != null) {
             return this.defaultEntityReferenceSerializer.serialize(newTargetReference, currentReference);
         } else {
             return this.compactEntityReferenceSerializer.serialize(newTargetReference, currentReference);

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/ResourceReferenceRenamerTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/ResourceReferenceRenamerTest.java
@@ -72,6 +72,9 @@ class ResourceReferenceRenamerTest
     private EntityReferenceSerializer<String> compactEntityReferenceSerializer;
 
     @MockComponent
+    private EntityReferenceSerializer<String> defaultEntityReferenceSerializer;
+
+    @MockComponent
     private DocumentReferenceResolver<EntityReference> defaultReferenceDocumentReferenceResolver;
 
     @MockComponent
@@ -94,7 +97,7 @@ class ResourceReferenceRenamerTest
     @Test
     void updateResourceReferenceRelative()
     {
-        DocumentResourceReference resourceReference = new DocumentResourceReference("xwiki:Main.WebHome");
+        DocumentResourceReference resourceReference = new DocumentResourceReference("Main.WebHome");
         AttachmentReference oldReference =
             new AttachmentReference("file.txt", new DocumentReference("wiki", "space", "page"));
         AttachmentReference newReference =

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/ResourceReferenceRenamerTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/ResourceReferenceRenamerTest.java
@@ -26,6 +26,7 @@ import javax.inject.Provider;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.xwiki.model.EntityType;
 import org.xwiki.model.reference.AttachmentReference;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.DocumentReferenceResolver;
@@ -81,6 +82,10 @@ class ResourceReferenceRenamerTest
     private PageReferenceResolver<EntityReference> defaultReferencePageReferenceResolver;
 
     @MockComponent
+    @Named("relative")
+    private EntityReferenceResolver<ResourceReference> relativeEntityReferenceResolver;
+
+    @MockComponent
     private Provider<XWikiContext> contextProvider;
 
     @BeforeEach
@@ -95,16 +100,46 @@ class ResourceReferenceRenamerTest
     }
 
     @Test
-    void updateResourceReferenceRelative()
+    void updateResourceReferenceRelativeOtherWiki()
     {
         DocumentResourceReference resourceReference = new DocumentResourceReference("Main.WebHome");
         AttachmentReference oldReference =
             new AttachmentReference("file.txt", new DocumentReference("wiki", "space", "page"));
+
+        EntityReference relativeReference = new EntityReference("file.txt", EntityType.ATTACHMENT,
+            new EntityReference("page", EntityType.DOCUMENT, new EntityReference("space", EntityType.SPACE,
+                new EntityReference("wiki", EntityType.WIKI))));
         AttachmentReference newReference =
             new AttachmentReference("file2.txt", new DocumentReference("wiki", "space", "page"));
         when(this.entityReferenceResolver.resolve(resourceReference, null)).thenReturn(oldReference);
         when(this.entityReferenceResolver.resolve(resourceReference, null, newReference)).thenReturn(newReference);
         when(this.entityReferenceResolver.resolve(resourceReference, null, oldReference)).thenReturn(oldReference);
+        when(this.relativeEntityReferenceResolver.resolve(resourceReference, null, null)).thenReturn(relativeReference);
+        when(this.compactEntityReferenceSerializer.serialize(oldReference, newReference)).thenReturn("file2.txt");
+
+        assertTrue(this.renamer.updateResourceReference(resourceReference,
+            oldReference,
+            newReference,
+            new DocumentReference("xwiki", "Space", "Page"), true, Map.of()));
+
+        verify(this.defaultEntityReferenceSerializer).serialize(oldReference, newReference);
+    }
+
+    @Test
+    void updateResourceReferenceRelativeSameWiki()
+    {
+        DocumentResourceReference resourceReference = new DocumentResourceReference("Main.WebHome");
+        AttachmentReference oldReference =
+            new AttachmentReference("file.txt", new DocumentReference("wiki", "space", "page"));
+
+        EntityReference relativeReference = new EntityReference("file.txt", EntityType.ATTACHMENT,
+            new EntityReference("page", EntityType.DOCUMENT, new EntityReference("space", EntityType.SPACE)));
+        AttachmentReference newReference =
+            new AttachmentReference("file2.txt", new DocumentReference("wiki", "space", "page"));
+        when(this.entityReferenceResolver.resolve(resourceReference, null)).thenReturn(oldReference);
+        when(this.entityReferenceResolver.resolve(resourceReference, null, newReference)).thenReturn(newReference);
+        when(this.entityReferenceResolver.resolve(resourceReference, null, oldReference)).thenReturn(oldReference);
+        when(this.relativeEntityReferenceResolver.resolve(resourceReference, null, null)).thenReturn(relativeReference);
         when(this.compactEntityReferenceSerializer.serialize(oldReference, newReference)).thenReturn("file2.txt");
 
         assertTrue(this.renamer.updateResourceReference(resourceReference,


### PR DESCRIPTION

# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22571

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

  * Use default serializer if the wiki is present in a link, not the compact serializer
  * Provide unit test and integration test to cover this

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Right now the oracle to guess if the link contains a wiki is by using a regex, but I'm not very happy with this, we should probably find a better way for detecting it.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Run tests in modules:
  * xwiki-platform-flamingo-skin-test-docker: 
    - [x] 2 failures to fix in DeletePageIT  
  * xwiki-platform-refactoring-default

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.x only