### PR TITLE
XWIKI-22485: Livedata option dropdown has no grouping semantics

### DIFF
--- a/xwiki-platform-core/xwiki-platform-bootstrap/src/main/less/dropdowns.less
+++ b/xwiki-platform-core/xwiki-platform-bootstrap/src/main/less/dropdowns.less
@@ -60,9 +60,18 @@
   .divider {
     .nav-divider(@dropdown-divider-bg);
   }
+  
+  // Dividers within the dropdown with an improved semantic representation
+  li:has(> ul) + li:has(> ul) {
+    border-top: solid 1px @dropdown-divider-bg;
+    padding-top: ((@line-height-computed / 2) - 1);
+  }
+  li:has(> ul):has(+ li > ul) {
+    margin-bottom: ((@line-height-computed / 2) - 1);
+  }
 
-  // Links within the dropdown menu
-  > li > a {
+  // Links within the dropdown menu and submenus
+  > li > a, > li > ul > li > a {
     display: block;
     padding: 3px 20px;
     clear: both;

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/LivedataDropdownMenu.spec.js
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/tests/unit/LivedataDropdownMenu.spec.js
@@ -56,12 +56,13 @@ function initWrapper() {
 
 // Since the <li> elements does not have distinguishing attributes, we look for the layout items by looking at the
 // elements located after the second separator (class dropdown-header).
+// The lis passed here are both group lis and item lis. Group lis contain a title and their own item lis.
 function findSecondDropdownHeaderIndex(lis) {
   var dropdownHeadersCptr = 0;
   var liIdx = 0;
   for (; liIdx < lis.length; liIdx++) {
     const li = lis.at(liIdx);
-    if (li.classes().includes('dropdown-header')) {
+    if (li.findAll('.dropdown-header').length > 0) {
       dropdownHeadersCptr++;
     }
     if (dropdownHeadersCptr >= 2) {

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/LivedataDropdownMenu.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/LivedataDropdownMenu.vue
@@ -48,43 +48,40 @@
 
       <!-- Actions -->
       <li><span class="dropdown-header">{{ $t('livedata.dropdownMenu.actions') }}</span><ul>
-
-      <li>
-        <!-- Refresh -->
-        <a href="#" @click.prevent="logic.updateEntries()" class="livedata-action-refresh">
-          <XWikiIcon :icon-descriptor="{name: 'repeat'}" /> 
-          {{ $t('livedata.action.refresh') }}
-        </a>
-      </li>
+        <li>
+          <!-- Refresh -->
+          <a href="#" @click.prevent="logic.updateEntries()" class="livedata-action-refresh">
+            <XWikiIcon :icon-descriptor="{name: 'repeat'}" /> 
+            {{ $t('livedata.action.refresh') }}
+          </a>
+        </li>
       </ul></li>
 
       <!-- Layouts -->
       <li><span class="dropdown-header">{{ $t('livedata.dropdownMenu.layouts') }}</span><ul>
-
-      <!-- Layout options -->
-      <li
-        v-for="layout in data.meta.layouts"
-        :key="layout.id"
-        :class="{
-          'disabled': isCurrentLayout(layout.id),
-        }"
-      >
-        <a href="#" @click.prevent="changeLayout(layout.id)">
-          <XWikiIcon :icon-descriptor="layout.icon"></XWikiIcon>
-          {{ layout.name }}
-        </a>
-      </li>
+        <!-- Layout options -->
+        <li
+          v-for="layout in data.meta.layouts"
+          :key="layout.id"
+          :class="{
+            'disabled': isCurrentLayout(layout.id),
+          }"
+        >
+          <a href="#" @click.prevent="changeLayout(layout.id)">
+            <XWikiIcon :icon-descriptor="layout.icon"></XWikiIcon>
+            {{ layout.name }}
+          </a>
+        </li>
       </ul></li>
 
       <!-- Panels -->
       <li><span class="dropdown-header">{{ $t('livedata.dropdownMenu.panels') }}</span><ul>
-
-      <li v-for="panel in logic.panels" :key="panel.id">
-        <a href="#" @click.prevent="logic.uniqueArrayToggle(logic.openedPanels, panel.id)">
-          <XWikiIcon :icon-descriptor="{name: panel.icon}"/>
-          {{ panel.name }}
-        </a>
-      </li>
+        <li v-for="panel in logic.panels" :key="panel.id">
+          <a href="#" @click.prevent="logic.uniqueArrayToggle(logic.openedPanels, panel.id)">
+            <XWikiIcon :icon-descriptor="{name: panel.icon}"/>
+            {{ panel.name }}
+          </a>
+        </li>
       </ul></li>
 
     </ul>

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/LivedataDropdownMenu.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/LivedataDropdownMenu.vue
@@ -47,7 +47,7 @@
     <ul class="dropdown-menu dropdown-menu-right">
 
       <!-- Actions -->
-      <li class="dropdown-header">{{ $t('livedata.dropdownMenu.actions') }}</li>
+      <li><span class="dropdown-header">{{ $t('livedata.dropdownMenu.actions') }}</span><ul>
 
       <li>
         <!-- Refresh -->
@@ -56,12 +56,10 @@
           {{ $t('livedata.action.refresh') }}
         </a>
       </li>
-
+      </ul></li>
 
       <!-- Layouts -->
-      <li role="separator" class="divider"></li>
-
-      <li class="dropdown-header">{{ $t('livedata.dropdownMenu.layouts') }}</li>
+      <li><span class="dropdown-header">{{ $t('livedata.dropdownMenu.layouts') }}</span><ul>
 
       <!-- Layout options -->
       <li
@@ -76,11 +74,10 @@
           {{ layout.name }}
         </a>
       </li>
+      </ul></li>
 
       <!-- Panels -->
-      <li role="separator" class="divider"></li>
-
-      <li class="dropdown-header">{{ $t('livedata.dropdownMenu.panels') }}</li>
+      <li><span class="dropdown-header">{{ $t('livedata.dropdownMenu.panels') }}</span><ul>
 
       <li v-for="panel in logic.panels" :key="panel.id">
         <a href="#" @click.prevent="logic.uniqueArrayToggle(logic.openedPanels, panel.id)">
@@ -88,6 +85,7 @@
           {{ panel.name }}
         </a>
       </li>
+      </ul></li>
 
     </ul>
 
@@ -130,7 +128,7 @@ export default {
 <style>
 
 .livedata-dropdown-menu {
-  // Similar to .flat-buttons()
+  /* Similar to .flat-buttons() */
   .btn-default {
     background-color: @breadcrumb-bg;
     background-image: none;
@@ -142,6 +140,12 @@ export default {
 
   .btn-default:hover, .btn-default:active, .btn-default:focus, .open .dropdown-toggle {
       border-color: darken(@dropdown-divider-bg, 10%);
+  }
+
+  /* Style each section of the dropdown */
+  ul.dropdown-menu > li > ul {
+    list-style: none;
+    padding-left: 0;
   }
 }
 

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/LivedataDropdownMenu.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/LivedataDropdownMenu.vue
@@ -47,42 +47,51 @@
     <ul class="dropdown-menu dropdown-menu-right">
 
       <!-- Actions -->
-      <li><span class="dropdown-header">{{ $t('livedata.dropdownMenu.actions') }}</span><ul>
-        <li>
-          <!-- Refresh -->
-          <a href="#" @click.prevent="logic.updateEntries()" class="livedata-action-refresh">
-            <XWikiIcon :icon-descriptor="{name: 'repeat'}" /> 
-            {{ $t('livedata.action.refresh') }}
-          </a>
-        </li>
-      </ul></li>
+      <li>
+        <span class="dropdown-header">{{ $t('livedata.dropdownMenu.actions') }}</span>
+        <ul>
+          <li>
+            <!-- Refresh -->
+            <a href="#" @click.prevent="logic.updateEntries()" class="livedata-action-refresh">
+              <XWikiIcon :icon-descriptor="{name: 'repeat'}" /> 
+              {{ $t('livedata.action.refresh') }}
+            </a>
+          </li>
+        </ul>
+      </li>
 
       <!-- Layouts -->
-      <li><span class="dropdown-header">{{ $t('livedata.dropdownMenu.layouts') }}</span><ul>
-        <!-- Layout options -->
-        <li
-          v-for="layout in data.meta.layouts"
-          :key="layout.id"
-          :class="{
-            'disabled': isCurrentLayout(layout.id),
-          }"
-        >
-          <a href="#" @click.prevent="changeLayout(layout.id)">
-            <XWikiIcon :icon-descriptor="layout.icon"></XWikiIcon>
-            {{ layout.name }}
-          </a>
-        </li>
-      </ul></li>
+      <li>
+        <span class="dropdown-header">{{ $t('livedata.dropdownMenu.layouts') }}</span>
+        <ul>
+          <!-- Layout options -->
+          <li
+            v-for="layout in data.meta.layouts"
+            :key="layout.id"
+            :class="{
+              'disabled': isCurrentLayout(layout.id),
+            }"
+          >
+            <a href="#" @click.prevent="changeLayout(layout.id)">
+              <XWikiIcon :icon-descriptor="layout.icon"></XWikiIcon>
+              {{ layout.name }}
+            </a>
+          </li>
+        </ul>
+      </li>
 
       <!-- Panels -->
-      <li><span class="dropdown-header">{{ $t('livedata.dropdownMenu.panels') }}</span><ul>
-        <li v-for="panel in logic.panels" :key="panel.id">
-          <a href="#" @click.prevent="logic.uniqueArrayToggle(logic.openedPanels, panel.id)">
-            <XWikiIcon :icon-descriptor="{name: panel.icon}"/>
-            {{ panel.name }}
-          </a>
-        </li>
-      </ul></li>
+      <li>
+        <span class="dropdown-header">{{ $t('livedata.dropdownMenu.panels') }}</span>
+        <ul>
+          <li v-for="panel in logic.panels" :key="panel.id">
+            <a href="#" @click.prevent="logic.uniqueArrayToggle(logic.openedPanels, panel.id)">
+              <XWikiIcon :icon-descriptor="{name: panel.icon}"/>
+              {{ panel.name }}
+            </a>
+          </li>
+        </ul>
+      </li>
 
     </ul>
 


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22485

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Updated the structure of the LiveData dropdown (namely, removed separator <li>s and grouped links together)
* Updated bootstrap dropdown styles to account for this new kind of separator in dropdowns.
* Updated the tests to work on this updated architecture

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Using separator list items can cause weird experiences for AT users, so instead of this I decided to just nest sublists inside the main list to make a semantic separation between the items.
* I brought the style changes directly on our fork of bootstrap because it made the most sense here. I could have added this style in the liveData code, but this change is generic so I thought it would be best as an update of our design system.
* I decided to keep the changes on the tests minimal. I could have reworked them to make them simpler. The workaround that was used is no longer needed. However, in order to simplify this, I'd need to rewrite a large part of each test because of the way it was coded. I went with the easy solution, feel free to let me know if we should add more changes to the tests in this PR.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
On the left is the dropdown before the changes in this PR, and on the right is the same dropdown after the changes in this PR. We can see that the styles are pretty much the same. This was the goal of this PR: improve the HTML architecture of the dropdown without regressing on the style.
![Screenshot from 2024-11-20 12-05-23](https://github.com/user-attachments/assets/27133c85-1014-49de-8acb-e3f85263135f)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Successfully built the livedata webjar with the quality profile: `mvn clean install -f xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/`.
Successfully passed livedata docker tests: `mvn clean install -f xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/`.
Manual tests on a local instance to check for style with Firefox (see screenshot above).
Sonarlint analysis on the updated files did not point out any recent quality regressions.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X