### PR TITLE
XWIKI-22121: Improve the registration experience

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/AbstractRegistrationPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/AbstractRegistrationPage.java
@@ -19,7 +19,7 @@
  */
 package org.xwiki.test.ui.po;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -65,7 +65,7 @@ public abstract class AbstractRegistrationPage extends BasePage
     public void fillRegisterForm(final String firstName, final String lastName, final String username,
         final String password, final String confirmPassword, final String email)
     {
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new LinkedHashMap<String, String>();
         // remove the onfocus on login, to avoid any problem to put the value.
         getDriver().executeJavascript("try{ document.getElementById('xwikiname').onfocus = null; " +
             "}catch(err){}");
@@ -78,11 +78,13 @@ public abstract class AbstractRegistrationPage extends BasePage
         if (StringUtils.isNotEmpty(username)) {
             map.put("xwikiname", username);
         }
-        if (StringUtils.isNotEmpty(password)) {
-            map.put("register_password", password);
-        }
+        // We invert the order of password fields fill to test that the validation of this second password is properly
+        // updated when the first password field is changed.
         if (StringUtils.isNotEmpty(confirmPassword)) {
             map.put("register2_password", confirmPassword);
+        }
+        if (StringUtils.isNotEmpty(password)) {
+            map.put("register_password", password);
         }
         if (StringUtils.isNotEmpty(email)) {
             map.put("register_email", email);

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/FormContainerElement.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/FormContainerElement.java
@@ -22,6 +22,7 @@ package org.xwiki.test.ui.po;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -72,7 +73,7 @@ public class FormContainerElement extends BaseElement
 
     public void fillFieldsByName(Map<String, String> valuesByNames)
     {
-        Map<WebElement, String> valuesByElements = new HashMap<>((int) (valuesByNames.size() / 0.75));
+        Map<WebElement, String> valuesByElements = new LinkedHashMap<>((int) (valuesByNames.size() / 0.75));
 
         for (String name : valuesByNames.keySet()) {
             valuesByElements.put(getFormElement().findElement(By.name(name)), valuesByNames.get(name));

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/register_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/register_macros.vm
@@ -300,6 +300,14 @@ $xwiki.get('ssfx').use('uicomponents/widgets/validation/livevalidation.css', tru
           #if ($mustMatch.name && $mustMatch.failureMessage && !$mustMatch.noscript)
             ${fieldName}Validator.add(Validate.Confirmation, {match: $$("input[name=$!mustMatch.name]")[0],
               failureMessage: "$!mustMatch.failureMessage", identifier: 'must-match'});
+            // We want to update the validation status of the field when its mustmatch field is updated.
+            // We use the 'blur' event, which is the same as the one used to trigger validation in
+            // livevalidation_prototype.js 
+            $$("input[name=$!mustMatch.name]")[0].on("blur", function() {
+              // Somehow in this context I couldn't get the 'trigger' function from jquery to work
+              // so instead we trigger the event with native javascript.
+              $$("input[name=$!fieldName]")[0].dispatchEvent(new Event("blur"));
+            });
           #end
         #end
         ##


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
Related to https://jira.xwiki.org/browse/XWIKI-22121
fix for https://ci.xwiki.org/job/XWiki%20Environment%20Tests/job/xwiki-platform/job/stable-16.10.x/4/testReport/junit/org.xwiki.administration.test.ui/AllIT$NestedUsersGroupsRightsManagementIT/MySQL_9_1__Tomcat_9_jdk21__Chrome___Docker_tests_for_xwiki_platform_administration___Build_for_MySQL_9_1__Tomcat_9_jdk21__Chrome___Docker_tests_for_xwiki_platform_administration___createAndDeleteUser_TestUtils__TestReference_/

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Improved consistency of the test with LinkedHashMaps.
* Fixed the issue with mustMatch fields status not being updated when their pair was updated.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* See comments in the code

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
None, mostly test changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

After building changes with `mvn clean install -f xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui ` and `mvn clean install -f xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates`, I could successfully pass `mvn clean install -f xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/ -Dit.test=UsersGroupsRightsManagementIT#createAndDeleteUser`. I tested the livevalidation changes locally and I can confirm that the changes fixed the issue.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X