### PR TITLE
XWIKI-22636: The navigation panel information box icon is smaller than expected

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/messages.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/messages.less
@@ -40,9 +40,8 @@ div.successmessage, div.errormessage, div.warningmessage, div.infomessage {
   border-left: 4px solid;
   box-shadow: none;
   
-  & > img {
-    // Improve alignment for silk icons
-    align-self: flex-start;
+  & > .icon-block > img {
+    max-width: unset;
   }
 
   & > div > .box-title,


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22636

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Fixed style for block Silk icons.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The structure was changed in a fix for XWIKI-21452 and not tested as well as it was initially. This code responsible for styling of Silk icons in block macros wasn't updated and was useless. I updated it and fixed the issue mentionned in the ticket.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Before the changes proposed in this PR:
![Screenshot from 2024-11-21 14-35-47](https://github.com/user-attachments/assets/e4d937de-19cb-4985-9e78-67f1e54469a6)
![image](https://github.com/user-attachments/assets/abeaf944-0ce2-4990-9668-e1a9304595f9)
After the changes proposed in this PR:
![Screenshot from 2024-11-21 14-39-33](https://github.com/user-attachments/assets/443ab102-838c-4a7c-befc-738eedc459ae)
![Screenshot from 2024-11-21 14-39-52](https://github.com/user-attachments/assets/e9726abf-7bd8-47b8-b29d-47fe8cf33092)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests, see screenshots above. 
Didn't execute any automated test since this is a style bug only that was reported only thanks to human observation.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X