### PR TITLE
XWIKI-13987: Navbar height is increased by 5px on small device (<768px)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/action-menus.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/action-menus.less
@@ -45,6 +45,10 @@
       float: left;
       margin-left: @navbar-padding-horizontal;
       margin-right: @navbar-padding-horizontal;
+      /* Without this rule, the left navbar will cause unexpected layout shifts even when it's empty. */
+      &:not(:has(> *)) {
+        margin-top: 0;
+      }  
     }
   }
 }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-13987

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Removed the space used by the left navbar when it has no children (xwiki standard's default)

## Clarification

I decided to be extra precise with the selector to not degrade the state of the navbar-left elements when there's some inside. I didn't test in this case, but the selector should avoid that this change have any unexpected effects.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
The screens for the state before the PR are on the ticket itself. 
Here is what this UI looks like with the changes proposed in this PR:

https://github.com/user-attachments/assets/c340391a-9288-4bd1-a044-b9cd2c6e96ed

We can see that there's not a middle step anymore. The only two states of the navbar are: everything on one line, icon on one line and actions on the next one. 

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests for style changes. See the video above.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X

# Assignee
Assigning surli since he already heard of this issue :)