### PR TITLE
XWIKI-22680: Regression on createAndDeleteUser

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/ResetPasswordCompletePage.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/ResetPasswordCompletePage.java
@@ -77,6 +77,9 @@ public class ResetPasswordCompletePage extends ViewPage
     public void setPasswordConfirmation(String newPasswordConfirmation)
     {
         this.newPasswordConfirmationField.sendKeys(newPasswordConfirmation);
+        getDriver().waitUntilCondition(
+            driver -> !this.newPasswordConfirmationField.getAttribute("class").isEmpty()
+        );
     }
 
     public ResetPasswordCompletePage clickSave()

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/AbstractRegistrationPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/AbstractRegistrationPage.java
@@ -65,7 +65,7 @@ public abstract class AbstractRegistrationPage extends BasePage
     public void fillRegisterForm(final String firstName, final String lastName, final String username,
         final String password, final String confirmPassword, final String email)
     {
-        LinkedHashMap<String, String> map = new LinkedHashMap<String, String>();
+        Map<String, String> map = new LinkedHashMap<String, String>();
         // remove the onfocus on login, to avoid any problem to put the value.
         getDriver().executeJavascript("try{ document.getElementById('xwikiname').onfocus = null; " +
             "}catch(err){}");

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/AbstractRegistrationPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/AbstractRegistrationPage.java
@@ -65,7 +65,7 @@ public abstract class AbstractRegistrationPage extends BasePage
     public void fillRegisterForm(final String firstName, final String lastName, final String username,
         final String password, final String confirmPassword, final String email)
     {
-        Map<String, String> map = new LinkedHashMap<String, String>();
+        LinkedHashMap<String, String> map = new LinkedHashMap<String, String>();
         // remove the onfocus on login, to avoid any problem to put the value.
         getDriver().executeJavascript("try{ document.getElementById('xwikiname').onfocus = null; " +
             "}catch(err){}");

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/FormContainerElement.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/FormContainerElement.java
@@ -71,12 +71,14 @@ public class FormContainerElement extends BaseElement
         return this.formElement;
     }
 
-    public void fillFieldsByName(LinkedHashMap<String, String> valuesByNames)
+    public void fillFieldsByName(Map<String, String> valuesByNames)
     {
-        LinkedHashMap<WebElement, String> valuesByElements = new LinkedHashMap<>((int) (valuesByNames.size() / 0.75));
-
+        Map<WebElement, String> valuesByElements = new LinkedHashMap<>();
+        
+        String lastElementName = null;
         for (String name : valuesByNames.keySet()) {
             valuesByElements.put(getFormElement().findElement(By.name(name)), valuesByNames.get(name));
+            lastElementName = name;
         }
         fillFieldsByElements(valuesByElements);
         
@@ -87,7 +89,7 @@ public class FormContainerElement extends BaseElement
           This is okay because the Map should not contain a lot of elements.
           */
         if(valuesByElements.size() > 0) {
-            WebElement lastElement = ((WebElement)valuesByElements.keySet().toArray()[valuesByElements.size() - 1]);
+            WebElement lastElement = getFormElement().findElement(By.name(lastElementName));
             getDriver().waitUntilCondition(driver -> !lastElement.getAttribute(CLASS_ATTRIBUTE).isEmpty());
         }
     }

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/FormContainerElement.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/FormContainerElement.java
@@ -75,7 +75,7 @@ public class FormContainerElement extends BaseElement
     {
         Map<WebElement, String> valuesByElements = new LinkedHashMap<>();
         
-        String lastElementName = null;
+        String lastElementName = "";
         for (String name : valuesByNames.keySet()) {
             valuesByElements.put(getFormElement().findElement(By.name(name)), valuesByNames.get(name));
             lastElementName = name;
@@ -88,7 +88,7 @@ public class FormContainerElement extends BaseElement
           Unfortunately in Java17 we do not have lastEntry(), so we use a few non optimized operations instead. 
           This is okay because the Map should not contain a lot of elements.
           */
-        if(valuesByElements.size() > 0) {
+        if(!valuesByElements.isEmpty()) {
             WebElement lastElement = getFormElement().findElement(By.name(lastElementName));
             getDriver().waitUntilCondition(driver -> !lastElement.getAttribute(CLASS_ATTRIBUTE).isEmpty());
         }

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/FormContainerElement.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/FormContainerElement.java
@@ -75,22 +75,23 @@ public class FormContainerElement extends BaseElement
     {
         Map<WebElement, String> valuesByElements = new LinkedHashMap<>();
         
-        String lastElementName = "";
+        WebElement lastElement = null;
         for (String name : valuesByNames.keySet()) {
-            valuesByElements.put(getFormElement().findElement(By.name(name)), valuesByNames.get(name));
-            lastElementName = name;
+            lastElement = getFormElement().findElement(By.name(name));
+            valuesByElements.put(lastElement, valuesByNames.get(name));
         }
         fillFieldsByElements(valuesByElements);
         
         /* Register password confirmation is usually the last element that needs to be validated by liveValidation.
           This wait allows to solve a race condition between the form submission and the computation of the status of
           those fields. We force the status to be solved before we try anything else, especially submitting the form.
-          Unfortunately in Java17 we do not have lastEntry(), so we use a few non optimized operations instead. 
+          Unfortunately in Java17 we do not have lastEntry() from LinkedHashMaps, 
+          so we use a few non optimized operations instead. 
           This is okay because the Map should not contain a lot of elements.
           */
         if(!valuesByElements.isEmpty()) {
-            WebElement lastElement = getFormElement().findElement(By.name(lastElementName));
-            getDriver().waitUntilCondition(driver -> !lastElement.getAttribute(CLASS_ATTRIBUTE).isEmpty());
+            WebElement finalLastElement = lastElement;
+            getDriver().waitUntilCondition(driver -> !finalLastElement.getAttribute(CLASS_ATTRIBUTE).isEmpty());
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/FormContainerElement.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/FormContainerElement.java
@@ -71,9 +71,9 @@ public class FormContainerElement extends BaseElement
         return this.formElement;
     }
 
-    public void fillFieldsByName(Map<String, String> valuesByNames)
+    public void fillFieldsByName(LinkedHashMap<String, String> valuesByNames)
     {
-        Map<WebElement, String> valuesByElements = new LinkedHashMap<>((int) (valuesByNames.size() / 0.75));
+        LinkedHashMap<WebElement, String> valuesByElements = new LinkedHashMap<>((int) (valuesByNames.size() / 0.75));
 
         for (String name : valuesByNames.keySet()) {
             valuesByElements.put(getFormElement().findElement(By.name(name)), valuesByNames.get(name));
@@ -83,10 +83,12 @@ public class FormContainerElement extends BaseElement
         /* Register password confirmation is usually the last element that needs to be validated by liveValidation.
           This wait allows to solve a race condition between the form submission and the computation of the status of
           those fields. We force the status to be solved before we try anything else, especially submitting the form.
+          Unfortunately in Java17 we do not have lastEntry(), so we use a few non optimized operations instead. 
+          This is okay because the Map should not contain a lot of elements.
           */
-        if (valuesByNames.containsKey("register2_password")) {
-            getDriver().waitUntilCondition(driver -> !getFormElement().findElement(By.name("register2_password"))
-                .getAttribute(CLASS_ATTRIBUTE).isEmpty());
+        if(valuesByElements.size() > 0) {
+            WebElement lastElement = ((WebElement)valuesByElements.keySet().toArray()[valuesByElements.size() - 1]);
+            getDriver().waitUntilCondition(driver -> !lastElement.getAttribute(CLASS_ATTRIBUTE).isEmpty());
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/FormContainerElement.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/FormContainerElement.java
@@ -89,7 +89,7 @@ public class FormContainerElement extends BaseElement
           so we use a few non optimized operations instead. 
           This is okay because the Map should not contain a lot of elements.
           */
-        if(!valuesByElements.isEmpty()) {
+        if(!valuesByElements.isEmpty() && lastElement != null) {
             WebElement finalLastElement = lastElement;
             getDriver().waitUntilCondition(driver -> !finalLastElement.getAttribute(CLASS_ATTRIBUTE).isEmpty());
         }

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-test/xwiki-platform-user-profile-test-pageobjects/src/main/java/org/xwiki/user/test/po/ChangePasswordPage.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-test/xwiki-platform-user-profile-test-pageobjects/src/main/java/org/xwiki/user/test/po/ChangePasswordPage.java
@@ -82,6 +82,7 @@ public class ChangePasswordPage extends BasePage
         this.password1.sendKeys(password);
         this.password2.clear();
         this.password2.sendKeys(password2);
+        getDriver().waitUntilElementHasNonEmptyAttributeValue(By.xpath("//input[@id='xwikipassword2']"),"class");
     }
 
     /**


### PR DESCRIPTION

# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22680
related to the regression introduced yesterday: https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/stable-16.10.x/7/testReport/junit/org.xwiki.administration.test.ui/AllIT$NestedRegisterIT/Platform_Builds___main___integration_tests___IT_for_xwiki_platform_core_xwiki_platform_administration_xwiki_platform_administration_test_xwiki_platform_administration_test_docker___Build_for_IT_for_xwiki_platform_core_xwiki_platform_administration_xwiki_platform_administration_test_xwiki_platform_administration_test_docker___registerExistingUser_boolean__boolean__boolean__TestUtils__2_/
# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Fixed the wait condition at the end of the formFilling function

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The wait was done on the password2 field. However, in the new testing conditions, this wait was incorrect because this field was not the last one we validate (yesterday we set a deterministic order where it wouldn't be the last). While editing, the field does not have any class on it. Once it's done being edited, it gets a class quickly after its validation. Here, we would still have the "old" validation state with an "invalid" class, that would end the wait immediately, but the form was not yet in its stable state. This means that the wait is too fast, and the form registration is tried when the state is incorrect, which means that the form is not submitted as we would want it to.
# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
None, test change only.
# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
After building the change with `mvn clean install -f xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui`, I ran all of the docker tests for administration `mvn clean install -f xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker`. They did pass successfully. Unfortunately I wasn't able to catch a lot of those wait time issues when running locally previously, I can't be sure it doesn't fail CI until it runs here... :/

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X , same as https://github.com/xwiki/xwiki-platform/pull/3666