### PR TITLE
XWIKI-22680: Regression on createAndDeleteUser

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/FormContainerElement.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/FormContainerElement.java
@@ -88,8 +88,12 @@ public class FormContainerElement extends BaseElement
           Unfortunately in Java17 we do not have lastEntry() from LinkedHashMaps, 
           so we use a few non optimized operations instead. 
           This is okay because the Map should not contain a lot of elements.
+          ---
+          Not all forms use live-validation, we make sure the last element has some validation going on before waiting.
           */
-        if(!valuesByElements.isEmpty() && lastElement != null) {
+        if(!valuesByElements.isEmpty() && lastElement != null && !lastElement.findElements(
+            By.xpath("//following-sibling::span[contains(@class, 'LV_validation_message')]"))
+            .isEmpty()) {
             WebElement finalLastElement = lastElement;
             getDriver().waitUntilCondition(driver -> !finalLastElement.getAttribute(CLASS_ATTRIBUTE).isEmpty());
         }


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22680

Fix for the CI regressions: https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/stable-16.10.x/9/testReport/junit/org.xwiki.invitation.test.docker/AllIT$NestedInvitationIT/Platform_Builds___main___integration_tests___IT_for_xwiki_platform_core_xwiki_platform_invitation_xwiki_platform_invitation_test_xwiki_platform_invitation_test_docker___Build_for_IT_for_xwiki_platform_core_xwiki_platform_invitation_xwiki_platform_invitation_test_xwiki_platform_invitation_test_docker___nonAdminCanSend_TestUtils_/ and https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/stable-16.10.x/lastCompletedBuild/testReport/org.xwiki.invitation.test.docker/AllIT$NestedInvitationIT/Platform_Builds___main___integration_tests___IT_for_xwiki_platform_core_xwiki_platform_invitation_xwiki_platform_invitation_test_xwiki_platform_invitation_test_docker___Build_for_IT_for_xwiki_platform_core_xwiki_platform_invitation_xwiki_platform_invitation_test_xwiki_platform_invitation_test_docker___guestActionsOnNonexistantMessage_TestUtils_/


# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Removed the waiting for forms that do not use livevalidation.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* I failed to consider those forms before. Thanks to luck, the conditions to wait did not influence the invitation form. However, with the latest merge, the condition were not enough. In order to solve this, I used the presence of a validation message to check if the form relied on the livevalidation script. Without this validation message, there is no need for a  wait because there's nothing stopping the form from being submitted.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
None, test only change.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

After building the changes with `mvn clean install -f xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui`, I could pass the tests locally: `mvn clean install -f xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-test/xwiki-platform-invitation-test-docker -Dit.test=InvitationIT#guestActionsOnNonexistantMessage` and `mvn clean install -f xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker -Dit.test=ResetPasswordIT#resetForgottenPassword`. 

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X, similar to https://github.com/xwiki/xwiki-platform/pull/3675