### PR TITLE
XWIKI-22344: When renaming a tag, the same tags but with different ca…

### DIFF
--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/com/xpn/xwiki/plugin/tag/TagPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/com/xpn/xwiki/plugin/tag/TagPlugin.java
@@ -349,7 +349,13 @@ public class TagPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfac
     public List<String> getDocumentsWithTag(String tag, boolean includeHiddenDocuments, XWikiContext context)
         throws XWikiException
     {
-        return TagQueryUtils.getDocumentsWithTag(tag, includeHiddenDocuments, context);
+        return getDocumentsWithTag(tag, includeHiddenDocuments, false);
+    }
+
+    private List<String> getDocumentsWithTag(String tag, boolean includeHiddenDocuments, boolean caseSensitive)
+        throws XWikiException
+    {
+        return TagQueryUtils.getDocumentsWithTag(tag, includeHiddenDocuments, caseSensitive);
     }
 
     /**
@@ -560,10 +566,13 @@ public class TagPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfac
      */
     protected TagOperationResult renameTag(String tag, String newTag, XWikiContext context) throws XWikiException
     {
+        // if the user is renaming a tag to change its case, we want to ensure that we only retrieve tags based on
+        // the case. Else we want to rename the tag for all pages whatever the case.
+        boolean caseSensitive = StringUtils.equalsIgnoreCase(tag, newTag);
         // Since we're renaming a tag, we want to rename it even if the document is hidden. A hidden document is still
         // accessible to users, it's just not visible for simple users; it doesn't change permissions.
-        List<String> docNamesToProcess = getDocumentsWithTag(tag, true, context);
-        if (StringUtils.equals(tag, newTag) || docNamesToProcess.size() == 0 || StringUtils.isBlank(newTag)) {
+        List<String> docNamesToProcess = getDocumentsWithTag(tag, true, caseSensitive);
+        if (StringUtils.equals(tag, newTag) || docNamesToProcess.isEmpty() || StringUtils.isBlank(newTag)) {
             return TagOperationResult.NO_EFFECT;
         }
 

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/com/xpn/xwiki/plugin/tag/TagQueryUtils.java
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/com/xpn/xwiki/plugin/tag/TagQueryUtils.java
@@ -146,8 +146,26 @@ public final class TagQueryUtils
     public static List<String> getDocumentsWithTag(String tag, boolean includeHiddenDocuments, XWikiContext context)
         throws XWikiException
     {
+        return getDocumentsWithTag(tag, includeHiddenDocuments, false);
+    }
+
+    /**
+     * Get documents with the passed tags with the result depending on whether the caller decides to include hidden
+     * documents or not.
+     *
+     * @param tag a list of tags to match.
+     * @param includeHiddenDocuments if true then include hidden documents
+     * @param caseSensitive {@code true} if the case of the tag should be used in the query {@code false} for getting
+     * results whatever the case of the tag.
+     * @return list of docNames.
+     * @throws XWikiException if search query fails (possible failures: DB access problems, etc).
+     * @since 6.2M1
+     */
+    public static List<String> getDocumentsWithTag(String tag, boolean includeHiddenDocuments, boolean caseSensitive)
+        throws XWikiException
+    {
         try {
-            return getTagsSelector().getDocumentsWithTag(tag, includeHiddenDocuments);
+            return getTagsSelector().getDocumentsWithTag(tag, includeHiddenDocuments, caseSensitive);
         } catch (TagException e) {
             throw new XWikiException(MODULE_XWIKI_STORE, ERROR_XWIKI_UNKNOWN,
                 String.format("Failed to get all documents with tag [%s]", tag), e);

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/org/xwiki/tag/internal/TagsSelector.java
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/org/xwiki/tag/internal/TagsSelector.java
@@ -71,8 +71,11 @@ public interface TagsSelector
      *
      * @param tag the tag to list documents for
      * @param includeHiddenDocuments when {@code true} hidden document are returned as well
+     * @param caseSensitive {@code true} if the case of the tag should be used in the query {@code false} for getting
+     * results whatever the case of the tag.
      * @return the list of serialized document reference of document containing a given tag
      * @throws TagException in cas of issue where retrieving the documents
      */
-    List<String> getDocumentsWithTag(String tag, boolean includeHiddenDocuments) throws TagException;
+    List<String> getDocumentsWithTag(String tag, boolean includeHiddenDocuments, boolean caseSensitive)
+        throws TagException;
 }

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/org/xwiki/tag/internal/selector/AbstractTagsSelector.java
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/org/xwiki/tag/internal/selector/AbstractTagsSelector.java
@@ -72,11 +72,16 @@ public abstract class AbstractTagsSelector implements TagsSelector
     protected DocumentReferenceResolver<String> stringDocumentReferenceResolver;
 
     @Override
-    public List<String> getDocumentsWithTag(String tag, boolean includeHiddenDocuments) throws TagException
+    public List<String> getDocumentsWithTag(String tag, boolean includeHiddenDocuments, boolean caseSensitive)
+        throws TagException
     {
         String hql = ", BaseObject as obj, DBStringListProperty as prop join prop.list item"
-            + " where obj.className=:className and obj.name=doc.fullName and obj.id=prop.id.id and prop.id.name='tags'"
-            + " and lower(item)=lower(:item)";
+            + " where obj.className=:className and obj.name=doc.fullName and obj.id=prop.id.id and prop.id.name='tags'";
+        if (caseSensitive) {
+            hql += "and item = :item";
+        } else {
+            hql += " and lower(item)=lower(:item)";
+        }
 
         try {
             Query query = this.contextProvider.get().getWiki().getStore().getQueryManager().createQuery(hql, Query.HQL);

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/org/xwiki/tag/internal/selector/DefaultTagsSelector.java
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/main/java/org/xwiki/tag/internal/selector/DefaultTagsSelector.java
@@ -106,8 +106,9 @@ public class DefaultTagsSelector implements TagsSelector, Initializable
     }
 
     @Override
-    public List<String> getDocumentsWithTag(String tag, boolean includeHiddenDocuments) throws TagException
+    public List<String> getDocumentsWithTag(String tag, boolean includeHiddenDocuments, boolean caseSensitive)
+        throws TagException
     {
-        return this.tagsSelector.getDocumentsWithTag(tag, includeHiddenDocuments);
+        return this.tagsSelector.getDocumentsWithTag(tag, includeHiddenDocuments, caseSensitive);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/test/java/org/xwiki/tag/internal/selector/ExhaustiveCheckTagsSelectorTest.java
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/test/java/org/xwiki/tag/internal/selector/ExhaustiveCheckTagsSelectorTest.java
@@ -327,7 +327,7 @@ class ExhaustiveCheckTagsSelectorTest
             .forEach((key, value) -> when(this.contextualAuthorizationManager.hasAccess(VIEW, key)).thenReturn(value));
         when(this.query.<String>execute()).thenReturn(results);
 
-        assertEquals(expected, this.tagsSelector.getDocumentsWithTag("Tag0", false));
+        assertEquals(expected, this.tagsSelector.getDocumentsWithTag("Tag0", false, false));
     }
 
     private void initializeDocumentReferenceResolver()

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/test/java/org/xwiki/tag/internal/selector/UnsafeTagsSelectorTest.java
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-api/src/test/java/org/xwiki/tag/internal/selector/UnsafeTagsSelectorTest.java
@@ -217,7 +217,7 @@ class UnsafeTagsSelectorTest
     {
         when(this.query.<String>execute()).thenReturn(results);
 
-        assertEquals(expected, this.tagsSelector.getDocumentsWithTag("Tag0", false));
+        assertEquals(expected, this.tagsSelector.getDocumentsWithTag("Tag0", false, false));
         verifyNoInteractions(this.stringDocumentReferenceResolver);
         verifyNoInteractions(this.contextualAuthorizationManager);
     }

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-test/xwiki-platform-tag-test-docker/src/test/it/org/xwiki/tag/test/ui/TagIT.java
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-test/xwiki-platform-tag-test-docker/src/test/it/org/xwiki/tag/test/ui/TagIT.java
@@ -19,10 +19,13 @@
  */
 package org.xwiki.tag.test.ui;
 
+import java.util.List;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.SpaceReference;
 import org.xwiki.tag.test.po.AddTagsPane;
 import org.xwiki.tag.test.po.TagPage;
 import org.xwiki.tag.test.po.TaggablePage;
@@ -31,6 +34,7 @@ import org.xwiki.test.docker.junit5.UITest;
 import org.xwiki.test.ui.TestUtils;
 
 import static org.apache.commons.lang3.RandomStringUtils.secure;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -49,9 +53,12 @@ class TagIT
     private TagPage tagPage;
 
     @BeforeEach
-    void setUp(TestUtils setup)
+    void setUp(TestUtils setup, TestReference testReference) throws Exception
     {
         setup.loginAsSuperAdmin();
+        // Create a new test page.
+        setup.rest().delete(testReference);
+        setup.rest().savePage(testReference, "", "");
     }
 
     /**
@@ -61,7 +68,7 @@ class TagIT
     @Order(1)
     void addRemoveTag(TestUtils setup, TestReference testReference)
     {
-        TaggablePage taggablePage = resetTaggablePage(setup, testReference);
+        TaggablePage taggablePage = TaggablePage.gotoPage(testReference);
         String tag = secure().nextAlphanumeric(4);
         assertFalse(taggablePage.hasTag(tag));
         AddTagsPane addTagsPane = taggablePage.addTags();
@@ -79,7 +86,7 @@ class TagIT
     @Order(2)
     void cancelAddTag(TestUtils setup, TestReference testReference)
     {
-        TaggablePage taggablePage = resetTaggablePage(setup, testReference);
+        TaggablePage taggablePage = TaggablePage.gotoPage(testReference);
         String firstTag = secure().nextAlphanumeric(4);
         assertFalse(taggablePage.hasTag(firstTag));
         AddTagsPane addTagsPane = taggablePage.addTags();
@@ -102,7 +109,7 @@ class TagIT
     @Order(3)
     void addManyRemoveOneTag(TestUtils setup, TestReference testReference)
     {
-        TaggablePage taggablePage = resetTaggablePage(setup, testReference);
+        TaggablePage taggablePage = TaggablePage.gotoPage(testReference);
         String firstTag = secure().nextAlphanumeric(4);
         assertFalse(taggablePage.hasTag(firstTag));
         String secondTag = secure().nextAlphanumeric(4);
@@ -125,7 +132,7 @@ class TagIT
     @Order(4)
     void addExistingTag(TestUtils setup, TestReference testReference)
     {
-        TaggablePage taggablePage = resetTaggablePage(setup, testReference);
+        TaggablePage taggablePage = TaggablePage.gotoPage(testReference);
         String tag = secure().nextAlphanumeric(4);
         assertFalse(taggablePage.hasTag(tag));
         AddTagsPane addTagsPane = taggablePage.addTags();
@@ -146,7 +153,7 @@ class TagIT
     @Order(5)
     void testAddTagContainingPipe(TestUtils setup, TestReference testReference)
     {
-        TaggablePage taggablePage = resetTaggablePage(setup, testReference);
+        TaggablePage taggablePage = TaggablePage.gotoPage(testReference);
         String tag = secure().nextAlphanumeric(3) + "|" + secure().nextAlphanumeric(3);
         assertFalse(taggablePage.hasTag(tag));
         AddTagsPane addTagsPane = taggablePage.addTags();
@@ -168,7 +175,7 @@ class TagIT
     @Order(6)
     void stripLeadingAndTrailingSpacesFromTags(TestUtils setup, TestReference testReference)
     {
-        TaggablePage taggablePage = resetTaggablePage(setup, testReference);
+        TaggablePage taggablePage = TaggablePage.gotoPage(testReference);
         String firstTag = secure().nextAlphanumeric(4);
         assertFalse(taggablePage.hasTag(firstTag));
         String secondTag = secure().nextAlphanumeric(4);
@@ -189,7 +196,7 @@ class TagIT
     @Order(7)
     void testTagCaseIsIgnored(TestUtils setup, TestReference testReference)
     {
-        TaggablePage taggablePage = resetTaggablePage(setup, testReference);
+        TaggablePage taggablePage = TaggablePage.gotoPage(testReference);
         String firstTag = "taG1";
         assertFalse(taggablePage.hasTag(firstTag));
         // Second tag is same as first tag but with different uppercase/lowercase chars.
@@ -204,30 +211,69 @@ class TagIT
         assertTrue(taggablePage.hasTag(firstTag));
         assertFalse(taggablePage.hasTag(secondTag));
         assertTrue(taggablePage.hasTag(thirdTag));
+
+        SpaceReference testSpace = testReference.getLastSpaceReference();
+        String subPageTitle = "SubPage";
+        DocumentReference otherPage = new DocumentReference(subPageTitle, testSpace);
+        setup.createPage(otherPage, "Some content", subPageTitle);
+        taggablePage = new TaggablePage();
+        addTagsPane = taggablePage.addTags();
+        addTagsPane.setTags(secondTag);
+        assertTrue(addTagsPane.add());
+        assertFalse(taggablePage.hasTag(firstTag));
+        assertTrue(taggablePage.hasTag(secondTag));
+        TagPage tagPage = taggablePage.clickOnTag(secondTag);
+        assertEquals(List.of(subPageTitle, testSpace.getName()), tagPage.getTaggedPages());
+
+        setup.gotoPage(testReference);
+        taggablePage = new TaggablePage();
+        tagPage = taggablePage.clickOnTag(firstTag);
+        assertEquals(List.of(subPageTitle, testSpace.getName()), tagPage.getTaggedPages());
+        tagPage = tagPage.renameTag(secondTag);
+        assertEquals(List.of(subPageTitle, testSpace.getName()), tagPage.getTaggedPages());
+
+        taggablePage = TaggablePage.gotoPage(testReference);
+        assertFalse(taggablePage.hasTag(firstTag));
+        assertTrue(taggablePage.hasTag(secondTag));
+        assertTrue(taggablePage.hasTag(thirdTag));
+
+        tagPage = taggablePage.clickOnTag(secondTag);
+        assertEquals(List.of(subPageTitle, testSpace.getName()), tagPage.getTaggedPages());
+        String tag4 = "tag4";
+        tagPage = tagPage.renameTag(tag4);
+        assertEquals(List.of(subPageTitle, testSpace.getName()), tagPage.getTaggedPages());
+        taggablePage = TaggablePage.gotoPage(testReference);
+        assertFalse(taggablePage.hasTag(firstTag));
+        assertFalse(taggablePage.hasTag(secondTag));
+        assertTrue(taggablePage.hasTag(thirdTag));
+        assertTrue(taggablePage.hasTag(tag4));
+
+        taggablePage = TaggablePage.gotoPage(otherPage);
+        assertFalse(taggablePage.hasTag(firstTag));
+        assertFalse(taggablePage.hasTag(secondTag));
+        assertFalse(taggablePage.hasTag(thirdTag));
+        assertTrue(taggablePage.hasTag(tag4));
     }
 
     @Test
     @Order(8)
     void addAndRenameTagFromTagPage(TestUtils setup, TestReference testReference)
     {
-        TaggablePage taggablePage = resetTaggablePage(setup, testReference);
+        TaggablePage taggablePage = TaggablePage.gotoPage(testReference);
         String tag = "MyTag";
         AddTagsPane addTagsPane = taggablePage.addTags();
         addTagsPane.setTags(tag);
         assertTrue(addTagsPane.add());
         assertTrue(taggablePage.hasTag(tag));
         this.tagPage = taggablePage.clickOnTag(tag);
-        this.tagPage.clickRenameButton();
-        this.tagPage.setNewTagName("MyTagRenamed");
-        this.tagPage.clickConfirmRenameTagButton();
-        assertTrue(this.tagPage.hasTagHighlight("MyTagRenamed"));
+        this.tagPage.renameTag("MyTagRenamed");
     }
 
     @Test
     @Order(9)
     void addAndDeleteTagFromTagPage(TestUtils setup, TestReference testReference)
     {
-        TaggablePage taggablePage = resetTaggablePage(setup, testReference);
+        TaggablePage taggablePage = TaggablePage.gotoPage(testReference);
         String tag = "MyTagToBeDeleted";
         AddTagsPane addTagsPane = taggablePage.addTags();
         addTagsPane.setTags(tag);
@@ -236,14 +282,6 @@ class TagIT
         this.tagPage = taggablePage.clickOnTag(tag);
         this.tagPage.clickDeleteButton();
         this.tagPage.clickConfirmDeleteTag();
-        assertTrue(this.tagPage.hasConfirmationMessage(tag));
-    }
-
-    private TaggablePage resetTaggablePage(TestUtils setup, DocumentReference entityReference)
-    {
-        // Create a new test page.
-        setup.deletePage(entityReference);
-        setup.createPage(entityReference, "");
-        return new TaggablePage();
+        assertTrue(this.tagPage.hasConfirmationMessage());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-test/xwiki-platform-tag-test-pageobjects/src/main/java/org/xwiki/tag/test/po/TagPage.java
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-test/xwiki-platform-tag-test-pageobjects/src/main/java/org/xwiki/tag/test/po/TagPage.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.tag.test.po;
 
+import java.util.List;
+
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
@@ -30,6 +32,8 @@ import org.xwiki.test.ui.po.ViewPage;
  */
 public class TagPage extends ViewPage
 {
+    private final String tag;
+
     @FindBy(xpath = "//a[@class='button rename']")
     private WebElement buttonRenameTag;
 
@@ -48,23 +52,17 @@ public class TagPage extends ViewPage
     @FindBy(xpath = "//input[@value='Rename']")
     private WebElement buttonConfirmRename;
 
-    public void clickRenameButton()
+    public TagPage(String tag)
     {
-      this.buttonRenameTag.click();
-    }
-    
-    public void setNewTagName(String newTagName)
-    {
-        this.renameTagInput.sendKeys(newTagName);
+        this.tag = tag;
     }
 
-    public void clickCancelRenameButton()
+    public TagPage renameTag(String newTagName)
     {
-        this.buttonDeleteTag.click();
-    }
-    public void clickConfirmRenameTagButton()
-    {
+        this.buttonRenameTag.click();
+        this.renameTagInput.sendKeys(newTagName);
         this.buttonConfirmRename.click();
+        return new TagPage(newTagName);
     }
     
     public void clickDeleteButton()
@@ -76,16 +74,19 @@ public class TagPage extends ViewPage
         this.buttonConfirmDeleteTag.click();
     }
 
-    public boolean hasTagHighlight(String tagName)
-    {   
-        return getDriver().findElementsWithoutWaiting(
-            By.xpath("//span[@class='highlight tag' and contains(text()[1], '" + tagName + "')]")).size() == 1;
-    }
-    public boolean hasConfirmationMessage(String tagName)
+    public boolean hasConfirmationMessage()
     {
         return getDriver().findElementsWithoutWaiting(
             By.xpath("//div[@class='box infomessage' and contains(. ,'has been successfully deleted')]"))
             .size() == 1;
+    }
+
+    public List<String> getTaggedPages()
+    {
+        String titleId = "HAllpagestaggedwith" + tag;
+        return getDriver().findElementsWithoutWaiting(By.cssSelector(String.format("h3[id='%s'] ~ ul > li", titleId)))
+            .stream().map(WebElement::getText)
+            .toList();
     }
 
 }

--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-test/xwiki-platform-tag-test-pageobjects/src/main/java/org/xwiki/tag/test/po/TaggablePage.java
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-test/xwiki-platform-tag-test-pageobjects/src/main/java/org/xwiki/tag/test/po/TaggablePage.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
+import org.xwiki.model.reference.EntityReference;
 import org.xwiki.test.ui.po.ViewPage;
 
 /**
@@ -39,6 +40,12 @@ public class TaggablePage extends ViewPage
      */
     @FindBy(id = "xdocTags")
     private WebElement tagsContainer;
+
+    public static TaggablePage gotoPage(EntityReference entityReference)
+    {
+        getUtil().gotoPage(entityReference);
+        return new TaggablePage();
+    }
 
     /**
      * @return {@code true} if this page has the specified tag, {@code false} otherwise
@@ -92,6 +99,6 @@ public class TaggablePage extends ViewPage
         WebElement tag = getDriver().findElementWithoutWaiting(
             By.xpath("//span[@class='tag']/a[. = '" + tagName + "' ]"));
         tag.click();
-        return new TagPage();
+        return new TagPage(tagName);
     }
 }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22344

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

  * Provide methods to allow querying document based on case sensitive tag
  * Use that method to get list of documents based on case sensitive tag when renaming a tag to change its case only to preserve backward compat of renaming
  * Refactoring of existing PO for integration test and cover the scenario in a new integration test

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
`mvn clean install -Pquality,integration-tests,docker` on xwiki-platform-tag

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.x