### PR TITLE
XWIKI-22709: XNotifications should have the alert role

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/notification.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/notification.js
@@ -107,7 +107,9 @@ widgets.Notification = Class.create({
   /** Creates the HTML structure for the notification. */
   createElement : function() {
     if (!this.element) {
-      this.element = new Element("div", {"class" : "xnotification xnotification-" + this.type}).update(this.text);
+      // The ARIA role `alert` should give implicit values for `aria-live` and `aria-atomic`.
+      this.element = new Element("div", {"class" : "xnotification xnotification-" + this.type,
+        "role": "alert"}).update(this.text);
       if (this.options.icon) {
         this.element.setStyle({backgroundImage : this.options.icon, paddingLeft : "22px"});
       }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22709

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added the `alert` role to xnotifications.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Using browserStack with Chrome 130 + NVDA ->

https://github.com/user-attachments/assets/4dc4287c-3654-4302-921d-54d25af46ea7

We can see that the content of the xnotifications for saving are now read out.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

None, except manual tests (see above). As far as I could see, the new attribute would not impact any test checking things on this element: https://github.com/search?q=repo%3Axwiki%2Fxwiki-platform%20xnotification&type=code 

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X