### PR TITLE
XWIKI-22496: Link dialog option button is not keyboard operable

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-link/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-link/plugin.js
@@ -522,13 +522,22 @@
     return {
       id: 'optionsToggle',
       type: 'html',
-      html: '<div class="linkOptionsToggle">' +
+      html: '<button class="linkOptionsToggle" type="button">' +
               '<label class="cke_dialog_ui_labeled_label">' +
                 '<span class="arrow arrow-right"></span> ' +
                 CKEDITOR.tools.htmlEncode(editor.localization.get('xwiki-link.options')) +
               '</label>' +
-            '</div>',
+            '</button>',
       onLoad: function() {
+        // Since we do not (and cannot without deeper changes) use the 'button' type, 
+        // we need to add this element explicitely to the Dialog focus list.
+        // We need to hardcode the position since we do not have access to the setupFocus function to reorder the list
+        // relative to native tab order.
+        // The four elements before this button are: display link, page selection *3
+        this.getDialog().addFocusable(this.getElement() , 4);
+        // Without this, the keyboard press on this focusable element will trigger the click twice...
+        this.getElement().removeAllListeners();
+        // We use the CKEDITOR.dom.element event utilities. This `on` is not related to JQuery.
         this.getElement().on('click', this.toggleLinkOptions, this);
       },
       toggleLinkOptions: function(event) {


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22496

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Updated the HTML of the button
* Added this button in the focusList
* Removed weird listeners that would come with this focusList

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

https://github.com/user-attachments/assets/072b09e1-9cd6-463b-b739-2c776ca2dd5a

Note that there's still issues with the pagepicker mode dropdown, but this PR's goal is not to fix this.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Successfully built `mvn clean install -f xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins ;mvn clean install -f xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-webjar/` and tested manually these changes on a live instance (see video above)

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X