### PR TITLE
XWIKI-22723: Warning message for application move has duplicated icons

### DIFF
--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/LiveTableViewSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/LiveTableViewSheet.xml
@@ -242,7 +242,7 @@
   #set ($classFullName = $doc.getValue('class'))
   #if ("$!classFullName" == '' || !$xwiki.exists($classFullName))
     {{warning}}
-    $services.icon.render('warning') {{translation key="platform.appwithinminutes.appHomePageMovedWarning"/}}
+    {{translation key="platform.appwithinminutes.appHomePageMovedWarning"/}}
     {{/warning}}
 
   #end


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22723
# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Removed the extra icon.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* There are two other uses of `$services.icon.render` in this XML's templates. However, those are for hardcodded box. Those will be removed at the same time as the boxes are moved to a standard macro use, see [XWIKI-22433](https://github.com/xwiki/xwiki-platform/pull/3555)

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
After the changes. We can see on the picture below that the duplicated icon is no more and things still look alright.
![image](https://github.com/user-attachments/assets/45a939d5-a6ae-49cf-9be8-0bda1d8a205e)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

None, this is a minor UI change on a non interactive element. Moreover, this regression on UI was found "by hand" and not reported by automated tests, so there's a high chance that the tests for this element are strict enough to be broken by this change.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X