### PR TITLE
XWIKI-22726: Allow customizing the validation of HQL queries through configuration

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/query/hql/internal/ConfigurableHQLQueryValidator.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/query/hql/internal/ConfigurableHQLQueryValidator.java
@@ -1,0 +1,104 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.query.hql.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.slf4j.Logger;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.phase.Initializable;
+import org.xwiki.component.phase.InitializationException;
+import org.xwiki.configuration.ConfigurationSource;
+
+/**
+ * A validator which can be configured.
+ * 
+ * @version $Id$
+ * @since 17.0.0RC1
+ * @since 16.10.2
+ * @since 15.10.16
+ * @since 16.4.6
+ */
+@Component
+@Singleton
+@Named("configuration")
+public class ConfigurableHQLQueryValidator implements HQLQueryValidator, Initializable
+{
+    @Inject
+    @Named("xwikiproperties")
+    private ConfigurationSource configuration;
+
+    @Inject
+    private Logger logger;
+
+    private List<Pattern> unsafe;
+
+    private List<Pattern> safe;
+
+    @Override
+    public void initialize() throws InitializationException
+    {
+        this.unsafe = getPatterns("query.hql.unsafe");
+        this.safe = getPatterns("query.hql.safe");
+    }
+
+    private List<Pattern> getPatterns(String key)
+    {
+        List<String> patternStrings = this.configuration.getProperty(key, List.class);
+
+        List<Pattern> patterns = new ArrayList<>(patternStrings.size());
+        for (String patternString : patternStrings) {
+            try {
+                patterns.add(Pattern.compile(patternString));
+            } catch (Exception e) {
+                this.logger.warn("Failed to parse pattern [{}] for configuration [{}]: {}", patternString, key,
+                    ExceptionUtils.getRootCauseMessage(e));
+            }
+        }
+
+        return patterns;
+    }
+
+    @Override
+    public Optional<Boolean> isSafe(String statement)
+    {
+        for (Pattern pattern : this.unsafe) {
+            if (pattern.matcher(statement).matches()) {
+                return Optional.of(Boolean.FALSE);
+            }
+        }
+
+        for (Pattern pattern : this.safe) {
+            if (pattern.matcher(statement).matches()) {
+                return Optional.of(Boolean.TRUE);
+            }
+        }
+
+        return Optional.empty();
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/query/hql/internal/DefaultHQLQueryValidator.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/query/hql/internal/DefaultHQLQueryValidator.java
@@ -1,0 +1,48 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.query.hql.internal;
+
+import java.util.Optional;
+
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+
+import com.xpn.xwiki.internal.store.hibernate.query.HqlQueryUtils;
+
+/**
+ * A HQL validator which relies on {@link HqlQueryUtils#isSafe(String)}.
+ * 
+ * @version $Id$
+ * @since 17.0.0RC1
+ * @since 16.10.2
+ * @since 15.10.16
+ * @since 16.4.6
+ */
+@Component
+@Singleton
+public class DefaultHQLQueryValidator implements HQLQueryValidator
+{
+    @Override
+    public Optional<Boolean> isSafe(String statement)
+    {
+        return Optional.of(HqlQueryUtils.isSafe(statement));
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/query/hql/internal/HQLQueryValidator.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/query/hql/internal/HQLQueryValidator.java
@@ -1,0 +1,44 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.query.hql.internal;
+
+import java.util.Optional;
+
+import org.xwiki.component.annotation.Role;
+
+/**
+ * A component in charge of validating a passed HQL statement.
+ * 
+ * @version $Id$
+ * @since 17.0.0RC1
+ * @since 16.10.2
+ * @since 15.10.16
+ * @since 16.4.6
+ */
+@Role
+public interface HQLQueryValidator
+{
+    /**
+     * @param statement the HQL statement to validate
+     * @return {@link Boolean#TRUE} if the passed statement is safe, {@link Boolean#FALSE} is it's not and
+     *         {@link Optional#empty()} otherwise.
+     */
+    Optional<Boolean> isSafe(String statement);
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/META-INF/components.txt
@@ -284,3 +284,5 @@ org.xwiki.internal.document.DocumentOverrideListener
 org.xwiki.internal.document.DocumentRequiredRightsReader
 org.xwiki.internal.document.RequiredRightClassMandatoryDocumentInitializer
 org.xwiki.internal.document.DefaultSimpleDocumentCache
+org.xwiki.query.hql.internal.ConfigurableHQLQueryValidator
+org.xwiki.query.hql.internal.DefaultHQLQueryValidator

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/hibernate/query/HqlQueryExecutorTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/hibernate/query/HqlQueryExecutorTest.java
@@ -26,14 +26,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.inject.Named;
+
 import org.hibernate.Session;
 import org.hibernate.boot.Metadata;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.engine.spi.NamedSQLQueryDefinition;
 import org.hibernate.query.NativeQuery;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.xwiki.component.manager.ComponentManager;
@@ -43,10 +44,16 @@ import org.xwiki.query.Query;
 import org.xwiki.query.QueryException;
 import org.xwiki.query.QueryFilter;
 import org.xwiki.query.WrappingQuery;
+import org.xwiki.query.hql.internal.DefaultHQLQueryValidator;
+import org.xwiki.query.hql.internal.HQLQueryValidator;
 import org.xwiki.query.internal.DefaultQuery;
 import org.xwiki.security.authorization.ContextualAuthorizationManager;
 import org.xwiki.security.authorization.Right;
-import org.xwiki.test.mockito.MockitoComponentMockingRule;
+import org.xwiki.test.annotation.AfterComponent;
+import org.xwiki.test.annotation.ComponentList;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
 
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
@@ -54,9 +61,9 @@ import com.xpn.xwiki.internal.store.hibernate.HibernateStore;
 import com.xpn.xwiki.store.XWikiHibernateBaseStore;
 import com.xpn.xwiki.store.XWikiHibernateStore;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -69,34 +76,44 @@ import static org.mockito.Mockito.when;
  *
  * @version $Id$
  */
-public class HqlQueryExecutorTest
+@ComponentTest
+@ComponentList(DefaultHQLQueryValidator.class)
+class HqlQueryExecutorTest
 {
-    @Rule
-    public MockitoComponentMockingRule<HqlQueryExecutor> mocker =
-        new MockitoComponentMockingRule<>(HqlQueryExecutor.class);
+    @InjectMockComponents
+    private HqlQueryExecutor executor;
 
+    @InjectMockComponents
+    private DefaultHQLQueryValidator defaultQueryValidator;
+
+    @MockComponent
     private ContextualAuthorizationManager authorization;
+
+    @MockComponent
+    private XWikiHibernateStore store;
+
+    @MockComponent
+    private HibernateStore hibernateStore;
+
+    @MockComponent
+    private Execution execution;
+
+    @MockComponent
+    @Named("context")
+    private ComponentManager contextComponentMannager;
 
     private boolean hasProgrammingRight;
 
-    /**
-     * The component under test.
-     */
-    private HqlQueryExecutor executor;
-
-    private XWikiHibernateStore store;
-
-    @Before
-    public void before() throws Exception
+    @AfterComponent
+    public void afterComponent()
     {
-        HibernateStore hibernateStore = this.mocker.getInstance(HibernateStore.class);
-        when(hibernateStore.getConfiguration()).thenReturn(new Configuration());
-        Metadata metadata = mock(Metadata.class);
-        when(hibernateStore.getConfigurationMetadata()).thenReturn(metadata);
+        when(this.hibernateStore.getConfiguration()).thenReturn(new Configuration());
+        when(this.hibernateStore.getConfigurationMetadata()).thenReturn(mock(Metadata.class));
+    }
 
-        this.executor = this.mocker.getComponentUnderTest();
-        this.authorization = this.mocker.getInstance(ContextualAuthorizationManager.class);
-
+    @BeforeEach
+    public void beforeEach() throws Exception
+    {
         when(this.authorization.hasAccess(Right.PROGRAM)).then(new Answer<Boolean>()
         {
             @Override
@@ -108,19 +125,20 @@ public class HqlQueryExecutorTest
 
         this.hasProgrammingRight = true;
 
+        when(this.contextComponentMannager.getInstanceList(HQLQueryValidator.class))
+            .thenReturn(List.of(this.defaultQueryValidator));
+
         // Actual Hibernate query
 
-        Execution execution = this.mocker.getInstance(Execution.class);
         ExecutionContext executionContext = mock(ExecutionContext.class);
-        when(execution.getContext()).thenReturn(executionContext);
+        when(this.execution.getContext()).thenReturn(executionContext);
         XWikiContext xwikiContext = mock(XWikiContext.class);
         when(executionContext.getProperty(XWikiContext.EXECUTIONCONTEXT_KEY)).thenReturn(xwikiContext);
         when(xwikiContext.getWikiId()).thenReturn("currentwikid");
 
         com.xpn.xwiki.XWiki xwiki = mock(com.xpn.xwiki.XWiki.class);
         when(xwikiContext.getWiki()).thenReturn(xwiki);
-        this.store = mock(XWikiHibernateStore.class);
-        when(xwiki.getHibernateStore()).thenReturn(store);
+        when(xwiki.getHibernateStore()).thenReturn(this.store);
     }
 
     private void execute(String statement, Boolean withProgrammingRights) throws QueryException
@@ -150,20 +168,20 @@ public class HqlQueryExecutorTest
     // Tests
 
     @Test
-    public void completeShortStatementWhenEmpty()
+    void completeShortStatementWhenEmpty()
     {
         assertEquals("select doc.fullName from XWikiDocument doc ", this.executor.completeShortFormStatement(""));
     }
 
     @Test
-    public void completeShortStatementStartingWithWhere()
+    void completeShortStatementStartingWithWhere()
     {
         assertEquals("select doc.fullName from XWikiDocument doc where doc.author='XWiki.Admin'",
             this.executor.completeShortFormStatement("where doc.author='XWiki.Admin'"));
     }
 
     @Test
-    public void completeShortStatementStartingWithFrom()
+    void completeShortStatementStartingWithFrom()
     {
         assertEquals(
             "select doc.fullName from XWikiDocument doc , BaseObject obj where doc.fullName=obj.name "
@@ -173,28 +191,28 @@ public class HqlQueryExecutorTest
     }
 
     @Test
-    public void completeShortStatementStartingWithOrderBy()
+    void completeShortStatementStartingWithOrderBy()
     {
         assertEquals("select doc.fullName from XWikiDocument doc order by doc.date desc",
             this.executor.completeShortFormStatement("order by doc.date desc"));
     }
 
     @Test
-    public void completeShortStatementPassingAnAlreadyCompleteQuery()
+    void completeShortStatementPassingAnAlreadyCompleteQuery()
     {
         assertEquals("select doc.fullName from XWikiDocument doc order by doc.date desc", this.executor
             .completeShortFormStatement("select doc.fullName from XWikiDocument doc order by doc.date desc"));
     }
 
     @Test
-    public void completeShortStatementPassingAQueryOnSomethingElseThanADocument()
+    void completeShortStatementPassingAQueryOnSomethingElseThanADocument()
     {
         assertEquals("select lock.docId from XWikiLock as lock ",
             this.executor.completeShortFormStatement("select lock.docId from XWikiLock as lock "));
     }
 
     @Test
-    public void setNamedParameter()
+    void setNamedParameter()
     {
         org.hibernate.query.Query query = mock(org.hibernate.query.Query.class);
         String name = "abc";
@@ -205,7 +223,7 @@ public class HqlQueryExecutorTest
     }
 
     @Test
-    public void setNamedParameterList()
+    void setNamedParameterList()
     {
         org.hibernate.query.Query query = mock(org.hibernate.query.Query.class);
         String name = "foo";
@@ -216,7 +234,7 @@ public class HqlQueryExecutorTest
     }
 
     @Test
-    public void setNamedParameterArray()
+    void setNamedParameterArray()
     {
         org.hibernate.query.Query query = mock(org.hibernate.query.Query.class);
         String name = "bar";
@@ -227,7 +245,7 @@ public class HqlQueryExecutorTest
     }
 
     @Test
-    public void populateParameters()
+    void populateParameters()
     {
         org.hibernate.query.Query hquery = mock(org.hibernate.query.Query.class);
         Query query = mock(Query.class);
@@ -253,7 +271,7 @@ public class HqlQueryExecutorTest
     }
 
     @Test
-    public void executeWhenStoreException() throws Exception
+    void executeWhenStoreException() throws Exception
     {
         XWikiException exception = mock(XWikiException.class);
         when(exception.getMessage()).thenReturn("nestedmessage");
@@ -272,7 +290,7 @@ public class HqlQueryExecutorTest
     }
 
     @Test
-    public void createNamedNativeHibernateQuery() throws Exception
+    void createNamedNativeHibernateQuery() throws Exception
     {
         DefaultQuery query = new DefaultQuery("queryName", this.executor);
 
@@ -294,8 +312,7 @@ public class HqlQueryExecutorTest
         when(definition.getResultSetRef()).thenReturn("someResultSet");
         when(definition.getName()).thenReturn(query.getStatement());
 
-        HibernateStore hibernateStore = this.mocker.getInstance(HibernateStore.class);
-        when(hibernateStore.getConfigurationMetadata().getNamedNativeQueryDefinition(query.getStatement()))
+        when(this.hibernateStore.getConfigurationMetadata().getNamedNativeQueryDefinition(query.getStatement()))
             .thenReturn(definition);
 
         assertSame(finalQuery, this.executor.createHibernateQuery(session, query));
@@ -304,7 +321,7 @@ public class HqlQueryExecutorTest
     }
 
     @Test
-    public void createHibernateQueryWhenFilter() throws Exception
+    void createHibernateQueryWhenFilter() throws Exception
     {
         Session session = mock(Session.class);
 
@@ -332,7 +349,7 @@ public class HqlQueryExecutorTest
     }
 
     @Test
-    public void createHibernateQueryAutomaticallyAddEscapeLikeParametersFilterWhenQueryParameter() throws Exception
+    void createHibernateQueryAutomaticallyAddEscapeLikeParametersFilterWhenQueryParameter() throws Exception
     {
         Session session = mock(Session.class);
         DefaultQuery query = new DefaultQuery("where space like :space", Query.HQL, this.executor);
@@ -342,8 +359,7 @@ public class HqlQueryExecutorTest
         when(filter.filterStatement(anyString(), anyString())).then(returnsFirstArg());
         when(filter.filterQuery(any(Query.class))).then(returnsFirstArg());
 
-        ComponentManager cm = this.mocker.getInstance(ComponentManager.class, "context");
-        when(cm.getInstance(QueryFilter.class, "escapeLikeParameters")).thenReturn(filter);
+        when(this.contextComponentMannager.getInstance(QueryFilter.class, "escapeLikeParameters")).thenReturn(filter);
 
         when(session.createQuery(anyString())).thenReturn(mock(org.hibernate.query.Query.class));
 
@@ -355,38 +371,38 @@ public class HqlQueryExecutorTest
     }
 
     @Test
-    public void executeShortWhereHQLQueryWithProgrammingRights() throws QueryException
+    void executeShortWhereHQLQueryWithProgrammingRights() throws QueryException
     {
         execute("where doc.space='Main'", true);
     }
 
     @Test
-    public void executeShortFromHQLQueryWithProgrammingRights() throws QueryException
+    void executeShortFromHQLQueryWithProgrammingRights() throws QueryException
     {
         execute(", BaseObject as obj", true);
     }
 
     @Test
-    public void executeCompleteHQLQueryWithProgrammingRights() throws QueryException
+    void executeCompleteHQLQueryWithProgrammingRights() throws QueryException
     {
         execute("select u from XWikiDocument as doc", true);
 
     }
 
     @Test
-    public void executeNamedQueryWithProgrammingRights() throws QueryException
+    void executeNamedQueryWithProgrammingRights() throws QueryException
     {
         executeNamed("somename", true);
     }
 
     @Test
-    public void executeShortWhereHQLQueryWithoutProgrammingRights() throws QueryException
+    void executeShortWhereHQLQueryWithoutProgrammingRights() throws QueryException
     {
         execute("where doc.space='Main'", false);
     }
 
     @Test
-    public void executeShortFromHQLQueryWithoutProgrammingRights() throws QueryException
+    void executeShortFromHQLQueryWithoutProgrammingRights() throws QueryException
     {
         execute(", BaseObject as obj", false);
     }
@@ -394,7 +410,7 @@ public class HqlQueryExecutorTest
     // Not allowed
 
     @Test
-    public void executeWhenNotAllowedSelect() throws Exception
+    void executeWhenNotAllowedSelect() throws Exception
     {
         try {
             execute("select notallowed.name from NotAllowedTable notallowed", false);
@@ -408,7 +424,7 @@ public class HqlQueryExecutorTest
     }
 
     @Test
-    public void executeDeleteWithoutProgrammingRight() throws Exception
+    void executeDeleteWithoutProgrammingRight() throws Exception
     {
         try {
             execute("delete from XWikiDocument as doc", false);
@@ -420,7 +436,7 @@ public class HqlQueryExecutorTest
     }
 
     @Test
-    public void executeNamedQueryWithoutProgrammingRight() throws Exception
+    void executeNamedQueryWithoutProgrammingRight() throws Exception
     {
         try {
             executeNamed("somename", false);
@@ -432,7 +448,7 @@ public class HqlQueryExecutorTest
     }
 
     @Test
-    public void executeUpdateWithoutProgrammingRight() throws Exception
+    void executeUpdateWithoutProgrammingRight() throws Exception
     {
         try {
             execute("update XWikiDocument set name='name'", false);

--- a/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.properties.vm
+++ b/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.properties.vm
@@ -879,6 +879,26 @@ distribution.automaticStartOnWiki=$xwikiPropertiesAutomaticStartOnWiki
 # security.requiredRights.protection=warning
 
 #-------------------------------------------------------------------------------------
+# Query
+#-------------------------------------------------------------------------------------
+
+#-# [Since 17.0.0RC1]
+#-# [Since 16.10.2]
+#-# [Since 15.10.16]
+#-# [Since 16.4.6]
+#-# While HQL queries executed by users without programming right are validated. It's sometimes necessary to
+#-# customize the behavior of the standard validator because it might be too strict (or not strict enough).
+#-# The following properties allows to give a list of (Java) regular expression.
+#-# In case both safe and unsafe patterns match the query, the priority goes to considering it unsafe.
+#-#
+# query.hql.unsafe=.*some native syntax.*
+#-# 
+#-# Note: be very careful to not use too large regular expression when adding a safe pattern as it could introduce a vulnerability.
+#-# 
+# query.hql.safe=select pro1, prop2 from CustomTable
+# query.hql.safe=select\\s+((prop1|prop2|prop3)\\s*,?\\s*)+\\s+from MyCustomTable
+
+#-------------------------------------------------------------------------------------
 # URL
 #-------------------------------------------------------------------------------------
 


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22726

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* introduce an (internal for now) extension point to provide HQL query validators in charge of check if a query is safe to be allowed for user who don't have programming right
* move the current validation to the new `DefaultHQLQueryValidator`
* introduce a regex based `ConfigurableHQLQueryValidator` and its corresponding `xwiki.properties` documentation

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* while it would be interesting to make a similar extension point public one day, I don't have the required time to spend on designing the cleanest extension point possible for this (we probably need something more generic)

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

TODO: add regex related tests

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches: 16.10.x, 16.4.x, 15.10.x