### PR TITLE
XWIKI-22675: Extra line below facet items

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/Main/SolrSearch.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/Main/SolrSearch.xml
@@ -722,19 +722,6 @@ a.search-result-highlightAll:after {
   position: relative;
 }
 
-.search-facet-header:after {
-  border-bottom: 1px dotted $theme.pageContentBackgroundColor;
-  border-top: 1px dotted $theme.borderColor;
-  clear: both;
-  content: "";
-  display: block;
-  height: 0;
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  width: 100%;
-}
-
 .search-facet:last-of-type .search-facet-header:after {
   border: medium none;
 }


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22675

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Removed the extra line

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The extra line was added through an `:after` pseudo element. It was its only purpose, we can remove this pseudo element without any side effect on the layout.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Before the changes proposed in this PR:
![Screenshot from 2024-12-12 13-58-06](https://github.com/user-attachments/assets/df0939a5-0dd2-495d-95d9-0607f5f9e848)
After the changes proposed in this PR:
![Screenshot from 2024-12-12 13-59-42](https://github.com/user-attachments/assets/e9c4de5e-4b0e-4026-99d8-41dd12a04465)

We can see that the lines are removed, and the layout is substantially the same. Note that these screenshots have been made on an instance where change for [XWIKI-22674](https://github.com/xwiki/xwiki-platform/pull/3758) were already made, it's slightly different from the default today. However, the difference between the before and after screenshots highlights that the changes proposed here have the expected effect.
# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual test only. See screenshots above. The affected UI was just a pseudo element, so I highly doubt it was tested at any point. This is a style change only so it makes it pretty safe nevertheless.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X