### PR TITLE
XWIKI-22738: Target syntax is not set on the transformation context when the document content is rendered

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-source/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-source/plugin.js
@@ -67,7 +67,6 @@
         // sure relative references within the edited content are properly resolved and serialized.
         htmlConverter: editor.config.sourceDocument.getURL('get', $.param({
           sheet: 'CKEditor.HTMLConverter',
-          outputSyntax: 'plain',
           language: editor.getContentLocale(),
           formToken: document.documentElement.dataset.xwikiFormToken || ''
         }))

--- a/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-api/src/main/java/org/xwiki/display/internal/DocumentContentAsyncExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-api/src/main/java/org/xwiki/display/internal/DocumentContentAsyncExecutor.java
@@ -393,6 +393,7 @@ public class DocumentContentAsyncExecutor
         TransformationContext txContext =
             new TransformationContext(this.xdom, this.syntax, this.parameters.isTransformationContextRestricted());
         txContext.setId(this.transformationId);
+        txContext.setTargetSyntax(this.parameters.getTargetSyntax());
         this.transformationManager.performTransformations(this.xdom, txContext);
     }
 }


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-22738

# Changes

## Description

* Set the target syntax on the transformation context, when displaying the document content, based on the display parameters
* Fix the URL used by the WYSIWYG editor to convert the HTML

## Clarifications

* I'm worried by the fact that I had to update the HTML Converter URL to remove the ``outputSyntax=plain``. This parameter is used in lots of places in conjunction with the ``get`` action, so I'm worried there might be other regressions...

# Executed Tests

None

# Expected merging strategy

* Prefers squash: Yes