### PR TITLE
Fix solr search cache location on Windows

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/EmbeddedSolr.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/EmbeddedSolr.java
@@ -94,7 +94,7 @@ public class EmbeddedSolr extends AbstractSolr implements Disposable, Initializa
     
     private static final String CORE_PROPERTIES_FILENAME = "core.properties";
     
-    private static final String DATA_DIR_PROPERTY = "DataDir";
+    private static final String DATA_DIR_PROPERTY = "dataDir";
 
     /**
      * Solr configuration.

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/test/java/org/xwiki/search/solr/internal/EmbeddedSolrInitializationTest.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/test/java/org/xwiki/search/solr/internal/EmbeddedSolrInitializationTest.java
@@ -234,8 +234,8 @@ class EmbeddedSolrInitializationTest
         try( BufferedReader in = new BufferedReader(new FileReader(file, StandardCharsets.UTF_8)); ){
         	properties.load(in);
         }
-        String dataDir = properties.getProperty("DataDir");
-        assertNotNull(dataDir, "DataDir property from properties file was null: "+file.toString());
+        String dataDir = properties.getProperty("dataDir");
+        assertNotNull(dataDir, "dataDir property from properties file was null: "+file.toString());
         String fileSeperator = System.getProperty("file.separator");
         assertTrue(dataDir.contains(fileSeperator),"File seperators were not escaped properly in the "
         		+ "cache path!: \""+dataDir+"\" does not contain '"+fileSeperator+"'!");


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-22741)](https://jira.xwiki.org/browse/XWIKI-22741

# Changes

In xwiki-platform/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/EmbeddedSolr.java:

Instead of appending a string to the properties file, load any existing properties file using the java.util.Properties class, set the property, then save it using the method on the class. 

## Description

The dataDir property in <perm>\xwiki\store\solr\search\core.properties" is not being written in the proper format. This showed up specifically because backslashes require escape on Windows, but not using the java.util.Properties standard library class to write properties files may cause other yet to be encountered formatting issues. The comment in the Properties store method says "Converts unicodes to encoded &#92;uxxxx and escapes special characters with a preceding slash".

The effect was that the property ends up as "cachesolrsearch" instead of "..\..\..\cache\solr\search" so the solr cache ends up in "<perm>\store\solr\search\cachesolrsearch" instead of <perm>\cache\solr\search".

  Using blame the issue goes back to 12.10.

# Executed Tests

I added a test to: xwiki-platform-search-solr-api/src/test/java/org/xwiki/search/solr/internal/EmbeddedSolrInitializationTest.java

I confirmed that this test fails without the code change and passes with it. I wasn't sure if tests are always run on supported OS's before release, but this showed up as a problem on Windows, and I expect the test will only find the regression on Windows.

# Expected merging strategy

* Prefers squash: Yes - I found I had misnamed the property after testing. Whoops. 
* Backport on branches:
 
 it dates back to 12.10 so any versions still supported need it. 