### PR TITLE
XWIKI-22613: Updating the history can take a very long time when there are a lot of objects

### DIFF
--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-default/src/main/java/org/xwiki/index/migration/R140300001XWIKI19571DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-default/src/main/java/org/xwiki/index/migration/R140300001XWIKI19571DataMigration.java
@@ -100,7 +100,7 @@ public class R140300001XWIKI19571DataMigration extends AbstractHibernateDataMigr
                 PersistentClass persistentClass =
                     this.hibernateStore.getConfigurationMetadata()
                         .getEntityBinding(XWikiDocumentIndexingTask.class.getName());
-                String tableName = this.hibernateStore.getConfiguredTableName(persistentClass);
+                String tableName = this.hibernateStore.getAdapter().getTableName(persistentClass);
                 String changeSet = "";
                 if (exists(databaseMetaData, tableName)) {
                     saveTasks(session, persistentClass, tableName);
@@ -138,10 +138,10 @@ public class R140300001XWIKI19571DataMigration extends AbstractHibernateDataMigr
      */
     private boolean exists(DatabaseMetaData databaseMetaData, String tableName) throws SQLException
     {
-        String databaseName = this.hibernateStore.getDatabaseFromWikiName();
+        String databaseName = this.hibernateStore.getAdapter().getDatabaseFromWikiName();
 
         ResultSet resultSet;
-        if (this.hibernateStore.isCatalog()) {
+        if (this.hibernateStore.getAdapter().isCatalog()) {
             resultSet = databaseMetaData.getTables(databaseName, null, tableName, null);
         } else {
             resultSet = databaseMetaData.getTables(null, databaseName, tableName, null);

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-default/src/test/java/org/xwiki/index/migration/R140300001XWIKI19571DataMigrationTest.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-default/src/test/java/org/xwiki/index/migration/R140300001XWIKI19571DataMigrationTest.java
@@ -45,6 +45,7 @@ import org.xwiki.context.Execution;
 import org.xwiki.context.ExecutionContext;
 import org.xwiki.doc.tasks.XWikiDocumentIndexingTask;
 import org.xwiki.index.internal.TasksStore;
+import org.xwiki.store.hibernate.HibernateAdapter;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
@@ -103,6 +104,9 @@ class R140300001XWIKI19571DataMigrationTest
     private Metadata metadata;
 
     @Mock
+    private HibernateAdapter adapter;
+
+    @Mock
     private PersistentClass persistentClass;
 
     @Mock
@@ -128,8 +132,10 @@ class R140300001XWIKI19571DataMigrationTest
         when(this.hibernateStore.getConfigurationMetadata()).thenReturn(this.metadata);
         when(this.metadata.getEntityBinding(XWikiDocumentIndexingTask.class.getName()))
             .thenReturn(this.persistentClass);
-        when(this.hibernateStore.getConfiguredTableName(this.persistentClass)).thenReturn("XWIKIDOCUMENTINDEXINGQUEUE");
-        when(this.hibernateStore.getDatabaseFromWikiName()).thenReturn("dbname");
+        when(this.hibernateStore.getAdapter()).thenReturn(this.adapter);
+        when(this.adapter.getTableName(this.persistentClass))
+            .thenReturn("XWIKIDOCUMENTINDEXINGQUEUE");
+        when(this.adapter.getDatabaseFromWikiName()).thenReturn("dbname");
         when(this.connection.getMetaData()).thenReturn(this.databaseMetaData);
         when(this.hibernateStore.getConfiguredColumnName(this.persistentClass, "docId")).thenReturn("DOC_ID");
         when(this.hibernateStore.getConfiguredColumnName(this.persistentClass, "version")).thenReturn("VERSION");
@@ -144,7 +150,7 @@ class R140300001XWIKI19571DataMigrationTest
     @Test
     void hibernateMigrateExistsIsCatalog() throws Exception
     {
-        when(this.hibernateStore.isCatalog()).thenReturn(true);
+        when(this.adapter.isCatalog()).thenReturn(true);
         ResultSet resultSet = mock(ResultSet.class);
         when(resultSet.next()).thenReturn(true);
         when(this.databaseMetaData.getTables("dbname", null, "XWIKIDOCUMENTINDEXINGQUEUE", null)).thenReturn(resultSet);
@@ -182,7 +188,7 @@ class R140300001XWIKI19571DataMigrationTest
     @Test
     void hibernateMigrateExistsIsNotCatalog() throws Exception
     {
-        when(this.hibernateStore.isCatalog()).thenReturn(false);
+        when(this.adapter.isCatalog()).thenReturn(false);
         ResultSet resultSet = mock(ResultSet.class);
         when(resultSet.next()).thenReturn(true);
         when(this.databaseMetaData.getTables(null, "dbname", "XWIKIDOCUMENTINDEXINGQUEUE", null)).thenReturn(resultSet);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocumentArchive.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocumentArchive.java
@@ -154,8 +154,8 @@ public class XWikiDocumentArchive
         XWikiRCSNodeInfo latestNode = getLatestNode();
         if (latestNode != null) {
             int nodesCount = getNodes().size();
-            int nodesPerFull = context.getWiki() == null ? 5
-                : Integer.parseInt(context.getWiki().getConfig().getProperty("xwiki.store.rcs.nodesPerFull", "5"));
+            int nodesPerFull = context.getWiki() == null ? 1
+                : Integer.parseInt(context.getWiki().getConfig().getProperty("xwiki.store.rcs.nodesPerFull", "1"));
             if (nodesPerFull <= 0 || (nodesCount % nodesPerFull) != 0) {
                 XWikiRCSNodeContent latestContent = latestNode.getContent(context);
                 latestContent.getPatch().setDiffVersion(latestContent.getPatch().getContent(), doc, context);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/HibernateStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/HibernateStore.java
@@ -450,7 +450,7 @@ public class HibernateStore implements Disposable, Initializable
             }
         }
 
-        // Fallback on the default adapter if not specific one could be found
+        // Fallback on the default adapter if no specific one could be found
         return this.defaultHibernateAdapterProvider.get();
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/HibernateStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/HibernateStore.java
@@ -30,11 +30,11 @@ import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
-import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.TimeZone;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
@@ -73,10 +73,7 @@ import org.hibernate.mapping.Column;
 import org.hibernate.mapping.KeyValue;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
-import org.hibernate.mapping.Table;
 import org.hibernate.query.NativeQuery;
-import org.hibernate.tool.hbm2ddl.SchemaUpdate;
-import org.hibernate.tool.schema.TargetType;
 import org.hibernate.tool.schema.extract.spi.ExtractionContext;
 import org.hibernate.tool.schema.extract.spi.SequenceInformation;
 import org.slf4j.Logger;
@@ -90,6 +87,9 @@ import org.xwiki.context.Execution;
 import org.xwiki.context.ExecutionContext;
 import org.xwiki.environment.Environment;
 import org.xwiki.logging.LoggerConfiguration;
+import org.xwiki.store.hibernate.HibernateAdapter;
+import org.xwiki.store.hibernate.HibernateAdapterFactory;
+import org.xwiki.store.hibernate.HibernateStoreException;
 import org.xwiki.wiki.descriptor.WikiDescriptorManager;
 import org.xwiki.wiki.manager.WikiManagerException;
 
@@ -111,11 +111,6 @@ import com.xpn.xwiki.store.migration.DataMigrationManager;
 @DisposePriority(10000)
 public class HibernateStore implements Disposable, Initializable
 {
-    /**
-     * @see #isConfiguredInSchemaMode()
-     */
-    private static final String VIRTUAL_MODE_SCHEMA = "schema";
-
     private static final String CONTEXT_SESSION = "hibsession";
 
     private static final String CONTEXT_TRANSACTION = "hibtransaction";
@@ -144,9 +139,6 @@ public class HibernateStore implements Disposable, Initializable
     private Execution execution;
 
     @Inject
-    private WikiDescriptorManager wikis;
-
-    @Inject
     private HibernateConfiguration hibernateConfiguration;
 
     @Inject
@@ -154,6 +146,15 @@ public class HibernateStore implements Disposable, Initializable
 
     @Inject
     private LoggerConfiguration loggerConfiguration;
+
+    @Inject
+    private List<HibernateAdapterFactory> adapterFactories;
+
+    @Inject
+    private WikiDescriptorManager wikis;
+
+    @Inject
+    private Provider<HibernateAdapter> defaultHibernateAdapterProvider;
 
     private DataMigrationManager dataMigrationManager;
 
@@ -168,6 +169,8 @@ public class HibernateStore implements Disposable, Initializable
     private Dialect dialect;
 
     private DatabaseProduct databaseProductCache = DatabaseProduct.UNKNOWN;
+
+    private HibernateAdapter adapter;
 
     private SessionFactory sessionFactory;
 
@@ -249,6 +252,8 @@ public class HibernateStore implements Disposable, Initializable
         if (this.bootstrapServiceRegistry != null) {
             this.bootstrapServiceRegistry.close();
         }
+
+        this.adapter = null;
     }
 
     private void createSessionFactory()
@@ -381,95 +386,6 @@ public class HibernateStore implements Disposable, Initializable
     }
 
     /**
-     * @return true if the user has configured Hibernate to use XWiki in schema mode (vs database mode)
-     * @since 11.6RC1
-     */
-    public boolean isConfiguredInSchemaMode()
-    {
-        String virtualModePropertyValue = getConfiguration().getProperty("xwiki.virtual_mode");
-        if (virtualModePropertyValue == null) {
-            virtualModePropertyValue = VIRTUAL_MODE_SCHEMA;
-        }
-        return StringUtils.equals(virtualModePropertyValue, VIRTUAL_MODE_SCHEMA);
-    }
-
-    /**
-     * Convert wiki name in database/schema name.
-     *
-     * @param wikiId the wiki name to convert.
-     * @param product the database engine type.
-     * @return the database/schema name.
-     */
-    public String getDatabaseFromWikiName(String wikiId, DatabaseProduct product)
-    {
-        if (wikiId == null) {
-            return null;
-        }
-
-        String database = wikiId;
-
-        // Some databases have special database for main wiki
-        // It's also possible to configure the name of the main wiki database
-        String mainWikiId = this.wikis.getMainWikiId();
-        if (StringUtils.equalsIgnoreCase(wikiId, mainWikiId)) {
-            database = this.hibernateConfiguration.getDB();
-            if (database == null) {
-                if (product == DatabaseProduct.DERBY) {
-                    database = "APP";
-                } else if (product == DatabaseProduct.HSQLDB || product == DatabaseProduct.H2) {
-                    database = "PUBLIC";
-                } else if (product == DatabaseProduct.POSTGRESQL && isConfiguredInSchemaMode()) {
-                    database = "public";
-                } else {
-                    database = wikiId;
-                }
-            }
-        }
-
-        // Minus (-) is not supported by many databases
-        database = database.replace('-', '_');
-
-        // In various places we need the canonical database name (which is upper case for HSQLDB, Oracle and H2) because
-        // the translation is not properly done by the Dialect
-        if (DatabaseProduct.HSQLDB == product || DatabaseProduct.ORACLE == product || DatabaseProduct.H2 == product) {
-            database = StringUtils.upperCase(database);
-        }
-
-        // Apply prefix
-        String prefix = this.hibernateConfiguration.getDBPrefix();
-        database = prefix + database;
-
-        return database;
-    }
-
-    /**
-     * Convert wiki name in database name.
-     * <p>
-     * Need Hibernate to be initialized.
-     *
-     * @param wikiId the wiki name to convert.
-     * @return the database name.
-     * @since 11.6RC1
-     */
-    public String getDatabaseFromWikiName(String wikiId)
-    {
-        return getDatabaseFromWikiName(wikiId, getDatabaseProductName());
-    }
-
-    /**
-     * Convert wiki name in database name.
-     * <p>
-     * Need hibernate to be initialized.
-     *
-     * @return the database name.
-     * @since 11.6RC1
-     */
-    public String getDatabaseFromWikiName()
-    {
-        return getDatabaseFromWikiName(this.wikis.getCurrentWikiId());
-    }
-
-    /**
      * Retrieve the current database product name.
      * <p>
      * Note that the database product name is cached for improved performances.
@@ -504,6 +420,38 @@ public class HibernateStore implements Disposable, Initializable
         }
 
         return this.databaseProductCache;
+    }
+
+    /**
+     * @return the Hibernate adapter
+     * @throws HibernateException when failing to get the adapter
+     */
+    public HibernateAdapter getAdapter() throws HibernateException
+    {
+        if (this.adapter == null) {
+            this.adapter = createHibernateAdapter();
+        }
+
+        return this.adapter;
+    }
+
+    private synchronized HibernateAdapter createHibernateAdapter()
+    {
+        // Gather metadata about the database
+        DatabaseMetaData metadata = getDatabaseMetaData();
+
+        // Ask the various factories for adapters matching the metadata and configuration
+        for (HibernateAdapterFactory factory : this.adapterFactories) {
+            Optional<HibernateAdapter> newAdapter = factory.createHibernateAdapter(metadata, getConfiguration());
+
+            // If a matching adapter was found, stop searching
+            if (newAdapter.isPresent()) {
+                return newAdapter.get();
+            }
+        }
+
+        // Fallback on the default adapter if not specific one could be found
+        return this.defaultHibernateAdapterProvider.get();
     }
 
     private String extractJDBCConnectionURLScheme(String fullConnectionURL)
@@ -547,29 +495,13 @@ public class HibernateStore implements Disposable, Initializable
     }
 
     /**
-     * @return true if the current database product is catalog based, false for a schema based databases
-     * @since 11.6RC1
-     */
-    public boolean isCatalog()
-    {
-        DatabaseProduct product = getDatabaseProductName();
-        if (DatabaseProduct.ORACLE == product
-            || (DatabaseProduct.POSTGRESQL == product && isConfiguredInSchemaMode())) {
-            return false;
-        } else {
-            return getDialect().canCreateCatalog();
-        }
-
-    }
-
-    /**
      * @since 11.5RC1
      */
     public void setWiki(MetadataBuilder builder, String wikiId)
     {
-        String databaseName = getDatabaseFromWikiName(wikiId);
+        String databaseName = getAdapter().getDatabaseFromWikiName(wikiId);
 
-        if (isCatalog()) {
+        if (getAdapter().isCatalog()) {
             builder.applyImplicitCatalogName(databaseName);
         } else {
             builder.applyImplicitSchemaName(databaseName);
@@ -633,35 +565,6 @@ public class HibernateStore implements Disposable, Initializable
     }
 
     /**
-     * Escape database name depending of the database engine.
-     *
-     * @param databaseName the schema name to escape
-     * @return the escaped version
-     * @since 11.6RC1
-     */
-    public String escapeDatabaseName(String databaseName)
-    {
-        String escapedDatabaseName;
-
-        // - Oracle converts user names in uppercase when no quotes is used.
-        // For example: "create user xwiki identified by xwiki;" creates a user named XWIKI (uppercase)
-        // - In Hibernate.cfg.xml we just specify: <property name="hibernate.connection.username">xwiki</property> and
-        // Hibernate
-        // seems to be passing this username as is to Oracle which converts it to uppercase.
-        //
-        // Thus for Oracle we don't escape the schema.
-        if (DatabaseProduct.ORACLE == getDatabaseProductName()) {
-            escapedDatabaseName = databaseName;
-        } else {
-            String closeQuote = String.valueOf(getDialect().closeQuote());
-            escapedDatabaseName =
-                getDialect().openQuote() + databaseName.replace(closeQuote, closeQuote + closeQuote) + closeQuote;
-        }
-
-        return escapedDatabaseName;
-    }
-
-    /**
      * @return a singleton instance of the configured {@link Dialect}
      */
     public Dialect getDialect()
@@ -699,8 +602,8 @@ public class HibernateStore implements Disposable, Initializable
 
             // Switch the database only if we did not switched on it last time
             if (wikiId != null) {
-                String databaseName = getDatabaseFromWikiName(wikiId);
-                String escapedDatabaseName = escapeDatabaseName(databaseName);
+                String databaseName = getAdapter().getDatabaseFromWikiName(wikiId);
+                String escapedDatabaseName = getAdapter().escapeDatabaseName(databaseName);
 
                 DatabaseProduct product = getDatabaseProductName();
                 if (DatabaseProduct.ORACLE == product) {
@@ -708,7 +611,7 @@ public class HibernateStore implements Disposable, Initializable
                 } else if (DatabaseProduct.DERBY == product || DatabaseProduct.HSQLDB == product
                     || DatabaseProduct.DB2 == product || DatabaseProduct.H2 == product) {
                     executeStatement("SET SCHEMA " + escapedDatabaseName, session);
-                } else if (DatabaseProduct.POSTGRESQL == product && isConfiguredInSchemaMode()) {
+                } else if (DatabaseProduct.POSTGRESQL == product && getAdapter().isConfiguredInSchemaMode()) {
                     executeStatement("SET search_path TO " + escapedDatabaseName, session);
                 } else {
                     session.doWork(connection -> {
@@ -832,7 +735,7 @@ public class HibernateStore implements Disposable, Initializable
 
         if (session != null) {
             String sessionDatabase = (String) session.getProperties().get("xwiki.database");
-            String contextDatabase = getDatabaseFromWikiName(contextWikiId);
+            String contextDatabase = getAdapter().getDatabaseFromWikiName(contextWikiId);
 
             // The current context is trying to manipulate a database different from the one in the current session
             if (!Objects.equals(sessionDatabase, contextDatabase)) {
@@ -1026,16 +929,17 @@ public class HibernateStore implements Disposable, Initializable
     /**
      * Automatically update the current database schema to contains what's defined in standard metadata.
      * 
+     * @throws HibernateStoreException when failing to update the database
      * @since 11.6RC1
      */
-    public void updateDatabase(String wikiId)
+    public void updateDatabase(String wikiId) throws HibernateStoreException
     {
         MetadataBuilder metadataBuilder = this.metadataSources.getMetadataBuilder();
 
         // Associate the metadata with a specific wiki
         setWiki(metadataBuilder, wikiId);
 
-        updateDatabase(metadataBuilder.build());
+        getAdapter().updateDatabase(metadataBuilder.build());
 
         // Workaround Hibernate bug which does not create the required sequence in some databases
         createSequenceIfMissing(wikiId);
@@ -1105,8 +1009,8 @@ public class HibernateStore implements Disposable, Initializable
     private void createSequenceIfMissing(String wikiId)
     {
         // There's no issue with catalog based databases, only with schemas.
-        if (!isCatalog() && getDialect().getNativeIdentifierGeneratorStrategy().equals("sequence")) {
-            String schemaName = getDatabaseFromWikiName(wikiId);
+        if (!getAdapter().isCatalog() && getDialect().getNativeIdentifierGeneratorStrategy().equals("sequence")) {
+            String schemaName = getAdapter().getDatabaseFromWikiName(wikiId);
 
             boolean ignoreError = false;
 
@@ -1160,38 +1064,14 @@ public class HibernateStore implements Disposable, Initializable
     }
 
     /**
-     * Automatically update the current database schema to contains what's defined in standard metadata.
-     * 
-     * @param metadata the metadata we want the current database to follow
-     * @since 11.6RC1
-     */
-    public void updateDatabase(Metadata metadata)
-    {
-        SchemaUpdate updater = new SchemaUpdate();
-        updater.execute(EnumSet.of(TargetType.DATABASE), metadata);
-
-        List<Exception> exceptions = updater.getExceptions();
-
-        if (exceptions.isEmpty()) {
-            return;
-        }
-
-        // Print the errors
-        for (Exception exception : exceptions) {
-            this.logger.error(exception.getMessage(), exception);
-        }
-
-        throw new HibernateException("Failed to update the database. See the log for all errors", exceptions.get(0));
-    }
-
-    /**
      * Allows to update the schema to match the Hibernate mapping
      *
      * @param wikiId the identifier of the wiki to update
      * @param force defines whether or not to force the update despite the xwiki.cfg settings
+     * @throws HibernateStoreException when failing to update the database
      * @since 11.6RC1
      */
-    public synchronized void updateDatabase(String wikiId, boolean force)
+    public synchronized void updateDatabase(String wikiId, boolean force) throws HibernateStoreException
     {
         // We don't update the database if the XWiki hibernate config parameter says not to update
         if (!force && !this.hibernateConfiguration.isUpdateSchema()) {
@@ -1263,28 +1143,6 @@ public class HibernateStore implements Disposable, Initializable
     }
 
     /**
-     * @since 11.6RC1
-     */
-    public String getConfiguredTableName(PersistentClass persistentClass)
-    {
-        return getConfiguredTableName(persistentClass.getTable());
-    }
-
-    /**
-     * @since 13.2
-     */
-    public String getConfiguredTableName(Table table)
-    {
-        String tableName = table.getName();
-        // HSQLDB and Oracle needs to use uppercase table name to retrieve the value.
-        if (getDatabaseProductName() == DatabaseProduct.HSQLDB || getDatabaseProductName() == DatabaseProduct.ORACLE) {
-            tableName = tableName.toUpperCase();
-        }
-
-        return tableName;
-    }
-
-    /**
      * Execute the passed function with the {@link DatabaseMetaData} {@link ResultSet} corresponding to the passed
      * entity and property.
      * 
@@ -1299,11 +1157,11 @@ public class HibernateStore implements Disposable, Initializable
     public <R> R metadataTableOrColumn(Class<?> entityType, String propertyName, R def, ResultSetFunction<R> function)
     {
         // retrieve the database name from the context
-        final String databaseName = getDatabaseFromWikiName();
+        final String databaseName = getAdapter().getDatabaseFromWikiName();
 
         PersistentClass persistentClass = getConfigurationMetadata().getEntityBinding(entityType.getName());
 
-        final String tableName = getConfiguredTableName(persistentClass);
+        final String tableName = getAdapter().getTableName(persistentClass);
 
         final String columnName = getConfiguredColumnName(persistentClass, propertyName);
 
@@ -1313,13 +1171,13 @@ public class HibernateStore implements Disposable, Initializable
             String name = databaseName;
 
             if (columnName != null) {
-                if (isCatalog()) {
+                if (getAdapter().isCatalog()) {
                     resultSet = databaseMetaData.getColumns(name, null, tableName, columnName);
                 } else {
                     resultSet = databaseMetaData.getColumns(null, name, tableName, columnName);
                 }
             } else {
-                if (isCatalog()) {
+                if (getAdapter().isCatalog()) {
                     resultSet = databaseMetaData.getTables(name, null, tableName, null);
                 } else {
                     resultSet = databaseMetaData.getTables(null, name, tableName, null);
@@ -1397,9 +1255,9 @@ public class HibernateStore implements Disposable, Initializable
      */
     public boolean isWikiDatabaseExist(String wikiName)
     {
-        final String databaseName = getDatabaseFromWikiName(wikiName);
+        final String databaseName = getAdapter().getDatabaseFromWikiName(wikiName);
 
-        if (isCatalog()) {
+        if (getAdapter().isCatalog()) {
             return isCatalogExist(databaseName);
         } else {
             return isSchemaExist(databaseName);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/DatabaseProduct.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/DatabaseProduct.java
@@ -119,6 +119,15 @@ public final class DatabaseProduct
         return this.productName;
     }
 
+    /**
+     * @return the JDBC scheme
+     * @since 17.1.0RC1
+     */
+    public String getJDBCScheme()
+    {
+        return this.jdbcScheme;
+    }
+
     @Override
     public boolean equals(Object object)
     {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateBaseStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateBaseStore.java
@@ -39,6 +39,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xwiki.context.Execution;
 import org.xwiki.logging.LoggerManager;
+import org.xwiki.stability.Unstable;
+import org.xwiki.store.hibernate.HibernateAdapter;
+import org.xwiki.store.hibernate.HibernateStoreException;
 
 import com.xpn.xwiki.XWiki;
 import com.xpn.xwiki.XWikiContext;
@@ -124,6 +127,16 @@ public class XWikiHibernateBaseStore extends AbstractXWikiStore
     public String getHint()
     {
         return HINT;
+    }
+
+    /**
+     * @return the {@link HibernateAdapter}
+     * @since 17.1.0RC1
+     */
+    @Unstable
+    public HibernateAdapter getHibernateAdapater()
+    {
+        return this.store.getAdapter();
     }
 
     /**
@@ -262,6 +275,8 @@ public class XWikiHibernateBaseStore extends AbstractXWikiStore
 
         try {
             this.store.updateDatabase(context.getWikiId(), force);
+        } catch (HibernateStoreException e) {
+            throw new HibernateException(e);
         } finally {
             restoreExecutionXContext();
         }
@@ -274,12 +289,14 @@ public class XWikiHibernateBaseStore extends AbstractXWikiStore
      * @param databaseProduct the database engine type.
      * @param inputxcontext the XWiki context.
      * @return the database/schema name.
+     * @deprecated use {@link HibernateAdapter#getDatabaseFromWikiName(String)} instead
      * @since 1.1.2
      * @since 1.2M2
      */
+    @Deprecated(since = "17.1.0RC1")
     protected String getSchemaFromWikiName(String wikiName, DatabaseProduct databaseProduct, XWikiContext inputxcontext)
     {
-        return this.store.getDatabaseFromWikiName(wikiName, databaseProduct);
+        return this.store.getAdapter().getDatabaseFromWikiName(wikiName);
     }
 
     /**
@@ -290,12 +307,14 @@ public class XWikiHibernateBaseStore extends AbstractXWikiStore
      * @param wikiId the wiki name to convert.
      * @param inputxcontext the XWiki context.
      * @return the database/schema name.
+     * @deprecated use {@link HibernateAdapter#getDatabaseFromWikiName(String)} instead
      * @since 1.1.2
      * @since 1.2M2
      */
+    @Deprecated(since = "17.1.0RC1")
     protected String getSchemaFromWikiName(String wikiId, XWikiContext inputxcontext)
     {
-        return this.store.getDatabaseFromWikiName(wikiId);
+        return this.store.getAdapter().getDatabaseFromWikiName(wikiId);
     }
 
     /**
@@ -305,12 +324,14 @@ public class XWikiHibernateBaseStore extends AbstractXWikiStore
      *
      * @param context the XWiki context.
      * @return the database/schema name.
+     * @deprecated use {@link HibernateAdapter#getDatabaseFromWikiName()} instead
      * @since 1.1.2
      * @since 1.2M2
      */
+    @Deprecated(since = "17.1.0RC1")
     public String getSchemaFromWikiName(XWikiContext context)
     {
-        return this.store.getDatabaseFromWikiName();
+        return this.store.getAdapter().getDatabaseFromWikiName();
     }
 
     /**
@@ -454,7 +475,9 @@ public class XWikiHibernateBaseStore extends AbstractXWikiStore
             }
 
             Metadata metadata = this.store.getMetadata(bclass.getName(), custommapping, context.getWikiId());
-            this.store.updateDatabase(metadata);
+            this.store.getAdapter().updateDatabase(metadata);
+        } catch (Exception e) {
+            throw new XWikiException("Failed to update the schema for class [" + bclass.getName() + "]", e);
         } finally {
             restoreExecutionXContext();
         }
@@ -513,10 +536,12 @@ public class XWikiHibernateBaseStore extends AbstractXWikiStore
      * @param schema the schema name to escape
      * @param context the XWiki context to get database engine identifier
      * @return the escaped version
+     * @deprecated use {@link HibernateAdapter#escapeDatabaseName(String)} instead
      */
+    @Deprecated(since = "17.1.0RC1")
     protected String escapeSchema(String schema, XWikiContext context)
     {
-        return this.store.escapeDatabaseName(schema);
+        return this.store.getAdapter().escapeDatabaseName(schema);
     }
 
     /**
@@ -951,10 +976,12 @@ public class XWikiHibernateBaseStore extends AbstractXWikiStore
     /**
      * @return true if the user has configured Hibernate to use XWiki in schema mode (vs database mode)
      * @since 4.5M1
+     * @deprecated use {@link HibernateAdapter#isConfiguredInSchemaMode()} instead
      */
+    @Deprecated(since = "17.1.0RC1")
     protected boolean isInSchemaMode()
     {
-        return this.store.isConfiguredInSchemaMode();
+        return this.store.getAdapter().isConfiguredInSchemaMode();
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R130200000XWIKI17200DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R130200000XWIKI17200DataMigration.java
@@ -173,13 +173,13 @@ public class R130200000XWIKI17200DataMigration extends AbstractHibernateDataMigr
     private void deleteIndexIfExist(Class entityClass, String indexName, DatabaseMetaData databaseMetaData,
         StringBuilder builder) throws SQLException
     {
-        String databaseName = this.hibernateStore.getDatabaseFromWikiName();
+        String databaseName = this.hibernateStore.getAdapter().getDatabaseFromWikiName();
         PersistentClass persistentClass =
             this.hibernateStore.getConfigurationMetadata().getEntityBinding(entityClass.getName());
-        String tableName = this.hibernateStore.getConfiguredTableName(persistentClass);
+        String tableName = this.hibernateStore.getAdapter().getTableName(persistentClass);
 
         ResultSet resultSet;
-        if (this.hibernateStore.isCatalog()) {
+        if (this.hibernateStore.getAdapter().isCatalog()) {
             resultSet = databaseMetaData.getIndexInfo(databaseName, null, tableName, false, false);
         } else {
             resultSet = databaseMetaData.getIndexInfo(null, databaseName, tableName, false, false);
@@ -209,7 +209,7 @@ public class R130200000XWIKI17200DataMigration extends AbstractHibernateDataMigr
 
         Property property = persistentClass.getProperty(propertyName);
 
-        String tableName = this.hibernateStore.getConfiguredTableName(persistentClass);
+        String tableName = this.hibernateStore.getAdapter().getTableName(persistentClass);
         String columnName = this.hibernateStore.getConfiguredColumnName(persistentClass, propertyName);
 
         try (ResultSet resultSet = getColumns(databaseMetaData, tableName, columnName)) {
@@ -264,12 +264,12 @@ public class R130200000XWIKI17200DataMigration extends AbstractHibernateDataMigr
     private ResultSet getColumns(DatabaseMetaData databaseMetaData, String tableName, String columnName)
         throws SQLException
     {
-        if (this.hibernateStore.isCatalog()) {
-            return databaseMetaData.getColumns(this.hibernateStore.getDatabaseFromWikiName(), null, tableName,
-                columnName);
+        if (this.hibernateStore.getAdapter().isCatalog()) {
+            return databaseMetaData.getColumns(this.hibernateStore.getAdapter().getDatabaseFromWikiName(), null,
+                tableName, columnName);
         } else {
-            return databaseMetaData.getColumns(null, this.hibernateStore.getDatabaseFromWikiName(), tableName,
-                columnName);
+            return databaseMetaData.getColumns(null, this.hibernateStore.getAdapter().getDatabaseFromWikiName(),
+                tableName, columnName);
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/AbstractHibernateAdapter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/AbstractHibernateAdapter.java
@@ -1,0 +1,246 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.store.hibernate;
+
+import java.util.EnumSet;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.apache.commons.lang3.StringUtils;
+import org.hibernate.HibernateException;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.boot.Metadata;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.mapping.Table;
+import org.hibernate.tool.hbm2ddl.SchemaUpdate;
+import org.hibernate.tool.schema.TargetType;
+import org.slf4j.Logger;
+import org.xwiki.stability.Unstable;
+import org.xwiki.wiki.descriptor.WikiDescriptorManager;
+
+import com.xpn.xwiki.internal.store.hibernate.HibernateConfiguration;
+import com.xpn.xwiki.internal.store.hibernate.HibernateStore;
+
+/**
+ * A base implementation of {@link HibernateAdapter} with a default implementation for each API.
+ * 
+ * @version $Id$
+ * @since 17.1.0RC1
+ */
+@Unstable
+public abstract class AbstractHibernateAdapter implements HibernateAdapter
+{
+    private static final String VIRTUAL_MODE_SCHEMA = "schema";
+
+    @Inject
+    protected WikiDescriptorManager wikis;
+
+    @Inject
+    protected Logger logger;
+
+    @Inject
+    private HibernateStore hibernateStore;
+
+    @Inject
+    private HibernateConfiguration hibernateConfiguration;
+
+    // Configuration
+
+    @Override
+    public boolean isConfiguredInSchemaMode()
+    {
+        String virtualModePropertyValue = this.hibernateStore.getConfiguration().getProperty("xwiki.virtual_mode");
+        if (virtualModePropertyValue == null) {
+            virtualModePropertyValue = VIRTUAL_MODE_SCHEMA;
+        }
+        return StringUtils.equals(virtualModePropertyValue, VIRTUAL_MODE_SCHEMA);
+    }
+
+    @Override
+    public String getDatabaseFromWikiName()
+    {
+        return getDatabaseFromWikiName(this.wikis.getCurrentWikiId());
+    }
+
+    @Override
+    public String getDatabaseFromWikiName(String wikiId)
+    {
+        if (wikiId == null) {
+            return null;
+        }
+
+        String database = wikiId;
+
+        // Apply the main wiki database configuration
+        String mainWikiId = this.wikis.getMainWikiId();
+        if (StringUtils.equalsIgnoreCase(wikiId, mainWikiId)) {
+            database = this.hibernateConfiguration.getDB();
+            if (database == null) {
+                // Some databases have special database for main wiki
+                database = getDefaultMainWikiDatabase(mainWikiId);
+            }
+        }
+
+        // Apply prefix
+        String prefix = this.hibernateConfiguration.getDBPrefix();
+        database = prefix + database;
+
+        // Make sure the database/schema format is correct
+        database = cleanDatabaseName(database);
+
+        return database;
+    }
+
+    protected String getDefaultMainWikiDatabase(String wikiId)
+    {
+        return wikiId;
+    }
+
+    protected String cleanDatabaseName(String name)
+    {
+        // Minus (-) is not supported by many databases
+        // TODO: move it to adapters which really needs it ?
+        String cleanName = name.replace('-', '_');
+
+        return cleanName;
+    }
+
+    @Override
+    public String getTableName(PersistentClass persistentClass)
+    {
+        return getTableName(persistentClass.getTable());
+    }
+
+    @Override
+    public String getTableName(Table table)
+    {
+        return getTableName(table.getName());
+    }
+
+    @Override
+    public String getTableName(String tableName)
+    {
+        return tableName;
+    }
+
+    @Override
+    public boolean isCompressed(PersistentClass entity)
+    {
+        return entity.getMetaAttribute(META_ATTRIBUTE_COMPRESSED) != null;
+    }
+
+    @Override
+    public String escapeDatabaseName(String databaseName)
+    {
+        String closeQuote = String.valueOf(getDialect().closeQuote());
+        return getDialect().openQuote() + databaseName.replace(closeQuote, closeQuote + closeQuote) + closeQuote;
+    }
+
+    // Global
+
+    @Override
+    public SessionFactory getSessionFactory()
+    {
+        return this.hibernateStore.getSessionFactory();
+    }
+
+    @Override
+    public Dialect getDialect()
+    {
+        return this.hibernateStore.getDialect();
+    }
+
+    // Database operations
+
+    @Override
+    public void updateDatabase(Metadata metadata) throws HibernateStoreException
+    {
+        try {
+            SessionFactory sessionFactory = getSessionFactory();
+
+            // Custom update before the Hibernate standard DDL
+            try (Session session = sessionFactory.openSession()) {
+                updateDatabaseBegin(metadata, session);
+            }
+
+            // Hibernate standard DDL
+            updateDatabaseStandard(metadata);
+
+            // Custom update after the Hibernate standard DDL
+            try (Session session = sessionFactory.openSession()) {
+                updateDatabaseAfter(metadata, session);
+            }
+        } catch (Exception e) {
+            throw new HibernateException("Failed to update the database", e);
+        }
+    }
+
+    private void updateDatabaseStandard(Metadata metadata) throws HibernateStoreException
+    {
+        SchemaUpdate updater = new SchemaUpdate();
+        updater.execute(EnumSet.of(TargetType.DATABASE), metadata);
+        List<Exception> exceptions = updater.getExceptions();
+
+        if (!exceptions.isEmpty()) {
+            // Print the errors
+            for (Exception exception : exceptions) {
+                this.logger.error(exception.getMessage(), exception);
+            }
+
+            throw new HibernateStoreException("Failed to update the database. See the previous log for all errors",
+                exceptions.get(0));
+        }
+    }
+
+    /**
+     * Execute everything not handled by the Hibernate DDL which needs to be done before.
+     * 
+     * @param metadata the configuration of the database to apply
+     * @param session the session in which to execute the update
+     * @throws HibernateStoreException when failing to update the database
+     */
+    protected void updateDatabaseBegin(Metadata metadata, Session session) throws HibernateStoreException
+    {
+
+    }
+
+    /**
+     * Execute everything not handled by the Hibernate DDL which needs to be done after.
+     * 
+     * @param metadata the configuration of the database to apply
+     * @param session the session in which to execute the update
+     * @throws HibernateStoreException when failing to update the database
+     */
+    protected void updateDatabaseAfter(Metadata metadata, Session session) throws HibernateStoreException
+    {
+
+    }
+
+    /**
+     * @return true if the current database product is catalog based, false for a schema based databases
+     */
+    public boolean isCatalog()
+    {
+        return getDialect().canCreateCatalog();
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/AbstractHibernateAdapter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/AbstractHibernateAdapter.java
@@ -173,13 +173,7 @@ public abstract class AbstractHibernateAdapter implements HibernateAdapter
     @Override
     public boolean isCompressionAllowed()
     {
-        Optional<Boolean> compressionAllowed = getCompressionAllowedConfiguration();
-
-        if (compressionAllowed.isPresent()) {
-            return compressionAllowed.get();
-        }
-
-        return false;
+        return getCompressionAllowedConfiguration().orElse(false);
     }
 
     // Global

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/AbstractHibernateAdapter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/AbstractHibernateAdapter.java
@@ -21,6 +21,7 @@ package org.xwiki.store.hibernate;
 
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Optional;
 
 import javax.inject.Inject;
 
@@ -154,6 +155,31 @@ public abstract class AbstractHibernateAdapter implements HibernateAdapter
     {
         String closeQuote = String.valueOf(getDialect().closeQuote());
         return getDialect().openQuote() + databaseName.replace(closeQuote, closeQuote + closeQuote) + closeQuote;
+    }
+
+    /**
+     * @return the value of the compression configuration, or empty if not configured
+     */
+    public Optional<Boolean> getCompressionAllowedConfiguration()
+    {
+        String configuration = this.hibernateStore.getConfiguration().getProperty("xwiki.compressionAllowed");
+        if (configuration == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(Boolean.valueOf(configuration));
+    }
+
+    @Override
+    public boolean isCompressionAllowed()
+    {
+        Optional<Boolean> compressionAllowed = getCompressionAllowedConfiguration();
+
+        if (compressionAllowed.isPresent()) {
+            return compressionAllowed.get();
+        }
+
+        return false;
     }
 
     // Global

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/AbstractHibernateAdapter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/AbstractHibernateAdapter.java
@@ -160,7 +160,7 @@ public abstract class AbstractHibernateAdapter implements HibernateAdapter
     /**
      * @return the value of the compression configuration, or empty if not configured
      */
-    public Optional<Boolean> getCompressionAllowedConfiguration()
+    protected Optional<Boolean> getCompressionAllowedConfiguration()
     {
         String configuration = this.hibernateStore.getConfiguration().getProperty("xwiki.compressionAllowed");
         if (configuration == null) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/DatabaseProductNameResolved.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/DatabaseProductNameResolved.java
@@ -1,0 +1,40 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.store.hibernate;
+
+import java.util.Optional;
+
+import org.xwiki.component.annotation.Role;
+
+/**
+ * Provide an common identifier from the actual produce name given by the database.
+ *
+ * @version $Id$
+ * @since 17.1.0RC1
+ */
+@Role
+public interface DatabaseProductNameResolved
+{
+    /**
+     * @param databaseProductName the database product name
+     * @return the identifier of the database, empty if the resolved does not match the database produce name
+     */
+    Optional<String> resolve(String databaseProductName);
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/DatabaseProductNameResolver.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/DatabaseProductNameResolver.java
@@ -24,13 +24,13 @@ import java.util.Optional;
 import org.xwiki.component.annotation.Role;
 
 /**
- * Provide an common identifier from the actual produce name given by the database.
+ * Provide an common identifier from the actual product name given by the database.
  *
  * @version $Id$
  * @since 17.1.0RC1
  */
 @Role
-public interface DatabaseProductNameResolved
+public interface DatabaseProductNameResolver
 {
     /**
      * @param databaseProductName the database product name

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/DatabaseProductNameResolver.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/DatabaseProductNameResolver.java
@@ -22,13 +22,15 @@ package org.xwiki.store.hibernate;
 import java.util.Optional;
 
 import org.xwiki.component.annotation.Role;
+import org.xwiki.stability.Unstable;
 
 /**
- * Provide an common identifier from the actual product name given by the database.
+ * Provide a common identifier from the actual product name given by the database.
  *
  * @version $Id$
  * @since 17.1.0RC1
  */
+@Unstable
 @Role
 public interface DatabaseProductNameResolver
 {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/HibernateAdapter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/HibernateAdapter.java
@@ -31,9 +31,19 @@ import org.xwiki.stability.Unstable;
 
 /**
  * Implement XWiki Hibernate features specific to a RDBMS. The goal is mainly to extend the Hibernate {@link Dialect}
- * and JDBC {@link Driver} concepts with features they don't support (database creation, etc.).
+ * and JDBC {@link Driver} concepts with features they don't support (table compression, wiki -> database name, etc.).
  * <p>
  * It's recommended to extend {@link AbstractHibernateAdapter}.
+ * <p>
+ * A {@link HibernateAdapter} is supposed to be provided by a {@link HibernateAdapterFactory}, but if you need to
+ * associate the {@link HibernateAdapter} to a specific database engine (and optionally to a specific minimum version)
+ * you can use the following helper format:
+ * <ul>
+ * <li>"jdbc scheme/minimum version" (for example the "mysql/8" adapter will be selected for a MySQL 9.0.1 server, if no
+ * adapter is registered for version 9)</li>
+ * <li>"jdbc scheme" (for example the "mysql" adapter will be selected for a MySQL 5.7 server, if no adapter is
+ * registered for version 5.7 or lower)</li>
+ * </ul>
  * 
  * @version $Id$
  * @since 17.1.0RC1

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/HibernateAdapter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/HibernateAdapter.java
@@ -111,6 +111,12 @@ public interface HibernateAdapter
      */
     String escapeDatabaseName(String databaseName);
 
+    /**
+     * @return true if compression is enabled for this database. Its possible to force it using hibernate.cfg.xml
+     *         {@code xwiki.compression} property, but the default may vary depending on the database.
+     */
+    boolean isCompressionAllowed();
+
     // Global
 
     /**

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/HibernateAdapter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/HibernateAdapter.java
@@ -1,0 +1,130 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.store.hibernate;
+
+import java.sql.Driver;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.boot.Metadata;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.mapping.Table;
+import org.xwiki.component.annotation.Role;
+import org.xwiki.stability.Unstable;
+
+/**
+ * Implement XWiki Hibernate features specific to a RDBMS. The goal is mainly to extend the Hibernate {@link Dialect}
+ * and JDBC {@link Driver} concepts with features they don't support (database creation, etc.).
+ * <p>
+ * It's recommended to extend {@link AbstractHibernateAdapter}.
+ * 
+ * @version $Id$
+ * @since 17.1.0RC1
+ */
+@Unstable
+@Role
+public interface HibernateAdapter
+{
+    /**
+     * The name of the meta attribute indicating if a table should be compressed.
+     */
+    String META_ATTRIBUTE_COMPRESSED = "xwiki-compressed";
+
+    // Configuration
+
+    /**
+     * Get the native database/schema name for the current wiki.
+     *
+     * @return the native database/schema name
+     */
+    String getDatabaseFromWikiName();
+
+    /**
+     * Get the native database/schema name for the passed wiki identifier.
+     *
+     * @param wikiId the identifier of the wiki
+     * @return the native database/schema name
+     */
+    String getDatabaseFromWikiName(String wikiId);
+
+    /**
+     * @return true if the user has configured Hibernate to use XWiki in schema mode (vs database mode)
+     */
+    boolean isConfiguredInSchemaMode();
+
+    /**
+     * @param persistentClass the Hibernate entity
+     * @return the table name
+     */
+    String getTableName(PersistentClass persistentClass);
+
+    /**
+     * @param table the Hibernate table representation
+     * @return the table name
+     */
+    String getTableName(Table table);
+
+    /**
+     * @param tableName the name of the table
+     * @return the name of the table in the right case/format
+     */
+    String getTableName(String tableName);
+
+    /**
+     * @param entity the Hibernate entity for which to extract the configuration
+     * @return true if the table should be compressed
+     */
+    boolean isCompressed(PersistentClass entity);
+
+    /**
+     * Escape database name to be used in a query.
+     *
+     * @param databaseName the schema name to escape
+     * @return the escaped version
+     */
+    String escapeDatabaseName(String databaseName);
+
+    // Global
+
+    /**
+     * @return the Hibernate {@link SessionFactory}
+     */
+    SessionFactory getSessionFactory();
+
+    /**
+     * @return the Hibernate {@link Dialect}
+     */
+    Dialect getDialect();
+
+    // Database operations
+
+    /**
+     * Automatically update the current database schema to contains what's defined in provided metadata.
+     * 
+     * @param metadata the metadata we want the current database to follow
+     * @throws HibernateStoreException when failing to update the database
+     */
+    void updateDatabase(Metadata metadata) throws HibernateStoreException;
+
+    /**
+     * @return true if the current database product is catalog based, false for a schema based databases
+     */
+    boolean isCatalog();
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/HibernateAdapterFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/HibernateAdapterFactory.java
@@ -28,7 +28,11 @@ import org.xwiki.component.annotation.Role;
 import org.xwiki.stability.Unstable;
 
 /**
- * Factory in charge of providing a {@link HibernateAdapter} instance.
+ * A factory in charge of providing a specific {@link HibernateAdapter} instance, generally based on information found
+ * in the {@link DatabaseMetaData} (database server related metadata) and {@link Configuration} (Hibernate configuration
+ * properties).
+ * <p>
+ * If no specific adapter is returned by the various factories, a default one is used.
  * 
  * @version $Id$
  * @since 17.1.0RC1

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/HibernateAdapterFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/HibernateAdapterFactory.java
@@ -1,0 +1,50 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.store.hibernate;
+
+import java.sql.DatabaseMetaData;
+import java.util.Optional;
+
+import org.hibernate.HibernateException;
+import org.hibernate.cfg.Configuration;
+import org.xwiki.component.annotation.Role;
+import org.xwiki.stability.Unstable;
+
+/**
+ * Factory in charge of providing a {@link HibernateAdapter} instance.
+ * 
+ * @version $Id$
+ * @since 17.1.0RC1
+ */
+@Unstable
+@Role
+public interface HibernateAdapterFactory
+{
+    /**
+     * Create a new {@link HibernateAdapter} instance corresponding to the passed {@link DatabaseMetaData}.
+     * 
+     * @param metaData the metadata gathered from the databases
+     * @param configuration the Hibernate configuration
+     * @return an {@link HibernateAdapter} instance if the this factory matches the passed metadata
+     * @throws HibernateException when failing to resolve the adapter
+     */
+    Optional<HibernateAdapter> createHibernateAdapter(DatabaseMetaData metaData, Configuration configuration)
+        throws HibernateException;
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/HibernateStoreException.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/HibernateStoreException.java
@@ -1,0 +1,55 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.store.hibernate;
+
+import org.xwiki.stability.Unstable;
+import org.xwiki.store.StoreException;
+
+/**
+ * Base exception for Hibernate store related APIs.
+ * 
+ * @version $Id$
+ * @since 17.1.0RC1
+ */
+@Unstable
+public class HibernateStoreException extends StoreException
+{
+    /**
+     * Serialization identifier.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * @param message exception message
+     */
+    public HibernateStoreException(String message)
+    {
+        super(message);
+    }
+
+    /**
+     * @param message exception message
+     * @param cause nested exception
+     */
+    public HibernateStoreException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/DefaultHibernateAdapter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/DefaultHibernateAdapter.java
@@ -1,0 +1,37 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.store.hibernate.internal;
+
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.store.hibernate.AbstractHibernateAdapter;
+
+/**
+ * A fully generic adapter.
+ * 
+ * @version $Id$
+ * @since 17.1.0RC1
+ */
+@Component
+@Singleton
+public class DefaultHibernateAdapter extends AbstractHibernateAdapter
+{
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/DefaultHibernateAdapterFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/DefaultHibernateAdapterFactory.java
@@ -1,0 +1,167 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.store.hibernate.internal;
+
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeMap;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.hibernate.HibernateException;
+import org.hibernate.cfg.Configuration;
+import org.slf4j.Logger;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.descriptor.ComponentDescriptor;
+import org.xwiki.component.manager.ComponentLookupException;
+import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.extension.version.Version;
+import org.xwiki.extension.version.internal.DefaultVersion;
+import org.xwiki.store.hibernate.DatabaseProductNameResolved;
+import org.xwiki.store.hibernate.HibernateAdapter;
+import org.xwiki.store.hibernate.HibernateAdapterFactory;
+
+import com.xpn.xwiki.store.DatabaseProduct;
+
+/**
+ * @version $Id$
+ */
+@Component
+@Singleton
+public class DefaultHibernateAdapterFactory implements HibernateAdapterFactory
+{
+    private static final Version DEFAULT_VERSION = new DefaultVersion("0");
+
+    @Inject
+    private ComponentManager componentManager;
+
+    @Inject
+    private List<DatabaseProductNameResolved> resolvers;
+
+    @Inject
+    private Logger logger;
+
+    @Override
+    public Optional<HibernateAdapter> createHibernateAdapter(DatabaseMetaData metaData,
+        Configuration hibernateConfiguration) throws HibernateException
+    {
+        HibernateAdapter adaparter = null;
+
+        // Index all adapters
+        Map<String, Map<Version, String>> mapping = getAdpaterMapping();
+
+        // Gather adapter(s) associated to the specific database product id
+        Map<Version, String> versions;
+        try {
+            // Resolved the database product identifier
+            String databaseProductId = getDatabaseId(metaData.getDatabaseProductName());
+
+            versions = mapping.get(databaseProductId);
+        } catch (SQLException e) {
+            throw new HibernateException("Failed to access the database product name", e);
+        }
+
+        if (versions != null) {
+            // Resolve the current database version
+            Version currentVersion;
+            try {
+                currentVersion = new DefaultVersion(metaData.getDatabaseProductVersion());
+            } catch (SQLException e) {
+                throw new HibernateException("Failed to access the database product version", e);
+            }
+
+            // Search if a registered adapter matched the current version
+            String roleHint = null;
+            for (Map.Entry<Version, String> entry : versions.entrySet()) {
+                if (entry.getKey().compareTo(currentVersion) <= 0) {
+                    roleHint = entry.getValue();
+                } else {
+                    break;
+                }
+            }
+
+            // Load the found adapter
+            if (roleHint != null) {
+                try {
+                    adaparter = this.componentManager.getInstance(HibernateAdapter.class, roleHint);
+                } catch (ComponentLookupException e) {
+                    throw new HibernateException("Failed to initialize the adapater", e);
+                }
+            }
+        }
+
+        return Optional.ofNullable(adaparter);
+    }
+
+    private String getDatabaseId(String databaseProductName)
+    {
+        for (DatabaseProductNameResolved resolver : this.resolvers) {
+            Optional<String> id = resolver.resolve(databaseProductName);
+
+            if (id.isPresent()) {
+                return id.get();
+            }
+        }
+
+        // Default resolution based on old DatabaseProduct resolution, except for MariaDB (since it's identified as
+        // MySQL)
+        if (databaseProductName.equalsIgnoreCase(MariaDBHibernateAdapter.HINT)) {
+            return MariaDBHibernateAdapter.HINT;
+        } else {
+            DatabaseProduct product = DatabaseProduct.toProduct(databaseProductName);
+
+            return product != DatabaseProduct.UNKNOWN ? product.getJDBCScheme() : databaseProductName.toLowerCase();
+        }
+    }
+
+    private Map<String, Map<Version, String>> getAdpaterMapping()
+    {
+        List<ComponentDescriptor<HibernateAdapter>> descriptors =
+            this.componentManager.getComponentDescriptorList(HibernateAdapter.class);
+
+        Map<String, Map<Version, String>> databases = new HashMap<>();
+        for (ComponentDescriptor<HibernateAdapter> descriptor : descriptors) {
+            String roleHint = descriptor.getRoleHint();
+            if (roleHint != null && !"default".equalsIgnoreCase(roleHint)) {
+                String databaseName = roleHint;
+                Version databaseVersion = DEFAULT_VERSION;
+                int index = roleHint.indexOf("/");
+                if (index > 0) {
+                    databaseName = roleHint.substring(0, index);
+                    if (roleHint.length() > index) {
+                        databaseVersion = new DefaultVersion(roleHint.substring(index + 1));
+                    }
+                }
+
+                Map<Version, String> databaseVersions =
+                    databases.computeIfAbsent(databaseName.toLowerCase(), n -> new TreeMap<>());
+
+                databaseVersions.put(databaseVersion, roleHint);
+            }
+        }
+
+        return databases;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/DerbyHibernateAdapter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/DerbyHibernateAdapter.java
@@ -1,0 +1,50 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.store.hibernate.internal;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.store.hibernate.AbstractHibernateAdapter;
+import org.xwiki.store.hibernate.HibernateAdapter;
+
+/**
+ * The {@link HibernateAdapter} for Derby.
+ * 
+ * @version $Id$
+ * @since 17.1.0RC1
+ */
+@Component
+@Named(DerbyHibernateAdapter.HINT)
+@Singleton
+public class DerbyHibernateAdapter extends AbstractHibernateAdapter
+{
+    /**
+     * The role hint of the component.
+     */
+    public static final String HINT = "derby";
+
+    @Override
+    protected String getDefaultMainWikiDatabase(String wikiId)
+    {
+        return "APP";
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/H2HibernateAdapter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/H2HibernateAdapter.java
@@ -1,0 +1,57 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.store.hibernate.internal;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.store.hibernate.AbstractHibernateAdapter;
+import org.xwiki.store.hibernate.HibernateAdapter;
+
+/**
+ * The {@link HibernateAdapter} for H2.
+ * 
+ * @version $Id$
+ * @since 17.1.0RC1
+ */
+@Component
+@Named(H2HibernateAdapter.HINT)
+@Singleton
+public class H2HibernateAdapter extends AbstractHibernateAdapter
+{
+    /**
+     * The role hint of the component.
+     */
+    public static final String HINT = "h2";
+
+    @Override
+    protected String getDefaultMainWikiDatabase(String wikiId)
+    {
+        return "PUBLIC";
+    }
+
+    @Override
+    protected String cleanDatabaseName(String name)
+    {
+        // H2 generally needs the schema name to be upper case
+        return super.cleanDatabaseName(name).toUpperCase();
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/HSQLDBHibernateAdapter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/HSQLDBHibernateAdapter.java
@@ -1,0 +1,64 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.store.hibernate.internal;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.store.hibernate.AbstractHibernateAdapter;
+import org.xwiki.store.hibernate.HibernateAdapter;
+
+/**
+ * The {@link HibernateAdapter} for HSQLDB.
+ * 
+ * @version $Id$
+ * @since 17.1.0RC1
+ */
+@Component
+@Named(HSQLDBHibernateAdapter.HINT)
+@Singleton
+public class HSQLDBHibernateAdapter extends AbstractHibernateAdapter
+{
+    /**
+     * The role hint of the component.
+     */
+    public static final String HINT = "hsqldb";
+
+    @Override
+    protected String getDefaultMainWikiDatabase(String wikiId)
+    {
+        return "PUBLIC";
+    }
+
+    @Override
+    public String getTableName(String tableName)
+    {
+        // HSQLDB generally needs the table name to be upper case
+        return tableName != null ? tableName.toUpperCase() : null;
+    }
+
+    @Override
+    protected String cleanDatabaseName(String name)
+    {
+        // HSQLDB generally needs the schema name to be upper case
+        return super.cleanDatabaseName(name).toUpperCase();
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/IDVersionHibernateAdapterFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/IDVersionHibernateAdapterFactory.java
@@ -49,8 +49,10 @@ import org.xwiki.store.hibernate.HibernateAdapterFactory;
  * <p>
  * It search for an implementation of {@link HibernateAdapter} with the following role hints:
  * <ul>
- * <li>"id/major version+" (for example the "mysql/8" one will be selected for a MySQL 9.0.1 server)</li>
- * <li>"id" (for example the "mysql" one will be selected for a MySQL 5.7 server)</li>
+ * <li>"jdbc scheme/minimum version" (for example the "mysql/8" adapter will be selected for a MySQL 9.0.1 server, if no
+ * adapter is registered for version 9)</li>
+ * <li>"jdbc scheme" (for example the "mysql" adapter will be selected for a MySQL 5.7 server, if no adapter is
+ * registered for version 5.7 or lower)</li>
  * </ul>
  * <p>
  * The version is supposed to mean that the adapter was designed for "this version of greater".

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/MariaDBDatabaseProductNameResolved.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/MariaDBDatabaseProductNameResolved.java
@@ -1,0 +1,50 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.store.hibernate.internal;
+
+import java.util.Optional;
+
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.store.hibernate.DatabaseProductNameResolved;
+
+/**
+ * Implementation of {@link DatabaseProductNameResolved} for MariaDB.
+ * 
+ * @version $Id$
+ * @since 17.1.0RC1
+ */
+@Component
+@Singleton
+@Named(MariaDBHibernateAdapter.HINT)
+public class MariaDBDatabaseProductNameResolved implements DatabaseProductNameResolved
+{
+    @Override
+    public Optional<String> resolve(String databaseProductName)
+    {
+        if (databaseProductName.equalsIgnoreCase(MariaDBHibernateAdapter.HINT)) {
+            return Optional.of(MariaDBHibernateAdapter.HINT);
+        }
+
+        return Optional.empty();
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/MariaDBDatabaseProductNameResolver.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/MariaDBDatabaseProductNameResolver.java
@@ -17,38 +17,34 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.xwiki.store;
+package org.xwiki.store.hibernate.internal;
 
-import org.xwiki.stability.Unstable;
+import java.util.Optional;
+
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.store.hibernate.DatabaseProductNameResolver;
 
 /**
- * Base exception for store related APIs.
- *
+ * Implementation of {@link DatabaseProductNameResolver} for MariaDB.
+ * 
  * @version $Id$
  * @since 17.1.0RC1
  */
-@Unstable
-public class StoreException extends Exception
+@Component
+@Singleton
+@Named(MariaDBHibernateAdapter.HINT)
+public class MariaDBDatabaseProductNameResolver implements DatabaseProductNameResolver
 {
-    /**
-     * Serialization identifier.
-     */
-    private static final long serialVersionUID = 1L;
-
-    /**
-     * @param message exception message
-     */
-    public StoreException(String message)
+    @Override
+    public Optional<String> resolve(String databaseProductName)
     {
-        super(message);
-    }
+        if (databaseProductName.equalsIgnoreCase(MariaDBHibernateAdapter.HINT)) {
+            return Optional.of(MariaDBHibernateAdapter.HINT);
+        }
 
-    /**
-     * @param message exception message
-     * @param cause nested exception
-     */
-    public StoreException(String message, Throwable cause)
-    {
-        super(message, cause);
+        return Optional.empty();
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/MariaDBHibernateAdapter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/MariaDBHibernateAdapter.java
@@ -1,0 +1,49 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.store.hibernate.internal;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.store.hibernate.HibernateAdapter;
+
+/**
+ * The {@link HibernateAdapter} for MariaDB.
+ * 
+ * @version $Id$
+ * @since 17.1.0RC1
+ */
+@Component
+@Named(MariaDBHibernateAdapter.HINT)
+@Singleton
+public class MariaDBHibernateAdapter extends MySQLHibernateAdapter
+{
+    /**
+     * The role hint of the component.
+     */
+    public static final String HINT = "mariadb";
+
+    @Override
+    public String getInformationShemaInnoDBTables()
+    {
+        return "information_schema.INNODB_SYS_TABLES";
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/MySQL8HibernateAdapter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/MySQL8HibernateAdapter.java
@@ -1,0 +1,50 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.store.hibernate.internal;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.store.hibernate.HibernateAdapter;
+
+/**
+ * The {@link HibernateAdapter} for MariaDB.
+ * 
+ * @version $Id$
+ * @since 17.1.0RC1
+ */
+@Component
+@Named(MySQL8HibernateAdapter.HINT)
+@Singleton
+public class MySQL8HibernateAdapter extends MySQLHibernateAdapter
+{
+    /**
+     * The role hint of the component.
+     */
+    public static final String HINT = "mysql/8";
+
+    @Override
+    public String getInformationShemaInnoDBTables()
+    {
+        // "INNODB_SYS_TABLES" was renamed to "INNODB_TABLES" in MySQL 8.0
+        return "information_schema.INNODB_TABLES";
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/MySQLHibernateAdapter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/MySQLHibernateAdapter.java
@@ -22,6 +22,7 @@ package org.xwiki.store.hibernate.internal;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -63,13 +64,15 @@ public class MySQLHibernateAdapter extends AbstractHibernateAdapter
         // Gather tables row formats
         Map<String, String> rowFormats = getRowFormats(session);
 
+        boolean compressionAllowed = isCompressionAllowed();
+
         // Make sure each table row format matches the configuration
         for (PersistentClass entity : metadata.getEntityBindings()) {
             // Get the exact table name for the entity
             String tableName = getTableName(entity);
 
             // Check if the table is configured to be compressed
-            boolean compressed = entity.getMetaAttribute(META_ATTRIBUTE_COMPRESSED) != null;
+            boolean compressed = compressionAllowed && entity.getMetaAttribute(META_ATTRIBUTE_COMPRESSED) != null;
 
             // Compute the query statement
             String statement = getAlterRowFormatString(tableName, compressed, rowFormats, session);
@@ -155,4 +158,15 @@ public class MySQLHibernateAdapter extends AbstractHibernateAdapter
         return "Compressed";
     }
 
+    @Override
+    public boolean isCompressionAllowed()
+    {
+        Optional<Boolean> compressionAllowed = getCompressionAllowedConfiguration();
+
+        if (compressionAllowed.isPresent()) {
+            return compressionAllowed.get();
+        }
+
+        return true;
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/MySQLHibernateAdapter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/MySQLHibernateAdapter.java
@@ -22,7 +22,6 @@ package org.xwiki.store.hibernate.internal;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import javax.inject.Named;
 import javax.inject.Singleton;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/MySQLHibernateAdapter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/MySQLHibernateAdapter.java
@@ -161,12 +161,6 @@ public class MySQLHibernateAdapter extends AbstractHibernateAdapter
     @Override
     public boolean isCompressionAllowed()
     {
-        Optional<Boolean> compressionAllowed = getCompressionAllowedConfiguration();
-
-        if (compressionAllowed.isPresent()) {
-            return compressionAllowed.get();
-        }
-
-        return true;
+        return getCompressionAllowedConfiguration().orElse(true);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/MySQLHibernateAdapter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/MySQLHibernateAdapter.java
@@ -1,0 +1,158 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.store.hibernate.internal;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.apache.commons.lang3.StringUtils;
+import org.hibernate.Session;
+import org.hibernate.boot.Metadata;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.query.NativeQuery;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.store.hibernate.AbstractHibernateAdapter;
+import org.xwiki.store.hibernate.HibernateAdapter;
+import org.xwiki.store.hibernate.HibernateStoreException;
+
+/**
+ * The default {@link HibernateAdapter} for MySQL. Based on MySQL 5.7 specifications.
+ * 
+ * @version $Id$
+ * @since 17.1.0RC1
+ */
+@Component
+@Singleton
+@Named(MySQLHibernateAdapter.HINT)
+public class MySQLHibernateAdapter extends AbstractHibernateAdapter
+{
+    /**
+     * The role hint of the component.
+     */
+    public static final String HINT = "mysql";
+
+    @Override
+    public void updateDatabaseAfter(Metadata metadata, Session session) throws HibernateStoreException
+    {
+        updateRowFormats(metadata, session);
+    }
+
+    protected void updateRowFormats(Metadata metadata, Session session) throws HibernateStoreException
+    {
+        // Gather tables row formats
+        Map<String, String> rowFormats = getRowFormats(session);
+
+        // Make sure each table row format matches the configuration
+        for (PersistentClass entity : metadata.getEntityBindings()) {
+            // Get the exact table name for the entity
+            String tableName = getTableName(entity);
+
+            // Check if the table is configured to be compressed
+            boolean compressed = entity.getMetaAttribute(META_ATTRIBUTE_COMPRESSED) != null;
+
+            // Compute the query statement
+            String statement = getAlterRowFormatString(tableName, compressed, rowFormats, session);
+            if (statement != null) {
+                // Create the query
+                NativeQuery<?> query = session.createNativeQuery(statement);
+
+                // Execute the query
+                session.getTransaction().begin();
+                query.executeUpdate();
+                session.getTransaction().commit();
+            }
+        }
+    }
+
+    /**
+     * @param tableName the name of the table to modify
+     * @param compressed true if the table should be compressed
+     * @param rowFormats the current row formats
+     * @param session the session in which to execute the query
+     * @return the SQL statement to execute if the table is not already compressed
+     * @throws HibernateStoreException when failing to check if the table is already compressed
+     */
+    public String getAlterRowFormatString(String tableName, boolean compressed, Map<String, String> rowFormats,
+        Session session) throws HibernateStoreException
+    {
+        String rowFormat = rowFormats.get(tableName);
+
+        this.logger.debug("Row format for table [{}]: {}", tableName, rowFormat);
+
+        String expectedRowFormat = compressed ? getCompressedRowFormat() : getDefaultRowFormat();
+
+        if (!StringUtils.equalsIgnoreCase(rowFormat, expectedRowFormat)) {
+            return "ALTER TABLE " + tableName + " ROW_FORMAT=" + expectedRowFormat;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param session the session in which to execute the query
+     * @return the row format of each table in the current database
+     */
+    public Map<String, String> getRowFormats(Session session)
+    {
+        String currentDatabase = getDatabaseFromWikiName();
+        NativeQuery<Object[]> query = session.createNativeQuery("SELECT DISTINCT NAME, ROW_FORMAT FROM "
+            + getInformationShemaInnoDBTables() + " WHERE LOWER(NAME) LIKE '" + currentDatabase.toLowerCase() + "/%'");
+
+        List<Object[]> results = query.list();
+
+        Map<String, String> rowFormats = new HashMap<>(results.size());
+        for (Object[] entry : results) {
+            String completeName = (String) entry[0];
+            String tableName = completeName.substring(completeName.indexOf('/') + 1);
+            rowFormats.put(tableName, (String) entry[1]);
+        }
+
+        return rowFormats;
+    }
+
+    /**
+     * @return the table where to find the InnoDB tables metadata
+     */
+    public String getInformationShemaInnoDBTables()
+    {
+        return "INFORMATION_SCHEMA.INNODB_SYS_TABLES";
+    }
+
+    /**
+     * @return the row format to use by default
+     */
+    public String getDefaultRowFormat()
+    {
+        return "Dynamic";
+    }
+
+    /**
+     * @return the row format to use for compressed tables
+     */
+    public String getCompressedRowFormat()
+    {
+        return "Compressed";
+    }
+
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/OracleHibernateAdapter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/OracleHibernateAdapter.java
@@ -1,0 +1,131 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.store.hibernate.internal;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.hibernate.Session;
+import org.hibernate.boot.Metadata;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.query.NativeQuery;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.store.hibernate.AbstractHibernateAdapter;
+import org.xwiki.store.hibernate.HibernateAdapter;
+import org.xwiki.store.hibernate.HibernateStoreException;
+
+/**
+ * The {@link HibernateAdapter} for Oracle.
+ * 
+ * @version $Id$
+ * @since 17.1.0RC1
+ */
+@Component
+@Named(OracleHibernateAdapter.HINT)
+@Singleton
+public class OracleHibernateAdapter extends AbstractHibernateAdapter
+{
+    /**
+     * The role hint of the component.
+     */
+    public static final String HINT = "oracle";
+
+    @Override
+    public void updateDatabaseAfter(Metadata metadata, Session session) throws HibernateStoreException
+    {
+        // Make sure all the configured tables have the right compression configuration
+        updateTableCompression(metadata, session);
+    }
+
+    private void updateTableCompression(Metadata metadata, Session session)
+    {
+        // Gather compressed tables
+        Set<String> compressedTables = getCompressedTables(session);
+
+        // Make sure each table compression status matches the configuration
+        for (PersistentClass entity : metadata.getEntityBindings()) {
+            // Get the exact table name for the entity
+            String tableName = getTableName(entity);
+
+            // Check if the table is configured to be compressed
+            boolean compressed = isCompressed(entity);
+
+            // Compute the query statement
+            if (compressedTables.contains(tableName) != compressed) {
+                // Create the query
+                NativeQuery<?> query = session
+                    .createNativeQuery("ALTER TABLE " + tableName + " " + (compressed ? "COMPRESS" : "NOCOMPRESS"));
+
+                // Execute the query
+                session.getTransaction().begin();
+                query.executeUpdate();
+                session.getTransaction().commit();
+            }
+        }
+    }
+
+    /**
+     * @param session the session in which to execute the query
+     * @return the tables which are configured to be compressed
+     */
+    public Set<String> getCompressedTables(Session session)
+    {
+        NativeQuery<String> query =
+            session.createNativeQuery("SELECT DISTINCT table_name FROM user_tables WHERE compression = 'ENABLED'");
+
+        return query.list().stream().map(String::toUpperCase).collect(Collectors.toSet());
+    }
+
+    @Override
+    public String getTableName(String tableName)
+    {
+        // Oracle generally needs the table name to be upper case
+        return tableName != null ? tableName.toUpperCase() : null;
+    }
+
+    @Override
+    protected String cleanDatabaseName(String name)
+    {
+        // Oracle generally needs the schema name to be upper case
+        return super.cleanDatabaseName(name).toUpperCase();
+    }
+
+    @Override
+    public String escapeDatabaseName(String databaseName)
+    {
+        // - Oracle converts user names in uppercase when no quotes is used.
+        // For example: "create user xwiki identified by xwiki;" creates a user named XWIKI (uppercase)
+        // - In Hibernate.cfg.xml we just specify: <property name="hibernate.connection.username">xwiki</property> and
+        // Hibernate
+        // seems to be passing this username as is to Oracle which converts it to uppercase.
+        //
+        // Thus for Oracle we don't escape the schema.
+        return databaseName;
+    }
+
+    @Override
+    public boolean isCatalog()
+    {
+        return false;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/OracleHibernateAdapter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/OracleHibernateAdapter.java
@@ -53,8 +53,10 @@ public class OracleHibernateAdapter extends AbstractHibernateAdapter
     @Override
     public void updateDatabaseAfter(Metadata metadata, Session session) throws HibernateStoreException
     {
-        // Make sure all the configured tables have the right compression configuration
-        updateTableCompression(metadata, session);
+        if (isCompressionAllowed()) {
+            // Make sure all the configured tables have the right compression configuration
+            updateTableCompression(metadata, session);
+        }
     }
 
     private void updateTableCompression(Metadata metadata, Session session)

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/PostgreSQLHibernateAdapter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/internal/PostgreSQLHibernateAdapter.java
@@ -1,0 +1,64 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.store.hibernate.internal;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.store.hibernate.AbstractHibernateAdapter;
+import org.xwiki.store.hibernate.HibernateAdapter;
+
+/**
+ * The {@link HibernateAdapter} for PostgreSQL.
+ * 
+ * @version $Id$
+ * @since 17.1.0RC1
+ */
+@Component
+@Named(PostgreSQLHibernateAdapter.HINT)
+@Singleton
+public class PostgreSQLHibernateAdapter extends AbstractHibernateAdapter
+{
+    /**
+     * The role hint of the component.
+     */
+    public static final String HINT = "postgresql";
+
+    @Override
+    protected String getDefaultMainWikiDatabase(String wikiId)
+    {
+        if (isConfiguredInSchemaMode()) {
+            return "public";
+        }
+
+        return super.getDefaultMainWikiDatabase(wikiId);
+    }
+
+    @Override
+    public boolean isCatalog()
+    {
+        if (isConfiguredInSchemaMode()) {
+            return false;
+        }
+
+        return super.isCatalog();
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/META-INF/components.txt
@@ -289,11 +289,12 @@ org.xwiki.query.hql.internal.ConfigurableHQLCompleteStatementValidator
 org.xwiki.query.hql.internal.DefaultHQLStatementValidator
 org.xwiki.query.hql.internal.StandardHQLCompleteStatementValidator
 org.xwiki.store.hibernate.internal.DefaultHibernateAdapter
-org.xwiki.store.hibernate.internal.DefaultHibernateAdapterFactory
 org.xwiki.store.hibernate.internal.DerbyHibernateAdapter
 org.xwiki.store.hibernate.internal.H2HibernateAdapter
 org.xwiki.store.hibernate.internal.HSQLDBHibernateAdapter
-org.xwiki.store.hibernate.internal.MariaDBDatabaseProductNameResolved
+org.xwiki.store.hibernate.internal.IDVersionHibernateAdapterFactory
+org.xwiki.store.hibernate.internal.LegacyDatabaseProductNameResolver
+org.xwiki.store.hibernate.internal.MariaDBDatabaseProductNameResolver
 org.xwiki.store.hibernate.internal.MariaDBHibernateAdapter
 org.xwiki.store.hibernate.internal.MySQL8HibernateAdapter
 org.xwiki.store.hibernate.internal.MySQLHibernateAdapter

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/META-INF/components.txt
@@ -288,3 +288,14 @@ org.xwiki.internal.document.DefaultSimpleDocumentCache
 org.xwiki.query.hql.internal.ConfigurableHQLCompleteStatementValidator
 org.xwiki.query.hql.internal.DefaultHQLStatementValidator
 org.xwiki.query.hql.internal.StandardHQLCompleteStatementValidator
+org.xwiki.store.hibernate.internal.DefaultHibernateAdapter
+org.xwiki.store.hibernate.internal.DefaultHibernateAdapterFactory
+org.xwiki.store.hibernate.internal.DerbyHibernateAdapter
+org.xwiki.store.hibernate.internal.H2HibernateAdapter
+org.xwiki.store.hibernate.internal.HSQLDBHibernateAdapter
+org.xwiki.store.hibernate.internal.MariaDBDatabaseProductNameResolved
+org.xwiki.store.hibernate.internal.MariaDBHibernateAdapter
+org.xwiki.store.hibernate.internal.MySQL8HibernateAdapter
+org.xwiki.store.hibernate.internal.MySQLHibernateAdapter
+org.xwiki.store.hibernate.internal.OracleHibernateAdapter
+org.xwiki.store.hibernate.internal.PostgreSQLHibernateAdapter

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/xwiki.hbm.xml
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/xwiki.hbm.xml
@@ -103,6 +103,7 @@
     </class>
 
     <class name="com.xpn.xwiki.doc.rcs.XWikiRCSNodeContent" table="xwikircs">
+        <meta attribute="xwiki-compressed"/>
         <composite-id name="id" class="com.xpn.xwiki.doc.rcs.XWikiRCSNodeId">
             <key-property name="docId" column="XWR_DOCID" type="long" />
             <key-property name="version1" column="XWR_VERSION1" type="integer" />

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/xwiki.oracle.hbm.xml
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/xwiki.oracle.hbm.xml
@@ -118,6 +118,7 @@
     </class>
 
     <class name="com.xpn.xwiki.doc.rcs.XWikiRCSNodeContent" table="xwikircs">
+        <meta attribute="xwiki-compressed"/>
         <composite-id name="id" class="com.xpn.xwiki.doc.rcs.XWikiRCSNodeId">
             <key-property name="docId" column="XWR_DOCID" type="long" />
             <key-property name="version1" column="XWR_VERSION1" type="integer" />

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/XWikiHibernateStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/XWikiHibernateStoreTest.java
@@ -51,6 +51,7 @@ import org.xwiki.model.reference.WikiReference;
 import org.xwiki.observation.EventListener;
 import org.xwiki.observation.ObservationManager;
 import org.xwiki.query.QueryManager;
+import org.xwiki.store.hibernate.HibernateAdapter;
 import org.xwiki.test.LogLevel;
 import org.xwiki.test.junit5.LogCaptureExtension;
 import org.xwiki.test.junit5.mockito.ComponentTest;
@@ -105,6 +106,9 @@ public class XWikiHibernateStoreTest
      */
     @Mock
     private Session session;
+
+    @Mock
+    private HibernateAdapter adapter;
 
     /**
      * The Hibernate transaction.
@@ -175,8 +179,9 @@ public class XWikiHibernateStoreTest
         when(this.hibernateStore.getCurrentSession()).thenReturn(session);
         when(this.hibernateStore.getCurrentTransaction()).thenReturn(transaction);
 
+        when(this.hibernateStore.getAdapter()).thenReturn(this.adapter);
         // Default is schema mode
-        when(this.hibernateStore.isConfiguredInSchemaMode()).thenReturn(true);
+        when(this.adapter.isConfiguredInSchemaMode()).thenReturn(true);
     }
 
     @Test
@@ -219,7 +224,7 @@ public class XWikiHibernateStoreTest
     @Test
     void executeDeleteWikiStatementForPostgreSQLWhenInDatabaseMode() throws Exception
     {
-        when(this.hibernateStore.isConfiguredInSchemaMode()).thenReturn(false);
+        when(this.adapter.isConfiguredInSchemaMode()).thenReturn(false);
 
         Statement statement = mock(Statement.class);
         DatabaseProduct databaseProduct = DatabaseProduct.POSTGRESQL;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/store/hibernate/internal/IDVersionHibernateAdapterFactoryTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/store/hibernate/internal/IDVersionHibernateAdapterFactoryTest.java
@@ -1,0 +1,118 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.store.hibernate.internal;
+
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+import java.util.Optional;
+
+import jakarta.inject.Named;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xwiki.store.hibernate.DatabaseProductNameResolver;
+import org.xwiki.store.hibernate.HibernateAdapter;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectComponentManager;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+import org.xwiki.test.mockito.MockitoComponentManager;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Validate {@link IDVersionHibernateAdapterFactory}.
+ * 
+ * @version $Id$
+ */
+@ComponentTest
+public class IDVersionHibernateAdapterFactoryTest
+{
+    @InjectMockComponents
+    private IDVersionHibernateAdapterFactory factory;
+
+    @InjectComponentManager
+    private MockitoComponentManager componentManager;
+
+    private DatabaseMetaData metaData = mock(DatabaseMetaData.class);
+
+    @MockComponent
+    @Named("resolver")
+    private DatabaseProductNameResolver resolver;
+
+    private Optional<HibernateAdapter> createHibernateAdapter(String databaseName, String databaseVersion)
+        throws SQLException
+    {
+        when(this.metaData.getDatabaseProductName()).thenReturn(databaseName);
+        when(this.metaData.getDatabaseProductVersion()).thenReturn(databaseVersion);
+
+        return this.factory.createHibernateAdapter(this.metaData, null);
+    }
+
+    private HibernateAdapter registerAdapter(String hint) throws Exception
+    {
+        return this.componentManager.registerMockComponent(HibernateAdapter.class, hint);
+    }
+
+    @BeforeEach
+    void beforeEach() throws Exception
+    {
+        this.componentManager.registerComponent(DatabaseProductNameResolver.class, "resolver1",
+            new DatabaseProductNameResolver()
+            {
+                @Override
+                public Optional<String> resolve(String databaseProductName)
+                {
+                    return databaseProductName.equals("database") ? Optional.of("database1") : Optional.empty();
+                }
+            });
+    }
+
+    @Test
+    void createHibernateAdapter() throws Exception
+    {
+        assertFalse(createHibernateAdapter("database", "version").isPresent());
+
+        HibernateAdapter adapter1 = registerAdapter("database1");
+        HibernateAdapter adapter2 = registerAdapter("database2");
+
+        assertFalse(createHibernateAdapter("database", "version").isPresent());
+        assertSame(adapter1, createHibernateAdapter("database1", "version").get());
+        assertSame(adapter2, createHibernateAdapter("database2", "version").get());
+
+        HibernateAdapter adapter11 = registerAdapter("database1/1.0");
+        HibernateAdapter adapter12 = registerAdapter("database1/2.0");
+
+        assertFalse(createHibernateAdapter("database", "version").isPresent());
+        assertSame(adapter1, createHibernateAdapter("database1", "version").get());
+        assertSame(adapter2, createHibernateAdapter("database2", "version").get());
+        assertSame(adapter11, createHibernateAdapter("database1", "1.0").get());
+        assertSame(adapter11, createHibernateAdapter("database1", "1.5").get());
+        assertSame(adapter12, createHibernateAdapter("database1", "2.0").get());
+        assertSame(adapter12, createHibernateAdapter("database1", "42").get());
+
+        when(this.resolver.resolve("database")).thenReturn(Optional.of("database1"));
+
+        assertSame(adapter1, createHibernateAdapter("database", "version").get());
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-api/src/main/java/org/xwiki/store/StoreException.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-api/src/main/java/org/xwiki/store/StoreException.java
@@ -1,0 +1,51 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.store;
+
+/**
+ * Base exception for store related APIs.
+ *
+ * @version $Id$
+ * @since 17.1.0RC1
+ */
+public class StoreException extends Exception
+{
+    /**
+     * Serialization identifier.
+     */
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * @param message exception message
+     */
+    public StoreException(String message)
+    {
+        super(message);
+    }
+
+    /**
+     * @param message exception message
+     * @param cause nested exception
+     */
+    public StoreException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/hibernate.cfg.xml.vm
+++ b/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/hibernate.cfg.xml.vm
@@ -304,6 +304,10 @@ jdbc:hsqldb:file:${environment.permanentDirectory}/database/xwiki_db;shutdown=tr
     <property name="hibernate.connection.useUnicode">true</property>
     <property name="hibernate.connection.characterEncoding">utf8</property>
 
+    <!-- To enable if basic compression feature is enabled in Oracle
+    <property name="xwiki.compressionAllowed">true</property>
+    -->
+
     <mapping resource="xwiki.oracle.hbm.xml"/>
     <mapping resource="feeds.oracle.hbm.xml"/>
 ## Note: This is starting the line in order not to put extra spaces when generated


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22613: Updating the history can take a very long time when there are a lot of objects
https://jira.xwiki.org/browse/XWIKI-22752: Allows indicating in the Hibernate hbm configuration files that an entity should be compressed
https://jira.xwiki.org/browse/XWIKI-22747: Introduce the concept of XWiki Hibernate adapter

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

The main goal of this change is to stop storing diff in the document history table.

The "stop storing diff" part is easy, but it implies trying to optimize the RCS table to try to reduce its size as much as possible by compressing it. Since the way to do this is not handled by Hibernate and quite different depending on the database engine, I also used this opportunity to improve how we deal with the difference between database engines with a new HibernateAdapater concept.

## Clarifications

See the following for more details and discussion around each subject:
* stop storing diff in the document history: https://forum.xwiki.org/t/stop-storing-diffs-by-default-in-the-history/15886
* new `HibernateAdapter` API: https://forum.xwiki.org/t/new-xwiki-api-to-extend-the-hibernate-dialects/16193

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

New tests:
* XWikiDocumentArchiveTest now contains several unit tests checking both the new (always full patch) and old behavior (full every 5 versions)

The main goal of this pull request is improving document save performances, which is not something which is easy to accurately test in an integration test.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches: none (too dangerous, at worst everything this change is automating can be done by hand in older versions)