### PR TITLE
XWIKI-22683: Move org.xwiki.security.authorization.DefaultAuthorizationManager to internal package

### DIFF
--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -497,6 +497,21 @@
                 </item>
               </differences>
             </revapi.differences>
+            <revapi.differences>
+              <justification>
+                This class should have never been exposed as an API as it's an internal component implementation.
+                It has been moved to an internal package following the vote performed on
+                https://forum.xwiki.org/t/move-defaultauthorizationmanager-to-an-internal-package/15926.
+              </justification>
+              <criticality>highlight</criticality>
+              <differences>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.class.removed</code>
+                  <old>class org.xwiki.security.authorization.DefaultAuthorizationManager</old>
+                </item>
+              </differences>
+            </revapi.differences>
           </analysisConfiguration>
         </configuration>
       </plugin>

--- a/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-macro/src/test/java/org/xwiki/rendering/internal/macro/DisplayMacroTest.java
+++ b/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-macro/src/test/java/org/xwiki/rendering/internal/macro/DisplayMacroTest.java
@@ -66,7 +66,7 @@ import org.xwiki.rendering.transformation.Transformation;
 import org.xwiki.rendering.wiki.WikiModel;
 import org.xwiki.security.authorization.AuthorizationManager;
 import org.xwiki.security.authorization.ContextualAuthorizationManager;
-import org.xwiki.security.authorization.DefaultAuthorizationManager;
+import org.xwiki.security.internal.authorization.DefaultAuthorizationManager;
 import org.xwiki.security.authorization.DocumentAuthorizationManager;
 import org.xwiki.security.authorization.Right;
 import org.xwiki.test.annotation.AllComponents;

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/include/IncludeMacroTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/include/IncludeMacroTest.java
@@ -70,7 +70,7 @@ import org.xwiki.rendering.transformation.Transformation;
 import org.xwiki.rendering.wiki.WikiModel;
 import org.xwiki.security.authorization.AuthorExecutor;
 import org.xwiki.security.authorization.ContextualAuthorizationManager;
-import org.xwiki.security.authorization.DefaultAuthorizationManager;
+import org.xwiki.security.internal.authorization.DefaultAuthorizationManager;
 import org.xwiki.security.authorization.DocumentAuthorizationManager;
 import org.xwiki.security.authorization.Right;
 import org.xwiki.test.annotation.AllComponents;

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/AuthorizationException.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/AuthorizationException.java
@@ -31,10 +31,10 @@ import org.xwiki.model.reference.EntityReference;
 public class AuthorizationException extends Exception
 {
     /** Constant value displayed for null entityReference. */
-    static final String NULL_ENTITY = "Main Wiki";
+    public static final String NULL_ENTITY = "Main Wiki";
 
     /** Constant value displayed for null userReference. */
-    static final String NULL_USER = "Public";
+    public static final String NULL_USER = "Public";
 
     /** Serialization identifier. */
     private static final long serialVersionUID = 1L;

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/Right.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/Right.java
@@ -206,7 +206,7 @@ public class Right implements RightDescription, Serializable, Comparable<Right>
      * @param impliedByRights the already existing rights that imply this new right.
      * @since 12.6
      */
-    Right(RightDescription description, Set<Right> impliedByRights)
+    public Right(RightDescription description, Set<Right> impliedByRights)
     {
         this(description.getName(), description.getDefaultState(), description.getTieResolutionPolicy(),
             description.getInheritanceOverridePolicy(),
@@ -420,7 +420,7 @@ public class Right implements RightDescription, Serializable, Comparable<Right>
      *
      * @since 13.5RC1
      */
-    void unregister()
+    public void unregister()
     {
         Set<EntityType> entityTypes = this.getTargetedEntityType();
         synchronized (VALUES) {
@@ -535,7 +535,7 @@ public class Right implements RightDescription, Serializable, Comparable<Right>
      * @param description a right description to compare this right to.
      * @return true if the right is equivalent to the provided description.
      */
-    boolean like(RightDescription description)
+    public boolean like(RightDescription description)
     {
         return new EqualsBuilder()
             .append(this.isReadOnly(), description.isReadOnly())

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/internal/authorization/DefaultAuthorizationManager.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/internal/authorization/DefaultAuthorizationManager.java
@@ -17,7 +17,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.xwiki.security.authorization;
+package org.xwiki.security.internal.authorization;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -37,6 +37,16 @@ import org.xwiki.model.reference.EntityReferenceSerializer;
 import org.xwiki.security.SecurityReference;
 import org.xwiki.security.SecurityReferenceFactory;
 import org.xwiki.security.UserSecurityReference;
+import org.xwiki.security.authorization.AccessDeniedException;
+import org.xwiki.security.authorization.AuthorizationException;
+import org.xwiki.security.authorization.AuthorizationManager;
+import org.xwiki.security.authorization.Right;
+import org.xwiki.security.authorization.RightDescription;
+import org.xwiki.security.authorization.RuleState;
+import org.xwiki.security.authorization.SecurityAccess;
+import org.xwiki.security.authorization.SecurityAccessEntry;
+import org.xwiki.security.authorization.SecurityRuleEntry;
+import org.xwiki.security.authorization.UnableToRegisterRightException;
 import org.xwiki.security.authorization.cache.SecurityCache;
 import org.xwiki.security.authorization.cache.SecurityCacheLoader;
 import org.xwiki.security.authorization.internal.DocumentRequiredRightsChecker;

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/resources/META-INF/components.txt
@@ -3,7 +3,7 @@ org.xwiki.security.authorization.cache.internal.DefaultSecurityCache
 org.xwiki.security.authorization.cache.internal.DefaultSecurityCacheLoader
 org.xwiki.security.authorization.internal.AuthorizationSettlerProvider
 org.xwiki.security.authorization.internal.DocumentRequiredRightsChecker
-org.xwiki.security.authorization.DefaultAuthorizationManager
+org.xwiki.security.internal.authorization.DefaultAuthorizationManager
 org.xwiki.security.authorization.internal.DefaultAuthorizationManagerConfiguration
 org.xwiki.security.authorization.internal.DefaultAuthorizationSettler
 org.xwiki.security.authorization.internal.PrioritizingAuthorizationSettler

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/DefaultAuthorizationManagerIntegrationTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/DefaultAuthorizationManagerIntegrationTest.java
@@ -72,6 +72,7 @@ import org.xwiki.security.authorization.testwikis.TestUserDocument;
 import org.xwiki.security.authorization.testwikis.TestWiki;
 import org.xwiki.security.internal.UserBridge;
 import org.xwiki.security.internal.XWikiBridge;
+import org.xwiki.security.internal.authorization.DefaultAuthorizationManager;
 import org.xwiki.test.LogLevel;
 import org.xwiki.test.annotation.BeforeComponent;
 import org.xwiki.test.annotation.ComponentList;

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/internal/DefaultAuthorizationSettlerTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/internal/DefaultAuthorizationSettlerTest.java
@@ -33,7 +33,7 @@ import org.xwiki.security.GroupSecurityReference;
 import org.xwiki.security.SecurityReference;
 import org.xwiki.security.UserSecurityReference;
 import org.xwiki.security.authorization.AbstractAdditionalRightsTestCase;
-import org.xwiki.security.authorization.DefaultAuthorizationManager;
+import org.xwiki.security.internal.authorization.DefaultAuthorizationManager;
 import org.xwiki.security.authorization.Right;
 import org.xwiki.security.authorization.RuleState;
 import org.xwiki.security.authorization.SecurityAccess;

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-bridge/src/main/java/org/xwiki/security/authorization/internal/BridgeAuthorizationManager.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-bridge/src/main/java/org/xwiki/security/authorization/internal/BridgeAuthorizationManager.java
@@ -27,7 +27,7 @@ import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
 import org.xwiki.rendering.async.AsyncContext;
 import org.xwiki.security.authorization.AccessDeniedException;
-import org.xwiki.security.authorization.DefaultAuthorizationManager;
+import org.xwiki.security.internal.authorization.DefaultAuthorizationManager;
 import org.xwiki.security.authorization.Right;
 
 /**


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

# Changes

https://jira.xwiki.org/browse/XWIKI-22683

## Description

<!-- Describe the main changes brought in this PR. -->

  * Move DefaultAuthorizationManager to internal package
  * Expose some APIs that were package protected to make them public so that the component implementation can access them
  * Add a revapi ignore to explain the removed public API

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Ran `mvn clean install -Pquality` on module `xwiki-platform-security`

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * No