### PR TITLE
XWIKI-22781: Load JavaScript skin extensions in standalone WYSIWYG editor by default

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-config/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-config/plugin.js
@@ -63,7 +63,7 @@
       allowedContent = $.extend(true, {}, config.allowedContentBySyntax[config.sourceSyntax]);
 
       // Forbid script tags if JavaScript skin extensions are not loaded.
-      if (!config.loadJavaScriptSkinExtensions && '$1' in allowedContent && 'elements' in allowedContent.$1) {
+      if (config.loadJavaScriptSkinExtensions === 0 && '$1' in allowedContent && 'elements' in allowedContent.$1) {
         delete allowedContent.$1.elements.script;
       }
 

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-filter/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-filter/plugin.js
@@ -79,7 +79,7 @@
       var dataFilter = editor.dataProcessor && editor.dataProcessor.dataFilter;
       if (dataFilter) {
         dataFilter.addRules(replaceEmptyLinesWithEmptyParagraphs, {priority: 5});
-        if (editor.config.loadJavaScriptSkinExtensions) {
+        if (editor.config.loadJavaScriptSkinExtensions !== 0) {
           dataFilter.addRules(unprotectAllowedScripts, {priority: 5});
         }
       }

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ConfigTemplate.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ConfigTemplate.xml
@@ -148,7 +148,7 @@
       <linkShowTargetTab>0</linkShowTargetTab>
     </property>
     <property>
-      <loadJavaScriptSkinExtensions>0</loadJavaScriptSkinExtensions>
+      <loadJavaScriptSkinExtensions>1</loadJavaScriptSkinExtensions>
     </property>
     <property>
       <removeButtons/>

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/ContentSheet.xml
@@ -73,7 +73,7 @@
       #set ($discard = $xwiki.ssx.use('CKEditor.ContentSheet'))
       ## Include the stylesheets that affect the content in view mode.
       #ckeditor_templateWithoutEmptyLines("stylesheets.vm")
-      #if ($xwiki.getDocument('CKEditor.Config').getValue('loadJavaScriptSkinExtensions') == 1)
+      #if ($xwiki.getDocument('CKEditor.Config').getValue('loadJavaScriptSkinExtensions') != 0)
         #ckeditor_templateWithoutEmptyLines("javascript.vm")
       #end
     &lt;/head&gt;


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-22781

# Changes

## Description

* Load JavaScript skin extensions (for now, only those that are marked as safe) in standalone WYSIWYG editor by default

## Clarifications

* https://forum.xwiki.org/t/load-javascript-skin-extensions-in-standalone-wysiwyg-editor-by-default/16246