### PR TITLE
XWIKI-22782: Only save modified xobjects

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -540,6 +540,8 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
      */
     private boolean isMetaDataDirty = true;
 
+    private boolean changeTracked;
+
     private int elements = HAS_OBJECTS | HAS_ATTACHMENTS;
 
     // Meta Data
@@ -2427,6 +2429,34 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
     public void setMetaDataDirty(boolean metaDataDirty)
     {
         this.isMetaDataDirty = metaDataDirty;
+    }
+
+    /**
+     * Indicate if flags indicating which part of the document has been modified can be trusted.
+     * 
+     * @return the true if change made to this {@link XWikiDocument} instance are tracked
+     * @since 17.1.0RC1
+     * @since 16.10.4
+     * @since 16.4.7
+     */
+    @Unstable
+    public boolean isChangeTracked()
+    {
+        return this.changeTracked;
+    }
+
+    /**
+     * Indicate if flags indicating which part of the document has been modified can be trusted.
+     * 
+     * @param changeTracked true if change made to this {@link XWikiDocument} instance are tracked
+     * @since 17.1.0RC1
+     * @since 16.10.4
+     * @since 16.4.7
+     */
+    @Unstable
+    public void setChangeTracked(boolean changeTracked)
+    {
+        this.changeTracked = changeTracked;
     }
 
     public String getAttachmentURL(String filename, XWikiContext context)
@@ -4594,6 +4624,10 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
         try {
             Constructor<? extends XWikiDocument> constructor = getClass().getConstructor(DocumentReference.class);
             doc = constructor.newInstance(newDocumentReference);
+
+            if (keepsIdentity && getDocumentReference().equals(doc.getDocumentReference())) {
+                doc.setChangeTracked(isChangeTracked());
+            }
 
             // Make sure the coordinate of the document is fully accurate before any other manipulation
             doc.setLocale(getLocale());

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/HibernateConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/HibernateConfiguration.java
@@ -21,6 +21,8 @@ package com.xpn.xwiki.internal.store.hibernate;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -29,6 +31,9 @@ import javax.inject.Singleton;
 import org.apache.commons.lang3.StringUtils;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.configuration.ConfigurationSource;
+import org.xwiki.model.EntityType;
+import org.xwiki.model.reference.EntityReference;
+import org.xwiki.model.reference.EntityReferenceResolver;
 
 import com.xpn.xwiki.internal.XWikiCfgConfigurationSource;
 
@@ -45,6 +50,10 @@ public class HibernateConfiguration
     @Inject
     @Named(XWikiCfgConfigurationSource.ROLEHINT)
     private ConfigurationSource xwikiConfiguration;
+
+    @Inject
+    @Named("relative")
+    private EntityReferenceResolver<String> resolver;
 
     private String path;
 
@@ -163,5 +172,22 @@ public class HibernateConfiguration
     public List<String> getIgnoredMigrations()
     {
         return getList("xwiki.store.migration.ignored");
+    }
+
+    /**
+     * @return the local references of the classes for which we should apply a save optimization (save only the modified
+     *         ones)
+     * @since 17.1.0RC1
+     * @since 16.10.4
+     * @since 16.4.7
+     */
+    public Set<EntityReference> getOptimizedXObjectClasses()
+    {
+        List<String> references =
+            this.xwikiConfiguration.getProperty("xwiki.store.hibernate.optimizedObjectSave.classes", List.class);
+
+        return references != null
+            ? references.stream().map(r -> this.resolver.resolve(r, EntityType.DOCUMENT)).collect(Collectors.toSet())
+            : null;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseCollection.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseCollection.java
@@ -30,6 +30,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
@@ -224,8 +225,12 @@ public abstract class BaseCollection<R extends EntityReference> extends BaseElem
             }
         }
 
-        this.xClassReference = ref;
-        this.xClassReferenceCache = null;
+        if (!Objects.equals(this.xClassReference, ref)) {
+            this.xClassReference = ref;
+            this.xClassReferenceCache = null;
+
+            setDirty(true);
+        }
     }
 
     /**
@@ -265,7 +270,6 @@ public abstract class BaseCollection<R extends EntityReference> extends BaseElem
     {
         addField(name, property);
         if (property instanceof BaseProperty) {
-            ((BaseProperty) property).setObject(this);
             ((BaseProperty) property).setName(name);
         }
     }
@@ -537,9 +541,15 @@ public abstract class BaseCollection<R extends EntityReference> extends BaseElem
     {
         this.fields.put(name, element);
 
-        if (element instanceof BaseElement) {
-            ((BaseElement) element).setOwnerDocument(getOwnerDocument());
+        if (element instanceof BaseElement baseElement) {
+            baseElement.setOwnerDocument(getOwnerDocument());
+
+            if (element instanceof BaseProperty baseProperty) {
+                baseProperty.setObject(this);
+            }
         }
+
+        setDirty(true);
     }
 
     public void removeField(String name)
@@ -548,6 +558,8 @@ public abstract class BaseCollection<R extends EntityReference> extends BaseElem
         if (field != null) {
             this.fields.remove(name);
             this.fieldsToRemove.add(field);
+
+            setDirty(true);
         }
     }
 
@@ -646,6 +658,8 @@ public abstract class BaseCollection<R extends EntityReference> extends BaseElem
             cfields.put(entry.getKey(), prop);
         }
         collection.setFields(cfields);
+
+        collection.setDirty(isDirty());
 
         return collection;
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseElement.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseElement.java
@@ -22,6 +22,7 @@ package com.xpn.xwiki.objects;
 import java.io.IOException;
 import java.io.Serializable;
 import java.io.StringWriter;
+import java.util.Objects;
 
 import javax.inject.Provider;
 
@@ -37,6 +38,7 @@ import org.xwiki.localization.ContextualLocalizationManager;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
 import org.xwiki.model.reference.EntityReferenceSerializer;
+import org.xwiki.stability.Unstable;
 import org.xwiki.store.merge.MergeManager;
 import org.xwiki.store.merge.MergeManagerResult;
 
@@ -101,7 +103,37 @@ public abstract class BaseElement<R extends EntityReference> implements ElementI
     private EntityReferenceSerializer<String> localUidStringEntityReferenceSerializer;
 
     private ContextualLocalizationManager localization;
-    
+
+    private transient boolean dirty = true;
+
+    /**
+     * @return true of the element was modified (or created)
+     * @since 17.1.0RC1
+     * @since 16.10.4
+     * @since 16.4.7
+     */
+    @Unstable
+    public boolean isDirty()
+    {
+        return this.dirty;
+    }
+
+    /**
+     * @param dirty true of the element was modified (or created)
+     * @since 17.1.0RC1
+     * @since 16.10.4
+     * @since 16.4.7
+     */
+    @Unstable
+    public void setDirty(boolean dirty)
+    {
+        this.dirty = dirty;
+
+        if (dirty && this.ownerDocument != null) {
+            this.ownerDocument.setMetaDataDirty(true);
+        }
+    }
+
     /**
      * @return a merge manager instance.
      * @since 11.8RC1
@@ -161,12 +193,16 @@ public abstract class BaseElement<R extends EntityReference> implements ElementI
     }
 
     @Override
-    public void setDocumentReference(DocumentReference reference)
+    public void setDocumentReference(DocumentReference documentReference)
     {
-        // If the name is already set then reset it since we're now using a reference
-        this.documentReference = reference;
-        this.name = null;
-        this.referenceCache = null;
+        if (!Objects.equals(documentReference, this.documentReference)) {
+            // If the name is already set then reset it since we're now using a reference
+            this.documentReference = documentReference;
+            this.name = null;
+            this.referenceCache = null;
+
+            setDirty(true);
+        }
     }
 
     /**
@@ -185,8 +221,12 @@ public abstract class BaseElement<R extends EntityReference> implements ElementI
             throw new IllegalStateException("BaseElement#setName could not be called when a reference has been set.");
         }
 
-        this.name = name;
-        this.referenceCache = null;
+        if (!StringUtils.equals(name, this.name)) {
+            this.name = name;
+            this.referenceCache = null;
+
+            setDirty(true);
+        }
     }
 
     public String getPrettyName()
@@ -349,6 +389,8 @@ public abstract class BaseElement<R extends EntityReference> implements ElementI
             }
 
             element.setPrettyName(getPrettyName());
+
+            element.dirty = this.dirty;
         } catch (Exception e) {
             // This should not happen
             element = null;
@@ -417,7 +459,13 @@ public abstract class BaseElement<R extends EntityReference> implements ElementI
      */
     public void setOwnerDocument(XWikiDocument ownerDocument)
     {
-        this.ownerDocument = ownerDocument;
+        if (this.ownerDocument != ownerDocument) {
+            this.ownerDocument = ownerDocument;
+
+            if (this.ownerDocument != null && isDirty()) {
+                this.ownerDocument.setMetaDataDirty(true);
+            }
+        }
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseObject.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseObject.java
@@ -19,7 +19,6 @@
  */
 package com.xpn.xwiki.objects;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -44,7 +43,7 @@ import com.xpn.xwiki.objects.classes.BaseClass;
 import com.xpn.xwiki.objects.classes.PropertyClass;
 import com.xpn.xwiki.web.Utils;
 
-public class BaseObject extends BaseCollection<BaseObjectReference> implements ObjectInterface, Serializable, Cloneable
+public class BaseObject extends BaseCollection<BaseObjectReference> implements ObjectInterface, Cloneable
 {
     private static final long serialVersionUID = 1L;
 
@@ -200,6 +199,8 @@ public class BaseObject extends BaseCollection<BaseObjectReference> implements O
         // We don't use #getGuid() because we actually want the same value and not generate a new guid when null (which
         // is expensive)
         object.setGuid(this.guid);
+
+        object.setDirty(isDirty());
 
         return object;
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BaseClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BaseClass.java
@@ -86,11 +86,6 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
     private String nameField;
 
     /**
-     * Set to true if the class is modified from the database version of it.
-     */
-    private boolean isDirty = true;
-
-    /**
      * Used to resolve a string into a proper Document Reference using the current document's reference to fill the
      * blanks, except for the page name for which the default page name is used instead and for the wiki name for which
      * the current wiki is used instead of the current document reference's wiki.
@@ -464,8 +459,9 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
         bclass.setValidationScript(getValidationScript());
         bclass.setNameField(getNameField());
 
-        bclass.setDirty(this.isDirty);
         bclass.setOwnerDocument(this.ownerDocument);
+
+        bclass.setDirty(isDirty());
 
         return bclass;
     }
@@ -1639,22 +1635,6 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
             if (this.ownerDocument != null) {
                 setDocumentReference(this.ownerDocument.getDocumentReference());
             }
-
-            if (ownerDocument != null && this.isDirty) {
-                ownerDocument.setMetaDataDirty(true);
-            }
-        }
-    }
-
-    /**
-     * @param isDirty Indicate if the dirty flag should be set or cleared.
-     * @since 4.3M2
-     */
-    public void setDirty(boolean isDirty)
-    {
-        this.isDirty = isDirty;
-        if (isDirty && this.ownerDocument != null) {
-            this.ownerDocument.setMetaDataDirty(true);
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PropertyClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PropertyClass.java
@@ -567,6 +567,9 @@ public class PropertyClass extends BaseCollection<ClassPropertyReference>
     {
         PropertyClass pclass = (PropertyClass) super.clone();
         pclass.setObject(getObject());
+
+        pclass.setDirty(isDirty());
+
         return pclass;
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentMockitoTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentMockitoTest.java
@@ -568,6 +568,17 @@ public class XWikiDocumentMockitoTest
     }
 
     @Test
+    void testCloneIdentical()
+    {
+        XWikiDocument document = new XWikiDocument(new DocumentReference("wiki", DOCSPACE, DOCNAME));
+        document.setChangeTracked(true);
+
+        XWikiDocument clonedDocument = document.clone();
+
+        assertTrue(clonedDocument.isChangeTracked());
+    }
+
+    @Test
     void testCloneNullObjects()
     {
         XWikiDocument document = new XWikiDocument(new DocumentReference("wiki", DOCSPACE, DOCNAME));

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/XWikiHibernateStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/XWikiHibernateStoreTest.java
@@ -45,14 +45,15 @@ import org.xwiki.bridge.event.ActionExecutingEvent;
 import org.xwiki.context.Execution;
 import org.xwiki.context.ExecutionContext;
 import org.xwiki.model.reference.DocumentReference;
-import org.xwiki.model.reference.DocumentReferenceResolver;
-import org.xwiki.model.reference.EntityReferenceSerializer;
+import org.xwiki.model.reference.LocalDocumentReference;
 import org.xwiki.model.reference.WikiReference;
 import org.xwiki.observation.EventListener;
 import org.xwiki.observation.ObservationManager;
 import org.xwiki.query.QueryManager;
 import org.xwiki.store.hibernate.HibernateAdapter;
+import org.xwiki.rendering.syntax.Syntax;
 import org.xwiki.test.LogLevel;
+import org.xwiki.test.annotation.AfterComponent;
 import org.xwiki.test.junit5.LogCaptureExtension;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
@@ -61,15 +62,19 @@ import org.xwiki.test.mockito.MockitoComponentManager;
 import org.xwiki.wiki.descriptor.WikiDescriptorManager;
 import org.xwiki.wiki.manager.WikiManagerException;
 
+import com.xpn.xwiki.CoreConfiguration;
 import com.xpn.xwiki.XWiki;
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.internal.store.hibernate.HibernateConfiguration;
 import com.xpn.xwiki.internal.store.hibernate.HibernateStore;
 import com.xpn.xwiki.objects.BaseObject;
 import com.xpn.xwiki.objects.BaseProperty;
 import com.xpn.xwiki.objects.LargeStringProperty;
 import com.xpn.xwiki.objects.StringProperty;
+import com.xpn.xwiki.test.reference.ReferenceComponentList;
+import com.xpn.xwiki.web.Utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -82,6 +87,7 @@ import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 /**
@@ -90,8 +96,13 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
+@ReferenceComponentList
 public class XWikiHibernateStoreTest
 {
+    private static final String WIKI_NAME = "wiki";
+
+    private static final WikiReference WIKI_REFERENCE = new WikiReference(WIKI_NAME);
+
     /**
      * A special component manager that mocks automatically all the dependencies of the component under test.
      */
@@ -129,6 +140,9 @@ public class XWikiHibernateStoreTest
     private QueryManager queryManager;
 
     @MockComponent
+    private HibernateConfiguration hibernateConfiguration;
+
+    @MockComponent
     private Provider<XWikiContext> contextProvider;
 
     @MockComponent
@@ -136,26 +150,29 @@ public class XWikiHibernateStoreTest
     private Provider<XWikiContext> readOnlyContextProvider;
 
     @MockComponent
-    @Named("local")
-    private EntityReferenceSerializer<String> localEntityReferenceSerializer;
-
-    @MockComponent
-    @Named("currentmixed")
-    private DocumentReferenceResolver<String> currentMixedDocumentReferenceResolver;
-
-    @MockComponent
-    @Named("compactwiki")
-    private EntityReferenceSerializer<String> compactWikiEntityReferenceSerializer;
-
-    @MockComponent
     private WikiDescriptorManager wikiDescriptorManager;
+
+    @MockComponent
+    private CoreConfiguration coreConfiguration;
 
     @RegisterExtension
     private LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.WARN);
 
+    @AfterComponent
+    void afterComponent()
+    {
+        when(this.hibernateConfiguration.getOptimizedXObjectClasses()).thenReturn(null);
+    }
+
     @BeforeEach
     void setUp(MockitoComponentManager componentManager) throws Exception
     {
+        Utils.setComponentManager(componentManager);
+        when(this.coreConfiguration.getDefaultDocumentSyntax()).thenReturn(Syntax.XWIKI_2_1);
+
+        when(this.xcontext.getWikiId()).thenReturn(WIKI_NAME);
+        when(this.xcontext.getWikiReference()).thenReturn(WIKI_REFERENCE);
+
         // For XWikiHibernateBaseStore#initialize()
 
         ExecutionContext executionContext = mock(ExecutionContext.class);
@@ -290,7 +307,7 @@ public class XWikiHibernateStoreTest
         when(sqlQuery.executeUpdate()).thenReturn(0);
 
         this.store.createHibernateSequenceIfRequired(
-            new String[] { "whatever", "create sequence schema.hibernate_sequence" }, "schema", session);
+            new String[] {"whatever", "create sequence schema.hibernate_sequence"}, "schema", session);
 
         verify(session, never()).createSQLQuery("create sequence schema.hibernate_sequence");
         verify(sqlQuery, never()).executeUpdate();
@@ -435,7 +452,6 @@ public class XWikiHibernateStoreTest
         when(query.execute()).thenReturn(translationList);
 
         when(queryManager.createQuery(any(String.class), eq(org.xwiki.query.Query.HQL))).thenReturn(query);
-        when(localEntityReferenceSerializer.serialize(documentReference.getParent())).thenReturn("Path.To");
 
         assertEquals(translationList, store.getTranslationList(doc, xcontext));
 
@@ -452,7 +468,6 @@ public class XWikiHibernateStoreTest
         // We are currently in the context of "xwiki"
         WikiReference currentWikiReference = new WikiReference("xwiki");
         when(this.xcontext.getWikiReference()).thenReturn(currentWikiReference);
-        when(this.compactWikiEntityReferenceSerializer.serialize(documentReference)).thenReturn("B.WebHome");
         List<String> resultList = new ArrayList<>();
         resultList.add("A.WebHome");
 
@@ -461,7 +476,6 @@ public class XWikiHibernateStoreTest
         when(this.session.createQuery(anyString(), same(String.class))).thenReturn(query);
         when(query.list()).thenReturn(resultList);
         DocumentReference expectedBacklink = new DocumentReference("xwiki", Arrays.asList("A"), "WebHome");
-        when(this.currentMixedDocumentReferenceResolver.resolve("A.WebHome")).thenReturn(expectedBacklink);
 
         List<DocumentReference> obtainedReferences = this.store.loadBacklinks(documentReference, true, this.xcontext);
         assertEquals(1, obtainedReferences.size());
@@ -479,7 +493,6 @@ public class XWikiHibernateStoreTest
         // We are currently in the context of "xwiki"
         WikiReference currentWikiReference = new WikiReference("xwiki");
         when(this.xcontext.getWikiReference()).thenReturn(currentWikiReference);
-        when(this.compactWikiEntityReferenceSerializer.serialize(documentReference)).thenReturn("subwiki:B.WebHome");
         List<String> resultList = new ArrayList<>();
         resultList.add("Foo.WebHome");
 
@@ -488,7 +501,6 @@ public class XWikiHibernateStoreTest
         when(this.session.createQuery(anyString(), same(String.class))).thenReturn(query);
         when(query.list()).thenReturn(resultList);
         DocumentReference expectedBacklink = new DocumentReference("xwiki", Arrays.asList("Foo"), "WebHome");
-        when(this.currentMixedDocumentReferenceResolver.resolve("Foo.WebHome")).thenReturn(expectedBacklink);
 
         List<DocumentReference> obtainedReferences = this.store.loadBacklinks(documentReference, true, this.xcontext);
         assertEquals(1, obtainedReferences.size());
@@ -496,5 +508,69 @@ public class XWikiHibernateStoreTest
         verify(query).setParameter("backlink", "subwiki:B.WebHome");
         verify(this.hibernateStore).beginTransaction();
         verify(this.hibernateStore).endTransaction(false);
+    }
+
+    @Test
+    void saveModifiedXObjects() throws XWikiException
+    {
+        XWikiDocument document = new XWikiDocument(new DocumentReference(WIKI_NAME, "space", "document"));
+
+        Query queryDocument = mock();
+        when(this.session.createQuery("select xwikidoc.id from XWikiDocument as xwikidoc where xwikidoc.id = :id"))
+            .thenReturn(queryDocument);
+        when(queryDocument.uniqueResult()).thenReturn(null);
+
+        LocalDocumentReference classReference = new LocalDocumentReference("space", "class");
+
+        BaseObject object1 = new BaseObject();
+        object1.setXClassReference(classReference);
+        document.addXObject(object1);
+
+        Query queryXObject = mock();
+        when(this.session.createQuery("select obj.id from BaseObject as obj where obj.id = :id", Long.class))
+            .thenReturn(queryXObject);
+        when(queryXObject.uniqueResult()).thenReturn(null);
+
+        // First save a new document
+
+        this.store.saveXWikiDoc(document, this.xcontext, true);
+
+        verify(this.session).save("com.xpn.xwiki.objects.BaseObject", object1);
+        verify(this.session, never()).update("com.xpn.xwiki.objects.BaseObject", object1);
+
+        // Save again of the same document
+
+        when(queryDocument.uniqueResult()).thenReturn(document.getId());
+        when(queryXObject.uniqueResult()).thenReturn(object1.getId());
+
+        this.store.saveXWikiDoc(document, this.xcontext, true);
+
+        verify(this.session).save("com.xpn.xwiki.objects.BaseObject", object1);
+        verify(this.session, never()).update("com.xpn.xwiki.objects.BaseObject", object1);
+
+        // Indicate that the xobject was modified
+
+        object1.setDirty(true);
+
+        this.store.saveXWikiDoc(document, this.xcontext, true);
+
+        verify(this.session).save("com.xpn.xwiki.objects.BaseObject", object1);
+        verify(this.session, times(1)).update("com.xpn.xwiki.objects.BaseObject", object1);
+
+        // Save again with no change
+
+        this.store.saveXWikiDoc(document, this.xcontext, true);
+
+        verify(this.session).save("com.xpn.xwiki.objects.BaseObject", object1);
+        verify(this.session, times(1)).update("com.xpn.xwiki.objects.BaseObject", object1);
+
+        // Save again but with disabled tracking
+
+        document.setChangeTracked(false);
+
+        this.store.saveXWikiDoc(document, this.xcontext, true);
+
+        verify(this.session).save("com.xpn.xwiki.objects.BaseObject", object1);
+        verify(this.session, times(2)).update("com.xpn.xwiki.objects.BaseObject", object1);
     }
 }


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-22782

# Changes

## Description

* added a flag to track if a BaseObject was modified
* made sure that any modification of something in that BaseObject (properties, direct metadata of that object) update this flag
* when saving the document skip any BaseObject which indicate that it was not modified
* had to do some `Serializable` cleanup (revapi was getting a bit lost). It's not even clear to me why `BaseElement` and its derivatives are `Serializable` in the first place, but that's another story…

## Clarifications

The general idea is to try to reduce the useless requests during document save. This pull request is focusing in making sure we don't re-save xobject which are identical to what's in the database already.

The save side of things is the easy part, most of the changes in the pull request are about trying to make sure we properly track modifications made to objects.

To avoid problems with complex use cases, this optimization is only applied if the document `isChangeTracked()` is true, and currently this is false by default and set to true only by the hibernate store when loading a document.

# Executed Tests

Counting on existing test to validate that at least there is no regression.

TODO: various unit tests to check the behavior of the new BaseObject (actually BaseElement, since BaseObject is not the only element with this concept) dirty flag.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches: stable-16.10.x