### PR TITLE
XWIKI-20109: Notification headers for autoreplies

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/AbstractMimeMessageIterator.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/AbstractMimeMessageIterator.java
@@ -426,6 +426,8 @@ public abstract class AbstractMimeMessageIterator implements Iterator<MimeMessag
             updateFactoryParameters(templateDocumentReference);
             message = ExtendedMimeMessage.wrap(this.factory.createMessage(templateDocumentReference,
                 this.factoryParameters));
+            message.setHeader("Auto-Submitted", "auto-generated");
+            message.setHeader("X-Auto-Response-Suppress", "All");
 
             List<EntityEvent> events = new ArrayList<>();
             this.currentEvents.forEach(


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

* https://jira.xwiki.org/browse/XWIKI-20109

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

*  Added common headers to notification emails to prevent autoresponses from various emails autoreply

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* This PR replaces https://github.com/xwiki/xwiki-platform/pull/1907

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

TBD

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.x