### PR TITLE
XWIKI-22492: Livedata filter options are misread

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/xwiki.selectize.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/xwiki.selectize.js
@@ -31,7 +31,7 @@ define('xwiki-selectize', [
   'xwiki-events-bridge'
 ], function($, Selectize, l10n) {
   var optionTemplate = [
-    '<div class="xwiki-selectize-option" role="option" aria-selected="false" data-value="">',
+    '<div class="xwiki-selectize-option" data-value="">',
       '<span class="xwiki-selectize-option-icon"></span>',
       '<span class="xwiki-selectize-option-label"></span>',
     '</div>'
@@ -206,10 +206,6 @@ define('xwiki-selectize', [
     let oldOnOptionSelect = this.selectize.onOptionSelect;
     this.selectize.onOptionSelect = function(...args) {
       const result = oldOnOptionSelect.apply(this, args);
-      // clear aria-selected state on all previously selected elements first
-      this.get$('dropdown').find('.option').attr('aria-selected','false');
-      // then set the aria-selected state of the newly selected element.
-      this.get$('dropdown').find('.selected').attr('aria-selected','true');
       return result;
     }
     let oldSetActiveOption = this.selectize.setActiveOption;


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22492

A regression on a11y tests has been reported caused by the commit for this ticket. E.g.
https://ci.xwiki.org/job/XWiki%20Environment%20Tests/job/xwiki-platform/job/master/786/testReport/org.xwiki.release.test.ui/AllIT/MySQL_9_1__Tomcat_11_jdk21__Chrome___Docker_tests_for_xwiki_platform_release___Build_for_MySQL_9_1__Tomcat_11_jdk21__Chrome___Docker_tests_for_xwiki_platform_release______/ 

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Removed the problematic semantics from the selectize options.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* We cannot keep the `aria-selected` attribute on regular elements.
* The other solution would be to set the role of parents of these `options` elements. However:
  * There is two places where those elements are used: in the dropdown and in the input display. The `listbox` role would fit for the dropdown but not for the input.
  * As far as I can see, those elements are generated by selectize and "internal". If we want to change them we'll have to rely on some javascript that "patches" the default selectize (on the opposite to what is done with the options where selectize supports us providing our own template).
* While testing, I saw that these option roles and aria-selected did not add anything to a basic screen reader experience. They are not necessary to resolve the problem of options being misread. In https://github.com/xwiki/xwiki-platform/pull/3700 I added this as a side improvement, but we can easily remove it because it fails tests.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

None, the screen reader experience is the same as the one that was found in https://github.com/xwiki/xwiki-platform/pull/3700 :
https://github.com/user-attachments/assets/5927a1bf-6232-4a54-a46c-e4a40f60f388

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Manual test with two screen readers to check that the changes reverted didn't revert the resolution from the initial commit. Everything is read out properly on Orca and NDVA.

Built the changes successfully with `mvn clean install -f xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war -Pquality`. After that, I checked one test suite that failed because of the changes in the initial commits:
`mvn clean install -f xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war -Pquality`. The only WCAG violations found were warnings (not test fails) about labels, unrelated to this ticket.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X, same as https://github.com/xwiki/xwiki-platform/pull/3700 