### PR TITLE
XWIKI-22798: The code macro is missing a required rights analyzer

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/pom.xml
@@ -68,5 +68,10 @@
       <artifactId>xwiki-platform-security-authorization-api</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-security-requiredrights-macro</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 </project>

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/main/java/org/xwiki/rendering/internal/macro/code/CodeMacroRequiredRightsAnalyzer.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/main/java/org/xwiki/rendering/internal/macro/code/CodeMacroRequiredRightsAnalyzer.java
@@ -1,0 +1,71 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rendering.internal.macro.code;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.platform.security.requiredrights.MacroRequiredRight;
+import org.xwiki.platform.security.requiredrights.MacroRequiredRightReporter;
+import org.xwiki.platform.security.requiredrights.MacroRequiredRightsAnalyzer;
+import org.xwiki.properties.BeanManager;
+import org.xwiki.properties.PropertyException;
+import org.xwiki.rendering.block.MacroBlock;
+import org.xwiki.rendering.macro.code.CodeMacroParameters;
+
+import static org.xwiki.rendering.macro.source.MacroContentSourceReference.TYPE_SCRIPT;
+
+/**
+ * Required rights analyzer for the code macro.
+ *
+ * @version $Id$
+ * @since 16.4.7
+ * @since 16.10.3
+ * @since 17.0.0
+ */
+@Component
+@Singleton
+@Named("code")
+public class CodeMacroRequiredRightsAnalyzer implements MacroRequiredRightsAnalyzer
+{
+    @Inject
+    private BeanManager beanManager;
+
+    @Override
+    public void analyze(MacroBlock macroBlock, MacroRequiredRightReporter reporter)
+    {
+        CodeMacroParameters parameters = new CodeMacroParameters();
+
+        try {
+            this.beanManager.populate(parameters, macroBlock.getParameters());
+
+            if (parameters.getSource() != null && TYPE_SCRIPT.equals(parameters.getSource().getType())) {
+                reporter.report(macroBlock, List.of(MacroRequiredRight.SCRIPT),
+                    "rendering.macro.code.requiredRights.scriptSource");
+            }
+        } catch (PropertyException e) {
+            // Ignore, the macro won't be executed when populating the parameters fails.
+        }
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/main/resources/ApplicationResources.properties
@@ -1,0 +1,46 @@
+# ---------------------------------------------------------------------------
+# See the NOTICE file distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+# ---------------------------------------------------------------------------
+
+###############################################################################
+# XWiki Core localization
+#
+# This contains the translations of the module in the default language
+# (generally English).
+# 
+# See https://dev.xwiki.org/xwiki/bin/view/Community/L10N/Conventions/ for more details about about
+# translation key naming.
+#
+# Comments: it's possible to add some detail about a key to make easier to
+#   translate it by adding a comment before it. To make sure a comment is not
+#   assigned to the following key use at least three sharps (###) for the comment
+#   or after it.
+# 
+# Deprecated keys:
+#   * when deleting a key it should be moved to deprecated section at the end
+#     of the file (between #@deprecatedstart and #@deprecatedend) and associated to the
+#     first version in which it started to be deprecated
+#   * when renaming a key, it should be moved to the same deprecated section
+#     and a comment should be added with the following syntax:
+#     #@deprecated new.key.name
+#     old.key.name=Some translation
+###############################################################################
+
+rendering.macro.code.requiredRights.scriptSource=Referencing a script variable in the source parameter \
+  of the code macro requires script right.

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/main/resources/META-INF/components.txt
@@ -1,4 +1,5 @@
 org.xwiki.rendering.internal.macro.code.CodeMacro
+org.xwiki.rendering.internal.macro.code.CodeMacroRequiredRightsAnalyzer
 org.xwiki.rendering.internal.macro.code.source.DefaultCodeMacroSourceFactory
 org.xwiki.rendering.internal.macro.code.source.ScriptCodeMacroSourceFactory
 org.xwiki.rendering.internal.macro.code.source.StringCodeMacroSourceFactory

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/test/java/org/xwiki/rendering/internal/macro/code/CodeMacroRequiredRightsAnalyzerTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/test/java/org/xwiki/rendering/internal/macro/code/CodeMacroRequiredRightsAnalyzerTest.java
@@ -1,0 +1,118 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rendering.internal.macro.code;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.mockito.Mock;
+import org.xwiki.platform.security.requiredrights.MacroRequiredRight;
+import org.xwiki.platform.security.requiredrights.MacroRequiredRightReporter;
+import org.xwiki.properties.BeanManager;
+import org.xwiki.properties.PropertyException;
+import org.xwiki.rendering.block.MacroBlock;
+import org.xwiki.rendering.macro.code.CodeMacroParameters;
+import org.xwiki.rendering.macro.source.MacroContentSourceReference;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.xwiki.rendering.macro.source.MacroContentSourceReference.TYPE_SCRIPT;
+import static org.xwiki.rendering.macro.source.MacroContentSourceReference.TYPE_STRING;
+
+/**
+ * Unit test for {@link CodeMacroRequiredRightsAnalyzer}.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+class CodeMacroRequiredRightsAnalyzerTest
+{
+    @InjectMockComponents
+    private CodeMacroRequiredRightsAnalyzer analyzer;
+
+    @MockComponent
+    private BeanManager beanManager;
+
+    @Mock
+    private MacroRequiredRightReporter reporter;
+
+    @Mock
+    private MacroBlock macroBlock;
+
+    private void setupMock(MacroContentSourceReference source) throws PropertyException
+    {
+        doAnswer(invocation -> {
+            CodeMacroParameters params = invocation.getArgument(0);
+            params.setSource(source);
+            return null;
+        }).when(this.beanManager).populate(any(), anyMap());
+    }
+
+    @Test
+    void analyzeWithScriptSource() throws PropertyException
+    {
+        setupMock(new MacroContentSourceReference(TYPE_SCRIPT, "script"));
+
+        this.analyzer.analyze(this.macroBlock, this.reporter);
+
+        verify(this.reporter).report(this.macroBlock, List.of(MacroRequiredRight.SCRIPT),
+            "rendering.macro.code.requiredRights.scriptSource");
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideSourceReferences")
+    @NullSource
+    void analyzeWithSource(MacroContentSourceReference source) throws PropertyException
+    {
+        setupMock(source);
+
+        this.analyzer.analyze(this.macroBlock, this.reporter);
+
+        verifyNoInteractions(this.reporter);
+    }
+
+    private static Stream<MacroContentSourceReference> provideSourceReferences()
+    {
+        return Stream.of(
+            new MacroContentSourceReference(TYPE_STRING, "non-script")
+        );
+    }
+
+    @Test
+    void analyzeWithPropertyException() throws PropertyException
+    {
+        doThrow(PropertyException.class).when(this.beanManager).populate(any(), anyMap());
+
+        this.analyzer.analyze(this.macroBlock, this.reporter);
+
+        verifyNoInteractions(this.reporter);
+    }
+}


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22798

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Add a required rights analyzer for the code macro.
* Add a test.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The bean manager is used to initialize the parameters to make sure that the behavior is exactly as in the actual macro execution.
* I don't think other sources should require any special rights.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

![grafik](https://github.com/user-attachments/assets/eebaf119-7381-4b67-b314-eed5a7fb0794)

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
LANG=C.UTF-8 mvn clean install -Pdocker,legacy,integration-tests,quality -pl :xwiki-platform-rendering-macro-code                       
```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-16.4.x
  * stable-16.10.x
  * stable-17.0.x