### PR TITLE
XWIKI-22800: Message boxes content doesn't extend to the right of the box

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/messages.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/messages.less
@@ -44,14 +44,15 @@ div.successmessage, div.errormessage, div.warningmessage, div.infomessage {
     max-width: unset;
   }
 
-  & > div > .box-title {
-    font-weight: bold;
-  }
-
-  // Main message content
+  // Main message block
   & > div {
     margin: 0;
     flex-grow: 1;
+    
+    // By default the title is bold.
+    & > .box-title {
+      font-weight: bold;
+    }
   }
 }
 

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/messages.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/messages.less
@@ -44,15 +44,14 @@ div.successmessage, div.errormessage, div.warningmessage, div.infomessage {
     max-width: unset;
   }
 
-  & > div > .box-title,
-  & > div > .xwiki-metadata-container[data-xwiki-parameter-name="title"] {
+  & > div > .box-title {
     font-weight: bold;
   }
 
   // Main message content
-  & > div > p,
-  & > div > [data-cke-display-name="$content"] {
+  & > div {
     margin: 0;
+    flex-grow: 1;
   }
 }
 


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22800

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Cleaned up selectors. With the new improved DOM, there's no need for selectors specific to CKeditor
* Added `flex-grow` on the content+title+image element. This way, whatever is in it, it will use all the available space in the macro.


## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

NA

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Before the PR:
![Screenshot from 2025-01-20 17-03-01](https://github.com/user-attachments/assets/31fc1f85-898c-41c7-9223-c323671c51cc)
After the PR:
![Screenshot from 2025-01-20 17-10-43](https://github.com/user-attachments/assets/667c257e-ba4f-4c42-af2f-42835bf6fde4)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Style change only. We don't have automatic tests to check their validity. I ran manual tests on my local instance. AFAICS these changes did not break the style and only fixed the place that was faulty. The most dangerous thing is that I removed the CKEditor specific selectors. From what I can remember, we needed them at first because the structure was different. With the current structure, in standard WYSIWYG mode as well as in inline mode, these new selectors seem to be enough.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X , like XWIKI-21452 (cause)