### PR TITLE
XWIKI-22706: The text on registration page is cut after applying invalid input

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/Registration.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/Registration.xml
@@ -344,15 +344,17 @@
   ## Display the heading
   $registrationConfig.heading
   ## If the submit button has been pressed, then we test the input and maybe create the user.
-#if($request.getParameter('xwikiname'))
-## Do server side validation of input fields.
-## This must not be in a #set directive as it will output messages if something goes wrong.
-#validateFields($fields, $request)
-## If server side validation was successfull, create the user
-#if($allFieldsValid)
-#createUser($fields, $request, $response, $doAfterRegistration)
-#end
-#end
+  #if($request.getParameter('xwikiname'))
+    ## Do server side validation of input fields.
+    ## This will output messages if something goes wrong, nothing if everything is alright.
+    ## We need to trim the output so that we can keep indentations in the validation script.
+    #set ($validationText = $stringtool.trim("#validateFields($fields, $request)"))
+    $validationText##
+    ## If server side validation was successfull, create the user
+    #if($allFieldsValid)
+      #createUser($fields, $request, $response, $doAfterRegistration)
+    #end
+  #end
   ## If the registration was not successful or if the user hasn't submitted the info yet
   ## Then we display the registration form.
   #if(!$registrationDone)

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/Registration.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/Registration.xml
@@ -344,15 +344,15 @@
   ## Display the heading
   $registrationConfig.heading
   ## If the submit button has been pressed, then we test the input and maybe create the user.
-  #if($request.getParameter('xwikiname'))
-    ## Do server side validation of input fields.
-    ## This must not be in a #set directive as it will output messages if something goes wrong.
-    #validateFields($fields, $request)
-    ## If server side validation was successfull, create the user
-    #if($allFieldsValid)
-      #createUser($fields, $request, $response, $doAfterRegistration)
-    #end
-  #end
+#if($request.getParameter('xwikiname'))
+## Do server side validation of input fields.
+## This must not be in a #set directive as it will output messages if something goes wrong.
+#validateFields($fields, $request)
+## If server side validation was successfull, create the user
+#if($allFieldsValid)
+#createUser($fields, $request, $response, $doAfterRegistration)
+#end
+#end
   ## If the registration was not successful or if the user hasn't submitted the info yet
   ## Then we display the registration form.
   #if(!$registrationDone)

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/Registration.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/Registration.xml
@@ -350,7 +350,7 @@
     ## We need to trim the output so that we can keep indentations in the validation script.
     #set ($validationText = $stringtool.trim("#validateFields($fields, $request)"))
     $validationText##
-    ## If server side validation was successfull, create the user
+    ## If server side validation was successful, create the user
     #if($allFieldsValid)
       #createUser($fields, $request, $response, $doAfterRegistration)
     #end


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22706

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Trimmed the output of the validation script so that it doesn't disturb the layout when there's no error message.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* See comments in the code.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
The state before the PR was buggy, see Jira ticket. 
Here is the form before any submission:
![Screenshot from 2025-01-21 16-54-12](https://github.com/user-attachments/assets/41664c49-7219-40cf-9a45-74f971d5c82a)

Here is the form after a submission done as described in the ticket def:
![Screenshot from 2025-01-21 17-19-44](https://github.com/user-attachments/assets/b4308c9b-e4f3-4528-bcdd-04b309aa47a7)

Here is the form with an error returned by the serverside validation (for the sake of ease of testing, I simulated such an error message by updating the `register_macros.vm` template a bit):
![Screenshot from 2025-01-21 16-53-32](https://github.com/user-attachments/assets/00df71af-7873-4118-bd70-c307e916d655)
I wanted to make sure everything was alright here since my change somehow went against the previous comment.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
The content impacted here looked definitely buggy. If this content had been tested in automatic tests, it would have been caught by CI, but it didn't.
This is a very low width change (the change does not impact multiple UIs or use cases), but pretty high impact since a lot of users will come into contact with the register UI at least once.
See the screenshots above, on the use case, the impact of these changes are controlled. I managed to successfully register even with the changes.

I successfully built `mvn clean install -f xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui -Pquality` with the changes.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.3 (high impact but relatively low risk)