### PR TITLE
XWIKI-22801: Toggles aren't displayed as expected when using "Notifications System Filters Preferences" macro

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsSystemFiltersPreferencesMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsSystemFiltersPreferencesMacro.xml
@@ -134,7 +134,7 @@
   ]
 });
 
-require(['jquery', 'xwiki-l10n!notifications-system-filters-preferences-macro', 'vue', 'xwiki-platform-notifications-webjar'], function ($, l10n, Vue, notifications) {
+require(['jquery', 'xwiki-l10n!notifications-system-filters-preferences-macro', 'vue', 'xwiki-platform-notifications-webjar', 'xwiki-bootstrap-switch'], function ($, l10n, Vue, notifications) {
   Vue.component('DisplayerToggle', notifications.DisplayerToggle)
   Vue.component('DisplayerStaticList', notifications.DisplayerStaticList);
 


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22801

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Add missing dependency to xwiki-bootstrap-switch in the javascript of NotificationSystemFilterPreferences

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* N/A

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

mvn clean install -Pquality,integration-tests,docker on notification module

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 17.0.x
  * 16.10.x
  * 16.4.x