### PR TITLE
XWIKI-22807: Livedata REST result have inconsistent results when called concurrently

### DIFF
--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/AnnotationsRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/AnnotationsRESTResource.java
@@ -20,7 +20,6 @@
 package org.xwiki.annotation.rest.internal;
 
 import javax.inject.Named;
-import javax.inject.Singleton;
 import javax.ws.rs.Encoded;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -41,7 +40,6 @@ import org.xwiki.rest.XWikiRestException;
 @Component
 @Named("org.xwiki.annotation.rest.internal.AnnotationsRESTResource")
 @Path("/wikis/{wikiName}/spaces/{spaceName: .+}/pages/{pageName}/annotations")
-@Singleton
 public class AnnotationsRESTResource extends AbstractAnnotationsRESTResource
 {
     /**

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/AnnotationsTranslationRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/AnnotationsTranslationRESTResource.java
@@ -22,7 +22,6 @@ package org.xwiki.annotation.rest.internal;
 import java.util.Locale;
 
 import javax.inject.Named;
-import javax.inject.Singleton;
 import javax.ws.rs.Encoded;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -45,7 +44,6 @@ import org.xwiki.rest.XWikiRestException;
 @Component
 @Named("org.xwiki.annotation.rest.internal.AnnotationsTranslationRESTResource")
 @Path("/wikis/{wikiName}/spaces/{spaceName: .+}/pages/{pageName}/translations/{language}/annotations")
-@Singleton
 public class AnnotationsTranslationRESTResource extends AbstractAnnotationsRESTResource
 {
     /**

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/SingleAnnotationRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/SingleAnnotationRESTResource.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 import java.util.Map;
 
 import javax.inject.Named;
-import javax.inject.Singleton;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.Encoded;
 import javax.ws.rs.PUT;
@@ -54,7 +53,6 @@ import com.xpn.xwiki.XWikiException;
 @Component
 @Named("org.xwiki.annotation.rest.internal.SingleAnnotationRESTResource")
 @Path("/wikis/{wikiName}/spaces/{spaceName: .+}/pages/{pageName}/annotation/{id}")
-@Singleton
 public class SingleAnnotationRESTResource extends AbstractAnnotationRESTResource
 {
     /**

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/internal/rest/DefaultLiveDataEntriesResource.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/internal/rest/DefaultLiveDataEntriesResource.java
@@ -29,7 +29,6 @@ import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-import javax.inject.Singleton;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
@@ -55,13 +54,12 @@ import org.xwiki.rest.model.jaxb.Link;
 
 /**
  * Default implementation of {@link LiveDataEntriesResource}.
- * 
+ *
  * @version $Id$
  * @since 12.10
  */
 @Component
 @Named("org.xwiki.livedata.internal.rest.DefaultLiveDataEntriesResource")
-@Singleton
 public class DefaultLiveDataEntriesResource extends AbstractLiveDataResource implements LiveDataEntriesResource
 {
     private static final String FILTERS_PREFIX = "filters.";
@@ -181,7 +179,7 @@ public class DefaultLiveDataEntriesResource extends AbstractLiveDataResource imp
     private LiveDataConfiguration initConfig(String sourceId, List<String> properties, List<String> matchAll,
         List<String> sort, List<Boolean> descending, long offset, int limit) throws LiveDataException
     {
-        // Workaround for https://github.com/restlet/restlet-framework-java/issues/922 (JaxRs multivalue 
+        // Workaround for https://github.com/restlet/restlet-framework-java/issues/922 (JaxRs multivalue
         // query-params gives list with null element).
         List<String> actualProperties = properties.stream().filter(Objects::nonNull).collect(Collectors.toList());
         List<String> actualMatchAll = matchAll.stream().filter(Objects::nonNull).collect(Collectors.toList());

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/internal/rest/DefaultLiveDataEntryPropertyResource.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/internal/rest/DefaultLiveDataEntryPropertyResource.java
@@ -22,7 +22,6 @@ package org.xwiki.livedata.internal.rest;
 import java.util.Optional;
 
 import javax.inject.Named;
-import javax.inject.Singleton;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -36,13 +35,12 @@ import org.xwiki.livedata.rest.LiveDataEntryPropertyResource;
 
 /**
  * Default implementation of {@link LiveDataEntryPropertyResource}.
- * 
+ *
  * @version $Id$
  * @since 12.10
  */
 @Component
 @Named("org.xwiki.livedata.internal.rest.DefaultLiveDataEntryPropertyResource")
-@Singleton
 public class DefaultLiveDataEntryPropertyResource extends AbstractLiveDataResource
     implements LiveDataEntryPropertyResource
 {

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/internal/rest/DefaultLiveDataEntryResource.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/internal/rest/DefaultLiveDataEntryResource.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import javax.inject.Named;
-import javax.inject.Singleton;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -38,13 +37,12 @@ import org.xwiki.livedata.rest.model.jaxb.Entry;
 
 /**
  * Default implementation of {@link LiveDataEntryResource}.
- * 
+ *
  * @version $Id$
  * @since 12.10
  */
 @Component
 @Named("org.xwiki.livedata.internal.rest.DefaultLiveDataEntryResource")
-@Singleton
 public class DefaultLiveDataEntryResource extends AbstractLiveDataResource implements LiveDataEntryResource
 {
     @Override
@@ -78,7 +76,7 @@ public class DefaultLiveDataEntryResource extends AbstractLiveDataResource imple
                 try {
                     values = entryStore.get(updatedEntryId.get());
                 } catch (UnsupportedOperationException e) {
-                    // Returns a success response without an entity when the entry store does not implement the get 
+                    // Returns a success response without an entity when the entry store does not implement the get
                     // operation (for instance the liveTable source).
                     return Response.status(Status.ACCEPTED).build();
                 }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/internal/rest/DefaultLiveDataPropertiesResource.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/internal/rest/DefaultLiveDataPropertiesResource.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.inject.Named;
-import javax.inject.Singleton;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
@@ -45,13 +44,12 @@ import org.xwiki.rest.model.jaxb.Link;
 
 /**
  * Default implementation of {@link LiveDataPropertiesResource}.
- * 
+ *
  * @version $Id$
  * @since 12.10
  */
 @Component
 @Named("org.xwiki.livedata.internal.rest.DefaultLiveDataPropertiesResource")
-@Singleton
 public class DefaultLiveDataPropertiesResource extends AbstractLiveDataResource implements LiveDataPropertiesResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/internal/rest/DefaultLiveDataPropertyResource.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/internal/rest/DefaultLiveDataPropertyResource.java
@@ -22,7 +22,6 @@ package org.xwiki.livedata.internal.rest;
 import java.util.Optional;
 
 import javax.inject.Named;
-import javax.inject.Singleton;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -36,13 +35,12 @@ import org.xwiki.livedata.rest.model.jaxb.PropertyDescriptor;
 
 /**
  * Default implementation of {@link LiveDataPropertyResource}.
- * 
+ *
  * @version $Id$
  * @since 12.10
  */
 @Component
 @Named("org.xwiki.livedata.internal.rest.DefaultLiveDataPropertyResource")
-@Singleton
 public class DefaultLiveDataPropertyResource extends AbstractLiveDataResource implements LiveDataPropertyResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/internal/rest/DefaultLiveDataPropertyTypeResource.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/internal/rest/DefaultLiveDataPropertyTypeResource.java
@@ -23,7 +23,6 @@ import java.util.Objects;
 import java.util.Optional;
 
 import javax.inject.Named;
-import javax.inject.Singleton;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
@@ -36,13 +35,12 @@ import org.xwiki.livedata.rest.model.jaxb.PropertyDescriptor;
 
 /**
  * Default implementation of {@link LiveDataPropertyTypeResource}.
- * 
+ *
  * @version $Id$
  * @since 12.10
  */
 @Component
 @Named("org.xwiki.livedata.internal.rest.DefaultLiveDataPropertyTypeResource")
-@Singleton
 public class DefaultLiveDataPropertyTypeResource extends AbstractLiveDataResource
     implements LiveDataPropertyTypeResource
 {

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/internal/rest/DefaultLiveDataPropertyTypesResource.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/internal/rest/DefaultLiveDataPropertyTypesResource.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.inject.Named;
-import javax.inject.Singleton;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
@@ -43,13 +42,12 @@ import org.xwiki.rest.model.jaxb.Link;
 
 /**
  * Default implementation of {@link LiveDataPropertyTypesResource}.
- * 
+ *
  * @version $Id$
  * @since 12.10
  */
 @Component
 @Named("org.xwiki.livedata.internal.rest.DefaultLiveDataPropertyTypesResource")
-@Singleton
 public class DefaultLiveDataPropertyTypesResource extends AbstractLiveDataResource
     implements LiveDataPropertyTypesResource
 {

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/internal/rest/DefaultLiveDataSourceResource.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/internal/rest/DefaultLiveDataSourceResource.java
@@ -22,7 +22,6 @@ package org.xwiki.livedata.internal.rest;
 import java.util.Optional;
 
 import javax.inject.Named;
-import javax.inject.Singleton;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
@@ -34,13 +33,12 @@ import org.xwiki.livedata.rest.model.jaxb.Source;
 
 /**
  * Default implementation of {@link LiveDataSourceResource}.
- * 
+ *
  * @version $Id$
  * @since 12.10
  */
 @Component
 @Named("org.xwiki.livedata.internal.rest.DefaultLiveDataSourceResource")
-@Singleton
 public class DefaultLiveDataSourceResource extends AbstractLiveDataResource implements LiveDataSourceResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/internal/rest/DefaultLiveDataSourcesResource.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/internal/rest/DefaultLiveDataSourcesResource.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.inject.Named;
-import javax.inject.Singleton;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
@@ -38,13 +37,12 @@ import org.xwiki.rest.model.jaxb.Link;
 
 /**
  * Default implementation of {@link LiveDataSourcesResource}.
- * 
+ *
  * @version $Id$
  * @since 12.10
  */
 @Component
 @Named("org.xwiki.livedata.internal.rest.DefaultLiveDataSourcesResource")
-@Singleton
 public class DefaultLiveDataSourcesResource extends AbstractLiveDataResource implements LiveDataSourcesResource
 {
     @Override

--- a/xwiki-platform-core/xwiki-platform-netflux/xwiki-platform-netflux-rest/src/main/java/org/xwiki/netflux/internal/rest/DefaultPageChannelsResource.java
+++ b/xwiki-platform-core/xwiki-platform-netflux/xwiki-platform-netflux-rest/src/main/java/org/xwiki/netflux/internal/rest/DefaultPageChannelsResource.java
@@ -29,7 +29,6 @@ import java.util.stream.Stream;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-import javax.inject.Singleton;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response.Status;
 
@@ -47,13 +46,12 @@ import org.xwiki.security.authorization.Right;
 
 /**
  * Default implementation of {@link PageChannelsResource}.
- * 
+ *
  * @version $Id$
  * @since 13.9RC1
  */
 @Component
 @Named("org.xwiki.netflux.internal.rest.DefaultPageChannelsResource")
-@Singleton
 public class DefaultPageChannelsResource extends XWikiResource implements PageChannelsResource
 {
     private static final String PATH_SEPARATOR = "/";

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/ExtensionRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/ExtensionRESTResource.java
@@ -21,7 +21,6 @@
 package org.xwiki.repository.internal.resources;
 
 import javax.inject.Named;
-import javax.inject.Singleton;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -41,7 +40,6 @@ import com.xpn.xwiki.doc.XWikiDocument;
 @Component
 @Named("org.xwiki.repository.internal.resources.ExtensionRESTResource")
 @Path(Resources.EXTENSION)
-@Singleton
 public class ExtensionRESTResource extends AbstractExtensionRESTResource
 {
     @GET

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/ExtensionVersionFileRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/ExtensionVersionFileRESTResource.java
@@ -27,7 +27,6 @@ import java.net.URL;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-import javax.inject.Singleton;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -77,7 +76,6 @@ import com.xpn.xwiki.objects.BaseObject;
 @Component
 @Named("org.xwiki.repository.internal.resources.ExtensionVersionFileRESTResource")
 @Path(Resources.EXTENSION_VERSION_FILE)
-@Singleton
 public class ExtensionVersionFileRESTResource extends AbstractExtensionRESTResource
 {
     @Inject

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/ExtensionVersionRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/ExtensionVersionRESTResource.java
@@ -21,7 +21,6 @@
 package org.xwiki.repository.internal.resources;
 
 import javax.inject.Named;
-import javax.inject.Singleton;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -41,7 +40,6 @@ import com.xpn.xwiki.doc.XWikiDocument;
 @Component
 @Named("org.xwiki.repository.internal.resources.ExtensionVersionRESTResource")
 @Path(Resources.EXTENSION_VERSION)
-@Singleton
 public class ExtensionVersionRESTResource extends AbstractExtensionRESTResource
 {
     @GET

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/ExtensionVersionsRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/ExtensionVersionsRESTResource.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 
 import javax.inject.Named;
-import javax.inject.Singleton;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -55,7 +54,6 @@ import org.xwiki.repository.Resources;
 @Component
 @Named("org.xwiki.repository.internal.resources.ExtensionVersionsRESTResource")
 @Path(Resources.EXTENSION_VERSIONS)
-@Singleton
 public class ExtensionVersionsRESTResource extends AbstractExtensionRESTResource
 {
     @GET

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/ExtensionsRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/ExtensionsRESTResource.java
@@ -21,7 +21,6 @@
 package org.xwiki.repository.internal.resources;
 
 import javax.inject.Named;
-import javax.inject.Singleton;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -40,7 +39,6 @@ import org.xwiki.repository.Resources;
 @Component
 @Named("org.xwiki.repository.internal.resources.ExtensionsRESTResource")
 @Path(Resources.EXTENSIONS)
-@Singleton
 public class ExtensionsRESTResource extends AbstractExtensionRESTResource
 {
     @GET

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/RepositoryRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/RepositoryRESTResource.java
@@ -21,7 +21,6 @@
 package org.xwiki.repository.internal.resources;
 
 import javax.inject.Named;
-import javax.inject.Singleton;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 
@@ -36,7 +35,6 @@ import org.xwiki.repository.Resources;
 @Component
 @Named("org.xwiki.repository.internal.resources.RepositoryRESTResource")
 @Path(Resources.ENTRYPOINT)
-@Singleton
 public class RepositoryRESTResource extends AbstractExtensionRESTResource
 {
     /**

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/SearchRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/SearchRESTResource.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.inject.Named;
-import javax.inject.Singleton;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -55,7 +54,6 @@ import org.xwiki.repository.internal.XWikiRepositoryModel;
 @Component
 @Named("org.xwiki.repository.internal.resources.SearchRESTResource")
 @Path(Resources.SEARCH)
-@Singleton
 public class SearchRESTResource extends AbstractExtensionRESTResource
 {
     /**


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22807

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* race condition when several livedata requests are executed concurrently

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* remove all the `@Singleton` annotations from children of XWikiResource, in particular on `DefaultLiveDataEntriesResource`, to prevent `org.xwiki.rest.XWikiResource#uriInfo` to be shared between requests.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

- [x] `mvn clean install -Pquality -pl :xwiki-platform-annotation-rest,:xwiki-platform-livedata-rest,:xwiki-platform-netflux-rest,:xwiki-platform-repository-server-api -amd`
- run all the functional tests from annotation, livedata, netflux and repository server
  - [x] `mvn clean install -f xwiki-platform-core/xwiki-platform-annotation -Pintegration-tests,docker`
  - [x] `mvn clean install -f xwiki-platform-core/xwiki-platform-livedata -Pintegration-tests,docker`
  - [x] `mvn clean install -f xwiki-platform-core/xwiki-platform-netflux -Pintegration-tests,docker`
  - [x] `mvn clean install -f xwiki-platform-core/xwiki-platform-repository -Pintegration-tests,docker`
- [x] run all the functional tests using page objects from the impacted modules `mvn clean install -Pintegration-tests,docker -pl :xwiki-platform-livedata-test-pageobjects,:xwiki-platform-annotation-test-pageobjects,:xwiki-platform-repository-test-pageobjects -amd`
- [x] manual test on jetty hsqldb

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-16.4.x
  * stable-16.10.x
  * stable-17.0.x