### PR TITLE
XWIKI-11544: Impossible to access the drawer menu with javascript deactivated

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/drawer.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/drawer.less
@@ -24,8 +24,6 @@
   right: -@xwiki-drawer-width;
 }
 
-
-
 #tmDrawer.drawer-nav {
   background-color: @xwiki-drawer-bg;
   width: @xwiki-drawer-width;
@@ -171,6 +169,16 @@
     color: @xwiki-drawer-menu-category-color;
     padding: @xwiki-drawer-menu-item-padding;
     font-size: larger;
+  }
+}
+
+@media (scripting: none), (scripting: initial-only) {
+  /* If scripting (understand here: javascript) is not supported on the current context, then we want to 
+    make sure the dialog which is closed by default is still visible. 
+    It's not looking very good but at least it works :) */
+  #tmDrawer.drawer-nav {
+    display: block;
+    margin-right: 0;
   }
 }
 

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/drawer.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/drawer.less
@@ -24,6 +24,8 @@
   right: -@xwiki-drawer-width;
 }
 
+
+
 #tmDrawer.drawer-nav {
   background-color: @xwiki-drawer-bg;
   width: @xwiki-drawer-width;


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-11544

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added a media query to display the drawer even when javascript is deactivated.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* By default, a non opened drawer will not be displayed. We need to display it and make sure it's in the page view by setting the margin to zero.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

After the PR:
![Screenshot from 2025-01-23 11-29-53](https://github.com/user-attachments/assets/3346fd06-2298-4cf8-aca2-d055fd41f018)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
This is a style change only on a very specific context. We don't have automatic tests for this. 
See the screenshot of a manual test on my local instance. In order to deactivate javascript in my Firefox, I used the `javascript.enabled` advanced parameter.
# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X