### PR TITLE
XWIKI-22814: Dashboard buttons layout is broken when there's a warning message

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/dashboard/dashboard.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/dashboard/dashboard.js
@@ -80,12 +80,18 @@ XWiki.Dashboard = Class.create( {
     // find out all the gadget-containers in element and add them ids
     this.containers = element.select(".gadget-container");
     this.createDragAndDrops();
-    this.addGadgetsHandlers();``
+    this.addGadgetsHandlers();
     // Create the section to contain add buttons
     var sectionAddButtons = new Element('section', {
       'class': 'containeradd'
-    })
-    this.element.insert({'top' : sectionAddButtons});
+    });
+    // check if the warning is there, if it is, put the button under it
+    var warning = this.element.down('.differentsource');
+    if (warning) {
+      warning.insert({'after' : sectionAddButtons});
+    } else {
+      this.element.insert({'top' : sectionAddButtons});
+    }
     this.addNewGadgetHandler();
     this.addNewContainerHandler();
 
@@ -295,13 +301,7 @@ XWiki.Dashboard = Class.create( {
     });
     addButton.update(icons.add + l10n['dashboard.actions.add.button']);
     addButton.observe('click', this.onAddGadgetClick.bindAsEventListener(this));
-    // check if the warning is there, if it is, put the button under it
-    var warning = this.element.down('.differentsource');
-    if (warning) {
-      warning.insert({'after' : addButton});
-    } else {
-      this.element.down('.containeradd').insert(addButton);
-    }
+    this.element.down('.containeradd').insert(addButton);
   },
 
   /**


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22814

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Fixed the layout construction to make sure everything is fine if there's a warning box.
* Removed typos

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Instead of placing the buttons after the warning message if there's one, we should have placed their container. Should have been done when adding this container in [XWIKI-11043](https://github.com/xwiki/xwiki-platform/pull/2648).

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Before the PR:
![image](https://github.com/user-attachments/assets/8996fdcb-3028-47cc-9daa-5da98e5948b9)

After the PR:
![Screenshot from 2025-01-24 11-15-32](https://github.com/user-attachments/assets/e8228f06-2225-47f6-8e7c-d0f1a3172d44)
![image](https://github.com/user-attachments/assets/9085e6f0-2d5c-40bb-afb5-fd86dd3357d1)

![Screenshot from 2025-01-24 11-15-09](https://github.com/user-attachments/assets/3b5dcbf5-30d8-483a-85eb-610559fe448c)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Successfully built the changes with `mvn clean install -f xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war -Pquality`.
Manual tests as seen in the screenshots above.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X