### PR TITLE
XWIKI-22817: Dashboards of users without script right have translation calls in gadget titles

### DIFF
--- a/xwiki-platform-core/xwiki-platform-dashboard/xwiki-platform-dashboard-macro/src/main/java/org/xwiki/rendering/internal/macro/dashboard/DefaultGadgetSource.java
+++ b/xwiki-platform-core/xwiki-platform-dashboard/xwiki-platform-dashboard-macro/src/main/java/org/xwiki/rendering/internal/macro/dashboard/DefaultGadgetSource.java
@@ -23,6 +23,8 @@ import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -33,6 +35,7 @@ import org.apache.velocity.VelocityContext;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.context.Execution;
 import org.xwiki.job.event.status.JobProgressManager;
+import org.xwiki.localization.ContextualLocalizationManager;
 import org.xwiki.model.EntityType;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.DocumentReferenceResolver;
@@ -79,6 +82,9 @@ public class DefaultGadgetSource implements GadgetSource
     protected static final EntityReference GADGET_CLASS =
         new EntityReference("GadgetClass", EntityType.DOCUMENT, new EntityReference("XWiki", EntityType.SPACE));
 
+    static final Pattern TRANSLATION_SCRIPT_PATTERN =
+        Pattern.compile("\\s*\\$services\\.localization\\.render\\(\\s*'([a-zA-Z0-9.]+)'\\s*\\)\\s*");
+
     /**
      * The execution context, to grab XWiki context and access to documents.
      */
@@ -121,6 +127,9 @@ public class DefaultGadgetSource implements GadgetSource
 
     @Inject
     private DocumentAuthorizationManager authorizationManager;
+
+    @Inject
+    private ContextualLocalizationManager localizationManager;
 
     /**
      * Prepare the parser to parse the title and content of the gadget into blocks.
@@ -196,17 +205,8 @@ public class DefaultGadgetSource implements GadgetSource
                 String position = xObject.getStringValue("position");
                 String id = xObject.getNumber() + "";
 
-                String gadgetTitle;
-
                 XWikiDocument ownerDocument = xObject.getOwnerDocument();
-                if (!ownerDocument.isRestricted() && this.authorizationManager.hasAccess(Right.SCRIPT,
-                    EntityType.DOCUMENT, ownerDocument.getAuthorReference(), ownerDocument.getDocumentReference()))
-                {
-                    gadgetTitle =
-                        this.evaluateVelocityTitle(velocityContext, velocityEngine, key, title, ownerDocument);
-                } else {
-                    gadgetTitle = title;
-                }
+                String gadgetTitle = evaluateTitle(title, ownerDocument, velocityContext, velocityEngine, key);
 
                 // parse both the title and content in the syntax of the transformation context
                 List<Block> titleBlocks =
@@ -228,6 +228,35 @@ public class DefaultGadgetSource implements GadgetSource
         }
 
         return gadgets;
+    }
+
+    private String evaluateTitle(String title, XWikiDocument ownerDocument, VelocityContext velocityContext,
+        VelocityEngine velocityEngine, String key) throws Exception
+    {
+        String gadgetTitle;
+        if (StringUtils.isBlank(title)) {
+            gadgetTitle = title;
+        } else {
+            // Gadgets are inserted with a localization script service call as title by default. To not break
+            // backwards compatibility with existing dashboards, just handle those translation calls directly here so
+            // they work even without scripting right.
+            Matcher matcher = TRANSLATION_SCRIPT_PATTERN.matcher(title);
+            if (matcher.matches()) {
+                String translationKey = matcher.group(1);
+                gadgetTitle = this.localizationManager.getTranslationPlain(translationKey);
+                if (gadgetTitle == null) {
+                    gadgetTitle = translationKey;
+                }
+            } else if (!ownerDocument.isRestricted() && this.authorizationManager.hasAccess(Right.SCRIPT,
+                EntityType.DOCUMENT, ownerDocument.getAuthorReference(), ownerDocument.getDocumentReference()))
+            {
+                gadgetTitle =
+                    this.evaluateVelocityTitle(velocityContext, velocityEngine, key, title, ownerDocument);
+            } else {
+                gadgetTitle = title;
+            }
+        }
+        return gadgetTitle;
     }
 
     private String evaluateVelocityTitle(VelocityContext velocityContext, VelocityEngine velocityEngine, String key,

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/dashboard/gadgetWizard.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/dashboard/gadgetWizard.js
@@ -68,8 +68,8 @@ define(['jquery', 'xwiki-ckeditor'], function($, ckeditorPromise) {
   };
 
   var getDefaultGadgetTitle = function(macroEditor) {
-    var gadgetName = macroEditor.attr('data-macroid').split('/')[0];
-    return "$services.localization.render('rendering.macro." + gadgetName + ".name')";
+    const gadgetName = macroEditor.attr('data-macroid').split('/')[0];
+    return '{{translation key="rendering.macro.' + gadgetName.replace('~', '~~').replace('"', '~"') + '.name"/}}';
   };
 
   var currentGadget;


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22817

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Catch titles with just a translation call and load the translation directly without evaluating any script.
* Adapt the required rights analyzer.
* Change the gadget wizard to produce a translation macro instead of a Velocity call.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The change in the JavaScript code isn't strictly necessary, but as we support wiki syntax in the titles, anyway, I thought it could be a nice solution to have something better supported for non-script users. The remaining changes are still necessary for fixing existing dashboards.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
LANG=C.UTF-8 mvn clean install -Pdocker,legacy,integration-tests,snapshotModules,quality -pl :xwiki-platform-dashboard-macro,:xwiki-platform-dashboard-test-docker
```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-16.10.x