### PR TITLE
XWIKI-22820: Solr field cache uses a lot of RAM

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-server/xwiki-platform-search-solr-server-core-search/src/main/resources/conf/managed-schema.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-server/xwiki-platform-search-solr-server-core-search/src/main/resources/conf/managed-schema.xml
@@ -367,7 +367,7 @@
     -->
 
     <!-- The StrField type is not analyzed, but indexed/stored verbatim. -->
-    <fieldType name="string" class="solr.StrField" sortMissingLast="true" />
+    <fieldType name="string" class="solr.StrField" sortMissingLast="true" docValues="true" />
     <fieldType name="strings" class="solr.StrField" sortMissingLast="true" multiValued="true" docValues="true" />
 
     <!-- boolean type: "true" or "false" -->


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22820

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Configure the "string" field type with docValues="true" as in the default configuration. In tests, this eliminates all fields in the field cache apart from the caches for title_sort and author_display_sort, which seem small in comparison.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* I don't know if we could or should also eliminate the field caches for the sorting caches, which seems to be the [lowercase](https://github.com/xwiki/xwiki-platform/blob/b4ca3da6a7eeaafba99e4076c708a3ea71a4a246/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-server/xwiki-platform-search-solr-server-core-search/src/main/resources/conf/managed-schema.xml#L636-L642) field type.
* I'm not sure if we should do anything for performing an automatic migration/re-indexing on upgrades.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Manual tests as mentioned above.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-16.10.x
  * stable-16.4.x