### PR TITLE
XWIKI-22821: Allow having generic analyzers for different types of macro arguments

### DIFF
--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/main/java/org/xwiki/platform/security/requiredrights/internal/analyzer/DefaultMacroBlockRequiredRightAnalyzer.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/main/java/org/xwiki/platform/security/requiredrights/internal/analyzer/DefaultMacroBlockRequiredRightAnalyzer.java
@@ -43,14 +43,12 @@ import org.xwiki.platform.security.requiredrights.MacroRequiredRightsAnalyzer;
 import org.xwiki.platform.security.requiredrights.RequiredRightAnalysisResult;
 import org.xwiki.platform.security.requiredrights.RequiredRightAnalyzer;
 import org.xwiki.platform.security.requiredrights.RequiredRightsException;
-import org.xwiki.properties.converter.Converter;
 import org.xwiki.rendering.block.Block;
 import org.xwiki.rendering.block.MacroBlock;
 import org.xwiki.rendering.macro.Macro;
 import org.xwiki.rendering.macro.descriptor.ContentDescriptor;
 import org.xwiki.rendering.macro.descriptor.ParameterDescriptor;
 import org.xwiki.rendering.macro.script.ScriptMacro;
-import org.xwiki.rendering.macro.source.MacroContentSourceReference;
 
 /**
  * Default analyzer for macro blocks. Recurses into the macro content if it is wiki syntax.
@@ -76,9 +74,6 @@ public class DefaultMacroBlockRequiredRightAnalyzer extends AbstractMacroBlockRe
 
     @Inject
     private Provider<DefaultMacroRequiredRightReporter> macroRequiredRightReporterProvider;
-
-    @Inject
-    private Converter<MacroContentSourceReference> macroContentSourceReferenceConverter;
 
     @Override
     public List<RequiredRightAnalysisResult> analyze(MacroBlock macroBlock)

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/main/resources/ApplicationResources.properties
@@ -79,6 +79,8 @@ security.requiredrights.macro.script.program=A [{0}] scripting macro requires pr
 security.requiredrights.macro.script.script=A [{0}] scripting macro requires script rights.
 security.requiredrights.macro.analyzer.error=An error occurred during the analysis of the macro [{0}]. \
   Please manually check which rights it requires including its contents. Root cause of the error: [{1}].
+security.requiredrights.macro.analyzer.parameterError=An error occurred during the analysis of the parameter [{0}] of \
+  the macro [{1}]. Please manually check which rights it requires. Root cause of the error: [{2}].
 
 ####################
 # For objects

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-macro/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-macro/pom.xml
@@ -34,13 +34,24 @@
     <xwiki.extension.name>Required Rights Macro Analysis API</xwiki.extension.name>
     <!-- Category to display in the Extension Manager. -->
     <xwiki.extension.category>api</xwiki.extension.category>
-    <xwiki.jacoco.instructionRatio>0.00</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>1.00</xwiki.jacoco.instructionRatio>
   </properties>
   <dependencies>
     <dependency>
       <groupId>org.xwiki.rendering</groupId>
       <artifactId>xwiki-rendering-api</artifactId>
       <version>${rendering.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.rendering</groupId>
+      <artifactId>xwiki-rendering-transformation-macro</artifactId>
+      <version>${rendering.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-tool-test-component</artifactId>
+      <version>${commons.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-macro/src/main/java/org/xwiki/platform/security/requiredrights/MacroParameterRequiredRightsAnalyzer.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-macro/src/main/java/org/xwiki/platform/security/requiredrights/MacroParameterRequiredRightsAnalyzer.java
@@ -30,7 +30,7 @@ import org.xwiki.stability.Unstable;
  * @param <T> the type of the macro parameter.
  * @version $Id$
  * @since 17.1.0RC1
- * @since 16.10.3
+ * @since 16.10.4
  * @since 16.4.7
  */
 // The type parameter isn't used in the interface itself, but it is used to differentiate component implementations

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-macro/src/main/java/org/xwiki/platform/security/requiredrights/MacroParameterRequiredRightsAnalyzer.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-macro/src/main/java/org/xwiki/platform/security/requiredrights/MacroParameterRequiredRightsAnalyzer.java
@@ -1,0 +1,54 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.platform.security.requiredrights;
+
+import org.xwiki.component.annotation.Role;
+import org.xwiki.rendering.block.MacroBlock;
+import org.xwiki.rendering.macro.descriptor.ParameterDescriptor;
+import org.xwiki.stability.Unstable;
+
+/**
+ * An analyzer for a macro parameter.
+ *
+ * @param <T> the type of the macro parameter.
+ * @version $Id$
+ * @since 17.1.0RC1
+ * @since 16.10.3
+ * @since 16.4.7
+ */
+// The type parameter isn't used in the interface itself, but it is used to differentiate component implementations
+// for different parameter types so it is definitely used.
+@SuppressWarnings("unused")
+@Role
+@Unstable
+public interface MacroParameterRequiredRightsAnalyzer<T>
+{
+    /**
+     * Analyzes the given parameter value in the given macro block and reports the required rights to the given
+     * reporter.
+     *
+     * @param macroBlock the macro block to analyze
+     * @param parameterDescriptor the descriptor of the parameter being analyzed
+     * @param value the value of the parameter being analyzed
+     * @param reporter the reporter to report the required rights to
+     */
+    void analyze(MacroBlock macroBlock, ParameterDescriptor parameterDescriptor,
+        String value, MacroRequiredRightReporter reporter);
+}

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-macro/src/main/java/org/xwiki/platform/security/requiredrights/internal/MacroContentSourceReferenceMacroParameterRequiredRightsAnalyzer.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-macro/src/main/java/org/xwiki/platform/security/requiredrights/internal/MacroContentSourceReferenceMacroParameterRequiredRightsAnalyzer.java
@@ -1,0 +1,68 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.platform.security.requiredrights.internal;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.platform.security.requiredrights.MacroParameterRequiredRightsAnalyzer;
+import org.xwiki.platform.security.requiredrights.MacroRequiredRight;
+import org.xwiki.platform.security.requiredrights.MacroRequiredRightReporter;
+import org.xwiki.properties.converter.Converter;
+import org.xwiki.rendering.block.MacroBlock;
+import org.xwiki.rendering.macro.descriptor.ParameterDescriptor;
+import org.xwiki.rendering.macro.source.MacroContentSourceReference;
+
+import static org.xwiki.rendering.macro.source.MacroContentSourceReference.TYPE_SCRIPT;
+
+/**
+ * Required rights analyzer for {@link MacroContentSourceReference} macro parameters. Reports script right for the
+ * script type.
+ *
+ * @version $Id$
+ * @since 17.1.0RC1
+ * @since 16.10.3
+ * @since 16.4.7
+ */
+@Component
+@Singleton
+public class MacroContentSourceReferenceMacroParameterRequiredRightsAnalyzer
+    implements MacroParameterRequiredRightsAnalyzer<MacroContentSourceReference>
+{
+    @Inject
+    private Converter<MacroContentSourceReference> macroContentSourceReferenceConverter;
+
+    @Override
+    public void analyze(MacroBlock macroBlock, ParameterDescriptor parameterDescriptor, String value,
+        MacroRequiredRightReporter reporter)
+    {
+        MacroContentSourceReference macroContentSourceReference =
+            this.macroContentSourceReferenceConverter.convert(MacroContentSourceReference.class, value);
+
+        if (TYPE_SCRIPT.equals(macroContentSourceReference.getType())) {
+            reporter.report(macroBlock, List.of(MacroRequiredRight.SCRIPT),
+                "security.requiredrights.macro.scriptContentSource",
+                parameterDescriptor.getId(), macroBlock.getId());
+        }
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-macro/src/main/java/org/xwiki/platform/security/requiredrights/internal/MacroContentSourceReferenceMacroParameterRequiredRightsAnalyzer.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-macro/src/main/java/org/xwiki/platform/security/requiredrights/internal/MacroContentSourceReferenceMacroParameterRequiredRightsAnalyzer.java
@@ -41,7 +41,7 @@ import static org.xwiki.rendering.macro.source.MacroContentSourceReference.TYPE_
  *
  * @version $Id$
  * @since 17.1.0RC1
- * @since 16.10.3
+ * @since 16.10.4
  * @since 16.4.7
  */
 @Component

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-macro/src/main/java/org/xwiki/platform/security/requiredrights/internal/WikiSyntaxMacroParameterRequiredRightsAnalyzer.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-macro/src/main/java/org/xwiki/platform/security/requiredrights/internal/WikiSyntaxMacroParameterRequiredRightsAnalyzer.java
@@ -1,0 +1,51 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.platform.security.requiredrights.internal;
+
+import java.util.List;
+
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.platform.security.requiredrights.MacroParameterRequiredRightsAnalyzer;
+import org.xwiki.platform.security.requiredrights.MacroRequiredRightReporter;
+import org.xwiki.rendering.block.Block;
+import org.xwiki.rendering.block.MacroBlock;
+import org.xwiki.rendering.macro.descriptor.ParameterDescriptor;
+
+/**
+ * Required rights analyzer for wiki syntax parameters.
+ *
+ * @version $Id$
+ * @since 17.1.0RC1
+ * @since 16.10.3
+ * @since 16.4.7
+ */
+@Component
+@Singleton
+public class WikiSyntaxMacroParameterRequiredRightsAnalyzer implements MacroParameterRequiredRightsAnalyzer<List<Block>>
+{
+    @Override
+    public void analyze(MacroBlock macroBlock, ParameterDescriptor parameterDescriptor, String value,
+        MacroRequiredRightReporter reporter)
+    {
+        reporter.analyzeContent(macroBlock, value);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-macro/src/main/java/org/xwiki/platform/security/requiredrights/internal/WikiSyntaxMacroParameterRequiredRightsAnalyzer.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-macro/src/main/java/org/xwiki/platform/security/requiredrights/internal/WikiSyntaxMacroParameterRequiredRightsAnalyzer.java
@@ -35,7 +35,7 @@ import org.xwiki.rendering.macro.descriptor.ParameterDescriptor;
  *
  * @version $Id$
  * @since 17.1.0RC1
- * @since 16.10.3
+ * @since 16.10.4
  * @since 16.4.7
  */
 @Component

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-macro/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-macro/src/main/resources/ApplicationResources.properties
@@ -1,0 +1,53 @@
+# ---------------------------------------------------------------------------
+# See the NOTICE file distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+# ---------------------------------------------------------------------------
+
+###############################################################################
+# Macro required rights localization
+#
+# This contains the translations of the module in the default language
+# (generally English).
+#
+# Translation key syntax:
+#   <short top level project name>.<short module name>.<propertyName>
+#   where:
+#   * <short top level project name> = top level project name without the "xwiki-" prefix,
+#                                     for example: commons, rendering, platform, enterprise, manager, etc
+#   * <short module name> = the name of the Maven module without the <short top level project name> prefix,
+#                           for example: oldcore, scheduler, activitystream, etc
+#   * <propertyName> = the name of the property using camel case,
+#                      for example updateJobClassCommitComment
+#
+# Comments: it's possible to add some detail about a key to make easier to
+#   translate it by adding a comment before it. To make sure a comment is not
+#   assigned to the following key use at least three sharps (###) for the comment
+#   or after it.
+#
+# Deprecated keys:
+#   * when deleting a key it should be moved to deprecated section at the end
+#     of the file (between #@deprecatedstart and #@deprecatedend) and associated to the
+#     first version in which it started to be deprecated
+#   * when renaming a key, it should be moved to the same deprecated section
+#     and a comment should be added with the following syntax:
+#     #@deprecated new.key.name
+#     old.key.name=Some translation
+###############################################################################
+
+security.requiredrights.macro.scriptContentSource=The script content source in parameter [{0}] of the {1} macro \
+  requires script right.

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-macro/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-macro/src/main/resources/META-INF/components.txt
@@ -1,0 +1,2 @@
+org.xwiki.platform.security.requiredrights.internal.MacroContentSourceReferenceMacroParameterRequiredRightsAnalyzer
+org.xwiki.platform.security.requiredrights.internal.WikiSyntaxMacroParameterRequiredRightsAnalyzer

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-macro/src/test/java/org/xwiki/platform/security/requiredrights/internal/MacroContentSourceReferenceMacroParameterRequiredRightsAnalyzerTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-macro/src/test/java/org/xwiki/platform/security/requiredrights/internal/MacroContentSourceReferenceMacroParameterRequiredRightsAnalyzerTest.java
@@ -1,0 +1,104 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.platform.security.requiredrights.internal;
+
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.xwiki.platform.security.requiredrights.MacroRequiredRight;
+import org.xwiki.platform.security.requiredrights.MacroRequiredRightReporter;
+import org.xwiki.properties.converter.Converter;
+import org.xwiki.rendering.block.MacroBlock;
+import org.xwiki.rendering.macro.descriptor.ParameterDescriptor;
+import org.xwiki.rendering.macro.source.MacroContentSourceReference;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit test for {@link MacroContentSourceReferenceMacroParameterRequiredRightsAnalyzer}.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+class MacroContentSourceReferenceMacroParameterRequiredRightsAnalyzerTest
+{
+    private static final String MACRO_ID = "macroId";
+
+    private static final String PARAMETER_ID = "parameterId";
+
+    @MockComponent
+    private Converter<MacroContentSourceReference> macroContentSourceReferenceConverter;
+
+    @Mock
+    private MacroRequiredRightReporter reporter;
+
+    @Mock
+    private MacroBlock macroBlock;
+
+    @Mock
+    private ParameterDescriptor parameterDescriptor;
+
+    @InjectMockComponents
+    private MacroContentSourceReferenceMacroParameterRequiredRightsAnalyzer analyzer;
+
+    @BeforeEach
+    void setUp()
+    {
+        when(this.macroBlock.getId()).thenReturn(MACRO_ID);
+        when(this.parameterDescriptor.getId()).thenReturn(PARAMETER_ID);
+        when(this.macroContentSourceReferenceConverter.convert(eq(MacroContentSourceReference.class), anyString()))
+            .then(invocation -> {
+                String[] values = StringUtils.split(invocation.getArgument(1), ":", 2);
+                return new MacroContentSourceReference(values[0], values[1]);
+            });
+    }
+
+    @Test
+    void analyzeReportsScriptRightForScriptType()
+    {
+        String value = "script:someScript";
+
+        this.analyzer.analyze(this.macroBlock, this.parameterDescriptor, value, this.reporter);
+
+        verify(this.reporter).report(this.macroBlock, List.of(MacroRequiredRight.SCRIPT),
+            "security.requiredrights.macro.scriptContentSource",
+            PARAMETER_ID, MACRO_ID);
+    }
+
+    @Test
+    void analyzeDoesNotReportScriptRightForNonScriptType()
+    {
+        String value = "other:someContent";
+
+        this.analyzer.analyze(this.macroBlock, this.parameterDescriptor, value, this.reporter);
+
+        verifyNoInteractions(this.reporter);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-macro/src/test/java/org/xwiki/platform/security/requiredrights/internal/WikiSyntaxMacroParameterRequiredRightsAnalyzerTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-macro/src/test/java/org/xwiki/platform/security/requiredrights/internal/WikiSyntaxMacroParameterRequiredRightsAnalyzerTest.java
@@ -1,0 +1,62 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.platform.security.requiredrights.internal;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.xwiki.platform.security.requiredrights.MacroRequiredRightReporter;
+import org.xwiki.rendering.block.MacroBlock;
+import org.xwiki.rendering.macro.descriptor.ParameterDescriptor;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+/**
+ * Unit test for {@link WikiSyntaxMacroParameterRequiredRightsAnalyzer}.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+class WikiSyntaxMacroParameterRequiredRightsAnalyzerTest
+{
+    @Mock
+    private MacroRequiredRightReporter reporter;
+
+    @Mock
+    private MacroBlock macroBlock;
+
+    @Mock
+    private ParameterDescriptor parameterDescriptor;
+
+    @InjectMockComponents
+    private WikiSyntaxMacroParameterRequiredRightsAnalyzer analyzer;
+
+    @Test
+    void analyze()
+    {
+        String content = "content";
+        this.analyzer.analyze(this.macroBlock, this.parameterDescriptor, content, this.reporter);
+
+        verify(this.reporter).analyzeContent(this.macroBlock, content);
+        verifyNoMoreInteractions(this.reporter);
+    }
+}


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22821

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Add a new MacroParameterRequiredRightsAnalyzer role.
* Add implementations for wiki content and macro content source references.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* This eliminates the need for #3810.
* As this fixes the bug of the missing required rights analyzer for the code macro, I propose backporting this improvement to the LTS branches.
* I put the parameter type as type parameter of the new role, but this type isn't used in the role anywhere so I added an explicit ignore for the warnings this causes. I don't know if we have a better solution for this.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

Example analysis of the following content:

```
{{code language="none" source="script:foo"}}{{/code}}

{{info title="{{groovy~}~}
println(~"Hello from Title~")
{{/groovy~}~}"}}
Type your information message here.
{{/info}}
```

![image](https://github.com/user-attachments/assets/b47e3d35-978e-4d18-b0ce-d8544c745885)

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
LANG=C.UTF-8 mvn clean install -Pdocker,legacy,integration-tests,snapshotModules,quality -pl :xwiki-platform-security-requiredrights-default,:xwiki-platform-security-requiredrights-macro
```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-16.10.x
  * stable-16.4.x