### PR TITLE
XWIKI-22829: ./start_xwiki_debug.sh: Permission denied when running ./start_xwiki.sh

### DIFF
--- a/xwiki-platform-tools/xwiki-platform-tool-jetty/xwiki-platform-tool-jetty-resources/src/main/resources/start_xwiki_debug.sh
+++ b/xwiki-platform-tools/xwiki-platform-tool-jetty/xwiki-platform-tool-jetty-resources/src/main/resources/start_xwiki_debug.sh
@@ -35,4 +35,4 @@ PRGDIR=`dirname "$PRG"`
 cd "$PRGDIR"
 
 # Call the standard start script
-./start_xwiki.sh --debug $@
+bash ./start_xwiki.sh --debug $@


### PR DESCRIPTION

# Jira URL

https://jira.xwiki.org/browse/XWIKI-22829

# Changes

## Description

Call ./start-xwiki.sh with bash to avoid running into a permission denied error.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches: all the supported branches would be good but this is not a huge issue, so none is fine too