### PR TITLE
XWIKI-22816: Icon and edit link aren't on the same line anymore when editing single object

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editobject.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/editobject.vm
@@ -247,7 +247,11 @@
   #if ($mustSync)
     <div class="box warningmessage deprecatedProperties">
       $services.localization.render('core.editors.object.removeDeprecatedProperties.all.info')
-      <div><a class="syncProperties syncAllProperties" href="$doc.getURL('objectsync')" title="$services.localization.render('core.editors.object.removeDeprecatedProperties.all.link.tooltip')">$services.localization.render('core.editors.object.removeDeprecatedProperties.all.link')</a></div>
+      <div><a class="syncProperties syncAllProperties" href="$doc.getURL('objectsync')" title="$services.localization
+      .render('core.editors.object.removeDeprecatedProperties.all.link.tooltip')">
+        $services.icon.renderHTML('cross')
+        $services.localization.render('core.editors.object.removeDeprecatedProperties.all.link')
+      </a></div>
     </div>
   #end
 #end ## checkPropertyDeprecation

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/editors/dataeditors.css
@@ -37,11 +37,6 @@ div#xwikiobjects input[type="radio"], div#xwikiclassproperties input[type="radio
   padding: 8px 2px;
 }
 
-.more-actions .edit-all {
-  display: block;
-  padding: 2px 18px;
-}
-
 /* Object editor */
 /* XClass */
 .xclass-title {


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22816

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Updated the style of the `edit all objects` link to behave as expected. This means removing customizations that were made to fit a CSS only icon.
* Added back a cross in the `remove deprecated property` link.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

See the ticket for the buggy looks of this UI before the changes proposed in this PR.
After the changes, here is what it looks like:
![Screenshot from 2025-01-29 11-27-16](https://github.com/user-attachments/assets/16d14fe1-0f63-4707-8d91-1ed28f5acae5)

When hovered, the whole link gets its `:hovered` style: it's dark blue, and the FA cross takes the same color :)

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
None, minor change to the DOM (adding an icon), and CSS layout changes are not tested.

Successfully built the two modules with changes with the `quality` profile : `mvn clean install -f xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war -Pquality` and `mvn clean install -f xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources -Pquality`.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X, like the cause `XWIKI-21236: Object edit mode does not use current icon theme`. It's a pretty safe backport.