### PR TITLE
XWIKI-22791: Costly and unconditional tag cloud computation done for all live table requests using the default source

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/macros.vm
@@ -129,7 +129,8 @@
       'transprefix': $transprefix,
       'classname': $classname,
       'collist': $stringtool.join($dataColumns, ','),
-      'queryFilters': $queryFilters
+      'queryFilters': $queryFilters,
+      'tagcloud': $tagcloud
     })
     #set ($discard = $parameters.putAll($classParams))
     #set ($resultPage = $options.resultPage)

--- a/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/main/resources/XWiki/LiveTableResultsMacros.xml
+++ b/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/main/resources/XWiki/LiveTableResultsMacros.xml
@@ -544,7 +544,9 @@
     #set($discard = $map.put('params', $sqlParams))
   #end
   #set($discard = $map.put('reqNo', $numbertool.toNumber($request.reqNo).intValue()))
-  #gridresult_buildTagCloudJSON($map)
+  #if("$!request.tagcloud" == 'true')
+    #gridresult_buildTagCloudJSON($map)
+  #end
   #gridresult_buildRowsJSON($map)
 #end
 

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -1398,7 +1398,8 @@ $Msz MB##
       'transprefix': $transprefix,
       'classname': $classname,
       'collist': $stringtool.join($dataColumns, ','),
-      'queryFilters': $queryFilters
+      'queryFilters': $queryFilters,
+      'tagcloud': $tagcloud
     })
     #set ($discard = $parameters.putAll($classParams))
     #set ($resultPage = $options.resultPage)


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-22791

# Changes

## Description

This PR makes the computation of the Live Table tag happen only when requested rather than systematically.

# Executed Tests

`mvn clean install -Pquality,integration-tests,docker` ran on modules: 
  - xwiki-platform-web
  - xwiki-platform-flamingo-skin-resources
  - xwiki-platform-livetable

Ran specific docker tests:
  - LiveTableGeneratorIT
  - AppsLiveTableIT
  
# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-16.10.x
  * stable-16.4.x