### PR TITLE
XWIKI-22844: Pass more parameter to the documentTree macro from the l…

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/locationPicker_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/locationPicker_macros.vm
@@ -234,7 +234,6 @@
           ## target top level documents (e.g. create a top level document, move a document to the top level, etc.).
           #set ($showRoot = !$showWikis)
           #set ($showTerminalDocuments = false || $options.showTerminalDocuments)
-          #set ($macro.showSpaces = false || $options.showSpaces)
           #set ($macro.filterHiddenDocuments = $options.filterHiddenDocuments != false)
           #documentTree({
             'class': 'location-tree',
@@ -246,7 +245,6 @@
             'showWikis': $showWikis,
             'exclusions': "$!options.exclusions",
             'root': "$!options.root",
-            'showSpaces': $macro.showSpaces,
             'filterHiddenDocuments': $macro.filterHiddenDocuments,
             'sortDocumentsBy': "$!options.sortDocumentsBy"
           })

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/locationPicker_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/locationPicker_macros.vm
@@ -235,7 +235,7 @@
           #set ($showRoot = !$showWikis)
           #set ($showTerminalDocuments = false || $options.showTerminalDocuments)
           #set ($macro.showSpaces = false || $options.showSpaces)
-          #set ($macro.filterHiddenDocuments = ($options.filterHiddenDocuments != false))
+          #set ($macro.filterHiddenDocuments = $options.filterHiddenDocuments != false)
           #documentTree({
             'class': 'location-tree',
             'finder': true,

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/locationPicker_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/locationPicker_macros.vm
@@ -234,6 +234,8 @@
           ## target top level documents (e.g. create a top level document, move a document to the top level, etc.).
           #set ($showRoot = !$showWikis)
           #set ($showTerminalDocuments = false || $options.showTerminalDocuments)
+          #set ($macro.showSpaces = false || $options.showSpaces)
+          #set ($macro.filterHiddenDocuments = ($options.filterHiddenDocuments != false))
           #documentTree({
             'class': 'location-tree',
             'finder': true,
@@ -242,7 +244,11 @@
             'showTerminalDocuments': $showTerminalDocuments,
             'showTranslations': false,
             'showWikis': $showWikis,
-            'exclusions': "$!options.exclusions"
+            'exclusions': "$!options.exclusions",
+            'root': "$!options.root",
+            'showSpaces': $macro.showSpaces,
+            'filterHiddenDocuments': $macro.filterHiddenDocuments,
+            'sortDocumentsBy': "$!options.sortDocumentsBy"
           })
         </div>
         <div class="modal-footer">


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-22844

# Changes

## Description

This is to add the support for more parameter in the location picker.

We need it by example here: https://github.com/xwiki-contrib/book-versions/commit/b9af3c76de088d2aa04818bb5408945907e11645#diff-fe2a2389c53f3d1b7046681db9ee06814e9eacd5b07f02091a41fb44e7f82ee3R222-R263

## Clarifications

For now I just added the most useful parameter (from my point of view). Some parameter on the `documentTree` don't make sens to be used in the `locationPicker` and some others are quite depreciated.

# Executed Tests

Tested the picker with the news options.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches: No