### PR TITLE
XWIKI-22791: Costly and unconditional tag cloud computation done for all live table requests using the default source

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/main/resources/XWiki/LiveTableResultsMacros.xml
+++ b/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/main/resources/XWiki/LiveTableResultsMacros.xml
@@ -544,7 +544,7 @@
     #set($discard = $map.put('params', $sqlParams))
   #end
   #set($discard = $map.put('reqNo', $numbertool.toNumber($request.reqNo).intValue()))
-  #if("$!request.tagcloud" == 'true')
+  #if("$!request.tagcloud" != 'false')
     #gridresult_buildTagCloudJSON($map)
   #end
   #gridresult_buildRowsJSON($map)


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-22791

# Changes

## Description

This PR makes the computation of the Live Table tag happen only when requested rather than systematically.

# Executed Tests

`mvn clean install -Pquality,integration-tests,docker` ran on modules: 
  - xwiki-platform-web
  - xwiki-platform-flamingo-skin-resources
  - xwiki-platform-livetable

I haven't been able to run any docker test due to the following error:

```
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 8.249 s <<< FAILURE! -- in org.xwiki.appwithinminutes.test.ui.AllIT
[ERROR] org.xwiki.appwithinminutes.test.ui.AllIT -- Time elapsed: 8.249 s <<< ERROR!
java.lang.RuntimeException: Error setting up the XWiki testing environment
        at org.xwiki.test.docker.internal.junit5.XWikiDockerExtension.raiseException(XWikiDockerExtension.java:500)
        at org.xwiki.test.docker.internal.junit5.XWikiDockerExtension.beforeAll(XWikiDockerExtension.java:106)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
Caused by: org.eclipse.aether.collection.DependencyCollectionException: Failed to collect dependencies at org.xwiki.platform:xwiki-platform-appwithinminutes-test-docker:jar:17.1.0-SNAPSHOT -> org.xwiki.platform:xwiki-platform-appwithinminutes-ui:xar:17.1.0-SNAPSHOT -> org.xwiki.platform:xwiki-platform-livetable-ui:xar:17.1.0-SNAPSHOT -> org.xwiki.platform:xwiki-platform-wiki-script:jar:17.1.0-SNAPSHOT -> org.xwiki.platform:xwiki-platform-wiki-default:jar:17.1.0-SNAPSHOT -> org.xwiki.platform:xwiki-platform-oldcore:jar:17.1.0-SNAPSHOT -> io.sf.carte:css4j:jar:5.1 -> io.sf.jclf:jclf-text:jar:[5.0.2,)
        at org.eclipse.aether.internal.impl.collect.DefaultDependencyCollector.collectDependencies(DefaultDependencyCollector.java:291)
        at org.eclipse.aether.internal.impl.DefaultRepositorySystem.collectDependencies(DefaultRepositorySystem.java:284)
        at org.xwiki.test.integration.maven.ArtifactResolver.getArtifactDependencies(ArtifactResolver.java:152)
        at org.xwiki.test.integration.maven.MavenResolver.getDependencies(MavenResolver.java:279)
        at org.xwiki.test.integration.maven.MavenResolver.resolveVersions(MavenResolver.java:321)
        at org.xwiki.test.integration.maven.MavenResolver.convertToArtifacts(MavenResolver.java:235)
        at org.xwiki.test.docker.internal.junit5.WARBuilder.build(WARBuilder.java:140)
        at org.xwiki.test.docker.internal.junit5.XWikiDockerExtension.beforeAllInternal(XWikiDockerExtension.java:154)
        at org.xwiki.test.docker.internal.junit5.XWikiDockerExtension.beforeAll(XWikiDockerExtension.java:104)
        ... 1 more
Caused by: org.eclipse.aether.resolution.VersionRangeResolutionException: No versions available for io.sf.jclf:jclf-text:jar:[5.0.2,) within specified range
```
  
# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-16.10.x
  * stable-16.4.x