### PR TITLE
XWIKI-22815: Variable $isSuperAdmin is not computed correctly on subwikis

### DIFF
--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/pom.xml
@@ -31,7 +31,7 @@
   <name>XWiki Platform - Security - Authorization - API</name>
   <description>Controls permissions to all the wiki elements</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.76</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.77</xwiki.jacoco.instructionRatio>
     <!-- TODO: Remove once the tests have been fixed to not output anything to the console! -->
     <xwiki.surefire.captureconsole.skip>true</xwiki.surefire.captureconsole.skip>
     <checkstyle.suppressions.location>${basedir}/src/checkstyle/checkstyle-suppressions.xml</checkstyle.suppressions.location>

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/AuthorizationManager.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/AuthorizationManager.java
@@ -50,10 +50,13 @@ public interface AuthorizationManager
     String SUPERADMIN_USER = "superadmin";
 
     /**
-     * Check whether the current user is {@code superadmin}.
+     * Check if the user is the super admin.
+     * <p>
+     * NOTE: We rely on that the authentication service especially authenticates user names matching superadmin's in a
+     * case-insensitive match, and will ignore any user profile's that may be matching the superadmin's user name.
      *
-     * @param user a user reference
-     * @return {@code true} if the current user is {@code superadmin}, {@code false} otherwise
+     * @param user a document reference representing a user identity
+     * @return {@code true} if and only if the user is determined to be the superuser
      * @since 17.2.0RC1
      * @since 16.10.5
      * @since 16.4.7
@@ -61,7 +64,7 @@ public interface AuthorizationManager
     @Unstable
     default boolean isSuperAdmin(DocumentReference user)
     {
-        return false;
+        return user != null && StringUtils.equalsIgnoreCase(user.getName(), SUPERADMIN_USER);
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/AuthorizationManager.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/AuthorizationManager.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import org.xwiki.component.annotation.Role;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
+import org.xwiki.stability.Unstable;
 
 /**
  * This API is for checking the access rights of any users on any XWiki entities. It replaces
@@ -47,6 +48,21 @@ public interface AuthorizationManager
      * The Superadmin username.
      */
     String SUPERADMIN_USER = "superadmin";
+
+    /**
+     * Check whether the current user is {@code superadmin}.
+     *
+     * @param user a user reference
+     * @return {@code true} if the current user is {@code superadmin}, {@code false} otherwise
+     * @since 17.2.0RC1
+     * @since 16.10.5
+     * @since 16.4.7
+     */
+    @Unstable
+    default boolean isSuperAdmin(DocumentReference user)
+    {
+        return false;
+    }
 
     /**
      * Check if the user identified by {@code userReference} has the access identified by {@code right} on the

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/AuthorizationManager.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/AuthorizationManager.java
@@ -21,6 +21,7 @@ package org.xwiki.security.authorization;
 
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
 import org.xwiki.component.annotation.Role;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/DefaultAuthorizationManager.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/DefaultAuthorizationManager.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.ModelContext;
@@ -88,23 +87,6 @@ public class DefaultAuthorizationManager implements AuthorizationManager
 
     @Inject
     private ModelContext modelContext;
-
-    /**
-     * Check if the user is the super admin.
-     *
-     * NOTE: We rely on that the authentication service especially
-     * authenticates user names matching superadmin's in a case
-     * insensitive match, and will ignore any user profile's that may
-     * be matching the superadmin's user name.
-     *
-     * @param user A document reference representing a user identity.
-     * @return {@code true} if and only if the user is determined to be the super user.
-     */
-    @Override
-    public boolean isSuperAdmin(DocumentReference user)
-    {
-        return user != null && StringUtils.equalsIgnoreCase(user.getName(), AuthorizationManager.SUPERADMIN_USER);
-    }
 
     @Override
     public void checkAccess(Right right, DocumentReference userReference, EntityReference entityReference)

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/DefaultAuthorizationManager.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/DefaultAuthorizationManager.java
@@ -100,7 +100,8 @@ public class DefaultAuthorizationManager implements AuthorizationManager
      * @param user A document reference representing a user identity.
      * @return {@code true} if and only if the user is determined to be the super user.
      */
-    private boolean isSuperAdmin(DocumentReference user)
+    @Override
+    public boolean isSuperAdmin(DocumentReference user)
     {
         return user != null && StringUtils.equalsIgnoreCase(user.getName(), AuthorizationManager.SUPERADMIN_USER);
     }

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/DefaultAuthorizationManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/DefaultAuthorizationManagerTest.java
@@ -1,0 +1,56 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.security.authorization;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.xwiki.security.authorization.AuthorizationManager.SUPERADMIN_USER;
+
+/**
+ * Test of {@link DefaultAuthorizationManager}.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+class DefaultAuthorizationManagerTest
+{
+    @InjectMockComponents
+    private DefaultAuthorizationManager defaultAuthorizationManager;
+
+    @Test
+    void isSuperAdminExpectTrue()
+    {
+        assertTrue(
+            this.defaultAuthorizationManager.isSuperAdmin(
+                new DocumentReference("s1", "Space", SUPERADMIN_USER)));
+    }
+
+    @Test
+    void isSuperAdminExpectFalse()
+    {
+        assertFalse(
+            this.defaultAuthorizationManager.isSuperAdmin(new DocumentReference("xwiki", "XWiki", "Admin")));
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-script/src/main/java/org/xwiki/security/authorization/script/SecurityAuthorizationScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-script/src/main/java/org/xwiki/security/authorization/script/SecurityAuthorizationScriptService.java
@@ -171,7 +171,7 @@ public class SecurityAuthorizationScriptService implements ScriptService
     }
 
     /**
-     * Check whether the current user is {@code superadmin}.
+     * Check whether the user is {@code superadmin}.
      *
      * @param user a user reference
      * @return {@code true} if the current user is {@code superadmin}, {@code false} otherwise

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-script/src/main/java/org/xwiki/security/authorization/script/SecurityAuthorizationScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-script/src/main/java/org/xwiki/security/authorization/script/SecurityAuthorizationScriptService.java
@@ -34,6 +34,7 @@ import org.xwiki.security.authorization.AuthorizationManager;
 import org.xwiki.security.authorization.ContextualAuthorizationManager;
 import org.xwiki.security.authorization.Right;
 import org.xwiki.security.script.SecurityScriptService;
+import org.xwiki.stability.Unstable;
 
 /**
  * Security Authorization Script Service.
@@ -167,5 +168,20 @@ public class SecurityAuthorizationScriptService implements ScriptService
     public List<String> getAllRightsNames()
     {
         return Right.getAllRightsAsString();
+    }
+
+    /**
+     * Check whether the current user is {@code superadmin}.
+     *
+     * @param user a user reference
+     * @return {@code true} if the current user is {@code superadmin}, {@code false} otherwise
+     * @since 17.2.0RC1
+     * @since 16.10.5
+     * @since 16.4.7
+     */
+    @Unstable
+    public boolean isSuperAdmin(DocumentReference user)
+    {
+        return this.authorizationManager.isSuperAdmin(user);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/xwikivars.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/xwikivars.vm
@@ -21,7 +21,7 @@
 ##!unique=request
 #template("frequentlyUsedDocs.vm")
 #set ($isGuest = $xcontext.getUser().equals('XWiki.XWikiGuest'))
-#set ($isSuperAdmin = ($xcontext.user == 'XWiki.superadmin') || ($xcontext.user == "${services.wiki.mainWikiId}:XWiki.superadmin"))
+#set ($isSuperAdmin = $services.security.authorization.isSuperAdmin($xcontext.getUser()))
 ## Does the current user have edit rights on the current document
 #set ($hasEdit = $services.security.authorization.hasAccess('edit'))
 ## Does the current user have admin rights on the current document

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/xwikivars.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/xwikivars.vm
@@ -21,7 +21,7 @@
 ##!unique=request
 #template("frequentlyUsedDocs.vm")
 #set ($isGuest = $xcontext.getUser().equals('XWiki.XWikiGuest'))
-#set ($isSuperAdmin = ($xcontext.user == 'XWiki.superadmin'))
+#set ($isSuperAdmin = ($xcontext.user == 'XWiki.superadmin') || ($xcontext.user == "${services.wiki.mainWikiId}:XWiki.superadmin"))
 ## Does the current user have edit rights on the current document
 #set ($hasEdit = $services.security.authorization.hasAccess('edit'))
 ## Does the current user have admin rights on the current document


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22815

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* generalize the condition for `$isSuperAdmin` to make it work on sub-wikis.

Duplicated/inconsistent definitions of `isSuperAdmin`:
- [ ] com.xpn.xwiki.internal.plugin.rightsmanager.UserIterator#isSuperAdmin
- [ ] com.xpn.xwiki.user.api.XWikiRightService#isSuperAdmin
- [ ] com.xpn.xwiki.user.api.XWikiUser#isSuperAdmin (using com.xpn.xwiki.user.api.XWikiRightService#isSuperAdmin)
- [ ] com.xpn.xwiki.user.impl.xwiki.AbstractXWikiAuthService#isSuperAdmin
- [ ] com.xpn.xwiki.user.impl.xwiki.XWikiRightServiceImpl#isSuperAdmin
- [ ] com.xpn.xwiki.internal.template.InternalTemplateManager.FilesystemTemplateContent#isPrivileged
- [ ] com.xpn.xwiki.user.impl.xwiki.XWikiRightServiceImpl#isSuperAdmin
- [ ] com.xpn.xwiki.user.impl.xwiki.XWikiRightServiceImpl#isSuperAdminOrProgramming
- [ ] org.xwiki.test.checker.internal.ProgrammingRightCheckerAuthorizationManager#check(org.xwiki.model.reference.DocumentReference, com.xpn.xwiki.doc.XWikiDocument)
- [ ] org.xwiki.user.internal.document.AbstractUserReferenceResolver#isSuperAdmin
- [ ] org.xwiki.user.internal.document.AbstractUserReferenceResolver#isSuperAdmin

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* the current implementation stays on string comparison. Let me know if using a proper entity reference comparison is preferable (couldn't find an existing script API).

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

* Build of `xwiki-platform-web-templates`
* Manual tests on sub-wikis
* Also, I found the condition `$isAdvancedUser || $isSuperAdmin` in at least 16 places, but afaiu `$isSuperAdmin` implies `$isAdvancedUser`, making the right hand side of the OR condition superfluous

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-16.4.x
  * stable-16.10.x