### PR TITLE
XWIKI-22787: Pinned Pages are lost on space move for non admin user

### DIFF
--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/AbstractCopyOrMoveJob.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/AbstractCopyOrMoveJob.java
@@ -19,11 +19,10 @@
  */
 package org.xwiki.refactoring.internal.job;
 
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.function.BiConsumer;
-import java.util.stream.Collectors;
 
 import org.xwiki.model.EntityType;
 import org.xwiki.model.reference.DocumentReference;
@@ -309,14 +308,28 @@ public abstract class AbstractCopyOrMoveJob<T extends AbstractCopyOrMoveRequest>
 
     protected boolean checkAllRights(DocumentReference oldReference, DocumentReference newReference) throws Exception
     {
-        if (!hasAccess(Right.VIEW, oldReference)) {
-            this.logger.error("You don't have sufficient permissions over the source document [{}].", oldReference);
-            return false;
-        } else if (!hasAccess(Right.EDIT, newReference)
-            || (this.modelBridge.exists(newReference) && !hasAccess(Right.DELETE, newReference))) {
-            this.logger.error("You don't have sufficient permissions over the destination document [{}].",
-                newReference);
-            return false;
+        boolean isWebPreferences =
+            isSpacePreferencesReference(oldReference) && isSpacePreferencesReference(newReference);
+        if (!isWebPreferences) {
+            if (!hasAccess(Right.VIEW, oldReference)) {
+                this.logger.error("You don't have sufficient permissions over the source document [{}].", oldReference);
+                return false;
+            } else if (!hasAccess(Right.EDIT, newReference)
+                || (this.modelBridge.exists(newReference) && !hasAccess(Right.DELETE, newReference)))
+            {
+                this.logger.error("You don't have sufficient permissions over the destination document [{}].",
+                    newReference);
+                return false;
+            }
+        } else {
+            DocumentReference newHomeReference = getSpaceHomeReference(newReference);
+            DocumentReference oldHomeReference = getSpaceHomeReference(oldReference);
+            if (!this.concernedEntities.containsKey(oldHomeReference) || !hasAccess(Right.EDIT, newHomeReference)) {
+                this.logger.error("You don't have sufficient permissions over the home document of WebPreferences "
+                        + "[{}].",
+                    newReference);
+                return false;
+            }
         }
         return true;
     }
@@ -352,14 +365,14 @@ public abstract class AbstractCopyOrMoveJob<T extends AbstractCopyOrMoveRequest>
 
             // Step 2: Delete the destination document if needed.
             this.progressManager.startStep(this);
-            if (this.modelBridge.exists(newReference)) {
-                if (this.request.isInteractive() && !this.modelBridge.canOverwriteSilently(newReference)
-                    && !confirmOverwrite(oldReference, newReference)) {
-                    this.logger.warn(
-                        "Skipping [{}] because [{}] already exists and the user doesn't want to overwrite it.",
-                        oldReference, newReference);
-                    return false;
-                }
+            if (this.modelBridge.exists(newReference)
+                && this.request.isInteractive()
+                && !this.modelBridge.canOverwriteSilently(newReference)
+                && !confirmOverwrite(oldReference, newReference)) {
+                this.logger.warn(
+                    "Skipping [{}] because [{}] already exists and the user doesn't want to overwrite it.",
+                    oldReference, newReference);
+                return false;
             }
             this.progressManager.endStep(this);
 
@@ -414,19 +427,6 @@ public abstract class AbstractCopyOrMoveJob<T extends AbstractCopyOrMoveRequest>
         List<EntityReference> entityReferences = new LinkedList<>(this.request.getEntityReferences());
         entityReferences.add(this.request.getDestination());
         return getCommonParent(entityReferences);
-    }
-
-    /**
-     * @return the list of references that have been selected to be refactored.
-     * @since 16.10.0RC1
-     */
-    public Map<EntityReference, EntityReference> getSelectedEntities()
-    {
-        return this.concernedEntities.values().stream()
-            .filter(EntitySelection::isSelected)
-            .filter(entity -> entity.getTargetEntityReference().isPresent())
-            .collect(Collectors.toMap(EntitySelection::getEntityReference,
-                entity -> entity.getTargetEntityReference().get()));
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/AbstractCopyOrMoveJob.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/AbstractCopyOrMoveJob.java
@@ -19,7 +19,6 @@
  */
 package org.xwiki.refactoring.internal.job;
 
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.BiConsumer;

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/AbstractEntityJob.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/AbstractEntityJob.java
@@ -69,9 +69,9 @@ public abstract class AbstractEntityJob<R extends EntityRequest, S extends Entit
         void visit(T node);
     }
 
-    private static final JobGroupPath ROOT_GROUP = new JobGroupPath(RefactoringJobs.GROUP, null);
+    protected static final String PREFERENCES_DOCUMENT_NAME = "WebPreferences";
 
-    private static final String PREFERENCES_DOCUMENT_NAME = "WebPreferences";
+    private static final JobGroupPath ROOT_GROUP = new JobGroupPath(RefactoringJobs.GROUP, null);
 
     /**
      * The component used to access the XWiki model and to perform low level operations on it.
@@ -261,7 +261,13 @@ public abstract class AbstractEntityJob<R extends EntityRequest, S extends Entit
             .equals(this.defaultEntityReferenceProvider.getDefaultReference(documentReference.getType()).getName());
     }
 
-    private boolean isSpacePreferencesReference(EntityReference entityReference)
+    protected DocumentReference getSpaceHomeReference(DocumentReference reference)
+    {
+        String referenceName = this.defaultEntityReferenceProvider.getDefaultReference(EntityType.DOCUMENT).getName();
+        return new DocumentReference(referenceName, reference.getLastSpaceReference());
+    }
+
+    protected boolean isSpacePreferencesReference(EntityReference entityReference)
     {
         return entityReference.getType() == EntityType.DOCUMENT
             && PREFERENCES_DOCUMENT_NAME.equals(entityReference.getName());

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/AbstractEntityJobWithChecks.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/AbstractEntityJobWithChecks.java
@@ -75,7 +75,9 @@ public abstract class AbstractEntityJobWithChecks<R extends EntityRequest, S ext
 
     /**
      * @return the list of references that have been selected to be refactored.
-     * @since 16.10.0RC1
+     * @since 17.2.0RC1
+     * @since 16.10.5
+     * @since 16.4.7
      */
     public Map<EntityReference, EntityReference> getSelectedEntities()
     {

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/AbstractEntityJobWithChecks.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/AbstractEntityJobWithChecks.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.xwiki.bridge.event.DocumentsDeletingEvent;
 import org.xwiki.model.reference.DocumentReference;
@@ -63,11 +64,26 @@ public abstract class AbstractEntityJobWithChecks<R extends EntityRequest, S ext
                 // Process
                 progressManager.startStep(this);
                 setContextUser();
+
+                // FIXME: this should probably be the selected entities only...
                 process(entityReferences);
             }
         } finally {
             progressManager.popLevelProgress(this);
         }
+    }
+
+    /**
+     * @return the list of references that have been selected to be refactored.
+     * @since 16.10.0RC1
+     */
+    public Map<EntityReference, EntityReference> getSelectedEntities()
+    {
+        return this.concernedEntities.values().stream()
+            .filter(EntitySelection::isSelected)
+            .filter(entity -> entity.getTargetEntityReference().isPresent())
+            .collect(Collectors.toMap(EntitySelection::getEntityReference,
+                entity -> entity.getTargetEntityReference().get()));
     }
 
     protected void getEntities(Collection<EntityReference> entityReferences)

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/MoveJob.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/MoveJob.java
@@ -79,9 +79,11 @@ public class MoveJob extends AbstractCopyOrMoveJob<MoveRequest>
     {
         boolean isWebPreferences =
             isSpacePreferencesReference(oldReference) && isSpacePreferencesReference(newReference);
-        if (isWebPreferences) {
-            DocumentReference oldHomeReference = getSpaceHomeReference(oldReference);
-            if (!this.concernedEntities.containsKey(oldHomeReference) || !hasAccess(Right.DELETE, oldHomeReference)) {
+        DocumentReference oldHomeReference = getSpaceHomeReference(oldReference);
+        // if it's a WebPreferences document and the operation concerns also its WebHome then we check the rights of the
+        // WebHome only.
+        if (isWebPreferences && this.concernedEntities.containsKey(oldHomeReference)) {
+            if (!hasAccess(Right.DELETE, oldHomeReference)) {
                 this.logger.error("You don't have sufficient permissions over the home document of WebPreferences "
                         + "[{}].",
                     newReference);

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/MoveJob.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/job/MoveJob.java
@@ -77,7 +77,18 @@ public class MoveJob extends AbstractCopyOrMoveJob<MoveRequest>
     @Override
     protected boolean checkAllRights(DocumentReference oldReference, DocumentReference newReference) throws Exception
     {
-        if (!hasAccess(Right.DELETE, oldReference)) {
+        boolean isWebPreferences =
+            isSpacePreferencesReference(oldReference) && isSpacePreferencesReference(newReference);
+        if (isWebPreferences) {
+            DocumentReference oldHomeReference = getSpaceHomeReference(oldReference);
+            if (!this.concernedEntities.containsKey(oldHomeReference) || !hasAccess(Right.DELETE, oldHomeReference)) {
+                this.logger.error("You don't have sufficient permissions over the home document of WebPreferences "
+                        + "[{}].",
+                    newReference);
+                return false;
+            }
+            return super.checkAllRights(oldReference, newReference);
+        } else if (!hasAccess(Right.DELETE, oldReference)) {
             // The move operation is implemented as Copy + Delete.
             this.logger.error("You are not allowed to delete [{}].", oldReference);
             return false;

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/job/MoveJobTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/job/MoveJobTest.java
@@ -58,6 +58,7 @@ import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -462,7 +463,6 @@ public class MoveJobTest extends AbstractMoveJobTest
         DocumentReference spaceHome = new DocumentReference("chess", List.of("A", "B", "C"), "WebHome");
         DocumentReference docFromSpace = new DocumentReference("X", spaceHome.getLastSpaceReference());
         DocumentReference otherDocFromSpace = new DocumentReference("Y", spaceHome.getLastSpaceReference());
-        DocumentReference prefFromSpace = new DocumentReference("WebPreferences", spaceHome.getLastSpaceReference());
         when(this.modelBridge.getDocumentReferences(spaceHome.getLastSpaceReference()))
             .thenReturn(List.of(spaceHome, docFromSpace, otherDocFromSpace));
         when(this.modelBridge.exists(spaceHome)).thenReturn(false);
@@ -490,6 +490,205 @@ public class MoveJobTest extends AbstractMoveJobTest
             )));
         assertEquals(1, getLogCapture().size());
         assertEquals("Skipping [chess:A.B.C.WebHome] because it doesn't exist.", getLogCapture().getMessage(0));
+    }
+
+    /*
+     * This test scenario checks performing a move of the space chess:A.B.C that contains docs WebHome, X et Y and a
+     * WebPreference to wiki tennis.
+     * The resulting references are tennis:C.X and tennis:C.Y. Note that it's a space move because the request is using
+     * deep flag set to true.
+     * Contrarily to previous test, this test checks the needed rights for the move and in particular for
+     * WebPreferences.
+     */
+    @Test
+    void moveSpaceHomeDeepWithPreferences() throws Throwable
+    {
+        DocumentReference spaceHome = new DocumentReference("chess", List.of("A", "B", "C"), "WebHome");
+        DocumentReference docFromSpace = new DocumentReference("X", spaceHome.getLastSpaceReference());
+        DocumentReference otherDocFromSpace = new DocumentReference("Y", spaceHome.getLastSpaceReference());
+        DocumentReference prefFromSpace = new DocumentReference("WebPreferences", spaceHome.getLastSpaceReference());
+        when(this.modelBridge.getDocumentReferences(spaceHome.getLastSpaceReference()))
+            .thenReturn(List.of(spaceHome, docFromSpace, otherDocFromSpace, prefFromSpace));
+        when(this.modelBridge.exists(spaceHome)).thenReturn(true);
+        when(this.modelBridge.exists(docFromSpace)).thenReturn(true);
+        when(this.modelBridge.exists(otherDocFromSpace)).thenReturn(true);
+        when(this.modelBridge.exists(prefFromSpace)).thenReturn(true);
+
+        DocumentReference authorReference = new DocumentReference("xwiki", "XWiki", "Author");
+        DocumentReference userReference = new DocumentReference("xwiki", "XWiki", "User");
+
+        // We check needed rights, but we don't need specific rights for the WebPreferences as we're checking right
+        // of the space home.
+        when(this.authorization.hasAccess(Right.VIEW, authorReference, spaceHome)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.VIEW, authorReference, docFromSpace)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.VIEW, authorReference, otherDocFromSpace)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.VIEW, authorReference, prefFromSpace)).thenReturn(false);
+
+        when(this.authorization.hasAccess(Right.VIEW, userReference, spaceHome)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.VIEW, userReference, docFromSpace)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.VIEW, userReference, otherDocFromSpace)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.VIEW, userReference, prefFromSpace)).thenReturn(false);
+
+        when(this.authorization.hasAccess(Right.DELETE, authorReference, spaceHome)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.DELETE, authorReference, docFromSpace)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.DELETE, authorReference, otherDocFromSpace)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.DELETE, authorReference, prefFromSpace)).thenReturn(false);
+
+        when(this.authorization.hasAccess(Right.DELETE, userReference, spaceHome)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.DELETE, userReference, docFromSpace)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.DELETE, userReference, otherDocFromSpace)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.DELETE, userReference, prefFromSpace)).thenReturn(false);
+
+        DocumentReference targetDoc1 = new DocumentReference("tennis", "C", "X");
+        DocumentReference targetDoc2 = new DocumentReference("tennis", "C", "Y");
+        DocumentReference targetDoc3 = new DocumentReference("tennis", "C", "WebPreferences");
+        DocumentReference targetDocSpaceHome = new DocumentReference("tennis", "C", "WebHome");
+
+        when(this.authorization.hasAccess(Right.EDIT, authorReference, spaceHome)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.EDIT, authorReference, targetDocSpaceHome)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.EDIT, authorReference, targetDoc1)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.EDIT, authorReference, targetDoc2)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.EDIT, authorReference, targetDoc3)).thenReturn(false);
+
+        when(this.authorization.hasAccess(Right.EDIT, userReference, spaceHome)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.EDIT, userReference, targetDocSpaceHome)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.EDIT, userReference, targetDoc1)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.EDIT, userReference, targetDoc2)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.EDIT, userReference, targetDoc3)).thenReturn(false);
+
+        WikiReference newWiki = new WikiReference("tennis");
+
+        MoveRequest request = createRequest(spaceHome, newWiki);
+        request.setCheckRights(true);
+        request.setCheckAuthorRights(true);
+        request.setDeep(true);
+        request.setAuthorReference(authorReference);
+        request.setUserReference(userReference);
+
+        run(request);
+
+        verify(this.modelBridge).rename(docFromSpace, targetDoc1);
+        verify(this.modelBridge).rename(otherDocFromSpace, targetDoc2);
+        verify(this.modelBridge).rename(prefFromSpace, targetDoc3);
+        verify(this.modelBridge).rename(spaceHome, targetDocSpaceHome);
+
+        verify(this.authorization).hasAccess(Right.VIEW, authorReference, spaceHome);
+        verify(this.authorization).hasAccess(Right.VIEW, authorReference, docFromSpace);
+        verify(this.authorization).hasAccess(Right.VIEW, authorReference, otherDocFromSpace);
+        verify(this.authorization, never()).hasAccess(Right.VIEW, authorReference, prefFromSpace);
+
+        verify(this.authorization).hasAccess(Right.VIEW, userReference, spaceHome);
+        verify(this.authorization).hasAccess(Right.VIEW, userReference, docFromSpace);
+        verify(this.authorization).hasAccess(Right.VIEW, userReference, otherDocFromSpace);
+        verify(this.authorization, never()).hasAccess(Right.VIEW, userReference, prefFromSpace);
+
+        verify(this.authorization, times(2)).hasAccess(Right.DELETE, authorReference, spaceHome);
+        verify(this.authorization).hasAccess(Right.DELETE, authorReference, docFromSpace);
+        verify(this.authorization).hasAccess(Right.DELETE, authorReference, otherDocFromSpace);
+        verify(this.authorization, never()).hasAccess(Right.DELETE, authorReference, prefFromSpace);
+
+        verify(this.authorization, times(2)).hasAccess(Right.DELETE, userReference, spaceHome);
+        verify(this.authorization).hasAccess(Right.DELETE, userReference, docFromSpace);
+        verify(this.authorization).hasAccess(Right.DELETE, userReference, otherDocFromSpace);
+        verify(this.authorization, never()).hasAccess(Right.DELETE, userReference, prefFromSpace);
+
+        verify(this.authorization).hasAccess(Right.EDIT, authorReference, spaceHome);
+        verify(this.authorization).hasAccess(Right.EDIT, authorReference, targetDocSpaceHome);
+        verify(this.authorization).hasAccess(Right.EDIT, authorReference, targetDoc1);
+        verify(this.authorization).hasAccess(Right.EDIT, authorReference, targetDoc2);
+        verify(this.authorization, never()).hasAccess(Right.EDIT, authorReference, targetDoc3);
+
+        verify(this.authorization).hasAccess(Right.EDIT, userReference, spaceHome);
+        verify(this.authorization).hasAccess(Right.EDIT, userReference, targetDocSpaceHome);
+        verify(this.authorization).hasAccess(Right.EDIT, userReference, targetDoc1);
+        verify(this.authorization).hasAccess(Right.EDIT, userReference, targetDoc2);
+        verify(this.authorization, never()).hasAccess(Right.EDIT, userReference, targetDoc3);
+
+        verify(this.observationManager).notify(any(DocumentsDeletingEvent.class), any(MoveJob.class),
+            eq(Map.of(
+                docFromSpace, new EntitySelection(docFromSpace, targetDoc1),
+                otherDocFromSpace, new EntitySelection(otherDocFromSpace, targetDoc2),
+                prefFromSpace, new EntitySelection(prefFromSpace, targetDoc3),
+                spaceHome, new EntitySelection(spaceHome, targetDocSpaceHome)
+            )));
+    }
+
+    @Test
+    void moveWebPreferencesWithoutHome() throws Throwable
+    {
+        DocumentReference spaceHome = new DocumentReference("chess", List.of("A", "B", "C"), "WebHome");
+        DocumentReference docFromSpace = new DocumentReference("X", spaceHome.getLastSpaceReference());
+        DocumentReference prefFromSpace = new DocumentReference("WebPreferences", spaceHome.getLastSpaceReference());
+        when(this.modelBridge.getDocumentReferences(spaceHome.getLastSpaceReference()))
+            .thenReturn(List.of(docFromSpace, prefFromSpace));
+        when(this.modelBridge.exists(spaceHome)).thenReturn(false);
+        when(this.modelBridge.exists(docFromSpace)).thenReturn(true);
+        when(this.modelBridge.exists(prefFromSpace)).thenReturn(true);
+
+        DocumentReference authorReference = new DocumentReference("xwiki", "XWiki", "Author");
+        DocumentReference userReference = new DocumentReference("xwiki", "XWiki", "User");
+
+        when(this.authorization.hasAccess(Right.VIEW, authorReference, docFromSpace)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.VIEW, authorReference, prefFromSpace)).thenReturn(false);
+
+        when(this.authorization.hasAccess(Right.VIEW, userReference, docFromSpace)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.VIEW, userReference, prefFromSpace)).thenReturn(false);
+
+        when(this.authorization.hasAccess(Right.DELETE, authorReference, docFromSpace)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.DELETE, authorReference, prefFromSpace)).thenReturn(false);
+
+        when(this.authorization.hasAccess(Right.DELETE, userReference, docFromSpace)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.DELETE, userReference, prefFromSpace)).thenReturn(false);
+
+        DocumentReference targetDoc1 = new DocumentReference("tennis", "C", "X");
+        DocumentReference targetDoc3 = new DocumentReference("tennis", "C", "WebPreferences");
+
+        when(this.authorization.hasAccess(Right.EDIT, authorReference, spaceHome)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.EDIT, authorReference, targetDoc1)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.EDIT, authorReference, targetDoc3)).thenReturn(false);
+
+        when(this.authorization.hasAccess(Right.EDIT, userReference, spaceHome)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.EDIT, userReference, targetDoc1)).thenReturn(true);
+        when(this.authorization.hasAccess(Right.EDIT, userReference, targetDoc3)).thenReturn(false);
+
+        WikiReference newWiki = new WikiReference("tennis");
+
+        MoveRequest request = createRequest(spaceHome, newWiki);
+        request.setCheckRights(true);
+        request.setCheckAuthorRights(true);
+        request.setDeep(true);
+        request.setAuthorReference(authorReference);
+        request.setUserReference(userReference);
+
+        run(request);
+
+        verify(this.modelBridge).rename(docFromSpace, targetDoc1);
+        verify(this.modelBridge, never()).rename(prefFromSpace, targetDoc3);
+
+        verify(this.authorization).hasAccess(Right.VIEW, authorReference, docFromSpace);
+        verify(this.authorization, never()).hasAccess(Right.VIEW, authorReference, prefFromSpace);
+
+        verify(this.authorization).hasAccess(Right.VIEW, userReference, docFromSpace);
+        verify(this.authorization, never()).hasAccess(Right.VIEW, userReference, prefFromSpace);
+
+        verify(this.authorization).hasAccess(Right.DELETE, authorReference, docFromSpace);
+        verify(this.authorization, never()).hasAccess(Right.DELETE, authorReference, prefFromSpace);
+
+        verify(this.authorization).hasAccess(Right.DELETE, userReference, docFromSpace);
+        verify(this.authorization).hasAccess(Right.DELETE, userReference, prefFromSpace);
+
+        verify(this.authorization).hasAccess(Right.EDIT, authorReference, targetDoc1);
+        verify(this.authorization, never()).hasAccess(Right.EDIT, authorReference, targetDoc3);
+
+        verify(this.authorization).hasAccess(Right.EDIT, userReference, targetDoc1);
+        verify(this.authorization, never()).hasAccess(Right.EDIT, userReference, targetDoc3);
+
+        verify(this.observationManager).notify(any(DocumentsDeletingEvent.class), any(MoveJob.class),
+            eq(Map.of(
+                docFromSpace, new EntitySelection(docFromSpace, targetDoc1)
+            )));
+        assertEquals(1, getLogCapture().size());
+        assertEquals("You are not allowed to delete [chess:A.B.C.WebPreferences].", getLogCapture().getMessage(0));
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/job/MoveJobTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/job/MoveJobTest.java
@@ -462,6 +462,7 @@ public class MoveJobTest extends AbstractMoveJobTest
         DocumentReference spaceHome = new DocumentReference("chess", List.of("A", "B", "C"), "WebHome");
         DocumentReference docFromSpace = new DocumentReference("X", spaceHome.getLastSpaceReference());
         DocumentReference otherDocFromSpace = new DocumentReference("Y", spaceHome.getLastSpaceReference());
+        DocumentReference prefFromSpace = new DocumentReference("WebPreferences", spaceHome.getLastSpaceReference());
         when(this.modelBridge.getDocumentReferences(spaceHome.getLastSpaceReference()))
             .thenReturn(List.of(spaceHome, docFromSpace, otherDocFromSpace));
         when(this.modelBridge.exists(spaceHome)).thenReturn(false);

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/TestUtils.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/TestUtils.java
@@ -1257,7 +1257,7 @@ public class TestUtils
             setDefaultCredentials(SUPER_ADMIN_CREDENTIALS);
 
             // Save the page with the content to execute
-            rest().savePage(reference, wikiContent, wikiSyntax.toIdString(), null, null);
+            rest().savePage(reference, wikiContent, wikiSyntax.toIdString(), null, null, false);
         } finally {
             // Restore initial credentials
             setDefaultCredentials(currentCredentials);
@@ -2799,7 +2799,7 @@ public class TestUtils
          */
         public void savePage(EntityReference reference) throws Exception
         {
-            savePage(reference, null, null, null, null);
+            savePage(reference, null, null, null, null, false);
         }
 
         /**
@@ -2807,14 +2807,14 @@ public class TestUtils
          */
         public void savePage(EntityReference reference, String content, String title) throws Exception
         {
-            savePage(reference, content, null, title, null);
+            savePage(reference, content, null, title, null, false);
         }
 
         /**
          * @since 7.3M1
          */
         public void savePage(EntityReference reference, String content, String syntaxId, String title,
-            String parentFullPageName) throws Exception
+            String parentFullPageName, boolean isHidden) throws Exception
         {
             Page page = page(reference);
 
@@ -2830,6 +2830,7 @@ public class TestUtils
             if (parentFullPageName != null) {
                 page.setParent(parentFullPageName);
             }
+            page.setHidden(isHidden);
 
             save(page, true);
         }
@@ -2862,7 +2863,8 @@ public class TestUtils
             // Make sure the page exist (object add fail otherwise)
             // TODO: improve object add API to allow adding an object in a page that does not yet exist
             if (!exists(documentReference)) {
-                savePage(documentReference);
+                boolean isHidden = "WebPreferences".equals(documentReference.getName());
+                savePage(documentReference, null, null, null, null, isHidden);
             }
 
             // Create the object

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/RefactoringStatusPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/RefactoringStatusPage.java
@@ -32,7 +32,8 @@ import org.openqa.selenium.support.FindBy;
 public class RefactoringStatusPage extends BasePage
 {
     private static final String MESSAGE_CSS_SELECTOR =
-        ".xcontent.job-status .box.successmessage, .xcontent.job-status .box.errormessage";
+        ".xcontent.job-status .box.successmessage, .xcontent.job-status .box.errormessage, .xcontent.job-status .box"
+            + ".warningmessage";
 
     @FindBy(css = MESSAGE_CSS_SELECTOR)
     private WebElement message;


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

  * https://jira.xwiki.org/browse/XWIKI-22787

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

  * Start work to have specific handling of WebPreferences in case of move/rename/copy of a full space
  * WIP: needs to add tests

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

TBD

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.x
  * 16.4.x but needs to ensure that previous work on refactoring has been backported first (see https://jira.xwiki.org/browse/XWIKI-12987)