### PR TITLE
XWIKI-22865: Gallery Macro does not display correctly images anymore on Chrome and Edge

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/gallery/gallery.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/gallery/gallery.css
@@ -33,6 +33,8 @@
   object-fit: scale-down;
   max-width: 100%;
   max-height: 100%;
+  /* Weirdly needed so that the image would behave as expected in the grid layout in chromiums... */
+  min-height: 0;
 }
 
 /* Transparent buttons that should fill the space they've been given on the grid */


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22865

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Fixed the issue specific to chromiums. This fix has no impact on the Firefox styles.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Tried out this fix because of https://stackoverflow.com/questions/50542629/make-image-fit-css-grid
* Since the value is non limitative and it was not set anywhere else for this element, this has no effect on the Firefox display, and only "expected" effects on Chrome/Edge.
* From what I can understand, this is just a quirk of using an image directly in a grid layout.


# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Here is a video demo showcasing the effect of the change. Made on Edge latest on browserstack.

https://github.com/user-attachments/assets/ffde77ca-eef5-4241-86b9-fd1c215fa2e1



# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Manual tests only, on Chrome, Edge and Firefox. The layout is now the same on the three browsers. Took the opportunity to make sure things are alright on Safari latest too. The layout behaved as expected on all supported browsers.

No automatic tests caught such an obvious layout issue, there's no need to run our tests on such a localized style change.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X, like https://jira.xwiki.org/browse/XWIKI-22581
