### PR TITLE
XWIKI-22754: Use noavatar.png instead of noavatargroup.png for non-existing groups in macros.vm

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -361,7 +361,7 @@ $xwiki.getUserName("xwiki:${username}")
 #macro(getUserAvatarURL $userName $return $size)
   #set ($specified = false)
   #set ($profileDoc = $xwiki.getDocument($userName))
-  #if ($profileDoc.getObject('XWiki.XWikiGroups'))
+  #if ($profileDoc.getObject('XWiki.XWikiGroups') || !$profileDoc.getObject('XWiki.XWikiGroups'))
     #set ($url = $xwiki.getSkinFile('icons/xwiki/noavatargroup.png', true))
   #else
     #set ($url = $xwiki.getSkinFile('icons/xwiki/noavatar.png', true))


### PR DESCRIPTION
# Jira URL

[XWIKI-22754: Use noavatar.png instead of noavatargroup.png for non-existing groups in macros.vm](https://jira.xwiki.org/browse/XWIKI-22754)

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* add extra condition

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

Before

![before fix](https://github.com/user-attachments/assets/226576b8-edd6-452a-8054-b63319f386f8)

After

![after fix](https://github.com/user-attachments/assets/2c06adab-5ae7-4e57-8949-ae1956472a4d)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 