### PR TITLE
XWIKI-22782: Only save modified xobjects

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
@@ -1181,7 +1181,11 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
                                 obj.setXClassReference(localGroupEntityReference);
                                 obj.setNumber(number.intValue());
                                 obj.setStringValue("member", member);
+                                // Mark the property that has just been loaded as clean.
+                                ((BaseProperty<?>) obj.getField("member")).setDirty(false);
                                 doc.setXObject(obj.getNumber(), obj);
+                                // The object just been loaded so make sure it's considered clean
+                                obj.setDirty(false);
                             }
                         }
                     }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22782

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Mark group objects as clean after loading them.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* I ran the "fixed" version locally and noticed that group objects were always marked as dirty even though group objects are the original target of this PR. This change fixes this for me.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI change.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
LANG=C.UTF-8 mvn clean install -Pdocker,legacy,integration-tests,snapshotModules,quality -pl :xwiki-platform-oldcore,:xwiki-platform-legacy-oldcore
```

Manual tests with an updated JAR to verify that the group objects are considered clean now.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-16.10.x
  * stable-16.4.x