### PR TITLE
JavadocVariable: Replaced property scope with new accessModifiers

### DIFF
--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/doc/InstalledExtensionDocumentTree.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/doc/InstalledExtensionDocumentTree.java
@@ -52,8 +52,10 @@ public class InstalledExtensionDocumentTree
 {
     private static final class InstalledExtensionDocumentTreeNode
     {
+        @SuppressWarnings("checkstyle:javadocvariable")
         public Set<Locale> customizedLocales;
 
+        @SuppressWarnings("checkstyle:javadocvariable")
         public Set<DocumentReference> children = Collections.newSetFromMap(new ConcurrentHashMap<>());
     }
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/src/main/java/org/xwiki/notifications/internal/DefaultGroupingEventStrategy.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/src/main/java/org/xwiki/notifications/internal/DefaultGroupingEventStrategy.java
@@ -46,10 +46,13 @@ public class DefaultGroupingEventStrategy implements GroupingEventStrategy
 
     private static final class BestSimilarity
     {
+        @SuppressWarnings("checkstyle:javadocvariable")
         public int value;
 
+        @SuppressWarnings("checkstyle:javadocvariable")
         public CompositeEvent compositeEvent;
 
+        @SuppressWarnings("checkstyle:javadocvariable")
         public Event event;
 
         public boolean isCompositeEventCompatibleWith(Event event)

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/livedata/AbstractNotificationFilterLiveDataEntryStore.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/livedata/AbstractNotificationFilterLiveDataEntryStore.java
@@ -76,7 +76,9 @@ public abstract class AbstractNotificationFilterLiveDataEntryStore implements Li
 
     protected static final class TargetInformation
     {
+        @SuppressWarnings("checkstyle:javadocvariable")
         public boolean isWikiTarget;
+        @SuppressWarnings("checkstyle:javadocvariable")
         public EntityReference ownerReference;
 
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/ImplicitlyAllowedValuesDBListQueryBuilder.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/ImplicitlyAllowedValuesDBListQueryBuilder.java
@@ -52,22 +52,31 @@ public class ImplicitlyAllowedValuesDBListQueryBuilder implements QueryBuilder<D
 {
     private static final class DBListQuerySpec
     {
+        @SuppressWarnings("checkstyle:javadocvariable")
         public String wiki;
 
+        @SuppressWarnings("checkstyle:javadocvariable")
         public String className;
 
+        @SuppressWarnings("checkstyle:javadocvariable")
         public String idField;
 
+        @SuppressWarnings("checkstyle:javadocvariable")
         public String valueField;
 
+        @SuppressWarnings("checkstyle:javadocvariable")
         public String parentField;
 
+        @SuppressWarnings("checkstyle:javadocvariable")
         public boolean hasClassName;
 
+        @SuppressWarnings("checkstyle:javadocvariable")
         public boolean hasIdField;
 
+        @SuppressWarnings("checkstyle:javadocvariable")
         public boolean hasValueField;
 
+        @SuppressWarnings("checkstyle:javadocvariable")
         public boolean hasParentField;
     }
 


### PR DESCRIPTION
As per upcoming changes in https://github.com/checkstyle/checkstyle/pull/16049 for [JavadocVariable](https://checkstyle.org/checks/javadoc/javadocvariable.html#JavadocVariable) check, and updates in xwiki-commons https://github.com/xwiki/xwiki-commons/pull/1241 to accommodate for the changes, this PR adds suppression where the new behavior of the check will fail as the surrounding scope is not accounted for. 

Javadocs can be added instead if required. 

>[!Note]
>This PR should be merged after the release of checkstyle 10.22.0 and https://github.com/xwiki/xwiki-commons/pull/1241 is merged