### PR TITLE
XWIKI-22904: WCAG not complied in navigation panel administration

### DIFF
--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/PanelsCode/NavigationConfigurationSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/PanelsCode/NavigationConfigurationSheet.xml
@@ -1154,10 +1154,26 @@ ul.exclusion-filter-pages a {
 .navigationPanelConfiguration .jstree-active + .jstree-actions .jstree-action-pin {
   display: inline-block;
 }
+
+// When a node is pinned but not in focus anymore, the pin is still shown, and we make sure an alternative text is still
+// available for assistive technologies.
+.navigationPanelConfiguration [data-pinned=true]:not(.jstree-clicked):not(.jstree-active) + .jstree-actions 
+.jstree-action-pin-off { 
+  display: inline;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  border: 0;
+}
+
 .navigationPanelConfiguration .jstree-action-pin-on,
 .navigationPanelConfiguration .jstree-action-pin-off {
   display: none;
 }
+
 .navigationPanelConfiguration .jstree-active[data-pinned=true] + .jstree-actions .jstree-action-pin-off,
 .navigationPanelConfiguration .jstree-clicked[data-pinned=true] + .jstree-actions .jstree-action-pin-off,
 .navigationPanelConfiguration .jstree-active:not([data-pinned=true]) + .jstree-actions .jstree-action-pin-on,

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/PanelsCode/NavigationConfigurationSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/src/main/resources/PanelsCode/NavigationConfigurationSheet.xml
@@ -704,7 +704,7 @@ require([
   //
 
   const pinActionTemplate = $(`
-    &lt;button class="jstree-action-pin" type="button"&gt;
+    &lt;button class="jstree-action-pin" type="button" aria-hidden="true" tabindex="-1"&gt;
       &lt;i class="icon fa fa-thumb-tack"&gt;&lt;/i&gt;
       &lt;span class="jstree-action-pin-on"&gt;&lt;/span&gt;
       &lt;span class="jstree-action-pin-off"&gt;&lt;/span&gt;


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22904

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Fixed the two accessibility regressions that were brought in previous PRs for this ticket.

```
WCAG fails in the test class [org.xwiki.panels.test.ui.docker.AllIT]:
__________
Validation in the test method [verifyPanelCaching]
Check for [org.xwiki.panels.test.po.NavigationPanelAdministrationPage] at [http://xwikiweb:8080/xwiki/bin/admin/XWiki/XWikiPreferences?form_token=MDyIPXPlyu0M6tkNYcRvEg&editor=globaladmin&forceEdit=true&section=panels.navigation&force=true&].
Found [2] items

1: Certain ARIA roles must contain particular children
Description: Ensure elements with an ARIA role that require child roles contain them
Help URL: https://dequeuniversity.com/rules/axe/4.10/aria-required-children?application=axeAPI
Help: Certain ARIA roles must contain particular children
Impact: critical
Tags: cat.aria, wcag2a, wcag131, EN-301-549, EN-9.1.3.1

HTML element: 
 <div class="xtree jstree-no-links jstree-xwiki-large jstree jstree-1 jstree-xwiki jstree-xwiki-responsive" data-responsive="true" data-url="/xwiki/bin/get/Panels/Navigation?outputSyntax=plain&amp;sheet=XWiki.DocumentTree&amp;showAttachments=false&amp;showTranslations=false&amp;exclusions=space%3ACarol&amp;exclusions=space%3AIconThemesCode&amp;exclusions=space%3APanels&amp;exclusions=space%3APanelsCode&amp;exclusions=space%3AIndex&amp;exclusions=space%3AAppWithinMinutes&amp;exclusions=space%3AAttachment&amp;exclusions=space%3AIconThemes" data-draganddrop="true" data-contextmenu="false" data-icons="false" data-edges="false" data-checkboxes="false" data-opento="document:xwiki:Panels.Navigation" data-finder="false" role="tree" aria-multiselectable="true" tabindex="0" aria-activedescendant="document:xwiki:A AA.WebHome" aria-busy="false">
Selector: [.jstree-no-links]
Fix any of the following:
  Element has children which are not allowed: button[tabindex]

2: Buttons must have discernible text
Description: Ensure buttons have discernible text
Help URL: https://dequeuniversity.com/rules/axe/4.10/button-name?application=axeAPI
Help: Buttons must have discernible text
Impact: critical
Tags: cat.name-role-value, wcag2a, wcag412, section508, section508.22.a, TTv5, TT6.a, EN-301-549, EN-9.4.1.2, ACT

HTML element: 
 <button class="jstree-action-pin" type="button">
Selector: [.jstree-leaf.jstree-node[role="none"]:nth-child(1) > .jstree-actions > .jstree-action-pin[type="button"]]
Fix any of the following:
  Element does not have inner text that is visible to screen readers
  aria-label attribute does not exist or is empty
  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
  Element has no title attribute
  Element does not have an implicit (wrapped) <label>
  Element does not have an explicit <label>
  Element's default semantics were not overridden with role="none" or role="presentation"

 ==> expected: <false> but was: <true>
```

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The 'no alternative text on the pin button' exception is straightforward to fix. We just need to make sure the `Pinned, click to unpin` message is shown to assistive technologies when the pin indicator is shown. We use an equivalent to sr-only to do that and don't need to add any HTML/Javascript.
* The 'only treeitem are allowed as 'leaf' nodes in a tree'  exception was more tricky. For the sake of getting a solution out quickly, I went for a compromise that sacrificed the accessibility of this feature, but passes tests. I decided to just hide those buttons from the assistive tree completely. Since this is some specific Admin UI, it's not as critical for accessibility as anything exposed to the end user. Other than that, I thought of a few changes that might have been better to represent what we mean with those buttons, but in the end I could use none:
  * Nest buttons inside the current treeitems. They are just some content of the option. Impossible because the treeitems are anchors. Nesting interactive elements should really be avoided because it can end up in inconsistent behaviours.
  * Making buttons treeitems doesn't make sense semantically and would just make the tree harder to understand.
  * Moving the treeitem role from the anchor to the list item, the common parent of both the anchor and the button. Difficult to do since this messes with things that are handled internally to jstree. I don't want to try messing with JSTree. It's poorly documented and not that easy to extend. It's really dangerous and could create a lot of bugs down the line.
  * Find an accepted class for such 'leaf' nodes that are not treeitems in trees. This doesn't exist from what I could read everywhere. The tree role is a bit restrictive and not really easy to use in varied situations...
  * Move the buttons out of the tree structure. Eventually I think this will be the best solution, but it'll probably cause bugs in the pinning javascript code. Moreover it will result in non anecdotal layout changes that would need to be adress with quite a few line changes.


# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No visual changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Built changes with `mvn clean install -f xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/ -Pquality`.
Tested them with `mvn clean install -f xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-ui/ -Pquality`. As expected, there was no WCAG violation reported anymore. The only failures in the test looked like flickers and an unrelated issue (that can already be seen on CI).

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X (like other PRs for XWIKI-22885)