### PR TITLE
applied checkstyle suppression

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataConfigurationResolver.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataConfigurationResolver.java
@@ -63,6 +63,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 @Component
 @Named("liveTable")
 @Singleton
+@SuppressWarnings("checkstyle:ClassFanOutComplexity")
 public class LiveTableLiveDataConfigurationResolver implements LiveDataConfigurationResolver<LiveTableConfiguration>
 {
     private static final String HTML = "html";


### PR DESCRIPTION
## Suppress ClassFanOutComplexity Checkstyle Rule
### Description
This PR suppresses the ClassFanOutComplexity Checkstyle rule for the relevant module, as the issue was previously discussed and addressed in [PR #1243](https://github.com/xwiki/xwiki-commons/pull/1243).

### Changes
Suppressed the ClassFanOutComplexity check for `LiveTableLiveDataConfigurationResolver.java`

### Implementation Notes
This PR should be merged after we release the new Checkstyle version and xwiki upgrades to it. Without this change, existing code that was previously compliant may fail validation checks.