### PR TITLE
XWIKI-22913: Analyzing mentions on a document with a huge number of objects takes very long

### DIFF
--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/analyzer/UpdatedDocumentMentionsAnalyzer.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/analyzer/UpdatedDocumentMentionsAnalyzer.java
@@ -54,9 +54,9 @@ import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.xwiki.annotation.Annotation.SELECTION_FIELD;
 import static org.xwiki.mentions.MentionLocation.ANNOTATION;
-import static org.xwiki.mentions.MentionLocation.TEXT_FIELD;
 import static org.xwiki.mentions.MentionLocation.COMMENT;
 import static org.xwiki.mentions.MentionLocation.DOCUMENT;
+import static org.xwiki.mentions.MentionLocation.TEXT_FIELD;
 
 /**
  * Analyzes the new mentions on updated documents.
@@ -201,12 +201,12 @@ public class UpdatedDocumentMentionsAnalyzer extends AbstractDocumentMentionsAna
     {
         List<MentionNotificationParameters> mentionNotificationParametersList = new ArrayList<>();
         if (baseObject != null) {
-            Optional<BaseObject> oldBaseObject = ofNullable(oldEntry).flatMap(
-                optOldEntries -> optOldEntries
-                    .stream()
-                    .filter(Objects::nonNull)
-                    .filter(it -> it.getId() == baseObject.getId())
-                    .findAny());
+            Optional<BaseObject> oldBaseObject;
+            if (oldEntry != null && oldEntry.size() > baseObject.getNumber()) {
+                oldBaseObject = Optional.ofNullable(oldEntry.get(baseObject.getNumber()));
+            } else {
+                oldBaseObject = Optional.empty();
+            }
 
             // Special treatment on comment objects to analyse only the comment field.
             if (Objects.equals(baseObject


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22913

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Don't do a linear search for finding the object with the correct number.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* `getId()` also just uses the object type and number from what I can see, so I don't think the linear search did anything more than the direct access that I'm using now.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

`mvn -f pom.xml clean verify -Pdocker,legacy,integration-tests,snapshotModules,quality` in `xwiki-platform-core/xwiki-platform-mentions`.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-16.4.x
  * stable-16.10.x