### PR TITLE
XWIKI-22917: Solr indexing takes very long when there are many objects with different values

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/DefaultSolrIndexer.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/DefaultSolrIndexer.java
@@ -57,8 +57,8 @@ import org.xwiki.search.solr.internal.api.SolrIndexerException;
 import org.xwiki.search.solr.internal.api.SolrInstance;
 import org.xwiki.search.solr.internal.job.IndexerJob;
 import org.xwiki.search.solr.internal.job.IndexerRequest;
-import org.xwiki.search.solr.internal.metadata.LengthSolrInputDocument;
 import org.xwiki.search.solr.internal.metadata.SolrMetadataExtractor;
+import org.xwiki.search.solr.internal.metadata.XWikiSolrInputDocument;
 import org.xwiki.search.solr.internal.reference.SolrReferenceResolver;
 import org.xwiki.store.ReadyIndicator;
 
@@ -501,7 +501,7 @@ public class DefaultSolrIndexer implements SolrIndexer, Initializable, Disposabl
 
                 switch (operation) {
                     case INDEX:
-                        LengthSolrInputDocument solrDocument = getSolrDocument(batchEntry.reference);
+                        XWikiSolrInputDocument solrDocument = getSolrDocument(batchEntry.reference);
                         if (solrDocument != null) {
                             solrInstance.add(solrDocument);
                             length += solrDocument.getLength();
@@ -599,7 +599,7 @@ public class DefaultSolrIndexer implements SolrIndexer, Initializable, Disposabl
      * @throws IllegalArgumentException if there is an incompatibility between a reference and the assigned extractor.
      * @throws ExecutionContextException
      */
-    private LengthSolrInputDocument getSolrDocument(EntityReference reference)
+    private XWikiSolrInputDocument getSolrDocument(EntityReference reference)
         throws SolrIndexerException, IllegalArgumentException, ExecutionContextException
     {
         SolrMetadataExtractor metadataExtractor = getMetadataExtractor(reference.getType());

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/AbstractSolrMetadataExtractor.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/AbstractSolrMetadataExtractor.java
@@ -151,11 +151,11 @@ public abstract class AbstractSolrMetadataExtractor implements SolrMetadataExtra
     }
 
     @Override
-    public LengthSolrInputDocument getSolrDocument(EntityReference entityReference)
+    public XWikiSolrInputDocument getSolrDocument(EntityReference entityReference)
         throws SolrIndexerException, IllegalArgumentException
     {
         try {
-            LengthSolrInputDocument solrDocument = new LengthSolrInputDocument();
+            XWikiSolrInputDocument solrDocument = new XWikiSolrInputDocument();
 
             solrDocument.setField(FieldUtils.ID, this.seachUtils.getId(entityReference));
             solrDocument.setField(FieldUtils.REFERENCE,
@@ -180,12 +180,12 @@ public abstract class AbstractSolrMetadataExtractor implements SolrMetadataExtra
     }
 
     /**
-     * @param solrDocument the {@link LengthSolrInputDocument} to modify
+     * @param solrDocument the {@link XWikiSolrInputDocument} to modify
      * @param entityReference the reference of the entity
      * @return false if the entity should not be indexed (generally mean it does not exist), true otherwise
      * @throws Exception in case of errors
      */
-    protected abstract boolean setFieldsInternal(LengthSolrInputDocument solrDocument, EntityReference entityReference)
+    protected abstract boolean setFieldsInternal(XWikiSolrInputDocument solrDocument, EntityReference entityReference)
         throws Exception;
 
     /**
@@ -365,7 +365,7 @@ public abstract class AbstractSolrMetadataExtractor implements SolrMetadataExtra
      * @param locale the locale of the indexed document; in case of translations, this will obviously be different than
      *            the original document's locale
      */
-    protected void setObjectContent(LengthSolrInputDocument solrDocument, BaseObject object, Locale locale)
+    protected void setObjectContent(XWikiSolrInputDocument solrDocument, BaseObject object, Locale locale)
     {
         if (object == null) {
             // Yes, the platform can return null objects.
@@ -392,7 +392,7 @@ public abstract class AbstractSolrMetadataExtractor implements SolrMetadataExtra
      * @param propertyClass the class that describes the given property
      * @param locale the locale of the indexed document
      */
-    protected void setPropertyValue(LengthSolrInputDocument solrDocument, BaseProperty<?> property,
+    protected void setPropertyValue(XWikiSolrInputDocument solrDocument, BaseProperty<?> property,
         PropertyClass propertyClass, Locale locale)
     {
         Object propertyValue = property.getValue();
@@ -454,7 +454,7 @@ public abstract class AbstractSolrMetadataExtractor implements SolrMetadataExtra
      * @param locale the locale of the indexed document
      * @see "XWIKI-9417: Search does not return any results for Static List values"
      */
-    private void setStaticListPropertyValue(LengthSolrInputDocument solrDocument, BaseProperty<?> property,
+    private void setStaticListPropertyValue(XWikiSolrInputDocument solrDocument, BaseProperty<?> property,
         StaticListClass propertyClass, Locale locale)
     {
         // The list of known values specified in the XClass.
@@ -489,7 +489,7 @@ public abstract class AbstractSolrMetadataExtractor implements SolrMetadataExtra
      * @param typedValue the value to add
      * @param locale the locale of the indexed document
      */
-    protected void setPropertyValue(LengthSolrInputDocument solrDocument, BaseProperty<?> property,
+    protected void setPropertyValue(XWikiSolrInputDocument solrDocument, BaseProperty<?> property,
         TypedValue typedValue, Locale locale)
     {
         // Collect all the property values from all the objects of a document in a single (localized) field.
@@ -508,7 +508,7 @@ public abstract class AbstractSolrMetadataExtractor implements SolrMetadataExtra
      * @param fieldName the field name
      * @param fieldValue the field value to add
      */
-    protected void addFieldValueOnce(LengthSolrInputDocument solrDocument, String fieldName, Object fieldValue)
+    protected void addFieldValueOnce(XWikiSolrInputDocument solrDocument, String fieldName, Object fieldValue)
     {
         solrDocument.addFieldOnce(fieldName, fieldValue);
     }

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/AbstractSolrMetadataExtractor.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/AbstractSolrMetadataExtractor.java
@@ -365,7 +365,7 @@ public abstract class AbstractSolrMetadataExtractor implements SolrMetadataExtra
      * @param locale the locale of the indexed document; in case of translations, this will obviously be different than
      *            the original document's locale
      */
-    protected void setObjectContent(SolrInputDocument solrDocument, BaseObject object, Locale locale)
+    protected void setObjectContent(LengthSolrInputDocument solrDocument, BaseObject object, Locale locale)
     {
         if (object == null) {
             // Yes, the platform can return null objects.
@@ -392,7 +392,7 @@ public abstract class AbstractSolrMetadataExtractor implements SolrMetadataExtra
      * @param propertyClass the class that describes the given property
      * @param locale the locale of the indexed document
      */
-    protected void setPropertyValue(SolrInputDocument solrDocument, BaseProperty<?> property,
+    protected void setPropertyValue(LengthSolrInputDocument solrDocument, BaseProperty<?> property,
         PropertyClass propertyClass, Locale locale)
     {
         Object propertyValue = property.getValue();
@@ -454,7 +454,7 @@ public abstract class AbstractSolrMetadataExtractor implements SolrMetadataExtra
      * @param locale the locale of the indexed document
      * @see "XWIKI-9417: Search does not return any results for Static List values"
      */
-    private void setStaticListPropertyValue(SolrInputDocument solrDocument, BaseProperty<?> property,
+    private void setStaticListPropertyValue(LengthSolrInputDocument solrDocument, BaseProperty<?> property,
         StaticListClass propertyClass, Locale locale)
     {
         // The list of known values specified in the XClass.
@@ -489,7 +489,7 @@ public abstract class AbstractSolrMetadataExtractor implements SolrMetadataExtra
      * @param typedValue the value to add
      * @param locale the locale of the indexed document
      */
-    protected void setPropertyValue(SolrInputDocument solrDocument, BaseProperty<?> property,
+    protected void setPropertyValue(LengthSolrInputDocument solrDocument, BaseProperty<?> property,
         TypedValue typedValue, Locale locale)
     {
         // Collect all the property values from all the objects of a document in a single (localized) field.
@@ -508,12 +508,9 @@ public abstract class AbstractSolrMetadataExtractor implements SolrMetadataExtra
      * @param fieldName the field name
      * @param fieldValue the field value to add
      */
-    protected void addFieldValueOnce(SolrInputDocument solrDocument, String fieldName, Object fieldValue)
+    protected void addFieldValueOnce(LengthSolrInputDocument solrDocument, String fieldName, Object fieldValue)
     {
-        Collection<Object> fieldValues = solrDocument.getFieldValues(fieldName);
-        if (fieldValues == null || !fieldValues.contains(fieldValue)) {
-            solrDocument.addField(fieldName, fieldValue);
-        }
+        solrDocument.addFieldOnce(fieldName, fieldValue);
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/AttachmentSolrMetadataExtractor.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/AttachmentSolrMetadataExtractor.java
@@ -51,7 +51,7 @@ public class AttachmentSolrMetadataExtractor extends AbstractSolrMetadataExtract
     private EntityReferenceSerializer<String> entityReferenceSerializer;
 
     @Override
-    public boolean setFieldsInternal(LengthSolrInputDocument solrDocument, EntityReference entityReference)
+    public boolean setFieldsInternal(XWikiSolrInputDocument solrDocument, EntityReference entityReference)
         throws Exception
     {
         AttachmentReference attachmentReference = new AttachmentReference(entityReference);

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/DocumentSolrMetadataExtractor.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/DocumentSolrMetadataExtractor.java
@@ -97,7 +97,7 @@ public class DocumentSolrMetadataExtractor extends AbstractSolrMetadataExtractor
     private SolrFieldNameEncoder fieldNameEncoder;
 
     @Override
-    public boolean setFieldsInternal(LengthSolrInputDocument solrDocument, EntityReference entityReference)
+    public boolean setFieldsInternal(XWikiSolrInputDocument solrDocument, EntityReference entityReference)
         throws Exception
     {
         DocumentReference documentReference = new DocumentReference(entityReference);
@@ -218,7 +218,7 @@ public class DocumentSolrMetadataExtractor extends AbstractSolrMetadataExtractor
      * @param locale the locale of which to index the extra data.
      * @throws XWikiException if problems occur.
      */
-    protected void setExtras(DocumentReference documentReference, LengthSolrInputDocument solrDocument, Locale locale)
+    protected void setExtras(DocumentReference documentReference, XWikiSolrInputDocument solrDocument, Locale locale)
         throws XWikiException
     {
         // We need to support the following types of queries:
@@ -244,7 +244,7 @@ public class DocumentSolrMetadataExtractor extends AbstractSolrMetadataExtractor
      * @param locale the locale for which to index the objects.
      * @param originalDocument the original document where the objects come from.
      */
-    protected void setObjects(LengthSolrInputDocument solrDocument, Locale locale, XWikiDocument originalDocument)
+    protected void setObjects(XWikiSolrInputDocument solrDocument, Locale locale, XWikiDocument originalDocument)
     {
         for (Map.Entry<DocumentReference, List<BaseObject>> objects : originalDocument.getXObjects().entrySet()) {
             boolean hasObjectsOfThisType = false;
@@ -260,7 +260,7 @@ public class DocumentSolrMetadataExtractor extends AbstractSolrMetadataExtractor
     }
 
     @Override
-    protected void setPropertyValue(LengthSolrInputDocument solrDocument, BaseProperty<?> property,
+    protected void setPropertyValue(XWikiSolrInputDocument solrDocument, BaseProperty<?> property,
         TypedValue typedValue, Locale locale)
     {
         Object value = typedValue.getValue();

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/DocumentSolrMetadataExtractor.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/DocumentSolrMetadataExtractor.java
@@ -218,7 +218,7 @@ public class DocumentSolrMetadataExtractor extends AbstractSolrMetadataExtractor
      * @param locale the locale of which to index the extra data.
      * @throws XWikiException if problems occur.
      */
-    protected void setExtras(DocumentReference documentReference, SolrInputDocument solrDocument, Locale locale)
+    protected void setExtras(DocumentReference documentReference, LengthSolrInputDocument solrDocument, Locale locale)
         throws XWikiException
     {
         // We need to support the following types of queries:
@@ -244,7 +244,7 @@ public class DocumentSolrMetadataExtractor extends AbstractSolrMetadataExtractor
      * @param locale the locale for which to index the objects.
      * @param originalDocument the original document where the objects come from.
      */
-    protected void setObjects(SolrInputDocument solrDocument, Locale locale, XWikiDocument originalDocument)
+    protected void setObjects(LengthSolrInputDocument solrDocument, Locale locale, XWikiDocument originalDocument)
     {
         for (Map.Entry<DocumentReference, List<BaseObject>> objects : originalDocument.getXObjects().entrySet()) {
             boolean hasObjectsOfThisType = false;
@@ -260,7 +260,7 @@ public class DocumentSolrMetadataExtractor extends AbstractSolrMetadataExtractor
     }
 
     @Override
-    protected void setPropertyValue(SolrInputDocument solrDocument, BaseProperty<?> property,
+    protected void setPropertyValue(LengthSolrInputDocument solrDocument, BaseProperty<?> property,
         TypedValue typedValue, Locale locale)
     {
         Object value = typedValue.getValue();

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/ObjectPropertySolrMetadataExtractor.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/ObjectPropertySolrMetadataExtractor.java
@@ -56,7 +56,7 @@ public class ObjectPropertySolrMetadataExtractor extends AbstractSolrMetadataExt
     private SolrReferenceResolver resolver;
 
     @Override
-    public boolean setFieldsInternal(LengthSolrInputDocument solrDocument, EntityReference entityReference)
+    public boolean setFieldsInternal(XWikiSolrInputDocument solrDocument, EntityReference entityReference)
         throws Exception
     {
         ObjectPropertyReference objectPropertyReference = new ObjectPropertyReference(entityReference);
@@ -90,7 +90,7 @@ public class ObjectPropertySolrMetadataExtractor extends AbstractSolrMetadataExt
     }
 
     @Override
-    protected void setPropertyValue(LengthSolrInputDocument solrDocument, BaseProperty<?> property,
+    protected void setPropertyValue(XWikiSolrInputDocument solrDocument, BaseProperty<?> property,
         TypedValue typedValue, Locale locale)
     {
         String fieldName = FieldUtils.getFieldName(FieldUtils.PROPERTY_VALUE, locale);
@@ -111,7 +111,7 @@ public class ObjectPropertySolrMetadataExtractor extends AbstractSolrMetadataExt
      * @param objectProperty the object property.
      * @throws Exception if problems occur.
      */
-    protected void setLocaleAndContentFields(DocumentReference documentReference, LengthSolrInputDocument solrDocument,
+    protected void setLocaleAndContentFields(DocumentReference documentReference, XWikiSolrInputDocument solrDocument,
         BaseProperty<ObjectPropertyReference> objectProperty) throws Exception
     {
         PropertyClass propertyClass = objectProperty.getPropertyClass(this.xcontextProvider.get());

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/ObjectPropertySolrMetadataExtractor.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/ObjectPropertySolrMetadataExtractor.java
@@ -25,7 +25,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.apache.solr.common.SolrInputDocument;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
@@ -91,7 +90,7 @@ public class ObjectPropertySolrMetadataExtractor extends AbstractSolrMetadataExt
     }
 
     @Override
-    protected void setPropertyValue(SolrInputDocument solrDocument, BaseProperty<?> property,
+    protected void setPropertyValue(LengthSolrInputDocument solrDocument, BaseProperty<?> property,
         TypedValue typedValue, Locale locale)
     {
         String fieldName = FieldUtils.getFieldName(FieldUtils.PROPERTY_VALUE, locale);
@@ -112,7 +111,7 @@ public class ObjectPropertySolrMetadataExtractor extends AbstractSolrMetadataExt
      * @param objectProperty the object property.
      * @throws Exception if problems occur.
      */
-    protected void setLocaleAndContentFields(DocumentReference documentReference, SolrInputDocument solrDocument,
+    protected void setLocaleAndContentFields(DocumentReference documentReference, LengthSolrInputDocument solrDocument,
         BaseProperty<ObjectPropertyReference> objectProperty) throws Exception
     {
         PropertyClass propertyClass = objectProperty.getPropertyClass(this.xcontextProvider.get());

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/ObjectSolrMetadataExtractor.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/ObjectSolrMetadataExtractor.java
@@ -54,7 +54,7 @@ public class ObjectSolrMetadataExtractor extends AbstractSolrMetadataExtractor
     private SolrReferenceResolver resolver;
 
     @Override
-    public boolean setFieldsInternal(LengthSolrInputDocument solrDocument, EntityReference entityReference)
+    public boolean setFieldsInternal(XWikiSolrInputDocument solrDocument, EntityReference entityReference)
         throws Exception
     {
         BaseObjectReference objectReference = new BaseObjectReference(entityReference);
@@ -95,7 +95,7 @@ public class ObjectSolrMetadataExtractor extends AbstractSolrMetadataExtractor
      * @param object the object.
      * @throws Exception if problems occur.
      */
-    protected void setLocaleAndContentFields(DocumentReference documentReference, LengthSolrInputDocument solrDocument,
+    protected void setLocaleAndContentFields(DocumentReference documentReference, XWikiSolrInputDocument solrDocument,
         BaseObject object) throws Exception
     {
         // Do the work for each locale.

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/ObjectSolrMetadataExtractor.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/ObjectSolrMetadataExtractor.java
@@ -25,7 +25,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.apache.solr.common.SolrInputDocument;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
@@ -96,7 +95,7 @@ public class ObjectSolrMetadataExtractor extends AbstractSolrMetadataExtractor
      * @param object the object.
      * @throws Exception if problems occur.
      */
-    protected void setLocaleAndContentFields(DocumentReference documentReference, SolrInputDocument solrDocument,
+    protected void setLocaleAndContentFields(DocumentReference documentReference, LengthSolrInputDocument solrDocument,
         BaseObject object) throws Exception
     {
         // Do the work for each locale.

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/SolrMetadataExtractor.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/SolrMetadataExtractor.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.search.solr.internal.metadata;
 
+import org.apache.solr.common.SolrInputDocument;
 import org.xwiki.component.annotation.Role;
 import org.xwiki.model.reference.EntityReference;
 import org.xwiki.search.solr.internal.api.SolrIndexerException;
@@ -45,6 +46,6 @@ public interface SolrMetadataExtractor
      * @throws SolrIndexerException if problems occur.
      * @throws IllegalArgumentException if the passed reference is not supported by the current implementation.
      */
-    LengthSolrInputDocument getSolrDocument(EntityReference entityReference) throws SolrIndexerException,
+    XWikiSolrInputDocument getSolrDocument(EntityReference entityReference) throws SolrIndexerException,
         IllegalArgumentException;
 }

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/XWikiSolrInputDocument.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/XWikiSolrInputDocument.java
@@ -26,14 +26,15 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.common.SolrInputField;
 
 /**
- * Extended SolrInputDocument with calculated size.
+ * Extended SolrInputDocument with calculated size and support for adding fields once.
  * 
  * @version $Id$
  * @since 5.1M2
  */
-public class LengthSolrInputDocument extends SolrInputDocument
+public class XWikiSolrInputDocument extends SolrInputDocument
 {
     /**
      * Serialization identifier.
@@ -66,9 +67,24 @@ public class LengthSolrInputDocument extends SolrInputDocument
             this.length += ((byte[]) value).length;
         }
 
+        // Remove the field as the values have been reset.
         this.uniqueFields.remove(name);
 
         // TODO: support more type ?
+    }
+
+    @Override
+    public SolrInputField removeField(String name)
+    {
+        this.uniqueFields.remove(name);
+        return super.removeField(name);
+    }
+
+    @Override
+    public void clear()
+    {
+        this.uniqueFields.clear();
+        super.clear();
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/XWikiSolrInputDocument.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/XWikiSolrInputDocument.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.search.solr.internal.metadata;
 
+import java.io.Serial;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -32,13 +33,16 @@ import org.apache.solr.common.SolrInputField;
  * Extended SolrInputDocument with calculated size and support for adding fields once.
  * 
  * @version $Id$
- * @since 5.1M2
+ * @since 16.4.7
+ * @since 16.10.5
+ * @since 17.2.0RC1
  */
 public class XWikiSolrInputDocument extends SolrInputDocument
 {
     /**
      * Serialization identifier.
      */
+    @Serial
     private static final long serialVersionUID = 1L;
 
     /**
@@ -61,10 +65,10 @@ public class XWikiSolrInputDocument extends SolrInputDocument
     {
         super.setField(name, value);
 
-        if (value instanceof String) {
-            this.length += ((String) value).length();
-        } else if (value instanceof byte[]) {
-            this.length += ((byte[]) value).length;
+        if (value instanceof String stringValue) {
+            this.length += stringValue.length();
+        } else if (value instanceof byte[] bytesValue) {
+            this.length += bytesValue.length;
         }
 
         // Remove the field as the values have been reset.
@@ -92,9 +96,6 @@ public class XWikiSolrInputDocument extends SolrInputDocument
      *
      * @param name the field name
      * @param value the value to add
-     * @since 16.4.7
-     * @since 16.10.5
-     * @since 17.2.0RC1
      */
     protected void addFieldOnce(String name, Object value)
     {

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/test/java/org/xwiki/search/solr/internal/metadata/XWikiSolrInputDocumentTest.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/test/java/org/xwiki/search/solr/internal/metadata/XWikiSolrInputDocumentTest.java
@@ -82,4 +82,16 @@ class XWikiSolrInputDocumentTest
         doc.addFieldOnce(FIELD_1, VALUE_1);
         assertEquals(List.of(VALUE_1), doc.getFieldValues(FIELD_1));
     }
+
+    @Test
+    void setField()
+    {
+        XWikiSolrInputDocument doc = new XWikiSolrInputDocument();
+        doc.setField(FIELD_1, VALUE_1);
+        assertEquals(VALUE_1.length(), doc.getLength());
+        doc.setField(FIELD_1, VALUE_1);
+        assertEquals(2 * VALUE_1.length(), doc.getLength());
+        doc.setField(FIELD_1, VALUE_1.getBytes());
+        assertEquals(3 * VALUE_1.length(), doc.getLength());
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/test/java/org/xwiki/search/solr/internal/metadata/XWikiSolrInputDocumentTest.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/test/java/org/xwiki/search/solr/internal/metadata/XWikiSolrInputDocumentTest.java
@@ -1,0 +1,85 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.search.solr.internal.metadata;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Unit tests for {@link XWikiSolrInputDocument}.
+ *
+ * @version $Id$
+ */
+class XWikiSolrInputDocumentTest
+{
+    protected static final String FIELD_1 = "field1";
+
+    protected static final String VALUE_1 = "value1";
+
+    @Test
+    void testAddField()
+    {
+        XWikiSolrInputDocument doc = new XWikiSolrInputDocument();
+        doc.addField(FIELD_1, VALUE_1);
+        doc.addField(FIELD_1, VALUE_1);
+        assertEquals(List.of(VALUE_1, VALUE_1), doc.getFieldValues(FIELD_1));
+    }
+
+    @Test
+    void testAddFieldOnce()
+    {
+        XWikiSolrInputDocument doc = new XWikiSolrInputDocument();
+        // Basic test: adding a value twice should only add it once.
+        doc.addFieldOnce(FIELD_1, VALUE_1);
+        doc.addFieldOnce(FIELD_1, VALUE_1);
+        assertEquals(List.of(VALUE_1), doc.getFieldValues(FIELD_1));
+        // Adding a different value should add it, and it's unique even when added without the "once" method first.
+        String value2 = "value2";
+        doc.addField(FIELD_1, value2);
+        doc.addFieldOnce(FIELD_1, value2);
+        assertEquals(List.of(VALUE_1, value2), doc.getFieldValues(FIELD_1));
+        // Setting the field removes the previous values.
+        doc.setField(FIELD_1, value2);
+        assertEquals(value2, doc.getFieldValue(FIELD_1));
+        // Adding a value after setting the field should add it.
+        doc.addFieldOnce(FIELD_1, VALUE_1);
+        assertEquals(List.of(value2, VALUE_1), doc.getFieldValues(FIELD_1));
+        // Removing the field should allow adding the value again.
+        doc.removeField(FIELD_1);
+        doc.addFieldOnce(FIELD_1, VALUE_1);
+        assertEquals(List.of(VALUE_1), doc.getFieldValues(FIELD_1));
+        // Adding the value to another field should not affect the first field.
+        String field2 = "field2";
+        doc.addFieldOnce(field2, VALUE_1);
+        assertEquals(List.of(VALUE_1), doc.getFieldValues(FIELD_1));
+        assertEquals(List.of(VALUE_1), doc.getFieldValues(field2));
+        // Clearing the document should remove all fields.
+        doc.clear();
+        assertNull(doc.getFieldValue(FIELD_1));
+        assertNull(doc.getFieldValue(field2));
+        // Adding a value after clearing should add it.
+        doc.addFieldOnce(FIELD_1, VALUE_1);
+        assertEquals(List.of(VALUE_1), doc.getFieldValues(FIELD_1));
+    }
+}


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22917

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Use a HashSet to compute unique values instead of a linear search.
* Use LengthSolrInputDocument in more places to use the new method.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Adding the index with the `HashSet` seemed to be the easiest solution, an alternative would have been to sort and remove duplicates at the end but that would have required much deeper changes.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

`LANG=C.UTF-8 mvn clean install -Pdocker,legacy,integration-tests,quality` in `xwiki-platform-core/xwiki-platform-search`.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-16.4.7
  * stable-16.10.5