### PR TITLE
XWIKI-22930: Scroll bars appear in the right side of each icon

### DIFF
--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-ui/src/main/resources/IconThemesCode/IconPicker.xml
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-ui/src/main/resources/IconThemesCode/IconPicker.xml
@@ -668,7 +668,7 @@ require(['jquery', 'xwiki-icon-picker'], function($) {
     The value below is just about twice the line-height. */
   max-height: 2.9em;
   /* For the few names that need three lines, we make sure the user can scroll to read the whole name. */
-  overflow-y: scroll;
+  overflow-y: auto;
   overflow-x: hidden;
   /* Make sure the name wraps onto multiple lines instead of overflowing. */
   white-space: pre-wrap;

--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-ui/src/main/resources/IconThemesCode/IconPicker.xml
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-ui/src/main/resources/IconThemesCode/IconPicker.xml
@@ -631,7 +631,8 @@ require(['jquery', 'xwiki-icon-picker'], function($) {
   overflow-y: scroll;
   gap: .3em;
   padding: .3em;
-  grid-template-columns: repeat(4, 1fr);  /* 4 columns, each a fraction of the whole width */
+  /* 4 columns, each a fraction of the whole width */
+  grid-template-columns: repeat(4, 1fr);
 }
 
 /* Avoid stretching on the Loader element. */

--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-ui/src/main/resources/IconThemesCode/IconPicker.xml
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-ui/src/main/resources/IconThemesCode/IconPicker.xml
@@ -625,11 +625,13 @@ require(['jquery', 'xwiki-icon-picker'], function($) {
 }
 
 .xwikiIconPickerList {
-  overflow-y: scroll;
+  display: grid;
+  max-width: 100%;
   height: 240px;
-  display: flex;
-  flex-wrap: wrap;
+  overflow-y: scroll;
   gap: .3em;
+  padding: .3em;
+  grid-template-columns: repeat(4, 1fr);  /* 4 columns, each a fraction of the whole width */
 }
 
 /* Avoid stretching on the Loader element. */
@@ -638,15 +640,19 @@ require(['jquery', 'xwiki-icon-picker'], function($) {
 }
 
 .xwikiIconPickerIcon {
-  height: 80px;
-  width: 100px;
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+  padding: 0;
   text-align: center;
   border-radius: 7px;
   vertical-align: middle;
-  overflow: hidden;
-  padding: 10px;
   cursor: pointer;
   background-color: transparent;
+}
+
+.xwikiIconPickerIcon * {
+  padding: 0;
 }
 
 .xwikiIconPickerIcon:hover {
@@ -664,12 +670,6 @@ require(['jquery', 'xwiki-icon-picker'], function($) {
 }
 
 .xwikiIconPickerIcon .xwikiIconPickerIconName {
-  /* We want to limit the number of lines in the name so that it always fit inside the standard button size. 
-    The value below is just about twice the line-height. */
-  max-height: 2.9em;
-  /* For the few names that need three lines, we make sure the user can scroll to read the whole name. */
-  overflow-y: auto;
-  overflow-x: hidden;
   /* Make sure the name wraps onto multiple lines instead of overflowing. */
   white-space: pre-wrap;
   word-break: break-word;


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22930
For reference, caused by the commit from: https://github.com/xwiki/xwiki-platform/pull/3800


# Changes

## Description

* Updated the overflow-y value so that the scroll control only appears for elements whose name actually overflows.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* On my firefox installation, this style does not make much difference. But on Chrome and other firefox installs, this small change revert the regression on style.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Before the changes, on Chrome:
![image](https://github.com/user-attachments/assets/42399f9d-745a-46cd-bb50-4d18e9d6f399)


After the changes, on Chrome:
![image](https://github.com/user-attachments/assets/bc9eae35-0acf-4007-b819-5514439bfc60)
We can see that the scroll indicators are no longer displayed everywhere but only for the names that can be scrolled.
This is the expected behaviour.
# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests as seen above, tested only on Firefox and Chrome on Debian.
No automatic tests. This regression wasn't caught by any automatic tests and the solution we picked is very specific, it won't impact other UIs.
# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X (same as https://jira.xwiki.org/browse/XWIKI-22339 )