### PR TITLE
XWIKI-22934: Bottom padding too large in box/message macros

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/messages.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/messages.less
@@ -65,7 +65,7 @@ fieldset.xwikimessage { // Used by: Login form, Delete messages
 // Remove space added by last elements inside box, like paragraphs.
 .box > div > *:last-child,
 // Do the same when the box macro is edited in-line.
-.box > .xwiki-metadata-container > *:last-child {
+.box > div > .xwiki-metadata-container > *:last-child {
   margin-bottom: 0;
 }
 

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/messages.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/messages.less
@@ -63,7 +63,7 @@ fieldset.xwikimessage { // Used by: Login form, Delete messages
 }
 
 // Remove space added by last elements inside box, like paragraphs.
-.box > *:last-child,
+.box > div > *:last-child,
 // Do the same when the box macro is edited in-line.
 .box > .xwiki-metadata-container > *:last-child {
   margin-bottom: 0;


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22934

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Updated the CSS rule to fit the latest DOM 

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* See ticket.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

Video demo of the changes proposed here on the UI:

https://github.com/user-attachments/assets/7246523c-3af7-4120-9f28-536891945ffd



# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

See video above. This style change behaves as expected when adding a title or an image to the box.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X (same as https://jira.xwiki.org/browse/XRENDERING-768 which is the cause)