### PR TITLE
XWIKI-18194: Exiting FullScreen from the gallery macro scrolls the page in a random location

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/gallery/gallery.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/gallery/gallery.js
@@ -121,6 +121,10 @@ XWiki.Gallery = Class.create({
       "${escapetool.javascript($services.localization.render('core.widgets.gallery.minimize'))}";
     this.container.toggleClassName('maximized');
     $(document.documentElement).toggleClassName('maximized');
+    // When a keyboard shortcut is used, the gallery is not focused by default. In order to keep the screen at the
+    // level of the gallery even when minimizing, we need to make sure it's always focused.
+    // Without this forced focus, minimizing the gallery by pressing the `Escape` key will
+    // unexpectedly send the user to the top of the page.
     this.maximizeToggle.focus();
   },
   show : function(index) {


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-18194

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Focused the maximizeToggle button even when using a shortcut, so that it stays in the screen view.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* When checking out the code, I figured out the exact same function call happens when clicking and pressing a key to minimize the gallery. Therefore the difference in behaviour must be related to "something else" that happens when clicking that does not happen when pressing the shortcut key. One of those things is that the user focus is set to the `maximize` toggle. I tried focusing the maximize toggle and this solved the bug. This change is pretty straightforward and doesn't impact much the user experience except for having correct scrolling.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Here is a demo of how the gallery minimizing behaves with the changes.

https://github.com/user-attachments/assets/efd25396-b1b0-4e01-8eeb-1a5a66ad514a

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests only, see video above.
Automatic tests didn't catch this behaviour, and the changes don't impact the DOM in any way, so I am almost certain that no automatic test will be broken by this change.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X (rather safe bugfix)