### PR TITLE
XWIKI-22931: The edit action modify the cached document when creating a page from template

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiAttachment.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiAttachment.java
@@ -214,7 +214,12 @@ public class XWikiAttachment implements Cloneable
     @Override
     public XWikiAttachment clone()
     {
-        return internalClone(false, false);
+        return internalClone(false, false, true);
+    }
+
+    protected XWikiAttachment cloneWithActualContent()
+    {
+        return internalClone(false, false, false);
     }
 
     /**
@@ -230,7 +235,7 @@ public class XWikiAttachment implements Cloneable
     public XWikiAttachment clone(String name, XWikiContext context)
         throws XWikiException, IOException
     {
-        XWikiAttachment clone = internalClone(true, true);
+        XWikiAttachment clone = internalClone(true, true, true);
         if (clone == null) {
             // According to #internalClone, this should never happen.
             throw new XWikiException("Failed to clone the attachment", null);
@@ -1498,7 +1503,15 @@ public class XWikiAttachment implements Cloneable
         }
     }
 
-    private XWikiAttachment internalClone(boolean skipArchive, boolean skipContent)
+    /**
+     *
+     * @param skipArchive {@code true} to skip the attachment archive when cloning
+     * @param skipContent {@code true} to skip content metadata
+     * @param skipActualContent {@code false} will also include {@link XWikiAttachmentContent} content, but this
+     * flag is only used if {@code skipContent} is {@code false}.
+     * @return
+     */
+    private XWikiAttachment internalClone(boolean skipArchive, boolean skipContent, boolean skipActualContent)
     {
         XWikiAttachment attachment = null;
 
@@ -1516,7 +1529,7 @@ public class XWikiAttachment implements Cloneable
             attachment.setRCSVersion(getRCSVersion());
             attachment.setMetaDataDirty(isMetaDataDirty());
             if (!skipContent && getAttachment_content() != null) {
-                attachment.setAttachment_content((XWikiAttachmentContent) getAttachment_content().clone());
+                attachment.setAttachment_content(getAttachment_content().clone(skipActualContent));
                 attachment.getAttachment_content().setAttachment(attachment);
             }
             if (!skipArchive && getAttachment_archive() != null) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiAttachmentContent.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiAttachmentContent.java
@@ -32,6 +32,7 @@ import org.apache.commons.io.input.AutoCloseInputStream;
 import org.apache.commons.io.input.BoundedInputStream;
 import org.apache.commons.io.output.ProxyOutputStream;
 import org.xwiki.environment.Environment;
+import org.xwiki.stability.Unstable;
 import org.xwiki.store.UnexpectedException;
 
 import com.xpn.xwiki.web.Utils;
@@ -153,7 +154,32 @@ public class XWikiAttachmentContent implements Cloneable
     @Override
     public Object clone()
     {
-        return new XWikiAttachmentContent(this);
+        return clone(true);
+    }
+
+    /**
+     * Clone current instance and possibly copy the content.
+     * Note that {@link #clone()} never copy the actual content of the instance.
+     * @param skipContent {@code false} to also copy the content while performing the clone.
+     * @return a clone with the copied content or not depending on the parameter.
+     * @since 17.2.0RC1
+     * @since 16.10.5
+     * @since 16.4.7
+     */
+    @Unstable
+    public XWikiAttachmentContent clone(boolean skipContent)
+    {
+        XWikiAttachmentContent clone = new XWikiAttachmentContent(this);
+        // this AttachmentContent is not attached to any document yet.
+        clone.setOwnerDocument(null);
+        if (!skipContent) {
+            try {
+                clone.setContent(getContentInputStream());
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to clone data to storage.", e);
+            }
+        }
+        return clone;
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentMockitoTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentMockitoTest.java
@@ -1180,23 +1180,11 @@ public class XWikiDocumentMockitoTest
         template.setAttachment(aliceAttachment);
 
         XWikiAttachment bobAttachment = new XWikiAttachment(template, "bob.png");
+        bobAttachment.setContent(new ByteArrayInputStream("bob content".getBytes()));
         bobAttachment.setVersion("5.3");
         bobAttachment.setDate(simpleDateFormat.parse("25/5/2019"));
         bobAttachment.setAuthorReference(templateAuthor);
         template.setAttachment(bobAttachment);
-
-        // Verify that the attachment content is loaded before being copied.
-        XWikiAttachmentStoreInterface attachmentContentStore = mock(XWikiAttachmentStoreInterface.class);
-        xcontext.getWiki().setDefaultAttachmentContentStore(attachmentContentStore);
-        doAnswer(invocation -> {
-            XWikiAttachment attachment = invocation.getArgument(0);
-            if ("bob.png".equals(attachment.getFilename())) {
-                XWikiAttachmentContent attachmentContent = new XWikiAttachmentContent(attachment);
-                attachmentContent.setContent(new ByteArrayInputStream("bob content".getBytes()));
-                attachment.setAttachment_content(attachmentContent);
-            }
-            return null;
-        }).when(attachmentContentStore).loadAttachmentContent(any(XWikiAttachment.class), eq(xcontext), eq(true));
 
         this.oldcore.getSpyXWiki().saveDocument(template, xcontext);
 


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22931

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

  * Fix XWikiDocument#copyAttachment to actually perform a real clone including the copy of the content
  * Introduce a XWikiAttachment#cloneWithActualContent to clone and copy the content
  * Introduce a XWikiAttachmentContent#clone(boolean) that allows to decide to skip or not copying the content

WIP: right now tests are passing but it shows a regression in logs when running PageTemplatesIT, probably due to the ownerDocument of XWikiAttachmnentContent in clone method

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.x
  * 16.4.x