### PR TITLE
XWIKI-22936: XWiki.SearchSuggestCode is not cached

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/SearchSuggestCode.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/main/resources/XWiki/SearchSuggestCode.xml
@@ -42,7 +42,13 @@
 ## search suggest contructor.
 #set ($sources = [])
 #set ($searchSuggestConfig = $xwiki.getDocument('XWiki.SearchSuggestConfig'))
-#foreach ($source in $searchSuggestConfig.getObjects('XWiki.SearchSuggestSourceClass'))
+#if ($request.getHeader('If-None-Match') == $searchSuggestConfig.version)
+  #set ($discard = $response.setStatus(304))
+  #rawResponse('')
+#else
+  #set ($discard = $response.setHeader('Cache-Control', 'must-revalidate'))
+  #set ($discard = $response.setHeader('ETag', $searchSuggestConfig.version))
+  #foreach ($source in $searchSuggestConfig.getObjects('XWiki.SearchSuggestSourceClass'))
   #if ($source.getProperty('activated').value == 1)
     #set ($engine = $source.getProperty('engine').value)
     #if ("$!engine" == '')
@@ -97,7 +103,8 @@
     #end
   #end
 #end
-#jsonResponse($sources)
+  #jsonResponse($sources)
+#end
 #end
 {{/velocity}}</content>
 </xwikidoc>


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22936

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* provide server side cache headers and invalidation logic 
* for now the logic is local to `XWiki.SearchSuggestCode` but it should be possible to generalize to make it easier to reuse in other cases

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->


# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 