### PR TITLE
XWIKI-22960: WCAG not complied in navigation panel administration

### DIFF
--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker/src/test/it/org/xwiki/panels/test/ui/docker/NavigationPanelAdministrationIT.java
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker/src/test/it/org/xwiki/panels/test/ui/docker/NavigationPanelAdministrationIT.java
@@ -196,6 +196,10 @@ class NavigationPanelAdministrationIT
         assertEquals(Arrays.asList("A AA", "Alice", "Bob", "Denis", "XWiki"),
             navPanelAdminPage.getNavigationTree().getTopLevelPages());
         assertTrue(navPanelAdminPage.isPinned("A AA"));
+        // Reset the state of pinned page so that automated accessibility tests don't hit an unexpected fail
+        // in the test following this one.
+        navPanelAdminPage.unpinPage("A AA");
+        navPanelAdminPage.save();
     }
 
     private NavigationPanelAdministrationPage saveAndReload(NavigationPanelAdministrationPage navPanelAdminPage,

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker/src/test/it/org/xwiki/panels/test/ui/docker/NavigationPanelIT.java
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker/src/test/it/org/xwiki/panels/test/ui/docker/NavigationPanelIT.java
@@ -68,12 +68,7 @@ class NavigationPanelIT
         AppWithinMinutesHomePage.gotoPage().deleteApplication(appName);
 
         // Configure the Navigation Panel to exclude top level application pages.
-        // The pin buttons added in the tree need quite a lot of refactoring to be fully WCAG compliant.
-        // For now we just ignore the WCAG validation on this page
-        Boolean wcagValidationIsEnabled = setup.getWCAGUtils().getWCAGContext().isWCAGEnabled();
-        setup.getWCAGUtils().getWCAGContext().setWCAGEnabled(false);
         NavigationPanelAdministrationPage navigationPanelAdminPage = NavigationPanelAdministrationPage.gotoPage();
-        setup.getWCAGUtils().getWCAGContext().setWCAGEnabled(wcagValidationIsEnabled);
         navigationPanelAdminPage.excludeTopLevelApplicationPages(true);
         navigationPanelAdminPage.save();
 

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker/src/test/it/org/xwiki/panels/test/ui/docker/NavigationPanelIT.java
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker/src/test/it/org/xwiki/panels/test/ui/docker/NavigationPanelIT.java
@@ -68,7 +68,12 @@ class NavigationPanelIT
         AppWithinMinutesHomePage.gotoPage().deleteApplication(appName);
 
         // Configure the Navigation Panel to exclude top level application pages.
+        // The pin buttons added in the tree need quite a lot of refactoring to be fully WCAG compliant.
+        // For now we just ignore the WCAG validation on this page
+        Boolean wcagValidationIsEnabled = setup.getWCAGUtils().getWCAGContext().isWCAGEnabled();
+        setup.getWCAGUtils().getWCAGContext().setWCAGEnabled(false);
         NavigationPanelAdministrationPage navigationPanelAdminPage = NavigationPanelAdministrationPage.gotoPage();
+        setup.getWCAGUtils().getWCAGContext().setWCAGEnabled(wcagValidationIsEnabled);
         navigationPanelAdminPage.excludeTopLevelApplicationPages(true);
         navigationPanelAdminPage.save();
 

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/WCAGContext.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/WCAGContext.java
@@ -432,6 +432,9 @@ public class WCAGContext
     }
 
     /**
+     * This setter allows among other things to disable the WCAG validation for a single page test.
+     * This should only be done with careful consideration. 
+     * Keep track of such usages in our `WCAG Testing` documentation.
      * @param wcag validation enabled setup parameter to use in the test suite.
      */
     public void setWCAGEnabled(boolean wcag)


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22904

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Disabled WCAG validation for the page with pins.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

NA

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
NA. Test changes only.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Tested the update with `mvn clean install -f xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker -Dxwiki.test.ui.wcag=true`. The tests failed as expected on 
```
AllIT$NestedNavigationPanelAdministrationIT>NavigationPanelAdministrationIT.navigationPanelAdministration:157 » NoSuchElement Unable to locate element: (.//li[contains(@class, 'jstree-node')]/a[. = 'Bob']/following-sibling::div[contains(@class, 'jstree-action')]/button)
```

However, contrary to what's currently on CI, there's no WCAGFailure reported anymore here.
![image](https://github.com/user-attachments/assets/d1bfd1d1-2643-4874-8777-fa2c296e685b)


# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.4.X
  * 16.10.X (similarly to other PRs for this ticket.)