### PR TITLE
XWIKI-22262: NotificationsIT.simpleNotifications is flickering

### DIFF
--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/EventStore.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/EventStore.java
@@ -30,7 +30,7 @@ import org.xwiki.component.annotation.Role;
 
 /**
  * Save and access store events.
- * 
+ *
  * @version $Id$
  * @since 12.4RC1
  */
@@ -172,5 +172,17 @@ public interface EventStore
     default List<EventStatus> getEventStatuses(Collection<Event> events, Collection<String> entityIds) throws Exception
     {
         return List.of();
+    }
+
+    /**
+     * @return the queue size wrapped in the {@link Optional} of the event store it exists, {@link Optional#empty()}
+     *     otherwise
+     * @since 17.2.0RC1
+     * @since 16.10.5
+     * @since 16.4.7
+     */
+    default Optional<Long> getQueueSize()
+    {
+        return Optional.empty();
     }
 }

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/EventStore.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/EventStore.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import org.xwiki.component.annotation.Role;
+import org.xwiki.stability.Unstable;
 
 /**
  * Save and access store events.
@@ -181,7 +182,8 @@ public interface EventStore
      * @since 16.10.5
      * @since 16.4.7
      */
-    default Optional<Long> getQueueSize()
+    @Unstable
+    default Optional<Long> getEventQueueSize()
     {
         return Optional.empty();
     }

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/internal/AbstractAsynchronousEventStore.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/internal/AbstractAsynchronousEventStore.java
@@ -204,7 +204,7 @@ public abstract class AbstractAsynchronousEventStore implements EventStore, Init
      * @since 12.7.1
      * @since 12.6.2
      */
-    public int getQueueSizeDelta()
+    public int getQueueSize()
     {
         int size = 0;
         for (EventStoreTask<?, ?> task : this.queue) {
@@ -224,7 +224,7 @@ public abstract class AbstractAsynchronousEventStore implements EventStore, Init
     }
 
     @Override
-    public Optional<Long> getQueueSize()
+    public Optional<Long> getEventQueueSize()
     {
         return Optional.of((long) this.queue.size());
     }

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/internal/AbstractAsynchronousEventStore.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/internal/AbstractAsynchronousEventStore.java
@@ -204,7 +204,7 @@ public abstract class AbstractAsynchronousEventStore implements EventStore, Init
      * @since 12.7.1
      * @since 12.6.2
      */
-    public int getQueueSize()
+    public int getQueueSizeDelta()
     {
         int size = 0;
         for (EventStoreTask<?, ?> task : this.queue) {
@@ -221,6 +221,12 @@ public abstract class AbstractAsynchronousEventStore implements EventStore, Init
         }
 
         return size;
+    }
+
+    @Override
+    public Optional<Long> getQueueSize()
+    {
+        return Optional.of((long) this.queue.size());
     }
 
     private <O, I> CompletableFuture<O> addTask(I input, EventStoreTaskType type)

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/internal/DefaultEventStore.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/internal/DefaultEventStore.java
@@ -455,10 +455,10 @@ public class DefaultEventStore implements EventStore, Initializable
     }
 
     @Override
-    public Optional<Long> getQueueSize()
+    public Optional<Long> getEventQueueSize()
     {
-        Optional<Long> storeCount = Optional.ofNullable(this.store).flatMap(EventStore::getQueueSize);
-        Optional<Long> legacyStoreCount = Optional.ofNullable(this.legacyStore).flatMap(EventStore::getQueueSize);
+        Optional<Long> storeCount = Optional.ofNullable(this.store).flatMap(EventStore::getEventQueueSize);
+        Optional<Long> legacyStoreCount = Optional.ofNullable(this.legacyStore).flatMap(EventStore::getEventQueueSize);
 
         return Stream.of(storeCount, legacyStoreCount)
             .filter(Optional::isPresent)

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/internal/DefaultEventStore.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/internal/DefaultEventStore.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -52,7 +53,7 @@ import org.xwiki.wiki.descriptor.WikiDescriptorManager;
 
 /**
  * The default implementation of {@link EventStore} dispatching the event in the various enabled stores.
- * 
+ *
  * @version $Id$
  * @since 12.4RC1
  */
@@ -451,5 +452,17 @@ public class DefaultEventStore implements EventStore, Initializable
         }
 
         return List.of();
+    }
+
+    @Override
+    public Optional<Long> getQueueSize()
+    {
+        Optional<Long> storeCount = Optional.ofNullable(this.store).flatMap(EventStore::getQueueSize);
+        Optional<Long> legacyStoreCount = Optional.ofNullable(this.legacyStore).flatMap(EventStore::getQueueSize);
+
+        return Stream.of(storeCount, legacyStoreCount)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .reduce(Long::sum);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/script/EventStreamScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/script/EventStreamScriptService.java
@@ -85,4 +85,15 @@ public class EventStreamScriptService implements ScriptService
     {
         return this.eventStore.search(new SimpleEventQuery(0, 0)).getTotalHits();
     }
+
+    /**
+     * @return the queue size wrapped of the event store it exists, {@code null} otherwise
+     * @since 17.2.0RC1
+     * @since 16.10.5
+     * @since 16.4.7
+     */
+    public Long getQueueSize()
+    {
+        return this.eventStore.getQueueSize().orElse(null);
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/script/EventStreamScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/script/EventStreamScriptService.java
@@ -32,6 +32,7 @@ import org.xwiki.eventstream.RecordableEventDescriptor;
 import org.xwiki.eventstream.RecordableEventDescriptorManager;
 import org.xwiki.eventstream.query.SimpleEventQuery;
 import org.xwiki.script.service.ScriptService;
+import org.xwiki.stability.Unstable;
 
 /**
  * Script services for the Event Stream Module.
@@ -92,8 +93,9 @@ public class EventStreamScriptService implements ScriptService
      * @since 16.10.5
      * @since 16.4.7
      */
-    public Long getQueueSize()
+    @Unstable
+    public Long getEventQueueSize()
     {
-        return this.eventStore.getQueueSize().orElse(null);
+        return this.eventStore.getEventQueueSize().orElse(null);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/AsynchronousEventStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/AsynchronousEventStoreTest.java
@@ -56,7 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -302,7 +302,7 @@ class AsynchronousEventStoreTest
     @Test
     void getQueueSize() throws InterruptedException
     {
-        assertEquals(0, this.store.getQueueSize());
+        assertEquals(0, this.store.getQueueSizeDelta());
 
         // Lock, add an event and wait for the lock to be in place in the store thread
         this.store.lock.lock();
@@ -310,23 +310,23 @@ class AsynchronousEventStoreTest
         try {
             this.store.saveEvent(event(""));
             Thread.sleep(10);
-            assertEquals(0, this.store.getQueueSize());
+            assertEquals(0, this.store.getQueueSizeDelta());
 
             this.store.saveEvent(event("id1"));
 
-            assertEquals(1, this.store.getQueueSize());
+            assertEquals(1, this.store.getQueueSizeDelta());
 
             this.store.saveEvent(event("id2"));
 
-            assertEquals(2, this.store.getQueueSize());
+            assertEquals(2, this.store.getQueueSizeDelta());
 
             this.store.deleteEvent(event("id3"));
 
-            assertEquals(1, this.store.getQueueSize());
+            assertEquals(1, this.store.getQueueSizeDelta());
 
             this.store.deleteEvent("id4");
 
-            assertEquals(0, this.store.getQueueSize());
+            assertEquals(0, this.store.getQueueSizeDelta());
         } finally {
             this.store.lock.unlock();
         }

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/AsynchronousEventStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/AsynchronousEventStoreTest.java
@@ -56,7 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -302,7 +302,7 @@ class AsynchronousEventStoreTest
     @Test
     void getQueueSize() throws InterruptedException
     {
-        assertEquals(0, this.store.getQueueSizeDelta());
+        assertEquals(0, this.store.getQueueSize());
 
         // Lock, add an event and wait for the lock to be in place in the store thread
         this.store.lock.lock();
@@ -310,23 +310,23 @@ class AsynchronousEventStoreTest
         try {
             this.store.saveEvent(event(""));
             Thread.sleep(10);
-            assertEquals(0, this.store.getQueueSizeDelta());
+            assertEquals(0, this.store.getQueueSize());
 
             this.store.saveEvent(event("id1"));
 
-            assertEquals(1, this.store.getQueueSizeDelta());
+            assertEquals(1, this.store.getQueueSize());
 
             this.store.saveEvent(event("id2"));
 
-            assertEquals(2, this.store.getQueueSizeDelta());
+            assertEquals(2, this.store.getQueueSize());
 
             this.store.deleteEvent(event("id3"));
 
-            assertEquals(1, this.store.getQueueSizeDelta());
+            assertEquals(1, this.store.getQueueSize());
 
             this.store.deleteEvent("id4");
 
-            assertEquals(0, this.store.getQueueSizeDelta());
+            assertEquals(0, this.store.getQueueSize());
         } finally {
             this.store.lock.unlock();
         }

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/DefaultEventStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/DefaultEventStoreTest.java
@@ -191,23 +191,23 @@ public class DefaultEventStoreTest
     }
 
     @Test
-    void getQueueSizeNoCount()
+    void getEventQueueSizeNoCount()
     {
-        assertEquals(Optional.empty(), this.defaultStore.getQueueSize());
+        assertEquals(Optional.empty(), this.defaultStore.getEventQueueSize());
     }
 
     @Test
-    void getQueueSizeOneCount()
+    void getEventQueueSizeOneCount()
     {
-        when(this.store.getQueueSize()).thenReturn(Optional.of(1L));
-        assertEquals(Optional.of(1L), this.defaultStore.getQueueSize());
+        when(this.store.getEventQueueSize()).thenReturn(Optional.of(1L));
+        assertEquals(Optional.of(1L), this.defaultStore.getEventQueueSize());
     }
 
     @Test
-    void getQueueSizeTwoCounts()
+    void getEventQueueSizeTwoCounts()
     {
-        when(this.store.getQueueSize()).thenReturn(Optional.of(1L));
-        when(this.legacyStore.getQueueSize()).thenReturn(Optional.of(2L));
-        assertEquals(Optional.of(3L), this.defaultStore.getQueueSize());
+        when(this.store.getEventQueueSize()).thenReturn(Optional.of(1L));
+        when(this.legacyStore.getEventQueueSize()).thenReturn(Optional.of(2L));
+        assertEquals(Optional.of(3L), this.defaultStore.getEventQueueSize());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/DefaultEventStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/DefaultEventStoreTest.java
@@ -35,6 +35,7 @@ import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -44,7 +45,7 @@ import static org.mockito.Mockito.when;
 
 /**
  * Validate {@link DefaultEventStore}.
- * 
+ *
  * @version $Id$
  */
 @ComponentTest
@@ -187,5 +188,26 @@ public class DefaultEventStoreTest
 
         verify(this.store).prefilterEvent(EVENT);
         verify(this.legacyStore).prefilterEvent(EVENT);
+    }
+
+    @Test
+    void getQueueSizeNoCount()
+    {
+        assertEquals(Optional.empty(), this.defaultStore.getQueueSize());
+    }
+
+    @Test
+    void getQueueSizeOneCount()
+    {
+        when(this.store.getQueueSize()).thenReturn(Optional.of(1L));
+        assertEquals(Optional.of(1L), this.defaultStore.getQueueSize());
+    }
+
+    @Test
+    void getQueueSizeTwoCounts()
+    {
+        when(this.store.getQueueSize()).thenReturn(Optional.of(1L));
+        when(this.legacyStore.getQueueSize()).thenReturn(Optional.of(2L));
+        assertEquals(Optional.of(3L), this.defaultStore.getQueueSize());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/src/test/it/org/xwiki/platform/notifications/test/ui/NotificationsIT.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/src/test/it/org/xwiki/platform/notifications/test/ui/NotificationsIT.java
@@ -179,7 +179,7 @@ class NotificationsIT
         DocumentReference queueSizeReference =
             new DocumentReference("QueueSize", testReference.getLastSpaceReference());
         setup.createPage(queueSizeReference,
-            "{{velocity}}$services.eventstream.getQueueSize(){{/velocity}}");
+            "{{velocity}}$services.eventstream.getEventQueueSize(){{/velocity}}");
 
         setup.getDriver().waitUntilCondition(input -> {
             setup.gotoPage(queueSizeReference, "get", "outputSyntax=plain&forceeload=" + System.currentTimeMillis());


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22262
# Changes

* Waits for the eventstream count to reach 0 before continuing to make sure to have a deterministic notification inbox when asserting values with user 2

## Description

<!-- Describe the main changes brought in this PR. -->

* introduce a `getQueueSize` method on `EventStore`
* introduce a `getQueueSize` method on `EventStreamScriptService`
* rename the old `getQueueSize` to `getQueueSizeDelta` in `AbstractAsynchronousEventStore` to avoid naming conflicts. I think it's better to rename the old method as it's not strictly speaking returning the queue size (cc @tmortagne)
* in the notification tests, create a page printing the result of `getQueueSize`, then poll it until it reaches 0

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
mvn clean install -pl :xwiki-platform-eventstream-api,:xwiki-platform-notifications-test-docker -Pintegration-tests,docker,quality
```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-16.10.x
  * stable-16.4.x