### PR TITLE
XWIKI-20703: Wrong attachment box size in attachment gallery picker when increasing body font size

### DIFF
--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-picker/xwiki-platform-attachment-picker-ui/src/main/resources/Attachment/Picker/Code/AttachmentGalleryPicker.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-picker/xwiki-platform-attachment-picker-ui/src/main/resources/Attachment/Picker/Code/AttachmentGalleryPicker.xml
@@ -271,10 +271,10 @@
         height: 100%;
         justify-content: space-evenly;
     }
-    
+
     .previewWrapper {
-      justify-content: center;
       display: flex;
+      justify-content: center;
     }
 
     img {

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-picker/xwiki-platform-attachment-picker-ui/src/main/resources/Attachment/Picker/Code/AttachmentGalleryPicker.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-picker/xwiki-platform-attachment-picker-ui/src/main/resources/Attachment/Picker/Code/AttachmentGalleryPicker.xml
@@ -268,8 +268,8 @@
       color: inherit;
       display: flex;
       flex-direction: column;
-        height: 100%;
-        justify-content: space-evenly;
+      height: 100%;
+      justify-content: space-evenly;
     }
 
     .previewWrapper {

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-picker/xwiki-platform-attachment-picker-ui/src/main/resources/Attachment/Picker/Code/AttachmentGalleryPicker.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-picker/xwiki-platform-attachment-picker-ui/src/main/resources/Attachment/Picker/Code/AttachmentGalleryPicker.xml
@@ -271,6 +271,11 @@
         height: 100%;
         justify-content: space-evenly;
     }
+    
+    .previewWrapper {
+      justify-content: center;
+      display: flex;
+    }
 
     img {
       object-fit: contain;

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-picker/xwiki-platform-attachment-picker-ui/src/main/resources/Attachment/Picker/Code/AttachmentGalleryPicker.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-picker/xwiki-platform-attachment-picker-ui/src/main/resources/Attachment/Picker/Code/AttachmentGalleryPicker.xml
@@ -266,15 +266,10 @@
 
     a {
       color: inherit;
-      display: block;
-      text-align: center;
-    }
-
-    .previewWrapper {
       display: flex;
-      align-items: flex-end;
-      height: 150px;
-      justify-content: center;
+      flex-direction: column;
+        height: 100%;
+        justify-content: space-evenly;
     }
 
     img {

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-picker/xwiki-platform-attachment-picker-webjar/src/main/webjar/attachmentGalleryPicker.js
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-picker/xwiki-platform-attachment-picker-webjar/src/main/webjar/attachmentGalleryPicker.js
@@ -227,11 +227,10 @@ define('xwiki-attachment-picker',
           .prop('href', downloadURL)
           .data('index', index)
           .append($('<span>').append(preview).addClass('previewWrapper'))
-          .append('<br/>')
           .append(textSpan);
 
         const attachmentGroup = $('<span class="attachmentGroup">')
-          .append($('<div/>').append(link))
+          .append(link)
           .data('id', result.id);
         if (result.isLocal) {
           attachmentGroup.addClass('localAttachment');


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-20703

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Removed some unecessary DOM: a non semantic and useless for style `div` AND a hanging `br` used only for styling.
* Updated the layout to display nicely whatever the values picked in the colorTheme.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* I removed the default height in the image wrapper. This means that the height can vary a bit depending on the image ratios and that all attachment names will not be lined up anymore. See the screenshot I took in test below. IMO it's okay to do things like this because the `<a>` height is set anyways. If the ratio is really off, the picture is still dimensionned to fit nicely in the space we give it.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Here are a few screenshot of the attachment picker after the changes proposed in this PR:
![Screenshot from 2025-03-06 11-41-08](https://github.com/user-attachments/assets/e4608759-72b5-44c7-aebc-369f210b3030)
![Screenshot from 2025-03-06 11-36-11](https://github.com/user-attachments/assets/4df83ede-1ed6-4a6b-bb81-5d510645a110)
![Screenshot from 2025-03-06 11-26-07](https://github.com/user-attachments/assets/7402baa1-fe1e-4abb-a668-adda558e64b9)
![Screenshot from 2025-03-06 11-23-51](https://github.com/user-attachments/assets/8d03217c-f54d-4d43-85fd-7ddd6aeff401)

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests, see above.
Successfully built the webjar with `mvn clean install -f xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-picker/xwiki-platform-attachment-picker-webjar -Pquality`. Other changes are style only, and do not hide any UI element.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X (pretty safe, low scope bugfix)