### PR TITLE
XWIKI-22950: Notifications Macro also displays mentions events that took place in other locations if Pages parameter is used

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterExpressionGenerator.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterExpressionGenerator.java
@@ -117,12 +117,6 @@ public class ScopeNotificationFilterExpressionGenerator
         while (it.hasNext()) {
             ScopeNotificationFilterPreference pref = it.next();
 
-            // We will handle "page only" filters afterwards (but only for pref that are stored in the database
-            // and loaded by the default user profile)
-            if (isPageOnly(pref)) {
-                continue;
-            }
-
             // For each exclusive filter, we want to generate a query to black list the location with a white list of
             // sub locations.
             // Ex:   "wiki1:Space1" is blacklisted but:
@@ -134,10 +128,6 @@ public class ScopeNotificationFilterExpressionGenerator
 
             // Children are a list of inclusive filters located under the current one.
             for (ScopeNotificationFilterPreference childFilter : pref.getChildren()) {
-                // We will handle "page only" filters afterwards
-                if (isPageOnly(childFilter)) {
-                    continue;
-                }
                 // child filter is something like "event.location = A.B"
                 filterNode = filterNode.or(generateNode(childFilter));
             }
@@ -171,11 +161,6 @@ public class ScopeNotificationFilterExpressionGenerator
         while (it.hasNext()) {
             ScopeNotificationFilterPreference pref = it.next();
 
-            // We will handle "page only" filters afterwards
-            if (isPageOnly(pref)) {
-                continue;
-            }
-
             if (topNode == null) {
                 topNode = generateNode(pref);
             } else {
@@ -192,18 +177,6 @@ public class ScopeNotificationFilterExpressionGenerator
         }
 
         return topNode;
-    }
-
-    private boolean isPageOnly(ScopeNotificationFilterPreference pref)
-    {
-        // We make sure we only handle preferences that come from "userProfile" that are actually saved in the database
-        // as NotificationFilterPreferences.
-        // For example, a preference that comes from the watchlist bridge is not stored in the database, so we have to
-        // handle it without using the subquery mechanism that we can see in
-        // filterExpression(Collection<NotificationFilterPreference> filterPreferences, NotificationFormat format,
-        //    NotificationFilterType type, DocumentReference user).
-        return StringUtils.isNotBlank(pref.getPageOnly())
-            && pref.getEventTypes().isEmpty();
     }
 
     private AbstractOperatorNode generateNode(ScopeNotificationFilterPreference scopeNotificationFilterPreference)

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterTest.java
@@ -275,8 +275,11 @@ class ScopeNotificationFilterTest
 
         // Test 1
         String result = this.scopeNotificationFilter.filterExpression(user, filterPreferences, preference).toString();
-        assertEquals("((WIKI = \"wikiA\" AND SPACE STARTS WITH \"wikiA:SpaceB\") "
-                + "AND DATE >= \""+ new Date(0).toString() + "\")", result);
+        String expectedResult = String.format("(((WIKI = \"wikiA\" AND SPACE STARTS WITH \"wikiA:SpaceB\") "
+            + "AND DATE >= \"%s\") "
+            + "OR ((WIKI = \"wikiA\" AND PAGE = \"wikiA:SpaceM.DocumentN\") "
+            + "AND DATE >= \"%s\"))", new Date(0), new Date(99000));
+        assertEquals(expectedResult, result);
 
         // Test with wikiA:SpaceE (filtered by γ & ζ)
         Event event1 = mock(Event.class);
@@ -413,8 +416,10 @@ class ScopeNotificationFilterTest
 
         // Test 1
         String result = this.scopeNotificationFilter.filterExpression(user, filterPreferences, preference).toString();
-        assertEquals("((WIKI = \"wikiA\" AND SPACE STARTS WITH \"wikiA:SpaceB\") "
-            + "AND DATE >= \""+ new Date(0).toString() + "\")", result);
+        String expectedResult = String.format("(NOT ((WIKI = \"wikiA\" AND PAGE = \"wikiA:SpaceM.DocumentN\")) "
+            + "AND ((WIKI = \"wikiA\" AND SPACE STARTS WITH \"wikiA:SpaceB\") "
+            + "AND DATE >= \"%s\"))", new Date(0));
+        assertEquals(expectedResult, result);
 
         // Test with wikiA:SpaceE -> should not be filtered since inclusive filter is ignored
         Event event1 = mock(Event.class);


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

* https://jira.xwiki.org/browse/XWIKI-22950

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Get rid of isPageOnly in ScopeNotificationFilterExpressionGenerator

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

The root cause of XWIKI-22950 is this line removed in `ScopeNotificationFilterExpressionGenerator#isPageOnly`: https://github.com/xwiki/xwiki-platform/commit/dfba8556a4f8ff9b167ba4e4034e16195fd97d0a#diff-653dc296d840770ddd559c6d7cbbacbb33e146f851a9d53b18f003e96f4cea33L207. 

This line was ensuring that `isPageOnly` would return true only 

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

`mvn clean install -Pquality,integration-tests,docker` on `xwiki-platform-notifications` and `xwiki-platform-legacy-notifications`

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * it should be backported in 16.10.x and 16.4.x but I'm not entirely comfortable with that, see clarifications.