### PR TITLE
XWIKI-15629: Menus background-color should differ from the actionmenu background-color

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/variables.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/variables.less
@@ -13,6 +13,27 @@
 // By default it uses the same color as the other links, but the colorTheme can override this value.
 @breadcrumb-link-color:             @link-color;
 
+// Colors used by the horizontal menus displayed right under the navbar
+// Their defaults are very close to the navbar defaults.
+// Introducing them makes it easier to customize this element.
+@header-default-color:              @navbar-default-color;
+// We create a guarded mixin to change the background color alternative differently depending on the
+// initial color. The simple 'if' syntax didn't compile without issues.
+._headerbackground-alt(@a) when (lightness(@a) < 50%) {
+  @header-default-bg:               lighten(@a, 5%);
+}
+._headerbackground-alt(@a) when (lightness(@a) >= 50%) {
+  @header-default-bg:               darken(desaturate(@a, 20%), 10%);
+}
+._headerbackground-alt(@navbar-default-bg);
+@header-default-link-color:         @navbar-default-link-color;
+@header-default-link-hover-color:   @navbar-default-link-hover-color;
+@header-default-link-hover-bg:      @navbar-default-link-hover-bg;
+@header-default-link-active-color:  @navbar-default-link-active-color;
+@header-default-link-active-bg:     @navbar-default-link-active-bg;
+@header-height:                     1.5lh; // Approximately 28px by default, smaller than navbar-height
+@header-default-border:             @navbar-default-border;
+
 //
 // Variables of bootstrap overrided by XWiki
 // --------------------------------------------------

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/variables.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/variables.less
@@ -13,26 +13,26 @@
 // By default it uses the same color as the other links, but the colorTheme can override this value.
 @breadcrumb-link-color:             @link-color;
 
-// Colors used by the horizontal menus displayed right under the navbar
+// Colors used by the menus displayed right under the navbar
 // Their defaults are very close to the navbar defaults.
 // Introducing them makes it easier to customize this element.
-@header-default-color:              @navbar-default-color;
+@menu-default-color:              @navbar-default-color;
 // We create a guarded mixin to change the background color alternative differently depending on the
-// initial color. The simple 'if' syntax didn't compile without issues.
-._headerbackground-alt(@a) when (lightness(@a) < 50%) {
-  @header-default-bg:               lighten(@a, 5%);
+// initial color. The simple 'if' syntax didn't compile.
+._menubackground-alt(@a) when (lightness(@a) < 50%) {
+  @menu-default-bg:               lighten(@a, 5%);
 }
-._headerbackground-alt(@a) when (lightness(@a) >= 50%) {
-  @header-default-bg:               darken(desaturate(@a, 20%), 10%);
+._menubackground-alt(@a) when (lightness(@a) >= 50%) {
+  @menu-default-bg:               darken(desaturate(@a, 20%), 10%);
 }
-._headerbackground-alt(@navbar-default-bg);
-@header-default-link-color:         @navbar-default-link-color;
-@header-default-link-hover-color:   @navbar-default-link-hover-color;
-@header-default-link-hover-bg:      @navbar-default-link-hover-bg;
-@header-default-link-active-color:  @navbar-default-link-active-color;
-@header-default-link-active-bg:     @navbar-default-link-active-bg;
-@header-height:                     1.5lh; // Approximately 28px by default, smaller than navbar-height
-@header-default-border:             @navbar-default-border;
+._menubackground-alt(@navbar-default-bg);
+@menu-default-link-color:         @navbar-default-link-color;
+@menu-default-link-hover-color:   @navbar-default-link-hover-color;
+@menu-default-link-hover-bg:      @navbar-default-link-hover-bg;
+@menu-default-link-active-color:  @navbar-default-link-active-color;
+@menu-default-link-active-bg:     @navbar-default-link-active-bg;
+@menu-height:                     1.5lh; // Approximately 28px by default, smaller than navbar-height
+@menu-default-border:             @navbar-default-border;
 
 //
 // Variables of bootstrap overrided by XWiki

--- a/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
@@ -725,11 +725,9 @@ require(['jquery','xwiki-l10n!menu-ui-translation-keys'], function($, l10n) {
   &amp;.menu-horizontal {
     /* Stylization: Navbars */
     .clearfix;
-    background-color: @navbar-default-bg;
-    border-color: @navbar-default-border;
-    /* Custom styling */
-    .box-shadow(0 2px 8px rgba(0,0,0,0.4) inset);
-    min-height: @navbar-height;
+    background-color: @header-default-bg;
+    border-color: @header-default-border;
+    min-height: @header-height;
     padding-left: 25px;
     .xDropdown.open {
       &gt; .xDropdown-header &gt; .xDropdown-header-toggle:before {
@@ -743,7 +741,7 @@ require(['jquery','xwiki-l10n!menu-ui-translation-keys'], function($, l10n) {
       padding-left: 0;
       list-style-type: none;
       margin: 0;
-      min-height: 50px;
+      min-height: @header-height;
       display: flex;
       align-items: stretch;
       &amp; &gt; li {
@@ -757,22 +755,21 @@ require(['jquery','xwiki-l10n!menu-ui-translation-keys'], function($, l10n) {
         @media (min-width: @grid-float-breakpoint) {
           float: left;
         }
-        line-height: @line-height-computed;
-        color: @navbar-default-link-color;
+        color: @header-default-link-color;
         &amp;:hover, &amp;:focus-within {
-          color: @navbar-default-link-hover-color;
-          background-color: @navbar-default-link-hover-bg;
-          background-color: @navbar-default-link-active-bg;
-          color: @navbar-default-link-active-color;
+          color: @header-default-link-hover-color;
+          background-color: @header-default-link-hover-bg;
+          background-color: @header-default-link-active-bg;
+          color: @header-default-link-active-color;
           /* When hovering, have the same color for text and link usage */
           &amp; &gt; span &gt; a {
-            background-color: @navbar-default-link-active-bg;
-            color: @navbar-default-link-active-color;
+            background-color: @header-default-link-active-bg;
+            color: @header-default-link-active-color;
           }
         }
         /* Links inside menu */
         a {
-          color: @navbar-default-link-color;
+          color: @header-default-link-color;
           &amp;:hover, &amp;:focus-within {
             text-decoration: none;
           }
@@ -780,7 +777,7 @@ require(['jquery','xwiki-l10n!menu-ui-translation-keys'], function($, l10n) {
         /* Containers, images inside menu */
         div, img {
           /* Limit the height to the nav height minus the padding and minus border */
-          max-height: @navbar-height - (2 * @navbar-padding-vertical) - 2px;
+          max-height: @header-height - (2 * @navbar-padding-vertical) - 2px;
           overflow: hidden;
           &amp;.xDropdown-header{
             /* No border on the dropdown header */
@@ -791,15 +788,15 @@ require(['jquery','xwiki-l10n!menu-ui-translation-keys'], function($, l10n) {
         &amp; &gt; .xDropdown-header &gt; .xDropdown-header-toggle {
           &amp;:hover, &amp;:focus-within {
             /* Change background color of the caret when hovering on the navbar. */
-            background-color: @navbar-default-bg;
+            background-color: @header-default-bg;
           }
         }
         /* Separator vertical inside menu */
         &amp;:empty {
-          height: @navbar-height;
+          height: @header-height;
           margin: 0 ((@line-height-computed / 2) - 1);
           padding: 0;
-          border-right: 1px solid @navbar-default-border;
+          border-right: 1px solid @header-default-border;
         }
       }
       /* Stylization: Dropdowns */
@@ -819,6 +816,8 @@ require(['jquery','xwiki-l10n!menu-ui-translation-keys'], function($, l10n) {
         background-color: @dropdown-bg;
         border: 1px solid @dropdown-border;
         border-radius: @border-radius-base;
+        /* On this element, the box-shadow is very useful since it appears in front of other elements. 
+          We don't want to remove it despite the Flamingo theme now using flat designs almost everywhere. */
         .box-shadow(0 6px 12px rgba(0,0,0,.175));
         background-clip: padding-box;
         margin-top: 0;
@@ -854,7 +853,7 @@ require(['jquery','xwiki-l10n!menu-ui-translation-keys'], function($, l10n) {
             line-height: @line-height-base;
             color: @dropdown-link-color;
             /* Empty dropdowns should have height in order to display the arrow */
-            min-height: 2 * @font-size-base;
+            min-height: 1lh;
             &amp;:hover, &amp;:focus-within {
               text-decoration: none;
               color: @dropdown-link-hover-color;
@@ -916,7 +915,7 @@ require(['jquery','xwiki-l10n!menu-ui-translation-keys'], function($, l10n) {
         margin: 0 0 0 -25px; /* Remove padding added in normal view */
         &gt; li {
           &amp;:empty {
-            .nav-divider(@navbar-default-border);
+            .nav-divider(@header-default-border);
           }
         }
         ul {
@@ -930,25 +929,25 @@ require(['jquery','xwiki-l10n!menu-ui-translation-keys'], function($, l10n) {
           box-shadow: none;
           li {
             /* Text inside menu */
-            color: @navbar-default-link-color;
+            color: @header-default-link-color;
             /* Links inside menu */
             a {
-              color: @navbar-default-link-color;
+              color: @header-default-link-color;
             }
             /* Submenus inside menu */
             &amp;.xDropdown {
-              color: @navbar-default-link-color;
+              color: @header-default-link-color;
               &amp;.open {
                 background-color: transparent;
                 color: inherit;
               }
               /* When in dropdown we also have a link */
               &gt; span &gt; a {
-                color: @navbar-default-link-color;
+                color: @header-default-link-color;
               }
             }
             &amp;:empty {
-              .nav-divider(@navbar-default-border);
+              .nav-divider(@header-default-border);
             }
           }
         }
@@ -978,15 +977,15 @@ require(['jquery','xwiki-l10n!menu-ui-translation-keys'], function($, l10n) {
 
 .menu-horizontal-toggle {
   .clearfix;
-  background-color: @navbar-default-bg;
-  border-color: @navbar-default-border;
+  background-color: @header-default-bg;
+  border-color: @header-default-border;
   .box-shadow(0 2px 8px rgba(0,0,0,0.4) inset);
-  min-height: @navbar-height;
+  min-height: @header-height;
   &amp; .navbar-toggle {
     float: left;
     padding-left: 15px;
     &amp; .icon-bar {
-      background-color: @navbar-default-link-color;
+      background-color: @header-default-link-color;
       transition: .3s ease all;
       &amp;:nth-of-type(2) {
         opacity: 0;

--- a/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
@@ -725,9 +725,9 @@ require(['jquery','xwiki-l10n!menu-ui-translation-keys'], function($, l10n) {
   &amp;.menu-horizontal {
     /* Stylization: Navbars */
     .clearfix;
-    background-color: @header-default-bg;
-    border-color: @header-default-border;
-    min-height: @header-height;
+    background-color: @menu-default-bg;
+    border-color: @menu-default-border;
+    min-height: @menu-height;
     padding-left: 25px;
     .xDropdown.open {
       &gt; .xDropdown-header &gt; .xDropdown-header-toggle:before {
@@ -741,7 +741,7 @@ require(['jquery','xwiki-l10n!menu-ui-translation-keys'], function($, l10n) {
       padding-left: 0;
       list-style-type: none;
       margin: 0;
-      min-height: @header-height;
+      min-height: @menu-height;
       display: flex;
       align-items: stretch;
       &amp; &gt; li {
@@ -755,21 +755,21 @@ require(['jquery','xwiki-l10n!menu-ui-translation-keys'], function($, l10n) {
         @media (min-width: @grid-float-breakpoint) {
           float: left;
         }
-        color: @header-default-link-color;
+        color: @menu-default-link-color;
         &amp;:hover, &amp;:focus-within {
-          color: @header-default-link-hover-color;
-          background-color: @header-default-link-hover-bg;
-          background-color: @header-default-link-active-bg;
-          color: @header-default-link-active-color;
+          color: @menu-default-link-hover-color;
+          background-color: @menu-default-link-hover-bg;
+          background-color: @menu-default-link-active-bg;
+          color: @menu-default-link-active-color;
           /* When hovering, have the same color for text and link usage */
           &amp; &gt; span &gt; a {
-            background-color: @header-default-link-active-bg;
-            color: @header-default-link-active-color;
+            background-color: @menu-default-link-active-bg;
+            color: @menu-default-link-active-color;
           }
         }
         /* Links inside menu */
         a {
-          color: @header-default-link-color;
+          color: @menu-default-link-color;
           &amp;:hover, &amp;:focus-within {
             text-decoration: none;
           }
@@ -777,7 +777,7 @@ require(['jquery','xwiki-l10n!menu-ui-translation-keys'], function($, l10n) {
         /* Containers, images inside menu */
         div, img {
           /* Limit the height to the nav height minus the padding and minus border */
-          max-height: @header-height - (2 * @navbar-padding-vertical) - 2px;
+          max-height: @menu-height - (2 * @navbar-padding-vertical) - 2px;
           overflow: hidden;
           &amp;.xDropdown-header{
             /* No border on the dropdown header */
@@ -788,15 +788,15 @@ require(['jquery','xwiki-l10n!menu-ui-translation-keys'], function($, l10n) {
         &amp; &gt; .xDropdown-header &gt; .xDropdown-header-toggle {
           &amp;:hover, &amp;:focus-within {
             /* Change background color of the caret when hovering on the navbar. */
-            background-color: @header-default-bg;
+            background-color: @menu-default-bg;
           }
         }
         /* Separator vertical inside menu */
         &amp;:empty {
-          height: @header-height;
+          height: @menu-height;
           margin: 0 ((@line-height-computed / 2) - 1);
           padding: 0;
-          border-right: 1px solid @header-default-border;
+          border-right: 1px solid @menu-default-border;
         }
       }
       /* Stylization: Dropdowns */
@@ -915,7 +915,7 @@ require(['jquery','xwiki-l10n!menu-ui-translation-keys'], function($, l10n) {
         margin: 0 0 0 -25px; /* Remove padding added in normal view */
         &gt; li {
           &amp;:empty {
-            .nav-divider(@header-default-border);
+            .nav-divider(@menu-default-border);
           }
         }
         ul {
@@ -929,25 +929,25 @@ require(['jquery','xwiki-l10n!menu-ui-translation-keys'], function($, l10n) {
           box-shadow: none;
           li {
             /* Text inside menu */
-            color: @header-default-link-color;
+            color: @menu-default-link-color;
             /* Links inside menu */
             a {
-              color: @header-default-link-color;
+              color: @menu-default-link-color;
             }
             /* Submenus inside menu */
             &amp;.xDropdown {
-              color: @header-default-link-color;
+              color: @menu-default-link-color;
               &amp;.open {
                 background-color: transparent;
                 color: inherit;
               }
               /* When in dropdown we also have a link */
               &gt; span &gt; a {
-                color: @header-default-link-color;
+                color: @menu-default-link-color;
               }
             }
             &amp;:empty {
-              .nav-divider(@header-default-border);
+              .nav-divider(@menu-default-border);
             }
           }
         }
@@ -977,16 +977,16 @@ require(['jquery','xwiki-l10n!menu-ui-translation-keys'], function($, l10n) {
 
 .menu-horizontal-toggle {
   .clearfix;
-  background-color: @header-default-bg;
-  border-color: @header-default-border;
-  min-height: @header-height;
+  background-color: @menu-default-bg;
+  border-color: @menu-default-border;
+  min-height: @menu-height;
   &amp; .navbar-toggle {
     float: left;
     padding-left: 15px;
     padding-top: 0;
     padding-bottom: 0;
     &amp; .icon-bar {
-      background-color: @header-default-link-color;
+      background-color: @menu-default-link-color;
       transition: .3s ease all;
       &amp;:nth-of-type(2) {
         opacity: 0;

--- a/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui/src/main/resources/Menu/MenuMacro.xml
@@ -979,11 +979,12 @@ require(['jquery','xwiki-l10n!menu-ui-translation-keys'], function($, l10n) {
   .clearfix;
   background-color: @header-default-bg;
   border-color: @header-default-border;
-  .box-shadow(0 2px 8px rgba(0,0,0,0.4) inset);
   min-height: @header-height;
   &amp; .navbar-toggle {
     float: left;
     padding-left: 15px;
+    padding-top: 0;
+    padding-bottom: 0;
     &amp; .icon-bar {
       background-color: @header-default-link-color;
       transition: .3s ease all;


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-15629

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Created a few LESS variables to match the need that was highlighted in the design.
* Used those LESS variables to control the display of menus.
* Updated the menu layout:
  * Reduced the height (1.5lh~=30px instead of 24px proposed in the initial design)
  * Changed the background color
  * Removed the drop shadow from the navbar above.
* Removed padding around the menu toggle so that it would fit on a line of similar height.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* I didn't provide a CSS variable alternative yet. IMO these variables could be internal (not API) because they are very similar semantically and in practice to their `@navbar-<...>` alternatives.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Here is a video demo of an instance with the changes applied. In this demo, I go through a range of zoom levels, screen widths and font-size-base values.


https://github.com/user-attachments/assets/10e115b1-2a0d-4549-baa9-d5794d534535
Here is a few screenshots of what the computed background color looks like for a few XWiki Standard colorThemes. 
In order: Iceberg, Charcoal, Cyborg, Darkly, Garden, Readable.
![Screenshot from 2025-03-10 18-20-01](https://github.com/user-attachments/assets/9fd87f20-3965-4f74-90de-cad13c3943b2)
![Screenshot from 2025-03-10 18-20-17](https://github.com/user-attachments/assets/990b8541-6341-4180-919b-fac3c62734ac)
![Screenshot from 2025-03-10 18-20-30](https://github.com/user-attachments/assets/d4e8aef3-224e-491f-abcb-9748635d1073)
![Screenshot from 2025-03-10 18-21-41](https://github.com/user-attachments/assets/c3fd187d-fd1b-470f-afa2-06131808fdf8)
![Screenshot from 2025-03-10 18-22-20](https://github.com/user-attachments/assets/93e1aa0c-b548-467f-9038-d0d3c222888f)
![Screenshot from 2025-03-10 18-22-46](https://github.com/user-attachments/assets/4d058d80-f659-43bf-a086-304f1391da1c)

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Manual tests, see above.
Successfully ran `mvn clean install -f xwiki-platform-core/xwiki-platform-menu/xwiki-platform-menu-ui -Pquality`.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, this is an improvement that changes some very visible UI, we shouldn't backport it on any stable branch.