### PR TITLE
XWIKI-22974: Mentions without an anchor in changed content don't trigger notifications

### DIFF
--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/pom.xml
@@ -55,5 +55,18 @@
       <artifactId>xwiki-platform-annotation-core</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-test-oldcore</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-annotation-io</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/analyzer/UpdatedDocumentMentionsAnalyzer.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/analyzer/UpdatedDocumentMentionsAnalyzer.java
@@ -143,9 +143,9 @@ public class UpdatedDocumentMentionsAnalyzer extends AbstractDocumentMentionsAna
 
             // Notify with an empty anchorId if there's new mentions without an anchor.
             if (newEmptyAnchorsNumber > oldEmptyAnchorsNumber) {
-                DisplayStyle displayStyle = findDisplayStyle(newMentions, reference, "");
-                addNewMention(ret, null,
-                    new MentionNotificationParameter(reference, "", displayStyle));
+                DisplayStyle displayStyle = findDisplayStyle(newMentions, reference, null);
+                addNewMention(ret, type,
+                    new MentionNotificationParameter(reference, null, displayStyle));
             }
 
             // Notify all new mentions with new anchors.

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/analyzer/UpdatedDocumentMentionsAnalyzerTest.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/test/java/org/xwiki/mentions/internal/analyzer/UpdatedDocumentMentionsAnalyzerTest.java
@@ -24,7 +24,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import javax.inject.Named;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.xwiki.annotation.AnnotationConfiguration;
+import org.xwiki.annotation.internal.AnnotationClassDocumentInitializer;
+import org.xwiki.component.internal.ContextComponentManagerProvider;
+import org.xwiki.job.event.status.JobProgressManager;
+import org.xwiki.localization.ContextualLocalizationManager;
 import org.xwiki.mentions.DisplayStyle;
 import org.xwiki.mentions.MentionLocation;
 import org.xwiki.mentions.internal.MentionXDOMService;
@@ -32,24 +40,36 @@ import org.xwiki.mentions.internal.MentionedActorReference;
 import org.xwiki.mentions.notifications.MentionNotificationParameter;
 import org.xwiki.mentions.notifications.MentionNotificationParameters;
 import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.LocalDocumentReference;
 import org.xwiki.model.reference.ObjectPropertyReference;
-import org.xwiki.model.reference.ObjectReference;
+import org.xwiki.observation.ObservationManager;
+import org.xwiki.properties.internal.DefaultConverterManager;
+import org.xwiki.properties.internal.converter.ConvertUtilsConverter;
+import org.xwiki.properties.internal.converter.EnumConverter;
 import org.xwiki.rendering.block.MacroBlock;
 import org.xwiki.rendering.block.WordBlock;
 import org.xwiki.rendering.block.XDOM;
-import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.rendering.parser.ContentParser;
+import org.xwiki.sheet.SheetBinder;
+import org.xwiki.test.annotation.ComponentList;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
 
+import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.internal.mandatory.XWikiCommentsDocumentInitializer;
 import com.xpn.xwiki.objects.BaseObject;
-import com.xpn.xwiki.objects.BaseObjectReference;
-import com.xpn.xwiki.objects.FloatProperty;
-import com.xpn.xwiki.objects.LargeStringProperty;
+import com.xpn.xwiki.objects.classes.NumberClass;
+import com.xpn.xwiki.test.MockitoOldcore;
+import com.xpn.xwiki.test.junit5.mockito.InjectMockitoOldcore;
+import com.xpn.xwiki.test.junit5.mockito.OldcoreTest;
+import com.xpn.xwiki.test.reference.ReferenceComponentList;
 
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.xwiki.annotation.Annotation.SELECTION_FIELD;
 import static org.xwiki.mentions.DisplayStyle.FIRST_NAME;
@@ -63,7 +83,16 @@ import static org.xwiki.rendering.syntax.Syntax.XWIKI_2_1;
  * @version $Id$
  * @since 12.10
  */
-@ComponentTest
+@OldcoreTest
+@ComponentList({
+    XWikiCommentsDocumentInitializer.class,
+    AnnotationClassDocumentInitializer.class,
+    DefaultConverterManager.class,
+    ContextComponentManagerProvider.class,
+    EnumConverter.class,
+    ConvertUtilsConverter.class
+})
+@ReferenceComponentList
 class UpdatedDocumentMentionsAnalyzerTest
 {
     private static final DocumentReference DOCUMENT_REFERENCE = new DocumentReference("xwiki", "XWiki", "Doc");
@@ -75,8 +104,12 @@ class UpdatedDocumentMentionsAnalyzerTest
     private static final DocumentReference ACLASS_DOCUMENT_REFERENCE =
         new DocumentReference("xwiki", "XWiki", "AClass");
 
-    private static final DocumentReference COMMENTS_DOCUMENT_REFERENCE =
-        new DocumentReference("xwiki", "XWiki", "XWikiComments");
+    private static final LocalDocumentReference COMMENTS_DOCUMENT_REFERENCE
+        = XWikiCommentsDocumentInitializer.LOCAL_REFERENCE;
+
+    private static final String TEXT_FIELD = "lspfield";
+
+    private static final String NUMBER_FIELD = "number";
 
     @InjectMockComponents
     private UpdatedDocumentMentionsAnalyzer updatedDocumentMentionsAnalyzer;
@@ -84,44 +117,78 @@ class UpdatedDocumentMentionsAnalyzerTest
     @MockComponent
     private MentionXDOMService xdomService;
 
+    @MockComponent
+    private ContentParser contentParser;
+
+    @InjectMockitoOldcore
+    private MockitoOldcore oldcore;
+
+    // Needed for the mandatory document initializer
+    @MockComponent
+    private JobProgressManager jobProgressManager;
+
+    @MockComponent
+    private ObservationManager observationManager;
+
+    @MockComponent
+    @Named("document")
+    private SheetBinder sheetBinder;
+
+    @MockComponent
+    private AnnotationConfiguration annotationConfiguration;
+
+    @MockComponent
+    private ContextualLocalizationManager contextualLocalizationManager;
+
+    @BeforeEach
+    void setUp() throws Exception
+    {
+        when(this.annotationConfiguration.getAnnotationClassReference())
+            .thenReturn(new DocumentReference(COMMENTS_DOCUMENT_REFERENCE, DOCUMENT_REFERENCE.getWikiReference()));
+        when(this.annotationConfiguration.isInstalled()).thenReturn(true);
+
+        this.oldcore.getSpyXWiki().initializeMandatoryDocuments(this.oldcore.getXWikiContext());
+        XWikiDocument classDocument =
+            this.oldcore.getSpyXWiki().getDocument(ACLASS_DOCUMENT_REFERENCE, this.oldcore.getXWikiContext());
+        classDocument.getXClass().addTextField(TEXT_FIELD, "Large Field", 30);
+        classDocument.getXClass().addNumberField(NUMBER_FIELD, "Number", 10, NumberClass.TYPE_FLOAT);
+        this.oldcore.getSpyXWiki().saveDocument(classDocument, "Initialize AClass", this.oldcore.getXWikiContext());
+    }
+
     /**
      * test empty anchors
      */
     @Test
-    void analyzeNoNewMention()
+    void analyzeNoNewMention() throws Exception
     {
-        XWikiDocument oldDoc = mock(XWikiDocument.class);
-        XWikiDocument newDoc = mock(XWikiDocument.class);
+        XWikiContext context = this.oldcore.getXWikiContext();
 
-        XDOM oldXDOM = new XDOM(asList(new WordBlock("v1.0")));
-        when(oldDoc.getXDOM()).thenReturn(oldXDOM);
-        Map<DocumentReference, List<BaseObject>> oldXObjects = new HashMap<>();
-        BaseObject oldAWMField = mock(BaseObject.class);
-        LargeStringProperty oldLSP = new LargeStringProperty();
-        oldLSP.setValue("OLD AWM CONTENT");
-        when(oldAWMField.getField("lspfield")).thenReturn(oldLSP);
-        oldXObjects.put(ACLASS_DOCUMENT_REFERENCE, asList(oldAWMField));
-        when(oldDoc.getXObjects()).thenReturn(oldXObjects);
-        XDOM newXDOM = new XDOM(asList(new WordBlock("v1.1")));
-        when(newDoc.getXDOM()).thenReturn(newXDOM);
-        Map<DocumentReference, List<BaseObject>> newXObjects = new HashMap<>();
-        BaseObject newAWMField = mock(BaseObject.class);
-        when(newAWMField.getXClassReference()).thenReturn(ACLASS_DOCUMENT_REFERENCE);
-        BaseObjectReference baseObjectReference =
-            new BaseObjectReference(new ObjectReference("XWiki.AClass", DOCUMENT_REFERENCE), DOCUMENT_REFERENCE);
-        when(newAWMField.getReference()).thenReturn(baseObjectReference);
-        LargeStringProperty newLSP = new LargeStringProperty();
-        newLSP.setName("lspfield");
-        newLSP.setValue("NEW AWM CONTENT");
-        newLSP.setObject(newAWMField);
-        when(newAWMField.getProperties()).thenReturn(new Object[] { newLSP, new FloatProperty() });
-        newXObjects.put(ACLASS_DOCUMENT_REFERENCE, asList(newAWMField));
-        when(newDoc.getXObjects()).thenReturn(newXObjects);
-        when(newDoc.getSyntax()).thenReturn(XWIKI_2_1);
+        XWikiDocument oldDoc = new XWikiDocument(DOCUMENT_REFERENCE);
+        oldDoc.setSyntax(XWIKI_2_1);
+        String oldContent = "v1.0";
+        oldDoc.setContent(oldContent);
+        BaseObject object = oldDoc.newXObject(ACLASS_DOCUMENT_REFERENCE, context);
+        String oldAwmContent = "OLD AWM CONTENT";
+        object.setLargeStringValue(TEXT_FIELD, oldAwmContent);
 
-        List<MacroBlock> oldMentions = asList(new MacroBlock("mention", new HashMap<>(), false));
+        XDOM oldXDOM = new XDOM(List.of(new WordBlock(oldContent)));
+        when(this.contentParser.parse(oldContent, XWIKI_2_1, DOCUMENT_REFERENCE))
+            .thenReturn(oldXDOM);
+
+        XWikiDocument newDoc = oldDoc.clone();
+        String newContent = "v1.1";
+        newDoc.setContent(newContent);
+        BaseObject newObject = newDoc.getXObject(object.getReference());
+        String newAwmContent = "NEW AWM CONTENT";
+        newObject.setLargeStringValue(TEXT_FIELD, newAwmContent);
+
+        XDOM newXDOM = new XDOM(List.of(new WordBlock(newContent)));
+        when(this.contentParser.parse(newContent, XWIKI_2_1, DOCUMENT_REFERENCE))
+            .thenReturn(newXDOM);
+
+        List<MacroBlock> oldMentions = List.of(new MacroBlock("mention", new HashMap<>(), false));
         when(this.xdomService.listMentionMacros(oldXDOM)).thenReturn(oldMentions);
-        List<MacroBlock> newMentions = asList(new MacroBlock("mention", new HashMap<>(), false));
+        List<MacroBlock> newMentions = List.of(new MacroBlock("mention", new HashMap<>(), false));
         when(this.xdomService.listMentionMacros(newXDOM)).thenReturn(newMentions);
 
         Map<MentionedActorReference, List<String>> oldCounts = new HashMap<>();
@@ -131,27 +198,43 @@ class UpdatedDocumentMentionsAnalyzerTest
         newCounts.put(new MentionedActorReference(USER_U1, "user"), asList("anchor0", "anchor1"));
         when(this.xdomService.groupAnchorsByUserReference(newMentions)).thenReturn(newCounts);
 
-        when(this.xdomService.parse("OLD AWM CONTENT", XWIKI_2_1))
-            .thenReturn(Optional.of(new XDOM(asList(new WordBlock("oldword")))));
-        when(this.xdomService.parse("NEW AWM CONTENT", XWIKI_2_1))
-            .thenReturn(Optional.of(new XDOM(asList(new WordBlock("newword")))));
+        when(this.xdomService.parse(oldAwmContent, XWIKI_2_1))
+            .thenReturn(Optional.of(new XDOM(List.of(new WordBlock("oldword")))));
+        when(this.xdomService.parse(newAwmContent, XWIKI_2_1))
+            .thenReturn(Optional.of(new XDOM(List.of(new WordBlock("newword")))));
 
         List<MentionNotificationParameters> analyze =
             this.updatedDocumentMentionsAnalyzer.analyze(oldDoc, newDoc, DOCUMENT_REFERENCE, "1.1", AUTHOR);
 
-        assertEquals(asList(), analyze);
+        assertEquals(List.of(), analyze);
+
+        verify(this.xdomService).listMentionMacros(oldXDOM);
+        verify(this.xdomService).listMentionMacros(newXDOM);
+        verify(this.xdomService).groupAnchorsByUserReference(same(oldMentions));
+        verify(this.xdomService).groupAnchorsByUserReference(same(newMentions));
+        verify(this.xdomService).parse(oldAwmContent, XWIKI_2_1);
+        verify(this.xdomService).parse(newAwmContent, XWIKI_2_1);
     }
 
     @Test
-    void analyzeNewMentionInBody()
+    void analyzeNewMentionInBody() throws Exception
     {
-        XWikiDocument oldDoc = mock(XWikiDocument.class);
-        XWikiDocument newDoc = mock(XWikiDocument.class);
+        XWikiDocument oldDoc = new XWikiDocument(DOCUMENT_REFERENCE);
+        oldDoc.setSyntax(XWIKI_2_1);
+        String oldContent = "v1.0";
+        oldDoc.setContent(oldContent);
 
-        XDOM oldXDOM = new XDOM(asList(new WordBlock("v1.0")));
-        when(oldDoc.getXDOM()).thenReturn(oldXDOM);
-        XDOM newXDOM = new XDOM(asList(new WordBlock("v1.1")));
-        when(newDoc.getXDOM()).thenReturn(newXDOM);
+        XDOM oldXDOM = new XDOM(List.of(new WordBlock(oldContent)));
+        when(this.contentParser.parse(oldContent, XWIKI_2_1, DOCUMENT_REFERENCE))
+            .thenReturn(oldXDOM);
+
+        XWikiDocument newDoc = oldDoc.clone();
+        String newContent = "v1.1";
+        newDoc.setContent(newContent);
+
+        XDOM newXDOM = new XDOM(List.of(new WordBlock(newContent)));
+        when(this.contentParser.parse(newContent, XWIKI_2_1, DOCUMENT_REFERENCE))
+            .thenReturn(newXDOM);
 
         List<MacroBlock> oldMentions = asList(
             buildMentionMacro(USER_U1, "anchor0", FIRST_NAME),
@@ -176,7 +259,7 @@ class UpdatedDocumentMentionsAnalyzerTest
             this.updatedDocumentMentionsAnalyzer.analyze(oldDoc, newDoc, DOCUMENT_REFERENCE, "1.1", AUTHOR);
 
         assertEquals(
-            asList(new MentionNotificationParameters(AUTHOR, DOCUMENT_REFERENCE, MentionLocation.DOCUMENT, "1.1")
+            List.of(new MentionNotificationParameters(AUTHOR, DOCUMENT_REFERENCE, MentionLocation.DOCUMENT, "1.1")
                 .addMention("user", new MentionNotificationParameter(USER_U1, "anchor0", FIRST_NAME))
                 .addMention("user", new MentionNotificationParameter(USER_U1, "anchor1", FIRST_NAME))
                 .addMention("user", new MentionNotificationParameter(USER_U1, "anchor2", FIRST_NAME))
@@ -185,62 +268,58 @@ class UpdatedDocumentMentionsAnalyzerTest
     }
 
     @Test
-    void analyzeNewMentionInUpdatedAWMField()
+    void analyzeNewMentionInUpdatedAWMField() throws Exception
     {
-        XWikiDocument oldDoc = mock(XWikiDocument.class);
-        XWikiDocument newDoc = mock(XWikiDocument.class);
+        XWikiDocument oldDoc = new XWikiDocument(DOCUMENT_REFERENCE);
+        oldDoc.setSyntax(XWIKI_2_1);
+        String oldContent = "v1.0";
+        oldDoc.setContent(oldContent);
 
-        when(oldDoc.getXDOM()).thenReturn(new XDOM(asList(new WordBlock("v1.0"))));
-        Map<DocumentReference, List<BaseObject>> oldXObjects = new HashMap<>();
-        BaseObject oldAWMField = mock(BaseObject.class);
-        LargeStringProperty oldLSP = new LargeStringProperty();
-        oldLSP.setValue("OLD AWM CONTENT");
-        when(oldAWMField.getField("lspfield")).thenReturn(oldLSP);
-        oldXObjects.put(ACLASS_DOCUMENT_REFERENCE, asList(oldAWMField));
-        when(oldDoc.getXObjects()).thenReturn(oldXObjects);
-        when(newDoc.getXDOM()).thenReturn(new XDOM(asList(new WordBlock("v1.1"))));
-        Map<DocumentReference, List<BaseObject>> newXObjects = new HashMap<>();
-        BaseObject newAWMField = mock(BaseObject.class);
-        when(newAWMField.getXClassReference()).thenReturn(ACLASS_DOCUMENT_REFERENCE);
-        BaseObjectReference baseObjectReference =
-            new BaseObjectReference(new ObjectReference("XWiki.AClass", DOCUMENT_REFERENCE), DOCUMENT_REFERENCE);
-        when(newAWMField.getReference()).thenReturn(baseObjectReference);
-        LargeStringProperty newLSP = new LargeStringProperty();
-        newLSP.setName("lspfield");
-        newLSP.setValue("NEW AWM CONTENT");
-        newLSP.setObject(newAWMField);
-        when(newAWMField.getProperties()).thenReturn(new Object[] { newLSP, new FloatProperty() });
-        newXObjects.put(ACLASS_DOCUMENT_REFERENCE, asList(newAWMField));
-        when(newDoc.getXObjects()).thenReturn(newXObjects);
-        when(newDoc.getSyntax()).thenReturn(XWIKI_2_1);
+        when(this.contentParser.parse(oldContent, XWIKI_2_1, DOCUMENT_REFERENCE))
+            .thenReturn(new XDOM(List.of(new WordBlock(oldContent))));
 
-        XDOM oldXDOM = new XDOM(asList(new WordBlock("oldword")));
-        when(this.xdomService.parse("OLD AWM CONTENT", XWIKI_2_1))
+        BaseObject oldObject = oldDoc.newXObject(ACLASS_DOCUMENT_REFERENCE, this.oldcore.getXWikiContext());
+        String oldAwmContent = "OLD AWM CONTENT";
+        oldObject.setLargeStringValue(TEXT_FIELD, oldAwmContent);
+
+        XWikiDocument newDoc = oldDoc.clone();
+        String newContent = "v1.1";
+        newDoc.setContent(newContent);
+
+        when(this.contentParser.parse(newContent, XWIKI_2_1, DOCUMENT_REFERENCE))
+            .thenReturn(new XDOM(List.of(new WordBlock(newContent))));
+
+        BaseObject newObject = newDoc.getXObject(oldObject.getReference());
+        String newAwmContent = "NEW AWM CONTENT";
+        newObject.setLargeStringValue(TEXT_FIELD, newAwmContent);
+
+        XDOM oldXDOM = new XDOM(List.of(new WordBlock("oldword")));
+        when(this.xdomService.parse(oldAwmContent, XWIKI_2_1))
             .thenReturn(Optional.of(oldXDOM));
-        XDOM newXDOM = new XDOM(asList(new WordBlock("newword")));
-        when(this.xdomService.parse("NEW AWM CONTENT", XWIKI_2_1))
+        XDOM newXDOM = new XDOM(List.of(new WordBlock("newword")));
+        when(this.xdomService.parse(newAwmContent, XWIKI_2_1))
             .thenReturn(Optional.of(newXDOM));
 
-        List<MacroBlock> oldMentions = asList(new MacroBlock("mention", new HashMap<>(), false));
+        List<MacroBlock> oldMentions = List.of(new MacroBlock("mention", new HashMap<>(), false));
         when(this.xdomService.listMentionMacros(oldXDOM)).thenReturn(oldMentions);
-        List<MacroBlock> newMentions = asList(
+        List<MacroBlock> newMentions = List.of(
             buildMentionMacro(USER_U1, "anchor1", FIRST_NAME),
             buildMentionMacro(USER_U1, "anchor2", FIRST_NAME));
         when(this.xdomService.listMentionMacros(newXDOM)).thenReturn(newMentions);
 
         // anchor0 is removed and anchor1 and anchor2 are added, all mentionning U1.
         Map<MentionedActorReference, List<String>> oldCounts = new HashMap<>();
-        oldCounts.put(new MentionedActorReference(USER_U1, "user"), asList("anchor0"));
+        oldCounts.put(new MentionedActorReference(USER_U1, "user"), List.of("anchor0"));
         when(this.xdomService.groupAnchorsByUserReference(oldMentions)).thenReturn(oldCounts);
         Map<MentionedActorReference, List<String>> newCounts = new HashMap<>();
-        newCounts.put(new MentionedActorReference(USER_U1, "user"), asList("anchor1", "anchor2"));
+        newCounts.put(new MentionedActorReference(USER_U1, "user"), List.of("anchor1", "anchor2"));
         when(this.xdomService.groupAnchorsByUserReference(newMentions)).thenReturn(newCounts);
 
         List<MentionNotificationParameters> analyze =
             this.updatedDocumentMentionsAnalyzer.analyze(oldDoc, newDoc, DOCUMENT_REFERENCE, "1.1", AUTHOR);
 
-        assertEquals(asList(
-            new MentionNotificationParameters(AUTHOR, new ObjectPropertyReference("lspfield", baseObjectReference),
+        assertEquals(List.of(
+            new MentionNotificationParameters(AUTHOR, new ObjectPropertyReference(TEXT_FIELD, oldObject.getReference()),
                 MentionLocation.TEXT_FIELD, "1.1")
                 .addMention("user", new MentionNotificationParameter(USER_U1, "anchor1", FIRST_NAME))
                 .addMention("user", new MentionNotificationParameter(USER_U1, "anchor2", FIRST_NAME))
@@ -250,45 +329,38 @@ class UpdatedDocumentMentionsAnalyzerTest
     }
 
     @Test
-    void analyzeNewMentionInNewAWMField()
+    void analyzeNewMentionInNewAWMField() throws Exception
     {
-        XWikiDocument oldDoc = mock(XWikiDocument.class);
-        XWikiDocument newDoc = mock(XWikiDocument.class);
+        XWikiDocument oldDoc = new XWikiDocument(DOCUMENT_REFERENCE);
+        oldDoc.setSyntax(XWIKI_2_1);
+        String oldContent = "v1.0";
+        oldDoc.setContent(oldContent);
 
-        when(oldDoc.getXDOM()).thenReturn(new XDOM(asList(new WordBlock("v1.0"))));
-        Map<DocumentReference, List<BaseObject>> oldXObjects = new HashMap<>();
-        BaseObject oldAWMField = mock(BaseObject.class);
-        LargeStringProperty oldLSP = new LargeStringProperty();
-        oldLSP.setValue("OLD AWM CONTENT");
-        when(oldAWMField.getField("lspfield")).thenReturn(oldLSP);
-//        oldXObjects.put(ACLASS_DOCUMENT_REFERENCE, asList(oldAWMField));
-        when(oldDoc.getXObjects()).thenReturn(oldXObjects);
-        when(newDoc.getXDOM()).thenReturn(new XDOM(asList(new WordBlock("v1.1"))));
-        Map<DocumentReference, List<BaseObject>> newXObjects = new HashMap<>();
-        BaseObject newAWMField = mock(BaseObject.class);
-        when(newAWMField.getXClassReference()).thenReturn(ACLASS_DOCUMENT_REFERENCE);
-        BaseObjectReference baseObjectReference =
-            new BaseObjectReference(new ObjectReference("XWiki.AClass", DOCUMENT_REFERENCE), DOCUMENT_REFERENCE);
-        when(newAWMField.getReference()).thenReturn(baseObjectReference);
-        LargeStringProperty newLSP = new LargeStringProperty();
-        newLSP.setName("lspfield");
-        newLSP.setValue("NEW AWM CONTENT");
-        newLSP.setObject(newAWMField);
-        when(newAWMField.getProperties()).thenReturn(new Object[] { newLSP, new FloatProperty() });
-        newXObjects.put(ACLASS_DOCUMENT_REFERENCE, asList(newAWMField));
-        when(newDoc.getXObjects()).thenReturn(newXObjects);
-        when(newDoc.getSyntax()).thenReturn(XWIKI_2_1);
+        when(this.contentParser.parse(oldContent, XWIKI_2_1, DOCUMENT_REFERENCE))
+            .thenReturn(new XDOM(List.of(new WordBlock(oldContent))));
 
-        XDOM oldXDOM = new XDOM(asList(new WordBlock("oldword")));
+        XWikiDocument newDoc = oldDoc.clone();
+        String newContent = "v1.1";
+        newDoc.setContent(newContent);
+
+        when(this.contentParser.parse(newContent, XWIKI_2_1, DOCUMENT_REFERENCE))
+            .thenReturn(new XDOM(List.of(new WordBlock(newContent))));
+
+        BaseObject newObject = newDoc.newXObject(ACLASS_DOCUMENT_REFERENCE, this.oldcore.getXWikiContext());
+        String newAwmContent = "NEW AWM CONTENT";
+        newObject.setLargeStringValue(TEXT_FIELD, newAwmContent);
+        newObject.setFloatValue(NUMBER_FIELD, 1.0f);
+
+        XDOM oldXDOM = new XDOM(List.of(new WordBlock("oldword")));
         when(this.xdomService.parse("OLD AWM CONTENT", XWIKI_2_1))
             .thenReturn(Optional.of(oldXDOM));
-        XDOM newXDOM = new XDOM(asList(new WordBlock("newword")));
+        XDOM newXDOM = new XDOM(List.of(new WordBlock("newword")));
         when(this.xdomService.parse("NEW AWM CONTENT", XWIKI_2_1))
             .thenReturn(Optional.of(newXDOM));
 
-        List<MacroBlock> oldMentions = asList(new MacroBlock("mention", new HashMap<>(), false));
+        List<MacroBlock> oldMentions = List.of(new MacroBlock("mention", new HashMap<>(), false));
         when(this.xdomService.listMentionMacros(oldXDOM)).thenReturn(oldMentions);
-        List<MacroBlock> newMentions = asList(
+        List<MacroBlock> newMentions = List.of(
             buildMentionMacro(USER_U1, "anchor1", FIRST_NAME),
             buildMentionMacro(USER_U1, "anchor2", FIRST_NAME)
         );
@@ -296,17 +368,17 @@ class UpdatedDocumentMentionsAnalyzerTest
 
         // anchor0 is removed and anchor1 and anchor2 are added, all mentionning U1.
         Map<MentionedActorReference, List<String>> oldCounts = new HashMap<>();
-        oldCounts.put(new MentionedActorReference(USER_U1, "user"), asList("anchor0"));
+        oldCounts.put(new MentionedActorReference(USER_U1, "user"), List.of("anchor0"));
         when(this.xdomService.groupAnchorsByUserReference(oldMentions)).thenReturn(oldCounts);
         Map<MentionedActorReference, List<String>> newCounts = new HashMap<>();
-        newCounts.put(new MentionedActorReference(USER_U1, "user"), asList("anchor1", "anchor2"));
+        newCounts.put(new MentionedActorReference(USER_U1, "user"), List.of("anchor1", "anchor2"));
         when(this.xdomService.groupAnchorsByUserReference(newMentions)).thenReturn(newCounts);
 
         List<MentionNotificationParameters> analyze =
             this.updatedDocumentMentionsAnalyzer.analyze(oldDoc, newDoc, DOCUMENT_REFERENCE, "1.1", AUTHOR);
 
-        assertEquals(asList(
-            new MentionNotificationParameters(AUTHOR, new ObjectPropertyReference("lspfield", baseObjectReference),
+        assertEquals(List.of(
+            new MentionNotificationParameters(AUTHOR, new ObjectPropertyReference(TEXT_FIELD, newObject.getReference()),
                 MentionLocation.TEXT_FIELD, "1.1")
                 .addMention("user", new MentionNotificationParameter(USER_U1, "anchor1", FIRST_NAME))
                 .addMention("user", new MentionNotificationParameter(USER_U1, "anchor2", FIRST_NAME))
@@ -316,35 +388,31 @@ class UpdatedDocumentMentionsAnalyzerTest
     }
 
     @Test
-    void analyzeNewMentionInUpdatedCommentField()
+    void analyzeNewMentionInUpdatedCommentField() throws Exception
     {
-        XWikiDocument oldDoc = mock(XWikiDocument.class);
-        XWikiDocument newDoc = mock(XWikiDocument.class);
+        XWikiDocument oldDoc = new XWikiDocument(DOCUMENT_REFERENCE);
+        oldDoc.setSyntax(XWIKI_2_1);
+        String oldContent = "v1.0";
+        oldDoc.setContent(oldContent);
 
-        when(oldDoc.getXDOM()).thenReturn(new XDOM(asList(new WordBlock("v1.0"))));
-        Map<DocumentReference, List<BaseObject>> oldXObjects = new HashMap<>();
-        BaseObject oldAWMField = mock(BaseObject.class);
-        LargeStringProperty oldLSP = new LargeStringProperty();
-        oldLSP.setValue("OLD AWM CONTENT");
+        when(this.contentParser.parse(oldContent, XWIKI_2_1, DOCUMENT_REFERENCE))
+            .thenReturn(new XDOM(List.of(new WordBlock(oldContent))));
+
+        BaseObject oldObject = oldDoc.newXObject(COMMENTS_DOCUMENT_REFERENCE, this.oldcore.getXWikiContext());
+        String oldAwmContent = "OLD AWM CONTENT";
         String fieldName = "comment";
-        when(oldAWMField.getField(fieldName)).thenReturn(oldLSP);
-        oldXObjects.put(COMMENTS_DOCUMENT_REFERENCE, asList(oldAWMField));
-        when(oldDoc.getXObjects()).thenReturn(oldXObjects);
-        when(newDoc.getXDOM()).thenReturn(new XDOM(asList(new WordBlock("v1.1"))));
-        Map<DocumentReference, List<BaseObject>> newXObjects = new HashMap<>();
-        BaseObject newAWMField = mock(BaseObject.class);
-        when(newAWMField.getXClassReference()).thenReturn(COMMENTS_DOCUMENT_REFERENCE);
-        BaseObjectReference baseObjectReference =
-            new BaseObjectReference(new ObjectReference("XWiki.AClass", DOCUMENT_REFERENCE), DOCUMENT_REFERENCE);
-        when(newAWMField.getReference()).thenReturn(baseObjectReference);
-        LargeStringProperty newLSP = new LargeStringProperty();
-        newLSP.setName(fieldName);
-        newLSP.setValue("NEW AWM CONTENT");
-        newLSP.setObject(newAWMField);
-        when(newAWMField.getField(fieldName)).thenReturn(newLSP);
-        newXObjects.put(ACLASS_DOCUMENT_REFERENCE, asList(newAWMField));
-        when(newDoc.getXObjects()).thenReturn(newXObjects);
-        when(newDoc.getSyntax()).thenReturn(XWIKI_2_1);
+        oldObject.setLargeStringValue(fieldName, oldAwmContent);
+
+        XWikiDocument newDoc = oldDoc.clone();
+        String newContent = "v1.1";
+        newDoc.setContent(newContent);
+
+        when(this.contentParser.parse(newContent, XWIKI_2_1, DOCUMENT_REFERENCE))
+            .thenReturn(new XDOM(List.of(new WordBlock(newContent))));
+
+        BaseObject newObject = newDoc.getXObject(oldObject.getReference());
+        String newAwmContent = "NEW AWM CONTENT";
+        newObject.setLargeStringValue(fieldName, newAwmContent);
 
         XDOM oldXDOM = new XDOM(asList(new WordBlock("oldword")));
         when(this.xdomService.parse("OLD AWM CONTENT", XWIKI_2_1))
@@ -371,7 +439,7 @@ class UpdatedDocumentMentionsAnalyzerTest
             this.updatedDocumentMentionsAnalyzer.analyze(oldDoc, newDoc, DOCUMENT_REFERENCE, "1.1", AUTHOR);
 
         assertEquals(asList(
-            new MentionNotificationParameters(AUTHOR, new ObjectPropertyReference(fieldName, baseObjectReference),
+            new MentionNotificationParameters(AUTHOR, new ObjectPropertyReference(fieldName, oldObject.getReference()),
                 COMMENT, "1.1")
                 .addMention("user", new MentionNotificationParameter(USER_U1, "anchor1", FIRST_NAME))
                 .addMention("user", new MentionNotificationParameter(USER_U1, "anchor2", FIRST_NAME))
@@ -381,50 +449,44 @@ class UpdatedDocumentMentionsAnalyzerTest
     }
 
     @Test
-    void analyzeNewMentionInUpdatedAnnotationField()
+    void analyzeNewMentionInUpdatedAnnotationField() throws Exception
     {
-        XWikiDocument oldDoc = mock(XWikiDocument.class);
-        XWikiDocument newDoc = mock(XWikiDocument.class);
+        XWikiDocument oldDoc = new XWikiDocument(DOCUMENT_REFERENCE);
+        oldDoc.setSyntax(XWIKI_2_1);
+        String oldDocumentContent = "v1.0";
+        oldDoc.setContent(oldDocumentContent);
 
-        when(oldDoc.getXDOM()).thenReturn(new XDOM(asList(new WordBlock("v1.0"))));
-        Map<DocumentReference, List<BaseObject>> oldXObjects = new HashMap<>();
-        BaseObject oldAWMField = mock(BaseObject.class);
-        LargeStringProperty oldLSP = new LargeStringProperty();
-        oldLSP.setValue("OLD AWM CONTENT");
+        when(this.contentParser.parse(oldDocumentContent, XWIKI_2_1, DOCUMENT_REFERENCE))
+            .thenReturn(new XDOM(List.of(new WordBlock(oldDocumentContent))));
+
+        BaseObject oldObject = oldDoc.newXObject(COMMENTS_DOCUMENT_REFERENCE, this.oldcore.getXWikiContext());
+        String oldAwmContent = "OLD AWM CONTENT";
         String fieldName = "comment";
-        when(oldAWMField.getField(fieldName)).thenReturn(oldLSP);
-        oldXObjects.put(COMMENTS_DOCUMENT_REFERENCE, asList(oldAWMField));
-        when(oldDoc.getXObjects()).thenReturn(oldXObjects);
-        when(newDoc.getXDOM()).thenReturn(new XDOM(asList(new WordBlock("v1.1"))));
-        Map<DocumentReference, List<BaseObject>> newXObjects = new HashMap<>();
-        BaseObject newAWMField = mock(BaseObject.class);
-        when(newAWMField.getXClassReference()).thenReturn(COMMENTS_DOCUMENT_REFERENCE);
-        BaseObjectReference baseObjectReference =
-            new BaseObjectReference(new ObjectReference("XWiki.AClass", DOCUMENT_REFERENCE), DOCUMENT_REFERENCE);
-        when(newAWMField.getReference()).thenReturn(baseObjectReference);
-        LargeStringProperty newLSP = new LargeStringProperty();
-        newLSP.setName(fieldName);
-        newLSP.setValue("NEW AWM CONTENT");
-        newLSP.setObject(newAWMField);
+        oldObject.setLargeStringValue(fieldName, oldAwmContent);
 
-        when(newAWMField.getField(fieldName)).thenReturn(newLSP);
-        LargeStringProperty selectionField = new LargeStringProperty();
-        selectionField.setValue("annotated text");
-        when(newAWMField.getField(SELECTION_FIELD)).thenReturn(selectionField);
-        newXObjects.put(ACLASS_DOCUMENT_REFERENCE, asList(newAWMField));
-        when(newDoc.getXObjects()).thenReturn(newXObjects);
-        when(newDoc.getSyntax()).thenReturn(XWIKI_2_1);
+        XWikiDocument newDoc = oldDoc.clone();
+        String newDocumentContent = "v1.1";
+        newDoc.setContent(newDocumentContent);
 
-        XDOM oldXDOM = new XDOM(asList(new WordBlock("oldword")));
-        when(this.xdomService.parse("OLD AWM CONTENT", XWIKI_2_1))
+        when(this.contentParser.parse(newDocumentContent, XWIKI_2_1, DOCUMENT_REFERENCE))
+            .thenReturn(new XDOM(List.of(new WordBlock(newDocumentContent))));
+
+        BaseObject newObject = newDoc.getXObject(oldObject.getReference());
+        String newAwmContent = "NEW AWM CONTENT";
+        newObject.setLargeStringValue(fieldName, newAwmContent);
+        String annotatedText = "annotated text";
+        newObject.setLargeStringValue(SELECTION_FIELD, annotatedText);
+
+        XDOM oldXDOM = new XDOM(List.of(new WordBlock("oldword")));
+        when(this.xdomService.parse(oldAwmContent, XWIKI_2_1))
             .thenReturn(Optional.of(oldXDOM));
-        XDOM newXDOM = new XDOM(asList(new WordBlock("newword")));
-        when(this.xdomService.parse("NEW AWM CONTENT", XWIKI_2_1))
+        XDOM newXDOM = new XDOM(List.of(new WordBlock("newword")));
+        when(this.xdomService.parse(newAwmContent, XWIKI_2_1))
             .thenReturn(Optional.of(newXDOM));
 
-        List<MacroBlock> oldMentions = asList(new MacroBlock("mention", new HashMap<>(), false));
+        List<MacroBlock> oldMentions = List.of(new MacroBlock("mention", new HashMap<>(), false));
         when(this.xdomService.listMentionMacros(oldXDOM)).thenReturn(oldMentions);
-        List<MacroBlock> newMentions = asList(
+        List<MacroBlock> newMentions = List.of(
             buildMentionMacro(USER_U1, null, FIRST_NAME),
             buildMentionMacro(USER_U1, "anchor2", FIRST_NAME)
         );
@@ -432,7 +494,7 @@ class UpdatedDocumentMentionsAnalyzerTest
 
         // anchor0 is removed and anchor1 and anchor2 are added, all mentionning U1.
         Map<MentionedActorReference, List<String>> oldCounts = new HashMap<>();
-        oldCounts.put(new MentionedActorReference(USER_U1, "user"), asList("anchor0"));
+        oldCounts.put(new MentionedActorReference(USER_U1, "user"), List.of("anchor0"));
         when(this.xdomService.groupAnchorsByUserReference(oldMentions)).thenReturn(oldCounts);
         Map<MentionedActorReference, List<String>> newCounts = new HashMap<>();
         newCounts.put(new MentionedActorReference(USER_U1, "user"), asList(null, "anchor2"));
@@ -441,8 +503,10 @@ class UpdatedDocumentMentionsAnalyzerTest
         List<MentionNotificationParameters> analyze =
             this.updatedDocumentMentionsAnalyzer.analyze(oldDoc, newDoc, DOCUMENT_REFERENCE, "1.1", AUTHOR);
 
+        verify(this.xdomService, never()).parse(annotatedText, XWIKI_2_1);
+
         assertEquals(asList(
-            new MentionNotificationParameters(AUTHOR, new ObjectPropertyReference(fieldName, baseObjectReference),
+            new MentionNotificationParameters(AUTHOR, new ObjectPropertyReference(fieldName, oldObject.getReference()),
                 ANNOTATION, "1.1")
                 .addMention("user", new MentionNotificationParameter(USER_U1, null, FIRST_NAME))
                 .addMention("user", new MentionNotificationParameter(USER_U1, "anchor2", FIRST_NAME))


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22974

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Change the test to @OldcoreTest to use actual documents and objects.
* Fix generating notifications for null anchors (which is covered by the test now).

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The existing test didn't detect the problem because the XObject that was supposed to be changed was returned with different XClass references, so the content was detected as new and not as changed.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI change.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
LANG=C.UTF-8 mvn clean install -Pdocker,legacy,integration-tests,snapshotModules,quality -pl :xwiki-platform-mentions-default,:xwiki-platform-mentions-test-docker
```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-16.10.x
  * stable-16.4.x