### PR TITLE
XWIKI-22977: Bottom padding too large in rendering errors

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/messages.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/messages.less
@@ -65,7 +65,9 @@ fieldset.xwikimessage { // Used by: Login form, Delete messages
 // Remove space added by last elements inside box, like paragraphs.
 .box > div > *:last-child,
 // Do the same when the box macro is edited in-line.
-.box > div > .xwiki-metadata-container > *:last-child {
+.box > div > .xwiki-metadata-container > *:last-child,
+// Keep the previous selector for backwards compatibility with hard coded boxes that didn't get updated
+.box > *:last-child, .box > .xwiki-metadata-container > *:last-child {
   margin-bottom: 0;
 }
 


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22977

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added back the former CSS selectors.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Those were removed in https://github.com/xwiki/xwiki-platform/pull/3934 and it was a regression on some boxes that do not follow the standard architecture yet.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

After the changes:
![Screenshot from 2025-03-18 11-45-37](https://github.com/user-attachments/assets/7cf0d34e-7c56-4c7c-8223-8318e07c5e9d)
I made sure the regular box was still looking okay.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Manual test, see above. Automated tests did not catch this.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X