### PR TITLE
XWIKI-22979: Access to pages is slow under high load on the security cache

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/main/java/org/xwiki/test/SecurityCachePerformanceTestScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/main/java/org/xwiki/test/SecurityCachePerformanceTestScriptService.java
@@ -1,0 +1,329 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.IntStream;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.slf4j.Logger;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.context.Execution;
+import org.xwiki.context.ExecutionContext;
+import org.xwiki.context.ExecutionContextManager;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.EntityReference;
+import org.xwiki.model.reference.SpaceReference;
+import org.xwiki.script.service.ScriptService;
+import org.xwiki.security.authorization.AuthorizationManager;
+import org.xwiki.security.authorization.Right;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.api.Document;
+import com.xpn.xwiki.api.Object;
+import com.xpn.xwiki.api.XWiki;
+import com.xpn.xwiki.util.XWikiStubContextProvider;
+
+/**
+ * Script service for performing a stress test on the security instance.
+ *
+ * @version $Id$
+ */
+@Component
+@Singleton
+@Named("securityCachePerformanceTest")
+public class SecurityCachePerformanceTestScriptService implements ScriptService
+{
+    protected static final String END_OF_MESSAGE = ".\n";
+
+    @Inject
+    private Logger logger;
+
+    @Inject
+    private Execution execution;
+
+    @Inject
+    private ExecutionContextManager executionContextManager;
+
+    @Inject
+    private XWikiStubContextProvider stubContextProvider;
+
+    @Inject
+    private Provider<XWikiContext> contextProvider;
+
+    @Inject
+    private AuthorizationManager authorizationManager;
+
+    /**
+     * Perform a stress test on the security cache. The results are logged.
+     *
+     * @return an empty string if everything is okay, a list of errors otherwise
+     * @throws InterruptedException if the test is interrupted.
+     */
+    public String perform() throws InterruptedException
+    {
+        XWikiContext context = this.contextProvider.get();
+
+        // Create a bit more than 8k document references, but avoid creating 20 top level spaces.
+        SpaceReference parentSpace = new SpaceReference("Security Cache Performance", context.getWikiReference());
+        List<DocumentReference> allPages = createSpaces(parentSpace, 2);
+
+        // Define user references
+        List<String> users = IntStream.range(0, 20)
+            .mapToObj(i -> "User" + i)
+            .toList();
+
+        SpaceReference userSpaceReference = new SpaceReference("xwiki", "XWiki");
+
+        List<DocumentReference> userReferences = users.stream()
+            .map(name -> new DocumentReference(name, userSpaceReference))
+            .toList();
+
+        StringBuilder errorOutput = new StringBuilder();
+
+        // Perform two runs to have some warm-up for the caches.
+        for (Integer i : List.of(100, 200)) {
+            this.logger.warn("Test run with {} pages.", i);
+            logResults(performTest(i, allPages, userReferences, errorOutput));
+        }
+
+        return errorOutput.toString();
+    }
+
+    private Map<String, Double> performTest(int numSaves, List<DocumentReference> allPages,
+        List<DocumentReference> userReferences, StringBuilder errorOutput) throws InterruptedException
+    {
+        // Calculate top 1k pages
+        List<DocumentReference> top1kPages = allPages.subList(0, 1000);
+        // Create random orders of document references
+        List<DocumentReference> randomOrder1 = new ArrayList<>(allPages);
+        Collections.shuffle(randomOrder1);
+
+        List<DocumentReference> randomOrder2 = new ArrayList<>(allPages);
+        Collections.shuffle(randomOrder2);
+
+        // Thread coordination
+        AtomicBoolean stop = new AtomicBoolean(false);
+
+        Map<Integer, List<Double>> top1kPagesTimes = new ConcurrentHashMap<>();
+        List<Double> randomOrderExecutionTimes = new ArrayList<>();
+        List<Double> randomOrderAllUsersExecutionTimes = new ArrayList<>();
+
+        this.logger.warn("Finished preparing the test, starting rights checks.");
+
+        // Create thread pool
+        ExecutorService executorService = Executors.newFixedThreadPool(12);
+
+        // Launch 10 threads to query top 1k pages for guest
+        for (int i = 0; i < 10; ++i) {
+            int finalI = i;
+            executorService.execute(() -> {
+                initializeContext();
+                top1kPagesTimes.put(finalI, checkAllAccess(top1kPages, Collections.singletonList(null), stop));
+            });
+        }
+
+        // Launch thread to query random order pages for guest
+        executorService.execute(() -> {
+            initializeContext();
+            randomOrderExecutionTimes.addAll(checkAllAccess(randomOrder1, Collections.singletonList(null), stop));
+        });
+
+        // Launch thread to query random order pages for all users
+        executorService.execute(() -> {
+            initializeContext();
+            randomOrderAllUsersExecutionTimes.addAll(checkAllAccess(randomOrder2, userReferences, stop));
+        });
+
+        List<Double> averageSaveTime = new ArrayList<>();
+
+        try {
+            averageSaveTime.addAll(updateRights(allPages.subList(0, numSaves), errorOutput));
+
+            this.logger.warn("Finishing test...");
+        } catch (Exception e) {
+            errorOutput.append("Error while performing the test: ");
+            errorOutput.append(ExceptionUtils.getStackTrace(e));
+        } finally {
+            stop.set(true);
+            executorService.shutdown();
+        }
+
+        if (!executorService.awaitTermination(5, TimeUnit.MINUTES)) {
+            errorOutput.append("Timeout while waiting for the rights checks threads to finish.\n");
+        }
+
+        List<Double> top1kAverages = top1kPagesTimes.values().stream().flatMap(List::stream).toList();
+
+        // Print results
+        return Map.of("Top 1k average", getAverage(top1kAverages),
+            "Random guest average", getAverage(randomOrderExecutionTimes),
+            "Random all users average", getAverage(randomOrderAllUsersExecutionTimes),
+            "Average saving time", getAverage(averageSaveTime));
+    }
+
+    private List<Double> updateRights(List<DocumentReference> pagesToUpdate, StringBuilder errorOutput)
+        throws XWikiException
+    {
+        List<Double> saveTimes = new ArrayList<>();
+        this.logger.warn("Starting {} updates of rights.", pagesToUpdate.size());
+        XWikiContext context = this.contextProvider.get();
+        XWiki apiWiki = new XWiki(context.getWiki(), context);
+
+        // Set and remove rights on the top pages to put maximum stress on the security cache.
+        for (DocumentReference page : pagesToUpdate) {
+            long startTime = System.currentTimeMillis();
+            testSettingRight(apiWiki, page, errorOutput);
+            saveTimes.add(((double) System.currentTimeMillis() - startTime) / 2);
+        }
+
+        return saveTimes;
+    }
+
+    private List<Double> checkAllAccess(List<DocumentReference> pages, List<DocumentReference> users,
+        AtomicBoolean stop)
+    {
+        List<Double> averageTime = new ArrayList<>();
+        int i = 0;
+        long startTime = System.currentTimeMillis();
+        while (!stop.get()) {
+            for (DocumentReference documentReference : pages) {
+                for (DocumentReference user : users) {
+                    this.authorizationManager.hasAccess(Right.VIEW, user, documentReference);
+                    ++i;
+
+                    if (i == 100) {
+                        long executionTime = System.currentTimeMillis() - startTime;
+                        averageTime.add((double) executionTime / i);
+                        startTime = System.currentTimeMillis();
+                        i = 0;
+                    }
+                }
+            }
+        }
+
+        if (i > 0) {
+            long executionTime = System.currentTimeMillis() - startTime;
+            averageTime.add((double) executionTime / i);
+        }
+
+        return averageTime;
+    }
+
+    private void testSettingRight(XWiki apiWiki, DocumentReference documentReference, StringBuilder errorOutput)
+        throws XWikiException
+    {
+        // Remove view right from the space by granting it to all users. When performed on top spaces, this should cause
+        // invalidation of a larger part of the security cache.
+        DocumentReference preferencesReference =
+            new DocumentReference("WebPreferences", documentReference.getLastSpaceReference());
+        Document preferencesDocument = apiWiki.getDocument(preferencesReference);
+
+        Object rightObject = preferencesDocument.newObject("XWiki.XWikiGlobalRights");
+        rightObject.set("levels", List.of("view"));
+        rightObject.set("groups", List.of("XWiki.XWikiAllGroup"));
+        rightObject.set("allow", 1);
+        preferencesDocument.saveAsAuthor();
+        if (this.authorizationManager.hasAccess(Right.VIEW, null, documentReference)) {
+            errorOutput.append("Error setting right on ");
+            errorOutput.append(preferencesReference);
+            errorOutput.append(". Guest has still view right on document ");
+            errorOutput.append(documentReference);
+            errorOutput.append(END_OF_MESSAGE);
+        }
+
+        preferencesDocument.removeObject(rightObject);
+        preferencesDocument.saveAsAuthor();
+        if (!this.authorizationManager.hasAccess(Right.VIEW, null, documentReference)) {
+            errorOutput.append("Error removing right on ");
+            errorOutput.append(preferencesReference);
+            errorOutput.append(". Guest has still no view right on document ");
+            errorOutput.append(documentReference);
+            errorOutput.append(END_OF_MESSAGE);
+        }
+    }
+
+    private List<DocumentReference> createSpaces(EntityReference parentReference, int remainingDepth)
+    {
+        List<DocumentReference> documentReferences = new ArrayList<>();
+
+        for (int i = 0; i < 20; ++i) {
+            SpaceReference space =
+                new SpaceReference(String.format("Page %d-%d", remainingDepth, i), parentReference);
+            documentReferences.add(new DocumentReference("WebHome", space));
+            if (remainingDepth > 0) {
+                documentReferences.addAll(createSpaces(space, remainingDepth - 1));
+            }
+        }
+
+        return documentReferences;
+    }
+
+    private void initializeContext()
+    {
+        ExecutionContext context = this.execution.getContext();
+        if (context == null) {
+            context = new ExecutionContext();
+
+            try {
+                this.executionContextManager.initialize(context);
+            } catch (Exception e) {
+                this.logger.error("Error while initializing execution context", e);
+            }
+
+            XWikiContext xwikiContext = this.stubContextProvider.createStubContext();
+            xwikiContext.declareInExecutionContext(context);
+            this.execution.pushContext(context);
+        }
+    }
+
+    private double getAverage(List<Double> numbers)
+    {
+        if (numbers.isEmpty()) {
+            return -1.0;
+        }
+        double sum = 0.0;
+        for (double number : numbers) {
+            sum += number;
+        }
+        return sum / numbers.size();
+    }
+
+    private void logResults(Map<String, Double> results)
+    {
+        for (Map.Entry<String, Double> result : results.entrySet()) {
+            this.logger.warn("\t{}: {}", result.getKey(), result.getValue());
+        }
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/main/java/org/xwiki/test/SecurityCachePerformanceTestScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/main/java/org/xwiki/test/SecurityCachePerformanceTestScriptService.java
@@ -28,7 +28,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.IntStream;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -88,10 +87,11 @@ public class SecurityCachePerformanceTestScriptService implements ScriptService
     /**
      * Perform a stress test on the security cache. The results are logged.
      *
+     * @param users the names of the users to use for the test
      * @return an empty string if everything is okay, a list of errors otherwise
      * @throws InterruptedException if the test is interrupted.
      */
-    public String perform() throws InterruptedException
+    public String perform(List<String> users) throws InterruptedException
     {
         XWikiContext context = this.contextProvider.get();
 
@@ -100,10 +100,6 @@ public class SecurityCachePerformanceTestScriptService implements ScriptService
         List<DocumentReference> allPages = createSpaces(parentSpace, 2);
 
         // Define user references
-        List<String> users = IntStream.range(0, 20)
-            .mapToObj(i -> "User" + i)
-            .toList();
-
         SpaceReference userSpaceReference = new SpaceReference("xwiki", "XWiki");
 
         List<DocumentReference> userReferences = users.stream()

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/main/resources/META-INF/components.txt
@@ -1,3 +1,4 @@
 org.xwiki.test.CustomUserUpdatedDocumentEventListener
 org.xwiki.test.TestMacro
 org.xwiki.test.SleepScriptService
+org.xwiki.test.SecurityCachePerformanceTestScriptService

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/AllIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/AllIT.java
@@ -218,4 +218,10 @@ public class AllIT
     class NestedPageReadyIT extends PageReadyIT
     {
     }
+
+    @Nested
+    @DisplayName("Security Cache Stress Tests")
+    class NestedSecurityCacheStressIT extends SecurityCacheStressIT
+    {
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/SecurityCacheStressIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/SecurityCacheStressIT.java
@@ -1,0 +1,322 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.flamingo.test.docker;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.test.docker.junit5.UITest;
+import org.xwiki.test.ui.TestUtils;
+import org.xwiki.text.StringUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Stress test for the security cache. This test takes about 15 minutes on a relatively powerful system of 2021 and
+ * doesn't really test anything, it rather gives some performance numbers. Therefore, it isn't executed by default.
+ *
+ * @version $Id$
+ */
+@UITest(properties = {
+    "xwikiPropertiesAdditionalProperties=test.prchecker.excludePattern=.*:Test\\.Execute\\..*"
+})
+class SecurityCacheStressIT
+{
+    private static final String STREE_TEST_SCRIPT = """
+        {{groovy wiki="false" output="false"}}
+        import org.xwiki.security.authorization.Right
+        import org.xwiki.context.Execution
+        import org.xwiki.context.ExecutionContext
+        import org.xwiki.context.ExecutionContextException
+        import org.xwiki.context.ExecutionContextManager
+        import org.xwiki.model.reference.DocumentReference
+        import org.xwiki.model.reference.EntityReference
+        import org.xwiki.model.reference.SpaceReference
+        import org.xwiki.model.reference.WikiReference
+        import java.util.concurrent.*
+        import java.util.Collections
+        import java.util.ArrayList
+        import java.util.concurrent.atomic.AtomicBoolean
+        import java.util.concurrent.atomic.AtomicReference
+        import java.util.stream.Collectors
+        import java.util.stream.IntStream
+        
+        import com.xpn.xwiki.XWikiContext
+        import com.xpn.xwiki.util.XWikiStubContextProvider
+        import com.xpn.xwiki.web.Utils
+        
+        def logger = services.logging.getLogger("SecurityCacheStressTest")
+        
+        // Create spaces and document references
+        def createSpaces(EntityReference parentReference, int remainingDepth) {
+            def documentReferences = new ArrayList<DocumentReference>()
+        
+            for (int i = 0; i < 20; ++i) {
+                def space = new SpaceReference(String.format("Page %d-%d", remainingDepth, i), parentReference)
+                documentReferences.add(new DocumentReference("WebHome", space))
+                if (remainingDepth > 0) {
+                    documentReferences.addAll(createSpaces(space, remainingDepth - 1))
+                }
+            }
+        
+            return documentReferences
+        }
+        
+        static def initializeContext() {
+            def execution = Utils.getComponent(Execution.class)
+            def context = execution.getContext()
+            if (context == null) {
+                context = new ExecutionContext()
+        
+                def executionContextManager = Utils.getComponent(ExecutionContextManager.class)
+                executionContextManager.initialize(context)
+        
+                def stubContextProvider = Utils.getComponent(XWikiStubContextProvider.class)
+                def xwikiContext = stubContextProvider.createStubContext()
+                xwikiContext.declareInExecutionContext(context)
+                execution.pushContext(context)
+            }
+        }
+        
+        // Helper function to calculate average
+        static def getAverage(times) {
+            if (times.isEmpty()) return -1.0
+            return times.sum() / times.size()
+        }
+        
+        // Create a bit more than 8k document references
+        def allPages = createSpaces(new WikiReference("xwiki"), 2)
+        
+        // Create pages
+        logger.warn("Creating pages...")
+        for (documentReference in allPages) {
+            try {
+                def myDoc = xwiki.getDocument(documentReference)
+                myDoc.setContent("Initial content")
+                myDoc.setTitle(documentReference.getLastSpaceReference().getName())
+                myDoc.saveAsAuthor("Created")
+            } catch (Exception e) {
+                println("Error creating page: " + e.getMessage())
+            }
+        }
+        
+        // Calculate top 1k pages - make it thread-safe with AtomicReference
+        def top1kPages = new AtomicReference<>(allPages.subList(0, 1000))
+        
+        // Define user references
+        List<String> users = IntStream.range(0, 20)
+            .mapToObj(i -> "User" + i)
+            .toList()
+        
+        SpaceReference userSpaceReference = new SpaceReference("xwiki", "XWiki")
+        List<DocumentReference> userReferences = users.stream()
+            .map(name -> new DocumentReference(name, userSpaceReference))
+            .toList()
+        
+        // Create random orders of document references
+        def randomOrder1 = new ArrayList<>(allPages)
+        Collections.shuffle(randomOrder1)
+        def randomOrder2 = new ArrayList<>(allPages)
+        Collections.shuffle(randomOrder2)
+        
+        def performTest = { int numSaves ->
+            // Thread coordination
+            def stop = new AtomicBoolean(false)
+            def top1kPagesTimes = new ConcurrentHashMap<Integer, List<Double>>()
+            def randomOrderExecutionTimes = Collections.synchronizedList(new ArrayList<Long>())
+            def randomOrderAllUsersExecutionTimes = Collections.synchronizedList(new ArrayList<Double>())
+        
+            // Store closure-local copies of the shared variables
+            def localTop1kPages = top1kPages.get()
+            def localRandomOrder1 = randomOrder1
+            def localRandomOrder2 = randomOrder2
+            def localUserReferences = userReferences
+        
+            // Create thread pool
+            def executorService = Executors.newFixedThreadPool(12)
+        
+            // Launch 10 threads to query top 1k pages for guest
+            for (int i = 0; i < 10; ++i) {
+                def finalI = i
+                executorService.execute({
+                    initializeContext()
+                    def authorization = services.security.authorization
+                    def executionTimes = new ArrayList<Double>()
+                    while (!stop.get()) {
+                        try {
+                            def startTime = System.currentTimeMillis()
+                            for (documentReference in localTop1kPages) {
+                                authorization.hasAccess(Right.VIEW, null, documentReference)
+                            }
+                            def endTime = System.currentTimeMillis()
+                            def executionTime = endTime - startTime
+                            executionTimes.add((double) executionTime / localTop1kPages.size())
+                        } catch (Exception e) {
+                            println("Error in top1k thread: " + e.getMessage())
+                        }
+                    }
+                    top1kPagesTimes.put(finalI, executionTimes)
+                })
+            }
+        
+            // Launch thread to query random order pages for guest
+            executorService.execute({
+                initializeContext()
+                def authorization = services.security.authorization
+                while (!stop.get()) {
+                    for (documentReference in localRandomOrder1) {
+                        if (stop.get()) break
+                        try {
+                            def startTime = System.currentTimeMillis()
+                            authorization.hasAccess(Right.VIEW, null, documentReference)
+                            def endTime = System.currentTimeMillis()
+                            def executionTime = endTime - startTime
+                            randomOrderExecutionTimes.add(executionTime)
+                        } catch (Exception e) {
+                            println("Error in random guest thread: " + e.getMessage())
+                        }
+                    }
+                }
+            })
+        
+            // Launch thread to query random order pages for all users
+            executorService.execute({
+                initializeContext()
+                def authorization = services.security.authorization
+                while (!stop.get()) {
+                    for (documentReference in localRandomOrder2) {
+                        if (stop.get()) break
+                        try {
+                            def startTime = System.currentTimeMillis()
+                            for (user in localUserReferences) {
+                                authorization.hasAccess(Right.VIEW, user, documentReference)
+                            }
+                            def endTime = System.currentTimeMillis()
+                            def executionTime = endTime - startTime
+                            randomOrderAllUsersExecutionTimes.add((double) executionTime / localUserReferences.size())
+                        } catch (Exception e) {
+                            println("Error in random users thread: " + e.getMessage())
+                        }
+                    }
+                }
+            })
+        
+            // Save some pages to test update performance
+            def averageSaveTime = []
+            def pagesToUpdate = new ArrayList<>(allPages)
+            Collections.shuffle(pagesToUpdate)
+            pagesToUpdate = pagesToUpdate.subList(0, numSaves)
+        
+            logger.warn("Updating pages...")
+            for (documentReference in pagesToUpdate) {
+                def startTime = System.currentTimeMillis()
+                try {
+                    def myDoc = xwiki.getDocument(documentReference)
+                    myDoc.setContent("Updated content 2")
+                    myDoc.saveAsAuthor("Updated")
+                    def endTime = System.currentTimeMillis()
+                    averageSaveTime.add(endTime - startTime)
+                } catch (Exception e) {
+                    println("Error updating page: " + e.getMessage())
+                }
+            }
+        
+            logger.warn("Finishing test...")
+            stop.set(true)
+        
+            executorService.shutdown()
+            executorService.awaitTermination(5, TimeUnit.MINUTES)
+        
+            // Calculate average times
+            def top1kAverages = []
+            top1kPagesTimes.values().each { times -> top1kAverages.addAll(times) }
+            def top1kAverage = getAverage(top1kAverages)
+            def randomGuestAverage = getAverage(randomOrderExecutionTimes)
+            def randomAllUsersAverage = getAverage(randomOrderAllUsersExecutionTimes)
+            def savingAverage = getAverage(averageSaveTime)
+        
+            // Print results
+            return [
+                top1kAverage: top1kAverage,
+                randomGuestAverage: randomGuestAverage,
+                randomAllUsersAverage: randomAllUsersAverage,
+                savingAverage: savingAverage
+            ]
+        }
+        
+        def result1 = performTest(100)
+        def result2 = performTest(500)
+        
+        
+        logger.warn("Test run 1 results (100 pages):")
+        logger.warn("Top1kAverage: ${result1.top1kAverage}ms")
+        logger.warn("RandomGuestAverage: ${result1.randomGuestAverage}ms")
+        logger.warn("RandomAllUsersAverage: ${result1.randomAllUsersAverage}ms")
+        logger.warn("Average saving time: ${result1.savingAverage}ms")
+        
+        logger.warn("Test run 2 results (500 pages):")
+        logger.warn("Top1kAverage: ${result2.top1kAverage}ms")
+        logger.warn("RandomGuestAverage: ${result2.randomGuestAverage}ms")
+        logger.warn("RandomAllUsersAverage: ${result2.randomAllUsersAverage}ms")
+        logger.warn("Average saving time: ${result2.savingAverage}ms")
+        {{/groovy}}
+        """;
+
+    @Test
+    void stressTest(TestUtils testUtils) throws Exception
+    {
+        testUtils.loginAsSuperAdmin();
+
+        // Create 20 users.
+        List<String> users = IntStream.range(0, 20)
+            .mapToObj(i -> "User" + i)
+            .toList();
+        for (String user : users) {
+            testUtils.createUser(user, user, null);
+        }
+
+        String stressTestName = "securityCacheStressTest";
+        testUtils.rest().savePage(new DocumentReference("xwiki", List.of("Test", "Execute"), stressTestName),
+            STREE_TEST_SCRIPT, "Security Cache Stress Test");
+        String baseURL = StringUtils.removeEnd(testUtils.rest().getBaseURL(), "rest");
+        String viewURL = baseURL + "bin/get/Test/Execute/" + stressTestName;
+
+        // Use Java 11 HTTP client to execute the script directly without browser involvement
+        HttpClient client = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofMinutes(2))
+            .build();
+
+        HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create(viewURL))
+            .timeout(Duration.ofMinutes(40))
+            .GET()
+            .build();
+
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, response.statusCode());
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/SecurityCacheStressIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/SecurityCacheStressIT.java
@@ -34,6 +34,7 @@ import org.xwiki.test.ui.TestUtils;
 import org.xwiki.text.StringUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Stress test for the security cache. This test takes about 15 minutes on a relatively powerful system of 2021 and
@@ -41,249 +42,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * @version $Id$
  */
-@UITest(properties = {
-    "xwikiPropertiesAdditionalProperties=test.prchecker.excludePattern=.*:Test\\.Execute\\..*"
-})
+@UITest
 class SecurityCacheStressIT
 {
     private static final String STREE_TEST_SCRIPT = """
-        {{groovy wiki="false" output="false"}}
-        import org.xwiki.security.authorization.Right
-        import org.xwiki.context.Execution
-        import org.xwiki.context.ExecutionContext
-        import org.xwiki.context.ExecutionContextException
-        import org.xwiki.context.ExecutionContextManager
-        import org.xwiki.model.reference.DocumentReference
-        import org.xwiki.model.reference.EntityReference
-        import org.xwiki.model.reference.SpaceReference
-        import org.xwiki.model.reference.WikiReference
-        import java.util.concurrent.*
-        import java.util.Collections
-        import java.util.ArrayList
-        import java.util.concurrent.atomic.AtomicBoolean
-        import java.util.concurrent.atomic.AtomicReference
-        import java.util.stream.Collectors
-        import java.util.stream.IntStream
-        
-        import com.xpn.xwiki.XWikiContext
-        import com.xpn.xwiki.util.XWikiStubContextProvider
-        import com.xpn.xwiki.web.Utils
-        
-        def logger = services.logging.getLogger("SecurityCacheStressTest")
-        
-        // Create spaces and document references
-        def createSpaces(EntityReference parentReference, int remainingDepth) {
-            def documentReferences = new ArrayList<DocumentReference>()
-        
-            for (int i = 0; i < 20; ++i) {
-                def space = new SpaceReference(String.format("Page %d-%d", remainingDepth, i), parentReference)
-                documentReferences.add(new DocumentReference("WebHome", space))
-                if (remainingDepth > 0) {
-                    documentReferences.addAll(createSpaces(space, remainingDepth - 1))
-                }
-            }
-        
-            return documentReferences
-        }
-        
-        static def initializeContext() {
-            def execution = Utils.getComponent(Execution.class)
-            def context = execution.getContext()
-            if (context == null) {
-                context = new ExecutionContext()
-        
-                def executionContextManager = Utils.getComponent(ExecutionContextManager.class)
-                executionContextManager.initialize(context)
-        
-                def stubContextProvider = Utils.getComponent(XWikiStubContextProvider.class)
-                def xwikiContext = stubContextProvider.createStubContext()
-                xwikiContext.declareInExecutionContext(context)
-                execution.pushContext(context)
-            }
-        }
-        
-        // Helper function to calculate average
-        static def getAverage(times) {
-            if (times.isEmpty()) return -1.0
-            return times.sum() / times.size()
-        }
-        
-        // Create a bit more than 8k document references
-        def allPages = createSpaces(new WikiReference("xwiki"), 2)
-        
-        // Create pages
-        logger.warn("Creating pages...")
-        for (documentReference in allPages) {
-            try {
-                def myDoc = xwiki.getDocument(documentReference)
-                myDoc.setContent("Initial content")
-                myDoc.setTitle(documentReference.getLastSpaceReference().getName())
-                myDoc.saveAsAuthor("Created")
-            } catch (Exception e) {
-                println("Error creating page: " + e.getMessage())
-            }
-        }
-        
-        // Calculate top 1k pages - make it thread-safe with AtomicReference
-        def top1kPages = new AtomicReference<>(allPages.subList(0, 1000))
-        
-        // Define user references
-        List<String> users = IntStream.range(0, 20)
-            .mapToObj(i -> "User" + i)
-            .toList()
-        
-        SpaceReference userSpaceReference = new SpaceReference("xwiki", "XWiki")
-        List<DocumentReference> userReferences = users.stream()
-            .map(name -> new DocumentReference(name, userSpaceReference))
-            .toList()
-        
-        // Create random orders of document references
-        def randomOrder1 = new ArrayList<>(allPages)
-        Collections.shuffle(randomOrder1)
-        def randomOrder2 = new ArrayList<>(allPages)
-        Collections.shuffle(randomOrder2)
-        
-        def performTest = { int numSaves ->
-            // Thread coordination
-            def stop = new AtomicBoolean(false)
-            def top1kPagesTimes = new ConcurrentHashMap<Integer, List<Double>>()
-            def randomOrderExecutionTimes = Collections.synchronizedList(new ArrayList<Long>())
-            def randomOrderAllUsersExecutionTimes = Collections.synchronizedList(new ArrayList<Double>())
-        
-            // Store closure-local copies of the shared variables
-            def localTop1kPages = top1kPages.get()
-            def localRandomOrder1 = randomOrder1
-            def localRandomOrder2 = randomOrder2
-            def localUserReferences = userReferences
-        
-            // Create thread pool
-            def executorService = Executors.newFixedThreadPool(12)
-        
-            // Launch 10 threads to query top 1k pages for guest
-            for (int i = 0; i < 10; ++i) {
-                def finalI = i
-                executorService.execute({
-                    initializeContext()
-                    def authorization = services.security.authorization
-                    def executionTimes = new ArrayList<Double>()
-                    while (!stop.get()) {
-                        try {
-                            def startTime = System.currentTimeMillis()
-                            for (documentReference in localTop1kPages) {
-                                authorization.hasAccess(Right.VIEW, null, documentReference)
-                            }
-                            def endTime = System.currentTimeMillis()
-                            def executionTime = endTime - startTime
-                            executionTimes.add((double) executionTime / localTop1kPages.size())
-                        } catch (Exception e) {
-                            println("Error in top1k thread: " + e.getMessage())
-                        }
-                    }
-                    top1kPagesTimes.put(finalI, executionTimes)
-                })
-            }
-        
-            // Launch thread to query random order pages for guest
-            executorService.execute({
-                initializeContext()
-                def authorization = services.security.authorization
-                while (!stop.get()) {
-                    for (documentReference in localRandomOrder1) {
-                        if (stop.get()) break
-                        try {
-                            def startTime = System.currentTimeMillis()
-                            authorization.hasAccess(Right.VIEW, null, documentReference)
-                            def endTime = System.currentTimeMillis()
-                            def executionTime = endTime - startTime
-                            randomOrderExecutionTimes.add(executionTime)
-                        } catch (Exception e) {
-                            println("Error in random guest thread: " + e.getMessage())
-                        }
-                    }
-                }
-            })
-        
-            // Launch thread to query random order pages for all users
-            executorService.execute({
-                initializeContext()
-                def authorization = services.security.authorization
-                while (!stop.get()) {
-                    for (documentReference in localRandomOrder2) {
-                        if (stop.get()) break
-                        try {
-                            def startTime = System.currentTimeMillis()
-                            for (user in localUserReferences) {
-                                authorization.hasAccess(Right.VIEW, user, documentReference)
-                            }
-                            def endTime = System.currentTimeMillis()
-                            def executionTime = endTime - startTime
-                            randomOrderAllUsersExecutionTimes.add((double) executionTime / localUserReferences.size())
-                        } catch (Exception e) {
-                            println("Error in random users thread: " + e.getMessage())
-                        }
-                    }
-                }
-            })
-        
-            // Save some pages to test update performance
-            def averageSaveTime = []
-            def pagesToUpdate = new ArrayList<>(allPages)
-            Collections.shuffle(pagesToUpdate)
-            pagesToUpdate = pagesToUpdate.subList(0, numSaves)
-        
-            logger.warn("Updating pages...")
-            for (documentReference in pagesToUpdate) {
-                def startTime = System.currentTimeMillis()
-                try {
-                    def myDoc = xwiki.getDocument(documentReference)
-                    myDoc.setContent("Updated content 2")
-                    myDoc.saveAsAuthor("Updated")
-                    def endTime = System.currentTimeMillis()
-                    averageSaveTime.add(endTime - startTime)
-                } catch (Exception e) {
-                    println("Error updating page: " + e.getMessage())
-                }
-            }
-        
-            logger.warn("Finishing test...")
-            stop.set(true)
-        
-            executorService.shutdown()
-            executorService.awaitTermination(5, TimeUnit.MINUTES)
-        
-            // Calculate average times
-            def top1kAverages = []
-            top1kPagesTimes.values().each { times -> top1kAverages.addAll(times) }
-            def top1kAverage = getAverage(top1kAverages)
-            def randomGuestAverage = getAverage(randomOrderExecutionTimes)
-            def randomAllUsersAverage = getAverage(randomOrderAllUsersExecutionTimes)
-            def savingAverage = getAverage(averageSaveTime)
-        
-            // Print results
-            return [
-                top1kAverage: top1kAverage,
-                randomGuestAverage: randomGuestAverage,
-                randomAllUsersAverage: randomAllUsersAverage,
-                savingAverage: savingAverage
-            ]
-        }
-        
-        def result1 = performTest(100)
-        def result2 = performTest(500)
-        
-        
-        logger.warn("Test run 1 results (100 pages):")
-        logger.warn("Top1kAverage: ${result1.top1kAverage}ms")
-        logger.warn("RandomGuestAverage: ${result1.randomGuestAverage}ms")
-        logger.warn("RandomAllUsersAverage: ${result1.randomAllUsersAverage}ms")
-        logger.warn("Average saving time: ${result1.savingAverage}ms")
-        
-        logger.warn("Test run 2 results (500 pages):")
-        logger.warn("Top1kAverage: ${result2.top1kAverage}ms")
-        logger.warn("RandomGuestAverage: ${result2.randomGuestAverage}ms")
-        logger.warn("RandomAllUsersAverage: ${result2.randomAllUsersAverage}ms")
-        logger.warn("Average saving time: ${result2.savingAverage}ms")
-        {{/groovy}}
+        {{velocity wiki="false"}}
+        $services.securityCachePerformanceTest.perform()
+        {{/velocity}}
         """;
 
     @Test
@@ -303,9 +68,10 @@ class SecurityCacheStressIT
         testUtils.rest().savePage(new DocumentReference("xwiki", List.of("Test", "Execute"), stressTestName),
             STREE_TEST_SCRIPT, "Security Cache Stress Test");
         String baseURL = StringUtils.removeEnd(testUtils.rest().getBaseURL(), "rest");
-        String viewURL = baseURL + "bin/get/Test/Execute/" + stressTestName;
+        String viewURL = baseURL + "bin/get/Test/Execute/" + stressTestName + "?outputSyntax=plain";
 
-        // Use Java 11 HTTP client to execute the script directly without browser involvement
+        // Use Java 11 HTTP client to execute the script directly without browser involvement as with the browser we
+        // get timeouts.
         HttpClient client = HttpClient.newBuilder()
             .connectTimeout(Duration.ofMinutes(2))
             .build();
@@ -318,5 +84,6 @@ class SecurityCacheStressIT
 
         HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
         assertEquals(200, response.statusCode());
+        assertTrue(StringUtils.isBlank(response.body()), response.body());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/cache/internal/DefaultSecurityCache.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/cache/internal/DefaultSecurityCache.java
@@ -104,7 +104,7 @@ public class DefaultSecurityCache implements SecurityCache, Initializable
     private final AtomicBoolean invalidationInProgress = new AtomicBoolean();
 
     /** Fair write lock. */
-    private final Lock writeLock = new ReentrantLock(true);
+    private final Lock writeLock = new ReentrantLock();
 
     private final ReadWriteLock invalidationReadWriteLock = new ReentrantReadWriteLock(true);
 

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/cache/internal/SecurityCache.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/cache/internal/SecurityCache.java
@@ -41,6 +41,7 @@ public interface SecurityCache extends org.xwiki.security.authorization.cache.Se
     /**
      * Add an entry to this cache.
      * @param entry The rule entry to add.
+     * @param invalidationCounter the invalidation counter from before starting the loading of the entry to add
      * @throws ParentEntryEvictedException when the parent entry of
      * this entry was evicted before this insertion.  Since all
      * entries, except wiki-entries, must have a parent cached, the
@@ -48,12 +49,13 @@ public interface SecurityCache extends org.xwiki.security.authorization.cache.Se
      * @throws ConflictingInsertionException when another thread have
      * inserted this entry, but with a different content.
      */
-    void add(SecurityRuleEntry entry)
+    void add(SecurityRuleEntry entry, long invalidationCounter)
         throws ParentEntryEvictedException, ConflictingInsertionException;
 
     /**
      * Add an entry to this cache.
      * @param entry The access entry to add.
+     * @param invalidationCounter the invalidation counter from before starting the loading of the entry to add
      * @throws ParentEntryEvictedException when the parent entry of
      * this entry was evicted before this insertion.  Since all
      * entries, except wiki-entries, must have a parent cached, the
@@ -61,12 +63,13 @@ public interface SecurityCache extends org.xwiki.security.authorization.cache.Se
      * @throws ConflictingInsertionException when another thread have
      * inserted this entry, but with a different content.
      */
-    void add(SecurityAccessEntry entry)
+    void add(SecurityAccessEntry entry, long invalidationCounter)
         throws ParentEntryEvictedException, ConflictingInsertionException;
 
     /**
      * Add an entry for access to a local wiki entity by a global user.
      * @param entry The access entry to add.
+     * @param invalidationCounter the invalidation counter from before starting the loading of the entry to add
      * @param wiki The sub-wiki context of this entry
      * @throws ParentEntryEvictedException when the parent entry of
      * this entry was evicted before this insertion.  Since all
@@ -77,7 +80,7 @@ public interface SecurityCache extends org.xwiki.security.authorization.cache.Se
      *
      * @since 5.0M2
      */
-    void add(SecurityAccessEntry entry, SecurityReference wiki)
+    void add(SecurityAccessEntry entry, SecurityReference wiki, long invalidationCounter)
         throws ParentEntryEvictedException, ConflictingInsertionException;
 
     /**
@@ -85,6 +88,7 @@ public interface SecurityCache extends org.xwiki.security.authorization.cache.Se
      *
      * @param entry The user/group entry to insert.
      * @param groups Local groups references that this user/group is a member.
+     * @param invalidationCounter the invalidation counter from before starting the loading of the entry to add
      * @exception ParentEntryEvictedException when the parent entry of
      * this entry was evicted before this insertion.  Since all
      * entries, except wiki-entries, must have a parent cached, the
@@ -92,7 +96,7 @@ public interface SecurityCache extends org.xwiki.security.authorization.cache.Se
      * @throws ConflictingInsertionException when another thread have
      * inserted this entry, but with a different content.
      */
-    void add(SecurityRuleEntry entry, Collection<GroupSecurityReference> groups)
+    void add(SecurityRuleEntry entry, Collection<GroupSecurityReference> groups, long invalidationCounter)
         throws ParentEntryEvictedException, ConflictingInsertionException;
 
     /**
@@ -100,6 +104,7 @@ public interface SecurityCache extends org.xwiki.security.authorization.cache.Se
      *
      * @param entry The user entry to insert.
      * @param groups Local group references that this user/group is a member.
+     * @param invalidationCounter the invalidation counter from before starting the loading of the entry to add
      * @exception ParentEntryEvictedException when the parent entry of
      * this entry was evicted before this insertion.  Since all
      * entries, except wiki-entries, must have a parent cached, the
@@ -109,8 +114,18 @@ public interface SecurityCache extends org.xwiki.security.authorization.cache.Se
      *
      * @since 5.0M2
      */
-    void add(SecurityShadowEntry entry, Collection<GroupSecurityReference> groups)
+    void add(SecurityShadowEntry entry, Collection<GroupSecurityReference> groups, long invalidationCounter)
         throws ParentEntryEvictedException, ConflictingInsertionException;
+
+    /**
+     * @return the invalidation counter. This value must be retrieved before loading any data for an entry to the
+     * security cache and then passed when adding the entry to the cache.
+     *
+     * @since 16.4.7
+     * @since 16.10.6
+     * @since 17.2.0RC1
+     */
+    long getInvalidationCounter();
 
     /**
      * Get immediate groups where the user/group is a member (directly in its wiki).
@@ -147,14 +162,14 @@ public interface SecurityCache extends org.xwiki.security.authorization.cache.Se
 
     /**
      * Suspend delivery of invalidation events.
-     * 
+     *
      * @since 10.4RC1
      */
     void suspendInvalidation();
 
     /**
      * Resume delivery of invalidation events.
-     * 
+     *
      * @since 10.4RC1
      */
     void resumeInvalidation();

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/cache/internal/SecurityCache.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/cache/internal/SecurityCache.java
@@ -121,8 +121,6 @@ public interface SecurityCache extends org.xwiki.security.authorization.cache.Se
      * @return the invalidation counter. This value must be retrieved before loading any data for an entry to the
      * security cache and then passed when adding the entry to the cache.
      *
-     * @since 16.4.7
-     * @since 16.10.6
      * @since 17.2.0RC1
      */
     long getInvalidationCounter();


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22979

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Remove the read lock of the security cache to avoid blocking read access during cache writes.
* Switch from a ReadWriteLock to a simple write lock as ReadWriteLocks might be slow, and we don't really need it anymore.
* Remove the useless check of the internal entries for security access entries to avoid needlessly acquiring the write lock.
* Improve the concurrency behavior of upgrading entries to user entries to ensure that removing the read lock is safe.
* Replace the invalidation lock used to prevent loading outdated data by an invalidation counter. This avoids holding any locks in the security cache while a document is potentially loaded from the database. Before that, it could happen that while a remove operation is waiting on the lock, a database load is executed under the invalidation read lock. That would block both the invalidation and all further cache loads as the invalidation read lock cannot be obtained any more as soon as a thread is waiting for the invalidation write lock.
* Update the security cache loader and the affected tests.
* Make the write lock in the security cache unfair for increased performance.
* Add a stress test for the security cache.


## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

The discarding of writes to the security cache could cause performance degradation in certain cases where a lot of documents are updated, in particular if the loaded document isn't kept in the document cache. However, this seems too unlikely that it would warrant a much more complex security cache (it is already complex enough). This PR implements approach 1 in [the design page](https://design.xwiki.org/xwiki/bin/view/Proposal/SecurityCacheRedesign#HInvalidationLock), to reduce the number of discarded additions, we would need to implement approach 2.

The stress test first creates 8k pages in a hierarchy of 3 levels (`A.B.C.WebHome`) and 20 users, and then executes 12 extra threads. They perform the following access control checks:

1. Thread 1-10 check access right for guest on the first 1k pages in an endless loop.
2. Thread 11 checks access right for guest on all pages in random order in an endless loop.
3. Thread 12 checks access right for all 20 users on all pages in another random order in an endless loop.

The main thread saves a random subset of pages while these loops are running. Then it sends a stop signal to the extra threads and builds the average times of these access control checks. To warm up the caches, the benchmark runs twice: first saving 100 pages, then saving 500 pages. As the security cache has only a capacity of 10k items and the document cache a capacity of 500 items, there are quite some cache misses and loads. 

I've executed the stress test both with the old and the new code on my laptop. Here are the results:

| | With old code and MariaDB 11.5: | | With new code and MariaDB 11.5: | |
| - | - | -  | - | - |
| | Test run 1 (100 pages):| Test run 2 (500 pages): | Test run 1 (100 pages):| Test run 2 (500 pages): |
| Top1kAverage: | 0.42ms   | 0.21ms  | 0.046ms  | 0.014ms  |
| RandomGuestAverage: | 2.82ms   |  1.13ms  | 5.59ms  | 4.74ms  |
| RandomAllUsersAverage: | 0.77ms | 0.90ms  |  0.43ms  | 0.35ms |
| Average saving time:  | 104.61ms | 95.18ms | 122.9ms | 103.68ms |

This table might need some explanation as some of these results seem counter-intuitive. First, as expected/desired, removing the read lock lead to quite a performance boost for cached reads. A factor 14 improvement seems quite good, in particular as the actual check in the security cache is only a part of that running time. I haven't recorded this information, but I can only assume that the worst-case running time before the changes was even worse.

Now regarding the other running times, in particular for guests, we see an almost factor 4 worse running time. I have two explanations for this:

1. The cache isn't fully deterministic, seeing much more hits for the top 1k pages might modify its behavior.
2. Due to the invalidation counter, we indeed don't insert some items into the cache. The guest test is more affected by this than the user cache due to a special behavior of the security cache: the access control check first checks if the page is in the security cache without security rules. If this is the case, it walks the hierarchy up until it finds an item with rules. As the benchmark doesn't generate any rights, this means that in the test with users, if the item for the page is inserted into the cache, all subsequent requests are most likely hits as the access control items on the root of the cache should never be evicted.

Overall, I have the impression that the new code works as expected from these tests.


# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
mvn clean install -Pquality,integration-tests,docker -pl :xwiki-platform-flamingo-skin-test-docker,:xwiki-platform-security-authorization-api -Dit.test=SecurityCacheStressIT -Dxwiki.test.ui.database=mariadb -Dxwiki.test.ui.databaseTag=11.5
```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * Difficult, I guess maybe after some time?