### PR TITLE
XWIKI-22998: Notification topbar toggle should use the `aria-expanded` attribute from the start

### DIFF
--- a/xwiki-platform-core/xwiki-platform-alerts/xwiki-platform-alerts-ui/src/main/resources/XWiki/Alerts/Code/AlertsMenuUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-alerts/xwiki-platform-alerts-ui/src/main/resources/XWiki/Alerts/Code/AlertsMenuUIX.xml
@@ -137,7 +137,7 @@
   #set ($cachedMenuContent = $menuContent.toString())
   #if ($stringtool.isNotBlank($cachedMenuContent))
     &lt;li class="dropdown" id="tmNotifications"&gt;
-      &lt;button class="dropdown-toggle" data-toggle="dropdown"
+      &lt;button class="dropdown-toggle" data-toggle="dropdown" aria-expanded="false"
       title="$services.localization.render('watchlist.notification.tooltip')"&gt;
         &lt;span class="sr-only"&gt;
           $services.localization.render('core.menu.toggleNavigation')


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22998

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Added the parameter in the initial template.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Tested manually on a local instance:
![Screenshot from 2025-03-20 17-23-34](https://github.com/user-attachments/assets/e62c45c6-7267-45ff-9a3d-dd4923acb583)

We can see on this screenshot that the attribute is here as soon as the page is loaded.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

None, minor attribute change on DOM. I checked selectors used in the BaseElement for this UI (NotificationsTrayPage) and none were broken by the changes.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None.