### PR TITLE
XWIKI-22997: Header notification toggle has an imprecise name

### DIFF
--- a/xwiki-platform-core/xwiki-platform-alerts/xwiki-platform-alerts-ui/src/main/resources/XWiki/Alerts/Code/AlertsMenuUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-alerts/xwiki-platform-alerts-ui/src/main/resources/XWiki/Alerts/Code/AlertsMenuUIX.xml
@@ -140,7 +140,7 @@
       &lt;button class="dropdown-toggle" data-toggle="dropdown"
       title="$services.localization.render('watchlist.notification.tooltip')"&gt;
         &lt;span class="sr-only"&gt;
-          $services.localization.render('core.menu.toggleNavigation')
+          $services.localization.render('notifications.alerts.toggle.hint')
         &lt;/span&gt;
         $services.icon.renderHTML('bell')
       &lt;/button&gt;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -4055,6 +4055,7 @@ web.editableProperty.viewFailed=Failed to view property.
 core.drawer.global=Global
 
 ## Notifications
+notifications.alerts.toggle.hint=Toggle notification center
 notifications.events.update.description=edited the page
 notifications.events.update.description.by.1user=edited by {0}
 notifications.events.update.description.by.users=edited by {0} users


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22997

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added a specific translation for this toggle. I tried to keep it as short and precise as possible.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
After the changes in this PR:
![image](https://github.com/user-attachments/assets/18e0e46f-b466-4d01-b2a9-7ceba522c1db)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
None, this is a minor translation value switch.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X (very safe bugfix)