### PR TITLE
XWIKI-23019: Oracle inconsistent datatypes error when using user suggest for multiple users

### DIFF
--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-docker/src/test/it/org/xwiki/appwithinminutes/test/ui/UserClassFieldIT.java
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-docker/src/test/it/org/xwiki/appwithinminutes/test/ui/UserClassFieldIT.java
@@ -21,6 +21,7 @@ package org.xwiki.appwithinminutes.test.ui;
 
 import java.util.List;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -62,14 +63,14 @@ import static org.junit.jupiter.api.Assertions.fail;
 class UserClassFieldIT
 {
     private static final String ADMIN_NAME = "Admin";
-
     private static final String ADMIN_AVATAR = "user";
+    private static final String USER_PREFIX = UserClassFieldIT.class.getSimpleName();
 
-    @BeforeEach
-    void setUp(TestUtils setup, TestReference testReference) throws Exception
+    @BeforeAll
+    void beforeAll(TestUtils setup) throws Exception
     {
         setup.createAdminUser();
-        // Create 2 users.
+        // Create 2 specific users.
         setup.createUserAndLogin("tmortagne", "tmortagne", "first_name", "Thomas", "last_name", "Mortagne", "avatar",
             "tmortagne.png");
         setup.attachFile("XWiki", "tmortagne", "tmortagne.png",
@@ -78,6 +79,25 @@ class UserClassFieldIT
             "Enygma2002.png");
         setup.attachFile("XWiki", "Enygma2002", "Enygma2002.png",
             UserClassFieldIT.class.getResourceAsStream("/appwithinminutes/Enygma2002.png"), false);
+
+        // Create 15 mock users just to test the request limits
+        for (int i = 0; i < 15; i++) {
+            createUser(setup, String.valueOf(i));
+        }
+        createUser(setup, "XXX");
+        createUser(setup, "YYY");
+        createUser(setup, "ZZZ");
+    }
+
+    private void createUser(TestUtils setup, String userSuffix)
+    {
+        String userId = String.format("%s_%s", USER_PREFIX, userSuffix);
+        setup.createUser(userId, userId, null);
+    }
+
+    @BeforeEach
+    void setUp(TestUtils setup, TestReference testReference)
+    {
         setup.loginAsSuperAdmin();
         setup.deleteSpace(testReference.getLastSpaceReference());
     }
@@ -159,6 +179,12 @@ class UserClassFieldIT
         assertEquals(singletonList("XWiki.Admin"), userPicker.getValues());
     }
 
+    /*
+    Note that this test does perform checks on the behaviour of the suggester, but it doesn't actually check the
+    behaviour of the query itself: since we don't save the application, the query is performed on the
+    AppWithinMinutes.Users property field which doesn't contain the same values than when saving a property for
+    multiple select. So we test that specific behaviour in the next test saveAndInitalSelection.
+     */
     @Test
     @Order(3)
     void multipleSelection(TestReference testReference)
@@ -232,8 +258,11 @@ class UserClassFieldIT
         assertUserSuggestion(selectedUsers.get(1), ADMIN_NAME, "Admin", ADMIN_AVATAR);
         assertEquals(asList("XWiki.tmortagne", "XWiki.Admin"), userPicker.getValues());
 
+        List<SuggestionElement> suggestions = userPicker.sendKeys("XXX").waitForSuggestions().getSuggestions();
+        assertEquals(1, suggestions.size());
+
         // We should be able to input free text also.
-        userPicker.sendKeys("foobar").waitForSuggestions().selectTypedText();
+        userPicker.clear().sendKeys("foobar").waitForSuggestions().selectTypedText();
         editor.clickSaveAndContinue();
         editor.clickCancel().edit();
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/UsedValuesListQueryBuilder.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/UsedValuesListQueryBuilder.java
@@ -42,7 +42,9 @@ import org.xwiki.security.authorization.ContextualAuthorizationManager;
 import org.xwiki.security.authorization.Right;
 import org.xwiki.text.StringUtils;
 
+import com.xpn.xwiki.internal.store.hibernate.HibernateStore;
 import com.xpn.xwiki.objects.classes.ListClass;
+import com.xpn.xwiki.store.DatabaseProduct;
 
 /**
  * Builds a query that returns the values used by a List property.
@@ -100,14 +102,29 @@ public class UsedValuesListQueryBuilder implements QueryBuilder<ListClass>
     @Named("current")
     private DocumentReferenceResolver<String> documentReferenceResolver;
 
+    @Inject
+    private HibernateStore hibernateStore;
+
     @Override
+    @SuppressWarnings("checkstyle:MultipleStringLiterals")
     public Query build(ListClass listClass) throws QueryException
     {
-        String statement = String.format("select %1$s, str(%1$s) as unfilterable1 "
-            + "from BaseObject as obj, %2$s "
-            + "where obj.className = :className and obj.name <> :templateName"
-            + " and prop.id.id = obj.id and prop.id.name = :propertyName "
-            + "order by unfilterable1 desc", getSelectColumnAndFromTable(listClass));
+        String statement;
+
+        if (hibernateStore.getDatabaseProductName() == DatabaseProduct.ORACLE) {
+            statement = String.format("select %1$s, str(%1$s) as unfilterable1 "
+                + "from BaseObject as obj, %2$s "
+                + "where obj.className = :className and obj.name <> :templateName"
+                + " and prop.id.id = obj.id and prop.id.name = :propertyName "
+                + "order by unfilterable1 desc", getSelectColumnAndFromTable(listClass));
+        } else {
+            statement = String.format("select %1$s, count(*) as unfilterable0 "
+                + "from BaseObject as obj, %2$s "
+                + "where obj.className = :className and obj.name <> :templateName"
+                + " and prop.id.id = obj.id and prop.id.name = :propertyName "
+                + "group by %1$s "
+                + "order by unfilterable0 desc", getSelectColumnAndFromTable(listClass));
+        }
         Query query = this.queryManager.createQuery(statement, Query.HQL);
         bindParameterValues(query, listClass);
         query.addFilter(new ViewableValueFilter(listClass));

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/UsedValuesListQueryBuilder.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/UsedValuesListQueryBuilder.java
@@ -103,10 +103,11 @@ public class UsedValuesListQueryBuilder implements QueryBuilder<ListClass>
     @Override
     public Query build(ListClass listClass) throws QueryException
     {
-        String statement = String.format("select %1$s, count(*) as unfilterable0 " + "from BaseObject as obj, %2$s "
+        String statement = String.format("select %1$s, str(%1$s) as unfilterable1 "
+            + "from BaseObject as obj, %2$s "
             + "where obj.className = :className and obj.name <> :templateName"
-            + " and prop.id.id = obj.id and prop.id.name = :propertyName " + "group by %1$s "
-            + "order by count(*) desc", getSelectColumnAndFromTable(listClass));
+            + " and prop.id.id = obj.id and prop.id.name = :propertyName "
+            + "order by unfilterable1 desc", getSelectColumnAndFromTable(listClass));
         Query query = this.queryManager.createQuery(statement, Query.HQL);
         bindParameterValues(query, listClass);
         query.addFilter(new ViewableValueFilter(listClass));

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/objects/classes/UsedValuesListQueryBuilderTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/objects/classes/UsedValuesListQueryBuilderTest.java
@@ -41,6 +41,8 @@ import com.xpn.xwiki.objects.classes.ListClass;
 import com.xpn.xwiki.web.Utils;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -52,7 +54,7 @@ import static org.mockito.Mockito.when;
  * @since 9.8RC1
  */
 @ComponentTest
-public class UsedValuesListQueryBuilderTest
+class UsedValuesListQueryBuilderTest
 {
     @MockComponent
     private QueryManager queryManager;
@@ -74,7 +76,7 @@ public class UsedValuesListQueryBuilderTest
     private UsedValuesListQueryBuilder usedValuesListQueryBuilder;
 
     @BeforeEach
-    public void before(MockitoComponentManager componentManager) throws Exception
+    void before(MockitoComponentManager componentManager) throws Exception
     {
         DocumentReference oneReference = new DocumentReference("wiki", "Page", "one");
         when(this.documentReferenceResolver.resolve("alice")).thenReturn(oneReference);
@@ -97,20 +99,19 @@ public class UsedValuesListQueryBuilderTest
     }
 
     @Test
-    public void buildForStringProperty() throws Exception
+    void buildForStringProperty() throws Exception
     {
         listClass.setMultiSelect(false);
 
         Query query = mock(Query.class);
-        when(this.queryManager.createQuery(
-            "select prop.value, count(*) as unfilterable0 " + "from BaseObject as obj, StringProperty as prop "
-                + "where obj.className = :className and obj.name <> :templateName"
-                + " and prop.id.id = obj.id and prop.id.name = :propertyName " + "group by prop.value "
-                + "order by count(*) desc",
-            Query.HQL)).thenReturn(query);
-
+        when(this.queryManager.createQuery(any(), eq(Query.HQL))).thenReturn(query);
         assertSame(query, this.usedValuesListQueryBuilder.build(listClass));
 
+        verify(this.queryManager).createQuery("select prop.value, str(prop.value) as unfilterable1 "
+            + "from BaseObject as obj, StringProperty as prop "
+            + "where obj.className = :className and obj.name <> :templateName and "
+            + "prop.id.id = obj.id and prop.id.name = :propertyName "
+            + "order by unfilterable1 desc", Query.HQL);
         verify(query).bindValue("className", "Blog.BlogPostClass");
         verify(query).bindValue("propertyName", "category");
         verify(query).bindValue("templateName", "Blog.BlogPostTemplate");
@@ -118,35 +119,36 @@ public class UsedValuesListQueryBuilderTest
     }
 
     @Test
-    public void buildForDBStringListProperty() throws Exception
+    void buildForDBStringListProperty() throws Exception
     {
         listClass.setMultiSelect(true);
         listClass.setRelationalStorage(true);
 
         Query query = mock(Query.class);
-        when(this.queryManager.createQuery("select listItem, count(*) as unfilterable0 "
-            + "from BaseObject as obj, DBStringListProperty as prop join prop.list listItem "
-            + "where obj.className = :className and obj.name <> :templateName"
-            + " and prop.id.id = obj.id and prop.id.name = :propertyName " + "group by listItem "
-            + "order by count(*) desc", Query.HQL)).thenReturn(query);
+        when(this.queryManager.createQuery(any(), eq(Query.HQL))).thenReturn(query);
 
         assertSame(query, this.usedValuesListQueryBuilder.build(listClass));
+        verify(this.queryManager).createQuery("select listItem, str(listItem) as unfilterable1 "
+            + "from BaseObject as obj, DBStringListProperty as prop join prop.list listItem "
+            + "where obj.className = :className and obj.name <> :templateName and "
+            + "prop.id.id = obj.id and prop.id.name = :propertyName "
+            + "order by unfilterable1 desc", Query.HQL);
     }
 
     @Test
-    public void buildForStringListProperty() throws Exception
+    void buildForStringListProperty() throws Exception
     {
         listClass.setMultiSelect(true);
         listClass.setRelationalStorage(false);
 
         Query query = mock(Query.class);
-        when(this.queryManager.createQuery(
-            "select prop.textValue, count(*) as unfilterable0 " + "from BaseObject as obj, StringListProperty as prop "
-                + "where obj.className = :className and obj.name <> :templateName"
-                + " and prop.id.id = obj.id and prop.id.name = :propertyName " + "group by prop.textValue "
-                + "order by count(*) desc",
-            Query.HQL)).thenReturn(query);
+        when(this.queryManager.createQuery(any(), eq(Query.HQL))).thenReturn(query);
 
         assertSame(query, this.usedValuesListQueryBuilder.build(listClass));
+        verify(this.queryManager).createQuery("select prop.textValue, str(prop.textValue) as unfilterable1 "
+            + "from BaseObject as obj, StringListProperty as prop "
+            + "where obj.className = :className and obj.name <> :templateName and "
+            + "prop.id.id = obj.id and prop.id.name = :propertyName "
+            + "order by unfilterable1 desc", Query.HQL);
     }
 }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-23019

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

  * Expose the bug in `UserClassFieldIT`
  * Refactor the query in `UsedValuesListQueryBuilder` to not order results based on number of occurences but only based on the actual values lexicographical order, avoiding a group by on a clob which is not allowed in oracle

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

The value field defined in hibernate schema for list is of type clob. This type cannot be used in quite a few operations in Oracle DB, including using this type of field in `group by` clauses. 
The value field is currently used in a `group by` clause in `UsedValuesListQueryBuilder` for ordering the result based on the number of occurrences. 
AFAIU the only purpose of having this ordering is to present the most commonly used values when opening the suggester, or when performing a REST API request on the property values (which the suggester uses). That being said, there's no simple way to fix this query for Oracle while keeping this ordering. So my fix proposal here consists in getting rid of this ordering: I dropped it in favor of a lexicographical ordering based on the values themselves. 

As a consequence, accepting this change involves a regression in the behaviour of the suggester when first focusing on it: instead of presenting the most used values, it will present the first values in lexicographical order. 

My take on that is that it's a good enough trade off for now between having a consistent order (not random results) and having a working suggester with Oracle DB. 

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

in `xwiki-platform-appwithinminutes-test-docker`: 
`mvn clean install -Dit.test=UserClassFieldIT` without arguments, and with arguments to test with Oracle DB. 
`mvn clean install -Dit.test=StaticListClassIT` 

All tests passing

in `xwiki-platform-flamingo-skin-test-docker`: `mvn clean install` -> all tests passing

in `xwiki-platform-oldcore` and `xwiki-platform-legacy-oldcore`: `mvn clean install -Pquality`

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-16.10.x
  * stable-16.4.x