### PR TITLE
XWIKI-22978: Comments are not ordered by date

### DIFF
--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -175,6 +175,7 @@
     <module>xwiki-platform-chart</module>
     <module>xwiki-platform-ckeditor</module>
     <module>xwiki-platform-classloader</module>
+    <module>xwiki-platform-comment</module>
     <module>xwiki-platform-component</module>
     <module>xwiki-platform-configuration</module>
     <module>xwiki-platform-container</module>

--- a/xwiki-platform-core/xwiki-platform-comment/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-comment/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.xwiki.platform</groupId>
+    <artifactId>xwiki-platform-core</artifactId>
+    <version>17.3.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>xwiki-platform-comment</artifactId>
+  <name>XWiki Platform - Comment - Parent POM</name>
+  <packaging>pom</packaging>
+  <description>XWiki Platform - Comment - Parent POM</description>
+  <modules>
+    <module>xwiki-platform-comment-api</module>
+    <module>xwiki-platform-comment-default</module>
+  </modules>
+</project>

--- a/xwiki-platform-core/xwiki-platform-comment/xwiki-platform-comment-api/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-comment/xwiki-platform-comment-api/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.xwiki.platform</groupId>
+    <artifactId>xwiki-platform-comment</artifactId>
+    <version>17.3.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>xwiki-platform-comment-api</artifactId>
+  <name>XWiki Platform - Comment - API</name>
+  <packaging>jar</packaging>
+  <description>XWiki Platform - Comment - API</description>
+  <properties>
+    <xwiki.jacoco.instructionRatio>1.00</xwiki.jacoco.instructionRatio>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-component-api</artifactId>
+      <version>${commons.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-script</artifactId>
+      <version>${commons.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-model-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-user-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>
+

--- a/xwiki-platform-core/xwiki-platform-comment/xwiki-platform-comment-api/src/main/java/org/xwiki/platform/comment/Comment.java
+++ b/xwiki-platform-core/xwiki-platform-comment/xwiki-platform-comment-api/src/main/java/org/xwiki/platform/comment/Comment.java
@@ -1,0 +1,33 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.platform.comment;
+
+import java.util.Date;
+
+import org.xwiki.user.UserReference;
+
+public interface Comment
+{
+    CommentId getId();
+    UserReference getAuthor();
+    String getContent();
+    Date getCreationDate();
+    CommentId getReplyTo();
+}

--- a/xwiki-platform-core/xwiki-platform-comment/xwiki-platform-comment-api/src/main/java/org/xwiki/platform/comment/CommentException.java
+++ b/xwiki-platform-core/xwiki-platform-comment/xwiki-platform-comment-api/src/main/java/org/xwiki/platform/comment/CommentException.java
@@ -1,0 +1,13 @@
+package org.xwiki.platform.comment;
+
+public class CommentException extends Exception
+{
+    public CommentException(String message)
+    {
+        super(message);
+    }
+    public CommentException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-comment/xwiki-platform-comment-api/src/main/java/org/xwiki/platform/comment/CommentId.java
+++ b/xwiki-platform-core/xwiki-platform-comment/xwiki-platform-comment-api/src/main/java/org/xwiki/platform/comment/CommentId.java
@@ -1,0 +1,27 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.platform.comment;
+
+import java.io.Serializable;
+
+public interface CommentId
+{
+    Serializable getSerializedId();
+}

--- a/xwiki-platform-core/xwiki-platform-comment/xwiki-platform-comment-api/src/main/java/org/xwiki/platform/comment/CommentManager.java
+++ b/xwiki-platform-core/xwiki-platform-comment/xwiki-platform-comment-api/src/main/java/org/xwiki/platform/comment/CommentManager.java
@@ -1,0 +1,31 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.platform.comment;
+
+import java.util.List;
+
+import org.xwiki.component.annotation.Role;
+import org.xwiki.model.reference.EntityReference;
+
+@Role
+public interface CommentManager
+{
+    List<Comment> getComments(EntityReference documentReference, boolean ascendindOrder) throws CommentException;
+}

--- a/xwiki-platform-core/xwiki-platform-comment/xwiki-platform-comment-api/src/main/java/org/xwiki/platform/comment/script/CommentScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-comment/xwiki-platform-comment-api/src/main/java/org/xwiki/platform/comment/script/CommentScriptService.java
@@ -1,0 +1,67 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.platform.comment.script;
+
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.EntityReference;
+import org.xwiki.platform.comment.Comment;
+import org.xwiki.platform.comment.CommentException;
+import org.xwiki.platform.comment.CommentManager;
+import org.xwiki.script.service.ScriptService;
+import org.xwiki.stability.Unstable;
+
+/**
+ * Script service dedicated to manipulate comments.
+ *
+ * @version $Id$
+ * @since 17.3.0RC1
+ * @since 16.10.6
+ * @since 16.4.7
+ */
+@Component
+@Named("comment")
+@Singleton
+@Unstable
+public class CommentScriptService implements ScriptService
+{
+    @Inject
+    private CommentManager commentManager;
+
+    /**
+     * Retrieve comments sorted by dates.
+     *
+     * @param entityReference the reference for which to retrieve comments.
+     * @param ascending {@code true} to retrieve comments in date ascending order, {@code false} for date descending
+     * order
+     * @return the list of comments associated to the given reference ordered by date
+     * @throws CommentException in case of problem to retrieve the comments
+     */
+    public List<Comment> getComments(EntityReference entityReference, boolean ascending) throws CommentException
+    {
+        return this.commentManager.getComments(entityReference, ascending);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-comment/xwiki-platform-comment-api/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-comment/xwiki-platform-comment-api/src/main/resources/META-INF/components.txt
@@ -1,0 +1,2 @@
+org.xwiki.platform.comment.internal.DefaultCommentManager
+org.xwiki.platform.comment.internal.XWikiCommentsDocumentInitializer

--- a/xwiki-platform-core/xwiki-platform-comment/xwiki-platform-comment-default/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-comment/xwiki-platform-comment-default/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.xwiki.platform</groupId>
+    <artifactId>xwiki-platform-comment</artifactId>
+    <version>17.3.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>xwiki-platform-comment-default</artifactId>
+  <name>XWiki Platform - Comment - Default</name>
+  <packaging>jar</packaging>
+  <description>XWiki Platform - Comment - Default</description>
+  <properties>
+    <xwiki.jacoco.instructionRatio>1.00</xwiki.jacoco.instructionRatio>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-comment-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-oldcore</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>
+

--- a/xwiki-platform-core/xwiki-platform-comment/xwiki-platform-comment-default/src/main/java/org/xwiki/platform/comment/internal/DefaultComment.java
+++ b/xwiki-platform-core/xwiki-platform-comment/xwiki-platform-comment-default/src/main/java/org/xwiki/platform/comment/internal/DefaultComment.java
@@ -1,0 +1,133 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.platform.comment.internal;
+
+import java.util.Date;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.xwiki.platform.comment.Comment;
+import org.xwiki.platform.comment.CommentId;
+import org.xwiki.user.UserReference;
+
+public class DefaultComment implements Comment
+{
+    private final CommentId id;
+    private UserReference author;
+    private Date created;
+    private String content;
+    private CommentId replyId;
+
+    public DefaultComment(int id)
+    {
+        this.id = new DefaultCommentId(id);
+    }
+
+    @Override
+    public CommentId getId()
+    {
+        return this.id;
+    }
+
+    @Override
+    public UserReference getAuthor()
+    {
+        return this.author;
+    }
+
+    @Override
+    public String getContent()
+    {
+        return this.content;
+    }
+
+    @Override
+    public Date getCreationDate()
+    {
+        return this.created;
+    }
+
+    @Override
+    public CommentId getReplyTo()
+    {
+        return this.replyId;
+    }
+
+    public DefaultComment setAuthor(UserReference author)
+    {
+        this.author = author;
+        return this;
+    }
+
+    public DefaultComment setCreated(Date created)
+    {
+        this.created = created;
+        return this;
+    }
+
+    public DefaultComment setContent(String content)
+    {
+        this.content = content;
+        return this;
+    }
+
+    public DefaultComment setReplyId(int replyId)
+    {
+        this.replyId = new DefaultCommentId(replyId);
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DefaultComment that = (DefaultComment) o;
+
+        return new EqualsBuilder().append(id, that.id).append(author, that.author)
+            .append(created, that.created).append(content, that.content).append(replyId, that.replyId).isEquals();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return new HashCodeBuilder(17, 35).append(id).append(author).append(created).append(content).append(replyId)
+            .toHashCode();
+    }
+
+    @Override
+    public String toString()
+    {
+        return new ToStringBuilder(this)
+            .append("id", id)
+            .append("author", author)
+            .append("created", created)
+            .append("content", content)
+            .append("replyId", replyId)
+            .toString();
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-comment/xwiki-platform-comment-default/src/main/java/org/xwiki/platform/comment/internal/DefaultCommentId.java
+++ b/xwiki-platform-core/xwiki-platform-comment/xwiki-platform-comment-default/src/main/java/org/xwiki/platform/comment/internal/DefaultCommentId.java
@@ -1,0 +1,40 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.platform.comment.internal;
+
+import java.io.Serializable;
+
+import org.xwiki.platform.comment.CommentId;
+
+public class DefaultCommentId implements CommentId
+{
+    private final Integer id;
+
+    public DefaultCommentId(int id)
+    {
+        this.id = id;
+    }
+
+    @Override
+    public Serializable getSerializedId()
+    {
+        return this.id;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-comment/xwiki-platform-comment-default/src/main/java/org/xwiki/platform/comment/internal/DefaultCommentManager.java
+++ b/xwiki-platform-core/xwiki-platform-comment/xwiki-platform-comment-default/src/main/java/org/xwiki/platform/comment/internal/DefaultCommentManager.java
@@ -1,0 +1,92 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.platform.comment.internal;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.model.EntityType;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.EntityReference;
+import org.xwiki.platform.comment.Comment;
+import org.xwiki.platform.comment.CommentException;
+import org.xwiki.platform.comment.CommentManager;
+import org.xwiki.user.UserReference;
+import org.xwiki.user.UserReferenceResolver;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.objects.BaseObject;
+
+@Component
+@Singleton
+public class DefaultCommentManager implements CommentManager
+{
+    @Inject
+    private Provider<XWikiContext> contextProvider;
+
+    @Inject
+    private UserReferenceResolver<String> userReferenceResolver;
+
+    @Override
+    public List<Comment> getComments(EntityReference entityReference, boolean ascendindOrder)
+        throws CommentException
+    {
+        if (entityReference.getType() != EntityType.DOCUMENT) {
+            throw new CommentException("Current implementation only support document entities");
+        }
+        XWikiContext context = this.contextProvider.get();
+        try {
+            XWikiDocument document = context.getWiki().getDocument(entityReference, context);
+            List<BaseObject> comments = document.getComments();
+            List<Comment> result = new ArrayList<>();
+            for (BaseObject comment : comments) {
+                result.add(this.buildComment(comment));
+            }
+            Comparator<Comment> comparator = Comparator.comparing(Comment::getCreationDate);
+            if (!ascendindOrder) {
+                comparator = comparator.reversed();
+            }
+            result.sort(comparator);
+            return result;
+        } catch (XWikiException e) {
+            throw new CommentException(
+                String.format("Error when accessing comments for document [%s].", entityReference), e);
+        }
+    }
+
+    private DefaultComment buildComment(BaseObject commentObject) throws XWikiException
+    {
+        DefaultComment result = new DefaultComment(commentObject.getNumber());
+        UserReference author = this.userReferenceResolver.resolve(commentObject.getStringValue("author"));
+        Date date = commentObject.getDateValue("date");
+        String content = commentObject.getStringValue("comment");
+        int replyTo = commentObject.getIntValue("replyto");
+        return result.setAuthor(author).setCreated(date).setContent(content).setReplyId(replyTo);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-comment/xwiki-platform-comment-default/src/main/java/org/xwiki/platform/comment/internal/XWikiCommentsDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-comment/xwiki-platform-comment-default/src/main/java/org/xwiki/platform/comment/internal/XWikiCommentsDocumentInitializer.java
@@ -17,7 +17,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package com.xpn.xwiki.internal.mandatory;
+package org.xwiki.platform.comment.internal;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -27,6 +27,7 @@ import org.xwiki.model.reference.LocalDocumentReference;
 import org.xwiki.model.reference.RegexEntityReference;
 
 import com.xpn.xwiki.XWiki;
+import com.xpn.xwiki.internal.mandatory.AbstractCommentsDocumentInitializer;
 import com.xpn.xwiki.objects.BaseObjectReference;
 import com.xpn.xwiki.objects.classes.BaseClass;
 import com.xpn.xwiki.objects.classes.TextAreaClass;

--- a/xwiki-platform-core/xwiki-platform-comment/xwiki-platform-comment-default/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-comment/xwiki-platform-comment-default/src/main/resources/META-INF/components.txt
@@ -1,0 +1,1 @@
+org.xwiki.platform.comment.script.CommentScriptService

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/commentsinline.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/commentsinline.vm
@@ -399,14 +399,15 @@ $xwiki.ssfx.use('uicomponents/viewers/comments.css', true)
   #end
 #else
 #if($xwiki.getSpacePreferenceAsInt('commentsorder', 1) == 1)
-  #set($comments = $doc.getComments())
+  #set($comments = $services.comment.comments($doc, true))
 #else
-  #set($comments = $doc.getComments(false))
+  #set($comments = $services.comment.comments($doc, false))
 #end
 ##
 ##
 <div id="commentscontent" class="xwikiintracontent">
   <div id="_comments">
+## TODO: the thread creation should be part of the new comment API.
 #if($comments.size() > 0)
   #set($rootKey = "-1")
   #set($commentThreads = {})

--- a/xwiki-platform-core/xwiki-platform-minimaldependencies/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-minimaldependencies/pom.xml
@@ -362,6 +362,13 @@
       <version>${project.version}</version>
       <scope>runtime</scope>
     </dependency>
+    <!-- Default Comment implementation -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-comment-default</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
 
     <!-- ********************************************************************** -->
     <!-- Plugins, hard to install as extensions (we need to get rid of all that) -->

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/META-INF/components.txt
@@ -64,7 +64,7 @@ com.xpn.xwiki.internal.mandatory.GlobalRedirectDocumentInitializer
 com.xpn.xwiki.internal.mandatory.RedirectClassDocumentInitializer
 com.xpn.xwiki.internal.mandatory.TagClassDocumentInitializer
 com.xpn.xwiki.internal.mandatory.XWikiAllGroupDocumentInitializer
-com.xpn.xwiki.internal.mandatory.XWikiCommentsDocumentInitializer
+org.xwiki.platform.comment.internal.XWikiCommentsDocumentInitializer
 com.xpn.xwiki.internal.mandatory.XWikiGlobalRightsDocumentInitializer
 com.xpn.xwiki.internal.mandatory.XWikiGroupsDocumentInitializer
 com.xpn.xwiki.internal.mandatory.XWikiPreferencesDocumentInitializer


### PR DESCRIPTION
:warning: 
WIP: missing docs and tests.

# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

Provide entirely new API for handling comments in XWiki and use that in the template for getting them ordered by date.
The goal is also to deprecate all existing comment API in oldcore.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-16.4.x
  * stable-16.10.x