### PR TITLE
XWIKI-22978: Comments are not ordered by date

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/commentsinline.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/commentsinline.vm
@@ -398,10 +398,45 @@ $xwiki.ssfx.use('uicomponents/viewers/comments.css', true)
     #error($services.localization.render('core.viewers.comments.edit.notFound'))
   #end
 #else
+#set($comments = $doc.getComments())
+
+## Build a map on the form Date -> List<Comment object>
+## We also keep the set of keys when we have multiple comments at same date just to order them later (it should be a
+## very rare case but let's ensure we keep a deterministic order)
+#set ($commentMap = {})
+#set ($keysWithMultipleComments = $collectiontool.getSet())
+#foreach ($comment in $comments)
+  #set ($key = $comment.date)
+  #if ($commentMap.containsKey($key))
+    #set ($discard = $commentMap.get($key).add($comment))
+    #set ($discard = $keysWithMultipleComments.add($key))
+  #else
+    #set ($discard = $commentMap.put($key, [$comment]))
+  #end
+#end
+
+## We perform an ascending ordering of the keys
+#set ($orderedKeys = $collectiontool.getLinkedList())
+#set ($discard = $orderedKeys.addAll($commentMap.keySet()))
+#set ($discard = $collectiontool.sortModifiable($orderedKeys))
+
 #if($xwiki.getSpacePreferenceAsInt('commentsorder', 1) == 1)
-  #set($comments = $doc.getComments())
+  #set ($orderSuffix = ":asc")
 #else
-  #set($comments = $doc.getComments(false))
+  #set ($orderSuffix = ":desc")
+  #set ($discard = $collectiontool.reverseModifiable($orderedKeys))
+#end
+
+## Ensure to order list with multiple entries if needed
+#foreach ($keyMultipleComment in $keysWithMultipleComments)
+  #set ($reorderedList = $collectiontool.sort($commentMap.get($keyMultipleComment), "number$orderSuffix"))
+  #set ($discard = $commentMap.put($keyMultipleComment, $reorderedList))
+#end
+
+## Finally obtained an ordered list
+#set ($comments = $collectiontool.getLinkedList())
+#foreach ($commentKey in $orderedKeys)
+  #set ($discard = $comments.addAll($commentMap.get($commentKey)))
 #end
 ##
 ##

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/commentsinline.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/commentsinline.vm
@@ -165,7 +165,7 @@ $xwiki.ssfx.use('uicomponents/viewers/comments.css', true)
   ## This variable should be true only for an authenticate user that matches the comment author.
   ## We don't allow guests to be edit or delete comments because we can't know if they are the comment author.
   #set ($isUserComment = $commentAuthor != '' && $services.model.resolveDocument($commentAuthor, 'user') == $xcontext.userReference)
-  <div id="xwikicomment_${comment.number}" class="xwikicomment  #if($comment.getProperty('author').value == $doc.creator) commentByCreator#end#if($isAnnotation) annotation#end">
+  <div id="xwikicomment_${comment.number}" #if("$!comment.replyto" != '')data-replyto="$comment.replyto"#end class="xwikicomment  #if($comment.getProperty('author').value == $doc.creator) commentByCreator#end#if($isAnnotation) annotation#end">
     <div class="commentavatar">#if("$!comment.replyto" == '')#largeUserAvatar($commentAuthor)#{else}#mediumUserAvatar($commentAuthor)#end</div>
     <div class="commentheader">
       <div>
@@ -398,12 +398,12 @@ $xwiki.ssfx.use('uicomponents/viewers/comments.css', true)
     #error($services.localization.render('core.viewers.comments.edit.notFound'))
   #end
 #else
-#set($comments = $doc.getComments())
+#set ($comments = $doc.getComments())
 
 ## Build a map on the form Date -> List<Comment object>
 ## We also keep the set of keys when we have multiple comments at same date just to order them later (it should be a
 ## very rare case but let's ensure we keep a deterministic order)
-#set ($commentMap = {})
+#set ($commentMap = $collectiontool.getSortedMap())
 #set ($keysWithMultipleComments = $collectiontool.getSet())
 #foreach ($comment in $comments)
   #set ($key = $comment.date)
@@ -416,15 +416,11 @@ $xwiki.ssfx.use('uicomponents/viewers/comments.css', true)
 #end
 
 ## We perform an ascending ordering of the keys
-#set ($orderedKeys = $collectiontool.getLinkedList())
-#set ($discard = $orderedKeys.addAll($commentMap.keySet()))
-#set ($discard = $collectiontool.sortModifiable($orderedKeys))
-
 #if($xwiki.getSpacePreferenceAsInt('commentsorder', 1) == 1)
-  #set ($orderSuffix = ":asc")
+  #set ($orderSuffix = ':asc')
 #else
-  #set ($orderSuffix = ":desc")
-  #set ($discard = $collectiontool.reverseModifiable($orderedKeys))
+  #set ($orderSuffix = ':desc')
+  #set ($commentMap = $commentMap.descendingMap())
 #end
 
 ## Ensure to order list with multiple entries if needed
@@ -435,8 +431,8 @@ $xwiki.ssfx.use('uicomponents/viewers/comments.css', true)
 
 ## Finally obtained an ordered list
 #set ($comments = $collectiontool.getLinkedList())
-#foreach ($commentKey in $orderedKeys)
-  #set ($discard = $comments.addAll($commentMap.get($commentKey)))
+#foreach ($commentList in $commentMap.values())
+  #set ($discard = $comments.addAll($commentList))
 #end
 ##
 ##

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/CommentsIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/CommentsIT.java
@@ -19,14 +19,22 @@
  */
 package org.xwiki.flamingo.test.docker;
 
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.NotFoundException;
+import org.xwiki.rest.model.jaxb.Object;
+import org.xwiki.rest.model.jaxb.Property;
 import org.xwiki.test.docker.junit5.TestReference;
 import org.xwiki.test.docker.junit5.UITest;
 import org.xwiki.test.ui.TestUtils;
+import org.xwiki.test.ui.po.CommentElement;
 import org.xwiki.test.ui.po.CommentForm;
 import org.xwiki.test.ui.po.CommentsTab;
+import org.xwiki.test.ui.po.ViewPage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -55,6 +63,8 @@ class CommentsIT
     private static final String USER_PASSWORD = "commentUserPassword";
 
     private static final String COMMENT_REPLACED_CONTENT = "Some replaced content";
+
+    private static final SimpleDateFormat DEFAULT_DATE_FORMAT = new SimpleDateFormat("dd/MM/yyyy HH:mm:ss");
 
     @Test
     @Order(1)
@@ -158,5 +168,118 @@ class CommentsIT
         addCommentForm = commentsTab.getAddCommentForm();
         addCommentForm.addToContentField("xyz");
         assertEquals("xyz", addCommentForm.clickPreview().getText());
+    }
+
+    private String getDateString(int seconds)
+    {
+        return DEFAULT_DATE_FORMAT.format(new Date(seconds * 1000L));
+    }
+
+    @Test
+    @Order(4)
+    void commentsAreOrderedByDate(TestUtils setup, TestReference reference) throws Exception
+    {
+        setup.loginAsSuperAdmin();
+        // ensure that all dates are using GMT-0 to be displayed.
+        setup.setPropertyInXWikiPreferences("timezone", "String", "UTC");
+        setup.rest().savePage(reference, "Test comment order", "Test comment order");
+        Property authorProperty = TestUtils.RestTestUtils.property("author", "XWiki.superadmin");
+
+        // Object 0 date 100 (order: 5)
+        Object commentObject = setup.rest().object(reference, "XWiki.XWikiComments");
+        Property dateProperty = TestUtils.RestTestUtils.property("date", getDateString(100));
+        Property contentProperty = TestUtils.RestTestUtils.property("comment", "Comment object 0 at date 100");
+        commentObject.getProperties().addAll(List.of(dateProperty, authorProperty, contentProperty));
+        setup.rest().add(commentObject);
+
+        // object 1 date 42 (order: 2)
+        commentObject = setup.rest().object(reference, "XWiki.XWikiComments");
+        dateProperty = TestUtils.RestTestUtils.property("date", getDateString(42));
+        contentProperty = TestUtils.RestTestUtils.property("comment", "Comment object 1 at date 42");
+        commentObject.getProperties().addAll(List.of(dateProperty, authorProperty, contentProperty));
+        setup.rest().add(commentObject);
+
+        // object 2 date 100 (order: 6)
+        commentObject = setup.rest().object(reference, "XWiki.XWikiComments");
+        dateProperty = TestUtils.RestTestUtils.property("date", getDateString(100));
+        contentProperty = TestUtils.RestTestUtils.property("comment", "Comment object 2 at date 100");
+        commentObject.getProperties().addAll(List.of(dateProperty, authorProperty, contentProperty));
+        setup.rest().add(commentObject);
+
+        // object 3 date 24 (order: 1)
+        commentObject = setup.rest().object(reference, "XWiki.XWikiComments");
+        dateProperty = TestUtils.RestTestUtils.property("date", getDateString(24));
+        contentProperty = TestUtils.RestTestUtils.property("comment", "Comment object 3 at date 24");
+        commentObject.getProperties().addAll(List.of(dateProperty, authorProperty, contentProperty));
+        setup.rest().add(commentObject);
+
+        // object 4 date 154 reply to 1 (order: 4 - thread 1)
+        commentObject = setup.rest().object(reference, "XWiki.XWikiComments");
+        dateProperty = TestUtils.RestTestUtils.property("date", getDateString(154));
+        contentProperty = TestUtils.RestTestUtils.property("comment", "Comment object 4 at date 154 reply to 1");
+        Property replyToProperty = TestUtils.RestTestUtils.property("replyto", 1);
+        commentObject.getProperties().addAll(List.of(dateProperty, authorProperty, contentProperty, replyToProperty));
+        setup.rest().add(commentObject);
+
+        // object 5 date 122 (order: 7)
+        commentObject = setup.rest().object(reference, "XWiki.XWikiComments");
+        dateProperty = TestUtils.RestTestUtils.property("date", getDateString(122));
+        contentProperty = TestUtils.RestTestUtils.property("comment", "Comment object 5 at date 122");
+        commentObject.getProperties().addAll(List.of(dateProperty, authorProperty, contentProperty));
+        setup.rest().add(commentObject);
+
+        // object 6 date 66 reply to 1 (order: 3 - thread 1)
+        commentObject = setup.rest().object(reference, "XWiki.XWikiComments");
+        dateProperty = TestUtils.RestTestUtils.property("date", getDateString(66));
+        contentProperty = TestUtils.RestTestUtils.property("comment", "Comment object 6 at date 66 reply to 1");
+        commentObject.getProperties().addAll(List.of(dateProperty, authorProperty, contentProperty, replyToProperty));
+        setup.rest().add(commentObject);
+
+        ViewPage viewPage = setup.gotoPage(reference);
+        CommentsTab commentsTab = viewPage.openCommentsDocExtraPane();
+        List<CommentElement> comments = commentsTab.getComments();
+        assertEquals(7, comments.size());
+
+        CommentElement commentElement = comments.get(0);
+        assertEquals("1970/01/01 00:00", commentElement.getDate());
+        assertEquals("Comment object 3 at date 24", commentElement.getContent());
+        assertEquals("superadmin", commentElement.getAuthor());
+        assertFalse(commentElement.isReply());
+
+        commentElement = comments.get(1);
+        assertEquals("Comment object 1 at date 42", commentElement.getContent());
+        assertEquals("superadmin", commentElement.getAuthor());
+        assertEquals("1970/01/01 00:00", commentElement.getDate());
+        assertFalse(commentElement.isReply());
+
+        commentElement = comments.get(2);
+        assertEquals("Comment object 6 at date 66 reply to 1", commentElement.getContent());
+        assertEquals("superadmin", commentElement.getAuthor());
+        assertEquals("1970/01/01 00:01", commentElement.getDate());
+        assertTrue(commentElement.isReply());
+
+        commentElement = comments.get(3);
+        assertEquals("Comment object 4 at date 154 reply to 1", commentElement.getContent());
+        assertEquals("superadmin", commentElement.getAuthor());
+        assertEquals("1970/01/01 00:02", commentElement.getDate());
+        assertTrue(commentElement.isReply());
+
+        commentElement = comments.get(4);
+        assertEquals("Comment object 0 at date 100", commentElement.getContent());
+        assertEquals("superadmin", commentElement.getAuthor());
+        assertEquals("1970/01/01 00:01", commentElement.getDate());
+        assertFalse(commentElement.isReply());
+
+        commentElement = comments.get(5);
+        assertEquals("Comment object 2 at date 100", commentElement.getContent());
+        assertEquals("superadmin", commentElement.getAuthor());
+        assertEquals("1970/01/01 00:01", commentElement.getDate());
+        assertFalse(commentElement.isReply());
+
+        commentElement = comments.get(6);
+        assertEquals("Comment object 5 at date 122", commentElement.getContent());
+        assertEquals("superadmin", commentElement.getAuthor());
+        assertEquals("1970/01/01 00:02", commentElement.getDate());
+        assertFalse(commentElement.isReply());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/CommentElement.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/CommentElement.java
@@ -1,0 +1,79 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.test.ui.po;
+
+import org.codehaus.plexus.util.StringUtils;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+/**
+ * Describe a unique comment in the UI.
+ *
+ * @version $Id$
+ * @since 17.3.0RC1
+ * @since 16.10.6
+ * @since 16.4.8
+ */
+public class CommentElement extends BaseElement
+{
+    private final WebElement container;
+
+    /**
+     * Default constructor.
+     *
+     * @param container the container element of this specific comment.
+     */
+    public CommentElement(WebElement container)
+    {
+        this.container = container;
+    }
+
+    /**
+     * @return the displayed author name.
+     */
+    public String getAuthor()
+    {
+        return getDriver().findElementWithoutWaiting(this.container, By.cssSelector("span.commentauthor")).getText();
+    }
+
+    /**
+     * @return the displayed date.
+     */
+    public String getDate()
+    {
+        return getDriver().findElementWithoutWaiting(this.container, By.cssSelector("span.commentdate")).getText();
+    }
+
+    /**
+     * @return te displayed content.
+     */
+    public String getContent()
+    {
+        return getDriver().findElementWithoutWaiting(this.container, By.cssSelector("div.commentcontent")).getText();
+    }
+
+    /**
+     * @return {@code true} iff the comment is a reply to another comment.
+     */
+    public boolean isReply()
+    {
+        return !StringUtils.isEmpty(this.container.getDomAttribute("data-replyto"));
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/CommentsTab.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/CommentsTab.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.test.ui.po;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.openqa.selenium.By;
@@ -279,5 +280,23 @@ public class CommentsTab extends BaseElement
             .findElement(By.id(String.format("xwikicomment_%d", id)))
             .findElement(By.cssSelector("blockquote.annotatedText"))
             .click();
+    }
+
+    /**
+     * Retrieve the list of comments in their displayed order. Note that in case of thread, the list contains also the
+     * comments that belongs to the threads in the order they appear. e.g. Comment 0, first reply of 0, second reply
+     * of 0, Comment 1, etc.
+     * @return the list of comments in their order of appearance.
+     * @since 17.3.0RC1
+     * @since 16.10.6
+     * @since 16.4.8
+     */
+    public List<CommentElement> getComments()
+    {
+        List<CommentElement> result = new ArrayList<CommentElement>();
+        for (WebElement xwikicomment : getDriver().findElementsWithoutWaiting(By.className("xwikicomment"))) {
+            result.add(new CommentElement(xwikicomment));
+        }
+        return result;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/comments2.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/comments2.vm
@@ -22,33 +22,30 @@
 #end
 #if($showcomments!="no")
 #set($comments = $doc.getComments())
-#set ($commentMap = {})
-#set ($keysWithMultipleComments = $collectiontool.getSet())
+#set($commentMap = $collectiontool.getSortedMap())
+#set($keysWithMultipleComments = $collectiontool.getSet())
 #foreach ($comment in $comments)
-#set ($key = $comment.date)
-#if ($commentMap.containsKey($key))
-#set ($discard = $commentMap.get($key).add($comment))
-#set ($discard = $keysWithMultipleComments.add($key))
+#set($key = $comment.date)
+#if($commentMap.containsKey($key))
+#set($discard = $commentMap.get($key).add($comment))
+#set($discard = $keysWithMultipleComments.add($key))
 #else
-#set ($discard = $commentMap.put($key, [$comment]))
+#set($discard = $commentMap.put($key, [$comment]))
 #end
 #end
-#set ($orderedKeys = $collectiontool.getLinkedList())
-#set ($discard = $orderedKeys.addAll($commentMap.keySet()))
-#set ($discard = $collectiontool.sortModifiable($orderedKeys))
 #if($xwiki.getSpacePreferenceAsInt('commentsorder', 1) == 1)
-#set ($orderSuffix = ":asc")
+#set($orderSuffix = ':asc')
 #else
-#set ($orderSuffix = ":desc")
-#set ($discard = $collectiontool.reverseModifiable($orderedKeys))
+#set($orderSuffix = ':desc')
+#set($commentMap = $commentMap.descendingMap())
 #end
-#foreach ($keyMultipleComment in $keysWithMultipleComments)
-#set ($reorderedList = $collectiontool.sort($commentMap.get($keyMultipleComment), "number$orderSuffix"))
-#set ($discard = $commentMap.put($keyMultipleComment, $reorderedList))
+#foreach($keyMultipleComment in $keysWithMultipleComments)
+#set($reorderedList = $collectiontool.sort($commentMap.get($keyMultipleComment), "number$orderSuffix"))
+#set($discard = $commentMap.put($keyMultipleComment, $reorderedList))
 #end
-#set ($comments = $collectiontool.getLinkedList())
-#foreach ($commentKey in $orderedKeys)
-#set ($discard = $comments.addAll($commentMap.get($commentKey)))
+#set($comments = $collectiontool.getLinkedList())
+#foreach($commentList in $commentMap.values())
+#set($discard = $comments.addAll($commentList))
 #end
 #if($comments.size()>0)
 <div id="xwikicomments" class="xwikidata">

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/comments2.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/comments2.vm
@@ -21,10 +21,34 @@
 #set($showcomments = $xwiki.getSpacePreference('showcomments'))
 #end
 #if($showcomments!="no")
-#if($xwiki.getSpacePreferenceAsInt('commentsorder', 1) == 0)
 #set($comments = $doc.getComments())
+#set ($commentMap = {})
+#set ($keysWithMultipleComments = $collectiontool.getSet())
+#foreach ($comment in $comments)
+#set ($key = $comment.date)
+#if ($commentMap.containsKey($key))
+#set ($discard = $commentMap.get($key).add($comment))
+#set ($discard = $keysWithMultipleComments.add($key))
 #else
-#set($comments = $doc.getComments(false))
+#set ($discard = $commentMap.put($key, [$comment]))
+#end
+#end
+#set ($orderedKeys = $collectiontool.getLinkedList())
+#set ($discard = $orderedKeys.addAll($commentMap.keySet()))
+#set ($discard = $collectiontool.sortModifiable($orderedKeys))
+#if($xwiki.getSpacePreferenceAsInt('commentsorder', 1) == 1)
+#set ($orderSuffix = ":asc")
+#else
+#set ($orderSuffix = ":desc")
+#set ($discard = $collectiontool.reverseModifiable($orderedKeys))
+#end
+#foreach ($keyMultipleComment in $keysWithMultipleComments)
+#set ($reorderedList = $collectiontool.sort($commentMap.get($keyMultipleComment), "number$orderSuffix"))
+#set ($discard = $commentMap.put($keyMultipleComment, $reorderedList))
+#end
+#set ($comments = $collectiontool.getLinkedList())
+#foreach ($commentKey in $orderedKeys)
+#set ($discard = $comments.addAll($commentMap.get($commentKey)))
 #end
 #if($comments.size()>0)
 <div id="xwikicomments" class="xwikidata">


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22978

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

Provide a quickfix for ordering the comments directly in commentsinline.vm. Since we cannot call directly $collectiontool.sort because the Object property cannot be accessed by beanutils, we build a map indexed by date and we perform the ordering manually, taking into account the rare possibility that 2 comments have been added at exact same date.
Also all this work is duplicated in comments2.vm for fixing it in old PDF export.
Note that ideally all this work should be refactored with a proper Java API for comments, see also XWIKI-23049.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Manual tests performed by creating comments objects and changing their dates, using some colliding dates and also setting the commentsorder value. 

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-16.10.x
  * stable-16.4.x
  * stable-17.2.x