### PR TITLE
XWIKI-22996: The contentmenu list of buttons should be coded as a list

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_content.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_content.vm
@@ -123,17 +123,18 @@
   ##
   ## Display the menu
   ##
-  <div id="contentmenu" class="pull-right actionmenu">
+  <ul id="contentmenu" class="pull-right actionmenu">
     $menuContent
 
     #if($keyboardShortcutsEnabled)
       #keyboardShortcuts()
     #end
-  </div>
+  </ul>
 #end
 
 #**
  * Display a menu if it has some content.
+ * This menu is a list item, made to fit inside the ul `#contentmenu`.
  *
  * @param $id the id of the menu
  * @param $icon the icon of the menu
@@ -150,7 +151,7 @@
  * @since 7.3M2
  *#
 #macro(displayMenu $id $icon $menuContent $titleKey $titleAsLabel $actionUrl $extraAttribute)
-  <div class="btn-group" id="$id">
+  <li class="btn-group" id="$id">
     <#if ("$!actionUrl" == '')button type="button"#{else}a#end class="btn btn-default#if ("$!actionUrl" == '') dropdown-toggle#end" title="$services.localization.render($titleKey)"##
     #if ("$!actionUrl" != '')
       href="$actionUrl"
@@ -174,7 +175,7 @@
         $menuContent
       </dl>
     #end
-  </div>
+  </li>
 #end
 
 #**

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsWatchUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsWatchUIX.xml
@@ -570,11 +570,11 @@
 
 #set ($buttonTitle = $services.localization.render('notifications.watch.button.title', [$watchText]))
 {{html clean='false'}}
-&lt;div class="btn-group" id="watchButton"&gt;
+&lt;li class="btn-group" id="watchButton"&gt;
   &lt;a href="#" role="button" title="$escapetool.xml($buttonTitle)" class="btn btn-default" data-toggle="modal" data-target="#watchModal"&gt;
     &lt;span class="fa $watchIcon"&gt;&lt;/span&gt; $watchText
   &lt;/a&gt;
-&lt;/div&gt;
+&lt;/li&gt;
 &lt;div class="modal fade" tabindex="-1" role="dialog" id="watchModal"&gt;
   &lt;div class="modal-dialog" role="document"&gt;
     &lt;div class="modal-content"&gt;

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BasePage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BasePage.java
@@ -67,10 +67,10 @@ public class BasePage extends BaseElement
     @FindBy(id = "contentmenu")
     private WebElement contentMenuBar;
 
-    @FindBy(xpath = "//div[@id='tmCreate']/a[contains(@class, 'btn')]")
+    @FindBy(xpath = "//li[@id='tmCreate']/a[contains(@class, 'btn')]")
     private WebElement tmCreate;
 
-    @FindBy(xpath = "//div[@id='tmMoreActions']/button")
+    @FindBy(xpath = "//li[@id='tmMoreActions']/button")
     private WebElement moreActionsMenu;
 
     @FindBy(xpath = "//input[@id='tmWatchDocument']/../span[contains(@class, 'bootstrap-switch-label')]")
@@ -191,7 +191,7 @@ public class BasePage extends BaseElement
      */
     protected void clickEditSubMenuEntry(String id)
     {
-        clickSubMenuEntryFromMenu(By.xpath("//div[@id='tmEdit']/*[contains(@class, 'dropdown-toggle')]"), id);
+        clickSubMenuEntryFromMenu(By.xpath("//li[@id='tmEdit']/*[contains(@class, 'dropdown-toggle')]"), id);
     }
 
     /**
@@ -200,7 +200,7 @@ public class BasePage extends BaseElement
     public void edit()
     {
         WebElement editMenuButton =
-            getDriver().findElement(By.xpath("//div[@id='tmEdit']/a[contains(@class, 'btn')]"));
+            getDriver().findElement(By.xpath("//li[@id='tmEdit']/a[contains(@class, 'btn')]"));
         editMenuButton.click();
     }
 
@@ -209,7 +209,7 @@ public class BasePage extends BaseElement
      */
     public String getEditURL()
     {
-        return getDriver().findElement(By.xpath("//div[@id='tmEdit']/a[contains(@class, 'btn')]")).getAttribute("href");
+        return getDriver().findElement(By.xpath("//li[@id='tmEdit']/a[contains(@class, 'btn')]")).getAttribute("href");
     }
 
     /**
@@ -317,7 +317,7 @@ public class BasePage extends BaseElement
      */
     public void clickMoreActionsSubMenuEntry(String id)
     {
-        clickSubMenuEntryFromMenu(By.xpath("//div[@id='tmMoreActions']/button"), id);
+        clickSubMenuEntryFromMenu(By.xpath("//li[@id='tmMoreActions']/button"), id);
     }
 
     /**


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22996

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Changed the tag used for the list of action buttons.
* Updated the vtl macro and use of the UIX to generate proper list items.
* Updated test object selectors.


## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Searched for XWiki Standard uses of this UIX with `org.xwiki.plaftorm.menu.content`
* Searched for the test object breaks with the IDs of the different buttons. As we can see here, in the end the only place where changes were needed was the BasePage object.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

Surprisingly, the styles did not change at all despite the change of HTML tag.
![Screenshot from 2025-03-27 17-39-56](https://github.com/user-attachments/assets/7e80ae2f-7440-477b-b5f8-f520f4eb8ede)
For the sake of demonstration, I left the Notification Menu use of the UIX unchanged for this screenshot. As we can see, it's still styled properly, but it returns an accessibility error. With the full PR applied, this WCAG violation in XWiki Standard doesn't happen.
![Screenshot from 2025-03-27 17-41-46](https://github.com/user-attachments/assets/97afe4b0-474b-4665-a9a7-9a14a2aa64b7)

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Built the changes with: 
* `mvn clean install -f xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui`
* `mvn clean install -f xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources -Pquality`
* `mvn clean install -f xwiki-platform-core/xwiki-platform-notifications/ -Pquality,docker`

Those builds passed successfully. Then, to double check the selectors were still properly working, I started some docker tests. The panel test suite is quite limited to most of them, and it did use the `editWiki` method from a basePage, which has been updated. Those docker tests passed successfully:
`mvn clean install -f xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker -Pdocker`

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, this is a somewhat breaking change with UIs