### PR TITLE
XWIKI-23055: The document cache may not be properly invalidated in case of concurrent loads

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiCacheStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiCacheStore.java
@@ -21,6 +21,7 @@ package com.xpn.xwiki.store;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -34,6 +35,7 @@ import org.xwiki.cache.CacheManager;
 import org.xwiki.cache.config.LRUCacheConfiguration;
 import org.xwiki.cache.event.CacheEntryEvent;
 import org.xwiki.cache.event.CacheEntryListener;
+import org.xwiki.cache.util.CacheLoader;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.annotation.InstantiationStrategy;
 import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
@@ -107,6 +109,8 @@ public class XWikiCacheStore extends AbstractXWikiStore
      * Used to cache the values asked by {@link #getLimitSize(XWikiContext, Class, String)}.
      */
     private Cache<Integer> limitSizePropertyCache;
+
+    private CacheLoader<XWikiDocument, XWikiException> cacheLoader = new CacheLoader();
 
     /**
      * Default constructor generally used by the Component Manager.
@@ -246,8 +250,7 @@ public class XWikiCacheStore extends AbstractXWikiStore
         } finally {
             // Flushing the cache for old document
             String key = getKey(doc, context);
-            getCache().remove(key);
-            getPageExistCache().remove(key);
+            invalidateCache(key);
 
             WikiReference originalWikiReference = doc.getDocumentReference().getWikiReference();
             // Flushing the cache for new document
@@ -256,8 +259,7 @@ public class XWikiCacheStore extends AbstractXWikiStore
             }
             XWikiDocument newDoc = new XWikiDocument(newReference, newReference.getLocale());
             key = getKey(newDoc, context);
-            getCache().remove(key);
-            getPageExistCache().remove(key);
+            invalidateCache(key);
             context.setWikiReference(originalWikiReference);
 
             // Restore the previous XWikiContext
@@ -278,8 +280,7 @@ public class XWikiCacheStore extends AbstractXWikiStore
         } finally {
             // Flushing the cache
             String key = getKey(doc, context);
-            getCache().remove(key);
-            getPageExistCache().remove(key);
+            invalidateCache(key);
 
             /*
              * We do not want to save the document in the cache at this time. If we did, this would introduce the
@@ -291,11 +292,21 @@ public class XWikiCacheStore extends AbstractXWikiStore
         }
     }
 
+    private void invalidateCache(String key)
+    {
+        this.cacheLoader.invalidate(key, k -> {
+            getCache().remove(k);
+            getPageExistCache().remove(k);
+        });
+    }
+
     @Override
     public void flushCache()
     {
-        getCache().removeAll();
-        getPageExistCache().removeAll();
+        this.cacheLoader.invalidateAll(() -> {
+            getCache().removeAll();
+            getPageExistCache().removeAll();
+        });
         getLimitSizePropertyCache().removeAll();
     }
 
@@ -318,14 +329,15 @@ public class XWikiCacheStore extends AbstractXWikiStore
     public void invalidate(XWikiDocument document)
     {
         String key = document.getKey();
+        this.cacheLoader.invalidate(key, k -> {
+            if (getCache() != null) {
+                getCache().remove(k);
+            }
 
-        if (getCache() != null) {
-            getCache().remove(key);
-        }
-
-        if (getPageExistCache() != null) {
-            getPageExistCache().remove(key);
-        }
+            if (getPageExistCache() != null) {
+                getPageExistCache().remove(k);
+            }
+        });
     }
 
     /**
@@ -411,27 +423,24 @@ public class XWikiCacheStore extends AbstractXWikiStore
                     cachedoc = doc;
                     cachedoc.setNew(true);
 
-                    // Make sure to always return a document with an original version, even for one that does not exist.
+                    // Make sure to always return a document with an original version, even for one that does
+                    // not exist.
                     // Allow writing more generic code.
                     cachedoc
-                        .setOriginalDocument(new XWikiDocument(cachedoc.getDocumentReference(), cachedoc.getLocale()));
+                        .setOriginalDocument(
+                            new XWikiDocument(cachedoc.getDocumentReference(), cachedoc.getLocale()));
                 } else {
-                    LOGGER.debug("Trying to get Document [{}] from persistent storage", key);
+                    cachedoc = this.cacheLoader.loadAndStoreInCache(key,
+                        k -> {
+                            LOGGER.debug("Trying to get Document [{}] from persistent storage", key);
 
-                    cachedoc = this.store.loadXWikiDoc(doc, context);
+                            XWikiDocument databaseDocument = this.store.loadXWikiDoc(doc, context);
 
-                    LOGGER.debug("Document [{}] was retrieved from persistent storage", key);
-
-                    if (cachedoc.isNew()) {
-                        getPageExistCache().set(key, Boolean.FALSE);
-                    } else {
-                        getCache().set(key, cachedoc);
-
-                        // Also update exist cache
-                        getPageExistCache().set(key, Boolean.TRUE);
-                    }
-
-                    LOGGER.debug("Document [{}] was put in cache", key);
+                            LOGGER.debug("Document [{}] was retrieved from persistent storage", key);
+                            return databaseDocument;
+                        },
+                        this::storeInCache
+                    );
                 }
             }
 
@@ -439,9 +448,29 @@ public class XWikiCacheStore extends AbstractXWikiStore
             LOGGER.debug("Ending checking for Document [{}] in cache", key);
 
             return cachedoc;
+        } catch (ExecutionException e) {
+            if (e.getCause() instanceof XWikiException xwikiException) {
+                throw xwikiException;
+            } else {
+                throw new XWikiException("Error loading document [%s]".formatted(getKey(doc, context)), e);
+            }
         } finally {
             restoreExecutionXContext();
         }
+    }
+
+    private void storeInCache(String key, XWikiDocument document)
+    {
+        if (document.isNew()) {
+            getPageExistCache().set(key, Boolean.FALSE);
+        } else {
+            getCache().set(key, document);
+
+            // Also update exist cache
+            getPageExistCache().set(key, Boolean.TRUE);
+        }
+
+        LOGGER.debug("Document [{}] was put in cache", key);
     }
 
     @Override
@@ -456,9 +485,11 @@ public class XWikiCacheStore extends AbstractXWikiStore
 
             this.store.deleteXWikiDoc(doc, context);
 
-            getCache().remove(key);
-            getPageExistCache().remove(key);
-            getPageExistCache().set(key, Boolean.FALSE);
+            this.cacheLoader.invalidate(key, k -> {
+                getCache().remove(k);
+                getPageExistCache().remove(k);
+                getPageExistCache().set(k, Boolean.FALSE);
+            });
         } finally {
             restoreExecutionXContext();
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiCacheStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiCacheStore.java
@@ -35,7 +35,7 @@ import org.xwiki.cache.CacheManager;
 import org.xwiki.cache.config.LRUCacheConfiguration;
 import org.xwiki.cache.event.CacheEntryEvent;
 import org.xwiki.cache.event.CacheEntryListener;
-import org.xwiki.cache.util.CacheLoader;
+import org.xwiki.cache.internal.CacheLoader;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.annotation.InstantiationStrategy;
 import org.xwiki.component.descriptor.ComponentInstantiationStrategy;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/XWikiCacheStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/XWikiCacheStoreTest.java
@@ -20,6 +20,12 @@
 package com.xpn.xwiki.store;
 
 import java.io.ByteArrayInputStream;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -49,7 +55,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -147,6 +156,122 @@ class XWikiCacheStoreTest
         assertTrue(cacheDocument.isMetaDataDirty());
 
         assertNotSame(cacheDocument, store.loadXWikiDoc(documentReference, this.oldcore.getXWikiContext()));
+    }
+
+    @Test
+    void documentSavedDuringLoadIsVisibleInNextLoad() throws Exception
+    {
+        // Save a document
+        this.oldcore.getXWikiContext().setWikiId("wiki");
+        XWikiDocument document = new XWikiDocument(new DocumentReference("wiki", "space", "page"));
+        XWikiDocument initialDocument = document.clone();
+
+        XWikiStoreInterface hibernateStore = this.oldcore.getMockStore();
+        XWikiCacheStore store = new XWikiCacheStore(hibernateStore, this.oldcore.getXWikiContext());
+        CompletableFuture<XWikiDocument> arrivedLoadFuture = new CompletableFuture<>();
+        CompletableFuture<XWikiDocument> storeLoadFuture = new CompletableFuture<>();
+
+        when(hibernateStore.loadXWikiDoc(any(), any())).then(invocation -> {
+            arrivedLoadFuture.complete(document);
+            return storeLoadFuture.get(10, TimeUnit.SECONDS);
+        });
+
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+        try {
+            Future<XWikiDocument> firstLoadFuture =
+                executorService.submit(() -> store.loadXWikiDoc(document, this.oldcore.getXWikiContext()));
+
+            assertSame(document, arrivedLoadFuture.get(10, TimeUnit.SECONDS));
+
+            XWikiDocument savedDocument = document.clone();
+            savedDocument.setTitle("Saved");
+            store.saveXWikiDoc(savedDocument, this.oldcore.getXWikiContext());
+
+            storeLoadFuture.complete(initialDocument);
+
+            assertSame(initialDocument, firstLoadFuture.get(10, TimeUnit.SECONDS));
+
+            assertEquals("{}", this.cache.toString());
+            verify(hibernateStore).saveXWikiDoc(savedDocument, this.oldcore.getXWikiContext(), true);
+            assertEquals(savedDocument, this.oldcore.getDocuments().get(document.getDocumentReferenceWithLocale()));
+
+            when(hibernateStore.loadXWikiDoc(any(), any())).thenReturn(savedDocument);
+
+            XWikiDocument secondLoadDocument = store.loadXWikiDoc(document, this.oldcore.getXWikiContext());
+            assertSame(savedDocument, secondLoadDocument);
+            // This should call the hibernate store again as the document shouldn't have been put in the cache.
+            verify(hibernateStore, times(2)).loadXWikiDoc(document, this.oldcore.getXWikiContext());
+
+            XWikiDocument thirdDocument = store.loadXWikiDoc(document, this.oldcore.getXWikiContext());
+            assertSame(savedDocument, thirdDocument);
+            // Now the document should be cached, so no more call.
+            verify(hibernateStore, times(2)).loadXWikiDoc(document, this.oldcore.getXWikiContext());
+        } finally {
+            executorService.shutdown();
+        }
+        assertTrue(executorService.awaitTermination(10, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void parallelLoadTriggerOnlyOneLoad() throws Exception
+    {
+        this.oldcore.getXWikiContext().setWikiId("wiki");
+        XWikiDocument document = new XWikiDocument(new DocumentReference("wiki", "space", "page"));
+        XWikiDocument initialDocument = document.clone();
+
+        XWikiStoreInterface hibernateStore = this.oldcore.getMockStore();
+        XWikiCacheStore store = new XWikiCacheStore(hibernateStore, this.oldcore.getXWikiContext());
+        CompletableFuture<XWikiDocument> arrivedLoadFuture = new CompletableFuture<>();
+        CompletableFuture<XWikiDocument> storeLoadFuture = new CompletableFuture<>();
+
+        when(hibernateStore.loadXWikiDoc(any(), any()))
+            .then(invocation -> {
+                arrivedLoadFuture.complete(document);
+                return storeLoadFuture.get(10, TimeUnit.SECONDS);
+            })
+            .thenThrow(new RuntimeException("Load should never be called twice in this test."));
+
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+
+        try {
+            Future<XWikiDocument> firstLoadFuture =
+                executorService.submit(() -> store.loadXWikiDoc(document, this.oldcore.getXWikiContext()));
+            Future<XWikiDocument> secondLoadFuture =
+                executorService.submit(() -> store.loadXWikiDoc(document, this.oldcore.getXWikiContext()));
+
+            assertSame(document, arrivedLoadFuture.get(10, TimeUnit.SECONDS));
+
+            // Ensure that both futures wait.
+            assertThrows(TimeoutException.class, () -> firstLoadFuture.get(500, TimeUnit.MILLISECONDS));
+            assertThrows(TimeoutException.class, () -> secondLoadFuture.get(500, TimeUnit.MILLISECONDS));
+
+            storeLoadFuture.complete(initialDocument);
+
+            assertSame(initialDocument, firstLoadFuture.get(10, TimeUnit.SECONDS));
+            assertSame(initialDocument, secondLoadFuture.get(10, TimeUnit.SECONDS));
+            verify(hibernateStore).loadXWikiDoc(document, this.oldcore.getXWikiContext());
+        } finally {
+            executorService.shutdown();
+        }
+        assertTrue(executorService.awaitTermination(10, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void loadExceptionIsPropagated() throws Exception
+    {
+        this.oldcore.getXWikiContext().setWikiId("wiki");
+        XWikiDocument document = new XWikiDocument(new DocumentReference("wiki", "space", "page"));
+
+        XWikiStoreInterface hibernateStore = this.oldcore.getMockStore();
+        XWikiCacheStore store = new XWikiCacheStore(hibernateStore, this.oldcore.getXWikiContext());
+
+        XWikiException exception = new XWikiException();
+        when(hibernateStore.loadXWikiDoc(any(), any())).thenThrow(exception);
+
+        XWikiException actualException =
+            assertThrows(XWikiException.class, () -> store.loadXWikiDoc(document, this.oldcore.getXWikiContext()));
+        assertSame(exception, actualException);
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/test/MockitoOldcore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/test/MockitoOldcore.java
@@ -734,6 +734,12 @@ public class MockitoOldcore
                 return null;
             }
         }).when(getMockStore()).saveXWikiDoc(anyXWikiDocument(), anyXWikiContext());
+        doAnswer(invocation -> {
+            XWikiDocument document = invocation.getArgument(0);
+            XWikiContext xcontext = invocation.getArgument(1);
+            getMockStore().saveXWikiDoc(document, xcontext);
+            return null;
+        }).when(getMockStore()).saveXWikiDoc(anyXWikiDocument(), anyXWikiContext(), anyBoolean());
         when(getMockStore().getLimitSize(any(), any(), any())).thenReturn(255);
 
         // XWikiVersioningStoreInterface


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-23055

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Use CacheLoader to synchronize cache loads.
* Add tests for the scenario in the issue and some more scenarios.
* Mock com.xpn.xwiki.store.XWikiStoreInterface.saveXWikiDoc( com.xpn.xwiki.doc.XWikiDocument, com.xpn.xwiki.XWikiContext, boolean) in
 MockitoOldcore to make testing of the cache store easier.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* This depends on https://github.com/xwiki/xwiki-commons/pull/1282

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
mvn clean install -Pquality,integration-tests,docker -pl :xwiki-platform-flamingo-skin-test-docker,,:xwiki-platform-oldcore -Dit.test=SecurityCacheStressIT
```


# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-17.2.x
  * stable-16.10.x
  * stable-16.4.x