### PR TITLE
XRENDERING-778: Rendering a page with thousands of macros is slow

### DIFF
--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-macro/src/main/java/org/xwiki/icon/macro/internal/DisplayIconMacro.java
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-macro/src/main/java/org/xwiki/icon/macro/internal/DisplayIconMacro.java
@@ -197,4 +197,10 @@ public class DisplayIconMacro extends AbstractExecutedContentMacro<DisplayIconMa
 
         return iconSet;
     }
+
+    @Override
+    public boolean isExecutionIsolated(DisplayIconMacroParameters parameters, String content)
+    {
+        return true;
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-macro/src/main/java/org/xwiki/livedata/internal/macro/LiveDataMacro.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-macro/src/main/java/org/xwiki/livedata/internal/macro/LiveDataMacro.java
@@ -78,4 +78,10 @@ public class LiveDataMacro extends AbstractMacro<LiveDataMacroParameters>
     {
         return false;
     }
+
+    @Override
+    public boolean isExecutionIsolated(LiveDataMacroParameters parameters, String content)
+    {
+        return true;
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-macro/src/test/java/org/xwiki/livedata/internal/macro/LiveDataMacroTest.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-macro/src/test/java/org/xwiki/livedata/internal/macro/LiveDataMacroTest.java
@@ -80,6 +80,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 import static org.xwiki.rendering.test.integration.junit5.BlockAssert.assertBlocks;
 
@@ -393,6 +394,12 @@ class LiveDataMacroTest
         List<Block> blocks = this.liveDataMacro.execute(parameters, json(advancedConfig.toString()),
             this.macroTransformationContext);
         assertBlocks(expected, blocks, this.rendererFactory);
+    }
+
+    @Test
+    void isIsolated()
+    {
+        assertTrue(this.liveDataMacro.isExecutionIsolated(new LiveDataMacroParameters(), "test"));
     }
 
     private String json(String text)

--- a/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-macro/src/main/java/org/xwiki/localization/macro/internal/TranslationMacro.java
+++ b/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-macro/src/main/java/org/xwiki/localization/macro/internal/TranslationMacro.java
@@ -165,4 +165,10 @@ public class TranslationMacro extends AbstractMacro<TranslationMacroParameters>
     {
         return true;
     }
+
+    @Override
+    public boolean isExecutionIsolated(TranslationMacroParameters parameters, String content)
+    {
+        return true;
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-macro/src/main/java/org/xwiki/rendering/internal/macro/office/OfficeMacro.java
+++ b/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-macro/src/main/java/org/xwiki/rendering/internal/macro/office/OfficeMacro.java
@@ -158,4 +158,10 @@ public class OfficeMacro extends AbstractMacro<OfficeMacroParameters>
 
         return resourceReference;
     }
+
+    @Override
+    public boolean isExecutionIsolated(OfficeMacroParameters parameters, String content)
+    {
+        return true;
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/main/java/org/xwiki/rendering/internal/macro/code/CodeMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/main/java/org/xwiki/rendering/internal/macro/code/CodeMacro.java
@@ -271,4 +271,10 @@ public class CodeMacro extends AbstractBoxMacro<CodeMacroParameters>
     {
         return (List<Block>) macroBlock.getAttribute(ATTRIBUTE_PREPARE_RESULT);
     }
+
+    @Override
+    public boolean isExecutionIsolated(CodeMacroParameters parameters, String content)
+    {
+        return true;
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-gallery/src/main/java/org/xwiki/rendering/internal/macro/gallery/GalleryMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-gallery/src/main/java/org/xwiki/rendering/internal/macro/gallery/GalleryMacro.java
@@ -144,4 +144,10 @@ public class GalleryMacro extends AbstractMacro<GalleryMacroParameters>
     {
         return false;
     }
+
+    @Override
+    public boolean isExecutionIsolated(GalleryMacroParameters parameters, String content)
+    {
+        return true;
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacro.java
@@ -71,6 +71,8 @@ public class DefaultWikiMacro extends AbstractAsyncContentBaseObjectWikiComponen
 
     private int macroPriority;
 
+    private boolean executionIsolated;
+
     /**
      * Constructs a new {@link DefaultWikiMacro}.
      * 
@@ -85,6 +87,7 @@ public class DefaultWikiMacro extends AbstractAsyncContentBaseObjectWikiComponen
 
         this.descriptor = descriptor;
         this.macroPriority = baseObject.getIntValue(MACRO_PRIORITY_PROPERTY, 1000);
+        this.executionIsolated = baseObject.getIntValue(MACRO_EXECUTION_ISOLATED_PROPERTY, 0) == 1;
     }
 
     @Override
@@ -207,5 +210,11 @@ public class DefaultWikiMacro extends AbstractAsyncContentBaseObjectWikiComponen
     boolean isCacheAllowed()
     {
         return this.cacheAllowed;
+    }
+
+    @Override
+    public boolean isExecutionIsolated(WikiMacroParameters parameters, String content)
+    {
+        return this.executionIsolated;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/WikiMacroClassDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/WikiMacroClassDocumentInitializer.java
@@ -46,6 +46,8 @@ public class WikiMacroClassDocumentInitializer extends AbstractAsyncClassDocumen
 {
     private static final String PROPERTY_PIPE = "|";
 
+    private static final String YESNO = "yesno";
+
     /**
      * Default constructor.
      */
@@ -63,7 +65,7 @@ public class WikiMacroClassDocumentInitializer extends AbstractAsyncClassDocumen
         xclass.addTextAreaField(MACRO_DESCRIPTION_PROPERTY, "Macro description", 40, 5,
             TextAreaClass.ContentType.PURE_TEXT);
         xclass.addStaticListField(MACRO_DEFAULT_CATEGORIES_PROPERTY, "Default categories", 1, true, "", "input");
-        xclass.addBooleanField(MACRO_INLINE_PROPERTY, "Supports inline mode", "yesno");
+        xclass.addBooleanField(MACRO_INLINE_PROPERTY, "Supports inline mode", YESNO);
         xclass.addStaticListField(MACRO_VISIBILITY_PROPERTY, "Macro visibility", 1, false,
             "Current User|Current Wiki|Global", ListClass.DISPLAYTYPE_SELECT, PROPERTY_PIPE);
         xclass.addStaticListField(MACRO_CONTENT_TYPE_PROPERTY, "Macro content availability", 1, false,
@@ -79,6 +81,7 @@ public class WikiMacroClassDocumentInitializer extends AbstractAsyncClassDocumen
         xclass.addTextAreaField(MACRO_CODE_PROPERTY, "Macro code", 40, 20, TextAreaClass.EditorType.TEXT);
 
         xclass.addNumberField(MACRO_PRIORITY_PROPERTY, "Priority", 10, "integer");
+        xclass.addBooleanField(MACRO_EXECUTION_ISOLATED_PROPERTY, "Isolated Execution", YESNO, Boolean.FALSE);
 
         super.createClass(xclass);
     }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/WikiMacroConstants.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/WikiMacroConstants.java
@@ -136,6 +136,13 @@ public interface WikiMacroConstants
     String MACRO_PRIORITY_PROPERTY = "priority";
 
     /**
+     * Constant for representing if the macro execution is isolated.
+     *
+     * @since 17.3.0RC1
+     */
+    String MACRO_EXECUTION_ISOLATED_PROPERTY = "executionIsolated";
+
+    /**
      * Constant for representing XWiki.WikiMacroParameterClass xwiki class space name.
      */
     String WIKI_MACRO_PARAMETER_CLASS_SPACE = "XWiki";

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/WikiMacroContentMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/WikiMacroContentMacro.java
@@ -92,4 +92,10 @@ public class WikiMacroContentMacro extends AbstractNoParameterMacro
             return Collections.singletonList(new GroupBlock(placeholderParameters));
         }
     }
+
+    @Override
+    public boolean isExecutionIsolated(Object parameters, String content)
+    {
+        return true;
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/WikiMacroParameterMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/WikiMacroParameterMacro.java
@@ -102,4 +102,10 @@ public class WikiMacroParameterMacro extends AbstractMacro<WikiMacroParameterMac
             return Collections.singletonList(new GroupBlock(placeholderParameters));
         }
     }
+
+    @Override
+    public boolean isExecutionIsolated(WikiMacroParameterMacroParameters parameters, String content)
+    {
+        return true;
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/resources/ApplicationResources.properties
@@ -66,7 +66,7 @@ XWiki.WikiMacroClass_async_cached=Cached
 XWiki.WikiMacroClass_async_context=Context elements
 XWiki.WikiMacroClass_priority=Priority
 XWiki.WikiMacroClass_executionIsolated=Execution is isolated
-XWiki.WikiMacroClass_executionIsolated.hint=If the execution of the macro doesn't modify the XDOM (including through \
+XWiki.WikiMacroClass_executionIsolated_hint=If the execution of the macro doesn't modify the XDOM (including through \
   the direct execution of other macros, e.g., parsed from the content or another page). Reading the XDOM and reading \
   and writing other context information is okay. Marking the macro execution as isolated speeds up the execution of \
   macros.

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/resources/ApplicationResources.properties
@@ -65,6 +65,11 @@ XWiki.WikiMacroClass_async_enabled=Asynchronous rendering
 XWiki.WikiMacroClass_async_cached=Cached
 XWiki.WikiMacroClass_async_context=Context elements
 XWiki.WikiMacroClass_priority=Priority
+XWiki.WikiMacroClass_executionIsolated=Execution is isolated
+XWiki.WikiMacroClass_executionIsolated.hint=If the execution of the macro doesn't modify the XDOM (including through \
+  the direct execution of other macros, e.g., parsed from the content or another page). Reading the XDOM and reading \
+  and writing other context information is okay. Marking the macro execution as isolated speeds up the execution of \
+  macros.
 XWiki.WikiMacroParameterClass_name=Parameter name
 XWiki.WikiMacroParameterClass_description=Parameter description
 XWiki.WikiMacroParameterClass_mandatory=Parameter mandatory

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/test/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroFactoryTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/test/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroFactoryTest.java
@@ -28,6 +28,8 @@ import javax.inject.Named;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.xwiki.component.util.DefaultParameterizedType;
 import org.xwiki.component.wiki.internal.bridge.ContentParser;
 import org.xwiki.model.EntityType;
@@ -40,6 +42,7 @@ import org.xwiki.rendering.macro.descriptor.DefaultContentDescriptor;
 import org.xwiki.rendering.macro.wikibridge.WikiMacro;
 import org.xwiki.rendering.macro.wikibridge.WikiMacroDescriptor;
 import org.xwiki.rendering.macro.wikibridge.WikiMacroException;
+import org.xwiki.rendering.macro.wikibridge.WikiMacroParameters;
 import org.xwiki.rendering.macro.wikibridge.WikiMacroVisibility;
 import org.xwiki.rendering.transformation.Transformation;
 import org.xwiki.security.authorization.Right;
@@ -275,5 +278,18 @@ class DefaultWikiMacroFactoryTest
         saveDocument();
 
         assertFalse(this.wikiMacroFactory.containsWikiMacro(DOCUMENT_REFERENCE));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void createWikiMacroWithIsolatedExecution(boolean isolated) throws Exception
+    {
+        this.macroObject.setIntValue(WikiMacroConstants.MACRO_EXECUTION_ISOLATED_PROPERTY, isolated ? 1 : 0);
+        saveDocument();
+
+        WikiMacro macro = this.wikiMacroFactory.createWikiMacro(DOCUMENT_REFERENCE);
+        assertNotNull(macro);
+
+        assertEquals(isolated, macro.isExecutionIsolated(new WikiMacroParameters(), "test"));
     }
 }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XRENDERING-778

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Introduce the concept of isolated execution in wiki macros.
* Mark many macros as isolated.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* This needs xwiki/xwiki-rendering#330.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

![grafik](https://github.com/user-attachments/assets/4f052b0b-b389-4485-8507-80389c0989d8)

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
LANG=C.UTF-8 mvn clean install -Pdocker,legacy,integration-tests,snapshotModules,quality,distribution,flavor-integration-tests -pl $(git diff --name-only --merge-base origin/master | awk -F'/' '{for(i=NF-1; i>0; i--){if($i ~ /src$/){printf(":%s\n", $(i-1)); break;}}}' | sort -u | paste -sd "," -)
```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None for now, probably later.