### PR TITLE
XWIKI-22804: Improve consistency of wiki macro parameters by being able to define them advanced, hidden, or deprecated

### DIFF
--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-rendering/xwiki-platform-legacy-rendering-wikimacro/xwiki-platform-legacy-rendering-wikimacro-api/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-rendering/xwiki-platform-legacy-rendering-wikimacro/xwiki-platform-legacy-rendering-wikimacro-api/pom.xml
@@ -34,7 +34,7 @@
     <xwiki.extension.features>
       org.xwiki.platform:xwiki-platform-rendering-wikimacro-api
     </xwiki.extension.features>
-    <xwiki.jacoco.instructionRatio>0.17</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.16</xwiki.jacoco.instructionRatio>
     <!-- Skipping spoon since the inspection of WikiMacroDescriptorAspect is causing troubles during the processing. -->
     <xwiki.spoon.skip>true</xwiki.spoon.skip>
   </properties>

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-rendering/xwiki-platform-legacy-rendering-wikimacro/xwiki-platform-legacy-rendering-wikimacro-api/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-rendering/xwiki-platform-legacy-rendering-wikimacro/xwiki-platform-legacy-rendering-wikimacro-api/pom.xml
@@ -34,7 +34,7 @@
     <xwiki.extension.features>
       org.xwiki.platform:xwiki-platform-rendering-wikimacro-api
     </xwiki.extension.features>
-    <xwiki.jacoco.instructionRatio>0.20</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.17</xwiki.jacoco.instructionRatio>
     <!-- Skipping spoon since the inspection of WikiMacroDescriptorAspect is causing troubles during the processing. -->
     <xwiki.spoon.skip>true</xwiki.spoon.skip>
   </properties>

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-api/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-api/pom.xml
@@ -31,7 +31,7 @@
   <name>XWiki Platform - Rendering - Wiki Macro Bridge - API</name>
   <description>XWiki Platform - Rendering - Wiki Macro Bridge - API</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.48</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.43</xwiki.jacoco.instructionRatio>
     <!-- Skipping revapi since xwiki-platform-legacy-rendering-wikimacro-api wraps this module and runs checks on it -->
     <xwiki.revapi.skip>true</xwiki.revapi.skip>
     <checkstyle.suppressions.location>${basedir}/src/checkstyle/checkstyle-suppressions.xml</checkstyle.suppressions.location>

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-api/src/main/java/org/xwiki/rendering/macro/wikibridge/WikiMacroParameterDescriptor.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-api/src/main/java/org/xwiki/rendering/macro/wikibridge/WikiMacroParameterDescriptor.java
@@ -20,6 +20,7 @@
 package org.xwiki.rendering.macro.wikibridge;
 
 import java.lang.reflect.Type;
+import java.util.Map;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -37,6 +38,46 @@ import org.xwiki.text.XWikiToStringBuilder;
  */
 public class WikiMacroParameterDescriptor implements ParameterDescriptor
 {
+    /**
+     * Constant to be used in the parameters map of the constructor to define whether the parameter is advanced or
+     * not: the accepted value should be a boolean or its serialized value.
+     * @see #isAdvanced()
+     * @since 17.3.0RC1
+     * @since 16.10.6
+     */
+    @Unstable
+    public static final String ADVANCED_PARAMETER_NAME = "advanced";
+
+    /**
+     * Constant to be used in the parameters map of the constructor to define whether the parameter is hidden or
+     * not: the accepted value should be a boolean or its serialized value.
+     * @see #isDisplayHidden()
+     * @since 17.3.0RC1
+     * @since 16.10.6
+     */
+    @Unstable
+    public static final String HIDDEN_PARAMETER_NAME = "hidden";
+
+    /**
+     * Constant to be used in the parameters map of the constructor to define whether the parameter is deprecated or
+     * not: the accepted value should be a boolean or its serialized value.
+     * @see #isDeprecated()
+     * @since 17.3.0RC1
+     * @since 16.10.6
+     */
+    @Unstable
+    public static final String DEPRECATED_PARAMETER_NAME = "deprecated";
+
+    /**
+     * Constant to be used in the parameters map of the constructor to define the group: the accepted value should be
+     * of type {@link PropertyGroupDescriptor}.
+     * @see #getGroupDescriptor()
+     * @since 17.3.0RC1
+     * @since 16.10.6
+     */
+    @Unstable
+    public static final String GROUP_PARAMETER_NAME = "group";
+
     /**
      * Identifier of the parameter.
      * 
@@ -64,11 +105,11 @@ public class WikiMacroParameterDescriptor implements ParameterDescriptor
      */
     private final Type parameterType;
 
-    private boolean advanced;
-    private boolean displayHidden;
-    private boolean deprecated;
+    private final boolean advanced;
+    private final boolean displayHidden;
+    private final boolean deprecated;
 
-    private PropertyGroupDescriptor groupDescriptor;
+    private final PropertyGroupDescriptor groupDescriptor;
 
     /**
      * Creates a new {@link WikiMacroParameterDescriptor} instance.
@@ -109,11 +150,39 @@ public class WikiMacroParameterDescriptor implements ParameterDescriptor
     public WikiMacroParameterDescriptor(String id, String description, boolean mandatory, Object defaultValue,
             Type parameterType)
     {
+        this(id, description, mandatory, defaultValue, parameterType, Map.of());
+    }
+
+    /**
+     * Creates a new {@link WikiMacroParameterDescriptor} instance.
+     *
+     * @param id parameter identifier.
+     * @param description parameter description.
+     * @param mandatory if the parameter is mandatory.
+     * @param defaultValue parameter default value.
+     * @param parameterType parameter type.
+     * @param parameters a map of other parameters of the descriptor. See also the documented constants of this class
+     * to know the value allowed in that map.
+     * @since 17.3.0RC1
+     * @since 16.10.6
+     */
+    @Unstable
+    public WikiMacroParameterDescriptor(String id, String description, boolean mandatory, Object defaultValue,
+        Type parameterType, Map<String, Object> parameters)
+    {
         this.id = id;
         this.description = description;
         this.mandatory = mandatory;
         this.defaultValue = defaultValue;
         this.parameterType = parameterType;
+        this.advanced = Boolean.parseBoolean(String.valueOf(parameters.get(ADVANCED_PARAMETER_NAME)));
+        this.displayHidden = Boolean.parseBoolean(String.valueOf(parameters.get(HIDDEN_PARAMETER_NAME)));
+        this.deprecated = Boolean.parseBoolean(String.valueOf(parameters.get(DEPRECATED_PARAMETER_NAME)));
+        if (parameters.get(GROUP_PARAMETER_NAME) instanceof PropertyGroupDescriptor localGroupDescriptor) {
+            this.groupDescriptor = localGroupDescriptor;
+        } else {
+            this.groupDescriptor = null;
+        }
     }
 
     @Override
@@ -174,39 +243,10 @@ public class WikiMacroParameterDescriptor implements ParameterDescriptor
         return advanced;
     }
 
-    /**
-     * Allows to set whether the parameter is advanced or not. See {@link #isAdvanced()}.
-     * @param advanced {@code true} if the parameter is advanced.
-     * @return the current instance (builder pattern)
-     * @since 17.3.0RC1
-     * @since 16.10.6
-     */
-    @Unstable
-    public WikiMacroParameterDescriptor setAdvanced(boolean advanced)
-    {
-        this.advanced = advanced;
-        return this;
-    }
-
     @Override
     public boolean isDisplayHidden()
     {
         return displayHidden;
-    }
-
-    /**
-     * Allows to set whether the parameter is hidden or not. See {@link #isDisplayHidden()}.
-     *
-     * @param displayHidden {@code true} if the parameter is hidden.
-     * @return the current instance (builder pattern)
-     * @since 17.3.0RC1
-     * @since 16.10.6
-     */
-    @Unstable
-    public WikiMacroParameterDescriptor setDisplayHidden(boolean displayHidden)
-    {
-        this.displayHidden = displayHidden;
-        return this;
     }
 
     @Override
@@ -215,40 +255,10 @@ public class WikiMacroParameterDescriptor implements ParameterDescriptor
         return deprecated;
     }
 
-    /**
-     * Allows to set whether the parameter is deprecated or not. See {@link #isDeprecated()}.
-     *
-     * @param deprecated {@code true} if the parameter is deprecated.
-     * @return the current instance (builder pattern)
-     * @since 17.3.0RC1
-     * @since 16.10.6
-     */
-    @Unstable
-    public WikiMacroParameterDescriptor setDeprecated(boolean deprecated)
-    {
-        this.deprecated = deprecated;
-        return this;
-    }
-
     @Override
     public PropertyGroupDescriptor getGroupDescriptor()
     {
         return groupDescriptor;
-    }
-
-    /**
-     * Allows to set the group descriptor of the parameter. See {@link #getGroupDescriptor()}.
-     *
-     * @param groupDescriptor the group descriptor of the parameter.
-     * @return the current instance (builder pattern)
-     * @since 17.3.0RC1
-     * @since 16.10.6
-     */
-    @Unstable
-    public WikiMacroParameterDescriptor setGroupDescriptor(PropertyGroupDescriptor groupDescriptor)
-    {
-        this.groupDescriptor = groupDescriptor;
-        return this;
     }
 
     @Override
@@ -302,9 +312,9 @@ public class WikiMacroParameterDescriptor implements ParameterDescriptor
             .append("mandatory", mandatory)
             .append("defaultValue", defaultValue)
             .append("parameterType", parameterType)
-            .append("advanced", advanced)
+            .append(ADVANCED_PARAMETER_NAME, advanced)
             .append("displayHidden", displayHidden)
-            .append("deprecated", deprecated)
+            .append(DEPRECATED_PARAMETER_NAME, deprecated)
             .append("groupDescriptor", groupDescriptor)
             .toString();
     }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-api/src/main/java/org/xwiki/rendering/macro/wikibridge/WikiMacroParameterDescriptor.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-api/src/main/java/org/xwiki/rendering/macro/wikibridge/WikiMacroParameterDescriptor.java
@@ -27,6 +27,7 @@ import org.xwiki.component.util.ReflectionUtils;
 import org.xwiki.properties.PropertyGroupDescriptor;
 import org.xwiki.rendering.macro.descriptor.ParameterDescriptor;
 import org.xwiki.stability.Unstable;
+import org.xwiki.text.XWikiToStringBuilder;
 
 /**
  * {@link ParameterDescriptor} for describing wiki macro parameters.
@@ -58,16 +59,16 @@ public class WikiMacroParameterDescriptor implements ParameterDescriptor
      */
     private final Object defaultValue;
 
+    /**
+     * Type of the parameter.
+     */
+    private final Type parameterType;
+
     private boolean advanced;
     private boolean displayHidden;
     private boolean deprecated;
 
     private PropertyGroupDescriptor groupDescriptor;
-
-    /**
-     * Type of the parameter.
-     */
-    private Type parameterType;
 
     /**
      * Creates a new {@link WikiMacroParameterDescriptor} instance.
@@ -290,5 +291,21 @@ public class WikiMacroParameterDescriptor implements ParameterDescriptor
             .append(groupDescriptor)
             .append(parameterType)
             .toHashCode();
+    }
+
+    @Override
+    public String toString()
+    {
+        return new XWikiToStringBuilder(this)
+            .append("id", id)
+            .append("description", description)
+            .append("mandatory", mandatory)
+            .append("defaultValue", defaultValue)
+            .append("parameterType", parameterType)
+            .append("advanced", advanced)
+            .append("displayHidden", displayHidden)
+            .append("deprecated", deprecated)
+            .append("groupDescriptor", groupDescriptor)
+            .toString();
     }
 }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-api/src/main/java/org/xwiki/rendering/macro/wikibridge/WikiMacroParameterDescriptor.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-api/src/main/java/org/xwiki/rendering/macro/wikibridge/WikiMacroParameterDescriptor.java
@@ -21,8 +21,12 @@ package org.xwiki.rendering.macro.wikibridge;
 
 import java.lang.reflect.Type;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.xwiki.component.util.ReflectionUtils;
+import org.xwiki.properties.PropertyGroupDescriptor;
 import org.xwiki.rendering.macro.descriptor.ParameterDescriptor;
+import org.xwiki.stability.Unstable;
 
 /**
  * {@link ParameterDescriptor} for describing wiki macro parameters.
@@ -37,29 +41,28 @@ public class WikiMacroParameterDescriptor implements ParameterDescriptor
      * 
      * @since 2.1M1
      */
-    private String id;
-
-    /**
-     * Display name of the parameter.
-     * 
-     * @since 2.1M1
-     */
-    private String name;
+    private final String id;
 
     /**
      * Description of the parameter.
      */
-    private String description;
+    private final String description;
 
     /**
      * Boolean indicating if the parameter is mandatory.
      */
-    private boolean mandatory;
+    private final boolean mandatory;
 
     /**
      * Default value of the parameter.
      */
-    private Object defaultValue;
+    private final Object defaultValue;
+
+    private boolean advanced;
+    private boolean displayHidden;
+    private boolean deprecated;
+
+    private PropertyGroupDescriptor groupDescriptor;
 
     /**
      * Type of the parameter.
@@ -121,7 +124,7 @@ public class WikiMacroParameterDescriptor implements ParameterDescriptor
     @Override
     public String getName()
     {
-        return this.name;
+        return this.id;
     }
 
     @Override
@@ -162,5 +165,130 @@ public class WikiMacroParameterDescriptor implements ParameterDescriptor
     public boolean isMandatory()
     {
         return mandatory;
+    }
+
+    @Override
+    public boolean isAdvanced()
+    {
+        return advanced;
+    }
+
+    /**
+     * Allows to set whether the parameter is advanced or not. See {@link #isAdvanced()}.
+     * @param advanced {@code true} if the parameter is advanced.
+     * @return the current instance (builder pattern)
+     * @since 17.3.0RC1
+     * @since 16.10.6
+     */
+    @Unstable
+    public WikiMacroParameterDescriptor setAdvanced(boolean advanced)
+    {
+        this.advanced = advanced;
+        return this;
+    }
+
+    @Override
+    public boolean isDisplayHidden()
+    {
+        return displayHidden;
+    }
+
+    /**
+     * Allows to set whether the parameter is hidden or not. See {@link #isDisplayHidden()}.
+     *
+     * @param displayHidden {@code true} if the parameter is hidden.
+     * @return the current instance (builder pattern)
+     * @since 17.3.0RC1
+     * @since 16.10.6
+     */
+    @Unstable
+    public WikiMacroParameterDescriptor setDisplayHidden(boolean displayHidden)
+    {
+        this.displayHidden = displayHidden;
+        return this;
+    }
+
+    @Override
+    public boolean isDeprecated()
+    {
+        return deprecated;
+    }
+
+    /**
+     * Allows to set whether the parameter is deprecated or not. See {@link #isDeprecated()}.
+     *
+     * @param deprecated {@code true} if the parameter is deprecated.
+     * @return the current instance (builder pattern)
+     * @since 17.3.0RC1
+     * @since 16.10.6
+     */
+    @Unstable
+    public WikiMacroParameterDescriptor setDeprecated(boolean deprecated)
+    {
+        this.deprecated = deprecated;
+        return this;
+    }
+
+    @Override
+    public PropertyGroupDescriptor getGroupDescriptor()
+    {
+        return groupDescriptor;
+    }
+
+    /**
+     * Allows to set the group descriptor of the parameter. See {@link #getGroupDescriptor()}.
+     *
+     * @param groupDescriptor the group descriptor of the parameter.
+     * @return the current instance (builder pattern)
+     * @since 17.3.0RC1
+     * @since 16.10.6
+     */
+    @Unstable
+    public WikiMacroParameterDescriptor setGroupDescriptor(PropertyGroupDescriptor groupDescriptor)
+    {
+        this.groupDescriptor = groupDescriptor;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        WikiMacroParameterDescriptor that = (WikiMacroParameterDescriptor) o;
+
+        return new EqualsBuilder()
+            .append(mandatory, that.mandatory)
+            .append(advanced, that.advanced)
+            .append(displayHidden, that.displayHidden)
+            .append(deprecated, that.deprecated)
+            .append(id, that.id)
+            .append(description, that.description)
+            .append(defaultValue, that.defaultValue)
+            .append(groupDescriptor, that.groupDescriptor)
+            .append(parameterType, that.parameterType)
+            .isEquals();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return new HashCodeBuilder(17, 63)
+            .append(id)
+            .append(description)
+            .append(mandatory)
+            .append(defaultValue)
+            .append(advanced)
+            .append(displayHidden)
+            .append(deprecated)
+            .append(groupDescriptor)
+            .append(parameterType)
+            .toHashCode();
     }
 }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/pom.xml
@@ -31,7 +31,7 @@
   <name>XWiki Platform - Rendering - Wiki Macro Bridge - Store</name>
   <description>Defines the ability to store macros into wiki pages</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.67</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.72</xwiki.jacoco.instructionRatio>
     <!-- Name to display by the Extension Manager -->
     <xwiki.extension.name>Wiki Macro Store</xwiki.extension.name>
   </properties>

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroFactory.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroFactory.java
@@ -280,7 +280,7 @@ public class DefaultWikiMacroFactory implements WikiMacroFactory, WikiMacroConst
     private List<WikiMacroParameterDescriptor> buildParameterDescriptors(XWikiDocument doc) throws WikiMacroException
     {
         List<WikiMacroParameterDescriptor> parameterDescriptors = new ArrayList<>();
-        Collection<BaseObject> macroParameters = doc.getObjects(WIKI_MACRO_PARAMETER_CLASS);
+        Collection<BaseObject> macroParameters = doc.getXObjects(WIKI_MACRO_PARAMETER_CLASS_REFERENCE);
         Map<String, PropertyGroupDescriptor> groupDescriptorMap = new HashMap<>();
 
         if (macroParameters != null) {
@@ -335,15 +335,13 @@ public class DefaultWikiMacroFactory implements WikiMacroFactory, WikiMacroConst
                 // group.
 
                 String groupProperty = macroParameter.getStringValue(PARAMETER_GROUP_PROPERTY);
-                PropertyGroupDescriptor groupDescriptor;
+                PropertyGroupDescriptor groupDescriptor = null;
                 if (!StringUtils.isEmpty(groupProperty) && groupDescriptorMap.containsKey(groupProperty)) {
                     groupDescriptor = groupDescriptorMap.get(groupProperty);
                 } else if (!StringUtils.isEmpty(groupProperty)) {
                     groupDescriptor =
-                        new PropertyGroupDescriptor(List.of(groupProperty));
+                        new PropertyGroupDescriptor(List.of(groupProperty.split("\\|")));
                     groupDescriptorMap.put(groupProperty, groupDescriptor);
-                } else {
-                    groupDescriptor = new PropertyGroupDescriptor(null);
                 }
 
                 // Handle feature property in the group descriptor: note that it's expected that it might impact an
@@ -352,6 +350,9 @@ public class DefaultWikiMacroFactory implements WikiMacroFactory, WikiMacroConst
                 // org.xwiki.properties.internal.DefaultBeanDescriptor#handlePropertyFeatureAndGroupAnnotations
                 String featureProperty = macroParameter.getStringValue(PARAMETER_FEATURE_PROPERTY);
                 if (!StringUtils.isEmpty(featureProperty)) {
+                    if (groupDescriptor == null) {
+                        groupDescriptor = new PropertyGroupDescriptor(null);
+                    }
                     groupDescriptor.setFeature(featureProperty);
                     groupDescriptor
                         .setFeatureMandatory(macroParameter.getIntValue(PARAMETER_FEATURE_MANDATORY_PROPERTY) != 0);

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/WikiMacroConstants.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/WikiMacroConstants.java
@@ -200,4 +200,51 @@ public interface WikiMacroConstants
      */
     String PARAMETER_TYPE_UNKNOWN = MACRO_CONTENT_TYPE_UNKNOWN;
 
+    /**
+     * Constant for representing the feature property of the parameter.
+     *
+     * @since 17.3.0RC1
+     * @since 16.10.6
+     */
+    String PARAMETER_FEATURE_PROPERTY = "feature";
+
+    /**
+     * Constant for representing the group property of the parameter.
+     *
+     * @since 17.3.0RC1
+     * @since 16.10.6
+     */
+    String PARAMETER_GROUP_PROPERTY = "group";
+
+    /**
+     * Constant for representing the hidden property of the parameter.
+     *
+     * @since 17.3.0RC1
+     * @since 16.10.6
+     */
+    String PARAMETER_HIDDEN_PROPERTY = "hidden";
+
+    /**
+     * Constant for representing the advanced property of the parameter.
+     *
+     * @since 17.3.0RC1
+     * @since 16.10.6
+     */
+    String PARAMETER_ADVANCED_PROPERTY = "advanced";
+
+    /**
+     * Constant for representing the feature mandatory property of the parameter.
+     *
+     * @since 17.3.0RC1
+     * @since 16.10.6
+     */
+    String PARAMETER_FEATURE_MANDATORY_PROPERTY = "featureMandatory";
+
+    /**
+     * Constant for representing the deprecated property of the parameter.
+     *
+     * @since 17.3.0RC1
+     * @since 16.10.6
+     */
+    String PARAMETER_DEPRECATED_PROPERTY = "deprecated";
 }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/WikiMacroConstants.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/WikiMacroConstants.java
@@ -156,6 +156,13 @@ public interface WikiMacroConstants
      * Constant for representing XWiki.WikiMacroParameterClass xwiki class.
      */
     String WIKI_MACRO_PARAMETER_CLASS = WIKI_MACRO_PARAMETER_CLASS_SPACE + '.' + WIKI_MACRO_PARAMETER_CLASS_PAGE;
+    /**
+     * Constant for representing XWiki.WikiMacroParameterClass local reference.
+     * @since 17.3.0RC1
+     * @since 16.10.6
+     */
+    LocalDocumentReference WIKI_MACRO_PARAMETER_CLASS_REFERENCE =
+        new LocalDocumentReference(WIKI_MACRO_PARAMETER_CLASS_SPACE, WIKI_MACRO_PARAMETER_CLASS);
 
     /**
      * Constant for representing parameter name property. Same as MACRO_NAME_PROPERTY (Check style Fix)

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/WikiMacroConstants.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/WikiMacroConstants.java
@@ -162,7 +162,7 @@ public interface WikiMacroConstants
      * @since 16.10.6
      */
     LocalDocumentReference WIKI_MACRO_PARAMETER_CLASS_REFERENCE =
-        new LocalDocumentReference(WIKI_MACRO_PARAMETER_CLASS_SPACE, WIKI_MACRO_PARAMETER_CLASS);
+        new LocalDocumentReference(WIKI_MACRO_PARAMETER_CLASS_SPACE, WIKI_MACRO_PARAMETER_CLASS_PAGE);
 
     /**
      * Constant for representing parameter name property. Same as MACRO_NAME_PROPERTY (Check style Fix)

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/WikiMacroParameterClassDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/WikiMacroParameterClassDocumentInitializer.java
@@ -45,6 +45,7 @@ public class WikiMacroParameterClassDocumentInitializer extends AbstractMandator
     implements WikiMacroConstants
 {
     private static final String PROPERTY_PIPE = "|";
+    private static final String PROPERTY_YESNO = "yesno";
 
     /**
      * Default constructor.
@@ -59,10 +60,16 @@ public class WikiMacroParameterClassDocumentInitializer extends AbstractMandator
     {
         xclass.addTextField(PARAMETER_NAME_PROPERTY, "Parameter name", 30);
         xclass.addTextAreaField(PARAMETER_DESCRIPTION_PROPERTY, "Parameter description", 40, 5);
-        xclass.addBooleanField(PARAMETER_MANDATORY_PROPERTY, "Parameter mandatory", "yesno");
+        xclass.addBooleanField(PARAMETER_MANDATORY_PROPERTY, "Parameter mandatory", PROPERTY_YESNO);
         xclass.addTextField(PARAMETER_DEFAULT_VALUE_PROPERTY, "Parameter default value", 30);
         xclass.addStaticListField(PARAMETER_TYPE_PROPERTY, "Parameter type", 1, false, false,
             StringUtils.join(Arrays.asList(PARAMETER_TYPE_UNKNOWN, PARAMETER_TYPE_WIKI), PROPERTY_PIPE),
             ListClass.DISPLAYTYPE_INPUT, PROPERTY_PIPE, PARAMETER_TYPE_UNKNOWN, ListClass.FREE_TEXT_ALLOWED, true);
+        xclass.addTextField(PARAMETER_FEATURE_PROPERTY, "Parameter feature", 30);
+        xclass.addTextField(PARAMETER_GROUP_PROPERTY, "Parameter group", 30);
+        xclass.addBooleanField(PARAMETER_HIDDEN_PROPERTY, "Parameter hidden", PROPERTY_YESNO);
+        xclass.addBooleanField(PARAMETER_ADVANCED_PROPERTY, "Parameter advanced", PROPERTY_YESNO);
+        xclass.addBooleanField(PARAMETER_DEPRECATED_PROPERTY, "Parameter deprecated", PROPERTY_YESNO);
+        xclass.addBooleanField(PARAMETER_FEATURE_MANDATORY_PROPERTY, "Parameter feature mandatory", PROPERTY_YESNO);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/WikiMacroParameterClassDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/WikiMacroParameterClassDocumentInitializer.java
@@ -26,7 +26,6 @@ import javax.inject.Singleton;
 
 import org.apache.commons.lang3.StringUtils;
 import org.xwiki.component.annotation.Component;
-import org.xwiki.model.reference.LocalDocumentReference;
 
 import com.xpn.xwiki.doc.AbstractMandatoryClassInitializer;
 import com.xpn.xwiki.objects.classes.BaseClass;
@@ -52,7 +51,7 @@ public class WikiMacroParameterClassDocumentInitializer extends AbstractMandator
      */
     public WikiMacroParameterClassDocumentInitializer()
     {
-        super(new LocalDocumentReference(WIKI_MACRO_PARAMETER_CLASS_SPACE, WIKI_MACRO_PARAMETER_CLASS_PAGE));
+        super(WIKI_MACRO_PARAMETER_CLASS_REFERENCE);
     }
 
     @Override
@@ -66,7 +65,8 @@ public class WikiMacroParameterClassDocumentInitializer extends AbstractMandator
             StringUtils.join(Arrays.asList(PARAMETER_TYPE_UNKNOWN, PARAMETER_TYPE_WIKI), PROPERTY_PIPE),
             ListClass.DISPLAYTYPE_INPUT, PROPERTY_PIPE, PARAMETER_TYPE_UNKNOWN, ListClass.FREE_TEXT_ALLOWED, true);
         xclass.addTextField(PARAMETER_FEATURE_PROPERTY, "Parameter feature", 30);
-        xclass.addTextField(PARAMETER_GROUP_PROPERTY, "Parameter group", 30);
+        xclass.addStaticListField(PARAMETER_GROUP_PROPERTY, "Parameter group property", 1, true, false, null,
+            ListClass.DISPLAYTYPE_INPUT, PROPERTY_PIPE, null, ListClass.FREE_TEXT_ALLOWED, false);
         xclass.addBooleanField(PARAMETER_HIDDEN_PROPERTY, "Parameter hidden", PROPERTY_YESNO);
         xclass.addBooleanField(PARAMETER_ADVANCED_PROPERTY, "Parameter advanced", PROPERTY_YESNO);
         xclass.addBooleanField(PARAMETER_DEPRECATED_PROPERTY, "Parameter deprecated", PROPERTY_YESNO);

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/resources/ApplicationResources.properties
@@ -75,6 +75,12 @@ XWiki.WikiMacroParameterClass_description=Parameter description
 XWiki.WikiMacroParameterClass_mandatory=Parameter mandatory
 XWiki.WikiMacroParameterClass_defaultValue=Parameter default value
 XWiki.WikiMacroParameterClass_type=Parameter type
+XWiki.WikiMacroParameterClass_feature=Parameter feature
+XWiki.WikiMacroParameterClass_group=Parameter group
+XWiki.WikiMacroParameterClass_deprecated=Parameter deprecated
+XWiki.WikiMacroParameterClass_hidden=Parameter hidden
+XWiki.WikiMacroParameterClass_advanced=Parameter advanced
+XWiki.WikiMacroParameterClass_featureMandatory=Parameter feature mandatory
 
 rendering.wikimacro.error.failedResolveContentPlaceholder=Failed to resolve macro content placeholder
 rendering.wikimacro.error.failedResolveParameterPlaceholder=Failed to resolve macro parameter placeholder

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/resources/ApplicationResources.properties
@@ -44,10 +44,15 @@
 
 ### Wiki macros classes
 XWiki.WikiMacroClass_id=Macro id
+XWiki.WikiMacroClass_id_hint=The identifier of the macro is also what will be used in the syntax: e.g. {{yourId /}}.
 XWiki.WikiMacroClass_name=Macro name
+XWiki.WikiMacroClass_name_hint=The name of the macro displayed in the editor UI.
 XWiki.WikiMacroClass_description=Macro description
+XWiki.WikiMacroClass_description_hint=The description of the macro displayed in the editor UI.
 XWiki.WikiMacroClass_defaultCategory=Default category
+XWiki.WikiMacroClass_defaultCategory_hint=The category where the macro will be displayed in the editor UI.
 XWiki.WikiMacroClass_supportsInlineMode=Supports inline mode
+XWiki.WikiMacroClass_supportsInlineMode_hint=If no the macro will display an error when used inline.
 XWiki.WikiMacroClass_visibility=Macro visibility
 XWiki.WikiMacroClass_visibility_Current\ User=Current User
 XWiki.WikiMacroClass_visibility_Current\ Wiki=Current Wiki
@@ -71,16 +76,26 @@ XWiki.WikiMacroClass_executionIsolated_hint=If the execution of the macro doesn'
   and writing other context information is okay. Marking the macro execution as isolated speeds up the execution of \
   macros.
 XWiki.WikiMacroParameterClass_name=Parameter name
+XWiki.WikiMacroParameterClass_name_hint=The name of the parameter is the one used in the syntax: e.g. {{yourMacro paramName="xx" /}}. You can use a translation key such as rendering.macro.yourMacro.parameter.paramName.name to change the name displayed in the editor UI.
 XWiki.WikiMacroParameterClass_description=Parameter description
+XWiki.WikiMacroParameterClass_description_hint=The description of the parameter. It can also be translated with a key such as rendering.macro.yourMacro.parameter.paramName.description
 XWiki.WikiMacroParameterClass_mandatory=Parameter mandatory
+XWiki.WikiMacroParameterClass_mandatory_hint=If yes, then the parameter value needs to be set, else the parameter is optional. Note that this may impact the visibility of the parameter.
 XWiki.WikiMacroParameterClass_defaultValue=Parameter default value
+XWiki.WikiMacroParameterClass_defaultValue_hint=Default value should only be used for optional parameters and it allows to avoid setting a value when using the macro. It is not to be considered as a placeholder for a value in the editor UI.
 XWiki.WikiMacroParameterClass_type=Parameter type
+XWiki.WikiMacroParameterClass_type_hint=Unknown means that it will be considered as a String value, Wiki means that the wiki syntax of the page will be used, then it's possible to indicate any custom type provided its fully qualified name is given, e.g. java.util.List.
 XWiki.WikiMacroParameterClass_feature=Parameter feature
+XWiki.WikiMacroParameterClass_feature_hint=Parameters that are bound to the same feature are mutually exclusive. Note that a feature can be associated to a group: in such case all parameters of same group will be bound to same feature.
 XWiki.WikiMacroParameterClass_group=Parameter group
+XWiki.WikiMacroParameterClass_group_hint=Allows to visually group parameters together in the UI.
 XWiki.WikiMacroParameterClass_deprecated=Parameter deprecated
 XWiki.WikiMacroParameterClass_hidden=Parameter hidden
+XWiki.WikiMacroParameterClass_hidden_hint=If yes, the parameter will never be displayed in the editor UI, but it can still be used in the syntax.
 XWiki.WikiMacroParameterClass_advanced=Parameter advanced
-XWiki.WikiMacroParameterClass_featureMandatory=Parameter feature mandatory
+XWiki.WikiMacroParameterClass_advanced_hint=If yes, the parameter will always be put in a collapsed section of the editor UI.
+XWiki.WikiMacroParameterClass_featureMandatory=Parameter feature mandatory.
+XWiki.WikiMacroParameterClass_featureMandatory_hint=If yes, then even if all parameters bound to the feature are optional, one of them needs to be used.
 
 rendering.wikimacro.error.failedResolveContentPlaceholder=Failed to resolve macro content placeholder
 rendering.wikimacro.error.failedResolveParameterPlaceholder=Failed to resolve macro parameter placeholder

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/test/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroFactoryTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/test/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroFactoryTest.java
@@ -147,7 +147,7 @@ class DefaultWikiMacroFactoryTest
         param2.setIntValue(WikiMacroConstants.PARAMETER_MANDATORY_PROPERTY, 0);
         param2.setIntValue(WikiMacroConstants.PARAMETER_ADVANCED_PROPERTY, 1);
         param2.setStringValue(WikiMacroConstants.PARAMETER_TYPE_PROPERTY, WikiMacroConstants.PARAMETER_TYPE_WIKI);
-        param2.setStringValue(WikiMacroConstants.PARAMETER_GROUP_PROPERTY, "foo");
+        param2.setStringListValue(WikiMacroConstants.PARAMETER_GROUP_PROPERTY, List.of("foo"));
         param2.setStringValue(WikiMacroConstants.PARAMETER_FEATURE_PROPERTY, "bar");
         param2.setIntValue(WikiMacroConstants.PARAMETER_FEATURE_MANDATORY_PROPERTY, 1);
         this.macroDefinitionDoc.addXObject(param2);
@@ -158,7 +158,7 @@ class DefaultWikiMacroFactoryTest
         param3.setStringValue(WikiMacroConstants.PARAMETER_NAME_PROPERTY, "param3");
         param3.setStringValue(WikiMacroConstants.PARAMETER_DESCRIPTION_PROPERTY, "Third parameter description");
         param3.setIntValue(WikiMacroConstants.PARAMETER_HIDDEN_PROPERTY, 1);
-        param3.setStringValue(WikiMacroConstants.PARAMETER_GROUP_PROPERTY, "foo");
+        param3.setStringListValue(WikiMacroConstants.PARAMETER_GROUP_PROPERTY, List.of("foo"));
         this.macroDefinitionDoc.addXObject(param3);
 
         // fourth param is mandatory, deprecated, and advanced, belongs to groups foo and buz
@@ -169,7 +169,7 @@ class DefaultWikiMacroFactoryTest
         param4.setIntValue(WikiMacroConstants.PARAMETER_MANDATORY_PROPERTY, 1);
         param4.setIntValue(WikiMacroConstants.PARAMETER_ADVANCED_PROPERTY, 1);
         param4.setIntValue(WikiMacroConstants.PARAMETER_DEPRECATED_PROPERTY, 1);
-        param4.setStringValue(WikiMacroConstants.PARAMETER_GROUP_PROPERTY, "foo|buz");
+        param4.setStringListValue(WikiMacroConstants.PARAMETER_GROUP_PROPERTY, List.of("foo", "buz"));
         this.macroDefinitionDoc.addXObject(param4);
 
         // Fifth parameter is optional, of type java.util.List, as default value [1,2], bound to feature foo
@@ -212,35 +212,35 @@ class DefaultWikiMacroFactoryTest
         assertNull(macro.getDescriptor().getContentDescriptor());
 
         WikiMacroParameterDescriptor descriptor1 =
-            new WikiMacroParameterDescriptor("param1", "First parameter description", true, "42", String.class)
-                .setDeprecated(true);
+            new WikiMacroParameterDescriptor("param1", "First parameter description", true, "42", String.class,
+                Map.of(WikiMacroParameterDescriptor.DEPRECATED_PARAMETER_NAME, true));
 
         PropertyGroupDescriptor fooGroupDescriptor = new PropertyGroupDescriptor(List.of("foo"));
         fooGroupDescriptor.setFeature("bar");
         fooGroupDescriptor.setFeatureMandatory(true);
         WikiMacroParameterDescriptor descriptor2 =
             new WikiMacroParameterDescriptor("param2", "Second parameter description", false, null,
-                Block.LIST_BLOCK_TYPE)
-                .setAdvanced(true)
-                .setGroupDescriptor(fooGroupDescriptor);
+                Block.LIST_BLOCK_TYPE, Map.of(
+                    WikiMacroParameterDescriptor.ADVANCED_PARAMETER_NAME, true,
+                    WikiMacroParameterDescriptor.GROUP_PARAMETER_NAME, fooGroupDescriptor));
 
         WikiMacroParameterDescriptor descriptor3 =
-            new WikiMacroParameterDescriptor("param3", "Third parameter description", false, null, String.class)
-                .setDisplayHidden(true)
-                .setGroupDescriptor(fooGroupDescriptor);
+            new WikiMacroParameterDescriptor("param3", "Third parameter description", false, null, String.class, Map.of(
+                WikiMacroParameterDescriptor.HIDDEN_PARAMETER_NAME, true,
+                WikiMacroParameterDescriptor.GROUP_PARAMETER_NAME, fooGroupDescriptor));
 
         PropertyGroupDescriptor fooBuzGroupDescriptor = new PropertyGroupDescriptor(List.of("foo", "buz"));
         WikiMacroParameterDescriptor descriptor4 =
-            new WikiMacroParameterDescriptor("param4", "Fourth parameter description", true, null, String.class)
-                .setDeprecated(true)
-                .setAdvanced(true)
-                .setGroupDescriptor(fooBuzGroupDescriptor);
+            new WikiMacroParameterDescriptor("param4", "Fourth parameter description", true, null, String.class, Map.of(
+                WikiMacroParameterDescriptor.ADVANCED_PARAMETER_NAME, true,
+                WikiMacroParameterDescriptor.DEPRECATED_PARAMETER_NAME, true,
+                WikiMacroParameterDescriptor.GROUP_PARAMETER_NAME, fooBuzGroupDescriptor));
 
         PropertyGroupDescriptor featureFooGroupDescriptor = new PropertyGroupDescriptor(null);
         featureFooGroupDescriptor.setFeature("foo");
         WikiMacroParameterDescriptor descriptor5 =
-            new WikiMacroParameterDescriptor("param5", "", false, "1,2", List.class)
-                .setGroupDescriptor(featureFooGroupDescriptor);
+            new WikiMacroParameterDescriptor("param5", "", false, "1,2", List.class, Map.of(
+                WikiMacroParameterDescriptor.GROUP_PARAMETER_NAME, featureFooGroupDescriptor));
 
         Map<String, WikiMacroParameterDescriptor> descriptorMap = new LinkedHashMap<>();
         descriptorMap.put("param1", descriptor1);

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/test/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroFactoryTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/test/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroFactoryTest.java
@@ -20,6 +20,7 @@
 package org.xwiki.rendering.wikimacro.internal;
 
 import java.lang.reflect.Type;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -34,6 +35,7 @@ import org.xwiki.component.util.DefaultParameterizedType;
 import org.xwiki.component.wiki.internal.bridge.ContentParser;
 import org.xwiki.model.EntityType;
 import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.properties.PropertyGroupDescriptor;
 import org.xwiki.rendering.async.internal.block.BlockAsyncRendererExecutor;
 import org.xwiki.rendering.block.Block;
 import org.xwiki.rendering.macro.MacroContentParser;
@@ -43,6 +45,7 @@ import org.xwiki.rendering.macro.wikibridge.WikiMacro;
 import org.xwiki.rendering.macro.wikibridge.WikiMacroDescriptor;
 import org.xwiki.rendering.macro.wikibridge.WikiMacroException;
 import org.xwiki.rendering.macro.wikibridge.WikiMacroParameters;
+import org.xwiki.rendering.macro.wikibridge.WikiMacroParameterDescriptor;
 import org.xwiki.rendering.macro.wikibridge.WikiMacroVisibility;
 import org.xwiki.rendering.transformation.Transformation;
 import org.xwiki.security.authorization.Right;
@@ -104,7 +107,7 @@ class DefaultWikiMacroFactoryTest
     private MockitoOldcore oldcore;
 
     @BeforeEach
-    protected void setUp() throws Exception
+    void setUp() throws Exception
     {
         // Build the macro definition document.
         this.macroObject = new BaseObject();
@@ -122,6 +125,62 @@ class DefaultWikiMacroFactoryTest
         this.macroDefinitionDoc =
             this.oldcore.getSpyXWiki().getDocument(DOCUMENT_REFERENCE, this.oldcore.getXWikiContext());
         this.macroDefinitionDoc.addXObject(this.macroObject);
+
+        // add parameters
+
+        // first param is mandatory and deprecated, of type unknown with default value 42
+        BaseObject param1 = new BaseObject();
+        param1.setXClassReference(WikiMacroConstants.WIKI_MACRO_PARAMETER_CLASS_REFERENCE);
+        param1.setStringValue(WikiMacroConstants.PARAMETER_NAME_PROPERTY, "param1");
+        param1.setStringValue(WikiMacroConstants.PARAMETER_DESCRIPTION_PROPERTY, "First parameter description");
+        param1.setIntValue(WikiMacroConstants.PARAMETER_MANDATORY_PROPERTY, 1);
+        param1.setIntValue(WikiMacroConstants.PARAMETER_DEPRECATED_PROPERTY, 1);
+        param1.setStringValue(WikiMacroConstants.PARAMETER_DEFAULT_VALUE_PROPERTY, "42");
+        this.macroDefinitionDoc.addXObject(param1);
+
+        // second param is optional, advanced, it belongs to group foo and expose mandatory feature bar and is of type
+        // wiki
+        BaseObject param2 = new BaseObject();
+        param2.setXClassReference(WikiMacroConstants.WIKI_MACRO_PARAMETER_CLASS_REFERENCE);
+        param2.setStringValue(WikiMacroConstants.PARAMETER_NAME_PROPERTY, "param2");
+        param2.setStringValue(WikiMacroConstants.PARAMETER_DESCRIPTION_PROPERTY, "Second parameter description");
+        param2.setIntValue(WikiMacroConstants.PARAMETER_MANDATORY_PROPERTY, 0);
+        param2.setIntValue(WikiMacroConstants.PARAMETER_ADVANCED_PROPERTY, 1);
+        param2.setStringValue(WikiMacroConstants.PARAMETER_TYPE_PROPERTY, WikiMacroConstants.PARAMETER_TYPE_WIKI);
+        param2.setStringValue(WikiMacroConstants.PARAMETER_GROUP_PROPERTY, "foo");
+        param2.setStringValue(WikiMacroConstants.PARAMETER_FEATURE_PROPERTY, "bar");
+        param2.setIntValue(WikiMacroConstants.PARAMETER_FEATURE_MANDATORY_PROPERTY, 1);
+        this.macroDefinitionDoc.addXObject(param2);
+
+        // third param is optional, hidden, it belongs to group foo
+        BaseObject param3 = new BaseObject();
+        param3.setXClassReference(WikiMacroConstants.WIKI_MACRO_PARAMETER_CLASS_REFERENCE);
+        param3.setStringValue(WikiMacroConstants.PARAMETER_NAME_PROPERTY, "param3");
+        param3.setStringValue(WikiMacroConstants.PARAMETER_DESCRIPTION_PROPERTY, "Third parameter description");
+        param3.setIntValue(WikiMacroConstants.PARAMETER_HIDDEN_PROPERTY, 1);
+        param3.setStringValue(WikiMacroConstants.PARAMETER_GROUP_PROPERTY, "foo");
+        this.macroDefinitionDoc.addXObject(param3);
+
+        // fourth param is mandatory, deprecated, and advanced, belongs to groups foo and buz
+        BaseObject param4 = new BaseObject();
+        param4.setXClassReference(WikiMacroConstants.WIKI_MACRO_PARAMETER_CLASS_REFERENCE);
+        param4.setStringValue(WikiMacroConstants.PARAMETER_NAME_PROPERTY, "param4");
+        param4.setStringValue(WikiMacroConstants.PARAMETER_DESCRIPTION_PROPERTY, "Fourth parameter description");
+        param4.setIntValue(WikiMacroConstants.PARAMETER_MANDATORY_PROPERTY, 1);
+        param4.setIntValue(WikiMacroConstants.PARAMETER_ADVANCED_PROPERTY, 1);
+        param4.setIntValue(WikiMacroConstants.PARAMETER_DEPRECATED_PROPERTY, 1);
+        param4.setStringValue(WikiMacroConstants.PARAMETER_GROUP_PROPERTY, "foo|buz");
+        this.macroDefinitionDoc.addXObject(param4);
+
+        // Fifth parameter is optional, of type java.util.List, as default value [1,2], bound to feature foo
+        BaseObject param5 = new BaseObject();
+        param5.setXClassReference(WikiMacroConstants.WIKI_MACRO_PARAMETER_CLASS_REFERENCE);
+        param5.setStringValue(WikiMacroConstants.PARAMETER_NAME_PROPERTY, "param5");
+        param5.setStringValue(WikiMacroConstants.PARAMETER_TYPE_PROPERTY, "java.util.List");
+        param5.setStringValue(WikiMacroConstants.PARAMETER_DEFAULT_VALUE_PROPERTY, "1,2");
+        param5.setStringValue(WikiMacroConstants.PARAMETER_FEATURE_PROPERTY, "foo");
+        this.macroDefinitionDoc.addXObject(param5);
+
         saveDocument();
     }
 
@@ -151,7 +210,46 @@ class DefaultWikiMacroFactoryTest
         assertEquals(WikiMacroVisibility.USER, ((WikiMacroDescriptor) macro.getDescriptor()).getVisibility());
         assertTrue(macro.supportsInlineMode());
         assertNull(macro.getDescriptor().getContentDescriptor());
-        assertTrue(macro.getDescriptor().getParameterDescriptorMap().isEmpty());
+
+        WikiMacroParameterDescriptor descriptor1 =
+            new WikiMacroParameterDescriptor("param1", "First parameter description", true, "42", String.class)
+                .setDeprecated(true);
+
+        PropertyGroupDescriptor fooGroupDescriptor = new PropertyGroupDescriptor(List.of("foo"));
+        fooGroupDescriptor.setFeature("bar");
+        fooGroupDescriptor.setFeatureMandatory(true);
+        WikiMacroParameterDescriptor descriptor2 =
+            new WikiMacroParameterDescriptor("param2", "Second parameter description", false, null,
+                Block.LIST_BLOCK_TYPE)
+                .setAdvanced(true)
+                .setGroupDescriptor(fooGroupDescriptor);
+
+        WikiMacroParameterDescriptor descriptor3 =
+            new WikiMacroParameterDescriptor("param3", "Third parameter description", false, null, String.class)
+                .setDisplayHidden(true)
+                .setGroupDescriptor(fooGroupDescriptor);
+
+        PropertyGroupDescriptor fooBuzGroupDescriptor = new PropertyGroupDescriptor(List.of("foo", "buz"));
+        WikiMacroParameterDescriptor descriptor4 =
+            new WikiMacroParameterDescriptor("param4", "Fourth parameter description", true, null, String.class)
+                .setDeprecated(true)
+                .setAdvanced(true)
+                .setGroupDescriptor(fooBuzGroupDescriptor);
+
+        PropertyGroupDescriptor featureFooGroupDescriptor = new PropertyGroupDescriptor(null);
+        featureFooGroupDescriptor.setFeature("foo");
+        WikiMacroParameterDescriptor descriptor5 =
+            new WikiMacroParameterDescriptor("param5", "", false, "1,2", List.class)
+                .setGroupDescriptor(featureFooGroupDescriptor);
+
+        Map<String, WikiMacroParameterDescriptor> descriptorMap = new LinkedHashMap<>();
+        descriptorMap.put("param1", descriptor1);
+        descriptorMap.put("param2", descriptor2);
+        descriptorMap.put("param3", descriptor3);
+        descriptorMap.put("param4", descriptor4);
+        descriptorMap.put("param5", descriptor5);
+
+        assertEquals(descriptorMap, macro.getDescriptor().getParameterDescriptorMap());
 
         // Verify that the wiki macro descriptor has a macro id without a syntax since wiki macros are registered for
         // all syntaxes.


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22804

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

  * Add the various needed property in xclass
  * Add missing fields and getter/setters in WikiMacroParameterDescriptor
  * Properly build the WikiParameterDescriptor based on the object properties
  * Provide translation keys
  * Add unit test for building parameter descriptors

WIP: we should probably provide parameter hints

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* I decided to be consistent with what we have with java, meaning that wikimacro also allows to specify a list of groups even we never really use that possibility

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

![image](https://github.com/user-attachments/assets/6ae0af4c-f723-4b38-abf0-94da5d284201)
![image](https://github.com/user-attachments/assets/bb432421-eb1f-4a26-bca3-6eacd9773286)

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Ran `mvn clean install -Pquality` on both `xwiki-platform-rendering-wikimacro` and `xwiki-platform-legacy-rendering-wikimacro` 

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.x 