### PR TITLE
XWIKI-22995: Underline inline link for the document original author

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/general.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/general.less
@@ -164,6 +164,7 @@ body {
 
     // UIs where we want to underline outside of content.
     .xdocLastModification, // Under the title, this link is inline so we want to underline it.
+    .xdocCreation, // In the document footer, this link is inline, similarly to last modification.
     .panel[class*="HelpTipsPanel "], // This panel, unlike other panels, contains mostly text with underline links.
     .commentauthor, #commentform > label, // Similarly to the page last modificator, we want to underline comment authors
     .xHint // Form input hints, covered even outside of regular page content.


### PR DESCRIPTION

# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22995

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added an exception for the Page creator link.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Before the PR:
![Screenshot from 2025-04-04 15-50-39](https://github.com/user-attachments/assets/501f261f-aafd-4126-b1a6-e1f2f2b61d1a)
After the PR:
![Screenshot from 2025-04-04 15-53-15](https://github.com/user-attachments/assets/708ec69f-102b-426b-98ed-cf2af80822ee)

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Manual test only. This is a style change only, it doesn't impact the results of our current test framework. Additionally, this link is only here when the creator of a page is not the superadmin but an actual user, which does not happen in automatic tests (the automatic accessibility tests would have highlighted this violation before if it happened).

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X, small bugfix that is pretty safe to merge.