### PR TITLE
XWIKI-23081: Fetching backlinks is slow and consumes a lot of memory on large instances

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/DefaultLinkStore.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/DefaultLinkStore.java
@@ -60,6 +60,8 @@ import org.xwiki.store.ReadyIndicator;
 @Singleton
 public class DefaultLinkStore implements LinkStore
 {
+    private static final int ROWS = 1000;
+
     @Inject
     private Solr solr;
 
@@ -163,7 +165,7 @@ public class DefaultLinkStore implements LinkStore
 
         SolrQuery solrQuery = new SolrQuery(filter.toString());
 
-        solrQuery.setRows(1000);
+        solrQuery.setRows(ROWS);
         // Set sorting based on the ID for cursor-based pagination to work.
         solrQuery.addSort(FieldUtils.ID, SolrQuery.ORDER.asc);
         solrQuery.set(CursorMarkParams.CURSOR_MARK_PARAM, CursorMarkParams.CURSOR_MARK_START);
@@ -191,7 +193,7 @@ public class DefaultLinkStore implements LinkStore
             }
 
             solrQuery.set(CursorMarkParams.CURSOR_MARK_PARAM, response.getNextCursorMark());
-        } while (response.getResults().size() == 1000);
+        } while (response.getResults().size() == ROWS);
 
         return references;
     }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-23081

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Use cursor-based pagination to fetch all documents instead of setting a high query limit.
* Add a test to verify that the pagination works.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Solr allocates memory for storing some values that is proportional to the requested limit. According to what I found, it seems to be around 18 bytes per requested document. The limit is decreased to the total number of indexed items, but if that is high, like 37 million, this could result in 700MB memory per backlink query.
* I initially considered doing a first query with a low limit to fetch the number of results and then doing a second query with that number of results as limit. However, the total number of results might not be exact for large sets of documents. Therefore, I chose this approach based on cursor-based pagination that shouldn't suffer from any memory problems as Solr should be able to derive an efficient filter based on the document ID.
* Eventually, we should introduce paginated APIs in the link store as displaying all backlinks at once is not scalable.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
LANG=C.UTF-8 mvn clean install -Pdocker,legacy,integration-tests,snapshotModules,quality,distribution,flavor-integration-tests -pl :xwiki-platform-search-solr-api
```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-16.10.x (seems like a safe change to me, and it is an important performance/memory usage improvement)