### PR TITLE
XWIKI-22727: Make the width of panel column flexible

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/flamingo.js
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/flamingo.js
@@ -134,14 +134,14 @@ require(['jquery', 'jquery-ui'], function($) {
   };
   // In order to avoid code duplication, a lot of code has been segmented in functions hereafter.
   let valueIsSimilarToDefault = function (valueString, side) {
-    let diff = Math.abs(parseInt(valueString) - initialPanelColumnWidth[side])
+    let diff = Math.abs(parseInt(valueString) - initialPanelColumnWidth[side]);
     // If the value provided is not a number or the difference is lower than 24px, we assume they are about the same.
     // This 24px threshold was picked arbitrarily.
     return !diff || diff < 24;
   };
   let storageValueIsSimilarToDefault = function (side) {
     return valueIsSimilarToDefault(localStorage.getItem(localStoragePrefix + side), side);
-  }
+  };
   let applyLocalStorageValues = function(side) {
     // We only update the value from local storage if this new value is significantly different from the default
     // The user shouldn't be able to save those values, but it's an extra safety in case the threshold used above
@@ -151,7 +151,7 @@ require(['jquery', 'jquery-ui'], function($) {
       document.body.style.setProperty('--panel-column-' + side + '-width',
         localStorage.getItem(localStoragePrefix + side));
     }
-  }
+  };
   applyLocalStorageValues(left);
   applyLocalStorageValues(right);
 
@@ -175,7 +175,7 @@ require(['jquery', 'jquery-ui'], function($) {
     if (!document.hidden) return;
     let currentValueIsSimilarToDefault = function (side) {
       return valueIsSimilarToDefault(document.body.style.getPropertyValue('--panel-column-' + side + '-width'), side);
-    }
+    };
     let updateLocalStorageValueForSide = function (side) {
       // We only update the local storage when the last value is different enough from the default value.
       // This is important to keep this as long as we don't have a proper UI to reset the panel column size.
@@ -187,10 +187,10 @@ require(['jquery', 'jquery-ui'], function($) {
         // If the values are similar, we remove whatever was stored in the localStorage.
         localStorage.removeItem(localStoragePrefix + side);
       }
-    }
+    };
     updateLocalStorageValueForSide(left);
     updateLocalStorageValueForSide(right);
-  }
+  };
   document.addEventListener('visibilitychange', savePanelWidthInLocalStorage);
 });
 


### PR DESCRIPTION

# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22727
https://github.com/xwiki/xwiki-platform/pull/3957 contained a regression on codestyle that is reported by JSHint on our CI.

![image](https://github.com/user-attachments/assets/fa40f7a3-1b89-45bc-a969-7d526df72ad0)
from https://ci.xwiki.org/blue/organizations/jenkins/XWiki%2Fxwiki-platform/detail/master/7870/pipeline
# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Fixed codestyle regarding JSHint (missing semicolons on the javascript I added after the initial changes, which I forgot to properly build)


# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
None, codestyle changes only. 
# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Built with JSHint: `mvn -f xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources clean install -Plegacy,integration-tests,snapshot -U -Dmaven.test.failure.ignore -Dxwiki.checkstyle.skip=true -Dxwiki.surefire.captureconsole.skip=true -Dxwiki.revapi.skip=true -DskipITs` . I could reproduce the CI error locally with it, and after the changes proposed in this PR, the build passes successfully.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None (same as https://github.com/xwiki/xwiki-platform/pull/3957 )