### PR TITLE
XWIKI-23052: Solr still uses a lot of field related RAM

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-server/xwiki-platform-search-solr-server-core-search/src/main/resources/conf/managed-schema.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-server/xwiki-platform-search-solr-server-core-search/src/main/resources/conf/managed-schema.xml
@@ -633,13 +633,11 @@
       </analyzer>
     </fieldType>
 
-    <!-- lowercases the entire field value, keeping it as a single token.  -->
-    <fieldType name="lowercase" class="solr.TextField" positionIncrementGap="100">
-      <analyzer>
-        <tokenizer name="keyword"/>
-        <filter name="lowercase" />
-      </analyzer>
-    </fieldType>
+    <!--
+    Custom lowercase field that is like a String field but lowercases the value before indexing, querying, and storing.
+    -->
+    <fieldType name="lowercase" class="org.xwiki.search.solr.LowerCaseStrField" docValues="true"
+      sortMissingLast="true"/>
 
     <!--
       Example of using PathHierarchyTokenizerFactory at index time, so

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-server/xwiki-platform-search-solr-server-plugin/src/main/java/org/xwiki/search/solr/LowerCaseStrField.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-server/xwiki-platform-search-solr-server-plugin/src/main/java/org/xwiki/search/solr/LowerCaseStrField.java
@@ -1,0 +1,57 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.search.solr;
+
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.lucene.index.IndexableField;
+import org.apache.solr.schema.SchemaField;
+import org.apache.solr.schema.StrField;
+
+/**
+ * A custom Solr field type that transforms the value to lowercase for indexing, storage, and query.
+ *
+ * @version $Id$
+ * @since 17.3.0RC1
+ */
+public class LowerCaseStrField extends StrField
+{
+    @Override
+    public List<IndexableField> createFields(SchemaField field, Object value)
+    {
+        // Transform the value here, too, to ensure that the value is in lowercase also when stored as doc value.
+        Object val;
+        if (value instanceof String inputString) {
+            val = toInternal(inputString);
+        } else {
+            val = value;
+        }
+
+        return super.createFields(field, val);
+    }
+
+    @Override
+    public String toInternal(String val)
+    {
+        // Transform the value to lowercase for indexing, storage, and query.
+        return StringUtils.toRootLowerCase(val);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-server/xwiki-platform-search-solr-server-plugin/src/test/java/org/xwiki/search/solr/LowerCaseStrFieldTest.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-server/xwiki-platform-search-solr-server-plugin/src/test/java/org/xwiki/search/solr/LowerCaseStrFieldTest.java
@@ -1,0 +1,98 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.search.solr;
+
+import java.util.List;
+
+import org.apache.lucene.index.IndexableField;
+import org.apache.solr.schema.SchemaField;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link LowerCaseStrField}.
+ *
+ * @version $Id$
+ */
+class LowerCaseStrFieldTest
+{
+    private LowerCaseStrField field;
+
+    private SchemaField schemaField;
+
+    @BeforeEach
+    void setUp()
+    {
+        this.field = new LowerCaseStrField();
+        this.schemaField = mock();
+        when(this.schemaField.hasDocValues()).thenReturn(true);
+        when(this.schemaField.stored()).thenReturn(true);
+        when(this.schemaField.indexed()).thenReturn(true);
+        when(this.schemaField.getName()).thenReturn("testField");
+        when(this.schemaField.getType()).thenReturn(this.field);
+    }
+
+    @Test
+    void createFieldsTransformsStringValueToLowerCase()
+    {
+        Object value = "TeStVaLuE";
+
+        List<IndexableField> fields = this.field.createFields(this.schemaField, value);
+
+        assertEquals("testvalue", fields.get(0).stringValue());
+    }
+
+    @Test
+    void createFieldsHandlesNonStringValuesWithoutTransformation()
+    {
+        Object value = 12345;
+
+        List<IndexableField> fields = this.field.createFields(this.schemaField, value);
+
+        assertEquals("12345", fields.get(0).stringValue());
+    }
+
+    @Test
+    void toInternalConvertsStringToLowerCase()
+    {
+        String result = this.field.toInternal("TeStVaLuE");
+
+        assertEquals("testvalue", result);
+    }
+
+    @Test
+    void toInternalHandlesEmptyString()
+    {
+        String result = this.field.toInternal("");
+
+        assertEquals("", result);
+    }
+
+    @Test
+    void toInternalHandlesNullValue()
+    {
+        assertNull(this.field.toInternal(null));
+    }
+}


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-23052

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Introduce a new LowerCaseStrField field type.
* Change the lowercase field type in the search schema to use LowerCaseStrField.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

I unfortunately couldn't find much documentation on how to create custom Solr field types. This implementation is based on an initial implementation suggested by GPT-4o that I've adapted to actually work and remove parts that obviously weren't needed. As the custom field type is only slightly modifying `StrField` I believe it should be fine, but I don't know. Looking at [UUIDField](https://github.com/apache/solr/blob/main/solr/core/src/java/org/apache/solr/schema/UUIDField.java) that also extends `StrField`, it seems similar. The part where I'm least sure is the `createFields` method but from reading the code, it seems like there is no other way to ensure that the lowercase string is stored in the docValues which seems important to me.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
LANG=C.UTF-8 mvn clean install -Pdocker,legacy,integration-tests,snapshotModules,quality,distribution,flavor-integration-tests -pl :xwiki-platform-search-solr-server-plugin,:xwiki-platform-search-solr-server-core-search,:xwiki-platform-search-solr-api
```

Manual test with a full re-index (deleting the core + letting it automatically recreate). Sorting and searching seems to work as expected, it is as expected case-insensitive. The field is returned by the [JSON service](https://extensions.xwiki.org/xwiki/bin/view/Extension/Solr%20Search%20Application#HJSONService), as expected it is lowercase. I checked the cache and there is no more data in the field cache.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * At least initially I suggest no backport.