### PR TITLE
XWIKI-23115: Page displayer in edit mode shows the document's full name instead of its title

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -2770,7 +2770,7 @@ Recursive title display detected!##
     'name': $id,
     'value': $value,
     'class': 'suggest-propertyValues',
-    'data-className': $field.className,
+    'data-className': $services.model.serialize($field.reference.parent, 'default'),
     'data-propertyName': $name
   })
   #if ("$!freeText" != '')


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-23115

# Changes

## Description

* Provide the wiki id in the data class name parameter of the page displayer.

## Clarifications

* When a class has a page field and that field is displayed in edit mode in another wiki that doesn't have the class, the displayer shows the document's full name instead of its title.
* When the wiki id is present, the displayer will use the class from the target document's' wiki

# Screenshots & Video

Before:
![image](https://github.com/user-attachments/assets/e5ba5b25-45ac-43c2-bb57-649e5cd4d165)

After:
![image](https://github.com/user-attachments/assets/4571efc4-410e-4fd3-98da-a727f239a839)


# Executed Tests

Manually tested in different wiki the following code
```
$xwiki.getDocument('wiki:Space.Page').display('page', 'edit')
```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
    * 16.10.x
    * 16.4.x