### PR TITLE
XWIKI-22433: Provide consistency in info / warning / error class usages in templates

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/RegisterIT.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/RegisterIT.java
@@ -270,7 +270,7 @@ class RegisterIT
         // Can't use validateAndRegister here because user existence is not checked by LiveValidation.
         assertFalse(tryToRegister(testUtils, registrationPage, isModal));
         if (closedWiki) {
-            assertTrue(registrationPage.errorMessageInclude("Error: User already exists."));
+            assertTrue(registrationPage.errorMessageInclude("User already exists."));
         } else {
             assertTrue(registrationPage.validationFailureMessagesInclude("User already exists."));
         }
@@ -356,7 +356,7 @@ class RegisterIT
             assertTrue(validateAndRegister(testUtils, isModal, registrationPage), String.format("isModal: %s close "
                 + "wiki: %s withRegistrationConfig: %s", isModal, closedWiki, withRegistrationConfig));
             // TODO: looks like a pretty strange behavior, there might be a message box title missing somewhere
-            String messagePrefix = closedWiki ? "" : "Information ";
+            String messagePrefix = "Information ";
             messagePrefix = !closedWiki&&withRegistrationConfig ? "Welcome ": messagePrefix;
             // TODO: clean up this test with a better final assertion. 
             //  As of now, the string retrieved changes a lot depending on the test parameters

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/DeletePageIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/DeletePageIT.java
@@ -87,7 +87,7 @@ class DeletePageIT
 
     private static final String PAGE_TITLE = "Page title that will be deleted";
 
-    private static final String DELETE_SUCCESSFUL = "Done.";
+    private static final String DELETE_SUCCESSFUL = "Success\nDone.";
 
     @BeforeEach
     void setUp(TestUtils setup, TestReference testReference)
@@ -352,7 +352,7 @@ class DeletePageIT
         // Trigger the actual restore.
         RestoreStatusPage restoreStatusPage = undeletePage.clickRestore();
         restoreStatusPage.waitUntilFinished();
-        assertEquals("Done.", restoreStatusPage.getInfoMessage());
+        assertEquals("Success\nDone.", restoreStatusPage.getInfoMessage());
         page = restoreStatusPage.gotoRestoredPage();
 
         // Check the page have been effectively restored.

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/DeletePageIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/DeletePageIT.java
@@ -87,7 +87,7 @@ class DeletePageIT
 
     private static final String PAGE_TITLE = "Page title that will be deleted";
 
-    private static final String ACTION_SUCCESSFUL = "Success\nDone.";
+    private static final String ACTION_SUCCESSFUL = "Done.";
 
     @BeforeEach
     void setUp(TestUtils setup, TestReference testReference)

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/DeletePageIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/DeletePageIT.java
@@ -87,7 +87,7 @@ class DeletePageIT
 
     private static final String PAGE_TITLE = "Page title that will be deleted";
 
-    private static final String DELETE_SUCCESSFUL = "Success\nDone.";
+    private static final String ACTION_SUCCESSFUL = "Success\nDone.";
 
     @BeforeEach
     void setUp(TestUtils setup, TestReference testReference)
@@ -119,7 +119,7 @@ class DeletePageIT
         deletingPage.waitUntilFinished();
         // Note: it's better to wait instead of using isSuccess() since there could be some timeframe between
         // the hiding of the progress UI and the display of the success message.
-        assertEquals(DELETE_SUCCESSFUL, deletingPage.getInfoMessage());
+        assertEquals(ACTION_SUCCESSFUL, deletingPage.getInfoMessage());
         DeletePageOutcomePage deleteOutcome = deletingPage.getDeletePageOutcomePage();
 
         List<DeletedPageEntry> deletedPagesEntries = deleteOutcome.getDeletedPagesEntries();
@@ -289,7 +289,7 @@ class DeletePageIT
 
         DeletingPage deletingPage = confirmationPage.confirmDeletePage();
         deletingPage.waitUntilFinished();
-        assertEquals(DELETE_SUCCESSFUL, deletingPage.getInfoMessage());
+        assertEquals(ACTION_SUCCESSFUL, deletingPage.getInfoMessage());
         // Check the page have been effectively removed
         ViewPage page = setup.gotoPage(parentReference);
         assertFalse(page.exists());
@@ -352,7 +352,7 @@ class DeletePageIT
         // Trigger the actual restore.
         RestoreStatusPage restoreStatusPage = undeletePage.clickRestore();
         restoreStatusPage.waitUntilFinished();
-        assertEquals("Success\nDone.", restoreStatusPage.getInfoMessage());
+        assertEquals(ACTION_SUCCESSFUL, restoreStatusPage.getInfoMessage());
         page = restoreStatusPage.gotoRestoredPage();
 
         // Check the page have been effectively restored.
@@ -505,7 +505,7 @@ class DeletePageIT
         confirmationPage.clickYes();
         DeletingPage deletingPage = new DeletingPage();
         deletingPage.waitUntilFinished();
-        assertEquals(DELETE_SUCCESSFUL, deletingPage.getInfoMessage());
+        assertEquals(ACTION_SUCCESSFUL, deletingPage.getInfoMessage());
         DeletePageOutcomePage deleteOutcome = deletingPage.getDeletePageOutcomePage();
         List<DeletedPageEntry> deletedPagesEntries = deleteOutcome.getDeletedPagesEntries();
         assertEquals(1, deletedPagesEntries.size());
@@ -527,7 +527,7 @@ class DeletePageIT
         confirmationPage.clickYes();
         DeletingPage deletingPage = new DeletingPage();
         deletingPage.waitUntilFinished();
-        assertEquals(DELETE_SUCCESSFUL, deletingPage.getInfoMessage());
+        assertEquals(ACTION_SUCCESSFUL, deletingPage.getInfoMessage());
         DeletePageOutcomePage deleteOutcome = deletingPage.getDeletePageOutcomePage();
         assertEquals(DOCUMENT_NOT_FOUND, deleteOutcome.getMessage());
         ViewPage viewPage1 = new ViewPage();
@@ -768,7 +768,7 @@ class DeletePageIT
         confirmationPage.clickYes();
         DeletingPage deletingPage = new DeletingPage();
         deletingPage.waitUntilFinished();
-        assertEquals(DELETE_SUCCESSFUL, deletingPage.getInfoMessage());
+        assertEquals(ACTION_SUCCESSFUL, deletingPage.getInfoMessage());
 
         // Verify that a redirect was added and the link was updated.
         viewPage = testUtils.gotoPage(reference);
@@ -806,7 +806,7 @@ class DeletePageIT
         deletingPage.waitUntilFinished();
 
         // Verify that there is no redirect and the links were not altered.
-        assertEquals(DELETE_SUCCESSFUL, deletingPage.getInfoMessage());
+        assertEquals(ACTION_SUCCESSFUL, deletingPage.getInfoMessage());
         DeletePageOutcomePage deleteOutcome = deletingPage.getDeletePageOutcomePage();
         assertEquals(LOGGED_USERNAME, deleteOutcome.getPageDeleter());
         assertEquals(DOCUMENT_NOT_FOUND, deleteOutcome.getMessage());
@@ -853,7 +853,7 @@ class DeletePageIT
         deletingPage.waitUntilFinished();
 
         // Verify that there is no redirect on the child page and backlink was not altered.
-        assertEquals(DELETE_SUCCESSFUL, deletingPage.getInfoMessage());
+        assertEquals(ACTION_SUCCESSFUL, deletingPage.getInfoMessage());
         String newContent =
             String.format(format, testUtils.serializeLocalReference(newTargetReference), childFullName);
         assertEquals(newContent, testUtils.rest().<Page>get(backlinkDocReference).getContent());

--- a/xwiki-platform-core/xwiki-platform-sharepage/xwiki-platform-sharepage-test/xwiki-platform-sharepage-test-pageobjects/src/main/java/org/xwiki/sharepage/test/po/ShareResultDialog.java
+++ b/xwiki-platform-core/xwiki-platform-sharepage/xwiki-platform-sharepage-test/xwiki-platform-sharepage-test-pageobjects/src/main/java/org/xwiki/sharepage/test/po/ShareResultDialog.java
@@ -32,7 +32,7 @@ import org.xwiki.test.ui.po.ViewPage;
  */
 public class ShareResultDialog extends BaseElement
 {
-    @FindBy(xpath = "//div[contains(@class, 'infomessage')]")
+    @FindBy(xpath = "//div[contains(@class, 'infomessage')]//div")
     private WebElement infoDiv;
 
     @FindBy(xpath = "//a[contains(@class, 'share-backlink')]")

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/AbstractRegistrationPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/AbstractRegistrationPage.java
@@ -129,7 +129,7 @@ public abstract class AbstractRegistrationPage extends BasePage
     public boolean errorMessageInclude(String message)
     {
         return !getDriver().findElementsWithoutWaiting(
-                By.xpath("//div[@class = 'box errormessage' and . = '" + message + "']"))
+                By.xpath("//div[contains(@class, 'errormessage') and contains(., '" + message + "')]"))
             .isEmpty();
     }
 

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/RefactoringStatusPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/RefactoringStatusPage.java
@@ -32,8 +32,8 @@ import org.openqa.selenium.support.FindBy;
 public class RefactoringStatusPage extends BasePage
 {
     private static final String MESSAGE_CSS_SELECTOR =
-        ".xcontent.job-status .box.successmessage, .xcontent.job-status .box.errormessage, .xcontent.job-status .box"
-            + ".warningmessage";
+        ".xcontent.job-status .box.successmessage > div, .xcontent.job-status .box.errormessage > div, " 
+            + ".xcontent.job-status .box.warningmessage > div";
 
     @FindBy(css = MESSAGE_CSS_SELECTOR)
     private WebElement message;

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/job/question/ExtensionBreakingQuestion.form.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/job/question/ExtensionBreakingQuestion.form.vm
@@ -39,7 +39,14 @@
   </div>
   #questionButtons($jobStatus)
 #end
-
-#_genericMessage("$warningMessageContent", 'warning', 'warning', 'warning', false, 'deleteWarningExtensions', $escapetool.xml($services.localization.render("job.question.ExtensionBreakingQuestion.${job.type}.title")))
+#set( $parameters = {
+  'text': "$warningMessageContent",
+  'classAffix': 'warning',
+  'iconName': 'warning',
+  'prettyNameKey': 'warning',
+  'extraClass':'deleteWarningExtensions',
+  'title': $escapetool.xml($services.localization.render("job.question.ExtensionBreakingQuestion.${job.type}.title"))
+})
+#_genericMessage($parameters)
 
 #questionFooter()

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/job/question/XClassBreakingQuestion.form.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/job/question/XClassBreakingQuestion.form.vm
@@ -43,7 +43,15 @@
     <button class="btn btn-default btAnswerCancel">$escapetool.xml($services.localization.render(["job.question.${status.jobType}.cancel", 'job.question.button.cancel']))</button>
   </div>
 #end
-#_genericMessage("$errorMessageContent", 'error', 'exclamation', 'error', false, 'deleteWarningXClass', $escapetool.xml($services.localization.render("job.question.XClassBreakingQuestion.${job.type}.forbiddenTitle")))
+#set( $parameters = {
+  'text': "$errorMessageContent",
+  'classAffix': 'error',
+  'iconName': 'exclamation',
+  'prettyNameKey': 'error',
+  'extraClass':'deleteWarningXClass',
+  'title': $escapetool.xml($services.localization.render("job.question.XClassBreakingQuestion.${job.type}.forbiddenTitle"))
+})
+#_genericMessage($parameters)
 #else
 #define ($warningMessageContent)
   <p>$escapetool.xml($services.localization.render("job.question.XClassBreakingQuestion.${job.type}.explanation"))</p>
@@ -62,6 +70,14 @@
   </div>
   #questionButtons($jobStatus)
 #end
-#_genericMessage("$warningMessageContent", 'warning', 'warning', 'warning', false, 'deleteWarningXClass', $escapetool.xml($services.localization.render("job.question.XClassBreakingQuestion.${job.type}.title")))
+#set( $parameters = {
+  'text': "$warningMessageContent",
+  'classAffix': 'warning',
+  'iconName': 'warning',
+  'prettyNameKey': 'warning',
+  'extraClass':'deleteWarningXClass',
+  'title': $escapetool.xml($services.localization.render("job.question.XClassBreakingQuestion.${job.type}.title"))
+})
+#_genericMessage($parameters)
 #end
 #questionFooter()

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -955,55 +955,108 @@ $html
 
 ### This velocity macro aims at providing an element similar to a XWiki Macro-Message in places where this XWikiMacro 
 ### cannot be used.
-#macro(_genericMessage $text $classAffix $iconName $prettyNameKey $isInline $extraClass $title)
-  <#if($isInline)span#{else}div#end class="box ${classAffix}message $!{extraClass}">
-    <span class="icon-block">$services.icon.renderHTML($iconName)</span>
-    <span class="sr-only">$services.localization.render($prettyNameKey)</span>
+## The parameter object can contain $text $classAffix $iconName $prettyNameKey $isInline $extraClass $title
+#macro(_genericMessage $parameters)
+  <#if($parameters.isInline)span#{else}div#end class="box ${parameters.classAffix}message $!{parameters.extraClass}">
+    <span class="icon-block">$services.icon.renderHTML($parameters.iconName)</span>
+    <span class="sr-only">$services.localization.render($parameters.prettyNameKey)</span>
     <div>
-      #if("$!title" != "")<div class="box-title">$!title</div>#end
-      $text
+      #if("$!parameters.title" != "")<div class="box-title">$!parameters.title</div>#end
+      $parameters.text
     </div>
-  </#if($isInline)span#{else}div#end>
+  </#if($parameters.isInline)span#{else}div#end>
 #end
 
 ## Display a block warning message with the content $text.
 #macro(warning $text)
-#_genericMessage($text 'warning' 'warning' 'warning')
+#set( $parameters = {
+'text': $text,
+'classAffix': 'warning',
+'iconName': 'warning',
+'prettyNameKey': 'warning'
+})
+#_genericMessage($parameters)
 #end
 
 ## Display an inline warning message with the content $text.
 #macro(inlineWarning $text)
-#_genericMessage($text 'warning' 'warning' 'warning' true)
+#set( $parameters = {
+  'text': $text,
+  'classAffix': 'warning',
+  'iconName': 'warning',
+  'prettyNameKey': 'warning',
+  'isInline': true
+})
+#_genericMessage($parameters)
 #end
 
 ## Display a block error message with the content $text.  
 #macro(error $text)
-#_genericMessage($text 'error' 'exclamation' 'error')
+#set( $parameters = {
+  'text': $text,
+  'classAffix': 'error',
+  'iconName': 'exclamation',
+  'prettyNameKey': 'error'
+})
+#_genericMessage($parameters)
 #end
 
 ## Display an inline error message with the content $text.
 #macro(inlineError $text)
-  #_genericMessage($text 'error' 'exclamation' 'error' true)
+#set( $parameters = {
+  'text': $text,
+  'classAffix': 'error',
+  'iconName': 'exclamation',
+  'prettyNameKey': 'error',
+  'isInline': true
+})
+#_genericMessage($parameters)
 #end
 
 ## Display a block info message with the content $text.  
 #macro(info $text)
-#_genericMessage($text 'info' 'info' 'info')
+#set( $parameters = {
+  'text': $text,
+  'classAffix': 'info',
+  'iconName': 'info',
+  'prettyNameKey': 'info'
+})
+#_genericMessage($parameters)
 #end
 
 ## Display an inline info message with the content $text.
 #macro(inlineInfo $text)
-  #_genericMessage($text 'info' 'info' 'info' true)
+#set( $parameters = {
+  'text': $text,
+  'classAffix': 'info',
+  'iconName': 'info',
+  'prettyNameKey': 'info',
+  'isInline': true
+})
+#_genericMessage($parameters)
 #end
 
 ## Display a block success message with the content $text.  
 #macro(success $text)
-#_genericMessage($text 'success' 'check' 'success')
+#set( $parameters = {
+  'text': $text,
+  'classAffix': 'success',
+  'iconName': 'check',
+  'prettyNameKey': 'success'
+})
+#_genericMessage($parameters)
 #end
 
 ## Display an inline success message with the content $text.
 #macro(inlineSuccess $text)
-  #_genericMessage($text 'success' 'check' 'success' true)
+#set( $parameters = {
+  'text': $text,
+  'classAffix': 'success',
+  'iconName': 'check',
+  'prettyNameKey': 'success',
+  'isInline': true
+})
+#_genericMessage($parameters)
 #end
 
 #macro(message $text)

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/JobStatusJSONPageTest.java
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/test/java/org/xwiki/web/JobStatusJSONPageTest.java
@@ -20,13 +20,20 @@
 package org.xwiki.web;
 
 import javax.inject.Inject;
+import javax.inject.Named;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.xwiki.icon.IconManagerScriptService;
+import org.xwiki.script.service.ScriptService;
 import org.xwiki.template.TemplateManager;
+import org.xwiki.test.junit5.mockito.MockComponent;
 import org.xwiki.test.page.PageTest;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalToCompressingWhiteSpace;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 /**
  * Page test for {@code job_status_json.vm}.
@@ -38,6 +45,17 @@ class JobStatusJSONPageTest extends PageTest
     @Inject
     private TemplateManager templateManager;
 
+    @MockComponent(classToMock = IconManagerScriptService.class)
+    @Named("icon")
+    private ScriptService iconManagerScriptService;
+
+    @BeforeEach
+    void setup()
+    {
+        when(((IconManagerScriptService)this.iconManagerScriptService).renderHTML(any(String.class)))
+            .then(invocationOnMock -> invocationOnMock.getArgument(0) + "Icon");
+    }
+
     @Test
     void nonExistingJob() throws Exception
     {
@@ -48,7 +66,7 @@ class JobStatusJSONPageTest extends PageTest
 
         assertThat(output.strip(), equalToCompressingWhiteSpace("""
             <div class="box errormessage ">
-            <span class="icon-block">$services.icon.renderHTML($iconName)</span>
+            <span class="icon-block">exclamationIcon</span>
             <span class="sr-only">error</span>
             <div>
                 &#60;test&#62;.notFound


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22433

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Updated the velocimacro to avoid colliding variables
* Updated the docker test tools to not retrieve the icon name that's now in the messages

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Built the changes with:

-     mvn clean install -f xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui + mvn clean install -f xwiki-platform-core/xwiki-platform-test/
-     mvn clean install -f xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/ + mvn clean install -f xwiki-platform-core/xwiki-platform-web/
-      mvn clean install -f xwiki-platform-core/xwiki-platform-sharepage/xwiki-platform-sharepage-test/xwiki-platform-sharepage-test-pageobjects

Then I succesfully ran docker tests:

-     mvn clean install -f xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-docker
-     mvn clean install -f xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker -Pdocker -Dit.test=DeletePageIT
-     mvn clean install -f xwiki-platform-core/xwiki-platform-sharepage/xwiki-platform-sharepage-test/xwiki-platform-sharepage-test-docker/
-     mvn clean install -f xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker -Dit.test=RegisterIT


# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None