### PR TITLE
XWIKI-22996: The contentmenu list of buttons should be coded as a list

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/export_modal.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/export_modal.vm
@@ -23,7 +23,7 @@
  *#
 #macro(exportModal)
   #set ($discard = $xwiki.jsfx.use('uicomponents/exporter/exporter.js', {'forceSkinAction': true}))
-  <div class="modal fade text-left" id="exportModal" tabindex="-1" role="dialog" aria-labelledby="exportModalLabel"
+  <li class="modal fade text-left" id="exportModal" tabindex="-1" role="dialog" aria-labelledby="exportModalLabel"
       aria-hidden="true">
     <div class="modal-dialog">
       <div class="modal-content">
@@ -46,7 +46,7 @@
         </div>
       </div>
     </div>
-  </div>
+  </li>
   #if ($doc.documentReference.name == 'WebHome' && $xwiki.exists('XWiki.ExportDocumentTree'))
     #exportTreeModal()
   #end
@@ -203,7 +203,7 @@
 #end
 ##
 #macro(exportTreeModal)
-  <div class="modal fade text-left" id="exportTreeModal" tabindex="-1" role="dialog"
+  <li class="modal fade text-left" id="exportTreeModal" tabindex="-1" role="dialog"
       aria-labelledby="exportTreeModalLabel" aria-hidden="true">
     <div class="modal-dialog">
       <div class="modal-content">
@@ -237,5 +237,5 @@
         </div>
       </div>
     </div>
-  </div>
+  </li>
 #end

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsWatchUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsWatchUIX.xml
@@ -575,7 +575,7 @@
     &lt;span class="fa $watchIcon"&gt;&lt;/span&gt; $watchText
   &lt;/a&gt;
 &lt;/li&gt;
-&lt;div class="modal fade" tabindex="-1" role="dialog" id="watchModal"&gt;
+&lt;li class="modal fade" tabindex="-1" role="dialog" id="watchModal"&gt;
   &lt;div class="modal-dialog" role="document"&gt;
     &lt;div class="modal-content"&gt;
       &lt;div class="modal-header"&gt;
@@ -682,7 +682,7 @@
       &lt;/div&gt;
     &lt;/div&gt;&lt;!-- /.modal-content --&gt;
   &lt;/div&gt;&lt;!-- /.modal-dialog --&gt;
-&lt;/div&gt;&lt;!-- /.modal --&gt;
+&lt;/li&gt;&lt;!-- /.modal --&gt;
 {{/html}}
 #end
 {{/velocity}}</content>


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22996

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Made the few modals in the list `li`s instead of leaving them as `div`s

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*The webstandard WCAG tests based on the Dutch accessibility guidelines are a bit stricter than WCAG tested with Axe core here, it does not allow hidden elements to be child of a `ul` if they are not `li`s
* PageObjects and tests use selectors that rely only on the ID of these modals, so there's no changes needed on them despite the change in the DOM

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

![Screenshot from 2025-04-17 11-36-19](https://github.com/user-attachments/assets/c717abe8-1f25-4134-8de9-4abd877b2106)
We can see that as the Dutch web guidelines expect, all the children of the ul are now `li`.
# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Tested on a local instance, the changes did not impact the way the modals are displayed or the way they work.

I tried to test automatically what was found on CI and couldn't reproduce the errors...
Note that I had warnings that triggered logging the content of pretty much every single page and made the attempts extra slow. I had to toggle https://github.com/xwiki/xwiki-platform/blob/ba27f91dac80069a1a2e2e29e0f5f9ad68189310/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards/src/test/it/org/xwiki/test/webstandards/framework/DefaultValidationTest.java#L197 off to be able to even run some of these testsefficiently (log flooding reduced testing speed significantly and decrease the readablility of results...)
# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, same as https://github.com/xwiki/xwiki-platform/pull/4016 