### PR TITLE
XWIKI-21417: BaseObject#set always set the metadata dirty flag of the owner doc to true

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-oldcore/pom.xml
@@ -791,7 +791,6 @@
                 **/objects/classes/ListItem.java,
                 **/objects/classes/NumberClass.java,
                 **/objects/classes/PasswordClass.java,
-                **/objects/classes/PropertyClassInterface.java,
                 **/objects/classes/PropertyClass.java,
                 **/objects/classes/StaticListClass.java,
                 **/objects/classes/StringClass.java,

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseObject.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseObject.java
@@ -366,7 +366,7 @@ public class BaseObject extends BaseCollection<BaseObjectReference> implements O
         PropertyClass pclass = (PropertyClass) bclass.get(fieldname);
         BaseProperty prop = (BaseProperty) safeget(fieldname);
         if ((value instanceof String) && (pclass != null)) {
-            prop = pclass.fromString((String) value);
+            prop = pclass.fromString((String) value, prop);
         } else {
             if ((prop == null) && (pclass != null)) {
                 prop = pclass.newProperty();

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BaseClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BaseClass.java
@@ -409,14 +409,23 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
         for (PropertyClass property : (Collection<PropertyClass>) getFieldList()) {
             String name = property.getName();
             Object formvalues = map.get(name);
+            BaseProperty baseProperty = null;
+            try {
+                PropertyInterface propertyInterface = object.get(name);
+                if (propertyInterface instanceof BaseProperty obtainedProperty) {
+                    baseProperty = obtainedProperty;
+                }
+            } catch (XWikiException e) {
+                LOGGER.error("Error while loading property [{}] from object [{}]", name, object, e);
+            }
             if (formvalues != null) {
                 BaseProperty objprop;
                 if (formvalues instanceof String[]) {
-                    objprop = property.fromStringArray(((String[]) formvalues));
+                    objprop = property.fromStringArray(((String[]) formvalues), baseProperty);
                 } else if (formvalues instanceof String) {
-                    objprop = property.fromString(formvalues.toString());
+                    objprop = property.fromString(formvalues.toString(), baseProperty);
                 } else {
-                    objprop = property.fromValue(formvalues);
+                    objprop = property.fromValue(formvalues, baseProperty);
                 }
 
                 if (objprop != null) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BooleanClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BooleanClass.java
@@ -36,6 +36,11 @@ import com.xpn.xwiki.objects.BaseProperty;
 import com.xpn.xwiki.objects.IntegerProperty;
 import com.xpn.xwiki.objects.meta.PropertyMetaClass;
 
+/**
+ * Representation of a boolean property.
+ *
+ * @version $Id$
+ */
 public class BooleanClass extends PropertyClass
 {
     private static final long serialVersionUID = 1L;
@@ -47,12 +52,19 @@ public class BooleanClass extends PropertyClass
 
     /** Other string values that might be used to represent "false" values. */
     private static final Pattern FALSE_PATTERN = Pattern.compile("no|false", Pattern.CASE_INSENSITIVE);
-    
+
+    /**
+     * Constructor taking the given metaclass.
+     * @param wclass the metaclass to use.
+     */
     public BooleanClass(PropertyMetaClass wclass)
     {
         super(XCLASSNAME, "Boolean", wclass);
     }
 
+    /**
+     * Default constructor.
+     */
     public BooleanClass()
     {
         this(null);
@@ -98,9 +110,9 @@ public class BooleanClass extends PropertyClass
     }
 
     @Override
-    public BaseProperty fromString(String value)
+    public BaseProperty fromString(String value, BaseProperty baseProperty)
     {
-        BaseProperty property = getCurrentOrNewProperty();
+        BaseProperty property = getCurrentOrNewProperty(baseProperty);
         Number nvalue = null;
         if (StringUtils.isNotEmpty(value)) {
             if (StringUtils.isNumeric(value)) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BooleanClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BooleanClass.java
@@ -100,7 +100,7 @@ public class BooleanClass extends PropertyClass
     @Override
     public BaseProperty fromString(String value)
     {
-        BaseProperty property = newProperty();
+        BaseProperty property = getCurrentOrNewProperty();
         Number nvalue = null;
         if (StringUtils.isNotEmpty(value)) {
             if (StringUtils.isNumeric(value)) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/DateClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/DateClass.java
@@ -172,7 +172,7 @@ public class DateClass extends PropertyClass
     @Override
     public BaseProperty fromString(String value)
     {
-        BaseProperty property = newProperty();
+        BaseProperty property = getCurrentOrNewProperty();
 
         if (StringUtils.isEmpty(value)) {
             if (getEmptyIsToday() == 1) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/DateClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/DateClass.java
@@ -170,9 +170,9 @@ public class DateClass extends PropertyClass
     }
 
     @Override
-    public BaseProperty fromString(String value)
+    public BaseProperty fromString(String value, BaseProperty baseProperty)
     {
-        BaseProperty property = getCurrentOrNewProperty();
+        BaseProperty property = getCurrentOrNewProperty(baseProperty);
 
         if (StringUtils.isEmpty(value)) {
             if (getEmptyIsToday() == 1) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/GroupsClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/GroupsClass.java
@@ -139,15 +139,15 @@ public class GroupsClass extends ListClass
     }
 
     @Override
-    public BaseProperty fromString(String value)
+    public BaseProperty fromString(String value, BaseProperty baseProperty)
     {
-        BaseProperty prop = getCurrentOrNewProperty();
+        BaseProperty prop = getCurrentOrNewProperty(baseProperty);
         prop.setValue(value);
         return prop;
     }
 
     @Override
-    public BaseProperty fromStringArray(String[] strings)
+    public BaseProperty fromStringArray(String[] strings, BaseProperty baseProperty)
     {
         List<String> list;
         if ((strings.length == 1) && (getDisplayType().equals(DISPLAYTYPE_INPUT) || isMultiSelect())) {
@@ -156,7 +156,7 @@ public class GroupsClass extends ListClass
             list = Arrays.asList(strings);
         }
 
-        BaseProperty prop = getCurrentOrNewProperty();
+        BaseProperty prop = getCurrentOrNewProperty(baseProperty);
         fromList(prop, list);
         return prop;
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/GroupsClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/GroupsClass.java
@@ -141,7 +141,7 @@ public class GroupsClass extends ListClass
     @Override
     public BaseProperty fromString(String value)
     {
-        BaseProperty prop = newProperty();
+        BaseProperty prop = getCurrentOrNewProperty();
         prop.setValue(value);
         return prop;
     }
@@ -156,7 +156,7 @@ public class GroupsClass extends ListClass
             list = Arrays.asList(strings);
         }
 
-        BaseProperty prop = newProperty();
+        BaseProperty prop = getCurrentOrNewProperty();
         fromList(prop, list);
         return prop;
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/LevelsClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/LevelsClass.java
@@ -106,15 +106,15 @@ public class LevelsClass extends ListClass
     }
 
     @Override
-    public BaseProperty fromString(String value)
+    public BaseProperty fromString(String value, BaseProperty baseProperty)
     {
-        BaseProperty prop = getCurrentOrNewProperty();
+        BaseProperty prop = getCurrentOrNewProperty(baseProperty);
         prop.setValue(value);
         return prop;
     }
 
     @Override
-    public BaseProperty fromStringArray(String[] strings)
+    public BaseProperty fromStringArray(String[] strings, BaseProperty baseProperty)
     {
         List<String> list;
         if ((strings.length == 1) && (getDisplayType().equals(DISPLAYTYPE_INPUT) || isMultiSelect())) {
@@ -123,7 +123,7 @@ public class LevelsClass extends ListClass
             list = Arrays.asList(strings);
         }
 
-        BaseProperty prop = getCurrentOrNewProperty();
+        BaseProperty prop = getCurrentOrNewProperty(baseProperty);
         fromList(prop, list, true);
         return prop;
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/LevelsClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/LevelsClass.java
@@ -108,7 +108,7 @@ public class LevelsClass extends ListClass
     @Override
     public BaseProperty fromString(String value)
     {
-        BaseProperty prop = newProperty();
+        BaseProperty prop = getCurrentOrNewProperty();
         prop.setValue(value);
         return prop;
     }
@@ -123,7 +123,7 @@ public class LevelsClass extends ListClass
             list = Arrays.asList(strings);
         }
 
-        BaseProperty prop = newProperty();
+        BaseProperty prop = getCurrentOrNewProperty();
         fromList(prop, list, true);
         return prop;
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
@@ -591,7 +591,7 @@ public abstract class ListClass extends PropertyClass
     @Override
     public BaseProperty fromString(String value)
     {
-        BaseProperty prop = newProperty();
+        BaseProperty prop = getCurrentOrNewProperty();
         if (isMultiSelect()) {
             ((ListProperty) prop).setList(getListFromString(value, getSeparators(), false));
         } else {
@@ -606,7 +606,7 @@ public abstract class ListClass extends PropertyClass
         if (!isMultiSelect()) {
             return fromString(strings[0]);
         }
-        BaseProperty prop = newProperty();
+        BaseProperty prop = getCurrentOrNewProperty();
         // FIXME: this should be probably removed since we can never reach it.
         if (prop instanceof StringProperty) {
             return fromString(strings[0]);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
@@ -589,9 +589,9 @@ public abstract class ListClass extends PropertyClass
     }
 
     @Override
-    public BaseProperty fromString(String value)
+    public BaseProperty fromString(String value, BaseProperty baseProperty)
     {
-        BaseProperty prop = getCurrentOrNewProperty();
+        BaseProperty prop = getCurrentOrNewProperty(baseProperty);
         if (isMultiSelect()) {
             ((ListProperty) prop).setList(getListFromString(value, getSeparators(), false));
         } else {
@@ -601,12 +601,12 @@ public abstract class ListClass extends PropertyClass
     }
 
     @Override
-    public BaseProperty fromStringArray(String[] strings)
+    public BaseProperty fromStringArray(String[] strings, BaseProperty baseProperty)
     {
         if (!isMultiSelect()) {
             return fromString(strings[0]);
         }
-        BaseProperty prop = getCurrentOrNewProperty();
+        BaseProperty prop = getCurrentOrNewProperty(baseProperty);
         // FIXME: this should be probably removed since we can never reach it.
         if (prop instanceof StringProperty) {
             return fromString(strings[0]);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/NumberClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/NumberClass.java
@@ -121,9 +121,9 @@ public class NumberClass extends PropertyClass
     }
 
     @Override
-    public BaseProperty fromString(String value)
+    public BaseProperty fromString(String value, BaseProperty baseProperty)
     {
-        BaseProperty property = getCurrentOrNewProperty();
+        BaseProperty property = getCurrentOrNewProperty(baseProperty);
         String ntype = getNumberType();
         Number nvalue = null;
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/NumberClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/NumberClass.java
@@ -123,7 +123,7 @@ public class NumberClass extends PropertyClass
     @Override
     public BaseProperty fromString(String value)
     {
-        BaseProperty property = newProperty();
+        BaseProperty property = getCurrentOrNewProperty();
         String ntype = getNumberType();
         Number nvalue = null;
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PasswordClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PasswordClass.java
@@ -74,7 +74,7 @@ public class PasswordClass extends StringClass
         if (value.equals(FORM_PASSWORD_PLACEHODLER)) {
             return null;
         }
-        BaseProperty property = newProperty();
+        BaseProperty property = getCurrentOrNewProperty();
         if (value.isEmpty() || value.startsWith(HASH_IDENTIFIER + SEPARATOR)
             || value.startsWith(CRYPT_IDENTIFIER + SEPARATOR)) {
             property.setValue(value);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PasswordClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PasswordClass.java
@@ -69,12 +69,12 @@ public class PasswordClass extends StringClass
     }
 
     @Override
-    public BaseProperty fromString(String value)
+    public BaseProperty fromString(String value, BaseProperty baseProperty)
     {
         if (value.equals(FORM_PASSWORD_PLACEHODLER)) {
             return null;
         }
-        BaseProperty property = getCurrentOrNewProperty();
+        BaseProperty property = getCurrentOrNewProperty(baseProperty);
         if (value.isEmpty() || value.startsWith(HASH_IDENTIFIER + SEPARATOR)
             || value.startsWith(CRYPT_IDENTIFIER + SEPARATOR)) {
             property.setValue(value);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PropertyClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PropertyClass.java
@@ -48,6 +48,7 @@ import com.xpn.xwiki.internal.xml.XMLAttributeValueFilter;
 import com.xpn.xwiki.objects.BaseCollection;
 import com.xpn.xwiki.objects.BaseObject;
 import com.xpn.xwiki.objects.BaseProperty;
+import com.xpn.xwiki.objects.PropertyInterface;
 import com.xpn.xwiki.objects.meta.MetaClass;
 import com.xpn.xwiki.objects.meta.PropertyMetaClass;
 import com.xpn.xwiki.validation.XWikiValidationStatus;
@@ -193,6 +194,33 @@ public class PropertyClass extends BaseCollection<ClassPropertyReference>
     public BaseProperty fromString(String value)
     {
         return null;
+    }
+
+    /**
+     * Retrieve the already existing base property based on current name, or create a new one.
+     *
+     * @return the existing {@link BaseProperty} or a new one.
+     * @since 17.3.0RC1
+     */
+    @Unstable
+    protected BaseProperty getCurrentOrNewProperty()
+    {
+        PropertyInterface propertyInterface = null;
+        if (getObject() != null && getName() != null) {
+            try {
+                propertyInterface = getObject().get(getName());
+            } catch (XWikiException e) {
+                // in theory it should never really happen, I'm not sure why the exception is thrown...
+                LOGGER.error(String.format("Error while retrieving property [%s]", getName()), e);
+            }
+        }
+        BaseProperty property;
+        if (propertyInterface instanceof BaseProperty propertyField) {
+            property = propertyField;
+        } else {
+            property = newProperty();
+        }
+        return property;
     }
 
     public BaseProperty newPropertyfromXML(Element ppcel)

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PropertyClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PropertyClass.java
@@ -48,7 +48,6 @@ import com.xpn.xwiki.internal.xml.XMLAttributeValueFilter;
 import com.xpn.xwiki.objects.BaseCollection;
 import com.xpn.xwiki.objects.BaseObject;
 import com.xpn.xwiki.objects.BaseProperty;
-import com.xpn.xwiki.objects.PropertyInterface;
 import com.xpn.xwiki.objects.meta.MetaClass;
 import com.xpn.xwiki.objects.meta.PropertyMetaClass;
 import com.xpn.xwiki.validation.XWikiValidationStatus;
@@ -193,6 +192,12 @@ public class PropertyClass extends BaseCollection<ClassPropertyReference>
     @Override
     public BaseProperty fromString(String value)
     {
+        return fromString(value, null);
+    }
+
+    @Override
+    public BaseProperty fromString(String value, BaseProperty baseProperty)
+    {
         return null;
     }
 
@@ -203,24 +208,9 @@ public class PropertyClass extends BaseCollection<ClassPropertyReference>
      * @since 17.3.0RC1
      */
     @Unstable
-    protected BaseProperty getCurrentOrNewProperty()
+    protected BaseProperty getCurrentOrNewProperty(BaseProperty property)
     {
-        PropertyInterface propertyInterface = null;
-        if (getObject() != null && getName() != null) {
-            try {
-                propertyInterface = getObject().get(getName());
-            } catch (XWikiException e) {
-                // in theory it should never really happen, I'm not sure why the exception is thrown...
-                LOGGER.error(String.format("Error while retrieving property [%s]", getName()), e);
-            }
-        }
-        BaseProperty property;
-        if (propertyInterface instanceof BaseProperty propertyField) {
-            property = propertyField;
-        } else {
-            property = newProperty();
-        }
-        return property;
+        return (property != null) ? property : newProperty();
     }
 
     public BaseProperty newPropertyfromXML(Element ppcel)
@@ -724,7 +714,12 @@ public class PropertyClass extends BaseCollection<ClassPropertyReference>
 
     public BaseProperty fromStringArray(String[] strings)
     {
-        return fromString(strings[0]);
+        return fromStringArray(strings, null);
+    }
+
+    public BaseProperty fromStringArray(String[] strings, BaseProperty baseProperty)
+    {
+        return fromString(strings[0], baseProperty);
     }
 
     public boolean isValidColumnTypes(Property hibprop)
@@ -735,7 +730,13 @@ public class PropertyClass extends BaseCollection<ClassPropertyReference>
     @Override
     public BaseProperty fromValue(Object value)
     {
-        BaseProperty property = newProperty();
+        return fromValue(value, null);
+    }
+
+    @Override
+    public BaseProperty fromValue(Object value, BaseProperty baseProperty)
+    {
+        BaseProperty property = getCurrentOrNewProperty(baseProperty);
         if (property != null) {
             property.setValue(value);
             return property;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PropertyClassInterface.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PropertyClassInterface.java
@@ -20,6 +20,8 @@
 
 package com.xpn.xwiki.objects.classes;
 
+import org.xwiki.stability.Unstable;
+
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.objects.BaseCollection;
 import com.xpn.xwiki.objects.BaseProperty;
@@ -36,17 +38,85 @@ import com.xpn.xwiki.objects.PropertyInterface;
  */
 public interface PropertyClassInterface extends ObjectInterface, PropertyInterface
 {
+    /**
+     * Serialize the given property as a string.
+     * @param property the property to serialize.
+     * @return the serialized property.
+     */
     String toString(BaseProperty property);
 
+    /**
+     * Creates a new property and set its value based on the given string.
+     * @param value the value to set in the new property.
+     * @return the created property
+     */
     BaseProperty fromString(String value);
 
+    /**
+     * Sets the value of the given property from the given string parameter. Note that if the given property is
+     * {@code null} then the method should create a new property and set its value.
+     * @param value the value to set in the new property.
+     * @param baseProperty the property instance to set the value for, or {@code null} to create a new property.
+     * @return the modified property
+     * @since 17.4.0RC1
+     */
+    @Unstable
+    default BaseProperty fromString(String value, BaseProperty baseProperty)
+    {
+        return fromString(value);
+    }
+
+    /**
+     * Creates a new property and set its value based on the given parameter.
+     * @param value the value to set in the new property.
+     * @return the created property
+     */
     BaseProperty fromValue(Object value);
 
+    /**
+     * Sets the value of the given property from the given parameter. Note that if the given property is {@code null}
+     * then the method should create a new property and set its value.
+     *
+     * @param value the value to set in the new property.
+     * @param baseProperty the property instance to set the value for, or {@code null} to create a new property.
+     * @return the modified property
+     * @since 17.4.0RC1
+     */
+    @Unstable
+    default BaseProperty fromValue(Object value, BaseProperty baseProperty)
+    {
+        return fromValue(value);
+    }
+
+    /**
+     * Output in the given buffer, hidden form elements for the property identified by the name in the given object.
+     * @param buffer the buffer where to output the result
+     * @param name the name of the property for which to output a form
+     * @param prefix the prefix to use for the form id and name elements
+     * @param object the object where to find the property
+     * @param context the context to use
+     */
     void displayHidden(StringBuffer buffer, String name, String prefix, BaseCollection object, XWikiContext context);
 
+    /**
+     * Output in the given buffer, a visual representation for the property identified by the name in the given object.
+     * @param buffer the buffer where to output the result
+     * @param name the name of the property for which to output a view of the property
+     * @param prefix the prefix to use for the form id and name elements
+     * @param object the object where to find the property
+     * @param context the context to use
+     */
     void displayView(StringBuffer buffer, String name, String prefix, BaseCollection object, XWikiContext context);
 
     /**
+     * Output in the given buffer, a visual representation for the property identified by the name in the given object.
+     * @param buffer the buffer where to output the result
+     * @param name the name of the property for which to output a view of the property
+     * @param prefix the prefix to use for the form id and name elements
+     * @param object the object where to find the property
+     * @param isolated {@code true} if the representation should be computed outside of the context of the current
+     * document reference.
+     * @param context the context to use
      * @since 13.0
      */
     default void displayView(StringBuffer buffer, String name, String prefix, BaseCollection object, boolean isolated,
@@ -55,9 +125,25 @@ public interface PropertyClassInterface extends ObjectInterface, PropertyInterfa
         displayView(buffer, name, prefix, object, context);
     }
 
+    /**
+     * Output in the given buffer, a representation allowing to edit the property identified by the name in the given
+     * object.
+     * @param buffer the buffer where to output the result
+     * @param name the name of the property for which to output a view of the property
+     * @param prefix the prefix to use for the form id and name elements
+     * @param object the object where to find the property
+     * document reference.
+     * @param context the context to use
+     */
     void displayEdit(StringBuffer buffer, String name, String prefix, BaseCollection object, XWikiContext context);
 
+    /**
+     * @return a new property corresponding to the current class.
+     */
     BaseProperty newProperty();
 
+    /**
+     * Invalidate all caches used in the implementations (e.g. the cache of displayers)
+     */
     void flushCache();
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/StringClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/StringClass.java
@@ -80,9 +80,9 @@ public class StringClass extends PropertyClass
     }
 
     @Override
-    public BaseProperty fromString(String value)
+    public BaseProperty fromString(String value, BaseProperty baseProperty)
     {
-        BaseProperty property = getCurrentOrNewProperty();
+        BaseProperty property = getCurrentOrNewProperty(baseProperty);
         property.setValue(value);
         return property;
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/StringClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/StringClass.java
@@ -82,7 +82,7 @@ public class StringClass extends PropertyClass
     @Override
     public BaseProperty fromString(String value)
     {
-        BaseProperty property = newProperty();
+        BaseProperty property = getCurrentOrNewProperty();
         property.setValue(value);
         return property;
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/UsersClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/UsersClass.java
@@ -156,7 +156,7 @@ public class UsersClass extends ListClass
     @Override
     public BaseProperty fromString(String value)
     {
-        BaseProperty prop = newProperty();
+        BaseProperty prop = getCurrentOrNewProperty();
         prop.setValue(value);
         return prop;
     }
@@ -170,7 +170,7 @@ public class UsersClass extends ListClass
         } else {
             list = Arrays.asList(strings);
         }
-        BaseProperty prop = newProperty();
+        BaseProperty prop = getCurrentOrNewProperty();
         fromList(prop, list);
         return prop;
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/UsersClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/UsersClass.java
@@ -154,15 +154,15 @@ public class UsersClass extends ListClass
     }
 
     @Override
-    public BaseProperty fromString(String value)
+    public BaseProperty fromString(String value, BaseProperty baseProperty)
     {
-        BaseProperty prop = getCurrentOrNewProperty();
+        BaseProperty prop = getCurrentOrNewProperty(baseProperty);
         prop.setValue(value);
         return prop;
     }
 
     @Override
-    public BaseProperty fromStringArray(String[] strings)
+    public BaseProperty fromStringArray(String[] strings, BaseProperty baseProperty)
     {
         List<String> list;
         if ((strings.length == 1) && (getDisplayType().equals(DISPLAYTYPE_INPUT) || isMultiSelect())) {
@@ -170,7 +170,7 @@ public class UsersClass extends ListClass
         } else {
             list = Arrays.asList(strings);
         }
-        BaseProperty prop = getCurrentOrNewProperty();
+        BaseProperty prop = getCurrentOrNewProperty(baseProperty);
         fromList(prop, list);
         return prop;
     }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

* https://jira.xwiki.org/browse/XWIKI-21417

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

  * Provide a new API to retrieve current property or create a new one, use that call in all fromString and fromStringArray methods

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Ran `mvn clean install -Pquality` on both oldcore and legacy-oldcore and executed docker test in `xwiki-platform-appwithinminutes-test-docker`.

:warning: However we need dedicated unit test and at least a manual test.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * No: feels too dangerous for backport