### PR TITLE
XWIKI-23122: Add an API to check if a wiki contains any user

### DIFF
--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-api/src/main/java/org/xwiki/user/UserManager.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-api/src/main/java/org/xwiki/user/UserManager.java
@@ -20,6 +20,8 @@
 package org.xwiki.user;
 
 import org.xwiki.component.annotation.Role;
+import org.xwiki.model.reference.WikiReference;
+import org.xwiki.stability.Unstable;
 
 /**
  * CRUD operations on users. Note that for retrieving a user's properties you should use a
@@ -38,4 +40,16 @@ public interface UserManager
      *     the user
      */
     boolean exists(UserReference userReference) throws UserException;
+
+    /**
+     * @param wiki the reference of the wiki where to check of users exist
+     * @return true if at least one user is available on that target wiki
+     * @throws UserException when failing to check if a user exist on the target wiki
+     * @since 17.3.0RC1
+     */
+    @Unstable
+    default boolean hasUsers(WikiReference wiki) throws UserException
+    {
+        return false;
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-api/src/main/java/org/xwiki/user/UserManager.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-api/src/main/java/org/xwiki/user/UserManager.java
@@ -42,10 +42,13 @@ public interface UserManager
     boolean exists(UserReference userReference) throws UserException;
 
     /**
-     * @param wiki the reference of the wiki where to check of users exist
+     * Verify if a wiki contains any user. This method only look at the given wiki, it's not taking into account global
+     * users when the target wiki is a sub-wiki.
+     * 
+     * @param wiki the reference of the wiki where to search for users
      * @return true if at least one user is available on that target wiki
      * @throws UserException when failing to check if a user exist on the target wiki
-     * @since 17.3.0RC1
+     * @since 17.4.0RC1
      */
     @Unstable
     default boolean hasUsers(WikiReference wiki) throws UserException

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/DefaultUserManager.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/DefaultUserManager.java
@@ -26,12 +26,14 @@ import javax.inject.Singleton;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.manager.ComponentLookupException;
 import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.model.reference.WikiReference;
 import org.xwiki.user.CurrentUserReference;
 import org.xwiki.user.GuestUserReference;
 import org.xwiki.user.SuperAdminUserReference;
 import org.xwiki.user.UserException;
 import org.xwiki.user.UserManager;
 import org.xwiki.user.UserReference;
+import org.xwiki.user.internal.document.DocumentUserManager;
 
 /**
  * Document-based implementation of {@link UserManager} which proxies to the specific UserManager implementation
@@ -47,6 +49,10 @@ public class DefaultUserManager implements UserManager
     @Inject
     @Named("context")
     private ComponentManager componentManager;
+
+    @Inject
+    @Named(DocumentUserManager.HINT)
+    private UserManager documentUserManager;
 
     @Override
     public boolean exists(UserReference userReference) throws UserException
@@ -79,5 +85,11 @@ public class DefaultUserManager implements UserManager
                 "Failed to find user manager for role [%s] and hint [%s]", UserManager.class.getName(),
                 userReference.getClass().getName()), e);
         }
+    }
+
+    @Override
+    public boolean hasUsers(WikiReference wiki) throws UserException
+    {
+        return this.documentUserManager.hasUsers(wiki);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/document/CurrentUserManager.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/document/CurrentUserManager.java
@@ -87,5 +87,4 @@ public class CurrentUserManager implements UserManager
     {
         return this.contextProvider.get();
     }
-
 }

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/document/DocumentUserManager.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/document/DocumentUserManager.java
@@ -26,6 +26,10 @@ import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.WikiReference;
+import org.xwiki.query.Query;
+import org.xwiki.query.QueryException;
+import org.xwiki.query.QueryManager;
 import org.xwiki.user.UserException;
 import org.xwiki.user.UserManager;
 import org.xwiki.user.UserReference;
@@ -44,15 +48,28 @@ import com.xpn.xwiki.internal.mandatory.XWikiUsersDocumentInitializer;
  * @since 12.2
  */
 @Component
-@Named("org.xwiki.user.internal.document.DocumentUserReference")
+@Named(DocumentUserManager.HINT)
 @Singleton
 public class DocumentUserManager implements UserManager
 {
+    /**
+     * The role hint of the component.
+     * 
+     * @since 17.3.0RC1
+     */
+    public static final String HINT = "org.xwiki.user.internal.document.DocumentUserReference";
+
     @Inject
     private Provider<XWikiContext> xwikiContextProvider;
 
     @Inject
     private WikiDescriptorManager wikiDescriptorManager;
+
+    @Inject
+    private QueryManager queryManager;
+
+    @Inject
+    private UserCache userCache;
 
     @Override
     public boolean exists(UserReference userReference) throws UserException
@@ -93,5 +110,25 @@ public class DocumentUserManager implements UserManager
                 e);
         }
         return result;
+    }
+
+    @Override
+    public boolean hasUsers(WikiReference wiki) throws UserException
+    {
+        return this.userCache.computeIfAbsent(wiki, this::hasUserInternal);
+    }
+
+    private Boolean hasUserInternal(WikiReference wiki) throws UserException
+    {
+        try {
+            Query query = this.queryManager
+                .createQuery("select doc.id from Document doc, doc.object(XWiki.XWikiUsers) as user", Query.XWQL);
+            query.setLimit(1);
+            query.setWiki(wiki.getName());
+
+            return !query.execute().isEmpty();
+        } catch (QueryException e) {
+            throw new UserException("Failed to query users", e);
+        }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/document/DocumentUserManager.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/document/DocumentUserManager.java
@@ -55,7 +55,7 @@ public class DocumentUserManager implements UserManager
     /**
      * The role hint of the component.
      * 
-     * @since 17.3.0RC1
+     * @since 17.4.0RC1
      */
     public static final String HINT = "org.xwiki.user.internal.document.DocumentUserReference";
 

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/document/UserCache.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/document/UserCache.java
@@ -38,7 +38,7 @@ import org.xwiki.model.reference.WikiReference;
  * Cache various user related information.
  * 
  * @version $Id$
- * @since 17.3.0RC1
+ * @since 17.4.0RC1
  */
 @Component(roles = UserCache.class)
 @Singleton

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/document/UserCache.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/document/UserCache.java
@@ -1,0 +1,111 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.user.internal.document;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.apache.commons.lang3.function.FailableFunction;
+import org.xwiki.cache.Cache;
+import org.xwiki.cache.CacheException;
+import org.xwiki.cache.CacheManager;
+import org.xwiki.cache.config.LRUCacheConfiguration;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.manager.ComponentLifecycleException;
+import org.xwiki.component.phase.Disposable;
+import org.xwiki.component.phase.Initializable;
+import org.xwiki.component.phase.InitializationException;
+import org.xwiki.model.reference.WikiReference;
+
+/**
+ * Cache various user related information.
+ * 
+ * @version $Id$
+ * @since 17.3.0RC1
+ */
+@Component(roles = UserCache.class)
+@Singleton
+public class UserCache implements Initializable, Disposable
+{
+    @Inject
+    private CacheManager cacheManager;
+
+    private Cache<Boolean> hasUserCache;
+
+    @Override
+    public void initialize() throws InitializationException
+    {
+        try {
+            this.hasUserCache = this.cacheManager.createNewCache(new LRUCacheConfiguration("use.hasUsers"));
+        } catch (CacheException e) {
+            throw new InitializationException("Failed to create the cache to store if a user exist in a given wiki", e);
+        }
+    }
+
+    @Override
+    public void dispose() throws ComponentLifecycleException
+    {
+        this.hasUserCache.dispose();
+    }
+
+    /**
+     * @param <E> the type of the exception
+     * @param wikiReference the reference of the wiki
+     * @param function the function to use to check of a user exist
+     * @return true if a user exist for the passed wiki, false otherwise
+     * @throws E when failing to check if a user exist
+     */
+    public <E extends Throwable> boolean computeIfAbsent(WikiReference wikiReference,
+        FailableFunction<WikiReference, Boolean, E> function) throws E
+    {
+        Boolean hasUser = this.hasUserCache.get(wikiReference.getName());
+
+        if (hasUser == null) {
+            synchronized (this.hasUserCache) {
+                hasUser = function.apply(wikiReference);
+
+                this.hasUserCache.set(wikiReference.getName(), hasUser);
+            }
+        }
+
+        return hasUser;
+    }
+
+    /**
+     * @param wikiReference the reference of the wiki
+     * @param hasUsers true if a user exist for the passed wiki, false otherwise
+     */
+    public void set(WikiReference wikiReference, Boolean hasUsers)
+    {
+        if (hasUsers == null) {
+            invalidate(wikiReference);
+        } else {
+            this.hasUserCache.set(wikiReference.getName(), hasUsers);
+        }
+    }
+
+    /**
+     * @param wikiReference the reference of the wiki for which to invalidate the cache
+     */
+    public void invalidate(WikiReference wikiReference)
+    {
+        this.hasUserCache.remove(wikiReference.getName());
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/document/UserCache.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/document/UserCache.java
@@ -53,7 +53,7 @@ public class UserCache implements Initializable, Disposable
     public void initialize() throws InitializationException
     {
         try {
-            this.hasUserCache = this.cacheManager.createNewCache(new LRUCacheConfiguration("use.hasUsers"));
+            this.hasUserCache = this.cacheManager.createNewCache(new LRUCacheConfiguration("user.hasUsers"));
         } catch (CacheException e) {
             throw new InitializationException("Failed to create the cache to store if a user exist in a given wiki", e);
         }

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/document/UserListener.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/document/UserListener.java
@@ -1,0 +1,86 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.user.internal.document;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import org.xwiki.bridge.event.WikiDeletedEvent;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.model.reference.RegexEntityReference;
+import org.xwiki.model.reference.WikiReference;
+import org.xwiki.observation.AbstractEventListener;
+import org.xwiki.observation.event.Event;
+
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.internal.event.XObjectAddedEvent;
+import com.xpn.xwiki.internal.event.XObjectDeletedEvent;
+import com.xpn.xwiki.internal.event.XObjectEvent;
+import com.xpn.xwiki.internal.mandatory.XWikiUsersDocumentInitializer;
+import com.xpn.xwiki.objects.BaseObjectReference;
+
+/**
+ * Invalidate the cache based on user events.
+ * 
+ * @version $Id$
+ * @since 17.3.0RC1
+ */
+@Component
+@Named(UserListener.NAME)
+@Singleton
+public class UserListener extends AbstractEventListener
+{
+    /**
+     * The hint of the component and the name of the listener.
+     */
+    public static final String NAME = "org.xwiki.user.internal.document.UserListener";
+
+    private static final RegexEntityReference USER_REFERENCE =
+        BaseObjectReference.any(XWikiUsersDocumentInitializer.CLASS_REFERENCE_STRING);
+
+    @Inject
+    private UserCache cache;
+
+    /**
+     * Listener to user creation/deleting.
+     */
+    public UserListener()
+    {
+        super(NAME, new XObjectAddedEvent(USER_REFERENCE), new XObjectDeletedEvent(USER_REFERENCE),
+            new WikiDeletedEvent());
+    }
+
+    @Override
+    public void onEvent(Event event, Object source, Object data)
+    {
+        if (event instanceof XObjectEvent) {
+            XWikiDocument document = (XWikiDocument) source;
+            WikiReference wiki = document.getDocumentReference().getWikiReference();
+            if (event instanceof XObjectAddedEvent) {
+                this.cache.set(wiki, true);
+            } else if (event instanceof XObjectDeletedEvent) {
+                this.cache.invalidate(wiki);
+            }
+        } else if (event instanceof WikiDeletedEvent wikiEvent) {
+            this.cache.invalidate(new WikiReference(wikiEvent.getWikiId()));
+        }
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/document/UserListener.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/document/UserListener.java
@@ -41,7 +41,7 @@ import com.xpn.xwiki.objects.BaseObjectReference;
  * Invalidate the cache based on user events.
  * 
  * @version $Id$
- * @since 17.3.0RC1
+ * @since 17.4.0RC1
  */
 @Component
 @Named(UserListener.NAME)

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/resources/META-INF/components.txt
@@ -33,6 +33,8 @@ org.xwiki.user.internal.document.SecureUserDocumentUserPropertiesResolver
 org.xwiki.user.internal.document.XWikiUserUserReferenceResolver
 org.xwiki.user.internal.document.DocumentDocumentReferenceUserReferenceSerializer
 org.xwiki.user.internal.document.NormalUserConfigurationSourceAuthorization
+org.xwiki.user.internal.document.UserCache
+org.xwiki.user.internal.document.UserListener
 org.xwiki.user.internal.group.DefaultGroupManager
 org.xwiki.user.internal.group.GroupCacheInvalidationListener
 org.xwiki.user.internal.group.GroupMembersCache

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/UserListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/UserListenerTest.java
@@ -1,0 +1,118 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.user.internal.document;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.bridge.event.WikiDeletedEvent;
+import org.xwiki.cache.CacheManager;
+import org.xwiki.cache.internal.MapCache;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.WikiReference;
+import org.xwiki.test.annotation.BeforeComponent;
+import org.xwiki.test.annotation.ComponentList;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.internal.event.XObjectAddedEvent;
+import com.xpn.xwiki.internal.event.XObjectDeletedEvent;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Validate {@link UserListener}.
+ * 
+ * @version $Id$
+ */
+@ComponentTest
+@ComponentList(UserCache.class)
+class UserListenerTest
+{
+    private static final WikiReference WIKI = new WikiReference("wiki");
+
+    @InjectMockComponents
+    private UserListener listener;
+
+    @InjectMockComponents
+    private UserCache userCache;
+
+    @MockComponent
+    private CacheManager cacheManager;
+
+    private MapCache<Boolean> cache = new MapCache<>();
+
+    @BeforeComponent
+    public void beforeComponent() throws Exception
+    {
+        when(this.cacheManager.<Boolean>createNewCache(any())).thenReturn(this.cache);
+    }
+
+    @Test
+    void userDeleted()
+    {
+        assertNull(this.cache.get(WIKI.getName()));
+
+        this.userCache.computeIfAbsent(WIKI, w -> true);
+
+        assertTrue(this.cache.get(WIKI.getName()));
+
+        this.listener.onEvent(new XObjectDeletedEvent(),
+            new XWikiDocument(new DocumentReference("wiki2", "space", "page")), null);
+
+        assertTrue(this.cache.get(WIKI.getName()));
+
+        this.listener.onEvent(new XObjectDeletedEvent(),
+            new XWikiDocument(new DocumentReference("wiki", "space", "page")), null);
+
+        assertNull(this.cache.get(WIKI.getName()));
+    }
+
+    @Test
+    void userAdded()
+    {
+        assertNull(this.cache.get(WIKI.getName()));
+
+        this.listener.onEvent(new XObjectAddedEvent(),
+            new XWikiDocument(new DocumentReference("wiki2", "space", "page")), null);
+
+        assertNull(this.cache.get(WIKI.getName()));
+
+        this.listener.onEvent(new XObjectAddedEvent(),
+            new XWikiDocument(new DocumentReference("wiki", "space", "page")), null);
+
+        assertTrue(this.cache.get(WIKI.getName()));
+    }
+
+    @Test
+    void wikiDeleted()
+    {
+        this.userCache.computeIfAbsent(WIKI, w -> true);
+
+        assertTrue(this.cache.get(WIKI.getName()));
+
+        this.listener.onEvent(new WikiDeletedEvent(WIKI.getName()), null, null);
+
+        assertNull(this.cache.get(WIKI.getName()));
+    }
+}


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-23122

and as a bonus (it was actually the end goal): https://jira.xwiki.org/browse/XWIKI-23073

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

The idea if to provide a new API to check if a wiki contains any user. The result is also cached.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

The name of the API is still negotiable, if you have a better idea…

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Add various unit tests.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches: No