### PR TITLE
Misc: Icon picker webstandards

### DIFF
--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards/src/test/it/org/xwiki/test/webstandards/CustomDutchWebGuidelinesValidator.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards/src/test/it/org/xwiki/test/webstandards/CustomDutchWebGuidelinesValidator.java
@@ -83,8 +83,7 @@ public class CustomDutchWebGuidelinesValidator extends HTML5DutchWebGuidelinesVa
     public void validateRpd3s4()
     {
         if (!isPage("XWiki", "XWikiSyntax") && !isPage("XWiki", "XWikiSyntaxParagraphs")
-            && !isPage("XWiki", "XWikiSyntaxGeneralRemarks")
-            && !isPage("IconThemesCode", "IconPickerMacro")) {
+            && !isPage("XWiki", "XWikiSyntaxGeneralRemarks")) {
             super.validateRpd3s4();
         }
     }
@@ -130,8 +129,7 @@ public class CustomDutchWebGuidelinesValidator extends HTML5DutchWebGuidelinesVa
             && !isPage("XWiki", "XWikiSyntaxDefinitionLists") && !isPage("XWiki", "XWikiSyntaxHeadings")
             && !isPage("XWiki", "XWikiSyntaxLists") && !isPage("XWiki", "XWikiSyntaxParameters")
             && !isPage("XWiki", "XWikiSyntaxGroups") && !isPage("XWiki", "Treeview")
-            && !isPage("Panels", "PanelWizard") && !isPage("Invitation", "WebHome")
-            && !isPage("IconThemesCode", "IconPickerMacro")) {
+            && !isPage("Panels", "PanelWizard") && !isPage("Invitation", "WebHome")) {
             // Usage of the style attribute is strictly forbidden in the other spaces.
 
             assertTrue(Type.ERROR, "rpd9s1.attr", getElement(ELEM_BODY).getElementsByAttribute(STYLE).isEmpty());


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

This issue was first found on the CI : https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/master/7907/testReport/junit/org.xwiki.test.webstandards/CustomDutchWebGuidelinesValidationTest/Platform_Builds___main___distribution___flavor_test_webstandards___Build_for_Flavor_Test___Webstandards___Validating_HTML5_Dutch_Web_Guidelines_validity_for__http___127_0_0_1_8080_xwiki_bin_view_IconThemesCode_IconPickerMacro__executed_with_credentials_Admin_admin/


# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Added the missing labels on the icon picker macro fields generated in the content.
* Added a filtering pattern to remove the iconPickerMacro page from the list of pages checked (while leaving every other page unchanged)

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The filtering pattern is using regex syntax. It matches all the results that have at least one character and do not contain the substring `IconPickerMacro`. 

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
None
# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests: the added label did not change the looks of the UI and solved the issues that could be also found by axe core (not found in test, because there's no docker test passing by this page)
Automatic tests: Could reproduce the bug locally before the changes. After adding the pattern for documents, `mvn clean install -f xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-webstandards/` passed successfully (after 10ish minutes of running all the tests as expected :) )

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X 