### PR TITLE
XWIKI-23107: Moving a page with a relative link from one wiki to another breaks the link

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/RenamePageIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/RenamePageIT.java
@@ -674,8 +674,12 @@ class RenamePageIT
         throws Exception
     {
         SpaceReference rootSpaceReference = testReference.getLastSpaceReference();
+        DocumentReference externalLinkPage = new DocumentReference("xwiki", "RenamePageIT", "ExternalPage");
+        testUtils.rest().savePage(externalLinkPage);
         testUtils.rest().savePage(testReference, 
-            String.format("[[Alice]]%n[[page:../%s/Alice]]%n[[Bob]]%n[[Eve]]", rootSpaceReference.getName()), 
+            String.format("[[Alice]]%n[[page:../%s/Alice]]%n[[Bob]]%n[[Eve]]"
+                    + "%n[[Other link>>RenamePageIT.ExternalPage]]",
+                rootSpaceReference.getName()),
             "Test relative links");
         
         SpaceReference aliceSpace = new SpaceReference("Alice", rootSpaceReference);
@@ -697,7 +701,8 @@ class RenamePageIT
             new SpaceReference(rootSpaceReference.getName() + "Foo", rootSpaceReference.getParent());
         WikiEditPage wikiEditPage = statusPage.gotoNewPage().editWiki();
         String newRootSpaceSerialized = testUtils.serializeLocalReference(newRootSpace).replaceAll("\\.", "/");
-        assertEquals(String.format("[[Alice]]%n[[page:%s/Alice]]%n[[Bob]]%n[[Eve]]", newRootSpaceSerialized),
+        assertEquals(String.format("[[Alice]]%n[[page:%s/Alice]]%n[[Bob]]%n[[Eve]]"
+                + "%n[[Other link>>RenamePageIT.ExternalPage]]", newRootSpaceSerialized),
             wikiEditPage.getContent());
 
         SpaceReference newBobSpace = new SpaceReference("Bob", newRootSpace);
@@ -716,7 +721,8 @@ class RenamePageIT
         DocumentReference alice2Reference = new DocumentReference("WebHome", alice2Space);
         wikiEditPage = WikiEditPage.gotoPage(new DocumentReference("WebHome", newRootSpace));
         String serializedAlice2Reference = testUtils.serializeLocalReference(alice2Reference);
-        assertEquals(String.format("[[%s]]%n[[page:%s/Alice2]]%n[[Bob]]%n[[Eve]]",
+        assertEquals(String.format("[[%s]]%n[[page:%s/Alice2]]%n[[Bob]]%n[[Eve]]"
+                + "%n[[Other link>>RenamePageIT.ExternalPage]]",
             serializedAlice2Reference, newRootSpaceSerialized), wikiEditPage.getContent());
 
         // FIXME: ideally this one should be refactored too, however it's not a regression.

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/ResourceReferenceRenamer.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/ResourceReferenceRenamer.java
@@ -249,7 +249,6 @@ public class ResourceReferenceRenamer
         // current link, use the old document's reference to fill in blanks.
         EntityReference oldLinkReference =
             this.entityReferenceResolver.resolve(resourceReference, null, oldReference);
-        EntityReference absoluteResolvedReference = this.entityReferenceResolver.resolve(resourceReference, null);
 
         boolean docExists = false;
         EntityType entityType = linkEntityReference.getType();
@@ -271,13 +270,10 @@ public class ResourceReferenceRenamer
                 && documentReferenceTarget.equals(updatedEntities.get(documentReference))));
 
         // We should update the reference if:
-        //  - it's relative: the resolution of the reference without any parameter, and the resolution of the reference
-        //                   with the new reference should give different results
         //  - it doesn't match any reference moved in the same job, i.e. in the same hierarchy
         //  - the new and old link references don`t match
         //  - the link refers to a doc that exists
-        boolean shouldBeUpdated = !absoluteResolvedReference.equals(linkEntityReference)
-            && !anyMatchInMovedReferences
+        boolean shouldBeUpdated = !anyMatchInMovedReferences
             && !linkEntityReference.equals(oldLinkReference)
             && docExists;
 

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultReferenceUpdaterTest.java
@@ -264,8 +264,6 @@ class DefaultReferenceUpdaterTest
         AttachmentReference oldImageTargetAttachment = new AttachmentReference("attachment.txt", oldReference);
         DocumentReference newReference = new DocumentReference("wiki", "X", "Y");
         AttachmentReference newImageTargetAttachment = new AttachmentReference("attachment.txt", newReference);
-        AttachmentReference absoluteTargetAttachment = new AttachmentReference("attachment.txt",
-            new DocumentReference("wiki", "Main", "WebHome"));
 
         XWikiDocument newDocument = mock(XWikiDocument.class);
         DocumentAuthors authors = mock(DocumentAuthors.class);
@@ -304,12 +302,9 @@ class DefaultReferenceUpdaterTest
         DocumentReference absoluteDocLinkReference = new DocumentReference("WebHome", new SpaceReference("wiki", "C"));
         EntityReference relativeDocLinkReference = new EntityReference("WebHome", EntityType.DOCUMENT,
             new EntityReference("C", EntityType.SPACE));
-        when(this.resourceReferenceResolver.resolve(docLinkReference, null))
-            .thenReturn(absoluteDocLinkReference);
+
         when(this.relativeEntityReferenceResolver.resolve(docLinkReference, null, null))
             .thenReturn(relativeDocLinkReference);
-        when(this.resourceReferenceResolver.resolve(absoluteDocLinkResourceReference, null))
-            .thenReturn(absoluteDocLinkReference);
         when(this.relativeEntityReferenceResolver.resolve(absoluteDocLinkResourceReference, null, null))
             .thenReturn(absoluteDocLinkReference);
         when(this.resourceReferenceResolver.resolve(docLinkReference, null, oldReference))
@@ -322,8 +317,7 @@ class DefaultReferenceUpdaterTest
             .thenReturn(relativeDocLinkReference);
         when(this.resourceReferenceResolver.resolve(xobjectDocLinkReference, null, oldReference))
             .thenReturn(originalDocLinkReference);
-        when(this.resourceReferenceResolver.resolve(imageReference, null))
-            .thenReturn(absoluteTargetAttachment);
+
         when(this.resourceReferenceResolver.resolve(imageReference, null, oldReference))
             .thenReturn(oldImageTargetAttachment);
         when(this.relativeEntityReferenceResolver.resolve(imageReference, null, null))
@@ -341,14 +335,12 @@ class DefaultReferenceUpdaterTest
 
         SpaceReference originalSpaceReference = new SpaceReference("wiki", "Z");
         EntityReference relativeSpaceReference = new EntityReference("Z", EntityType.SPACE);
-        when(this.resourceReferenceResolver.resolve(spaceLinkReference, null))
-            .thenReturn(originalSpaceReference);
+
         when(this.relativeEntityReferenceResolver.resolve(spaceLinkReference, null, null))
             .thenReturn(relativeSpaceReference);
         when(this.resourceReferenceResolver.resolve(spaceLinkReference, null, oldReference))
             .thenReturn(originalSpaceReference);
-        when(this.resourceReferenceResolver.resolve(xobjectSpaceLinkReference, null))
-            .thenReturn(originalSpaceReference);
+
         when(this.resourceReferenceResolver.resolve(xobjectSpaceLinkReference, null, oldReference))
             .thenReturn(originalSpaceReference);
         when(this.resourceReferenceResolver.resolve(spaceLinkReference, null, newReference))
@@ -411,11 +403,9 @@ class DefaultReferenceUpdaterTest
             .thenReturn(List.of(docLinkBlock, spaceLinkBlock));
 
         DocumentReference originalDocLinkReference = new DocumentReference("C", oldReference.getLastSpaceReference());
-        DocumentReference absoluteDocLinkReference = new DocumentReference("C", new SpaceReference("xwiki", "Main"));
         EntityReference relativeDocLinkReference = new EntityReference("C", EntityType.DOCUMENT,
             new EntityReference("B", EntityType.SPACE));
         EntityReference relativeSpaceLinkReference = new EntityReference("Z", EntityType.SPACE);
-        when(this.resourceReferenceResolver.resolve(docLinkReference, null)).thenReturn(absoluteDocLinkReference);
         when(this.resourceReferenceResolver.resolve(docLinkReference, null, oldReference))
             .thenReturn(originalDocLinkReference);
         DocumentReference newDocLinkReference = new DocumentReference("C", newReference.getLastSpaceReference());
@@ -425,8 +415,6 @@ class DefaultReferenceUpdaterTest
             .thenReturn(relativeDocLinkReference);
 
         SpaceReference originalSpaceReference = new SpaceReference("wiki1", "Z");
-        SpaceReference absoluteSpaceReference = new SpaceReference("xwiki", "Z");
-        when(this.resourceReferenceResolver.resolve(spaceLinkReference, null)).thenReturn(absoluteSpaceReference);
         when(this.resourceReferenceResolver.resolve(spaceLinkReference, null, oldReference))
             .thenReturn(originalSpaceReference);
         SpaceReference newSpaceReference = new SpaceReference("wiki2", "Z");

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/ResourceReferenceRenamerTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/ResourceReferenceRenamerTest.java
@@ -111,7 +111,6 @@ class ResourceReferenceRenamerTest
                 new EntityReference("wiki", EntityType.WIKI))));
         AttachmentReference newReference =
             new AttachmentReference("file2.txt", new DocumentReference("wiki", "space", "page"));
-        when(this.entityReferenceResolver.resolve(resourceReference, null)).thenReturn(oldReference);
         when(this.entityReferenceResolver.resolve(resourceReference, null, newReference)).thenReturn(newReference);
         when(this.entityReferenceResolver.resolve(resourceReference, null, oldReference)).thenReturn(oldReference);
         when(this.relativeEntityReferenceResolver.resolve(resourceReference, null, null)).thenReturn(relativeReference);
@@ -136,7 +135,6 @@ class ResourceReferenceRenamerTest
             new EntityReference("page", EntityType.DOCUMENT, new EntityReference("space", EntityType.SPACE)));
         AttachmentReference newReference =
             new AttachmentReference("file2.txt", new DocumentReference("wiki", "space", "page"));
-        when(this.entityReferenceResolver.resolve(resourceReference, null)).thenReturn(oldReference);
         when(this.entityReferenceResolver.resolve(resourceReference, null, newReference)).thenReturn(newReference);
         when(this.entityReferenceResolver.resolve(resourceReference, null, oldReference)).thenReturn(oldReference);
         when(this.relativeEntityReferenceResolver.resolve(resourceReference, null, null)).thenReturn(relativeReference);


### PR DESCRIPTION

(cherry picked from commit aed29a8dbced7264408b31ba4e368caed9595a6d)

# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-23107

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

  * Cherry pick of changes performed in master
  * don't check if the link is relative or not for refactoring it as it's a bad criteria
  * cover with tests in both single and multi wikis


## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->



# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 