### PR TITLE
XWIKI-23132: Document tabs have border between tab label and content

### DIFF
--- a/xwiki-platform-core/xwiki-platform-bootstrap/src/main/node/less/navs.less
+++ b/xwiki-platform-core/xwiki-platform-bootstrap/src/main/node/less/navs.less
@@ -12,7 +12,6 @@
   padding-left: 0; // Override default ul/ol
   margin-bottom: 0;
   list-style: none;
-  &:extend(.clearfix all);
 
   > li {
     position: relative;
@@ -77,14 +76,16 @@
 // Give the tabs something to sit on
 .nav-tabs {
   border-bottom: 1px solid @nav-tabs-border-color;
+  display: flex;
+  gap: .2em;
+  flex-wrap: wrap;
   > li {
-    float: left;
     // Make the list-items overlay the bottom border
+    z-index: 2;
     margin-bottom: -1px;
 
     // Actual tabs (as links)
     > a {
-      margin-right: 2px;
       line-height: @line-height-base;
       border: 1px solid transparent;
       border-radius: @border-radius-base @border-radius-base 0 0;

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/docextra.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/docextra.vm
@@ -86,7 +86,7 @@
 ##
 #if($docextras.size() > 0)
   <div id="xwikidatacontents">
-    <div class="floatcontainer" id="docExtraTabs">
+    <div id="docExtraTabs">
       <ul class="xwikitabbar" id="docExtrasTabsUl">
         #foreach($docextra in $docextras)
           <li id="${docextra.get(0)}tab" data-template="$escapetool.xml($docextra.get(4))">

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/Main/AllDocs.xml
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-ui/src/main/resources/Main/AllDocs.xml
@@ -74,7 +74,7 @@
 ## Display the Tabs
 ##===========
 {{html}}
-&lt;div class="floatcontainer"&gt;
+&lt;div&gt;
   &lt;ul class="xwikitabbar"&gt;
 #foreach ($tab in $tabs)
   &lt;li id="xwiki$tab['idSuffix']"#if($view == $tab['tabName']) class="active"#end&gt;&lt;a href="$doc.getURL('view', "view=$tab['tabName']&amp;amp;$!param")"&gt;$services.localization.render($tab['translationKey'])&lt;/a&gt;&lt;/li&gt;

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/children.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/children.vm
@@ -80,7 +80,7 @@
   ##===========
   ## Display the Tabs
   ##===========
-  <div class="floatcontainer">
+  <div>
     <ul class="xwikitabbar">
       #foreach ($tab in $tabs)
         <li id="xwiki$tab['tabName']"#if($view == $tab['tabName']) class="active"#end>


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-23132

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Removed the useless `floatcontainer` from a few places in the UI. There's no use for these classes either in styles or javascript... they were purely assistance to understand the structure. IMO it's clearer without it now.
* Removed the float specific styles from the `.nav` bootstrap class. AFAICS, we only used nav in combination with other classes, it is never in charge of the layout in the XS uses.
* Replaced the float layout with a basic flex layout for the `nav-tabs` class. This is more flexible and robust.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

I checked the changes with the few places where we use these nav-tabs classes:

https://github.com/user-attachments/assets/b76d5476-3d4a-4093-b615-374c2a908bcc

AFAICS, everything looks fine now.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
See the video above for an idea of the manual tests I conducted.
This is pretty much only style changes. This regression was not caught by automatic tests.

The only DOM changes are about `.floatcontainer`, but it's not used in the project anywhere (CSS nor JS).

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 17.3.X (like XWIKI-22727)