### PR TITLE
XWIKI-23129: Add an `end of DOM` UIXP 

### DIFF
--- a/xwiki-platform-core/xwiki-platform-bootstrap/src/main/node/less/modals.less
+++ b/xwiki-platform-core/xwiki-platform-bootstrap/src/main/node/less/modals.less
@@ -27,6 +27,12 @@
   // Prevent Chrome on Windows from adding a focus outline. For details, see
   // https://github.com/twbs/bootstrap/pull/10951.
   outline: 0;
+  
+  // If this element is a dialog, we want to reset those default styles. The children elements are the ones painted.
+  dialog& {
+    background-color: transparent;
+    border: 0;
+  }
 
   // When fading in the modal, animate it to slide down
   &.fade .modal-dialog {

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/contentheader.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/contentheader.vm
@@ -24,7 +24,7 @@
     ## Display UI Extensions before the title element
     ## --------------------------------------------------------
     #foreach ($uix in $services.uix.getExtensions('org.xwiki.platform.template.title.before'))
-      $services.rendering.render($uix.execute(), 'xhtml/1.0')
+      $services.rendering.render($uix.execute(), 'html/5.0')
     #end
     <div id="document-title"><h1>$titleToDisplay</h1></div>
     #if (!$doc.isNew())

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/contentheader.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/contentheader.vm
@@ -24,7 +24,7 @@
     ## Display UI Extensions before the title element
     ## --------------------------------------------------------
     #foreach ($uix in $services.uix.getExtensions('org.xwiki.platform.template.title.before'))
-      $services.rendering.render($uix.execute(), 'html/5.0')
+      $services.rendering.render($uix.execute(), 'xhtml/1.0')
     #end
     <div id="document-title"><h1>$titleToDisplay</h1></div>
     #if (!$doc.isNew())

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/export_modal.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/export_modal.vm
@@ -23,7 +23,7 @@
  *#
 #macro(exportModal)
   #set ($discard = $xwiki.jsfx.use('uicomponents/exporter/exporter.js', {'forceSkinAction': true}))
-  <div class="modal fade text-left" id="exportModal" tabindex="-1" role="dialog" aria-labelledby="exportModalLabel"
+  <dialog class="modal fade text-left" id="exportModal" aria-labelledby="exportModalLabel"
       aria-hidden="true">
     <div class="modal-dialog">
       <div class="modal-content">
@@ -46,7 +46,7 @@
         </div>
       </div>
     </div>
-  </div>
+  </dialog>
   #if ($doc.documentReference.name == 'WebHome' && $xwiki.exists('XWiki.ExportDocumentTree'))
     #exportTreeModal()
   #end
@@ -204,7 +204,7 @@
 #end
 ##
 #macro(exportTreeModal)
-  <div class="modal fade text-left" id="exportTreeModal" tabindex="-1" role="dialog"
+  <dialog class="modal fade text-left" id="exportTreeModal"
       aria-labelledby="exportTreeModalLabel" aria-hidden="true">
     <div class="modal-dialog">
       <div class="modal-content">
@@ -238,5 +238,5 @@
         </div>
       </div>
     </div>
-  </div>
+  </dialog>
 #end

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/export_modal.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/export_modal.vm
@@ -47,7 +47,7 @@
       </div>
     </div>
   </dialog>
-  #if ($doc.documentReference.name == 'WebHome' && $xwiki.exists('XWiki.ExportDocumentTree'))
+  #if ($doc.documentReference.name == $services.model.getEntityReference('DOCUMENT', 'default').name && $xwiki.exists('XWiki.ExportDocumentTree'))
     #exportTreeModal()
   #end
 #end
@@ -107,7 +107,7 @@
     'name': $doc.fullName,
     'pages': [$services.model.serialize($doc.documentReference, 'default')]
   })
-  #if ($doc.documentReference.name == 'WebHome')
+  #if ($doc.documentReference.name == $services.model.getEntityReference('DOCUMENT', 'default').name)
     ## When nested page also export WebPreferences which contain among other things the right of this entity
     #set ($preferencesReference = $services.model.createDocumentReference('WebPreferences',
       $doc.documentReference.lastSpaceReference))

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_content.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_content.vm
@@ -110,9 +110,6 @@
     ## Note: Both the admin actions and the more actions menus are now merged into one.
     #if ($displayAdminMenu || $displayMoreActionsMenu)
       #displayOptionsMenu()
-      #if ($canView)
-        #template("export_modal.vm")
-      #end
     #end
   #end
   #set ($discard = $topStaticExtensions.add( { 'content': "$!actionsMenu", 'order': 40000}))
@@ -132,10 +129,6 @@
       #keyboardShortcuts()
     #end
   </ul>
-## Display the submenu modals next to the list. Note that those could be pretty much anywhere but in the ul for HTML
-## correctness sake.
-#if ("$!notificationsWatchModal" != "")$notificationsWatchModal#end
-#if ($!_exportModalAvailable)#exportModal()#end
 #end
 
 #**

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsWatchUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsWatchUIX.xml
@@ -502,24 +502,7 @@
 #set($discard = $xwiki.ssx.use('XWiki.Notifications.Code.NotificationsWatchUIX'))
 #set($discard = $xwiki.jsx.use('XWiki.Notifications.Code.NotificationsWatchUIX'))
 #set ($watchedStatus = $services.notification.watch.getLocationWatchedStatus($doc))
-## FIXME: the different icons should use the icon service
-#set ($iconWhenWatched = 'fa-bell')
-#set ($iconWhenNotSet = 'fa-bell-o')
-#set ($iconWhenBlocked = 'fa-bell-slash')
-#set ($iconWhenCustom = 'fa-bullhorn')
-#if ($watchedStatus == 'NOT_SET')
-  #set ($watchIcon = $iconWhenNotSet)
-  #set ($watchText = $services.localization.render('notifications.watch.button.status.notset', 'html/5.0', []))
-#elseif ($watchedStatus.isWatched())
-  #set ($watchIcon = $iconWhenWatched)
-  #set ($watchText = $services.localization.render('notifications.watch.button.status.followed', 'html/5.0', []))
-#elseif ($watchedStatus.isBlocked())
-  #set ($watchIcon = $iconWhenBlocked)
-  #set ($watchText = $services.localization.render('notifications.watch.button.status.blocked', 'html/5.0', []))
-#else
-  #set ($watchIcon = $iconWhenCustom)
-  #set ($watchText = $services.localization.render('notifications.watch.button.status.custom', 'html/5.0', []))
-#end
+#_notificationsWatchStatusIcon($watchedStatus)
 #set ($buttonTitle = $services.localization.render('notifications.watch.button.title', [$watchText]))
 {{html clean='false'}}
 &lt;div class="btn-group" id="watchButton">
@@ -699,6 +682,7 @@
 #end
 
 #set ($watchedStatus = $services.notification.watch.getLocationWatchedStatus($doc))
+#_notificationsWatchStatusIcon($watchedStatus)
 ## If the watched status informs that the filter is about children it means it's a filter for the space,
 ## so we should look for ancestor of the space.
 #set ($refForAncestorFirstFilter = $doc.getDocumentReference())

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsWatchUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsWatchUIX.xml
@@ -830,7 +830,7 @@
       <name>org.xwiki.platform.notification.watchModal</name>
     </property>
     <property>
-      <parameters></parameters>
+      <parameters>order=1000</parameters>
     </property>
     <property>
       <scope>wiki</scope>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsWatchUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsWatchUIX.xml
@@ -502,17 +502,6 @@
 #set($discard = $xwiki.ssx.use('XWiki.Notifications.Code.NotificationsWatchUIX'))
 #set($discard = $xwiki.jsx.use('XWiki.Notifications.Code.NotificationsWatchUIX'))
 #set ($watchedStatus = $services.notification.watch.getLocationWatchedStatus($doc))
-## If the watched status informs that the filter is about children it means it's a filter for the space,
-## so we should look for ancestor of the space.
-#set ($refForAncestorFirstFilter = $doc.getDocumentReference())
-#if ($watchedStatus == 'WATCHED_WITH_CHILDREN_FOR_ALL_EVENTS_AND_FORMATS' || $watchedStatus == 'BLOCKED_WITH_CHILDREN_FOR_ALL_EVENTS_AND_FORMATS')
-  #set ($refForAncestorFirstFilter = $doc.getDocumentReference().parent)
-#end
-#set ($ancestorFirstFilter = $services.notification.watch.getFirstFilteredAncestor($refForAncestorFirstFilter))
-#if ($ancestorFirstFilter)
-  #set ($ancestorRef = $ancestorFirstFilter.left)
-  #set ($ancestorWatchStatus = $ancestorFirstFilter.right)
-#end
 ## FIXME: the different icons should use the icon service
 #set ($iconWhenWatched = 'fa-bell')
 #set ($iconWhenNotSet = 'fa-bell-o')
@@ -531,8 +520,159 @@
   #set ($watchIcon = $iconWhenCustom)
   #set ($watchText = $services.localization.render('notifications.watch.button.status.custom', 'html/5.0', []))
 #end
-## TODO: better way for that?
-#set ($isTerminal = ($doc.getDocumentReference().name != 'WebHome'))
+#set ($buttonTitle = $services.localization.render('notifications.watch.button.title', [$watchText]))
+{{html clean='false'}}
+&lt;div class="btn-group" id="watchButton">
+  &lt;a href="#" role="button" title="$escapetool.xml($buttonTitle)" class="btn btn-default" data-toggle="modal" data-target="#watchModal">
+    &lt;span class="fa $watchIcon">&lt;/span> $watchText
+  &lt;/a>
+&lt;/div>
+{{/html}}
+#end
+{{/velocity}}
+</content>
+    </property>
+    <property>
+      <extensionPointId>org.xwiki.plaftorm.menu.content</extensionPointId>
+    </property>
+    <property>
+      <name>org.xwiki.platform.notification.watch</name>
+    </property>
+    <property>
+      <parameters>order=39000</parameters>
+    </property>
+    <property>
+      <scope>wiki</scope>
+    </property>
+  </object>
+  <object>
+    <name>XWiki.Notifications.Code.NotificationsWatchUIX</name>
+    <number>1</number>
+    <className>XWiki.UIExtensionClass</className>
+    <guid>ad3c491c-2532-48c7-8559-286a36a90cfb</guid>
+    <class>
+      <name>XWiki.UIExtensionClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <async_cached>
+        <defaultValue>0</defaultValue>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType/>
+        <name>async_cached</name>
+        <number>3</number>
+        <prettyName>Cached</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </async_cached>
+      <async_context>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
+        <name>async_context</name>
+        <number>4</number>
+        <prettyName>Context elements</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator>, </separator>
+        <separators>|, </separators>
+        <size>5</size>
+        <unmodifiable>0</unmodifiable>
+        <values>action=Action|doc.reference=Document|doc.revision|icon.theme=Icon theme|locale=Language|rendering.defaultsyntax=Default syntax|rendering.restricted=Restricted|rendering.targetsyntax=Target syntax|request.base=Request base URL|request.cookies|request.headers|request.parameters=Request parameters|request.remoteAddr|request.session|request.url=Request URL|request.wiki=Request wiki|sheet|user=User|wiki=Wiki</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </async_context>
+      <async_enabled>
+        <defaultValue>0</defaultValue>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType/>
+        <name>async_enabled</name>
+        <number>2</number>
+        <prettyName>Asynchronous rendering</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </async_enabled>
+      <content>
+        <disabled>0</disabled>
+        <editor>Text</editor>
+        <name>content</name>
+        <number>1</number>
+        <prettyName>Executed Content</prettyName>
+        <restricted>0</restricted>
+        <rows>25</rows>
+        <size>120</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </content>
+      <extensionPointId>
+        <disabled>0</disabled>
+        <name>extensionPointId</name>
+        <number>5</number>
+        <prettyName>Extension Point ID</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </extensionPointId>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>6</number>
+        <prettyName>Extension ID</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <parameters>
+        <contenttype>PureText</contenttype>
+        <disabled>0</disabled>
+        <editor>PureText</editor>
+        <name>parameters</name>
+        <number>7</number>
+        <prettyName>Extension Parameters</prettyName>
+        <restricted>0</restricted>
+        <rows>10</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </parameters>
+      <scope>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>scope</name>
+        <number>8</number>
+        <prettyName>Extension Scope</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>wiki=Current Wiki|user=Current User|global=Global</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </scope>
+    </class>
+    <property>
+      <async_cached>0</async_cached>
+    </property>
+    <property>
+      <async_context/>
+    </property>
+    <property>
+      <async_enabled>0</async_enabled>
+    </property>
+    <property>
+      <content>{{velocity}}
+#if (!$isGuest)
 #macro (_displayOption $attributeName $optionValue $translationSuffix $iconName $panelClass)
   &lt;div class="panel panel-default $panelClass"&gt;
     &lt;div class="panel-radio"&gt;
@@ -540,10 +680,10 @@
     &lt;/div&gt;
     &lt;div class="panel-heading" role="tab" id="heading-$attributeName"&gt;
         &lt;div class="panel-title" id="title-$attributeName"&gt;
-          $services.icon.renderHTML("$iconName") 
+          $services.icon.renderHTML("$iconName")
           &lt;label for="option-$attributeName"&gt;$services.localization.render("notifications.watch.modal.option.${translationSuffix}.title", 'html/5.0', [])&lt;/label&gt;
-          &lt;a role="button" data-toggle="collapse" data-parent="#watch-options-accordion" 
-            href="#xhint-$attributeName" aria-controls="xhint-$attributeName" 
+          &lt;a role="button" data-toggle="collapse" data-parent="#watch-options-accordion"
+            href="#xhint-$attributeName" aria-controls="xhint-$attributeName"
             title="$escapetool.xml($services.localization.render('notifications.watch.modal.option.hint.toggle'))"&gt;
             &lt;span class="help-icon"&gt;$services.icon.renderHTML('question')&lt;/span&gt;
             &lt;span class="sr-only"&gt;$escapetool.xml($services.localization.render('notifications.watch.modal.option.hint.toggle'))&lt;/span&gt;
@@ -557,6 +697,23 @@
     &lt;/div&gt;&lt;!-- end collapsed xhint --&gt;
   &lt;/div&gt;&lt;!-- end panel --&gt;
 #end
+
+#set ($watchedStatus = $services.notification.watch.getLocationWatchedStatus($doc))
+## If the watched status informs that the filter is about children it means it's a filter for the space,
+## so we should look for ancestor of the space.
+#set ($refForAncestorFirstFilter = $doc.getDocumentReference())
+#if ($watchedStatus == 'WATCHED_WITH_CHILDREN_FOR_ALL_EVENTS_AND_FORMATS' || $watchedStatus == 'BLOCKED_WITH_CHILDREN_FOR_ALL_EVENTS_AND_FORMATS')
+  #set ($refForAncestorFirstFilter = $doc.getDocumentReference().parent)
+#end
+#set ($ancestorFirstFilter = $services.notification.watch.getFirstFilteredAncestor($refForAncestorFirstFilter))
+#if ($ancestorFirstFilter)
+  #set ($ancestorRef = $ancestorFirstFilter.left)
+  #set ($ancestorWatchStatus = $ancestorFirstFilter.right)
+#end
+
+## TODO: better way for that?
+#set ($isTerminal = ($doc.getDocumentReference().name != 'WebHome'))
+
 #set ($watchPageOption = "#_displayOption('watch-page','watchPage','watchpage','page','')")
 #set ($watchSpaceOption = "#_displayOption('watch-space','watchSpace','watchspace','chart-organisation','')")
 #set ($unwatchPageAndWatchSpaceOption = "#_displayOption('unwatch-page-watch-space','unwatchPageWatchSpace','watchspace','chart-organisation','')")
@@ -570,136 +727,127 @@
 #set ($unblockPageOption = "#_displayOption('unblock-page','unblockPage','unblockpage','page','')")
 #set ($unblockSpaceOption = "#_displayOption('unblock-space','unblockSpace','unblockspace','chart-organisation','')")
 #set ($unblockWikiOption = "#_displayOption('unblock-wiki','unblockWiki','unblockwiki','world','wiki-option')")
-
-#set ($buttonTitle = $services.localization.render('notifications.watch.button.title', [$watchText]))
 {{html clean='false'}}
-&lt;li class="btn-group" id="watchButton"&gt;
-  &lt;button type="button" title="$escapetool.xml($buttonTitle)" class="btn btn-default" data-toggle="modal" data-target="#watchModal"&gt;
-    &lt;span class="fa $watchIcon"&gt;&lt;/span&gt; $watchText
-  &lt;/button&gt;
-&lt;/li&gt;
+&lt;div class="modal fade" tabindex="-1" role="dialog" id="watchModal"&gt;
+  &lt;div class="modal-dialog" role="document"&gt;
+    &lt;div class="modal-content"&gt;
+      &lt;div class="modal-header"&gt;
+        &lt;button type="button" class="close close-modal" data-dismiss="modal" aria-label="$escapetool.xml($services.localization.render('notifications.watch.modal.close'))"&gt;
+          &lt;span aria-hidden="true"&gt;
+            $services.icon.renderHTML('cross')
+          &lt;/span&gt;&lt;/button&gt;
+        &lt;div class="modal-title"&gt;
+          &lt;span class="fa $watchIcon"&gt;&lt;/span&gt; $services.localization.render("notifications.watch.modal.title.$watchedStatus", 'html/5.0', [])
+        &lt;/div&gt;
+      &lt;/div&gt;
+      &lt;div class="modal-body"&gt;
+        &lt;div class="watch-status-container"&gt;
+          $services.localization.render("notifications.watch.modal.description.$watchedStatus", 'html/5.0', [])
+          &lt;hr /&gt;
+          #if (($watchedStatus == 'WATCHED_BY_ANCESTOR_FOR_ALL_EVENTS_AND_FORMATS' || $watchedStatus == 'BLOCKED_BY_ANCESTOR_FOR_ALL_EVENTS_AND_FORMATS') &amp;&amp; $ancestorRef.type == 'SPACE' &amp;&amp; $services.security.authorization.hasAccess('view', $ancestorRef))
+            #set ($ancestorDoc = $xwiki.getDocument($ancestorRef))
+            #set ($ancestorDocUrl = $ancestorDoc.getURL())
+            #set ($ancestorDocTitle = $ancestorDoc.displayTitle)
+            #set ($ancestorLink = "&lt;a href=""$ancestorDocUrl""&gt;$ancestorDocTitle&lt;/a&gt;")
+            $services.localization.render('notifications.watch.modal.description.ancestoroption', [$ancestorLink])
+          #end
+        &lt;/div&gt;
+        &lt;div class="watch-options-container panel-group" id="watch-options-accordion" role="tablist" aria-multiselectable="false"&gt;
+        #set ($blockedByAncestor = ("$!ancestorWatchStatus" == '' || $ancestorWatchStatus.isBlocked()))
+        #set ($watchedByAncestor = ($ancestorWatchStatus.isWatched()))
+        #if ($watchedStatus == 'NOT_SET')
+          $watchPageOption
+          #if (!$isTerminal)
+          $watchSpaceOption
+          #end
+          $watchWikiOption
+        #elseif ($watchedStatus == 'WATCHED_FOR_ALL_EVENTS_AND_FORMATS')
+          #if ($blockedByAncestor)
+          $unwatchPageOption
+          #else
+          $blockPageOption
+          #end
+          #if (!$isTerminal &amp;&amp; $blockedByAncestor)
+          $unwatchPageAndWatchSpaceOption
+          #elseif (!$isTerminal &amp;&amp; !$blockedByAncestor)
+          $blockSpaceOption
+          #end
+        #elseif ($watchedStatus == 'WATCHED_WITH_CHILDREN_FOR_ALL_EVENTS_AND_FORMATS')
+          #if ($blockedByAncestor)
+          $unwatchSpaceOption
+          #else
+          $blockPageOption
+          $blockSpaceOption
+          #end
+        #elseif ($watchedStatus == 'WATCHED_BY_ANCESTOR_FOR_ALL_EVENTS_AND_FORMATS')
+          $blockPageOption
+          #if (!$isTerminal)
+          $blockSpaceOption
+          #end
+          #if ($ancestorRef.type == 'WIKI')
+          $unwatchWikiOption
+          #end
+        #elseif ($watchedStatus == 'BLOCKED_FOR_ALL_EVENTS_AND_FORMATS')
+          #if ($watchedByAncestor)
+          $unblockPageOption
+          #else
+          $watchPageOption
+          #end
+          #if (!$isTerminal &amp;&amp; $watchedByAncestor)
+          $unblockPageAndBlockSpaceOption
+          #elseif (!$isTerminal &amp;&amp; !$watchedByAncestor)
+          $watchSpaceOption
+          #end
+        #elseif ($watchedStatus == 'BLOCKED_WITH_CHILDREN_FOR_ALL_EVENTS_AND_FORMATS')
+          #if ($watchedByAncestor)
+          $unblockSpaceOption
+          #else
+          $watchPageOption
+          $watchSpaceOption
+          #end
+        #elseif ($watchedStatus == 'BLOCKED_BY_ANCESTOR_FOR_ALL_EVENTS_AND_FORMATS')
+          $watchPageOption
+          #if (!$isTerminal)
+          $watchSpaceOption
+          #end
+          #if ($ancestorRef.type == 'WIKI')
+          $unblockWikiOption
+          #end
+        #end
+        &lt;/div&gt;&lt;!-- end panel group --&gt;
+        &lt;div class="modal-body-footer"&gt;
+          #set ($userDoc = $xwiki.getDocument($xcontext.userReference))
+          #set ($settingsLink = "$userDoc.getURL('view','category=notifications')#Hnotifications.settings.filters.preferences.custom.title")
+          &lt;a href="$settingsLink" class="goto-settings"&gt;
+            $services.localization.render('notifications.watch.modal.gotosettings', 'html/5.0', []) $services.icon.renderHTML('move')
+          &lt;/a&gt;
+        &lt;/div&gt;
+      &lt;/div&gt;&lt;!-- end modal body --&gt;
+      &lt;div class="modal-footer"&gt;
+        &lt;button type="button" class="btn btn-default close-modal" data-dismiss="modal"&gt;
+          $services.localization.render('notifications.watch.modal.close', 'html/5.0', [])
+        &lt;/button&gt;
+        #if ($watchedStatus != 'CUSTOM')
+        &lt;button type="button" class="btn btn-primary" disabled="disabled"&gt;
+          $services.localization.render('notifications.watch.modal.savechanges', 'html/5.0', [])
+        &lt;/button&gt;
+        #end
+      &lt;/div&gt;
+    &lt;/div&gt;&lt;!-- /.modal-content --&gt;
+  &lt;/div&gt;&lt;!-- /.modal-dialog --&gt;
+&lt;/div&gt;&lt;!-- /.modal --&gt;
 {{/html}}
-#define ($notificationsWatchModal)
-  &lt;div class="modal fade" tabindex="-1" role="dialog" id="watchModal"&gt;
-    &lt;div class="modal-dialog" role="document"&gt;
-      &lt;div class="modal-content"&gt;
-        &lt;div class="modal-header"&gt;
-          &lt;button type="button" class="close close-modal" data-dismiss="modal" aria-label="$escapetool.xml($services.localization.render('notifications.watch.modal.close'))"&gt;
-            &lt;span aria-hidden="true"&gt;
-              $services.icon.renderHTML('cross')
-            &lt;/span&gt;&lt;/button&gt;
-          &lt;div class="modal-title"&gt;
-            &lt;span class="fa $watchIcon"&gt;&lt;/span&gt; $services.localization.render("notifications.watch.modal.title.$watchedStatus", 'html/5.0', [])
-          &lt;/div&gt;
-        &lt;/div&gt;
-        &lt;div class="modal-body"&gt;
-          &lt;div class="watch-status-container"&gt;
-            $services.localization.render("notifications.watch.modal.description.$watchedStatus", 'html/5.0', [])
-            &lt;hr /&gt;
-            #if (($watchedStatus == 'WATCHED_BY_ANCESTOR_FOR_ALL_EVENTS_AND_FORMATS' || $watchedStatus == 'BLOCKED_BY_ANCESTOR_FOR_ALL_EVENTS_AND_FORMATS') &amp;&amp; $ancestorRef.type == 'SPACE' &amp;&amp; $services.security.authorization.hasAccess('view', $ancestorRef))
-              #set ($ancestorDoc = $xwiki.getDocument($ancestorRef))
-              #set ($ancestorDocUrl = $ancestorDoc.getURL())
-              #set ($ancestorDocTitle = $ancestorDoc.displayTitle)
-              #set ($ancestorLink = "&lt;a href=""$ancestorDocUrl""&gt;$ancestorDocTitle&lt;/a&gt;")
-              $services.localization.render('notifications.watch.modal.description.ancestoroption', [$ancestorLink])
-            #end
-          &lt;/div&gt;
-          &lt;div class="watch-options-container panel-group" id="watch-options-accordion" role="tablist" aria-multiselectable="false"&gt;
-          #set ($blockedByAncestor = ("$!ancestorWatchStatus" == '' || $ancestorWatchStatus.isBlocked()))
-          #set ($watchedByAncestor = ($ancestorWatchStatus.isWatched()))
-          #if ($watchedStatus == 'NOT_SET')
-            $watchPageOption
-            #if (!$isTerminal)
-            $watchSpaceOption
-            #end
-            $watchWikiOption
-          #elseif ($watchedStatus == 'WATCHED_FOR_ALL_EVENTS_AND_FORMATS')
-            #if ($blockedByAncestor)
-            $unwatchPageOption
-            #else
-            $blockPageOption
-            #end
-            #if (!$isTerminal &amp;&amp; $blockedByAncestor)
-            $unwatchPageAndWatchSpaceOption
-            #elseif (!$isTerminal &amp;&amp; !$blockedByAncestor)
-            $blockSpaceOption
-            #end
-          #elseif ($watchedStatus == 'WATCHED_WITH_CHILDREN_FOR_ALL_EVENTS_AND_FORMATS')
-            #if ($blockedByAncestor)
-            $unwatchSpaceOption
-            #else
-            $blockPageOption
-            $blockSpaceOption
-            #end
-          #elseif ($watchedStatus == 'WATCHED_BY_ANCESTOR_FOR_ALL_EVENTS_AND_FORMATS')
-            $blockPageOption
-            #if (!$isTerminal)
-            $blockSpaceOption
-            #end
-            #if ($ancestorRef.type == 'WIKI')
-            $unwatchWikiOption
-            #end
-          #elseif ($watchedStatus == 'BLOCKED_FOR_ALL_EVENTS_AND_FORMATS')
-            #if ($watchedByAncestor)
-            $unblockPageOption
-            #else
-            $watchPageOption
-            #end
-            #if (!$isTerminal &amp;&amp; $watchedByAncestor)
-            $unblockPageAndBlockSpaceOption
-            #elseif (!$isTerminal &amp;&amp; !$watchedByAncestor)
-            $watchSpaceOption
-            #end
-          #elseif ($watchedStatus == 'BLOCKED_WITH_CHILDREN_FOR_ALL_EVENTS_AND_FORMATS')
-            #if ($watchedByAncestor)
-            $unblockSpaceOption
-            #else
-            $watchPageOption
-            $watchSpaceOption
-            #end
-          #elseif ($watchedStatus == 'BLOCKED_BY_ANCESTOR_FOR_ALL_EVENTS_AND_FORMATS')
-            $watchPageOption
-            #if (!$isTerminal)
-            $watchSpaceOption
-            #end
-            #if ($ancestorRef.type == 'WIKI')
-            $unblockWikiOption
-            #end
-          #end
-          &lt;/div&gt;&lt;!-- end panel group --&gt;
-          &lt;div class="modal-body-footer"&gt;
-            #set ($userDoc = $xwiki.getDocument($xcontext.userReference))
-            #set ($settingsLink = "$userDoc.getURL('view','category=notifications')#Hnotifications.settings.filters.preferences.custom.title")
-            &lt;a href="$settingsLink" class="goto-settings"&gt;
-              $services.localization.render('notifications.watch.modal.gotosettings', 'html/5.0', []) $services.icon.renderHTML('move')
-            &lt;/a&gt;
-          &lt;/div&gt;
-        &lt;/div&gt;&lt;!-- end modal body --&gt;
-        &lt;div class="modal-footer"&gt;
-          &lt;button type="button" class="btn btn-default close-modal" data-dismiss="modal"&gt;
-            $services.localization.render('notifications.watch.modal.close', 'html/5.0', [])
-          &lt;/button&gt;
-          #if ($watchedStatus != 'CUSTOM')
-          &lt;button type="button" class="btn btn-primary" disabled="disabled"&gt;
-            $services.localization.render('notifications.watch.modal.savechanges', 'html/5.0', [])
-          &lt;/button&gt;
-          #end
-        &lt;/div&gt;
-      &lt;/div&gt;&lt;!-- /.modal-content --&gt;
-    &lt;/div&gt;&lt;!-- /.modal-dialog --&gt;
-  &lt;/div&gt;&lt;!-- /.modal --&gt;
-  #end
 #end
 {{/velocity}}</content>
     </property>
     <property>
-      <extensionPointId>org.xwiki.plaftorm.menu.content</extensionPointId>
+      <extensionPointId>org.xwiki.platform.template.body.end</extensionPointId>
     </property>
     <property>
-      <name>org.xwiki.platform.notification.watch</name>
+      <name>org.xwiki.platform.notification.watchModal</name>
     </property>
     <property>
-      <parameters>order=39000</parameters>
+      <parameters></parameters>
     </property>
     <property>
       <scope>wiki</scope>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsWatchUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsWatchUIX.xml
@@ -695,8 +695,7 @@
   #set ($ancestorWatchStatus = $ancestorFirstFilter.right)
 #end
 
-## TODO: better way for that?
-#set ($isTerminal = ($doc.getDocumentReference().name != 'WebHome'))
+#set ($isTerminal = ($doc.documentReference.name != $services.model.getEntityReference('DOCUMENT', 'default').name))
 
 #set ($watchPageOption = "#_displayOption('watch-page','watchPage','watchpage','page','')")
 #set ($watchSpaceOption = "#_displayOption('watch-space','watchSpace','watchspace','chart-organisation','')")

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsWatchUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsWatchUIX.xml
@@ -711,7 +711,7 @@
 #set ($unblockSpaceOption = "#_displayOption('unblock-space','unblockSpace','unblockspace','chart-organisation','')")
 #set ($unblockWikiOption = "#_displayOption('unblock-wiki','unblockWiki','unblockwiki','world','wiki-option')")
 {{html clean='false'}}
-&lt;dialog class="modal fade" id="watchModal"&gt;
+&lt;dialog class="modal fade" id="watchModal" aria-labelledby="watchModalLabel"&gt;
   &lt;div class="modal-dialog" role="document"&gt;
     &lt;div class="modal-content"&gt;
       &lt;div class="modal-header"&gt;
@@ -719,7 +719,7 @@
           &lt;span aria-hidden="true"&gt;
             $services.icon.renderHTML('cross')
           &lt;/span&gt;&lt;/button&gt;
-        &lt;div class="modal-title"&gt;
+        &lt;div class="modal-title" id="watchModalLabel"&gt;
           &lt;span class="fa $watchIcon"&gt;&lt;/span&gt; $services.localization.render("notifications.watch.modal.title.$watchedStatus", 'html/5.0', [])
         &lt;/div&gt;
       &lt;/div&gt;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsWatchUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsWatchUIX.xml
@@ -728,7 +728,7 @@
 #set ($unblockSpaceOption = "#_displayOption('unblock-space','unblockSpace','unblockspace','chart-organisation','')")
 #set ($unblockWikiOption = "#_displayOption('unblock-wiki','unblockWiki','unblockwiki','world','wiki-option')")
 {{html clean='false'}}
-&lt;div class="modal fade" tabindex="-1" role="dialog" id="watchModal"&gt;
+&lt;dialog class="modal fade" id="watchModal"&gt;
   &lt;div class="modal-dialog" role="document"&gt;
     &lt;div class="modal-content"&gt;
       &lt;div class="modal-header"&gt;
@@ -835,7 +835,7 @@
       &lt;/div&gt;
     &lt;/div&gt;&lt;!-- /.modal-content --&gt;
   &lt;/div&gt;&lt;!-- /.modal-dialog --&gt;
-&lt;/div&gt;&lt;!-- /.modal --&gt;
+&lt;/dialog&gt;&lt;!-- /.modal --&gt;
 {{/html}}
 #end
 {{/velocity}}</content>

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/htmlfooter.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/htmlfooter.vm
@@ -31,7 +31,7 @@
 ## We don't care about order for this extension point, none of the extensions should have 'visible' content.
 ## The primary use of this extension point is to gather modal elements that did not get loaded asynchronously.
 #foreach ($uix in $services.uix.getExtensions('org.xwiki.platform.template.body.end'))
-  $services.rendering.render($uix.execute(), 'xhtml/1.0')
+  $services.rendering.render($uix.execute(), 'html/5.0')
 #end
 </div>
 </body>

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/htmlfooter.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/htmlfooter.vm
@@ -24,6 +24,10 @@
 #template('debug.vm')
 #end
 <div class="modal-container">
+#if (($displayAdminMenu || $displayMoreActionsMenu) && $canView)
+  #template("export_modal.vm")
+  #exportModal()
+#end
 ## We don't care about order for this extension point, none of the extensions should have 'visible' content.
 ## The primary use of this extension point is to gather modal elements that did not get loaded asynchronously.
 #foreach ($uix in $services.uix.getExtensions('org.xwiki.platform.template.body.end'))

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/htmlfooter.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/htmlfooter.vm
@@ -23,6 +23,13 @@
 #if ($services.debug.isEnabled())
 #template('debug.vm')
 #end
+<div class="modal-container">
+## We don't care about order for this extension point, none of the extensions should have 'visible' content.
+## The primary use of this extension point is to gather modal elements that did not get loaded asynchronously.
+#foreach ($uix in $services.uix.getExtensions('org.xwiki.platform.template.body.end'))
+  $services.rendering.render($uix.execute(), 'xhtml/1.0')
+#end
+</div>
 </body>
 </html>
 #else ## Portlet Mode

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/htmlfooter.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/htmlfooter.vm
@@ -23,7 +23,7 @@
 #if ($services.debug.isEnabled())
 #template('debug.vm')
 #end
-<div class="modal-container">
+<div class="end-of-dom-container">
 #if (($displayAdminMenu || $displayMoreActionsMenu) && $canView)
   #template("export_modal.vm")
   #exportModal()

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/htmlfooter.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/htmlfooter.vm
@@ -28,9 +28,8 @@
   #template("export_modal.vm")
   #exportModal()
 #end
-## We don't care about order for this extension point, none of the extensions should have 'visible' content.
 ## The primary use of this extension point is to gather modal elements that did not get loaded asynchronously.
-#foreach ($uix in $services.uix.getExtensions('org.xwiki.platform.template.body.end'))
+#foreach ($uix in $services.uix.getExtensions('org.xwiki.platform.template.body.end', {'sortByParameter': 'order'}))
   $services.rendering.render($uix.execute(), 'html/5.0')
 #end
 </div>

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -3329,8 +3329,7 @@ $!stringtool.removeEnd($stringtool.removeStart($displayOutput, '{{html clean="fa
  * Returns the FA4 class of the icon corresponding to the provided watchStatus in $watchIcon
  * AND
  * Returns the status label in $watchText
- * @since 17.4.2
- * @since 17.5.0RC1
+ * @since 18.6.0RC1
  *#
 #macro (_notificationsWatchStatusIcon $watchedStatus)
 ## FIXME: the different icons should use the icon service

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -3321,3 +3321,35 @@ $!stringtool.removeEnd($stringtool.removeStart($displayOutput, '{{html clean="fa
 {{translation key="$txkey"/}}##
 #end
 #end
+
+#**
+ * XWiki Standard use only.
+ * $watchStatus is a WatchedEntityReference.WatchedStatus returned by script services
+ * similar to $services.notification.watch.getLocationWatchedStatus
+ * Returns the FA4 class of the icon corresponding to the provided watchStatus in $watchIcon
+ * AND
+ * Returns the status label in $watchText
+ * @since 17.4.2
+ * @since 17.5.0RC1
+ *#
+#macro (_notificationsWatchStatusIcon $watchedStatus)
+## FIXME: the different icons should use the icon service
+## They should be added to the XWiki Icon set
+#set ($iconWhenWatched = 'fa-bell')
+#set ($iconWhenNotSet = 'fa-bell-o')
+#set ($iconWhenBlocked = 'fa-bell-slash')
+#set ($iconWhenCustom = 'fa-bullhorn')
+#if ($watchedStatus == 'NOT_SET')
+  #set ($watchIcon = $iconWhenNotSet)
+  #set ($watchText = $services.localization.render('notifications.watch.button.status.notset', 'html/5.0', []))
+#elseif ($watchedStatus.isWatched())
+  #set ($watchIcon = $iconWhenWatched)
+  #set ($watchText = $services.localization.render('notifications.watch.button.status.followed', 'html/5.0', []))
+#elseif ($watchedStatus.isBlocked())
+  #set ($watchIcon = $iconWhenBlocked)
+  #set ($watchText = $services.localization.render('notifications.watch.button.status.blocked', 'html/5.0', []))
+#else
+  #set ($watchIcon = $iconWhenCustom)
+  #set ($watchText = $services.localization.render('notifications.watch.button.status.custom', 'html/5.0', []))
+#end
+#end

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -3345,3 +3345,35 @@ $!stringtool.removeEnd($stringtool.removeStart($displayOutput, '{{html clean="fa
 {{translation key="$txkey"/}}##
 #end
 #end
+
+#**
+ * XWiki Standard use only.
+ * $watchStatus is a WatchedEntityReference.WatchedStatus returned by script services
+ * similar to $services.notification.watch.getLocationWatchedStatus
+ * Returns the FA4 class of the icon corresponding to the provided watchStatus in $watchIcon
+ * AND
+ * Returns the status label in $watchText
+ * @since 17.4.2
+ * @since 17.5.0RC1
+ *#
+#macro (_notificationsWatchStatusIcon $watchedStatus)
+## FIXME: the different icons should use the icon service
+## They should be added to the XWiki Icon set
+#set ($iconWhenWatched = 'fa-bell')
+#set ($iconWhenNotSet = 'fa-bell-o')
+#set ($iconWhenBlocked = 'fa-bell-slash')
+#set ($iconWhenCustom = 'fa-bullhorn')
+#if ($watchedStatus == 'NOT_SET')
+  #set ($watchIcon = $iconWhenNotSet)
+  #set ($watchText = $services.localization.render('notifications.watch.button.status.notset', 'html/5.0', []))
+#elseif ($watchedStatus.isWatched())
+  #set ($watchIcon = $iconWhenWatched)
+  #set ($watchText = $services.localization.render('notifications.watch.button.status.followed', 'html/5.0', []))
+#elseif ($watchedStatus.isBlocked())
+  #set ($watchIcon = $iconWhenBlocked)
+  #set ($watchText = $services.localization.render('notifications.watch.button.status.blocked', 'html/5.0', []))
+#else
+  #set ($watchIcon = $iconWhenCustom)
+  #set ($watchText = $services.localization.render('notifications.watch.button.status.custom', 'html/5.0', []))
+#end
+#end

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -3353,8 +3353,7 @@ $!stringtool.removeEnd($stringtool.removeStart($displayOutput, '{{html clean="fa
  * Returns the FA4 class of the icon corresponding to the provided watchStatus in $watchIcon
  * AND
  * Returns the status label in $watchText
- * @since 17.4.2
- * @since 17.5.0RC1
+ * @since 18.6.0RC1
  *#
 #macro (_notificationsWatchStatusIcon $watchedStatus)
 ## FIXME: the different icons should use the icon service


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-23129

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added the UIXP
* Used the UIX for one of the blocking modals for XWIKI-22669
* Handled the #exportModal and #exportTreeModal move
* Changed the nature of the modal elements to avoid overcomplicated/low reliability ARIA markup combinations.
* Updated the bootstrap style for modal to make it look as it used to with this new DOM.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Since the exportModal and exportTreeModal were defined in flamingo VTL templates, I decided to just move it before the UIXP in their new template. Note that in all cases, this new template should be loaded, and it's not much of an issue if we load the modals if we don't have the buttons to open them, they stay hidden by default.
* On the opposite to a `div`, a dialog element has a default look (white background and black border). We update bootstrap to keep the class while updating the nature of the nodes without it impacting the looks.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
![Screenshot from 2025-04-24 10-07-57](https://github.com/user-attachments/assets/92f11199-2ae3-4396-b9c6-323b8443e744)


https://github.com/user-attachments/assets/3dc86e15-80db-47c3-b72f-4a8f83b0abfb


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests on the three modals.
Checked the automated test paths, which is IMO the most likely thing that could have gotten broken by this:
* ExportModal: https://github.com/xwiki/xwiki-platform/blob/bfa5b81135badafae03b04646d84448ebe013987/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-pageobjects/src/main/java/org/xwiki/flamingo/skin/test/po/ExportModal.java#L42 everything is fine, the selector uses only the ID, it doesn't care about the nature or the position of the element.
* TreeExportModal: same as ExportModal
* watchModal: https://github.com/search?q=repo%3Axwiki%2Fxwiki-platform%20%23watchModal&type=code **None** The page object is built similarly to the export modal one

Successfully built:
* `mvn clean install -f xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/ -Pquality`
*  `mvn clean install -f xwiki-platform-core/xwiki-platform-web; mvn clean install -f xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui -Pquality; mvn clean install -f xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker` (note that without building the whole xwiki-platform-web module, those tests were failing because the distrib used in the docker tests did not get the updated template)


# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, this is a DOM change that applies on all pages so it's pretty dangerous. 