### PR TITLE
XWIKI-23101: XWiki Notifications alert too often

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/notification.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/notification.js
@@ -107,9 +107,8 @@ widgets.Notification = Class.create({
   /** Creates the HTML structure for the notification. */
   createElement : function() {
     if (!this.element) {
-      // The ARIA role `alert` should give implicit values for `aria-live` and `aria-atomic`.
-      this.element = new Element("div", {"class" : "xnotification xnotification-" + this.type,
-        "role": "alert"}).update(this.text);
+      // The notification container is already an ARIA "alert", those notifications do not need extra semantics.
+      this.element = new Element("div", {"class" : "xnotification xnotification-" + this.type}).update(this.text);
       if (this.options.icon) {
         this.element.setStyle({backgroundImage : this.options.icon, paddingLeft : "22px"});
       }
@@ -167,6 +166,7 @@ widgets.Notification.getContainer = function() {
   if (!widgets.Notification.container) {
     widgets.Notification.container = new Element('div', {"class" : "xnotification-container"});
     // Make notifications alert / accessible for screen readers
+    // The ARIA role `alert` should give implicit values for `aria-live` and `aria-atomic`.
     widgets.Notification.container.writeAttribute("role", "alert");
     // Insert the container in the document body.
     $('body').insert(widgets.Notification.container);


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Removed the harmful role from the notifications themselves. The role is already on the container and handles notifying non visual users.
* Added comments to avoid repeating the mistake I did in XWIKI-22709

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* When [implementing XWIKI-22709](https://github.com/xwiki/xwiki-platform/pull/3707), I wasn't aware that the container itself was an alert. I was also probably tricked by the fact that this .js is stored in the `xwiki.bundle.min.js`, which makes edits after the first patch more complex. When checking the demo video, it seems I was testing on an unpatched version :/

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Before the changes:

https://github.com/user-attachments/assets/4d47c5de-5a35-4abb-8a76-2e41249dffae

After the changes:

https://github.com/user-attachments/assets/d8b4c784-f24d-41f4-b350-596f1a8f88c6



# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Manual tests only. This is pretty much just a revert of https://github.com/xwiki/xwiki-platform/pull/3707 which did not have any test change and did not create any automated test regression.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X