### PR TITLE
XWIKI-23097: Quicksearch: no alert when results are shown

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggest.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggest.js
@@ -494,8 +494,14 @@ var XWiki = (function(XWiki){
 
     if (!$(this.options.parentContainer).down('.suggestItems')) {
       // If the suggestion top container is not in the DOM already, we create it and inject it
-
-      var div = new Element("div", { 'class': "suggestItems "+ this.options.className });
+      
+      // We populate the suggestion container with information that was not on the page.
+      // This meaningful change in the DOM must be announced 
+      // so that assistive technology users can notice it without trouble.
+      var div = new Element("div", { 
+        'class': "suggestItems "+ this.options.className ,
+        'role': 'alert'
+      });
 
       // Get position of target textfield
       var pos = $(this.options.parentContainer).tagName.toLowerCase() == 'body' ? this.fld.cumulativeOffset() : this.fld.positionedOffset();

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggest.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggest.js
@@ -499,7 +499,7 @@ var XWiki = (function(XWiki){
       // This meaningful change in the DOM must be announced 
       // so that assistive technology users can notice it without trouble.
       var div = new Element("div", { 
-        'class': "suggestItems "+ this.options.className ,
+        'class': "suggestItems "+ this.options.className,
         'role': 'alert'
       });
 


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-23097

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Added the alert role to the container of suggestions.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The component is already pretty accessible, but nothing was conveyed to notice the users that some new content has been queried and displayed. This attribute is enough to fulfill this lack of info.
* There is a lot of info read out when the dropdown is activated. This is an issue for clarity, but I guess it's not that important and it's better than no information at all.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Video demo with the changes proposed here applied:

https://github.com/user-attachments/assets/7a5f65c3-1c90-4a48-b9e2-b12fa58c3f6a

Made using browserStack, Chrome 136 + NVDA

Note that before the changes in here were applied, all that would be read out to the user are the letters they added to the input:
```
p
a
g
e
```
Now, as we can listen to in this demo, those letters are followed by the content of the asynchronously generated dropdown:
```
p
a
g
e
Go to search page button.
[...]
```

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests, see above.
https://github.com/search?q=org%3Axwiki+suggestItems&type=code shows that the changes do not affect the pageobject associated to this element used in docker tests.

Successfully built `mvn clean install -f xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/ -Pquality`.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X, this is a minor bug with a very low risk solution.