### PR TITLE
XWIKI-23127: Implement improvements to labels and links

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/forms.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/forms.less
@@ -99,10 +99,9 @@ select[size="0"], select[size="1"] {
       }
       .label {
         color: @text-color;
-        font-size: 0.85em;
-        font-weight: 700;
+        font-size: 1em;
+        font-weight: 600;
         margin-bottom: 0.3em;
-        text-transform: uppercase;
         .buttonwrapper a {
           .btn-xs;
           margin: 0;
@@ -129,6 +128,7 @@ select[size="0"], select[size="1"] {
     .text-muted-smaller;
     font-weight: 400;
     text-transform: none;
+    margin-bottom: .5em;
   }
   .xHint {
     display: block;

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/type.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/type.less
@@ -5,7 +5,7 @@
 // Local Mixins ===========================================================
 
 .text-smaller {
-  font-size: floor(@font-size-base * 0.9);
+  font-size: floor(@font-size-base * 0.95);
 }
 
 .text-muted-smaller {


### PR DESCRIPTION
* Labels: removed uppercase, increased base size, changed weight
* Hints: Increased size (inherited from .text-smaller)

# Jira URL

https://jira.xwiki.org/browse/XWIKI-23127

# Changes

## Description

Changed the default styles to the ones discussed in the forums, removing the all caps labels and balancing it with an font-size and font-weight.

## Clarifications

* The changes in the hint styles were done using the `.text-smaller` style to maintain consistency. However, this also increased other instances of small text in the interface. From manual testing, it doesn't seem to break anything.

# Screenshots & Video

TODO

# Executed Tests

-

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 