### PR TITLE
XWIKI-23160: Move XWikiPreferences meta field to a templates

### DIFF
--- a/xwiki-platform-distribution/xwiki-platform-distribution-migrations/src/main/java/org/xwiki/migrations/internal/R170400000XWIKI23160DataMigration.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-migrations/src/main/java/org/xwiki/migrations/internal/R170400000XWIKI23160DataMigration.java
@@ -22,7 +22,7 @@ package org.xwiki.migrations.internal;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Locale;
-import java.util.Objects;
+import java.util.Set;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -70,7 +70,18 @@ import static org.xwiki.migrations.internal.XWikiPropertiesMetaFieldCleanupTaskC
 @Singleton
 public class R170400000XWIKI23160DataMigration extends AbstractHibernateDataMigration
 {
+
     private static final String META_FIELD = "meta";
+
+    /**
+     * The set of expected ids for the default distribution xar files containing XWiki.XWikiPreferences
+     */
+    private static final Set<String> DISTRIBUTION_XAR_IDS = Set.of(
+        // Id in recent distributions
+        "org.xwiki.platform:xwiki-platform-distribution-ui-base",
+        // Id in older distributions
+        "org.xwiki.platform:xwiki-platform-distribution-flavor"
+    );
 
     @Inject
     private Packager packager;
@@ -138,8 +149,7 @@ public class R170400000XWIKI23160DataMigration extends AbstractHibernateDataMigr
             Collection<XarInstalledExtension> xarInstalledExtensions =
                 xarInstalledExtensionRepository.getXarInstalledExtensions(xwikiPreferencesDocumentReference);
             XarInstalledExtension xarInstalledExtension = xarInstalledExtensions.stream()
-                .filter(
-                    it -> Objects.equals(it.getId().getId(), "org.xwiki.platform:xwiki-platform-distribution-ui-base"))
+                .filter(it -> DISTRIBUTION_XAR_IDS.contains(it.getId().getId()))
                 .findFirst()
                 .orElse(null);
             if (xarInstalledExtension != null) {


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-23160

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* fix a specific case for the upgrade from version 8.4 where the xar id is not the same.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Upgrade of 8.4 and 16.10

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A