### PR TITLE
XWIKI-23188: Race condition in Solr index synchronization can delete existing documents from the index

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/test/java/org/xwiki/search/solr/internal/job/IndexerJobTest.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/test/java/org/xwiki/search/solr/internal/job/IndexerJobTest.java
@@ -1,0 +1,211 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.search.solr.internal.job;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.inject.Named;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.xwiki.bridge.DocumentAccessBridge;
+import org.xwiki.job.JobGroupPath;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.EntityReference;
+import org.xwiki.model.reference.EntityReferenceSerializer;
+import org.xwiki.search.solr.internal.api.SolrIndexer;
+import org.xwiki.test.LogLevel;
+import org.xwiki.test.junit5.LogCaptureExtension;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link IndexerJob}.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+class IndexerJobTest
+{
+    private static final String WIKI = "wiki";
+
+    private static final String SPACE = "space";
+
+    private static final DocumentReference DOCUMENT_ONE = new DocumentReference(WIKI, SPACE, "document1");
+
+    private static final DocumentReference DOCUMENT_TWO = new DocumentReference(WIKI, SPACE, "document2");
+
+    private static final String VERSION_ONE = "1.0";
+
+    private static final String VERSION_TWO = "2.0";
+
+    private static final JobGroupPath INDEXER_JOB_GROUP_PATH = new JobGroupPath(List.of("solr", "indexer"));
+
+    @MockComponent
+    private SolrIndexer mockIndexer;
+
+    @MockComponent
+    @Named("database")
+    private DocumentIterator<String> mockDatabaseIterator;
+
+    @MockComponent
+    @Named("solr")
+    private DocumentIterator<String> mockSolrIterator;
+
+    @MockComponent
+    private EntityReferenceSerializer<String> mockEntityReferenceSerializer;
+
+    @MockComponent
+    private DocumentAccessBridge mockDocumentAccessBridge;
+
+    @InjectMockComponents
+    private IndexerJob indexerJob;
+
+    @RegisterExtension
+    private LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.INFO);
+
+    private final IndexerRequest request = new IndexerRequest();
+
+    @BeforeEach
+    void setUp()
+    {
+        this.indexerJob.initialize(this.request);
+    }
+
+    @Test
+    void testRunInternalOverwrite() throws Exception
+    {
+        this.request.setOverwrite(true);
+        this.request.setRootReference(DOCUMENT_ONE);
+
+        this.indexerJob.runInternal();
+
+        verify(this.mockIndexer).index(DOCUMENT_ONE, true);
+        assertEquals("Index documents in [{}].", this.logCapture.getLogEvent(0).getMessage());
+        assertEquals(DOCUMENT_ONE, this.logCapture.getLogEvent(0).getArgumentArray()[0]);
+    }
+
+    @Test
+    void testRunInternalUpdateSolrIndexNoChanges() throws Exception
+    {
+        mockIterator(this.mockDatabaseIterator, Pair.of(DOCUMENT_ONE, VERSION_ONE));
+        mockIterator(this.mockSolrIterator, Pair.of(DOCUMENT_ONE, VERSION_ONE));
+
+        this.indexerJob.runInternal();
+
+        verifyNoInteractions(this.mockIndexer);
+        assertLog(0, 0, 0);
+    }
+
+    @Test
+    void testRunInternalUpdateSolrIndexAddAction() throws Exception
+    {
+        mockIterator(this.mockDatabaseIterator, Pair.of(DOCUMENT_ONE, VERSION_ONE), Pair.of(DOCUMENT_TWO, VERSION_TWO));
+        mockIterator(this.mockSolrIterator, Pair.of(DOCUMENT_ONE, VERSION_ONE));
+
+        this.indexerJob.runInternal();
+
+        verify(this.mockIndexer).index(DOCUMENT_TWO, true);
+
+        assertLog(1, 0, 0);
+    }
+
+    @Test
+    void testGetGroupPathWithoutRootReference()
+    {
+        JobGroupPath result = this.indexerJob.getGroupPath();
+
+        assertEquals(INDEXER_JOB_GROUP_PATH, result);
+    }
+
+    @Test
+    void testGetGroupPathWithRootReference()
+    {
+        EntityReference rootReference = new DocumentReference(WIKI, SPACE, "documentRoot");
+        String expectedPath = "serializedRootReference";
+        when(this.mockEntityReferenceSerializer.serialize(rootReference)).thenReturn(expectedPath);
+
+        this.request.setRootReference(rootReference);
+
+        JobGroupPath result = this.indexerJob.getGroupPath();
+
+        assertEquals(new JobGroupPath(expectedPath, INDEXER_JOB_GROUP_PATH), result);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void testRunInternalUpdateSolrIndexDeleteAction(boolean exists) throws Exception
+    {
+        mockIterator(this.mockDatabaseIterator, Pair.of(DOCUMENT_ONE, VERSION_ONE));
+        mockIterator(this.mockSolrIterator, Pair.of(DOCUMENT_ONE, VERSION_ONE), Pair.of(DOCUMENT_TWO, VERSION_TWO));
+
+        when(this.mockDocumentAccessBridge.exists(DOCUMENT_TWO)).thenReturn(exists);
+
+        this.indexerJob.runInternal();
+
+        if (!exists) {
+            verify(this.mockIndexer).delete(DOCUMENT_TWO, true);
+            assertLog(0, 1, 0);
+        } else {
+            assertLog(0, 0, 0);
+        }
+        verifyNoMoreInteractions(this.mockIndexer);
+    }
+
+    @Test
+    void testRunInternalUpdateSolrIndexUpdateAction() throws Exception
+    {
+        mockIterator(this.mockDatabaseIterator, Pair.of(DOCUMENT_ONE, VERSION_ONE), Pair.of(DOCUMENT_TWO, VERSION_TWO));
+        mockIterator(this.mockSolrIterator, Pair.of(DOCUMENT_ONE, VERSION_ONE), Pair.of(DOCUMENT_TWO, VERSION_ONE));
+
+        this.indexerJob.runInternal();
+
+        verify(this.mockIndexer).index(DOCUMENT_TWO, true);
+        verifyNoMoreInteractions(this.mockIndexer);
+        assertLog(0, 0, 1);
+    }
+
+    private void assertLog(int added, int deleted, int updated)
+    {
+        assertEquals("%d documents added, %d deleted and %d updated during the synchronization of the Solr index."
+                .formatted(added, deleted, updated),
+            this.logCapture.getLogEvent(0).getFormattedMessage());
+    }
+
+    @SafeVarargs
+    private void mockIterator(DocumentIterator<String> mockIterator, Pair<DocumentReference, String>... pairs)
+    {
+        var iterator = Arrays.asList(pairs).iterator();
+        when(mockIterator.hasNext()).then(invocation -> iterator.hasNext());
+        when(mockIterator.next()).then(invocation -> iterator.next());
+    }
+}


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-23188

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Double-check that a document actually doesn't exist anymore before requesting its deletion from the index.
* Add a unit test for IndexerJob.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* In theory, there is still the possibility of a race condition where the document is deleted again between the check and the addition to the index queue. I decided to ignore this possibility as the probability seems very small and the only scenario where this would matter is if a document is created and immediately deleted again while the index synchronization is running.
* This is primarily an attempt at fixing a flickering test than a problem that was actually observed in practice.
* The additional check could slow down the job a bit but in practice this should be rare as actual synchronization activity shouldn't happen.
* As a nice side effect this will prevent incomplete search indexes in case the sorting order is messed up.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
mvn clean install -Pquality,integration-tests,docker -pl :xwiki-platform-search-solr-api,:xwiki-platform-search-test-docker
```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-16.10.x