### PR TITLE
XWIKI-9363: Have a consistent naming for Indexes applications

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -2596,7 +2596,7 @@ xe.attachmentSelector.cancel=Cancel and return to page
 xe.attachmentSelector.postUpload.comment=Update field {0}
 
 ### Users Directory
-xe.userdirectory.title=User Directory
+xe.userdirectory.title=User Index
 xe.userdirectory.customizeSaveButtonLabel=Save
 xe.userdirectory.customizeResetButtonLabel=Reset to default
 xe.userdirectory.customizePreviewTitle=Preview


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-9363

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Updated the only translation default value that was inconsistent. It's used in https://github.com/xwiki/xwiki-platform/blob/ad18f5bf16b0b35ece8cd2aba406dc5e1958bdd4/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-directory/xwiki-platform-user-directory-ui/src/main/resources/Main/UserDirectory.xml#L34 

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

None. Translation value change only.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
None. Translation value change only. I could not find the translation key or value inside test files.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X (safe bugfix)