### PR TITLE
XWIKI-23097: Quicksearch: no alert when results are shown

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggest.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggest.js
@@ -498,7 +498,7 @@ var XWiki = (function(XWiki){
       // We populate the suggestion container with information that was not on the page.
       // This meaningful change in the DOM must be announced 
       // so that assistive technology users can notice it without trouble.
-      var div = new Element("div", { 
+      let div = new Element("div", { 
         'class': "suggestItems "+ this.options.className,
         'role': 'alert'
       });


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-23097

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Fixed a new sonarcloud codesmell.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The codesmell is described in https://sonarcloud.io/project/issues?sinceLeakPeriod=true&issueStatuses=OPEN%2CCONFIRMED&branch=stable-16.10.x&id=org.xwiki.platform%3Axwiki-platform&open=AZbyyFuFawS2eEWuxMIb&tab=code and 

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
None

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
None. I reviewed the uses of this var in the script, it seems declaring it with `let` would not change anything.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X, same as https://github.com/xwiki/xwiki-platform/pull/4128.