### PR TITLE
XWIKI-23154: Link creation dialog shouldn't allow to be validated without selecting a suggestion value

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-link/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-link/plugin.js
@@ -406,23 +406,9 @@
       },
       setup: function(data) {
         // Create a link to a new page if the resource reference is not provided.
-        var resourceReference = data.resourceReference;
-        $(this.getResourcePickerInput().$).prop('disabled', true);
-        if (resourceReference) {
-          this.setDefaultValue(this, resourceReference);
-        } else {
-          let self = this;
-
-          this.getDefaultResourceReference()
-              .done(ref => self.setDefaultValue(self, ref))
-              .fail(function () {
-                self.setDefaultValue(self, self.getDefaultResourceReferenceFallback());
-              });
-        }
-      },
-      setDefaultValue: function(self, resourceReference) {
-        if (resourceReference.type === 'space' && self.resourceTypes.indexOf('space') < 0 &&
-            self.resourceTypes.indexOf('doc') >= 0) {
+        var resourceReference = data.resourceReference || this.getDefaultResourceReference();
+        if (resourceReference.type === 'space' && this.resourceTypes.indexOf('space') < 0 &&
+            this.resourceTypes.indexOf('doc') >= 0) {
           // Convert the space resource reference to a document resource reference.
           resourceReference = {
             type: 'doc',
@@ -431,47 +417,7 @@
             reference: resourceReference.reference + '.WebHome'
           };
         }
-        self.setValue(resourceReference);
-        $(self.getResourcePickerInput().$).prop('disabled', false);
-      },
-      getDefaultResourceReference: function() {
-        let self = this;
-        // Compute the default reference by cleaning up the link label.
-        // Fall-back on the empty string if there's no text selection (e.g. if an image is selected).
-        var linkLabel = this.getDialog().getParentEditor().getSelection().getSelectedText() || '';
-        // Normalize the white space.
-        var defaultReference = linkLabel.trim().replace(/\s+/g, ' ');
-        var deferred = $.Deferred();
-        $.post(new XWiki.Document('LinkNameStrategyHelper', 'CKEditor').getURL('get'), {
-          outputSyntax: 'plain',
-          input: defaultReference,
-          base: XWiki.Model.serialize(this.base.getBase())
-        }).done(function(data) {
-          deferred.resolve({
-            reference: data[0].reference,
-            location: data[0].location,
-            type: self.resourceTypes[0],
-            // Make sure the picker doesn't try to resolve the link label as a resource reference.
-            isNew: true
-          });
-        }).fail(function(data) {
-          console.error("Error while loading creation link response", data);
-          deferred.resolve(self.getDefaultResourceReferenceFallback());
-        });
-        return deferred.promise();
-      },
-      getDefaultResourceReferenceFallback: function() {
-        // Compute the default reference by cleaning up the link label.
-        // Fall-back on the empty string if there's no text selection (e.g. if an image is selected).
-        var linkLabel = this.getDialog().getParentEditor().getSelection().getSelectedText() || '';
-        // Normalize the white space.
-        var defaultReference = linkLabel.trim().replace(/\s+/g, ' ');
-        return {
-          type: this.resourceTypes[0],
-          reference: defaultReference,
-          // Make sure the picker doesn't try to resolve the link label as a resource reference.
-          isNew: true
-        };
+        this.setValue(resourceReference);
       },
       commit: function(data) {
         var resourceReference = this.getValue();
@@ -514,6 +460,19 @@
         });
         dialog.getContentElement('info', 'optionsToggle').sync();
         dialog.layout();
+      },
+      getDefaultResourceReference: function() {
+        // Compute the default reference by cleaning up the link label.
+        // Fall-back on the empty string if there's no text selection (e.g. if an image is selected).
+        var linkLabel = this.getDialog().getParentEditor().getSelection().getSelectedText() || '';
+        // Normalize the white space.
+        var defaultReference = linkLabel.trim().replace(/\s+/g, ' ');
+        return {
+          type: this.resourceTypes[0],
+          reference: defaultReference,
+          // Make sure the picker doesn't try to resolve the link label as a resource reference.
+          isNew: true
+        };
       }
     });
   };

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-link/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-link/plugin.js
@@ -471,7 +471,8 @@
           type: this.resourceTypes[0],
           reference: defaultReference,
           // Make sure the picker doesn't try to resolve the link label as a resource reference.
-          isNew: true
+          isNew: true,
+          isInitialValue: true
         };
       }
     });

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-resource/entityResourceSuggester.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-resource/entityResourceSuggester.js
@@ -64,7 +64,8 @@ define('entityResourceSuggester', [
     $.post(new XWiki.Document('LinkNameStrategyHelper', 'CKEditor').getURL('get'), {
       outputSyntax: 'plain',
       input: input,
-      base: XWiki.Model.serialize(base)
+      base: XWiki.Model.serialize(base),
+      action: 'suggest'
     }).done(function(data) {
       data.forEach(function (item) {
         suggestions.push(createDocumentFromLinkNameStrategyHelperResult(item, base));

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-resource/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-resource/plugin.js
@@ -177,12 +177,12 @@
         validateInput: function(resourceReference) {
           if (!this.validationRequest) {
             // Trigger a new validation.
-            this.validationRequest = this.validateAsync(resourceReference).always((function() {
+            this.validationRequest = this.validateAsync(resourceReference).always(() => {
               // Re-submit the dialog after the current event is handled.
-              setTimeout((function() {
+              setTimeout(() => {
                 this.getDialog().click('ok');
-              }).bind(this), 0);
-            }).bind(this));
+              }, 0);
+            });
             return false;
           } else if (this.validationRequest.state() === 'pending') {
             // Block the submit while the validation takes place.

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-resource/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-resource/plugin.js
@@ -162,13 +162,15 @@
         },
         validate: function() {
           var resourceReference = this.getValue();
+          var resourceTypeConfig = $resource.types[resourceReference.type] || {};
           if (resourceReference.reference === '') {
             // Check if the selected resource type supports empty references.
-            var resourceTypeConfig = $resource.types[resourceReference.type] || {};
             if (resourceTypeConfig.allowEmptyReference !== true) {
               return this.getDialog().getParentEditor().localization.get('xwiki-resource.notSpecified',
                 this.getLabelElement().getText());
             }
+          } else if (resourceReference.notSelected && resourceTypeConfig.mustBeSelected) {
+            return this.getDialog().getParentEditor().localization.get('xwiki-resource.selectValue');
           }
           return true;
         },
@@ -187,6 +189,10 @@
               this.selectedResource.reference.reference === resourceReference.reference) {
             // Preserve the typed field if the resource type and reference have not changed.
             resourceReference.typed = this.selectedResource.reference.typed;
+          }
+          if (this.selectedResource.reference.isInitialValue ||
+              this.selectedResource.reference.reference !== resourceReference.reference) {
+            resourceReference.notSelected = true;
           }
           return resourceReference;
         },

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-resource/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-resource/plugin.js
@@ -200,12 +200,12 @@
             outputSyntax: 'plain',
             input: resourceReference.reference,
             action: 'validate'
-          }).done((function(data) {
+          }).done(data => {
             this.validationRequestResult = data.validated;
-          }).bind(this)).fail((function(data) {
-            console.error("Error while loading validation link response", data);
+          }).fail(error => {
+            console.error("Error while loading validation link response", error);
             this.validationRequestResult = false;
-          }).bind(this));
+          });
         },
         getValue: function() {
           var resourcePickerInput = this.getResourcePickerInput();

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-resource/resource.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-resource/resource.js
@@ -45,7 +45,8 @@ define('resource', ['l10n!resource'], function(translations) {
       label: translations.get('attach.label'),
       icon: 'glyphicon glyphicon-paperclip',
       placeholder: translations.get('attach.placeholder'),
-      entityType: 'attachment'
+      entityType: 'attachment',
+      mustBeSelected: true
     },
     data: {
       label: translations.get('data.label'),
@@ -57,7 +58,8 @@ define('resource', ['l10n!resource'], function(translations) {
       icon: 'glyphicon glyphicon-file',
       placeholder: translations.get('doc.placeholder'),
       allowEmptyReference: true,
-      entityType: 'document'
+      entityType: 'document',
+      mustBeSelected: true
     },
     icon: {
       label: translations.get('icon.label'),
@@ -92,7 +94,8 @@ define('resource', ['l10n!resource'], function(translations) {
     user: {
       label: translations.get('user.label'),
       icon: 'glyphicon glyphicon-user',
-      placeholder: translations.get('user.placeholder')
+      placeholder: translations.get('user.placeholder'),
+      mustBeSelected: true
     }
   };
 

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-resource/resourcePicker.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-resource/resourcePicker.js
@@ -300,6 +300,7 @@ define('resourcePicker', [
       resourceReferenceInput.on('keydown', stopPropagationIfShowingSuggestions).typeahead({
         afterSelect: selectResource.bind(resourcePicker),
         delay: 500,
+        showHintOnFocus: true,
         displayText: function(resource) {
           // HACK: The string returned by this function is passed to the highlighter where we need to access all the
           // resource properties in order to be able to display the resource suggestion.

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/LinkNameStrategyHelper.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/LinkNameStrategyHelper.xml
@@ -52,6 +52,29 @@
   #setVariable("$result" $location)
 #end
 
+#macro (handleValidationRequest)
+  #set ($requestedReference = $services.model.resolveDocument($request.input, 'default'))
+  #if ($xwiki.exists($requestedReference))
+    #set ($answer = {
+      'validated': true,
+      'validation': 'exists',
+      'input': $request.input
+    })
+  #elseif ($services.modelvalidation.isValid($requestedReference))
+    #set ($answer = {
+      'validated': true,
+      'validation': 'name',
+      'input': $request.input
+    })
+  #else
+    #set ($answer = {
+      'validated': false,
+      'input': $request.input
+    })
+  #end
+  #jsonResponse($answer)
+#end
+
 #macro (handleSuggestionRequest)
   #set ($isAdvanced = $services.user.properties.type == 'ADVANCED')
   #set ($result = [])
@@ -82,8 +105,12 @@
 #end
 {{/velocity}}
 {{velocity}}
-#if ($xcontext.action == 'get' &amp;&amp; $request.input != '')
-#handleSuggestionRequest()
+#if ($xcontext.action == 'get' &amp;&amp; $request.input != '' &amp;&amp; $request.action != '')
+  #if ($request.action == 'suggest')
+    #handleSuggestionRequest()
+  #elseif ($request.action == 'validate')
+    #handleValidationRequest()
+  #end
 #else
 Technical page to help using the name strategy when suggesting links.
 #end

--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/Translations.xml
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-ui/src/main/resources/CKEditor/Translations.xml
@@ -94,6 +94,7 @@ ckeditor.plugin.office.importer.noUploadURL=File upload URL is not configured.
 ckeditor.plugin.office.importer.failedToLoadForm=Failed to load the form.
 
 ckeditor.plugin.resource.notSpecified=The {0} is not specified.
+ckeditor.plugin.resource.selectValue=Please select a value for the link location.
 ckeditor.plugin.save.leaveConfirmationMessage=There are unsaved changes. Do you want to discard them?
 ckeditor.plugin.save.failed=The content cannot be saved because of a CKEditor internal error. You should try to copy your important changes and reload the editor.
 ckeditor.plugin.source.conversionFailed=Failed to perform the conversion.


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-23154

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

  * Revert the original commit that was automatically putting a computed reference in the selection since it appears to be bad in terms of usability
  * Define the type of resources that must be selected and not just
    typed in the input field
  * Perform a check to ensure that the value is not just typed but is
    actually selected
  * Provide an initial value at setup which is considered as a typed
    value
  * Provide translation for the error message
  * Improve LinkStrategyHelper to also performs validation of inputs 

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

Before 16.8 it was possible to insert a link without any validation of the input, leading to use the actual selected word in the input field of the link dialog. This was changed to ensure that the name strategy was enforced when creating a link, by transforming automatically the selected input to comply with the name strategy. This led to a regression with terminal page, and also it was less usable for users. 

The PR here contains various changes. First, I reverted the change done to transform automatically the input based on the name strategy. So the users will again see the original selection in the link dialog. Then I added a small improvment: when a user focuses on the input for the page location, the suggest now appears immediately. And finally I added 2 checks: first, if the user selects a suggestion proposed when focusing in the input, then the dialog is validated and the link created; then, if the user only type in the input, or keep the original selection, another check is performed to verify whether the page exists, or, if it doesn't, if the input doesn't comply with the name strategy: then, and only then, I prevent validating the dialog with an error message.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

[Capture vidéo du 2025-05-22 14-51-55.webm](https://github.com/user-attachments/assets/ab2c52be-29bf-4548-bfdd-06543f69b087)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

`mvn clean install -Pquality` on `xwiki-platform-ckeditor-plugins`

- [x] Run the whole xwiki-platform-ckeditor with integration tests

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.x and 17.4.x: those changes are also fixing a regression related to links in terminal pages (see https://jira.xwiki.org/browse/XWIKI-23206)