### PR TITLE
XCOMMONS-3348: The servlet environment triggers a second load of the xwiki.properties configuration

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/AllIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/AllIT.java
@@ -224,4 +224,10 @@ public class AllIT
     class NestedSecurityCacheStressIT extends SecurityCacheStressIT
     {
     }
+
+    @Nested
+    @DisplayName("Servlet Environment Cache Tests")
+    class NestedServletEnvironmentCacheIT extends ServletEnvironmentCacheIT
+    {
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/ServletEnvironmentCacheIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/ServletEnvironmentCacheIT.java
@@ -43,7 +43,6 @@ class ServletEnvironmentCacheIT
         assertEquals("<p>Resource URL Cache is initialized.<br/></p>", setup.executeWiki("""
             {{groovy wiki="false"}}
             import org.xwiki.environment.Environment
-            import org.xwiki.environment.internal.ServletEnvironment
             
             def environment = services.component.getInstance(Environment.class)
             // Load the same resource twice to check if we get the same URL instance, which is only the case when it is

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/ServletEnvironmentCacheIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/ServletEnvironmentCacheIT.java
@@ -46,13 +46,16 @@ class ServletEnvironmentCacheIT
             import org.xwiki.environment.internal.ServletEnvironment
             
             def environment = services.component.getInstance(Environment.class)
-            if (!(environment instanceof ServletEnvironment)) {
-                println("Expected ServletEnvironment, got: " + environment.getClass().getName())
-            }
-            if (environment.resourceURLCache == null) {
-                println("Error: Resource URL Cache is null.")
-            } else {
+            // Load the same resource twice to check if we get the same URL instance, which is only the case when it is
+            // stored in a cache.
+            def url1 = environment.getResource('/WEB-INF/xwiki.properties')
+            def url2 = environment.getResource('/WEB-INF/xwiki.properties')
+            if (url1 == null) {
+                println("Error: URL is null")
+            } else if (url1 === url2) {
                 println("Resource URL Cache is initialized.")
+            } else {
+                println("Error: URLs aren't identical, resource URL Cache is NOT initialized.")
             }
             {{/groovy}}
             """, Syntax.XWIKI_2_1));

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/ServletEnvironmentCacheIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/ServletEnvironmentCacheIT.java
@@ -1,0 +1,60 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.flamingo.test.docker;
+
+import org.junit.jupiter.api.Test;
+import org.xwiki.rendering.syntax.Syntax;
+import org.xwiki.test.docker.junit5.UITest;
+import org.xwiki.test.ui.TestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Integration test to ensure that the {@link org.xwiki.environment.internal.ServletEnvironmentCacheInitializer} has
+ * been executed.
+ *
+ * @version $Id$
+ */
+@UITest(properties = "xwikiPropertiesAdditionalProperties=test.prchecker.excludePattern=.*:Test\\.Execute\\..*")
+class ServletEnvironmentCacheIT
+{
+    @Test
+    void testCacheInitialized(TestUtils setup) throws Exception
+    {
+        setup.loginAsSuperAdmin();
+
+        assertEquals("<p>Resource URL Cache is initialized.<br/></p>", setup.executeWiki("""
+            {{groovy wiki="false"}}
+            import org.xwiki.environment.Environment
+            import org.xwiki.environment.internal.ServletEnvironment
+            
+            def environment = services.component.getInstance(Environment.class)
+            if (!(environment instanceof ServletEnvironment)) {
+                println("Expected ServletEnvironment, got: " + environment.getClass().getName())
+            }
+            if (environment.resourceURLCache == null) {
+                println("Error: Resource URL Cache is null.")
+            } else {
+                println("Resource URL Cache is initialized.")
+            }
+            {{/groovy}}
+            """, Syntax.XWIKI_2_1));
+    }
+}


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XCOMMONS-3348

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Add an integration test to ensure that the cache in the servlet environment has actually been initialized (a missing cache doesn't cause any problems except for slower performance).

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* As it is hard to detect if the cache is active or not (it just slightly increases the loading time of pages), I thought it would be good to add a test to ensure that the initialization is actually working.
* This depends on https://github.com/xwiki/xwiki-commons/pull/1346

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
LANG=C.UTF-8 mvn clean install -Pdocker,legacy,integration-tests,snapshotModules,quality,distribution,flavor-integration-tests -pl :xwiki-platform-flamingo-skin-test-docker -Dit.test=ServletEnvironmentCacheIT
```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-16.10.x
  * stable-17.4.x