### PR TITLE
XWIKI-22990: The `More actions` button currently relies only on the title for its alternative text

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_content.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_content.vm
@@ -158,10 +158,10 @@
       data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
     #end
     #if ("$!extraAttribute" != '') ${extraAttribute}#end>
-    $services.icon.renderHTML($icon)
-    ## Screen readers benefit from having some kind of text alternative for an interactive element outside of the 
-    ## title attribute.
-    <span class="#if ($titleAsLabel)btn-label#{else}sr-only#end">$services.localization.render($titleKey)</span>
+      $services.icon.renderHTML($icon)
+      ## Screen readers benefit from having some kind of text alternative for an interactive element outside of the 
+      ## title attribute.
+      <span class="#if ($titleAsLabel)btn-label#{else}sr-only#end">$services.localization.render($titleKey)</span>
     </#if ("$!actionUrl" == '')button#{else}a#end>
     #if ($stringtool.isNotBlank("$!menuContent"))
       #if ("$!actionUrl" != '')

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_content.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_content.vm
@@ -137,9 +137,9 @@
  *
  * @param $id the id of the menu
  * @param $icon the icon of the menu
- * @param $content the content of the menu
+ * @param $menuContent the content of the menu
  * @param $titleKey translation key of the link title to use
- * @param $titleAsLabel if the link title should also be used as link label
+ * @param $titleAsLabel if the title should also be used as a visible label
  * @param $actionUrl (optional) the link of the top menu entry.
  *   If not provided, the top menu entry will act as an activator for the dropdown
  * @param $extraAttribute (optional) additional attributes to add (such as ref="nofollow" for example)
@@ -158,10 +158,10 @@
       data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
     #end
     #if ("$!extraAttribute" != '') ${extraAttribute}#end>
-      $services.icon.renderHTML($icon)
-      #if ($titleAsLabel)
-        <span class="btn-label">$services.localization.render($titleKey)</span>
-      #end
+    $services.icon.renderHTML($icon)
+    ## Screen readers benefit from having some kind of text alternative for an interactive element outside of the 
+    ## title attribute.
+    <span class="#if ($titleAsLabel)btn-label#{else}sr-only#end">$services.localization.render($titleKey)</span>
     </#if ("$!actionUrl" == '')button#{else}a#end>
     #if ($stringtool.isNotBlank("$!menuContent"))
       #if ("$!actionUrl" != '')


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22990

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* If the label of the menu button is not shown, still put it in the DOM, but visually hidden with `sr-only`.
* Updated comments

## Clarification

* Technically I updated this velocimacro API to make the meaning of `$titleAsLabel` a bit more specific. I think it'd alright to do because most users won't even see the difference here, and for those who do, for any use of this macro I can think of, this will be an improvement. I guess this can be a regression if the user already has some custom script to inject a proper text alternative in there, but IMO it's quite unlikely, and easy to fix as long as they know where their custom script is.


# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
After the changes proposed in this PR were applied on my local instance, I could see that the more action button had a proper alternative text, and there was no change on the other buttons (those which already used their title as labels).
![Screenshot from 2025-06-02 10-10-22](https://github.com/user-attachments/assets/f2f8bc9a-7ec2-4a3f-b384-94bb839af96d)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests on a local 17.4-snapshot instance, see above.
I checked the different selectors in https://github.com/search?q=org%3Axwiki%20tmMoreActions&type=code and couldn't find one test that would break because of our changes. Note that our change only adds DOM, it does not remove or replace existing one. Except for selectors relying on child position (which AFAICS we do not have in our codebase for this place), the changes proposed here should not impact any selector.

Visually, the added node should always be hidden, so I doubt it'd introduce any visual change.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X (low risk bugfix)