### PR TITLE
XWIKI-23273: "SMTP PASSWORD" in Invitation configuration page is not masked

### DIFF
--- a/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/main/resources/Invitation/InvitationConfig.xml
+++ b/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/main/resources/Invitation/InvitationConfig.xml
@@ -274,16 +274,19 @@
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </smtp_server>
       <smtp_server_password>
+        <algorithm/>
+        <customDisplay/>
         <disabled>0</disabled>
         <name>smtp_server_password</name>
         <number>11</number>
         <picker>0</picker>
         <prettyName>Smtp password</prettyName>
         <size>30</size>
+        <storageType>Clear</storageType>
         <unmodifiable>0</unmodifiable>
         <validationMessage/>
         <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+        <classType>com.xpn.xwiki.objects.classes.PasswordClass</classType>
       </smtp_server_password>
       <smtp_server_username>
         <disabled>0</disabled>

--- a/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/main/resources/Invitation/InvitationConfig.xml
+++ b/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/main/resources/Invitation/InvitationConfig.xml
@@ -277,6 +277,7 @@
         <algorithm/>
         <customDisplay/>
         <disabled>0</disabled>
+        <hint/>
         <name>smtp_server_password</name>
         <number>11</number>
         <picker>0</picker>

--- a/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/main/resources/Invitation/WebHome.xml
+++ b/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/main/resources/Invitation/WebHome.xml
@@ -714,16 +714,20 @@ $xwiki.get('ssx').use($config.get('commonPage'))
       <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
     </smtp_server>
     <smtp_server_password>
+      <algorithm/>
+      <customDisplay/>
       <disabled>0</disabled>
+      <hint/>
       <name>smtp_server_password</name>
       <number>11</number>
       <picker>0</picker>
       <prettyName>Smtp password</prettyName>
       <size>30</size>
+      <storageType>Clear</storageType>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      <classType>com.xpn.xwiki.objects.classes.PasswordClass</classType>
     </smtp_server_password>
     <smtp_server_username>
       <disabled>0</disabled>

--- a/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/main/resources/Invitation/WebPreferences.xml
+++ b/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/main/resources/Invitation/WebPreferences.xml
@@ -1177,6 +1177,7 @@
         <algorithm/>
         <customDisplay/>
         <disabled>0</disabled>
+        <hint/>
         <name>smtp_server_password</name>
         <number>23</number>
         <picker>0</picker>

--- a/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/main/resources/Invitation/WebPreferences.xml
+++ b/xwiki-platform-core/xwiki-platform-invitation/xwiki-platform-invitation-ui/src/main/resources/Invitation/WebPreferences.xml
@@ -1174,6 +1174,7 @@
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </smtp_server>
       <smtp_server_password>
+        <algorithm/>
         <customDisplay/>
         <disabled>0</disabled>
         <name>smtp_server_password</name>
@@ -1181,10 +1182,11 @@
         <picker>0</picker>
         <prettyName>Server password (optional)</prettyName>
         <size>30</size>
+        <storageType>Clear</storageType>
         <unmodifiable>0</unmodifiable>
         <validationMessage/>
         <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+        <classType>com.xpn.xwiki.objects.classes.PasswordClass</classType>
       </smtp_server_password>
       <smtp_server_username>
         <customDisplay/>

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiPreferencesDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiPreferencesDocumentInitializer.java
@@ -144,7 +144,7 @@ public class XWikiPreferencesDocumentInitializer extends AbstractMandatoryClassI
         xclass.addTextField("smtp_server", "SMTP Server", 30);
         xclass.addTextField("smtp_port", "SMTP Port", 5);
         xclass.addTextField("smtp_server_username", "Server username (optional)", 30);
-        xclass.addTextField("smtp_server_password", "Server password (optional)", 30);
+        xclass.addPasswordField("smtp_server_password", "Server password (optional)", 30, PasswordMetaClass.CLEAR);
         xclass.addTextAreaField("javamail_extra_props", "Additional JavaMail properties", 60, 6, ContentType.PURE_TEXT);
         xclass.addTextAreaField("validation_email_content", "Validation eMail Content", 72, 10, ContentType.PURE_TEXT);
         xclass.addTextAreaField("confirmation_email_content", "Confirmation eMail Content", 72, 10,

--- a/xwiki-platform-distribution/xwiki-platform-distribution-ui/xwiki-platform-distribution-ui-base/src/main/resources/XWiki/XWikiPreferences.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-ui/xwiki-platform-distribution-ui-base/src/main/resources/XWiki/XWikiPreferences.xml
@@ -2588,17 +2588,20 @@
         <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
       </smtp_server>
       <smtp_server_password>
+        <algorithm/>
         <customDisplay/>
         <disabled>0</disabled>
+        <hint/>
         <name>smtp_server_password</name>
         <number>23</number>
         <picker>0</picker>
         <prettyName>Server password (optional)</prettyName>
         <size>30</size>
+        <storageType>Clear</storageType>
         <unmodifiable>0</unmodifiable>
         <validationMessage/>
         <validationRegExp/>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+        <classType>com.xpn.xwiki.objects.classes.PasswordClass</classType>
       </smtp_server_password>
       <smtp_server_username>
         <customDisplay/>

--- a/xwiki-platform-distribution/xwiki-platform-distribution-ui/xwiki-platform-distribution-ui-base/src/main/resources/XWiki/XWikiPreferences.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-ui/xwiki-platform-distribution-ui-base/src/main/resources/XWiki/XWikiPreferences.xml
@@ -1080,17 +1080,20 @@
       <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
     </smtp_server>
     <smtp_server_password>
+      <algorithm/>
       <customDisplay/>
       <disabled>0</disabled>
+      <hint/>
       <name>smtp_server_password</name>
       <number>23</number>
       <picker>0</picker>
       <prettyName>Server password (optional)</prettyName>
       <size>30</size>
+      <storageType>Clear</storageType>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>
       <validationRegExp/>
-      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      <classType>com.xpn.xwiki.objects.classes.PasswordClass</classType>
     </smtp_server_password>
     <smtp_server_username>
       <customDisplay/>


### PR DESCRIPTION
# Jira URL

[XWIKI-23273:"SMTP PASSWORD" in Invitation configuration page is not masked](https://jira.xwiki.org/browse/XWIKI-23273)

# Changes

## Description

* Replace `com.xpn.xwiki.objects.classes.StringClass` classtype for `smtp_server_password` with `com.xpn.xwiki.objects.classes.PasswordClass`

## Clarifications

* Used same approach for password field from Mail configuration.

# Screenshots & Video

Initial issue
![Знімок екрана_5-6-2025_12048_localhost](https://github.com/user-attachments/assets/6be518d5-723a-42ea-a83d-f36d4b447652)

After fix
![Знімок екрана_5-6-2025_115957_localhost](https://github.com/user-attachments/assets/2c10e6cb-3690-4674-bf05-7dca2b452a02)


# Executed Tests

Manual performed tests in UI.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X (low bugfix)