### PR TITLE
XWIKI-22987: Avatar edition modal does not have the proper modal markup

### DIFF
--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
@@ -540,7 +540,7 @@ $xwiki.jsx.use($attachmentPickerDocName)
      * @param property the property being edited, as the containing div with class="attachment-picker"
      * @param dialog the modal dialog where the gallery was loaded
      */
-    initialize(property, modal) {
+    constructor(property, modal) {
       this.property = property;
       this.modal = modal;
       this.gallery = modal.find('.modal-body');

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
@@ -777,6 +777,14 @@ $xwiki.jsx.use($attachmentPickerDocName)
   // reference XWiki.AttachmentPicker directly.
   XWiki.AttachmentPicker = AttachmentPicker;
 
+  /* Bootstrap modals are meant to be a direct child of &lt;body&gt;, both to avoid z-index/stacking
+     context issues and so CSS scoped to the picker's surrounding container (e.g. an ID-scoped
+     selector on the page embedding the picker) doesn't unintentionally bleed into the gallery
+     dialog. Move any inline-rendered modal there once the DOM is ready. */
+  $(function() {
+    $('.attachment-selector-modal').appendTo(document.body);
+  });
+
   /* The modal is opened natively by Bootstrap, triggered by the data-toggle="modal"/data-target
      attributes set on the ".attachment-picker-start" buttons; load the gallery via AJAX once the
      modal is visible. Delegating the listener on the document also covers pickers added to the
@@ -1472,7 +1480,7 @@ $xwiki.ssx.use($xcontext.macro.doc.fullName)##
       &lt;button type="button" class="close" data-dismiss="modal"&gt;
       &lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;
       &lt;/button&gt;
-      &lt;h4 class="modal-title"&gt;&lt;/h4&gt;
+      &lt;h4 class="modal-title"&gt;$escapetool.xml($services.localization.render('xe.attachmentSelector.gallery.title'))&lt;/h4&gt;
       &lt;/div&gt;
       &lt;div class="modal-body"&gt;&lt;/div&gt;
     &lt;/div&gt;

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
@@ -468,7 +468,7 @@ $xwiki.jsx.use($attachmentPickerDocName)
       <cache>long</cache>
     </property>
     <property>
-      <code>var XWiki = (function(XWiki) {
+      <code>require(['jquery','bootstrap'], function($) {
   function uploadTemporaryAttachment() {
     // Require jquery locally until we are able to fully migrate this code away from prototype.
     const form = this.property.up('form');
@@ -533,17 +533,17 @@ $xwiki.jsx.use($attachmentPickerDocName)
   }
 
   /** Handles the gallery buttons directly in the current page without reloading the window. */
-  XWiki.AttachmentPicker = Class.create({
+  class AttachmentPicker {
     /**
      * Constructor.
      *
      * @param property the property being edited, as the containing div with class="attachment-picker"
      * @param dialog the modal dialog where the gallery was loaded
      */
-    initialize : function(property, dialog) {
+    initialize(property, modal) {
       this.property = property;
-      this.dialog = dialog;
-      this.gallery = dialog.dialogBox;
+      this.modal = modal;
+      this.gallery = modal.find('.modal-body');
       if (!this.property.down('input')) {
         this.directSave = true;
       }
@@ -561,18 +561,17 @@ $xwiki.jsx.use($attachmentPickerDocName)
       this.addDeleteListeners();
       this.addSelectListeners();
       this.updateCurrentSelection();
-      this.addCloseListener();
       var img = this.property.down('img');
       if (img) {
         img.observe('load', function() {img.up('div').removeClassName('hidden');});
         img.observe('error', function() {img.up('div').addClassName('hidden');});
       }
-    },
+    }
     /**
      * Catches the upload form submission and stops it if the selected file is not of the accepted types (or not selected at all),
      * and saves the underlying form (if any) so that any unsaved changes won't be lost.
      */
-    filterFormUpload : function() {
+    filterFormUpload() {
       this.gallery.select('.uploadAttachment input[type="file"]').each(function(fileInput) {
         fileInput.__allowedExtensions = fileInput.title.toLowerCase().replace(/\s*[,|; ]\s*/g, " ").strip();
         if (fileInput.__allowedExtensions != '') {
@@ -613,8 +612,8 @@ $xwiki.jsx.use($attachmentPickerDocName)
           }
         }
       }.bindAsEventListener(this));
-    },
-    getFileExtension : function(filename) {
+    }
+    getFileExtension(filename) {
       var fpath = filename.replace('\\', '/');
       var pieces = fpath.split('/');
       if (pieces.length == 0) {
@@ -623,20 +622,20 @@ $xwiki.jsx.use($attachmentPickerDocName)
       var basename = pieces[pieces.length-1];
       pieces = basename.split('.');
       return pieces[pieces.length-1].toLowerCase();
-    },
+    }
 
     /** Catch attachment delete requests. */
-    addDeleteListeners : function() {
+    addDeleteListeners() {
       this.gallery.select('.gallery_actions .tool.delete').invoke('observe', 'click', this.onDelete.bindAsEventListener(this));
-    },
+    }
 
     /** Catch attachment selection requests. */
-    addSelectListeners : function() {
+    addSelectListeners() {
       this.gallery.select('.gallery_actions .tool.select').invoke('observe', 'click', this.onSelect.bindAsEventListener(this));
-    },
+    }
 
     /** AJAX deletion of attachments. */
-    onDelete : function(event) {
+    onDelete(event) {
       event.stop();
       const deleteTool = event.target.closest('.btn');
       if (!deleteTool.disabled) {
@@ -676,10 +675,10 @@ $xwiki.jsx.use($attachmentPickerDocName)
           }
         );
       }
-    },
+    }
 
     /** Update the property with the selected value without reloading the page. */
-    onSelect : function(event) {
+    onSelect(event) {
       event.stop();
       const targetElement = event.target.closest('.btn');
       var attachmentName = targetElement.up('.gallery_attachmentbox').down('.gallery_attachmenttitle').title;
@@ -728,10 +727,10 @@ $xwiki.jsx.use($attachmentPickerDocName)
         this.property.down('input').value = attachmentName;
         this.dialog.closeDialog();
       }
-    },
+    }
 
     /** Update the property display. */
-    updateAttachment : function(attachmentName, imageSource) {
+    updateAttachment(attachmentName, imageSource) {
       var img = this.property.down('img');
       if (img) {
         img.src = img.src.replace(/^[^\?]+($|\?)/, imageSource + "$1");
@@ -749,10 +748,10 @@ $xwiki.jsx.use($attachmentPickerDocName)
           }
         }
       }
-    },
+    }
 
     /** Update the gallery to reflect the currently selected value. */
-    updateCurrentSelection : function() {
+    updateCurrentSelection() {
       if (!this.directSave) {
         var selectedName =  this.property.down('input').value;
         var selectedElement = this.gallery.down('.gallery_attachmenttitle[title="' + selectedName.replace('"', '\\22 ') + '"]');
@@ -770,17 +769,10 @@ $xwiki.jsx.use($attachmentPickerDocName)
       } else {
         this.gallery.down('.current .tool.select').addClassName('hidden');
       }
-    },
-    addCloseListener : function () {
-      var closeButton = $('attachment-picker-close');
-      if (closeButton) {
-        closeButton.observe('click', function(event) {
-          event.stop();
-          this.dialog.closeDialog();
-        }.bindAsEventListener(this));
-      }
     }
-  });
+    
+    
+  };
 
   var loading = new Element('div', {'class' : 'imgcenter'}).update("&lt;img src=\"$xwiki.getSkinFile('icons/xwiki/ajax-loader-large.gif')\"/&gt;");
   var dialog;
@@ -789,183 +781,32 @@ $xwiki.jsx.use($attachmentPickerDocName)
   document.observe('xwiki:dom:loaded', function() {
     $$('.attachment-picker-start').invoke('observe', 'click', function(event) {
       event.stop();
+      let modal = $$('.attachment-selector-modal').modal();
       var targetElement = event.element();
       var url = targetElement.href;
       if (url.indexOf('?') &lt; 0) {
         url += '?';
       }
       url += "&amp;xpage=plain";
-      dialog = new XWiki.widgets.ModalPopup(
-        loading, {}, {
-          'verticalPosition' : 'top',
-          'removeOnClose' : true,
-          'title' : "$services.localization.render('xe.attachmentSelector.gallery.title')"
-        }
-      );
-      dialog.shortcuts.close.keys = [];
-      dialog.showDialog();
-      dialog.dialog.down().setStyle({position: "fixed"});
-      dialog.dialog.setStyle({top: document.viewport.getScrollOffsets().top + "px", position: "absolute"});
-      dialog.dialogBox.setStyle({overflow: "hidden", width: "80%", margin: "0 10%"});
+      modal.modal('show');
       new Ajax.Updater(loading.up(), url, {
         onComplete : function() {
           // Play nice with the Lightbox widget
           if (window.gallery_lb) {
             window.gallery_lb.updateImageList();
           }
-          // Manually convert the special rel values into target attributes for the newly inserted content (rel="_something" =&gt; target="something")
-          if (typeof (XWiki.fixLinksTargetAttribute) == 'function') {
-            // Trick the function into updating link targets in edit mode; normally the conversion only takes place in view mode
-            var __tmp = XWiki.contextaction;
-            XWiki.contextaction = 'view';
-            XWiki.fixLinksTargetAttribute(dialog.dialog);
-            XWiki.contextaction = __tmp;
-          }
-          new XWiki.AttachmentPicker(targetElement.up('.attachment-picker'), dialog);
+          new AttachmentPicker(targetElement.up('.attachment-picker'), modal);
         }
       });
     });
   });
-  return XWiki;
-}(XWiki || {}));</code>
+});</code>
     </property>
     <property>
       <name>Loads the image picker in a modal dialog</name>
     </property>
     <property>
       <parse>1</parse>
-    </property>
-    <property>
-      <use>currentPage</use>
-    </property>
-  </object>
-  <object>
-    <name>XWiki.AttachmentSelector</name>
-    <number>1</number>
-    <className>XWiki.JavaScriptExtension</className>
-    <guid>2aa565e6-b9bd-4095-a7a9-bbf47d75d079</guid>
-    <class>
-      <name>XWiki.JavaScriptExtension</name>
-      <customClass/>
-      <customMapping/>
-      <defaultViewSheet/>
-      <defaultEditSheet/>
-      <defaultWeb/>
-      <nameField/>
-      <validationScript/>
-      <cache>
-        <cache>0</cache>
-        <defaultValue>long</defaultValue>
-        <disabled>0</disabled>
-        <displayType>select</displayType>
-        <freeText>forbidden</freeText>
-        <largeStorage>0</largeStorage>
-        <multiSelect>0</multiSelect>
-        <name>cache</name>
-        <number>5</number>
-        <prettyName>Caching policy</prettyName>
-        <relationalStorage>0</relationalStorage>
-        <separator> </separator>
-        <separators>|, </separators>
-        <size>1</size>
-        <unmodifiable>0</unmodifiable>
-        <values>long|short|default|forbid</values>
-        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
-      </cache>
-      <code>
-        <contenttype>PureText</contenttype>
-        <disabled>0</disabled>
-        <editor>PureText</editor>
-        <name>code</name>
-        <number>2</number>
-        <prettyName>Code</prettyName>
-        <rows>20</rows>
-        <size>50</size>
-        <unmodifiable>0</unmodifiable>
-        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
-      </code>
-      <name>
-        <disabled>0</disabled>
-        <name>name</name>
-        <number>1</number>
-        <prettyName>Name</prettyName>
-        <size>30</size>
-        <unmodifiable>0</unmodifiable>
-        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
-      </name>
-      <parse>
-        <disabled>0</disabled>
-        <displayFormType>select</displayFormType>
-        <displayType>yesno</displayType>
-        <name>parse</name>
-        <number>4</number>
-        <prettyName>Parse content</prettyName>
-        <unmodifiable>0</unmodifiable>
-        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
-      </parse>
-      <use>
-        <cache>0</cache>
-        <disabled>0</disabled>
-        <displayType>select</displayType>
-        <freeText>forbidden</freeText>
-        <largeStorage>0</largeStorage>
-        <multiSelect>0</multiSelect>
-        <name>use</name>
-        <number>3</number>
-        <prettyName>Use this extension</prettyName>
-        <relationalStorage>0</relationalStorage>
-        <separator> </separator>
-        <separators>|, </separators>
-        <size>1</size>
-        <unmodifiable>0</unmodifiable>
-        <values>currentPage|onDemand|always</values>
-        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
-      </use>
-    </class>
-    <property>
-      <cache>long</cache>
-    </property>
-    <property>
-      <code>XWiki.widgets.ModalPopup.prototype.showDialog = function(event) {
-  if (event) {
-    Event.stop(event);
-  }
-  // Only do this if the dialog is not already active.
-  if (!this.active) {
-    this.active = true;
-    if (!this.dialog) {
-      // The dialog wasn't loaded, create it.
-      this.createDialog();
-    }
-    // Start listening to keyboard events
-    this.attachKeyListeners();
-    // Display the dialog
-    this.dialog.show();
-  }
-};
-XWiki.widgets.ModalPopup.prototype.closeDialog = function(event) {
-  if (event) {
-    Event.stop(event);
-  }
-  // Call optional callback
-  this.options.onClose.call(this);
-  // Hide the dialog, without removing it from the DOM.
-  this.dialog.hide();
-  if (this.options.removeOnClose) {
-    this.dialog.remove();
-  }
-  // Stop the UI shortcuts (except the initial Show Dialog one).
-  this.detachKeyListeners();
-  // Re-enable the 'show' behavior.
-  this.active = false;
-}
-</code>
-    </property>
-    <property>
-      <name>Patch for modalPopup.js, allowing to display several widgets on the same screen and removing position:fixed in IE</name>
-    </property>
-    <property>
-      <parse>0</parse>
     </property>
     <property>
       <use>currentPage</use>
@@ -1613,18 +1454,43 @@ $xwiki.ssx.use($xcontext.macro.doc.fullName)##
       #set ($queryString.targetdocname = $targetdoc.fullName)
     #end
     #set ($linkLabel = $services.rendering.escape($services.rendering.escape($buttontext, 'xwiki/2.1'), 'xwiki/2.1'))
-    (% class="buttonwrapper" %)[[$linkLabel&gt;&gt;${xcontext.macro.doc.fullName}||queryString="$escapetool.url($queryString)"
-      class="attachment-picker-start button" title="$services.rendering.escape($buttontext, 'xwiki/2.1')"]](%%)##
+    (% class="buttonwrapper"%)##
+     [[$linkLabel&gt;&gt;${xcontext.macro.doc.fullName}||queryString="$escapetool.url($queryString)" class="attachment-picker-start button" title="$services.rendering.escape($buttontext, 'xwiki/2.1')" data-target=".attachment-selector-modal" data-toggle="modal"]](%%)##
   #end
+#end
+
+## Include the attachment modal
+#macro (attachmentPicker_displayModal)
+#if ($targetPermView)
+
+{{html}}
+&lt;div class="modal fade attachment-selector-modal" tabindex="-1" role="dialog"&gt;
+  &lt;div class="modal-dialog" role="document"&gt;
+    &lt;div class="modal-content"&gt;
+      &lt;div class="modal-header"&gt;
+      &lt;button type="button" class="close" data-dismiss="modal"&gt;
+      &lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;
+      &lt;/button&gt;
+      &lt;h4 class="modal-title"&gt;&lt;/h4&gt;
+      &lt;/div&gt;
+      &lt;div class="modal-body"&gt;&lt;/div&gt;
+    &lt;/div&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+{{/html}}
+
+#end
 #end
 {{/velocity}}
 
 {{velocity}}
 #if ("${savemode}" == 'direct')
-  (% class="attachment-picker" %)(((#_attachmentPicker_displayAttachment($propValue $displayImage $link true) #_attachmentPicker_displayButton())))
+  (% class="attachment-picker" %)(((#_attachmentPicker_displayAttachment($propValue $displayImage $link true)##
+  #attachmentPicker_displayModal() #_attachmentPicker_displayButton())))
 #elseif ($xcontext.action == 'inline' || $xcontext.action == 'edit')
   (% class="attachment-picker" %)(((##
     #_attachmentPicker_displayAttachment($propValue $displayImage false true) #_attachmentPicker_displayButton()##
+    #attachmentPicker_displayModal()##
     {{html}}&lt;input type="hidden" name="$escapetool.xml("${classname}_${object}_${property}")" value="$escapetool.xml("${propValue}")" class="property-reference"/&gt;{{/html}}##
   )))
 #else

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
@@ -513,7 +513,7 @@ $xwiki.jsx.use($attachmentPickerDocName)
           .prop('value', response.fileName))
         propertyReferenceInput.value = response.fileName;
         this.updateAttachment(response.fileName, response.url);
-        this.dialog.closeDialog();
+        $(this.modal).modal('hide');
       }.bind(this)).fail(function  () {
         #set ($errorMessage = $escapetool.javascript($services.localization.render('attachment.attachmentSelector.temporaryUpload.failure')))notification.replace(new XWiki.widgets.Notification("$errorMessage", 'error'));
       });
@@ -538,12 +538,12 @@ $xwiki.jsx.use($attachmentPickerDocName)
      * Constructor.
      *
      * @param property the property being edited, as the containing div with class="attachment-picker"
-     * @param dialog the modal dialog where the gallery was loaded
+     * @param modal the modal dialog where the gallery was loaded
      */
     constructor(property, modal) {
       this.property = property;
       this.modal = modal;
-      this.gallery = modal.find('.modal-body');
+      this.gallery = modal.down('.modal-body');
       if (!this.property.down('input')) {
         this.directSave = true;
       }
@@ -704,7 +704,7 @@ $xwiki.jsx.use($attachmentPickerDocName)
               targetElement._x_notif.hide();
               // on success, update image
               this.updateAttachment(attachmentName, imageSource);
-              this.dialog.closeDialog();
+              $(this.modal).modal('hide');
             }.bindAsEventListener(this),
             onFailure : function(response) {
               var failureReason = response.statusText || 'Server not responding';
@@ -725,7 +725,7 @@ $xwiki.jsx.use($attachmentPickerDocName)
       } else {
         this.updateAttachment(attachmentName, imageSource);
         this.property.down('input').value = attachmentName;
-        this.dialog.closeDialog();
+        $(this.modal).modal('hide');
       }
     }
 
@@ -777,30 +777,28 @@ $xwiki.jsx.use($attachmentPickerDocName)
   // reference XWiki.AttachmentPicker directly.
   XWiki.AttachmentPicker = AttachmentPicker;
 
-  var loading = new Element('div', {'class' : 'imgcenter'}).update("&lt;img src=\"$xwiki.getSkinFile('icons/xwiki/ajax-loader-large.gif')\"/&gt;");
-  var dialog;
-
-  /* Hook onto the picker buttons so that the gallery is loaded via AJAX in a modal dialog. */
-  document.observe('xwiki:dom:loaded', function() {
-    $$('.attachment-picker-start').invoke('observe', 'click', function(event) {
-      event.stop();
-      let modal = $$('.attachment-selector-modal').modal();
-      var targetElement = event.element();
-      var url = targetElement.href;
-      if (url.indexOf('?') &lt; 0) {
-        url += '?';
-      }
-      url += "&amp;xpage=plain";
-      modal.modal('show');
-      new Ajax.Updater(loading.up(), url, {
-        onComplete : function() {
-          // Play nice with the Lightbox widget
-          if (window.gallery_lb) {
-            window.gallery_lb.updateImageList();
-          }
-          new AttachmentPicker(targetElement.up('.attachment-picker'), modal);
+  /* The modal is opened natively by Bootstrap, triggered by the data-toggle="modal"/data-target
+     attributes set on the ".attachment-picker-start" buttons; load the gallery via AJAX once the
+     modal is visible. Delegating the listener on the document also covers pickers added to the
+     page after this script runs. */
+  $(document).on('shown.bs.modal', '.attachment-selector-modal', function(event) {
+    var modal = this;
+    var targetElement = event.relatedTarget;
+    var url = targetElement.href;
+    if (url.indexOf('?') &lt; 0) {
+      url += '?';
+    }
+    url += "&amp;xpage=plain";
+    var modalBody = modal.down('.modal-body');
+    modalBody.update("&lt;img src=\"$xwiki.getSkinFile('icons/xwiki/ajax-loader-large.gif')\" class=\"imgcenter\"/&gt;");
+    new Ajax.Updater(modalBody, url, {
+      onComplete : function() {
+        // Play nice with the Lightbox widget
+        if (window.gallery_lb) {
+          window.gallery_lb.updateImageList();
         }
-      });
+        new AttachmentPicker(targetElement.up('.attachment-picker'), modal);
+      }
     });
   });
 });</code>
@@ -1458,7 +1456,7 @@ $xwiki.ssx.use($xcontext.macro.doc.fullName)##
     #end
     #set ($linkLabel = $services.rendering.escape($services.rendering.escape($buttontext, 'xwiki/2.1'), 'xwiki/2.1'))
     (% class="buttonwrapper"%)##
-     [[$linkLabel&gt;&gt;${xcontext.macro.doc.fullName}||queryString="$escapetool.url($queryString)" class="attachment-picker-start button" title="$services.rendering.escape($buttontext, 'xwiki/2.1')" data-target=".attachment-selector-modal" data-toggle="modal"]](%%)##
+     [[$linkLabel&gt;&gt;${xcontext.macro.doc.fullName}||queryString="$escapetool.url($queryString)" class="attachment-picker-start button" title="$services.rendering.escape($buttontext, 'xwiki/2.1')" data-target=".attachment-selector-modal" data-toggle="modal" data-remote="false"]](%%)##
   #end
 #end
 

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
@@ -937,7 +937,6 @@ $xwiki.jsx.use($attachmentPickerDocName)
 #set ($uploadBoxSize = $mathtool.add(2, $mathtool.add($mathtool.mul($boxSize, 2), $mathtool.mul($boxMargin, 2))))
 #set ($imgSize = $mathtool.sub($boxSize, $mathtool.mul($boxPadding, 2)))
 #set ($actionsHeight = 20)
-#set ($actionsWidth = 16)
 /*--------------------------------------------------------*/
 /* Attachment picker layout fixes                              */
 .attachment-picker p {
@@ -1079,8 +1078,12 @@ $xwiki.jsx.use($attachmentPickerDocName)
   right: 3px;
 }
 .gallery_attachmenttitle p {
+  ## The actions (select/delete) live in their own grid column (see ".gallery_actions p" above),
+  ## not overlapping this one, so there's no need to reserve space for them here.
   text-align: left;
-  margin-right: ${mathtool.add($mathtool.mul(2, $actionsWidth), $boxPadding)}px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 /* ------------------------------------ */
 /* Cancel button                        */

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
@@ -790,7 +790,7 @@ $xwiki.jsx.use($attachmentPickerDocName)
     }
     url += "&amp;xpage=plain";
     var modalBody = modal.down('.modal-body');
-    modalBody.update("&lt;img src=\"$xwiki.getSkinFile('icons/xwiki/ajax-loader-large.gif')\" class=\"imgcenter\"/&gt;");
+    modalBody.update();
     new Ajax.Updater(modalBody, url, {
       onComplete : function() {
         // Play nice with the Lightbox widget

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-ui/src/main/resources/XWiki/AttachmentSelector.xml
@@ -770,9 +770,12 @@ $xwiki.jsx.use($attachmentPickerDocName)
         this.gallery.down('.current .tool.select').addClassName('hidden');
       }
     }
-    
-    
+
+
   };
+  // Keep exposing the class on the XWiki namespace for backwards compatibility, since extensions may
+  // reference XWiki.AttachmentPicker directly.
+  XWiki.AttachmentPicker = AttachmentPicker;
 
   var loading = new Element('div', {'class' : 'imgcenter'}).update("&lt;img src=\"$xwiki.getSkinFile('icons/xwiki/ajax-loader-large.gif')\"/&gt;");
   var dialog;

--- a/xwiki-platform-core/xwiki-platform-bootstrap/src/main/node/less/close.less
+++ b/xwiki-platform-core/xwiki-platform-bootstrap/src/main/node/less/close.less
@@ -12,14 +12,14 @@
   line-height: 1;
   color: @close-color;
   text-shadow: @close-text-shadow;
-  .opacity(.2);
+  .opacity(.7);
 
   &:hover,
   &:focus {
     color: @close-color;
     text-decoration: none;
     cursor: pointer;
-    .opacity(.5);
+    .opacity(1);
   }
 
   // Additional properties for button version

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -913,6 +913,9 @@ core.copy.status.label=Copy Status
 core.copy.status.hint=The following copy operation has been started by {0} on {1}
 core.copy.status.notFound=The requested copy status could not be found.
 
+### XDialog
+core.xdialog.close.hint=Close
+
 ### Document Picker
 core.documentPicker.title=Select Page
 core.documentPicker.select=Select


### PR DESCRIPTION

# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22987
There's also small changes for https://jira.xwiki.org/browse/XWIKI-22988 and https://jira.xwiki.org/browse/XWIKI-22989 included in this PR. These two secondary tickets are really simple and very close to the first one so I figured it'd be okay to group their fixes together. If any of the changes needed for those secondary tickets create any discussion/complexity in implementation I'll remove them from here and propose them in another PR :)

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Edited the modalPopup component to use a dialog instead of a hard-coded background.
* Updated the styles to work with this new DOM and leverage better the up-to-date defaults.
* Added a translation for the button
* Reduced transparency of the close buttons. This improves the contrast. Note that our current automatic tester doesn't take opacity into account for calculations AFAIK...
* I tried to remove most of the useless styles, but there might be some left...
* Replaced all code related to the old colorthemes to use CSS variables instead. This avoid compiling velocity in a place where it's hardly even needed

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* I did not remove all the inline styles, but I tried to reduce it as much as I could without adding too many changes just for it.
* I did use a few prototypejs functions, because the `modalPopup.js` is using it and it wouldn't make sense to mix things too much (I didn't want to rework the whole file for this PR...).
* I added one translation of an untraslated string in the oldcore module because that's where similar translations are located.
* There is a breaking change in the DOM (removed the `dialog-modal-container`). Since this is a quite old UI, I think it's alright to break some of its DOM. I kept all of the other elements, but this one would not make any sense in the current context. It's goal was to control the layout of the dialog and its backdrop. Nowadays the dialog controls its own backdrop natively, the top container can be the dialog itself. Keeping it in an additional container only creates inconsistencies and liabilities on the long term.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Here is what the modal looks like after the changes:
![Screenshot from 2025-06-12 16-18-50](https://github.com/user-attachments/assets/d71a16f5-4f41-4254-98a5-06879652203b)
Here is another modal using the same basic component (for the sake of testing that the change did not break the layout features of the xmodal, I did try some funky alignment, it's in a weird place, but an expected one :) )
![Screenshot from 2025-06-12 16-19-10](https://github.com/user-attachments/assets/55cee9eb-ace1-49b1-b44e-c0ec3089ba07)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Checked occurences of `xdialog-modal-container` in the tests. I could not find any, and AFAICS in https://github.com/xwiki/xwiki-platform/blob/5aecf0c86c9d1567430f49b3d584d05e8a2a5371/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-test/xwiki-platform-tour-test-pageobjects/src/main/java/org/xwiki/tour/test/po/TourEditPage.java#L1-L108 , the usual way to test such a component is:
1. Test the button to open it. This button is unrelated to the XModal code itself.
2. Test how the content of the modal works when interacted with. AFAICS, the content has specific classes/ids and the XPath or CSS selector to find it is unrelated to the structure of the modal.
3. Interact with the default interactive elements of the modal: close button

Manual tests, as seen above.

Passed `mvn clean install -f xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/ -Pquality` successfully.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None. There is a DOM change that could break compatibility with some extensions/customizations.