### PR TITLE
XWIKI-23282: Toggle panels columns has issues when using Small or Large sized panels

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/layout.less
@@ -50,13 +50,6 @@
      doesn't interpret the double dash as the start of a HTML comment close.
      We add a HIDDEN block in between the two dashes. With the LESS4J lexer, inline comments are good for this.
      Once this file is migrated to native CSS, this hack can be removed. */
-  &.hideleft {
-    -/**/-panel-column-left-width: 0;
-    
-    & #leftPanels {
-      display: none;
-    }
-  }
 
   &.panel-left-width-Small {
     -/**/-panel-column-left-width: 8vw;
@@ -66,10 +59,12 @@
     -/**/-panel-column-left-width: 24vw;
   }
 
-  &.hideright {
-    -/**/-panel-column-right-width: 0;
+  /* The functionality to hide the panel takes precedence over the panel size defaults. 
+    This ruleset should come after the rules for .panel-left-width-<WIDTH> */
+  &.hideleft {
+    -/**/-panel-column-left-width: 0;
 
-    & #rightPanels {
+    & #leftPanels {
       display: none;
     }
   }
@@ -80,6 +75,16 @@
 
   &.panel-right-width-Large {
     -/**/-panel-column-right-width: 24vw;
+  }
+
+  /* The functionality to hide the panel takes precedence over the panel size defaults. 
+    This ruleset should come after the rules for .panel-right-width-<WIDTH> */
+  &.hideright {
+    -/**/-panel-column-right-width: 0;
+
+    & #rightPanels {
+      display: none;
+    }
   }
 
   &.hidelefthideright {


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-23282

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Moved the rulesets around so that the right ones take precedence.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Both rulesets have the same specificity, so order is all that makes the priority between both. AFAIK it's alright to keep selectors like this.
* Added a comment to explain what happened and make sure it's not reverted by mistake in the future :) Usually we don't rely much on order for CSS priority in the XS codebase.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Now the panels behave as expected even when larger or smaller are selected (video only shows the test for larger): 

https://github.com/user-attachments/assets/c3393d27-0709-4cd7-83eb-016a4e2ca269



# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Style changes only, this does not impact the visibility of any element at any point, only the way the main column is laid out.
Manual tests as shown in the video above.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 17.4.X (like https://github.com/xwiki/xwiki-platform/pull/2831 )