### PR TITLE
XWIKI-23307: Tag deletion confirmation test fails

### DIFF
--- a/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-test/xwiki-platform-tag-test-pageobjects/src/main/java/org/xwiki/tag/test/po/TagPage.java
+++ b/xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-test/xwiki-platform-tag-test-pageobjects/src/main/java/org/xwiki/tag/test/po/TagPage.java
@@ -76,7 +76,7 @@ public class TagPage extends ViewPage
 
     public boolean hasConfirmationMessage()
     {
-        return getDriver().findElementsWithoutWaiting(
+        return getDriver().findElements(
             By.xpath("//div[@class='box infomessage' and contains(. ,'has been successfully deleted')]"))
             .size() == 1;
     }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-23307

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Added back some wait to avoid flickers.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* See comments on https://jira.xwiki.org/browse/XWIKI-23307 to understand why I went with this solution

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
None, test changes only

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
I could not reproduce the flicker on my machine. Even on CI, it's quite rare: https://ge.xwiki.org/scans/tests?search.relativeStartTime=P90D&search.timeZoneId=Europe%2FParis&tests.container=*TagIT*#


Built the changes successfully with `mvn clean install -f xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-test/xwiki-platform-tag-test-pageobjects`.
Then, ran the flickering tests with: `mvn clean install -f xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-test/xwiki-platform-tag-test-docker ` These tests did not fail, meaning that the change did not make things worse. I believe they made things better, but I can't validate my point with observation until we witness that the flicker stopped on CI.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X (low criticity and low scope bugfix)
  * 17.4.X (low criticity and low scope bugfix)