### PR TITLE
XWIKI-23257: Required rights automated analysis messages are displayed out of the Required Rights modal

### DIFF
--- a/xwiki-platform-core/xwiki-platform-bootstrap/src/main/js/tooltip.js
+++ b/xwiki-platform-core/xwiki-platform-bootstrap/src/main/js/tooltip.js
@@ -660,9 +660,23 @@
     })
   }
 
-  var old = $.fn.tooltip
+  let other = $.fn.tooltip
 
-  $.fn.tooltip             = Plugin
+  // Prevent overriding this tooltip implementation by jQuery UI as in XWiki we ship both implementations but want
+  // to always use the Bootstrap one.
+  Object.defineProperty($.fn, 'tooltip', {
+    configurable: true,
+    get: function () {
+      return Plugin
+    },
+    set: function (value) {
+      // For increased compatibility with other libraries, we store the first assigned value to allow restoring it
+      // using noConflict.
+      if (typeof other === 'undefined') {
+        other = value
+      }
+    }
+  })
   $.fn.tooltip.Constructor = Tooltip
 
 
@@ -670,7 +684,8 @@
   // ===================
 
   $.fn.tooltip.noConflict = function () {
-    $.fn.tooltip = old
+    delete $.fn.tooltip
+    $.fn.tooltip = other
     return this
   }
 


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-23257

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Ensure that we're always using the Bootstrap tooltip implementation by preventing that it is overridden.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* I implemented the idea of defining a property as it seemed the simplest/cleanest one that achieves the goal without introducing lots of overhead of, e.g., building a custom webjar for jQuery-UI.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Manual tests with the required rights modal in Chrome.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-17.4.x