### PR TITLE
XWIKI-15166: SOLR reindexation job cause serious perfomance issues on large database

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/AbstractSolrCoreInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/AbstractSolrCoreInitializer.java
@@ -28,8 +28,6 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import org.apache.commons.collections4.MapUtils;
-import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.lucene.analysis.core.LowerCaseFilterFactory;
 import org.apache.lucene.analysis.standard.StandardTokenizerFactory;
 import org.apache.solr.client.solrj.SolrClient;
@@ -54,7 +52,6 @@ import org.apache.solr.schema.TextField;
 import org.slf4j.Logger;
 import org.xwiki.component.descriptor.ComponentDescriptor;
 import org.xwiki.search.solr.internal.DefaultSolrUtils;
-import org.xwiki.search.solr.internal.DefaultXWikiSolrCore;
 import org.xwiki.search.solr.internal.SolrSchemaUtils;
 import org.xwiki.stability.Unstable;
 
@@ -220,12 +217,6 @@ public abstract class AbstractSolrCoreInitializer implements SolrCoreInitializer
 
     @Inject
     private SolrSchemaUtils solrSchemaUtils;
-
-    @Override
-    public void initialize(SolrClient client) throws SolrException
-    {
-        initialize(new DefaultXWikiSolrCore(getCoreName(), getCoreName(), client));
-    }
 
     @Override
     public void initialize(XWikiSolrCore core) throws SolrException
@@ -608,7 +599,7 @@ public abstract class AbstractSolrCoreInitializer implements SolrCoreInitializer
      */
     protected Long getCurrentXWikiVersion() throws SolrException
     {
-        return getVersion(SOLR_TYPENAME_XVERSION);
+        return this.solrSchemaUtils.getVersion(this.core, SOLR_TYPENAME_XVERSION);
     }
 
     protected void setCurrentXWikiVersion(boolean add) throws SolrException
@@ -622,7 +613,7 @@ public abstract class AbstractSolrCoreInitializer implements SolrCoreInitializer
      */
     protected Long getCurrentCoreVersion() throws SolrException
     {
-        return getVersion(SolrSchemaUtils.SOLR_TYPENAME_CVERSION);
+        return this.solrSchemaUtils.getVersion(this.core, SolrSchemaUtils.SOLR_TYPENAME_CVERSION);
     }
 
     protected void setCurrentCoreVersion(boolean add) throws SolrException
@@ -630,28 +621,9 @@ public abstract class AbstractSolrCoreInitializer implements SolrCoreInitializer
         setVersion(SolrSchemaUtils.SOLR_TYPENAME_CVERSION, getVersion(), add);
     }
 
-    private Long getVersion(String name) throws SolrException
-    {
-        FieldTypeRepresentation fieldType = getFieldType(name);
-
-        if (fieldType == null) {
-            return null;
-        }
-
-        String value = (String) fieldType.getAttributes().get(SolrSchemaUtils.SOLR_VERSIONFIELDTYPE_VALUE);
-
-        return NumberUtils.createLong(value);
-    }
-
-    private FieldTypeRepresentation getFieldType(String name) throws SolrException
-    {
-        return getFieldTypes(false).get(name);
-    }
-
     private void setVersion(String name, long version, boolean add) throws SolrException
     {
-        setFieldType(name, "solr.ExternalFileField", add, SolrSchemaUtils.SOLR_VERSIONFIELDTYPE_VALUE,
-            String.valueOf(version));
+        this.solrSchemaUtils.setVersion(this.core, name, version, add);
     }
 
     /**
@@ -875,8 +847,7 @@ public abstract class AbstractSolrCoreInitializer implements SolrCoreInitializer
     protected void setStringField(String name, boolean multiValued, boolean dynamic, Object... attributes)
         throws SolrException
     {
-        setField(name, multiValued ? DefaultSolrUtils.SOLR_TYPE_STRINGS : DefaultSolrUtils.SOLR_TYPE_STRING, dynamic,
-            attributes);
+        this.solrSchemaUtils.setStringField(core, name, multiValued, dynamic, attributes);
     }
 
     /**
@@ -896,8 +867,7 @@ public abstract class AbstractSolrCoreInitializer implements SolrCoreInitializer
     protected void setTextGeneralField(String name, boolean multiValued, boolean dynamic, Object... attributes)
         throws SolrException
     {
-        setField(name, multiValued ? DefaultSolrUtils.SOLR_TYPE_TEXT_GENERALS : DefaultSolrUtils.SOLR_TYPE_TEXT_GENERAL,
-            dynamic, attributes);
+        this.solrSchemaUtils.setTextGeneralField(core, name, multiValued, dynamic, attributes);
     }
 
     /**
@@ -916,8 +886,7 @@ public abstract class AbstractSolrCoreInitializer implements SolrCoreInitializer
     protected void setBooleanField(String name, boolean multiValued, boolean dynamic, Object... attributes)
         throws SolrException
     {
-        setField(name, multiValued ? DefaultSolrUtils.SOLR_TYPE_BOOLEANS : DefaultSolrUtils.SOLR_TYPE_BOOLEAN, dynamic,
-            attributes);
+        this.solrSchemaUtils.setBooleanField(core, name, multiValued, dynamic, attributes);
     }
 
     /**
@@ -935,8 +904,7 @@ public abstract class AbstractSolrCoreInitializer implements SolrCoreInitializer
     protected void setPIntField(String name, boolean multiValued, boolean dynamic, Object... attributes)
         throws SolrException
     {
-        setField(name, multiValued ? DefaultSolrUtils.SOLR_TYPE_PINTS : DefaultSolrUtils.SOLR_TYPE_PINT, dynamic,
-            attributes);
+        this.solrSchemaUtils.setPIntField(core, name, multiValued, dynamic, attributes);
     }
 
     /**
@@ -954,8 +922,7 @@ public abstract class AbstractSolrCoreInitializer implements SolrCoreInitializer
     protected void setPFloatField(String name, boolean multiValued, boolean dynamic, Object... attributes)
         throws SolrException
     {
-        setField(name, multiValued ? DefaultSolrUtils.SOLR_TYPE_PFLOATS : DefaultSolrUtils.SOLR_TYPE_PFLOAT, dynamic,
-            attributes);
+        this.solrSchemaUtils.setPFloatField(core, name, multiValued, dynamic, attributes);
     }
 
     /**
@@ -973,8 +940,7 @@ public abstract class AbstractSolrCoreInitializer implements SolrCoreInitializer
     protected void setPLongField(String name, boolean multiValued, boolean dynamic, Object... attributes)
         throws SolrException
     {
-        setField(name, multiValued ? DefaultSolrUtils.SOLR_TYPE_PLONGS : DefaultSolrUtils.SOLR_TYPE_PLONG, dynamic,
-            attributes);
+        this.solrSchemaUtils.setPLongField(core, name, multiValued, dynamic, attributes);
     }
 
     /**
@@ -992,8 +958,7 @@ public abstract class AbstractSolrCoreInitializer implements SolrCoreInitializer
     protected void setPDoubleField(String name, boolean multiValued, boolean dynamic, Object... attributes)
         throws SolrException
     {
-        setField(name, multiValued ? DefaultSolrUtils.SOLR_TYPE_PDOUBLES : DefaultSolrUtils.SOLR_TYPE_PDOUBLE, dynamic,
-            attributes);
+        this.solrSchemaUtils.setPDoubleField(core, name, multiValued, dynamic, attributes);
     }
 
     /**
@@ -1011,8 +976,7 @@ public abstract class AbstractSolrCoreInitializer implements SolrCoreInitializer
     protected void setPDateField(String name, boolean multiValued, boolean dynamic, Object... attributes)
         throws SolrException
     {
-        setField(name, multiValued ? DefaultSolrUtils.SOLR_TYPE_PDATES : DefaultSolrUtils.SOLR_TYPE_PDATE, dynamic,
-            attributes);
+        this.solrSchemaUtils.setPDateField(core, name, multiValued, dynamic, attributes);
     }
 
     /**
@@ -1028,7 +992,7 @@ public abstract class AbstractSolrCoreInitializer implements SolrCoreInitializer
      */
     protected void setBinaryField(String name, boolean dynamic, Object... attributes) throws SolrException
     {
-        setField(name, DefaultSolrUtils.SOLR_TYPE_BINARY, dynamic, attributes);
+        this.solrSchemaUtils.setBinaryField(this.core, name, dynamic, attributes);
     }
 
     /**
@@ -1155,14 +1119,7 @@ public abstract class AbstractSolrCoreInitializer implements SolrCoreInitializer
      */
     protected void setFieldType(String name, String solrClass, boolean add, Object... attributes) throws SolrException
     {
-        Map<String, Object> attributesMap = new HashMap<>(2 + (attributes.length > 0 ? attributes.length / 2 : 0));
-
-        attributesMap.put(FieldType.TYPE_NAME, name);
-        attributesMap.put(FieldType.CLASS_NAME, solrClass);
-
-        MapUtils.putAll(attributesMap, attributes);
-
-        setFieldType(attributesMap, add);
+        this.solrSchemaUtils.setFieldType(this.core, name, solrClass, add, attributes);
     }
 
     /**
@@ -1174,10 +1131,7 @@ public abstract class AbstractSolrCoreInitializer implements SolrCoreInitializer
      */
     protected void setFieldType(Map<String, Object> attributes, boolean add) throws SolrException
     {
-        FieldTypeDefinition definition = new FieldTypeDefinition();
-        definition.setAttributes(attributes);
-
-        setFieldType(definition, add);
+        this.solrSchemaUtils.setFieldType(this.core, attributes, add);
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/SolrCoreInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/SolrCoreInitializer.java
@@ -21,6 +21,7 @@ package org.xwiki.search.solr;
 
 import org.apache.solr.client.solrj.SolrClient;
 import org.xwiki.component.annotation.Role;
+import org.xwiki.search.solr.internal.DefaultXWikiSolrCore;
 import org.xwiki.stability.Unstable;
 
 /**
@@ -45,7 +46,10 @@ public interface SolrCoreInitializer
      * @deprecated use {@link #initialize(XWikiSolrCore)} instead
      */
     @Deprecated(since = "16.1.0RC1")
-    void initialize(SolrClient client) throws SolrException;
+    default void initialize(SolrClient client) throws SolrException
+    {
+        initialize(new DefaultXWikiSolrCore(getCoreName(), getCoreName(), client));
+    }
 
     /**
      * Initialize the client after its creation.

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/SolrUtils.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/SolrUtils.java
@@ -200,8 +200,6 @@ public interface SolrUtils
      */
     void set(String fieldName, Collection<?> fieldValue, SolrInputDocument document);
 
-
-
     /**
      * Store in the document the value associated with the passed field name.
      * <p>
@@ -291,7 +289,6 @@ public interface SolrUtils
     {
         return toFilterQueryString(fieldValue, valueType);
     }
-
 
     /**
      * Extract from the document the value associated with the passed field name.

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/SolrIndexInitializeListener.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/SolrIndexInitializeListener.java
@@ -130,6 +130,9 @@ public class SolrIndexInitializeListener implements EventListener
                 }
 
                 if (request != null) {
+                    // Remove invalid entries after the synchronization
+                    request.setCleanInvalid(true);
+
                     this.solrIndexer.get().startIndex(request);
                 }
             } catch (SolrIndexerException | WikiManagerException e) {

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/SolrSchemaUtils.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/SolrSchemaUtils.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.inject.Singleton;
 
 import org.apache.commons.collections4.MapUtils;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.solr.client.solrj.request.schema.FieldTypeDefinition;
 import org.apache.solr.client.solrj.request.schema.SchemaRequest;
 import org.apache.solr.client.solrj.response.schema.FieldTypeRepresentation;
@@ -215,16 +216,31 @@ public class SolrSchemaUtils
      * 
      * @param core the core to update
      * @param definition the definition of the field to add
-     * @param add true if the field type should be added, false for replace
      * @throws SolrException when failing to add the field
      * @since 16.2.0RC1
      */
-    public void setFieldType(XWikiSolrCore core, FieldTypeDefinition definition, boolean add) throws SolrException
+    public void setFieldType(XWikiSolrCore core, FieldTypeDefinition definition) throws SolrException
     {
-        SolrCoreSchema schema = getSchema(core);
+        setFieldType(core, definition, null);
+    }
+
+    /**
+     * Add a field type in the Solr schema.
+     * 
+     * @param core the core to update
+     * @param definition the definition of the field to add
+     * @param add true or false to explicitly indicate if it's a new field, null to find automatically
+     * @throws SolrException when failing to add the field
+     * @since 17.8.0RC1
+     */
+    public void setFieldType(XWikiSolrCore core, FieldTypeDefinition definition, Boolean add) throws SolrException
+    {
+        String filedName = (String) definition.getAttributes().get(FieldType.TYPE_NAME);
+
+        Map<String, FieldTypeRepresentation> filedTypes = getFieldTypes(core, false);
 
         try {
-            if (add) {
+            if ((add == null && filedTypes.get(filedName) == null) || (add != null && add.equals(Boolean.TRUE))) {
                 new SchemaRequest.AddFieldType(definition).process(core.getClient());
             } else {
                 new SchemaRequest.ReplaceFieldType(definition).process(core.getClient());
@@ -242,7 +258,7 @@ public class SolrSchemaUtils
         representation.setQueryAnalyzer(definition.getQueryAnalyzer());
         representation.setSimilarity(definition.getSimilarity());
 
-        getFieldTypes(core, false).put((String) definition.getAttributes().get(FieldType.TYPE_NAME), representation);
+        filedTypes.put(filedName, representation);
     }
 
     /**
@@ -350,6 +366,189 @@ public class SolrSchemaUtils
     }
 
     /**
+     * Add or replace a field in the Solr schema.
+     * <p>
+     * String (UTF-8 encoded string or Unicode). Strings are intended for small fields and are not tokenized or analyzed
+     * in any way. They have a hard limit of slightly less than 32K.
+     * 
+     * @param core the core to update
+     * @param name the name of the field to set
+     * @param multiValued true if the field can contain several values
+     * @param dynamic true to create a dynamic field
+     * @param attributes attributed to add to the field definition
+     * @throws SolrException when failing to set the field
+     * @since 17.8.0RC1
+     */
+    public void setStringField(XWikiSolrCore core, String name, boolean multiValued, boolean dynamic,
+        Object... attributes) throws SolrException
+    {
+        setField(core, name, multiValued ? DefaultSolrUtils.SOLR_TYPE_STRINGS : DefaultSolrUtils.SOLR_TYPE_STRING,
+            dynamic, attributes);
+    }
+
+    /**
+     * Add or replace a field in the Solr schema.
+     * <p>
+     * A general text field that has reasonable, generic cross-language defaults: it tokenizes with StandardTokenizer,
+     * removes stop words from case-insensitive "stopwords.txt" (empty by default), and down cases. At query time only,
+     * it also applies synonyms.
+     * 
+     * @param core the core to update
+     * @param name the name of the field to set
+     * @param multiValued true if the field can contain several values
+     * @param dynamic true to create a dynamic field
+     * @param attributes attributed to add to the field definition
+     * @throws SolrException when failing to set the field
+     * @since 17.8.0RC1
+     */
+    public void setTextGeneralField(XWikiSolrCore core, String name, boolean multiValued, boolean dynamic,
+        Object... attributes) throws SolrException
+    {
+        setField(core, name,
+            multiValued ? DefaultSolrUtils.SOLR_TYPE_TEXT_GENERALS : DefaultSolrUtils.SOLR_TYPE_TEXT_GENERAL, dynamic,
+            attributes);
+    }
+
+    /**
+     * Add or replace a field in the Solr schema.
+     * <p>
+     * Contains either true or false. Values of "1", "t", or "T" in the first character are interpreted as true. Any
+     * other values in the first character are interpreted as false.
+     * 
+     * @param core the core to update
+     * @param name the name of the field to set
+     * @param multiValued true if the field can contain several values
+     * @param dynamic true to create a dynamic field
+     * @param attributes attributed to add to the field definition
+     * @throws SolrException when failing to set the field
+     * @since 17.8.0RC1
+     */
+    public void setBooleanField(XWikiSolrCore core, String name, boolean multiValued, boolean dynamic,
+        Object... attributes) throws SolrException
+    {
+        setField(core, name, multiValued ? DefaultSolrUtils.SOLR_TYPE_BOOLEANS : DefaultSolrUtils.SOLR_TYPE_BOOLEAN,
+            dynamic, attributes);
+    }
+
+    /**
+     * Add or replace a field in the Solr schema.
+     * <p>
+     * Integer field (32-bit signed integer).
+     * 
+     * @param core the core to update
+     * @param name the name of the field to set
+     * @param multiValued true if the field can contain several values
+     * @param dynamic true to create a dynamic field
+     * @param attributes attributed to add to the field definition
+     * @throws SolrException when failing to set the field
+     * @since 17.8.0RC1
+     */
+    public void setPIntField(XWikiSolrCore core, String name, boolean multiValued, boolean dynamic,
+        Object... attributes) throws SolrException
+    {
+        setField(core, name, multiValued ? DefaultSolrUtils.SOLR_TYPE_PINTS : DefaultSolrUtils.SOLR_TYPE_PINT, dynamic,
+            attributes);
+    }
+
+    /**
+     * Add or replace a field in the Solr schema.
+     * <p>
+     * Floating point field (32-bit IEEE floating point).
+     * 
+     * @param core the core to update
+     * @param name the name of the field to set
+     * @param multiValued true if the field can contain several values
+     * @param dynamic true to create a dynamic field
+     * @param attributes attributed to add to the field definition
+     * @throws SolrException when failing to set the field
+     * @since 17.8.0RC1
+     */
+    public void setPFloatField(XWikiSolrCore core, String name, boolean multiValued, boolean dynamic,
+        Object... attributes) throws SolrException
+    {
+        setField(core, name, multiValued ? DefaultSolrUtils.SOLR_TYPE_PFLOATS : DefaultSolrUtils.SOLR_TYPE_PFLOAT,
+            dynamic, attributes);
+    }
+
+    /**
+     * Add or replace a field in the Solr schema.
+     * <p>
+     * Long field (64-bit signed integer).
+     * 
+     * @param core the core to update
+     * @param name the name of the field to set
+     * @param multiValued true if the field can contain several values
+     * @param dynamic true to create a dynamic field
+     * @param attributes attributed to add to the field definition
+     * @throws SolrException when failing to set the field
+     * @since 17.8.0RC1
+     */
+    public void setPLongField(XWikiSolrCore core, String name, boolean multiValued, boolean dynamic,
+        Object... attributes) throws SolrException
+    {
+        setField(core, name, multiValued ? DefaultSolrUtils.SOLR_TYPE_PLONGS : DefaultSolrUtils.SOLR_TYPE_PLONG,
+            dynamic, attributes);
+    }
+
+    /**
+     * Add or replace a field in the Solr schema.
+     * <p>
+     * Double field (64-bit IEEE floating point).
+     * 
+     * @param core the core to update
+     * @param name the name of the field to set
+     * @param multiValued true if the field can contain several values
+     * @param dynamic true to create a dynamic field
+     * @param attributes attributed to add to the field definition
+     * @throws SolrException when failing to set the field
+     * @since 17.8.0RC1
+     */
+    public void setPDoubleField(XWikiSolrCore core, String name, boolean multiValued, boolean dynamic,
+        Object... attributes) throws SolrException
+    {
+        setField(core, name, multiValued ? DefaultSolrUtils.SOLR_TYPE_PDOUBLES : DefaultSolrUtils.SOLR_TYPE_PDOUBLE,
+            dynamic, attributes);
+    }
+
+    /**
+     * Add or replace a field in the Solr schema.
+     * <p>
+     * Date field. Represents a point in time with millisecond precision.
+     * 
+     * @param core the core to update
+     * @param name the name of the field to set
+     * @param multiValued true if the field can contain several values
+     * @param dynamic true to create a dynamic field
+     * @param attributes attributed to add to the field definition
+     * @throws SolrException when failing to set the field
+     * @since 17.8.0RC1
+     */
+    public void setPDateField(XWikiSolrCore core, String name, boolean multiValued, boolean dynamic,
+        Object... attributes) throws SolrException
+    {
+        setField(core, name, multiValued ? DefaultSolrUtils.SOLR_TYPE_PDATES : DefaultSolrUtils.SOLR_TYPE_PDATE,
+            dynamic, attributes);
+    }
+
+    /**
+     * Add or replace a field in the Solr schema.
+     * <p>
+     * Binary data.
+     * 
+     * @param core the core to update
+     * @param name the name of the field to set
+     * @param dynamic true to create a dynamic field
+     * @param attributes attributed to add to the field definition
+     * @throws SolrException when failing to set the field
+     * @since 17.8.0RC1
+     */
+    public void setBinaryField(XWikiSolrCore core, String name, boolean dynamic, Object... attributes)
+        throws SolrException
+    {
+        setField(core, name, DefaultSolrUtils.SOLR_TYPE_BINARY, dynamic, attributes);
+    }
+
+    /**
      * @param core the core to update
      * @param name the name of the field to delete
      * @param dynamic true to delete a dynamic field
@@ -423,5 +622,127 @@ public class SolrSchemaUtils
 
         // Reset the cache
         getSchema(core).reset();
+    }
+
+    private FieldTypeRepresentation getFieldType(XWikiSolrCore core, String name) throws SolrException
+    {
+        return getFieldTypes(core, false).get(name);
+    }
+
+    /**
+     * @param core the core
+     * @param name the name of the version
+     * @return the version, or null if no value could be found for the provided version name
+     * @throws SolrException when failing to get the version
+     * @since 17.8.0RC1
+     */
+    public Long getVersion(XWikiSolrCore core, String name) throws SolrException
+    {
+        FieldTypeRepresentation fieldType = getFieldType(core, name);
+
+        if (fieldType == null) {
+            return null;
+        }
+
+        String value = (String) fieldType.getAttributes().get(SolrSchemaUtils.SOLR_VERSIONFIELDTYPE_VALUE);
+
+        return NumberUtils.createLong(value);
+    }
+
+    /**
+     * Add a field type in the Solr schema.
+     * 
+     * @param core the core
+     * @param attributes the attributes of the field to add
+     * @throws SolrException when failing to add the field
+     * @since 17.8.0RC1
+     */
+    public void setFieldType(XWikiSolrCore core, Map<String, Object> attributes) throws SolrException
+    {
+        setFieldType(core, attributes, null);
+    }
+
+    /**
+     * Add a field type in the Solr schema.
+     * 
+     * @param core the core
+     * @param attributes the attributes of the field to add
+     * @param add true or false to explicitly indicate if it's a new field, null to find automatically
+     * @throws SolrException when failing to add the field
+     * @since 17.8.0RC1
+     */
+    public void setFieldType(XWikiSolrCore core, Map<String, Object> attributes, Boolean add) throws SolrException
+    {
+        FieldTypeDefinition definition = new FieldTypeDefinition();
+        definition.setAttributes(attributes);
+
+        setFieldType(core, definition, add);
+    }
+
+    /**
+     * Add a field type in the Solr schema.
+     * 
+     * @param core the core
+     * @param name the name of the field type
+     * @param solrClass the class of the field type
+     * @param attributes the other attributes of the field type
+     * @throws SolrException when failing to add the field
+     * @since 17.8.0RC1
+     */
+    public void setFieldType(XWikiSolrCore core, String name, String solrClass, Object... attributes)
+        throws SolrException
+    {
+        setFieldType(core, name, solrClass, null, attributes);
+    }
+
+    /**
+     * Add a field type in the Solr schema.
+     * 
+     * @param core the core
+     * @param name the name of the field type
+     * @param solrClass the class of the field type
+     * @param add true or false to explicitly indicate if it's a new field, null to find automatically
+     * @param attributes the other attributes of the field type
+     * @throws SolrException when failing to add the field
+     * @since 17.8.0RC1
+     */
+    public void setFieldType(XWikiSolrCore core, String name, String solrClass, Boolean add, Object... attributes)
+        throws SolrException
+    {
+        Map<String, Object> attributesMap = new HashMap<>(2 + (attributes.length > 0 ? attributes.length / 2 : 0));
+
+        attributesMap.put(FieldType.TYPE_NAME, name);
+        attributesMap.put(FieldType.CLASS_NAME, solrClass);
+
+        MapUtils.putAll(attributesMap, attributes);
+
+        setFieldType(core, attributesMap);
+    }
+
+    /**
+     * @param core the core
+     * @param name the name of the version
+     * @param version the version value
+     * @throws SolrException when failing to set the version
+     * @since 17.8.0RC1
+     */
+    public void setVersion(XWikiSolrCore core, String name, long version) throws SolrException
+    {
+        setFieldType(core, name, "solr.ExternalFileField", SolrSchemaUtils.SOLR_VERSIONFIELDTYPE_VALUE,
+            String.valueOf(version));
+    }
+
+    /**
+     * @param core the core
+     * @param name the name of the version
+     * @param version the version value
+     * @param add true or false to explicitly indicate if it's a new field, null to find automatically
+     * @throws SolrException when failing to set the version
+     * @since 17.8.0RC1
+     */
+    public void setVersion(XWikiSolrCore core, String name, long version, Boolean add) throws SolrException
+    {
+        setFieldType(core, name, "solr.ExternalFileField", SolrSchemaUtils.SOLR_VERSIONFIELDTYPE_VALUE,
+            String.valueOf(version), add);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/api/FieldUtils.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/api/FieldUtils.java
@@ -21,6 +21,8 @@ package org.xwiki.search.solr.internal.api;
 
 import java.util.Locale;
 
+import com.xpn.xwiki.doc.XWikiDocument;
+
 /**
  * Contains constants naming the Solr/Lucene index fields used by this module for indexing entities. Also contains
  * additional constants used for composing field names on multilingual fields.
@@ -47,6 +49,13 @@ public final class FieldUtils
      * versions of a document to be indexed. The value format is wiki:Space.Page_locale .
      */
     public static final String ID = "id";
+
+    /**
+     * The local id of the document as defined by {@link XWikiDocument#getId()}.
+     * 
+     * @since 17.8.0RC1
+     */
+    public static final String DOC_ID = "docid";
 
     /**
      * The reference of the entity, including the parameters and the entity type.
@@ -343,6 +352,27 @@ public final class FieldUtils
      * Underscore character, used to separate the field name from the suffix.
      */
     public static final String USCORE = "_";
+
+    /**
+     * The name of the dynamic field used to type simple string properties.
+     * 
+     * @since 17.8.0RC1
+     */
+    public static final String DYNAMIC_STRING = "*_string";
+
+    /**
+     * The name of the dynamic field used to index the lower case version of simple string properties.
+     * 
+     * @since 17.8.0RC1
+     */
+    public static final String DYNAMIC_STRING_LOWERCASE = "*_string_lowercase";
+
+    /**
+     * The type used to index exact strings as lower case.
+     * 
+     * @since 17.8.0RC1
+     */
+    public static final String TYPE_LOWERCASE = "lowercase";
 
     /**
      * Utility class.

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/job/DatabaseDocumentIterator.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/job/DatabaseDocumentIterator.java
@@ -212,9 +212,9 @@ public class DatabaseDocumentIterator extends AbstractDocumentIterator<String>
     private Query getQuery() throws QueryException
     {
         if (query == null) {
+            String select = "select doc.space, doc.name, doc.language, doc.version, doc.id from XWikiDocument doc";
             // This iterator must have the same order as the SolrDocumentIterator, otherwise the synchronization fails.
-            String select = "select doc.space, doc.name, doc.language, doc.version from XWikiDocument doc";
-            String orderBy = " order by doc.space, doc.name, doc.language nulls first";
+            String orderBy = " order by doc.id asc";
 
             EntityReference spaceReference = null;
             EntityReference documentReference = null;

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/job/IndexerRequest.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/job/IndexerRequest.java
@@ -54,6 +54,11 @@ public class IndexerRequest extends AbstractRequest
     private boolean removeMissing = true;
 
     /**
+     * @see #isCleanInvalid()
+     */
+    private boolean cleanInvalid;
+
+    /**
      * The default constructor.
      */
     public IndexerRequest()
@@ -116,6 +121,24 @@ public class IndexerRequest extends AbstractRequest
     public void setRemoveMissing(boolean removeMissing)
     {
         this.removeMissing = removeMissing;
+    }
+
+    /**
+     * @return if true the invalid Solr document entries are removed, if false nothing is checked
+     * @since 17.8.0RC1
+     */
+    public boolean isCleanInvalid()
+    {
+        return this.cleanInvalid;
+    }
+
+    /**
+     * @param cleanInvalid if true the invalid Solr document entries are removed, if false nothing is checked
+     * @since 17.8.0RC1
+     */
+    public void setCleanInvalid(boolean cleanInvalid)
+    {
+        this.cleanInvalid = cleanInvalid;
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/AbstractSolrMetadataExtractor.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/AbstractSolrMetadataExtractor.java
@@ -260,13 +260,17 @@ public abstract class AbstractSolrMetadataExtractor implements SolrMetadataExtra
 
         solrDocument.setField(FieldUtils.WIKI, documentReference.getWikiReference().getName());
         solrDocument.setField(FieldUtils.NAME, documentReference.getName());
+        solrDocument.setField(FieldUtils.FULLNAME, this.localSerializer.serialize(documentReference));
 
         // Set the fields that are used to query / filter the document hierarchy.
         setHierarchyFields(solrDocument, documentReference.getParent());
 
-        Locale locale = getLocale(documentReference);
-        solrDocument.setField(FieldUtils.LOCALE, locale.toString());
-        solrDocument.setField(FieldUtils.LANGUAGE, locale.getLanguage());
+        Locale realLocale = getRealLocale(documentReference);
+        solrDocument.setField(FieldUtils.LOCALE, realLocale.toString());
+        solrDocument.setField(FieldUtils.LANGUAGE, realLocale.getLanguage());
+
+        solrDocument.setField(FieldUtils.DOC_ID, new XWikiDocument(documentReference,
+            documentReference.getLocale() != null ? documentReference.getLocale() : Locale.ROOT).getId());
 
         return true;
     }
@@ -319,7 +323,7 @@ public abstract class AbstractSolrMetadataExtractor implements SolrMetadataExtra
         }
 
         // 4) Make sure that the original document's locale is there as well.
-        locales.add(getLocale(xdocument.getDocumentReference()));
+        locales.add(getRealLocale(xdocument.getDocumentReference()));
 
         return locales;
     }
@@ -338,7 +342,7 @@ public abstract class AbstractSolrMetadataExtractor implements SolrMetadataExtra
      * @return the locale code of the referenced document.
      * @throws SolrIndexerException if problems occur.
      */
-    protected Locale getLocale(DocumentReference documentReference) throws SolrIndexerException
+    protected Locale getRealLocale(DocumentReference documentReference) throws SolrIndexerException
     {
         Locale locale = null;
 

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/DocumentSolrMetadataExtractor.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/DocumentSolrMetadataExtractor.java
@@ -109,22 +109,20 @@ public class DocumentSolrMetadataExtractor extends AbstractSolrMetadataExtractor
             return false;
         }
 
-        Locale locale = getLocale(documentReference);
-
-        solrDocument.setField(FieldUtils.FULLNAME, localSerializer.serialize(documentReference));
+        Locale realLocale = getRealLocale(documentReference);
 
         // Rendered title.
         String plainTitle = translatedDocument.getRenderedTitle(Syntax.PLAIN_1_0, xcontext);
-        solrDocument.setField(FieldUtils.getFieldName(FieldUtils.TITLE, locale), plainTitle);
+        solrDocument.setField(FieldUtils.getFieldName(FieldUtils.TITLE, realLocale), plainTitle);
 
         // Raw Content
-        solrDocument.setField(FieldUtils.getFieldName(FieldUtils.DOCUMENT_RAW_CONTENT, locale),
+        solrDocument.setField(FieldUtils.getFieldName(FieldUtils.DOCUMENT_RAW_CONTENT, realLocale),
             translatedDocument.getContent());
 
         // Rendered content
         WikiPrinter plainContentPrinter = new DefaultWikiPrinter();
         this.renderer.render(translatedDocument.getXDOM(), plainContentPrinter);
-        solrDocument.setField(FieldUtils.getFieldName(FieldUtils.DOCUMENT_RENDERED_CONTENT, locale),
+        solrDocument.setField(FieldUtils.getFieldName(FieldUtils.DOCUMENT_RENDERED_CONTENT, realLocale),
             plainContentPrinter.toString());
 
         solrDocument.setField(FieldUtils.VERSION, translatedDocument.getVersion());
@@ -149,7 +147,7 @@ public class DocumentSolrMetadataExtractor extends AbstractSolrMetadataExtractor
         setLinks(solrDocument, translatedDocument, xcontext);
 
         // Add any extra fields (about objects, etc.) that can improve the findability of the document.
-        setExtras(documentReference, solrDocument, locale);
+        setExtras(documentReference, solrDocument, realLocale);
 
         // Extract more metadata
         this.extractorUtils.extract(documentReference, translatedDocument, solrDocument);

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/search/AbstractSearchCoreMigration.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/search/AbstractSearchCoreMigration.java
@@ -1,0 +1,48 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.search.solr.internal.search;
+
+import java.util.Comparator;
+
+import jakarta.inject.Inject;
+
+import org.xwiki.search.solr.SolrUtils;
+import org.xwiki.search.solr.internal.SolrSchemaUtils;
+
+/**
+ * Base class for {@link SearchCoreMigration} implementations.
+ * 
+ * @version $Id$
+ * @since 17.8.0RC1
+ */
+public abstract class AbstractSearchCoreMigration implements SearchCoreMigration
+{
+    @Inject
+    protected SolrUtils solrUtils;
+
+    @Inject
+    protected SolrSchemaUtils solrSchema;
+
+    @Override
+    public int compareTo(SearchCoreMigration other)
+    {
+        return Comparator.comparingLong(SearchCoreMigration::getVersion).compare(this, other);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/search/SearchCoreMigration.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/search/SearchCoreMigration.java
@@ -1,0 +1,53 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.search.solr.internal.search;
+
+import org.xwiki.component.annotation.Role;
+import org.xwiki.search.solr.SolrException;
+import org.xwiki.search.solr.XWikiSolrCore;
+
+/**
+ * Execute a Solr search core migration.
+ * <p>
+ * Migrations are executed from lowest to highest version number and are generally following the same format than the
+ * database migrations:
+ * {@code <major version><minor version><bugfix version><reserve 3 digits in case there are several>}. For example the
+ * first migration in XWiki version 17.7.0 will use version {@code 170700000}.
+ * <p>
+ * The best practice is also to follow the same format for the name of the class implementing
+ * {@link SearchCoreMigration}: {@code V170700000SearchCoreMigration}
+ * 
+ * @version $Id$
+ * @since 17.8.0RC1
+ */
+@Role
+public interface SearchCoreMigration extends Comparable<SearchCoreMigration>
+{
+    /**
+     * @return the version of the migration
+     */
+    long getVersion();
+
+    /**
+     * @param core the core to migrate
+     * @throws SolrException when failing to migrate the core
+     */
+    void migrate(XWikiSolrCore core) throws SolrException;
+}

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/search/SearchCoreMigrationManager.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/search/SearchCoreMigrationManager.java
@@ -1,0 +1,103 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.search.solr.internal.search;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.slf4j.Logger;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.phase.Initializable;
+import org.xwiki.component.phase.InitializationException;
+import org.xwiki.search.solr.SolrException;
+import org.xwiki.search.solr.XWikiSolrCore;
+import org.xwiki.search.solr.internal.SolrSchemaUtils;
+
+/**
+ * Class in charge of updating the search code through migrations.
+ * 
+ * @version $Id$
+ * @since 17.8.0RC1
+ */
+@Component(roles = SearchCoreMigrationManager.class)
+@Singleton
+public class SearchCoreMigrationManager implements Initializable
+{
+    /**
+     * The name of the version used to store the migration.
+     */
+    private static final String SOLR_TYPENAME_CMVERSION = "__cmversion";
+
+    @Inject
+    private SolrSchemaUtils solrSchema;
+
+    @Inject
+    private List<SearchCoreMigration> migrations;
+
+    @Inject
+    private Logger logger;
+
+    @Override
+    public void initialize() throws InitializationException
+    {
+        // Sort the migrations
+        this.migrations = new ArrayList<>(this.migrations);
+        Collections.sort(this.migrations);
+    }
+
+    /**
+     * Execute migrations on the search core (if needed).
+     * 
+     * @param core the core to update
+     * @throws SolrException when failing to update the Solr core
+     */
+    public void update(XWikiSolrCore core) throws SolrException
+    {
+        // Get the current version
+        Long currentVersion = this.solrSchema.getVersion(core, SOLR_TYPENAME_CMVERSION);
+
+        this.logger.info("Current Solr core migration version is [{}]", currentVersion);
+
+        // Execute migrations more recent that the current version
+        for (SearchCoreMigration migration : this.migrations) {
+            if (currentVersion == null || migration.getVersion() > currentVersion) {
+                this.logger.info("Starting the Solr search core migration [{}]", migration.getVersion());
+
+                executeMigration(migration, core);
+
+                this.logger.info("Finished the Solr search core migration [{}]", migration.getVersion());
+            }
+        }
+    }
+
+    private void executeMigration(SearchCoreMigration migration, XWikiSolrCore core) throws SolrException
+    {
+        // Execute the migration
+        migration.migrate(core);
+
+        // Update the version
+        this.solrSchema.setVersion(core, SOLR_TYPENAME_CMVERSION, migration.getVersion());
+        this.solrSchema.commit(core);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/search/V170700000SearchCoreMigration.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/search/V170700000SearchCoreMigration.java
@@ -1,0 +1,74 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.search.solr.internal.search;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.model.reference.EntityReferenceSerializer;
+import org.xwiki.search.solr.SolrException;
+import org.xwiki.search.solr.XWikiSolrCore;
+import org.xwiki.search.solr.internal.api.FieldUtils;
+
+/**
+ * Add fields introduced in XWiki 17.7.0:
+ * <ul>
+ * <li>{@code docid}.</li>
+ * <li>{@code *_lowercase} and corresponding copy field.</li>
+ * </ul>
+ * 
+ * @version $Id$
+ * @since 17.8.0RC1
+ */
+@Component
+@Named("170700000")
+@Singleton
+public class V170700000SearchCoreMigration extends AbstractSearchCoreMigration
+{
+    @Inject
+    @Named("local")
+    private EntityReferenceSerializer<String> localSerializer;
+
+    @Override
+    public long getVersion()
+    {
+        return 170500000;
+    }
+
+    @Override
+    public void migrate(XWikiSolrCore core) throws SolrException
+    {
+        if (this.solrSchema.getFields(core, false).get(FieldUtils.DOC_ID) == null) {
+            // Add the docid field to the schema
+            this.solrSchema.setPLongField(core, FieldUtils.DOC_ID, false, false);
+
+            // Add the *_lowercase dynamic field to the schema
+            this.solrSchema.setField(core, FieldUtils.DYNAMIC_STRING_LOWERCASE, FieldUtils.TYPE_LOWERCASE, true,
+                "multiValued", true);
+            // Add the copy field in charge of automatically providing a lower case version of all string fields
+            this.solrSchema.addCopyField(core, FieldUtils.DYNAMIC_STRING, FieldUtils.DYNAMIC_STRING_LOWERCASE);
+        }
+
+        // The standard re-index is going to take care of re-indexing all documents (because it skips documents without
+        // docid as invalid)
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/resources/META-INF/components.txt
@@ -38,4 +38,7 @@ org.xwiki.search.solr.internal.reference.SolrDocumentReferenceResolver
 org.xwiki.search.solr.internal.reference.SolrEntityReferenceResolver
 org.xwiki.search.solr.internal.reference.SpaceSolrReferenceResolver
 org.xwiki.search.solr.internal.reference.WikiSolrReferenceResolver
+org.xwiki.search.solr.internal.search.SearchCoreInitializer
+org.xwiki.search.solr.internal.search.SearchCoreMigrationManager
+org.xwiki.search.solr.internal.search.V170700000SearchCoreMigration
 org.xwiki.search.solr.script.SolrIndexScriptService

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/test/java/org/xwiki/search/solr/internal/DefaultSolrTest.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/test/java/org/xwiki/search/solr/internal/DefaultSolrTest.java
@@ -22,6 +22,7 @@ package org.xwiki.search.solr.internal;
 import java.io.File;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -134,6 +135,9 @@ class DefaultSolrTest
         inputDocument.addField(FieldUtils.LINKS_EXTENDED, "link1.1");
         inputDocument.addField(FieldUtils.LINKS_EXTENDED, "link1.2");
 
+        String propertyName = FieldUtils.PROPERTY_NAME + "_string";
+        inputDocument.addField(propertyName, "StringValue");
+
         String titleRootLocaleField = FieldUtils.getFieldName(FieldUtils.TITLE, Locale.ROOT);
         inputDocument.setField(titleRootLocaleField, "Some title");
 
@@ -145,6 +149,8 @@ class DefaultSolrTest
         assertEquals("", storedDocument.get(FieldUtils.DOCUMENT_LOCALE));
         assertEquals(Arrays.asList("link1", "link2"), storedDocument.getFieldValues(FieldUtils.LINKS));
         assertEquals(Arrays.asList("Some title"), storedDocument.get(titleRootLocaleField));
+        assertEquals(List.of("StringValue"), storedDocument.get(propertyName));
+        assertEquals(List.of("stringvalue"), storedDocument.get(propertyName + "_lowercase"));
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/test/java/org/xwiki/search/solr/internal/job/DatabaseDocumentIteratorTest.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/test/java/org/xwiki/search/solr/internal/job/DatabaseDocumentIteratorTest.java
@@ -66,7 +66,7 @@ import static org.mockito.Mockito.when;
 @ComponentTest
 class DatabaseDocumentIteratorTest
 {
-    private static final String ORDER_CLAUSE = " order by doc.space, doc.name, doc.language nulls first";
+    private static final String ORDER_CLAUSE = " order by doc.id asc";
 
     @MockComponent
     private WikiDescriptorManager wikiDescriptorManager;
@@ -157,9 +157,9 @@ class DatabaseDocumentIteratorTest
         when(countQuery.setWiki("chess")).thenReturn(chessCountQuery);
         when(countQuery.setWiki("tennis")).thenReturn(tennisCountQuery);
 
-        when(
-            this.queryManager.createQuery("select doc.space, doc.name, doc.language, doc.version from XWikiDocument doc"
-                                          + ORDER_CLAUSE, Query.HQL)).thenReturn(query);
+        when(this.queryManager.createQuery(
+            "select doc.space, doc.name, doc.language, doc.version, doc.id from XWikiDocument doc" + ORDER_CLAUSE,
+            Query.HQL)).thenReturn(query);
         when(this.queryManager.createQuery("", Query.HQL)).thenReturn(countQuery);
 
         DocumentIterator<String> iterator = this.databaseIterator;
@@ -207,9 +207,9 @@ class DatabaseDocumentIteratorTest
         when(countQuery.addFilter(this.countQueryFilter)).thenReturn(countQuery);
 
         String whereClause = " where doc.space = :space and doc.name = :name";
-        when(
-            this.queryManager.createQuery("select doc.space, doc.name, doc.language, doc.version from XWikiDocument doc"
-                                          + whereClause + ORDER_CLAUSE, Query.HQL)).thenReturn(query);
+        when(this.queryManager
+            .createQuery("select doc.space, doc.name, doc.language, doc.version, doc.id from XWikiDocument doc"
+                + whereClause + ORDER_CLAUSE, Query.HQL)).thenReturn(query);
         when(this.queryManager.createQuery(whereClause, Query.HQL)).thenReturn(countQuery);
 
         DocumentIterator<String> iterator = this.databaseIterator;

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/test/java/org/xwiki/search/solr/internal/job/IndexerJobTest.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/test/java/org/xwiki/search/solr/internal/job/IndexerJobTest.java
@@ -36,6 +36,7 @@ import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
 import org.xwiki.model.reference.EntityReferenceSerializer;
 import org.xwiki.search.solr.internal.api.SolrIndexer;
+import org.xwiki.search.solr.internal.api.SolrInstance;
 import org.xwiki.test.LogLevel;
 import org.xwiki.test.junit5.LogCaptureExtension;
 import org.xwiki.test.junit5.mockito.ComponentTest;
@@ -86,6 +87,9 @@ class IndexerJobTest
 
     @MockComponent
     private DocumentAccessBridge mockDocumentAccessBridge;
+
+    @MockComponent
+    private SolrInstance mockSolrInstance;
 
     @InjectMockComponents
     private IndexerJob indexerJob;

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-server/xwiki-platform-search-solr-server-core-search/src/main/resources/conf/managed-schema.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-server/xwiki-platform-search-solr-server-core-search/src/main/resources/conf/managed-schema.xml
@@ -65,13 +65,40 @@
        1.6: useDocValuesAsStored defaults to true.
     -->
 
-    <!-- XWIKI: the version of the schema from XWiki point of view.
-         The version should be updated when the configuration need to be updated for the core to work as expected.
-         It cause the whole schema to be re-created with embedded Solr setup.
+    <!-- XWiki changelog
 
-         160600000: added support for Ukrainian locale, this also requires a special JAR in the lib/ folder
+         14.8 (no schema version change):
+           * added field "reference"
+           * added field "links"
+           * added field "links_extended"
+
+         16.6.0 (160600000) (major):
+           * added support for Ukrainian locale, this also requires a special JAR in the lib/ folder
+
+         17.3.0 (no schema version change):
+           * "string" type moved to docValues="true"
+           * "lowercase" type implementation changed, and moved to docValues="true"
+
+         17.7.0 (170700000) (migration):
+           * a docid plong field has been added to store the XWiki document long local identifier (XWikiDocument#getId)
+           * a dynamic *_string_lowercase and a corresponding copy field have been added to automatically provide a lower case version of all exact string properties
+           * the fullname field is not set for all entities, not just DOCUMENT
+    -->
+    <!-- XWIKI: the versions of the schema from XWiki point of view.
+    
+         There are two possibilities:
+           * increment both "__cversion" and "__cmversion": the "search" core configuration and data will be deleted and re-created
+                (only in the case of the embedded setup, the standalone setup will require a manual intervention in this case)
+           * increment only "__cmversion": it won't recreate the "search" core, instead it will execute all SearchCoreMigration components
+                with versions greater than the current one
+
+         It's recommended to use migrations when possible (so only when the required changes can be fully done using SolrJ API):
+           * it avoid starting from scratch re-indexing sometimes huge instances
+           * it makes the upgrade of Solr standalone setups much easier
+           * it better support customizations of the Solr configuration (i.e. they are not reseted)
     -->
     <fieldType name="__cversion" class="solr.ExternalFileField" defVal="160600000"/>
+    <fieldType name="__cmversion" class="solr.ExternalFileField" defVal="170600000"/>
 
     <!-- Valid attributes for fields:
      name: mandatory - the name for the field
@@ -152,6 +179,8 @@
     <!-- The entity type: DOCUMENT, ATTACHMENT, OBJECT, OBJECT_PROPERTY -->
     <field name="type" type="string" indexed="true" stored="true" />
     <field name="wiki" type="string" indexed="true" stored="true" />
+    <!-- The unique identifier of the document in the wiki (see XWikiDocument#getId()) -->
+    <field name="docid" type="plong" indexed="true" stored="true" />
     <!-- The local space reference. For a document {@code A.B.C.Page} the value of this field is {@code A.B.C}.
       This field is analyzed and thus used for free text search.
       @deprecated since 7.2, use the "spaces" multiValued field instead -->
@@ -287,6 +316,10 @@
     <dynamicField name="*_double" type="pdoubles" indexed="true" stored="true" />
     <dynamicField name="*_string" type="string" indexed="true" stored="true" multiValued="true" />
     <dynamicField name="*_date" type="pdates" indexed="true" stored="true" />
+
+    <!-- Also automatically index a lowercase version of all string properties -->
+    <dynamicField name="*_string_lowercase" type="lowercase" indexed="true" stored="true" multiValued="true" />
+    <copyField source="*_string" dest="*_string_lowercase"/>
 
     <!-- Used to index the currency code sub-type (check the currency type definition) -->
     <dynamicField name="*_string_ns" type="string" indexed="true" stored="false" />
@@ -499,6 +532,9 @@
         <filter name="lowercase"/>
       </analyzer>
     </fieldType>
+
+    <!-- XWiki: lower cased text -->
+    <dynamicField name="*_lowercase" type="lowercase"  indexed="true"  stored="true" multiValued="true"/>
 
     <!-- A text field with defaults appropriate for English: it tokenizes with StandardTokenizer,
          removes English stop words (lang/stopwords_en.txt), down cases, protects words from protwords.txt, and

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-upgrade/xwiki-platform-distribution-flavor-test-upgrade-1610/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-upgrade/xwiki-platform-distribution-flavor-test-upgrade-1610/pom.xml
@@ -33,11 +33,16 @@
   <description>XWiki Platform - Distribution - Flavor - Functional Tests - Upgrade - From ${upgradetest.previousflavor.version}</description>
   <properties>
     <upgradetest.previousflavor.version>16.10.0</upgradetest.previousflavor.version>
+    <!--
+      * custom-0: complete solr search and extensions index (it's empty with the standard build) 
+     -->
+    <upgradetest.previousdata.classifier>custom-0</upgradetest.previousdata.classifier>
   </properties>
   <dependencies>
     <dependency>
       <groupId>${upgradetest.previousdata.groupId}</groupId>
       <artifactId>${upgradetest.previousdata.artifactId}</artifactId>
+      <classifier>${upgradetest.previousdata.classifier}</classifier>
       <!-- Using a fixed version instead of ${upgradetest.previousflavor.version} because of
            https://issues.apache.org/jira/browse/MRELEASE-799, causing "The artifact (...) requires a different
            version (...) than what is found (...) for the expression (upgradetest.previousflavor.version) in the


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

* [XWIKI-15166: SOLR reindexation job cause serious perfomance issues on large database](https://jira.xwiki.org/browse/XWIKI-15166)
* [XWIKI-23318: Add the doc id in the Solr search core index](https://jira.xwiki.org/browse/XWIKI-23318)
* [XWIKI-23319: Index the document fullName for attachment and objects too in the Solr search core](https://jira.xwiki.org/browse/XWIKI-23319)
* [XWIKI-23428: Add a case insensitive Solr field for all StringProperty and ListProperty fields](https://jira.xwiki.org/browse/XWIKI-23428)

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Start indexing the `docId` long from XWikiDocument#getId() in the Solr search core (for all types, not just documents)
* Index fullName in all entries (instead of just DOCUMENT entries)
* Start copying automatically all `*_string` fields into a corresponding `*_string_lowercase` field (XWIKI-23428)
* Add a generic (but still internal) migration system for the `search` core
  * Add a migration (`V170600000`) to:
    * automatically add the new `docId` field in the `search` core
* Refactor the Solr init index based on the new `docId` field. Also modify a bit the logic to skip "invalid" entries (like those without a docId, which is the trick I eventually decided to use to reindex the documents)
* A new step in the job indexer now remove invalid entries (after the indexing is fully finished)

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

The solr init currently sort document using the document space, name and locale properties. This is causing two problem:
* the exact way to sort utf8 characters is not always the same on Solr and on various databases side
* it can be very slow on database side because there is no (and there cannot really be) an index for this properties' combination 

One simple way to avoid this problem would be to sort document using the doc id `long` value. It's fast on database side and there is no debate on how it should be sorted whatever is the database engine.

Since we are starting to see huge instances for which reindexing the search core from scratch is a real pain (especially since the `search` core became much more important than the search use case), I also started the trend of trying to execute migrations for the `search` core when possible. It was only done for other, minimal package based, cores before which are also fully initialized programmatically.

I initially planned to add the docId through atomic Solr update, but it was way too fragile in the context of an upgrade. So the trick I finally ended up using is to make sure documents without docid are ignored in the Solr document iterator. It means the indexer job will see those as not existing and reindex them.

The Solr search index is fully re-indexed, but since it's not emptied and the docId is only used for the initial sync right now, this change should not impact other features.

The new fullname (XWIKI-23319) and lowercase (XWIKI-23428) indexing were of not required, but since they also need to reindex the whole farm, it was a good occasion.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

It's not easy to write tests for performance purposes, but it would already be nice to not break anything.

TODO: try to make sure via `UpgradeTest` that the migration is working (so when upgrading from 16.10.x)

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches: no backport