### PR TITLE
XWIKI-23168: The word "Comment" is displayed in bold above the editor box when editing a comment

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/commentfield.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/commentfield.vm
@@ -19,7 +19,7 @@
 ## ---------------------------------------------------------------------------
 ###
 #template('display_macros.vm')
-### Return a single comment field
+### Return a single comment field in edit mode
 ###
 ###
 ## requested field name containing the comment number (or not if it's a new comment)
@@ -45,7 +45,9 @@
 #set ($defaultEditorId = $services.edit.syntaxContent.defaultEditorId)
 <input type='hidden' name='defaultEditorId' value="$escapetool.xml($defaultEditorId)" />
 
-<label for="$escapetool.xml($inputName)">$escapetool.xml($services.localization.render('core.viewers.comments.add.comment.label'))</label>
+<label class='sr-only' for="$escapetool.xml($inputName)">
+  $escapetool.xml($services.localization.render('core.viewers.comments.edit.comment.label'))
+</label>
 #initRequiredSkinExtensions()
 ## This startupFocus parameter is used by the CKEditor WYSIWYG editor.
 #set ($wysiwygEditorConfig = {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -1093,6 +1093,7 @@ core.viewers.comments.preview.inProgress=Generating preview...
 core.viewers.comments.commentDeleted=Deleted comment.
 core.viewers.comments.deleteReplies.prompt=Also delete all replies to this comment?
 core.viewers.comments.edit=Edit
+core.viewers.comments.edit.comment.label=Edit the comment
 core.viewers.comments.edit.save=Save comment
 core.viewers.comments.edit.cancel=Cancel
 core.viewers.comments.edit.notAllowed=You are not allowed to edit this comment


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-23168

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added a unique translation for the comment editor label
* Updated the comment on commentfield.vm description to be more explicit
* Made the label sr-only. 

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Given the issue description, sighted users have enough context by this point to not need a visible label. However we don't want to remove it completely for accessibility reasons.
* In XS, the `commentfield.vm` template is used only in this specific context. We can update it without worrying about regressing in another place in the UI.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

![Screenshot from 2025-06-19 11-37-40](https://github.com/user-attachments/assets/9eebcec2-e7be-4f34-8a44-d7355540197f)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests (see above). I tried out with the two available default editors and it looked okay while passing accessibility tests.
Successfully passed `mvn clean install -f xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources -Pquality,integration-tests`.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.X, 17.4.X (safe changes with a very low scope)