### PR TITLE
XWIKI-23332: The width of the required rights modal depends on the displayed rights

### DIFF
--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-ui/src/main/resources/css/security/requiredrights/requiredRightsDialog.css
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-ui/src/main/resources/css/security/requiredrights/requiredRightsDialog.css
@@ -138,34 +138,20 @@
   display: none;
 }
 
-/* Switch rows and columns for small screens. The width uses em as the required width depends on the font size. */
-@media (max-width: 42em) {
-  #required-rights-dialog .rights-selection ul {
-    grid-template-columns: repeat(2, minmax(max-content, 1fr));
-    grid-template-rows: repeat(auto-fill, 1fr);
-  }
-
-  #required-rights-dialog .rights-selection li {
-    grid-column: span 2;
-    grid-row: span 1;
-  }
-
-  #required-rights-dialog .rights-selection li p {
-    text-align: start;
-    margin: auto 0;
-  }
+/* Vertical layout for when the dialog isn't wide enough to display the rights horizontally. */
+#required-rights-dialog .rights-selection ul.vertical {
+  grid-template-columns: repeat(2, minmax(max-content, 1fr));
+  grid-template-rows: repeat(auto-fill, 1fr);
 }
 
-/* In "wide" layout, make the dialog wide enough to fit the required rights selection. */
-@media (min-width: 42em) {
-  #required-rights-dialog .modal-dialog {
-    min-width: min-content;
-  }
+#required-rights-dialog .rights-selection ul.vertical li {
+  grid-column: span 2;
+  grid-row: span 1;
+}
 
-  /* When setting the minimum width to min-content, the required rights results shouldn't contribute to that width. */
-  #required-rights-dialog #required-rights-results {
-    contain: inline-size;
-  }
+#required-rights-dialog .rights-selection ul.vertical li p {
+  text-align: start;
+  margin: auto 0;
 }
 
 /* Styles for the warning box above the content. */


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-23332

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Measure the width of the rights using JavaScript.
* Switch to the vertical layout in JavaScript based on the available vs. required width.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* I originally developed these changes to fix https://jira.xwiki.org/browse/XWIKI-23288 before I noticed a much simpler option to ignore the width of the analysis results.
* With these changes, the width of the modal is always 600px again. Depending on the hints that are displayed but also depending on the translations of the names of the rights, this might not be enough so we can get the vertical layout also on big screens. If this isn't desired, we could also make the modal a bit wider in general - but I'm not sure how to choose that width.
* I'm not really happy with all this JavaScript logic. I'm wondering if we should simplify it by using some of the following ideas:
  * In JavaScript, generate CSS code and attach it to the HTML with a media or container query with the exact width that we measured on the content. This would eliminate the need for the JavaScript code for changing the class but generating CSS code in JavaScript doesn't seem that nice to me. This should also eliminate the flickering that you can see in the video below.
  * Simplify width measurements by hiding the rights differently, e.g., combining `visibility: hidden` and `height: 0`. This would actually solve the scenario described in the Jira issue even without any JavaScript code.

I would be happy to get some feedback on these options that I mentioned above or also any other feedback and then I can update the code.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

[Bildschirmaufnahme_20250624_151651.webm](https://github.com/user-attachments/assets/c284fb2e-5493-4d48-b0e2-8463ba9e3f5d)

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Manual tests as we have no real way to test such visual changes.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * Might not be important enough.