### PR TITLE
XWIKI-23335: The upload widget throws and error after uploading an attachment

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/viewers/attachments.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/viewers/attachments.js
@@ -277,9 +277,12 @@ require(['jquery', 'xwiki-events-bridge'], function($) {
    * Firing updateCount event when an attachment is successfully uploaded.
    */
   $(document).on('xwiki:html5upload:done', function() {
-    $("#docAttachments").data('liveData').updateEntries().then(() => {
-      updateCount($("#docAttachments").data('liveData').data.data.count);
-    });
+    let attachmentSectionLivedata = $("#docAttachments");
+    if (attachmentSectionLivedata.length) {
+      attachmentSectionLivedata.data('liveData').updateEntries().then(() => {
+        updateCount($("#docAttachments").data('liveData').data.data.count);
+      });
+    }
   });
 
   /**


### PR DESCRIPTION
…

# Jira URL
https://jira.xwiki.org/browse/XWIKI-23335

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

Updated the attachments.js to check for existence of the element before using it.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * Might not be important enough.