### PR TITLE
XWIKI-11112: Adding a rendering cache to the Icon Theme Application

### DIFF
--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-default/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-default/pom.xml
@@ -31,7 +31,7 @@
   <name>XWiki Platform - Icon - Default implementation</name>
   <description>XWiki Platform - Icon - Default implementation</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.97</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.96</xwiki.jacoco.instructionRatio>
   </properties>
   <dependencies>
     <dependency>
@@ -67,6 +67,11 @@
     <dependency>
       <groupId>org.xwiki.platform</groupId>
       <artifactId>xwiki-platform-security-requiredrights-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-webjars-api</artifactId>
       <version>${project.version}</version>
     </dependency>
 

--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-default/src/main/java/org/xwiki/icon/internal/DefaultIconRenderer.java
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-default/src/main/java/org/xwiki/icon/internal/DefaultIconRenderer.java
@@ -19,7 +19,6 @@
  */
 package org.xwiki.icon.internal;
 
-import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -58,7 +57,7 @@ public class DefaultIconRenderer implements IconRenderer
     private SkinExtension jsExtension;
 
     @Inject
-    private VelocityRenderer velocityRenderer;
+    private IconTemplateRendererManager iconTemplateRendererManager;
 
     @Override
     public String render(String iconName, IconSet iconSet) throws IconException
@@ -91,14 +90,8 @@ public class DefaultIconRenderer implements IconRenderer
         // Add the icon set resources
         use(iconSet);
 
-        // Interpret the velocity command
-        StringWriter contentToParse = new StringWriter();
-        contentToParse.write("#set($icon = \"");
-        contentToParse.write(icon.getValue());
-        contentToParse.write("\")\n");
-        contentToParse.write(renderer);
-
-        return this.velocityRenderer.render(contentToParse.toString(), iconSet.getSourceDocumentReference());
+        return this.iconTemplateRendererManager.getRenderer(renderer)
+            .render(icon.getValue(), iconSet.getSourceDocumentReference());
     }
 
     @Override
@@ -120,7 +113,8 @@ public class DefaultIconRenderer implements IconRenderer
 
     private void activeCSS(IconSet iconSet) throws IconException
     {
-        String url = this.velocityRenderer.render(iconSet.getCss(), iconSet.getSourceDocumentReference());
+        String url = this.iconTemplateRendererManager.getRenderer(iconSet.getCss())
+            .render(null, iconSet.getSourceDocumentReference());
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("rel", "stylesheet");
         this.linkExtension.use(url, parameters);

--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-default/src/main/java/org/xwiki/icon/internal/IconTemplateRenderer.java
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-default/src/main/java/org/xwiki/icon/internal/IconTemplateRenderer.java
@@ -1,0 +1,44 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.icon.internal;
+
+import org.xwiki.component.annotation.Role;
+import org.xwiki.icon.IconException;
+import org.xwiki.model.reference.DocumentReference;
+
+/**
+ * Interface for rendering icons based on a template.
+ *
+ * @version $Id$
+ * @since 17.6.0RC1
+ */
+@Role
+public interface IconTemplateRenderer
+{
+    /**
+     * Renders the given icon based on the template of the renderer.
+     *
+     * @param iconValue the icon to render
+     * @param contextDocumentReference the reference of the context document whose author's rights should be used
+     * @return the rendered string
+     * @throws IconException if the icon cannot be rendered
+     */
+    String render(String iconValue, DocumentReference contextDocumentReference) throws IconException;
+}

--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-default/src/main/java/org/xwiki/icon/internal/IconTemplateRendererManager.java
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-default/src/main/java/org/xwiki/icon/internal/IconTemplateRendererManager.java
@@ -1,0 +1,191 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.icon.internal;
+
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Provider;
+import jakarta.inject.Singleton;
+
+import org.xwiki.cache.Cache;
+import org.xwiki.cache.CacheException;
+import org.xwiki.cache.CacheFactory;
+import org.xwiki.cache.CacheManager;
+import org.xwiki.cache.config.CacheConfiguration;
+import org.xwiki.cache.config.LRUCacheConfiguration;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.manager.ComponentLookupException;
+import org.xwiki.component.phase.Initializable;
+import org.xwiki.component.phase.InitializationException;
+import org.xwiki.icon.IconException;
+import org.xwiki.velocity.VelocityManager;
+import org.xwiki.velocity.VelocityTemplate;
+import org.xwiki.velocity.internal.util.VelocityDetector;
+import org.xwiki.webjars.WebJarsUrlFactory;
+
+/**
+ * Manager for creating and caching {@link IconTemplateRenderer} instances based on templates.
+ * <p>
+ * This class handles the parsing of templates, and returns either a generic Velocity renderer or a specialized, more
+ * efficient renderer.
+ *
+ * @version $Id$
+ * @since 17.6.0RC1
+ */
+@Singleton
+@Component(roles = IconTemplateRendererManager.class)
+public class IconTemplateRendererManager implements Initializable
+{
+    private static final String ICON_RENDERER_CACHE_ID = "iconset.renderer";
+
+    private static final Pattern SIMPLE_REPLACEMENT_PATTERN =
+        Pattern.compile("^([^$#]*)\\$(?:icon|\\{icon\\})(|[^$#._a-zA-Z0-9][^$#]*)$");
+
+    private static final String ARGUMENT = "\\s*'([^']+)'\\s*";
+
+    private static final Pattern WEBJAR_URL_PATTERN =
+        Pattern.compile("^\\s*\\$services\\.webjars\\.url\\s*\\(%s(?:,%s(?:,%s)?)?\\)\\s*$"
+            .formatted(ARGUMENT, ARGUMENT, ARGUMENT));
+
+    @Inject
+    private VelocityDetector velocityDetector;
+
+    /**
+     * Make testing easier by not injecting a {@link WebJarsUrlFactory} directly.
+     */
+    @Inject
+    private Provider<WebJarsUrlFactory> webJarsUrlFactoryProvider;
+
+    @Inject
+    private VelocityManager velocityManager;
+
+    @Inject
+    private VelocityRenderer velocityRenderer;
+
+    @Inject
+    private CacheManager cacheManager;
+
+    private Cache<IconTemplateRenderer> cache;
+
+    @Override
+    public void initialize() throws InitializationException
+    {
+        try {
+            // We expect about 5 entries per icon theme, so 100 should be more than enough, this is primarily
+            // protection against excessive memory usage in unforeseen circumstances.
+            CacheConfiguration configuration = new LRUCacheConfiguration(ICON_RENDERER_CACHE_ID, 100);
+            CacheFactory cacheFactory = this.cacheManager.getCacheFactory();
+            this.cache = cacheFactory.newCache(configuration);
+        } catch (ComponentLookupException | CacheException e) {
+            throw new InitializationException("Failed to initialize the icon renderer Cache.", e);
+        }
+    }
+
+    /**
+     * Get a {@link IconTemplateRenderer} based on the given template.
+     *
+     * @param template the template to use for rendering icons
+     * @return a new instance of {@link IconTemplateRenderer}
+     * @throws IconException if the template is invalid or cannot be processed
+     */
+    public IconTemplateRenderer getRenderer(String template) throws IconException
+    {
+        IconTemplateRenderer renderer = this.cache.get(template);
+
+        if (renderer == null) {
+            renderer = this.createRenderer(template);
+
+            this.cache.set(template, renderer);
+        }
+
+        return renderer;
+    }
+
+    private IconTemplateRenderer createRenderer(String template) throws IconException
+    {
+        if (!this.velocityDetector.containsVelocityScript(template)) {
+            // No Velocity code - just return the template.
+            return (icon, documentReference) -> template;
+        } else {
+            Matcher matcher = SIMPLE_REPLACEMENT_PATTERN.matcher(template);
+            if (matcher.matches()) {
+                String start = matcher.group(1);
+                String end = matcher.group(2);
+                return (icon, documentReference) -> start + icon + end;
+            }
+
+            Optional<IconTemplateRenderer> webJarRenderer = getWebJarRenderer(template);
+
+            if (webJarRenderer.isPresent()) {
+                return webJarRenderer.get();
+            }
+        }
+
+        return getVelocityRenderer(template);
+    }
+
+    private IconTemplateRenderer getVelocityRenderer(String template) throws IconException
+    {
+        try {
+            VelocityTemplate velocityTemplate = this.velocityManager.compile(template, new StringReader(template));
+
+            return (icon, documentReference) ->
+                this.velocityRenderer.render(velocityTemplate, icon, documentReference);
+        } catch (Exception e) {
+            throw new IconException("Failed to compile Velocity template: " + template, e);
+        }
+    }
+
+    private Optional<IconTemplateRenderer> getWebJarRenderer(String template) throws IconException
+    {
+        Matcher webJarUrlMatcher = WEBJAR_URL_PATTERN.matcher(template);
+        if (webJarUrlMatcher.matches()) {
+            List<String> arguments = new ArrayList<>();
+            for (int i = 1; i <= webJarUrlMatcher.groupCount(); i++) {
+                String argument = webJarUrlMatcher.group(i);
+                if (argument != null) {
+                    arguments.add(argument);
+                }
+            }
+
+            WebJarsUrlFactory webJarsUrlFactory = this.webJarsUrlFactoryProvider.get();
+
+            if (arguments.size() == 1) {
+                return Optional.of((icon, documentReference) -> webJarsUrlFactory.url(arguments.get(0)));
+            } else if (arguments.size() == 2) {
+                return Optional.of((icon, documentReference) ->
+                    webJarsUrlFactory.url(arguments.get(0), arguments.get(1)));
+            } else if (arguments.size() == 3) {
+                return Optional.of((icon, documentReference) ->
+                    webJarsUrlFactory.url(arguments.get(0), arguments.get(1), arguments.get(2)));
+            } else {
+                throw new IconException("Invalid number of arguments for webjar URL: " + arguments.size());
+            }
+        }
+
+        return Optional.empty();
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-default/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-default/src/main/resources/META-INF/components.txt
@@ -8,3 +8,4 @@ org.xwiki.icon.internal.IconSetRequiredRightsAnalyzer
 org.xwiki.icon.internal.VelocityRenderer
 org.xwiki.icon.internal.context.IconContextStore
 org.xwiki.icon.internal.context.IconSetContext
+org.xwiki.icon.internal.IconTemplateRendererManager

--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-default/src/test/java/org/xwiki/icon/internal/DefaultIconManagerComponentList.java
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-default/src/test/java/org/xwiki/icon/internal/DefaultIconManagerComponentList.java
@@ -32,6 +32,7 @@ import org.xwiki.skinx.internal.JsDocumentSkinExtension;
 import org.xwiki.skinx.internal.JsFileSkinExtension;
 import org.xwiki.skinx.internal.LinkSkinExtension;
 import org.xwiki.test.annotation.ComponentList;
+import org.xwiki.velocity.internal.util.VelocityDetector;
 
 import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
 import static java.lang.annotation.ElementType.METHOD;
@@ -62,6 +63,8 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
     VelocityRenderer.class,
     DefaultDocumentContextExecutor.class,
     AuthorExecutor.class,
+    IconTemplateRendererManager.class,
+    VelocityDetector.class,
 })
 @Inherited
 public @interface DefaultIconManagerComponentList

--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-default/src/test/java/org/xwiki/icon/internal/DefaultIconRendererTest.java
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-default/src/test/java/org/xwiki/icon/internal/DefaultIconRendererTest.java
@@ -37,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -66,16 +67,17 @@ class DefaultIconRendererTest
     private SkinExtension jsExtension;
 
     @MockComponent
-    private VelocityRenderer velocityRenderer;
+    private IconTemplateRendererManager rendererManager;
 
     @Test
     void render() throws Exception
     {
         IconSet iconSet = new IconSet("default");
-        iconSet.setRenderWiki("image:$icon.png");
+        String template = "image:$icon.png";
+        iconSet.setRenderWiki(template);
         iconSet.addIcon("test", new Icon("blabla"));
-        when(this.velocityRenderer.render("#set($icon = \"blabla\")\nimage:$icon.png", null))
-            .thenReturn("image:blabla.png");
+
+        setupSimpleTemplate(template);
 
         // Test
         String result = this.iconRenderer.render("test", iconSet);
@@ -87,14 +89,27 @@ class DefaultIconRendererTest
         verify(this.jsExtension, never()).use(any());
     }
 
+    private void setupSimpleTemplate(String template) throws IconException
+    {
+        when(this.rendererManager.getRenderer(template)).thenReturn(
+            (icon, documentReference) -> template.replace("$icon", icon));
+    }
+
     @Test
     void renderWithCSS() throws Exception
     {
         IconSet iconSet = new IconSet("default");
-        iconSet.setRenderWiki("image:$icon.png");
+        String template = "image:$icon.png";
+        iconSet.setRenderWiki(template);
         iconSet.setCss("css");
         iconSet.addIcon("test", new Icon("blabla"));
-        when(this.velocityRenderer.render("css", null)).thenReturn("velocityParsedCSS");
+
+        IconTemplateRenderer mockRenderer = mock();
+        when(this.rendererManager.getRenderer("css")).thenReturn(mockRenderer);
+        String parsedCSS = "velocityParsedCSS";
+        when(mockRenderer.render(null, null)).thenReturn(parsedCSS);
+
+        setupSimpleTemplate(template);
 
         // Test
         this.iconRenderer.render("test", iconSet);
@@ -102,7 +117,7 @@ class DefaultIconRendererTest
         // Verify
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("rel", "stylesheet");
-        verify(this.linkExtension).use("velocityParsedCSS", parameters);
+        verify(this.linkExtension).use(parsedCSS, parameters);
         verify(this.skinExtension, never()).use(any());
         verify(this.jsExtension, never()).use(any());
     }
@@ -111,9 +126,12 @@ class DefaultIconRendererTest
     void renderWithSSX() throws Exception
     {
         IconSet iconSet = new IconSet("default");
-        iconSet.setRenderWiki("image:$icon.png");
+        String template = "image:$icon.png";
+        iconSet.setRenderWiki(template);
         iconSet.setSsx("ssx");
         iconSet.addIcon("test", new Icon("blabla"));
+
+        setupSimpleTemplate(template);
 
         // Test
         this.iconRenderer.render("test", iconSet);
@@ -128,9 +146,11 @@ class DefaultIconRendererTest
     void renderWithJSX() throws Exception
     {
         IconSet iconSet = new IconSet("default");
-        iconSet.setRenderWiki("image:$icon.png");
+        String template = "image:$icon.png";
+        iconSet.setRenderWiki(template);
         iconSet.setJsx("jsx");
         iconSet.addIcon("test", new Icon("blabla"));
+        setupSimpleTemplate(template);
 
         // Test
         this.iconRenderer.render("test", iconSet);
@@ -145,11 +165,11 @@ class DefaultIconRendererTest
     void renderHTML() throws Exception
     {
         IconSet iconSet = new IconSet("default");
-        iconSet.setRenderHTML("<img src=\"$icon.png\" />");
+        String template = "<img src=\"$icon.png\" />";
+        iconSet.setRenderHTML(template);
         iconSet.addIcon("test", new Icon("blabla"));
 
-        when(this.velocityRenderer.render("#set($icon = \"blabla\")\n<img src=\"$icon.png\" />", null))
-            .thenReturn("<img src=\"blabla.png\" />");
+        setupSimpleTemplate(template);
 
         // Test
         String result = this.iconRenderer.renderHTML("test", iconSet);
@@ -162,10 +182,17 @@ class DefaultIconRendererTest
     void renderHTMLWithCSS() throws Exception
     {
         IconSet iconSet = new IconSet("default");
-        iconSet.setRenderHTML("<img src=\"$icon.png\" />");
+        String template = "<img src=\"$icon.png\" />";
+        iconSet.setRenderHTML(template);
         iconSet.setCss("css");
         iconSet.addIcon("test", new Icon("blabla"));
-        when(this.velocityRenderer.render("css", null)).thenReturn("velocityParsedCSS");
+
+        IconTemplateRenderer mockRenderer = mock();
+        when(this.rendererManager.getRenderer("css")).thenReturn(mockRenderer);
+        String parsedCSS = "velocityParsedCSS";
+        when(mockRenderer.render(null, null)).thenReturn(parsedCSS);
+
+        setupSimpleTemplate(template);
 
         // Test
         this.iconRenderer.renderHTML("test", iconSet);
@@ -173,7 +200,7 @@ class DefaultIconRendererTest
         // Verify
         Map<String, Object> parameters = new HashMap<>();
         parameters.put("rel", "stylesheet");
-        verify(this.linkExtension).use("velocityParsedCSS", parameters);
+        verify(this.linkExtension).use(parsedCSS, parameters);
         verify(this.skinExtension, never()).use(any());
         verify(this.jsExtension, never()).use(any());
     }
@@ -182,9 +209,12 @@ class DefaultIconRendererTest
     void renderHTMLWithSSX() throws Exception
     {
         IconSet iconSet = new IconSet("default");
-        iconSet.setRenderHTML("<img src=\"$icon.png\" />");
+        String template = "<img src=\"$icon.png\" />";
+        iconSet.setRenderHTML(template);
         iconSet.setSsx("ssx");
         iconSet.addIcon("test", new Icon("blabla"));
+
+        setupSimpleTemplate(template);
 
         // Test
         this.iconRenderer.renderHTML("test", iconSet);
@@ -199,9 +229,12 @@ class DefaultIconRendererTest
     void renderHTMLWithJSX() throws Exception
     {
         IconSet iconSet = new IconSet("default");
-        iconSet.setRenderHTML("<img src=\"$icon.png\" />");
+        String template = "<img src=\"$icon.png\" />";
+        iconSet.setRenderHTML(template);
         iconSet.setJsx("jsx");
         iconSet.addIcon("test", new Icon("blabla"));
+
+        setupSimpleTemplate(template);
 
         // Test
         this.iconRenderer.renderHTML("test", iconSet);
@@ -231,7 +264,9 @@ class DefaultIconRendererTest
         iconSet.setRenderWiki("image:$icon.png");
         iconSet.addIcon("test", new Icon("blabla"));
         IconException exception = new IconException("exception");
-        when(this.velocityRenderer.render(any(), any())).thenThrow(exception);
+        IconTemplateRenderer mockRenderer = mock();
+        when(this.rendererManager.getRenderer(any())).thenReturn(mockRenderer);
+        when(mockRenderer.render(any(), any())).thenThrow(exception);
 
         // Test
         IconException caughtException = null;
@@ -251,12 +286,13 @@ class DefaultIconRendererTest
     {
         IconSet iconSet = new IconSet("iconSet");
         iconSet.addIcon("test", new Icon("hello"));
-        when(this.velocityRenderer.render("#set($icon = \"hello\")\nfa fa-$icon", null)).thenReturn("fa fa-hello");
+        String template = "fa fa-$icon";
+        setupSimpleTemplate(template);
 
         // Test
-        String renderedIcon1 = this.iconRenderer.render("test", iconSet, "fa fa-$icon");
-        String renderedIcon2 = this.iconRenderer.render("none", iconSet, "fa fa-$icon");
-        String renderedIcon3 = this.iconRenderer.render("none", null, "fa fa-$icon");
+        String renderedIcon1 = this.iconRenderer.render("test", iconSet, template);
+        String renderedIcon2 = this.iconRenderer.render("none", iconSet, template);
+        String renderedIcon3 = this.iconRenderer.render("none", null, template);
         String renderedIcon4 = this.iconRenderer.render("none", iconSet, null);
 
         // Verify

--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-default/src/test/java/org/xwiki/icon/internal/DefaultIconSetCacheTest.java
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-default/src/test/java/org/xwiki/icon/internal/DefaultIconSetCacheTest.java
@@ -38,7 +38,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -69,8 +68,8 @@ class DefaultIconSetCacheTest
         CacheFactory cacheFactory = mock(CacheFactory.class);
         when(this.cacheManager.getCacheFactory()).thenReturn(cacheFactory);
         CacheConfiguration configuration = new CacheConfiguration("iconset");
-        this.cache = mock(Cache.class);
-        when(cacheFactory.<IconSet>newCache(eq(configuration))).thenReturn(this.cache);
+        this.cache = mock();
+        when(cacheFactory.<IconSet>newCache(configuration)).thenReturn(this.cache);
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-default/src/test/java/org/xwiki/icon/internal/IconTemplateRendererManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-default/src/test/java/org/xwiki/icon/internal/IconTemplateRendererManagerTest.java
@@ -1,0 +1,194 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.icon.internal;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Test;
+import org.xwiki.cache.Cache;
+import org.xwiki.cache.CacheFactory;
+import org.xwiki.cache.CacheManager;
+import org.xwiki.cache.config.CacheConfiguration;
+import org.xwiki.cache.config.LRUCacheConfiguration;
+import org.xwiki.icon.IconException;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.test.annotation.BeforeComponent;
+import org.xwiki.test.annotation.ComponentList;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+import org.xwiki.velocity.VelocityManager;
+import org.xwiki.velocity.VelocityTemplate;
+import org.xwiki.velocity.internal.util.VelocityDetector;
+import org.xwiki.webjars.WebJarsUrlFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.assertArg;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link IconTemplateRendererManager}.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+@ComponentList(VelocityDetector.class)
+class IconTemplateRendererManagerTest
+{
+    @InjectMockComponents
+    private IconTemplateRendererManager iconTemplateRendererManager;
+
+    @MockComponent
+    private VelocityManager velocityManager;
+
+    @MockComponent
+    private VelocityRenderer velocityRenderer;
+
+    @MockComponent
+    private CacheManager cacheManager;
+
+    @MockComponent
+    private WebJarsUrlFactory webJarsUrlFactory;
+
+    private Cache<IconTemplateRenderer> cache;
+
+    @BeforeComponent
+    void beforeComponent() throws Exception
+    {
+        CacheFactory cacheFactory = mock();
+        when(this.cacheManager.getCacheFactory()).thenReturn(cacheFactory);
+        CacheConfiguration configuration = new LRUCacheConfiguration("iconset.renderer", 100);
+        this.cache = mock();
+        when(cacheFactory.<IconTemplateRenderer>newCache(configuration)).thenReturn(this.cache);
+    }
+
+    @Test
+    void getRendererShouldRetrieveFromCache() throws Exception
+    {
+        String template = "icon-template";
+        IconTemplateRenderer expectedRenderer = mock();
+        when(this.cache.get(template)).thenReturn(expectedRenderer);
+
+        IconTemplateRenderer renderer = this.iconTemplateRendererManager.getRenderer(template);
+
+        assertSame(expectedRenderer, renderer);
+        verifyNoInteractions(this.velocityManager, this.velocityRenderer, this.webJarsUrlFactory);
+    }
+
+    @Test
+    void getRendererShouldHandleNonVelocityTemplate() throws Exception
+    {
+        String template = "simple-template";
+
+        IconTemplateRenderer renderer = this.iconTemplateRendererManager.getRenderer(template);
+
+        assertEquals(template, renderer.render("icon", null));
+        verify(this.cache).set(template, renderer);
+        verifyNoInteractions(this.velocityManager, this.velocityRenderer, this.webJarsUrlFactory);
+    }
+
+    @Test
+    void getRendererShouldHandleSimpleReplacementPattern() throws Exception
+    {
+        String template = "Hello $icon!";
+
+        IconTemplateRenderer renderer = this.iconTemplateRendererManager.getRenderer(template);
+
+        assertEquals("Hello world!", renderer.render("world", null));
+        verifyNoInteractions(this.velocityManager, this.velocityRenderer, this.webJarsUrlFactory);
+    }
+
+    @Test
+    void getRendererShouldHandleWebJarUrlTemplate() throws Exception
+    {
+        String template = "$services.webjars.url('some-library')";
+        String expectedURL = "https://example.com/some-library";
+        when(this.webJarsUrlFactory.url("some-library")).thenReturn(expectedURL);
+
+        IconTemplateRenderer renderer = this.iconTemplateRendererManager.getRenderer(template);
+
+        assertEquals(expectedURL, renderer.render("icon", null));
+        verifyNoInteractions(this.velocityManager, this.velocityRenderer);
+    }
+
+    @Test
+    void getRendererShouldHandleWebJarUrlTemplateWithTwoArguments() throws Exception
+    {
+        String template = "$services.webjars.url('lib','ver')";
+        String expectedURL = "https://example.com/lib/ver";
+        when(this.webJarsUrlFactory.url("lib", "ver")).thenReturn(expectedURL);
+
+        IconTemplateRenderer renderer = this.iconTemplateRendererManager.getRenderer(template);
+
+        assertEquals(expectedURL, renderer.render("icon", null));
+        verifyNoInteractions(this.velocityManager, this.velocityRenderer);
+    }
+
+    @Test
+    void getRendererShouldHandleWebJarUrlTemplateWithThreeArguments() throws Exception
+    {
+        String template = "$services.webjars.url('lib','ver','file.js')";
+        String expectedURL = "https://example.com/lib/ver/file.js";
+        when(this.webJarsUrlFactory.url("lib", "ver", "file.js")).thenReturn(expectedURL);
+
+        IconTemplateRenderer renderer = this.iconTemplateRendererManager.getRenderer(template);
+
+        assertEquals(expectedURL, renderer.render("icon", null));
+        verifyNoInteractions(this.velocityManager, this.velocityRenderer);
+    }
+
+    @Test
+    void getRendererShouldHandleVelocityTemplate() throws Exception
+    {
+        String template = "#set($icon = 'cool-icon')$icon";
+        VelocityTemplate velocityTemplate = mock();
+        DocumentReference documentReference = mock();
+        when(this.velocityManager.compile(eq(template), assertArg(reader -> {
+            assertEquals(template, IOUtils.toString(reader));
+        }))).thenReturn(velocityTemplate);
+        when(this.velocityRenderer.render(velocityTemplate, "icon", documentReference)).thenReturn("cool-icon");
+
+        IconTemplateRenderer renderer = this.iconTemplateRendererManager.getRenderer(template);
+
+        assertEquals("cool-icon", renderer.render("icon", documentReference));
+        verify(this.cache).set(template, renderer);
+    }
+
+    @Test
+    void getRendererShouldThrowWhenVelocityParserThrows() throws Exception
+    {
+        String template = "#set($icon = 'fail')";
+        RuntimeException velocityException = new RuntimeException("Velocity error");
+        when(this.velocityManager.compile(eq(template), any())).thenThrow(velocityException);
+
+        IconException thrown =
+            assertThrows(IconException.class, () -> this.iconTemplateRendererManager.getRenderer(template));
+        assertEquals("Failed to compile Velocity template: " + template, thrown.getMessage());
+        assertEquals(velocityException, thrown.getCause());
+        verify(this.cache, never()).set(any(), any());
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-api/src/main/java/org/xwiki/url/internal/AbstractExtendedURLResourceReferenceSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-api/src/main/java/org/xwiki/url/internal/AbstractExtendedURLResourceReferenceSerializer.java
@@ -57,23 +57,23 @@ public abstract class AbstractExtendedURLResourceReferenceSerializer
     public ExtendedURL serialize(ResourceReference reference, String formatId)
         throws SerializeResourceReferenceException, UnsupportedResourceReferenceException
     {
-        // Step 1: Try to locate a Serializer registered for the specific passed resource type and for the passed URL
-        //         format id
         ResourceReferenceSerializer<ResourceReference, ExtendedURL> serializer;
+        DefaultParameterizedType roleType = new DefaultParameterizedType(null,
+            ResourceReferenceSerializer.class, reference.getClass(), ExtendedURL.class);
         try {
-            serializer = this.componentManager.getInstance(new DefaultParameterizedType(null,
-                ResourceReferenceSerializer.class, reference.getClass(), ExtendedURL.class), formatId);
-        } catch (ComponentLookupException e) {
-            // Step 2: Try to locate a Serializer registered only for the specific passed resource type and for all URL
-            //         format ids
-            try {
-                serializer = this.componentManager.getInstance(new DefaultParameterizedType(null,
-                    ResourceReferenceSerializer.class, reference.getClass(), ExtendedURL.class));
-            } catch (ComponentLookupException cle) {
-                throw new UnsupportedResourceReferenceException(String.format(
-                    "Failed to find serializer for Resource Reference [%s] and URL format [%s]", reference, formatId),
-                    cle);
+            // Step 1: Try to locate a Serializer registered for the specific passed resource type and for the passed
+            // URL format id
+            if (this.componentManager.hasComponent(roleType, formatId)) {
+                serializer = this.componentManager.getInstance(roleType, formatId);
+            } else {
+                // Step 2: Try to locate a Serializer registered only for the specific passed resource type and for all
+                // URL format ids
+                serializer = this.componentManager.getInstance(roleType);
             }
+        } catch (ComponentLookupException e) {
+            throw new UnsupportedResourceReferenceException(String.format(
+                "Failed to find serializer for Resource Reference [%s] and URL format [%s]", reference, formatId),
+                e);
         }
 
         return serializer.serialize(reference);


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-11112

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Introduce the internal concept of an `IconTemplateRenderer`.
* Add an internal IconTemplateRendererManager that provides icon template renderers and caches them.
* Cache parsed Velocity code.
* Add special cases for the most commonly used Velocity scripts to avoid expensive Velocity execution for those cases.
* Adapt and add tests.
* Decrease the expected code coverage to 0.96 as 0.97 is just unrealistic.
* Don't ask for non-existing components in the extended URL reference serializer. Instead, check if the component exists, first. This speeds up getting the WebJar URL for Font Awesome by about a factor of 5.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The last item/second commit could also be a separate Jira or a [Misc] commit, let me know if you want that more formal approach.
* I chose the approach of just caching the template, not caching the rendered output to avoid having to deal with cache invalidations. Further, I've added special cases to avoid Velocity rendering completely for Font Awesome.
* Some numbers of loading all icons for the icon picker (see also https://jira.xwiki.org/browse/XWIKI-22540):

| Icon theme | Before | After |
|------------------|-----------|---------|
| Font Awesome | 283ms | 20ms |
| Silk (first)| 10s | 8.67s |
| Silk (cached) | 770ms | 330ms |

We could decrease the cached running time of Silk further (might be another factor 2) by adding another special case to detect the calls `$xwiki.getSkinFile("icons/silk/${icon}.png")` but I'm not sure if it is worth the extra complexity.

The fraction of icon rendering of page loads went down from approximately 10% to 1% with Font Awesome. The remaining part is all about generating the WebJar URL.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Built the changed modules with quality profile. Performed manual tests (see also above).

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * Not sure, might be nice for performance, but the code is not completely trivial.