### PR TITLE
XWIKI-23303: Insufficient protection against stack overflows

### DIFF
--- a/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-api/src/main/java/org/xwiki/display/internal/DocumentReferenceDequeContext.java
+++ b/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-api/src/main/java/org/xwiki/display/internal/DocumentReferenceDequeContext.java
@@ -1,0 +1,80 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.display.internal;
+
+import java.util.Deque;
+import java.util.LinkedList;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.context.Execution;
+import org.xwiki.context.ExecutionContext;
+import org.xwiki.model.reference.DocumentReference;
+
+/**
+ * Provides a {@link Deque} that is stored in the execution context to store the stack of executed documents to avoid
+ * infinite recursion.
+ *
+ * @version $Id$
+ * @since 17.6.0RC1
+ * @since 17.4.3
+ * @since 16.10.10
+ */
+@Component(roles = DocumentReferenceDequeContext.class)
+@Singleton
+public class DocumentReferenceDequeContext
+{
+    /**
+     * The key used to store on the XWiki context map the stack of references to documents that are currently
+     * being evaluated (in the current execution context). This stack is used to prevent infinite recursion, which can
+     * happen if the title displayer is called on the current document from the title field or from a script within the
+     * first content heading.
+     */
+    private static final String DOCUMENT_REFERENCE_STACK_KEY = "internal.displayer.%s.documentReferenceStack";
+
+    /**
+     * Execution context handler, needed for accessing the XWiki context map.
+     */
+    @Inject
+    private Execution execution;
+
+    /**
+     * @param displayerName the name of the displayer, like "title" or "content".
+     * @return the stack of document references that are currently being evaluated
+     */
+    public Deque<DocumentReference> getDocumentReferenceDeque(String displayerName)
+    {
+        ExecutionContext econtext = this.execution.getContext();
+
+        String contextKey = DOCUMENT_REFERENCE_STACK_KEY.formatted(displayerName);
+        @SuppressWarnings("unchecked")
+        Deque<DocumentReference> documentReferenceStack =
+            (Deque<DocumentReference>) econtext.getProperty(contextKey);
+
+        if (documentReferenceStack == null) {
+            documentReferenceStack = new LinkedList<>();
+            econtext.newProperty(contextKey).inherited().initial(documentReferenceStack).declare();
+        }
+
+        return documentReferenceStack;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-api/src/main/java/org/xwiki/display/internal/DocumentReferenceDequeContext.java
+++ b/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-api/src/main/java/org/xwiki/display/internal/DocumentReferenceDequeContext.java
@@ -19,8 +19,8 @@
  */
 package org.xwiki.display.internal;
 
+import java.util.ArrayDeque;
 import java.util.Deque;
-import java.util.LinkedList;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -71,8 +71,8 @@ public class DocumentReferenceDequeContext
             (Deque<DocumentReference>) econtext.getProperty(contextKey);
 
         if (documentReferenceStack == null) {
-            documentReferenceStack = new LinkedList<>();
-            econtext.newProperty(contextKey).inherited().initial(documentReferenceStack).declare();
+            documentReferenceStack = new ArrayDeque<>();
+            econtext.newProperty(contextKey).inherited().initial(documentReferenceStack).makeFinal().declare();
         }
 
         return documentReferenceStack;

--- a/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-api/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-api/src/main/resources/META-INF/components.txt
@@ -5,4 +5,5 @@ org.xwiki.display.internal.DocumentContentAsyncExecutor
 org.xwiki.display.internal.DefaultDocumentDisplayer
 org.xwiki.display.internal.DocumentContentAsyncRenderer
 org.xwiki.display.internal.DocumentContentDisplayer
+org.xwiki.display.internal.DocumentReferenceDequeContext
 org.xwiki.display.internal.DocumentTitleDisplayer

--- a/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-api/src/test/java/org/xwiki/display/internal/DocumentContentDisplayerTest.java
+++ b/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-api/src/test/java/org/xwiki/display/internal/DocumentContentDisplayerTest.java
@@ -57,7 +57,10 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-@ComponentList({ DefaultDocumentContentAsyncParser.class })
+@ComponentList({
+    DefaultDocumentContentAsyncParser.class,
+    DocumentReferenceDequeContext.class
+})
 public class DocumentContentDisplayerTest
 {
     @InjectMockComponents

--- a/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-api/src/test/java/org/xwiki/display/internal/DocumentTitleDisplayerTest.java
+++ b/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-api/src/test/java/org/xwiki/display/internal/DocumentTitleDisplayerTest.java
@@ -47,6 +47,7 @@ import org.xwiki.rendering.block.XDOM;
 import org.xwiki.rendering.parser.Parser;
 import org.xwiki.security.authorization.DocumentAuthorizationManager;
 import org.xwiki.security.authorization.Right;
+import org.xwiki.test.annotation.ComponentList;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
@@ -70,6 +71,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
+@ComponentList(DocumentReferenceDequeContext.class)
 class DocumentTitleDisplayerTest
 {
     @InjectMockComponents

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-page/src/main/java/org/xwiki/test/page/PageComponentList.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-page/src/main/java/org/xwiki/test/page/PageComponentList.java
@@ -37,6 +37,7 @@ import org.xwiki.display.internal.DefaultDocumentDisplayer;
 import org.xwiki.display.internal.DocumentContentAsyncExecutor;
 import org.xwiki.display.internal.DocumentContentAsyncRenderer;
 import org.xwiki.display.internal.DocumentContentDisplayer;
+import org.xwiki.display.internal.DocumentReferenceDequeContext;
 import org.xwiki.display.internal.DocumentTitleDisplayer;
 import org.xwiki.internal.document.DocumentRequiredRightsReader;
 import org.xwiki.internal.script.XWikiScriptContextInitializer;
@@ -212,6 +213,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
     BaseAsyncRendererExecutor.class,
     DefaultAsyncContext.class,
     SheetDocumentDisplayer.class,
+    DocumentReferenceDequeContext.class,
 
     // Sheet
     DefaultSheetManager.class,


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-23303

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Extract the code for managing the document reference stack from the title displayer into a separate component.
* Set a limit of five recursions with the same document for the document content.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* For now, the main cause of infinite recursion seems to be document inclusion so I think a fix there should be enough for now.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

The document from the Jira issue displays the following error now:

![image](https://github.com/user-attachments/assets/da087839-364b-4ca4-be12-1e7172b98529)

Apart from that, there shouldn't be any UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Built the changed module with quality profile.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-17.4.x
  * stable-16.10.x