### PR TITLE
XWIKI-22999: Activity stream should use list semantics

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-macro/xwiki-platform-notifications-macro-ui/src/main/resources/XWiki/Notifications/Code/Macro/NotificationsMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-macro/xwiki-platform-notifications-macro-ui/src/main/resources/XWiki/Notifications/Code/Macro/NotificationsMacro.xml
@@ -396,7 +396,7 @@ require(['jquery', 'XWikiAsyncNotificationsMacro', 'xwiki-events-bridge'], funct
         self.blackList.push(entry.ids[i]);
       }
       // Create the container
-      var notif = $('&lt;div&gt;').addClass('notification-event');
+      var notif = $('&lt;li&gt;').addClass('notification-event');
       notif.attr('data-eventtype', entry.type);
       // Put the content
       notif.append(entry.html);
@@ -423,7 +423,7 @@ require(['jquery', 'XWikiAsyncNotificationsMacro', 'xwiki-events-bridge'], funct
       if (!entry.read) {
         // On click
         readButton.on('click', function() {
-          var notif = $(this).parents('div.notification-event');
+          var notif = $(this).parents('li.notification-event');
           notif.removeClass('notification-event-unread');
           var url = new XWiki.Document(XWiki.Model.resolve('XWiki.Notifications.Code.NotificationsDisplayerUIX',
             XWiki.EntityType.DOCUMENT)).getURL('get', 'outputSyntax=plain');
@@ -596,7 +596,7 @@ require(['jquery', 'XWikiAsyncNotificationsMacro', 'xwiki-events-bridge'], funct
           readButton.removeClass('hidden');
           // On click
           readButton.on('click', function() {
-            var notif = $(this).parents('div.notification-event');
+            var notif = $(this).parents('li.notification-event');
             notif.removeClass('notification-event-unread');
             var url = new XWiki.Document(XWiki.Model.resolve('XWiki.Notifications.Code.NotificationsDisplayerUIX',
               XWiki.EntityType.DOCUMENT)).getURL('get', 'outputSyntax=plain');
@@ -781,6 +781,7 @@ require(['jquery', 'XWikiAsyncNotificationsMacro', 'xwiki-events-bridge'], funct
   max-width: 500px;
   min-height: 50px;
   width: 100%;
+  padding-left: 0;
 }
 
 .notifications-macro-rss-link {
@@ -1175,7 +1176,8 @@ require(['jquery', 'XWikiAsyncNotificationsMacro', 'xwiki-events-bridge'], funct
 #set($notifParameters = $services.notification.sources.getNotificationParameters($parameters))
 #set($notifs = $services.notification.notifiers.getNotifications($notifParameters, true))
 {{html clean="false"}}
-&lt;div class="notifications-macro" data-displayReadStatus="$!escapetool.xml($xcontext.macro.params.displayReadStatus)" $stringtool.join($dataParameters, " ")&gt;
+&lt;ul class="notifications-macro" data-displayReadStatus="$!escapetool.xml($xcontext.macro.params.displayReadStatus)"
+ $stringtool.join($dataParameters, " ")&gt;
 #if ('true' == $xcontext.macro.params.displayRSSLink)
   ## Generate the RSS URL to display the same notifications but in the RSS format
   #set ($rssURL = $services.rest.url($doc.documentReference))
@@ -1194,10 +1196,10 @@ require(['jquery', 'XWikiAsyncNotificationsMacro', 'xwiki-events-bridge'], funct
   #set ($rssURL = "${rssURL}&amp;displayReadStatus=$!escapetool.url($xcontext.macro.params.displayReadStatus)")
   #set ($rssURL = "${rssURL}&amp;tags=$!escapetool.url($xcontext.macro.params.tags)")
   #set ($rssURL = "${rssURL}&amp;currentWiki=$!escapetool.url($services.wiki.currentWikiId)")
-  &lt;p class="notifications-macro-rss-link"&gt;&lt;a href="$rssURL" rel="nofollow external"&gt;$services.icon.renderHTML('rss') $escapetool.xml($services.localization.render('notifications.rss.feedLink'))&lt;/a&gt;&lt;/p&gt;
+  &lt;li class="notifications-macro-rss-link"&gt;&lt;a href="$rssURL" rel="nofollow external"&gt;$services.icon.renderHTML('rss') $escapetool.xml($services.localization.render('notifications.rss.feedLink'))&lt;/a&gt;&lt;/li&gt;
 #end
 $notifs
-&lt;/div&gt;
+&lt;/ul&gt;
 {{/html}}
 #end
 {{/velocity}}</code>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/InternalHtmlNotificationRenderer.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/InternalHtmlNotificationRenderer.java
@@ -110,6 +110,7 @@ public class InternalHtmlNotificationRenderer
     {
         Block renderedEvent = notificationRenderer.render(compositeEvent);
         GroupBlock parentDiv = new GroupBlock();
+        parentDiv.setParameter("role", "listitem");
         StringBuilder parentDivClass = new StringBuilder().append("notification-event");
 
         parentDiv.setParameter("data-eventtype", compositeEvent.getType());

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/InternalHtmlNotificationRendererTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/InternalHtmlNotificationRendererTest.java
@@ -117,18 +117,21 @@ public class InternalHtmlNotificationRendererTest
         when(eventRenderer.render(compositeEvent)).thenReturn(block);
         when(eventStatus.getStatus()).thenReturn(false);
 
-        String expectedResult = "<div data-eventtype=\"FooType\" data-ids=\"foo,bar,baz\" data-eventdate=\"42\" "
+        String expectedResult = "<div role=\"listitem\" data-eventtype=\"FooType\" data-ids=\"foo,bar,baz\" " 
+            + "data-eventdate=\"42\" "
             + "class=\"notification-event notification-event-unread\">"
             + "<div class=\"my-composite-event\"></div></div>";
         assertEquals(expectedResult, this.notificationRenderer.render(compositeEvent, eventStatus));
 
         when(eventStatus.getStatus()).thenReturn(true);
-        expectedResult = "<div data-eventtype=\"FooType\" data-ids=\"foo,bar,baz\" data-eventdate=\"42\" "
+        expectedResult = "<div role=\"listitem\" data-eventtype=\"FooType\" data-ids=\"foo,bar,baz\" " 
+            + "data-eventdate=\"42\" "
             + "class=\"notification-event\">"
             + "<div class=\"my-composite-event\"></div></div>";
         assertEquals(expectedResult, this.notificationRenderer.render(compositeEvent, eventStatus));
 
-        expectedResult = "<div data-eventtype=\"FooType\" data-ids=\"foo,bar,baz\" data-eventdate=\"42\" "
+        expectedResult = "<div role=\"listitem\" data-eventtype=\"FooType\" data-ids=\"foo,bar,baz\" " 
+            + "data-eventdate=\"42\" "
             + "class=\"notification-event\">"
             + "<div class=\"my-composite-event\"></div></div>";
         assertEquals(expectedResult, this.notificationRenderer.render(compositeEvent, null));
@@ -175,10 +178,12 @@ public class InternalHtmlNotificationRendererTest
         when(eventRenderer.render(compositeEvent2)).thenReturn(block2);
         when(eventStatus2.getStatus()).thenReturn(true);
 
-        expectedResult = "<div data-eventtype=\"FooType\" data-ids=\"foo,bar,baz\" data-eventdate=\"42\" "
+        expectedResult = "<div role=\"listitem\" data-eventtype=\"FooType\" data-ids=\"foo,bar,baz\" " 
+            + "data-eventdate=\"42\" "
             + "class=\"notification-event notification-event-unread\">"
             + "<div class=\"my-composite-event1\"></div></div>"
-            + "<div data-eventtype=\"BarType\" data-ids=\"oneId\" data-eventdate=\"12\" class=\"notification-event\">"
+            + "<div role=\"listitem\" data-eventtype=\"BarType\" data-ids=\"oneId\" data-eventdate=\"12\" " 
+            + "class=\"notification-event\">"
             + "<div class=\"my-composite-event2\"></div></div>"
             + "<div class=\"notifications-macro-load-more\"></div>";
 
@@ -187,10 +192,12 @@ public class InternalHtmlNotificationRendererTest
             Arrays.asList(eventStatus1, eventStatus2),
             true));
 
-        expectedResult = "<div data-eventtype=\"FooType\" data-ids=\"foo,bar,baz\" data-eventdate=\"42\" "
+        expectedResult = "<div role=\"listitem\" data-eventtype=\"FooType\" data-ids=\"foo,bar,baz\" " 
+            + "data-eventdate=\"42\" "
             + "class=\"notification-event\">"
             + "<div class=\"my-composite-event1\"></div></div>"
-            + "<div data-eventtype=\"BarType\" data-ids=\"oneId\" data-eventdate=\"12\" class=\"notification-event\">"
+            + "<div role=\"listitem\" data-eventtype=\"BarType\" data-ids=\"oneId\" data-eventdate=\"12\" " 
+            + "class=\"notification-event\">"
             + "<div class=\"my-composite-event2\"></div></div>"
             + "<div class=\"notifications-macro-load-more\"></div>";
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-pageobjects/src/main/java/org/xwiki/platform/notifications/test/po/GroupedNotificationElementPage.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-pageobjects/src/main/java/org/xwiki/platform/notifications/test/po/GroupedNotificationElementPage.java
@@ -35,7 +35,7 @@ import static org.openqa.selenium.By.cssSelector;
  */
 public class GroupedNotificationElementPage extends BaseElement
 {
-    protected static final String NOTIFICATION_EVENT_SELECTOR = "div.notification-event";
+    protected static final String NOTIFICATION_EVENT_SELECTOR = "li.notification-event";
 
     protected static final String TEXT_SELECTOR = "tr td.description";
 


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22999


# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added list semantics to the notification macro.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The notification macro is used among other things in the activity stream. It's also used notably in the notification dropdown.
* In order to minimize the DOM changes (and also not have to change much the blocks in the HTMLRenderer), I used the aria `role="listitem"` instead of `<li>` in the notifier script service.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Successfully built wqith the changes:
*  `mvn clean install -f xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api -Pquality`
* `mvn clean install -f xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-macro/xwiki-platform-notifications-macro-ui`


# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, this is a DOM change that could break extensions and customizations