### PR TITLE
XWIKI-23354: The #documentTree($option) is broken when using the showTerminalPages=false

### DIFF
--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/main/java/org/xwiki/index/tree/internal/nestedspaces/SpaceTreeNode.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/main/java/org/xwiki/index/tree/internal/nestedspaces/SpaceTreeNode.java
@@ -137,7 +137,7 @@ public class SpaceTreeNode extends AbstractEntityTreeNode
         } else {
             // Query only the spaces table.
             query = this.queryManager.createQuery(
-                "select reference, 0 as terminal from XWikiSpace page order by lower(name), name", Query.HQL);
+                "select reference, 0 as terminal from XWikiSpace space order by lower(name), name", Query.HQL);
         }
 
         query.setWiki(spaceReference.getWikiReference().getName());


### PR DESCRIPTION
# Jira URL

[https://jira.xwiki.org/browse/XWIKI-23354](https://jira.xwiki.org/browse/XWIKI-23354)

# Changes

## Description

Updated the alias of the `XWikiSpace` table to `spaces` instead of `page`, to match the alias used in the filters.

## Clarifications

When we do not want to show terminal documents, we reach [this else branch](https://github.com/xwiki/xwiki-platform/blob/28991f7cd8fb1c949277c12dfc405fad13720b0e/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/main/java/org/xwiki/index/tree/internal/nestedspaces/SpaceTreeNode.java#L137). The query created is:

```sql
select reference, 0 as terminal from XWikiSpace page order by lower(name), name
```

where the alias of `XWikiSpace` is `page`. Below, we add [some filters](https://github.com/xwiki/xwiki-platform/blob/28991f7cd8fb1c949277c12dfc405fad13720b0e/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/main/java/org/xwiki/index/tree/internal/nestedspaces/SpaceTreeNode.java#L147) and the `ChildPageFilter` uses `space` as the alias for the table:

[https://github.com/xwiki/xwiki-platform/blob/28991f7cd8fb1c949277c12dfc405fad13720b0e/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/main/java/org/xwiki/index/tree/internal/nestedpages/query/ChildPageFilter.java#L45](https://github.com/xwiki/xwiki-platform/blob/28991f7cd8fb1c949277c12dfc405fad13720b0e/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/main/java/org/xwiki/index/tree/internal/nestedpages/query/ChildPageFilter.java#L45) and because of this the query fails.


# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

# Expected Merging Strategy

* Prefers squash: Yes
* Backport on branches: 16.10.x
