### PR TITLE
avoid Promise.try usage

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-realtime/plugin.js
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-plugins/src/main/webjar/xwiki-realtime/plugin.js
@@ -344,7 +344,11 @@
    */
   function asyncRequireCallback(asyncCallback, resolve, reject) {
     return (...args) => {
-      Promise.try(asyncCallback, ...args).then(resolve).catch(reject);
+      try {
+        Promise.resolve(asyncCallback(...args)).then(resolve).catch(reject);
+      } catch (error) {
+        reject(error);
+      }
     };
   }
 


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-23377

# Changes

Use try catch and Promise.resolve to implement what Promise.try provides. Thus avoids re-enables support for older browsers, e.g. Firefox 128 ESR.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->