### PR TITLE
XWIKI-23324: In the Navigation Panel, the German umlauts are sorted after Z

### DIFF
--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-docker/src/test/it/org/xwiki/index/test/ui/docker/AllIT.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-docker/src/test/it/org/xwiki/index/test/ui/docker/AllIT.java
@@ -21,6 +21,7 @@ package org.xwiki.index.test.ui.docker;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.xwiki.test.docker.junit5.UITest;
 
 /**
@@ -29,6 +30,7 @@ import org.xwiki.test.docker.junit5.UITest;
  * @version $Id$
  * @since 11.4RC1
  */
+@ExtendWith(DynamicTestConfigurationExtension.class)
 @UITest
 public class AllIT
 {

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-docker/src/test/it/org/xwiki/index/test/ui/docker/DynamicTestConfigurationExtension.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-docker/src/test/it/org/xwiki/index/test/ui/docker/DynamicTestConfigurationExtension.java
@@ -1,0 +1,62 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.index.test.ui.docker;
+
+import java.util.Properties;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.xwiki.test.docker.internal.junit5.DockerTestUtils;
+import org.xwiki.test.docker.junit5.TestConfiguration;
+
+/**
+ * Inject a dynamically-generated {@link TestConfiguration} in order to set the {@code index.sortCollation} config
+ * property to a database-dependent collation.
+ *
+ * @version $Id$
+ * @since 17.6.0RC1
+ */
+public class DynamicTestConfigurationExtension implements BeforeAllCallback
+{
+    @Override
+    public void beforeAll(ExtensionContext extensionContext)
+    {
+        // Get the already loaded configuration to get the used database engine.
+        TestConfiguration loadedConfiguration = DockerTestUtils.getTestConfiguration(extensionContext);
+
+        // Collations to test. They were chosen such that they offer sorting for German umlauts that differs from the
+        // default "binary" sorting.
+        String collation = switch (loadedConfiguration.getDatabase()) {
+            case MYSQL, MARIADB -> "utf8mb4_german2_ci";
+            case HSQLDB_EMBEDDED -> "de_DE";
+            case POSTGRESQL -> "unicode";
+            case ORACLE -> "GENERIC_M_CI";
+        };
+
+        // Save a TestConfiguration in the global test context so that it's merged in XWikiDockerExtension.
+        ExtensionContext.Store globalStore = extensionContext.getRoot().getStore(ExtensionContext.Namespace.GLOBAL);
+        TestConfiguration configuration = new TestConfiguration();
+        Properties properties = new Properties();
+        properties.setProperty("xwikiPropertiesAdditionalProperties",
+            String.format("index.sortCollation=%s", collation));
+        configuration.setProperties(properties);
+        globalStore.put(TestConfiguration.class, configuration);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/main/resources/org/xwiki/index/tree/internal/nestedpages/query/queries.hbm.xml.vm
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/main/resources/org/xwiki/index/tree/internal/nestedpages/query/queries.hbm.xml.vm
@@ -114,7 +114,7 @@
 
     ) xwikiPage
 
-    order by lower(xwikiPage.title) $order, xwikiPage.title $order
+    order by BEFORE_ORDER_MODIFIER xwikiPage.title AFTER_ORDER_MODIFIER $order, xwikiPage.title $order
   </sql-query>
 #end
 
@@ -143,7 +143,7 @@
 
     ) xwikiPage
 
-    order by lower(xwikiPage.pageName) $order, xwikiPage.pageName $order
+    order by BEFORE_ORDER_MODIFIER xwikiPage.pageName AFTER_ORDER_MODIFIER $order, xwikiPage.pageName $order
   </sql-query>
 #end
 
@@ -206,7 +206,8 @@
             tdoc.XWD_WEB = XWS_REFERENCE and
             tdoc.XWD_NAME = 'WebHome' and
             tdoc.XWD_LANGUAGE = :locale)
-        order by lower(coalesce(nullif(tdoc.XWD_TITLE, ''), nullif(doc.XWD_TITLE, ''), XWS_NAME)) $order,
+        order by BEFORE_ORDER_MODIFIER coalesce(nullif(tdoc.XWD_TITLE, ''), nullif(doc.XWD_TITLE, ''), XWS_NAME)
+            AFTER_ORDER_MODIFIER $order,
             coalesce(nullif(tdoc.XWD_TITLE, ''), nullif(doc.XWD_TITLE, ''), XWS_NAME) $order
   </sql-query>
 #end

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/main/resources/org/xwiki/index/tree/internal/nestedpages/query/queries.hbm.xml.vm
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/main/resources/org/xwiki/index/tree/internal/nestedpages/query/queries.hbm.xml.vm
@@ -65,6 +65,9 @@
     advantage that the new entities could be queried using HQL and we could perform an outer join between the XWikiPage
     and the aggregated translations. The problem was that the sort by page title was very slow on MySql, because there
     were many constraints applied to the union instead of the inner selects and so MySql could not use the indexes.
+
+    The placeholders BEFORE_ORDER_MODIFIER and AFTER_ORDER_MODIFIER are replaced when loading this file.
+    They modify the sorting by either wrapping the expression in lower() (default) or adding a configured collation.
   -->
 
   <resultset name = "XWikiPageReference">

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/main/resources/org/xwiki/index/tree/internal/nestedspaces/query/queries.hbm.xml
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/main/resources/org/xwiki/index/tree/internal/nestedspaces/query/queries.hbm.xml
@@ -47,6 +47,11 @@
     slow on MySql, because there were many constraints applied to the union instead of the inner selects and so MySql
     could not use the indexes. -->
 
+  <!--
+    The placeholders BEFORE_ORDER_MODIFIER and AFTER_ORDER_MODIFIER are replaced when loading this file.
+    They modify the sorting by either wrapping the expression in lower() (default) or adding a configured collation.
+   -->
+
   <resultset name = "XWikiPageOrSpaceReference">
     <return-scalar column="reference" type="string" />
     <!-- This type information is very important because we want Hibernate to convert 0 and 1 into false and true. -->

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/main/resources/org/xwiki/index/tree/internal/nestedspaces/query/queries.hbm.xml
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/main/resources/org/xwiki/index/tree/internal/nestedspaces/query/queries.hbm.xml
@@ -82,7 +82,8 @@
 
     ) xwikiPageOrSpace
 
-    order by xwikiPageOrSpace.terminal, lower(xwikiPageOrSpace.title), xwikiPageOrSpace.title
+    order by xwikiPageOrSpace.terminal, BEFORE_ORDER_MODIFIER xwikiPageOrSpace.title AFTER_ORDER_MODIFIER,
+        xwikiPageOrSpace.title
   </sql-query>
 
   <!-- This query follows the SQL-2013 ANSI standard, but it uses a non-core feature F591 "Derived tables" which is
@@ -109,6 +110,7 @@
 
     ) xwikiPageOrSpace
 
-    order by xwikiPageOrSpace.terminal, lower(xwikiPageOrSpace.pageOrSpaceName), xwikiPageOrSpace.pageOrSpaceName
+    order by xwikiPageOrSpace.terminal, BEFORE_ORDER_MODIFIER xwikiPageOrSpace.pageOrSpaceName AFTER_ORDER_MODIFIER,
+        xwikiPageOrSpace.pageOrSpaceName
   </sql-query>
 </hibernate-mapping>

--- a/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.properties.vm
+++ b/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.properties.vm
@@ -1689,4 +1689,17 @@ edit.defaultEditor.org.xwiki.rendering.block.XDOM#wysiwyg=$xwikiPropertiesDefaul
 #-# when a parameter has a default value set to 'true' or 'false' and doesn't define a specific type.
 # wysiwyig.inferMacroParameterTypeBasedOnDefaultValue=true
 
+#-------------------------------------------------------------------------------------
+# Index Tree
+#-------------------------------------------------------------------------------------
+
+#-# [Since 17.6.0]
+#-# Define the database collation used for sorting entries in index trees. This can be used to enable locale-based
+#-# sorting like sorting accented characters at the same place or directly after their non-accented variants.
+#-# When this is set to a non-empty value, the default lowercase transformation for sorting is removed to allow for
+#-# locale-specific lowercase sort handling. Ensure you're using a case-insensitive collation if you want to keep
+#-# case-insensitive sorting. Possible values depend on the used database engine and its configuration, a possible
+#-# value for MariaDB is utf8mb4_general_ci. By default, no collation is configured.
+# index.sortCollation=
+
 $!xwikiPropertiesAdditionalProperties


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-23324

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Add a new configuration option to configure the collation used for sorting.
* Dynamically modify the named queries to use the configured collation.
* Configure a collation in the index tree docker test.
* Add unit and integration tests to ensure that sorting with collation is working.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Recent Hibernate versions add support for specifying collations in order by expressions, too, so when we upgrade to a more recent Hibernate version that doesn't need the named queries anymore, we can keep collation support. Further, we could add collations in more places.
* The supported collations depend completely on the used database engine, this stays true with official Hibernate support. Therefore, it's not really possible to have a nice default collation - we could, however, decide to have a default collation by database engine.
* It could make sense to switch collations by language. However, this doesn't work with the named queries. I think it shouldn't be too difficult, though, to find a collation that works for all languages.
* At the moment, the collation is only used for index trees but not for LiveTable/Live Data. I expect that at some point users will also want it there. This currently isn't really possible as this would require collation support in Hibernate.
* The collation is set only in the query, and we don't recommend setting it at the database level because, depending on the collation, this could have dramatic consequences, document names might become case-insensitive in certain cases for example, leading to very weird bugs.
* I totally expect that this is bad for performance, but the existing `lower()` call is probably not better. In both cases, indexes with the correct settings could help - but I'm not sure.
* I tried setting the collation dynamically in the test, but I didn't manage to change the Hibernate configuration at runtime. I tried re-executing the code that loads the configuration, but it led to an error "Duplicate ResultSetMapping mapping XWikiPageReference" when trying to rebuild the Hibernate session.
* The way the tests are currently configured, we're never testing with the `lower(…)` variant in the integration test. A possibility could be to change either MariaDB or MySQL to not use a collation as their collation support should be similar enough to not require separate testing.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

<img width="107" height="82" alt="grafik" src="https://github.com/user-attachments/assets/73596570-6637-4943-b850-f372b5f08dac" />

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

I've built the changed modules with the quality profile and executed the integration tests with all supported database engines to ensure that the collations work with all of them:

```
LANG=C.UTF-8 mvn clean install -Pdocker,legacy,integration-tests,snapshotModules,quality -pl :xwiki-platform-index-tree-api,:xwiki-platform-index-test-docker
LANG=C.UTF-8 mvn clean install -Pdocker,legacy,integration-tests,snapshotModules,quality -pl :xwiki-platform-index-test-docker -Dxwiki.test.ui.database=mysql -Dxwiki.test.ui.databaseTag=9.2  -Dxwiki.test.ui.servletEngine=jetty -Dxwiki.test.ui.servletEngineTag=12-jdk21
LANG=C.UTF-8 mvn clean install -Pdocker,legacy,integration-tests,snapshotModules,quality -pl :xwiki-platform-index-test-docker -Dxwiki.test.ui.database=oracle -Dxwiki.test.ui.servletEngine=jetty -Dxwiki.test.ui.servletEngineTag=12-jdk21
LANG=C.UTF-8 mvn clean install -Pdocker,legacy,integration-tests,snapshotModules,quality -pl :xwiki-platform-index-test-docker -Dxwiki.test.ui.database=postgresql -Dxwiki.test.ui.servletEngine=jetty -Dxwiki.test.ui.servletEngineTag=12-jdk21
LANG=C.UTF-8 mvn clean install -Pdocker,legacy,integration-tests,snapshotModules,quality -pl :xwiki-platform-index-test-docker -Dxwiki.test.ui.database=mariadb -Dxwiki.test.ui.databaseTag=11.5 -Dxwiki.test.ui.servletEngine=jetty -Dxwiki.test.ui.servletEngineTag=12-jdk21
```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, new feature.