### PR TITLE
XWIKI-23364: Rating stars are overlapping the progress bar on Distribution Wizard

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/job/job.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/job/job.css
@@ -55,6 +55,8 @@
   border-radius: 10px 10px 10px 10px;
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.3) inset, 0 1px 0 0 $theme.pageContentBackgroundColor;
   height: 8px;
+  /* Avoid that the progress bar is behind floating elements, like the rating of an extension. */
+  display: flow-root;
 }
 
 .ui-progress-bar {


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-23364

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Avoid that the progress bar disappears behind floating elements.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* This seems the simplest solution to me that doesn't involve completely changing the layout of the extension display.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

<img width="788" height="276" alt="grafik" src="https://github.com/user-attachments/assets/46159317-a1c6-4be9-aa11-6188337df97b" />

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Built `xwiki-platform-web-war` with the quality profile. Manually applied the changed selector to see the layout difference.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-17.6.x
  * stable-17.4.x
  * stable-16.10.x