### PR TITLE
XWIKI-22996: The contentmenu list of buttons should be coded as a list

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/export_modal.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/export_modal.vm
@@ -21,7 +21,7 @@
 #**
  * Export modal
  *#
-#macro(exportModal)
+#define($exportModal)
   #set ($discard = $xwiki.jsfx.use('uicomponents/exporter/exporter.js', {'forceSkinAction': true}))
   <div class="modal fade text-left" id="exportModal" tabindex="-1" role="dialog" aria-labelledby="exportModalLabel"
       aria-hidden="true">

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_content.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_content.vm
@@ -109,7 +109,6 @@
       #displayOptionsMenu()
       #if ($canView)
         #template("export_modal.vm")
-        #exportModal()
       #end
     #end
   #end
@@ -123,17 +122,22 @@
   ##
   ## Display the menu
   ##
-  <div id="contentmenu" class="pull-right actionmenu">
+  <ul id="contentmenu" class="pull-right actionmenu">
     $menuContent
 
     #if($keyboardShortcutsEnabled)
       #keyboardShortcuts()
     #end
-  </div>
+  </ul>
+## Display the submenu modals next to the list. Note that those could be pretty much anywhere but in the ul for HTML
+## correctness sake.
+#if ("$!notificationsWatchModal" != "")$notificationsWatchModal#end
+#if ("$!exportModal" != "")$exportModal#end
 #end
 
 #**
  * Display a menu if it has some content.
+ * This menu is a list item, made to fit inside the ul `#contentmenu`.
  *
  * @param $id the id of the menu
  * @param $icon the icon of the menu
@@ -150,7 +154,7 @@
  * @since 7.3M2
  *#
 #macro(displayMenu $id $icon $menuContent $titleKey $titleAsLabel $actionUrl $extraAttribute)
-  <div class="btn-group" id="$id">
+  <li class="btn-group" id="$id">
     <#if ("$!actionUrl" == '')button type="button"#{else}a#end class="btn btn-default#if ("$!actionUrl" == '') dropdown-toggle#end" title="$services.localization.render($titleKey)"##
     #if ("$!actionUrl" != '')
       href="$actionUrl"
@@ -174,7 +178,7 @@
         $menuContent
       </dl>
     #end
-  </div>
+  </li>
 #end
 
 #**

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsWatchUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsWatchUIX.xml
@@ -570,120 +570,122 @@
 
 #set ($buttonTitle = $services.localization.render('notifications.watch.button.title', [$watchText]))
 {{html clean='false'}}
-&lt;div class="btn-group" id="watchButton"&gt;
+&lt;li class="btn-group" id="watchButton"&gt;
   &lt;a href="#" role="button" title="$escapetool.xml($buttonTitle)" class="btn btn-default" data-toggle="modal" data-target="#watchModal"&gt;
     &lt;span class="fa $watchIcon"&gt;&lt;/span&gt; $watchText
   &lt;/a&gt;
-&lt;/div&gt;
-&lt;div class="modal fade" tabindex="-1" role="dialog" id="watchModal"&gt;
-  &lt;div class="modal-dialog" role="document"&gt;
-    &lt;div class="modal-content"&gt;
-      &lt;div class="modal-header"&gt;
-        &lt;button type="button" class="close close-modal" data-dismiss="modal" aria-label="$escapetool.xml($services.localization.render('notifications.watch.modal.close'))"&gt;
-          &lt;span aria-hidden="true"&gt;
-            $services.icon.renderHTML('cross')
-          &lt;/span&gt;&lt;/button&gt;
-        &lt;div class="modal-title"&gt;
-          &lt;span class="fa $watchIcon"&gt;&lt;/span&gt; $services.localization.render("notifications.watch.modal.title.$watchedStatus", 'html/5.0', [])
-        &lt;/div&gt;
-      &lt;/div&gt;
-      &lt;div class="modal-body"&gt;
-        &lt;div class="watch-status-container"&gt;
-          $services.localization.render("notifications.watch.modal.description.$watchedStatus", 'html/5.0', [])
-          &lt;hr /&gt;
-          #if (($watchedStatus == 'WATCHED_BY_ANCESTOR_FOR_ALL_EVENTS_AND_FORMATS' || $watchedStatus == 'BLOCKED_BY_ANCESTOR_FOR_ALL_EVENTS_AND_FORMATS') &amp;&amp; $ancestorRef.type == 'SPACE' &amp;&amp; $services.security.authorization.hasAccess('view', $ancestorRef))
-            #set ($ancestorDoc = $xwiki.getDocument($ancestorRef))
-            #set ($ancestorDocUrl = $ancestorDoc.getURL())
-            #set ($ancestorDocTitle = $ancestorDoc.displayTitle)
-            #set ($ancestorLink = "&lt;a href=""$ancestorDocUrl""&gt;$ancestorDocTitle&lt;/a&gt;")
-            $services.localization.render('notifications.watch.modal.description.ancestoroption', [$ancestorLink])
-          #end
-        &lt;/div&gt;
-        &lt;div class="watch-options-container panel-group" id="watch-options-accordion" role="tablist" aria-multiselectable="false"&gt;
-        #set ($blockedByAncestor = ("$!ancestorWatchStatus" == '' || $ancestorWatchStatus.isBlocked()))
-        #set ($watchedByAncestor = ($ancestorWatchStatus.isWatched()))
-        #if ($watchedStatus == 'NOT_SET')
-          $watchPageOption
-          #if (!$isTerminal)
-          $watchSpaceOption
-          #end
-          $watchWikiOption
-        #elseif ($watchedStatus == 'WATCHED_FOR_ALL_EVENTS_AND_FORMATS')
-          #if ($blockedByAncestor)
-          $unwatchPageOption
-          #else
-          $blockPageOption
-          #end
-          #if (!$isTerminal &amp;&amp; $blockedByAncestor)
-          $unwatchPageAndWatchSpaceOption
-          #elseif (!$isTerminal &amp;&amp; !$blockedByAncestor)
-          $blockSpaceOption
-          #end
-        #elseif ($watchedStatus == 'WATCHED_WITH_CHILDREN_FOR_ALL_EVENTS_AND_FORMATS')
-          #if ($blockedByAncestor)
-          $unwatchSpaceOption
-          #else
-          $blockPageOption
-          $blockSpaceOption
-          #end
-        #elseif ($watchedStatus == 'WATCHED_BY_ANCESTOR_FOR_ALL_EVENTS_AND_FORMATS')
-          $blockPageOption
-          #if (!$isTerminal)
-          $blockSpaceOption
-          #end
-          #if ($ancestorRef.type == 'WIKI')
-          $unwatchWikiOption
-          #end
-        #elseif ($watchedStatus == 'BLOCKED_FOR_ALL_EVENTS_AND_FORMATS')
-          #if ($watchedByAncestor)
-          $unblockPageOption
-          #else
-          $watchPageOption
-          #end
-          #if (!$isTerminal &amp;&amp; $watchedByAncestor)
-          $unblockPageAndBlockSpaceOption
-          #elseif (!$isTerminal &amp;&amp; !$watchedByAncestor)
-          $watchSpaceOption
-          #end
-        #elseif ($watchedStatus == 'BLOCKED_WITH_CHILDREN_FOR_ALL_EVENTS_AND_FORMATS')
-          #if ($watchedByAncestor)
-          $unblockSpaceOption
-          #else
-          $watchPageOption
-          $watchSpaceOption
-          #end
-        #elseif ($watchedStatus == 'BLOCKED_BY_ANCESTOR_FOR_ALL_EVENTS_AND_FORMATS')
-          $watchPageOption
-          #if (!$isTerminal)
-          $watchSpaceOption
-          #end
-          #if ($ancestorRef.type == 'WIKI')
-          $unblockWikiOption
-          #end
-        #end
-        &lt;/div&gt;&lt;!-- end panel group --&gt;
-        &lt;div class="modal-body-footer"&gt;
-          #set ($userDoc = $xwiki.getDocument($xcontext.userReference))
-          #set ($settingsLink = "$userDoc.getURL('view','category=notifications')#Hnotifications.settings.filters.preferences.custom.title")
-          &lt;a href="$settingsLink" class="goto-settings"&gt;
-            $services.localization.render('notifications.watch.modal.gotosettings', 'html/5.0', []) $services.icon.renderHTML('move')
-          &lt;/a&gt;
-        &lt;/div&gt;
-      &lt;/div&gt;&lt;!-- end modal body --&gt;
-      &lt;div class="modal-footer"&gt;
-        &lt;button type="button" class="btn btn-default close-modal" data-dismiss="modal"&gt;
-          $services.localization.render('notifications.watch.modal.close', 'html/5.0', [])
-        &lt;/button&gt;
-        #if ($watchedStatus != 'CUSTOM')
-        &lt;button type="button" class="btn btn-primary" disabled="disabled"&gt;
-          $services.localization.render('notifications.watch.modal.savechanges', 'html/5.0', [])
-        &lt;/button&gt;
-        #end
-      &lt;/div&gt;
-    &lt;/div&gt;&lt;!-- /.modal-content --&gt;
-  &lt;/div&gt;&lt;!-- /.modal-dialog --&gt;
-&lt;/div&gt;&lt;!-- /.modal --&gt;
+&lt;/li&gt;
 {{/html}}
+#define ($notificationsWatchModal)
+  &lt;div class="modal fade" tabindex="-1" role="dialog" id="watchModal"&gt;
+    &lt;div class="modal-dialog" role="document"&gt;
+      &lt;div class="modal-content"&gt;
+        &lt;div class="modal-header"&gt;
+          &lt;button type="button" class="close close-modal" data-dismiss="modal" aria-label="$escapetool.xml($services.localization.render('notifications.watch.modal.close'))"&gt;
+            &lt;span aria-hidden="true"&gt;
+              $services.icon.renderHTML('cross')
+            &lt;/span&gt;&lt;/button&gt;
+          &lt;div class="modal-title"&gt;
+            &lt;span class="fa $watchIcon"&gt;&lt;/span&gt; $services.localization.render("notifications.watch.modal.title.$watchedStatus", 'html/5.0', [])
+          &lt;/div&gt;
+        &lt;/div&gt;
+        &lt;div class="modal-body"&gt;
+          &lt;div class="watch-status-container"&gt;
+            $services.localization.render("notifications.watch.modal.description.$watchedStatus", 'html/5.0', [])
+            &lt;hr /&gt;
+            #if (($watchedStatus == 'WATCHED_BY_ANCESTOR_FOR_ALL_EVENTS_AND_FORMATS' || $watchedStatus == 'BLOCKED_BY_ANCESTOR_FOR_ALL_EVENTS_AND_FORMATS') &amp;&amp; $ancestorRef.type == 'SPACE' &amp;&amp; $services.security.authorization.hasAccess('view', $ancestorRef))
+              #set ($ancestorDoc = $xwiki.getDocument($ancestorRef))
+              #set ($ancestorDocUrl = $ancestorDoc.getURL())
+              #set ($ancestorDocTitle = $ancestorDoc.displayTitle)
+              #set ($ancestorLink = "&lt;a href=""$ancestorDocUrl""&gt;$ancestorDocTitle&lt;/a&gt;")
+              $services.localization.render('notifications.watch.modal.description.ancestoroption', [$ancestorLink])
+            #end
+          &lt;/div&gt;
+          &lt;div class="watch-options-container panel-group" id="watch-options-accordion" role="tablist" aria-multiselectable="false"&gt;
+          #set ($blockedByAncestor = ("$!ancestorWatchStatus" == '' || $ancestorWatchStatus.isBlocked()))
+          #set ($watchedByAncestor = ($ancestorWatchStatus.isWatched()))
+          #if ($watchedStatus == 'NOT_SET')
+            $watchPageOption
+            #if (!$isTerminal)
+            $watchSpaceOption
+            #end
+            $watchWikiOption
+          #elseif ($watchedStatus == 'WATCHED_FOR_ALL_EVENTS_AND_FORMATS')
+            #if ($blockedByAncestor)
+            $unwatchPageOption
+            #else
+            $blockPageOption
+            #end
+            #if (!$isTerminal &amp;&amp; $blockedByAncestor)
+            $unwatchPageAndWatchSpaceOption
+            #elseif (!$isTerminal &amp;&amp; !$blockedByAncestor)
+            $blockSpaceOption
+            #end
+          #elseif ($watchedStatus == 'WATCHED_WITH_CHILDREN_FOR_ALL_EVENTS_AND_FORMATS')
+            #if ($blockedByAncestor)
+            $unwatchSpaceOption
+            #else
+            $blockPageOption
+            $blockSpaceOption
+            #end
+          #elseif ($watchedStatus == 'WATCHED_BY_ANCESTOR_FOR_ALL_EVENTS_AND_FORMATS')
+            $blockPageOption
+            #if (!$isTerminal)
+            $blockSpaceOption
+            #end
+            #if ($ancestorRef.type == 'WIKI')
+            $unwatchWikiOption
+            #end
+          #elseif ($watchedStatus == 'BLOCKED_FOR_ALL_EVENTS_AND_FORMATS')
+            #if ($watchedByAncestor)
+            $unblockPageOption
+            #else
+            $watchPageOption
+            #end
+            #if (!$isTerminal &amp;&amp; $watchedByAncestor)
+            $unblockPageAndBlockSpaceOption
+            #elseif (!$isTerminal &amp;&amp; !$watchedByAncestor)
+            $watchSpaceOption
+            #end
+          #elseif ($watchedStatus == 'BLOCKED_WITH_CHILDREN_FOR_ALL_EVENTS_AND_FORMATS')
+            #if ($watchedByAncestor)
+            $unblockSpaceOption
+            #else
+            $watchPageOption
+            $watchSpaceOption
+            #end
+          #elseif ($watchedStatus == 'BLOCKED_BY_ANCESTOR_FOR_ALL_EVENTS_AND_FORMATS')
+            $watchPageOption
+            #if (!$isTerminal)
+            $watchSpaceOption
+            #end
+            #if ($ancestorRef.type == 'WIKI')
+            $unblockWikiOption
+            #end
+          #end
+          &lt;/div&gt;&lt;!-- end panel group --&gt;
+          &lt;div class="modal-body-footer"&gt;
+            #set ($userDoc = $xwiki.getDocument($xcontext.userReference))
+            #set ($settingsLink = "$userDoc.getURL('view','category=notifications')#Hnotifications.settings.filters.preferences.custom.title")
+            &lt;a href="$settingsLink" class="goto-settings"&gt;
+              $services.localization.render('notifications.watch.modal.gotosettings', 'html/5.0', []) $services.icon.renderHTML('move')
+            &lt;/a&gt;
+          &lt;/div&gt;
+        &lt;/div&gt;&lt;!-- end modal body --&gt;
+        &lt;div class="modal-footer"&gt;
+          &lt;button type="button" class="btn btn-default close-modal" data-dismiss="modal"&gt;
+            $services.localization.render('notifications.watch.modal.close', 'html/5.0', [])
+          &lt;/button&gt;
+          #if ($watchedStatus != 'CUSTOM')
+          &lt;button type="button" class="btn btn-primary" disabled="disabled"&gt;
+            $services.localization.render('notifications.watch.modal.savechanges', 'html/5.0', [])
+          &lt;/button&gt;
+          #end
+        &lt;/div&gt;
+      &lt;/div&gt;&lt;!-- /.modal-content --&gt;
+    &lt;/div&gt;&lt;!-- /.modal-dialog --&gt;
+  &lt;/div&gt;&lt;!-- /.modal --&gt;
+  #end
 #end
 {{/velocity}}</content>
     </property>

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BasePage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BasePage.java
@@ -56,7 +56,7 @@ public class BasePage extends BaseElement
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(BasePage.class);
 
-    private static final By EDIT_BUTTON_LOCATOR = By.xpath("//div[@id='tmEdit']/a[contains(@class, 'btn')]");
+    private static final By EDIT_BUTTON_LOCATOR = By.xpath("//li[@id='tmEdit']/a[contains(@class, 'btn')]");
 
     /**
      * Used for sending keyboard shortcuts to.
@@ -70,10 +70,10 @@ public class BasePage extends BaseElement
     @FindBy(id = "contentmenu")
     private WebElement contentMenuBar;
 
-    @FindBy(xpath = "//div[@id='tmCreate']/a[contains(@class, 'btn')]")
+    @FindBy(xpath = "//li[@id='tmCreate']/a[contains(@class, 'btn')]")
     private WebElement tmCreate;
 
-    @FindBy(xpath = "//div[@id='tmMoreActions']/button")
+    @FindBy(xpath = "//li[@id='tmMoreActions']/button")
     private WebElement moreActionsMenu;
 
     @FindBy(xpath = "//input[@id='tmWatchDocument']/../span[contains(@class, 'bootstrap-switch-label')]")
@@ -194,7 +194,7 @@ public class BasePage extends BaseElement
      */
     protected void clickEditSubMenuEntry(String id)
     {
-        clickSubMenuEntryFromMenu(By.xpath("//div[@id='tmEdit']/*[contains(@class, 'dropdown-toggle')]"), id);
+        clickSubMenuEntryFromMenu(By.xpath("//li[@id='tmEdit']/*[contains(@class, 'dropdown-toggle')]"), id);
     }
 
     /**
@@ -329,7 +329,7 @@ public class BasePage extends BaseElement
      */
     public void clickMoreActionsSubMenuEntry(String id)
     {
-        clickSubMenuEntryFromMenu(By.xpath("//div[@id='tmMoreActions']/button"), id);
+        clickSubMenuEntryFromMenu(By.xpath("//li[@id='tmMoreActions']/button"), id);
     }
 
     /**


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22996

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Coded the contentmenu as a list.
* Defined both of the modals in their own velocity variable in order to put them after the end of the list.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Abandonned the idea to create a UIXP for the end of DOM since it doesn't seem the goal of reducing dependencies between extensions did not match UIXPs goals. 
* The diff of NotificationsWatchUIX.xml computed on github looks weird, but the only change for the large block is that the modal is now wrapped into a `#define` declaration and I indented the whole block accordingly.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
These screenshots are made with the changes applied.
<img width="2542" height="1316" alt="image" src="https://github.com/user-attachments/assets/a62de2da-4571-43b9-9b00-ccd64e2a4797" />
<img width="782" height="306" alt="image" src="https://github.com/user-attachments/assets/c0f14b91-21b4-4eb3-b5e0-cfa8d127748e" />
We can see that the ul only contains li (except for the script tag, which does not interfere with usability or our WCAG tests).
The modals are contained right after and are displayed as usual.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests, see above.
Most of the changes (and the more critical ones) have already been tested in https://github.com/xwiki/xwiki-platform/pull/4016/files and even passed through CI, which did not report anything but the non li children in the ul for WCAG tests.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, change in the DOM.