### PR TITLE
XWIKI-23254: Page loads are slow for users with many watched pages

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterPreference.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterPreference.java
@@ -127,6 +127,22 @@ public class ScopeNotificationFilterPreference implements NotificationFilterPref
     }
 
     /**
+     * @return true if the current filter preference is a potential parent of other preferences, false otherwise.
+     */
+    public boolean isPotentialParent()
+    {
+        return getFilterType() == NotificationFilterType.EXCLUSIVE;
+    }
+
+    /**
+     * @return true if the current filter preference is a potential child of other preferences, false otherwise.
+     */
+    public boolean isPotentialChild()
+    {
+        return getFilterType() == NotificationFilterType.INCLUSIVE;
+    }
+
+    /**
      * @return the resolved reference of the current notification preference.
      */
     public EntityReference getScopeReference()

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterPreference.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterPreference.java
@@ -129,8 +129,8 @@ public class ScopeNotificationFilterPreference implements NotificationFilterPref
     /**
      * @return true if the current filter preference is a potential parent of other preferences, false otherwise
      * @since 17.7.0RC1
-     * @since 17.4.3
-     * @since 16.10.10
+     * @since 17.4.4
+     * @since 16.10.11
      */
     public boolean isPotentialParent()
     {
@@ -140,8 +140,8 @@ public class ScopeNotificationFilterPreference implements NotificationFilterPref
     /**
      * @return true if the current filter preference is a potential child of other preferences, false otherwise
      * @since 17.7.0RC1
-     * @since 17.4.3
-     * @since 16.10.10
+     * @since 17.4.4
+     * @since 16.10.11
      */
     public boolean isPotentialChild()
     {

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterPreference.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterPreference.java
@@ -121,13 +121,16 @@ public class ScopeNotificationFilterPreference implements NotificationFilterPref
         //
         // So a filter could be the parent of an other only if the other is an inclusive filter and if the current
         // is a exclusive filter
-        return getFilterType() == NotificationFilterType.EXCLUSIVE
-                && other.getFilterType() == NotificationFilterType.INCLUSIVE
-                && other.getScopeReference().hasParent(this.getScopeReference());
+        return isPotentialParent()
+            && other.isPotentialChild()
+            && other.getScopeReference().hasParent(this.getScopeReference());
     }
 
     /**
-     * @return true if the current filter preference is a potential parent of other preferences, false otherwise.
+     * @return true if the current filter preference is a potential parent of other preferences, false otherwise
+     * @since 17.7.0RC1
+     * @since 17.4.3
+     * @since 16.10.10
      */
     public boolean isPotentialParent()
     {
@@ -135,7 +138,10 @@ public class ScopeNotificationFilterPreference implements NotificationFilterPref
     }
 
     /**
-     * @return true if the current filter preference is a potential child of other preferences, false otherwise.
+     * @return true if the current filter preference is a potential child of other preferences, false otherwise
+     * @since 17.7.0RC1
+     * @since 17.4.3
+     * @since 16.10.10
      */
     public boolean isPotentialChild()
     {

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterPreferencesHierarchy.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterPreferencesHierarchy.java
@@ -46,14 +46,22 @@ public class ScopeNotificationFilterPreferencesHierarchy
     {
         this.preferences = preferences;
 
-        // Compare preferences 2 by 2 to see if some are children of the other
-        for (ScopeNotificationFilterPreference pref : preferences) {
-            for (ScopeNotificationFilterPreference otherPref : preferences) {
-                if (pref == otherPref) {
+        List<ScopeNotificationFilterPreference> potentialParents = preferences.stream()
+            .filter(ScopeNotificationFilterPreference::isPotentialParent)
+            .toList();
+
+        List<ScopeNotificationFilterPreference> potentialChildren = preferences.stream()
+            .filter(ScopeNotificationFilterPreference::isPotentialChild)
+            .toList();
+
+        // Compare potential parents and potential children to see if some are children of the other.
+        for (ScopeNotificationFilterPreference potentialParent : potentialParents) {
+            for (ScopeNotificationFilterPreference potentialChild : potentialChildren) {
+                if (potentialChild == potentialParent) {
                     continue;
                 }
-                if (otherPref.isParentOf(pref)) {
-                    otherPref.addChild(pref);
+                if (potentialParent.isParentOf(potentialChild)) {
+                    potentialParent.addChild(potentialChild);
                 }
             }
         }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-23254

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Don't compare all preferences with each other but only compare potential parents with potential children. This should help for the very likely case that users have primarily (or exclusively) inclusive notification filters.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* I haven't tested this much yet, but it seems quite straightforward that this should be correct and help a lot for the likely case that a user simply watches a lot of individual pages.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Built the module with quality profile.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-17.4.x
  * stable-16.10.x