### PR TITLE
XWIKI-23413: Separators in navigation tree dropdown

### DIFF
--- a/xwiki-platform-core/xwiki-platform-bootstrap/src/main/less/dropdowns.less
+++ b/xwiki-platform-core/xwiki-platform-bootstrap/src/main/less/dropdowns.less
@@ -59,15 +59,6 @@
     .nav-divider(@dropdown-divider-bg);
   }
 
-  // Dividers within the dropdown with an improved semantic representation
-  li:has(> ul) + li:has(> ul) {
-    padding-top: ((@line-height-computed / 2) - 1);
-    border-top: solid 1px @dropdown-divider-bg;
-  }
-  li:has(> ul):has(+ li > ul) {
-    margin-bottom: ((@line-height-computed / 2) - 1);
-  }
-
   // Links within the dropdown menu and submenus
   /* stylelint-disable selector-max-compound-selectors */
   > li > a,

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/node/src/components/LivedataDropdownMenu.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/node/src/components/LivedataDropdownMenu.vue
@@ -171,4 +171,16 @@ export default {
   text-align: center;
 }
 
+.livedata-dropdown-menu .dropdown-menu {
+  /* Dividers within the dropdown with an improved semantic representation */
+  li:has(> ul) + li:has(> ul) {
+    padding-top: calc(.5lh - 1px);
+    border-top: solid 1px var(--dropdown-divider-bg);
+  }
+
+  li:has(> ul):has(+ li > ul) {
+    margin-bottom: calc(.5lh - 1px);
+  }
+}
+
 </style>

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/base.less
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/base.less
@@ -54,12 +54,12 @@
 
 // We override the separator styles from bootstrap dropdown.less
 .dropdown-menu .jstree li:has(> ul):has(+ li > ul) {
-	margin-bottom: 0;
+  margin-bottom: 0;
 }
 
 .dropdown-menu .jstree li:has(> ul) + li:has(> ul) {
-	padding-top: 0;
-	border-top: none;
+  padding-top: 0;
+  border-top: none;
 }
 // XWiki customization end
 

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/base.less
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/base.less
@@ -51,16 +51,6 @@
     text-decoration: none;
   }
 }
-
-// We override the separator styles from bootstrap dropdown.less
-.dropdown-menu .jstree li:has(> ul):has(+ li > ul) {
-  margin-bottom: 0;
-}
-
-.dropdown-menu .jstree li:has(> ul) + li:has(> ul) {
-  padding-top: 0;
-  border-top: none;
-}
 // XWiki customization end
 
 // base jstree rtl

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/base.less
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/base.less
@@ -51,6 +51,16 @@
     text-decoration: none;
   }
 }
+
+// We override the separator styles from bootstrap dropdown.less
+.dropdown-menu .jstree li:has(> ul):has(+ li > ul) {
+	margin-bottom: 0;
+}
+
+.dropdown-menu .jstree li:has(> ul) + li:has(> ul) {
+	padding-top: 0;
+	border-top: none;
+}
 // XWiki customization end
 
 // base jstree rtl


### PR DESCRIPTION

# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-23413

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

~~* Provided the fix as a hard-coded exception to the updated bootstrap~~
<EDIT> The solution prooposed in this PR now is completely different to what was done initially </EDIT>

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
With the changes in the PR applied:
<img width="2560" height="1324" alt="Screenshot from 2025-07-28 17-05-47" src="https://github.com/user-attachments/assets/5516adfd-b658-452b-8c80-ce0ac752cbe0" />

Note that before applying that patch, I could reproduce the problem reported on this local instance. The state of this UI without the fix is available as an attachment to the equivalent jira ticket.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests only. The issue was reported after manual tests and style changes only hardly ever impact automated tests.
Built the jar with the quality profile successfully:
`mvn clean install -f xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar -Pquality`

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 17.4.X
  * 16.10.X