### PR TITLE
XWIKI-23419: Notification pre-filtering is slow with lots of users due to lots of Solr queries

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/UserEventDispatcher.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/UserEventDispatcher.java
@@ -170,16 +170,20 @@ public class UserEventDispatcher
 
                 // Pre-filter all the found events
                 Iterable<Event> it = () -> result.stream().iterator();
+                List<CompletableFuture<?>> completableFutures = new ArrayList<>((int) result.getSize());
                 for (Event event : it) {
                     try {
-                        CompletableFuture<?> completableFuture = prefilterEvent(event, types);
-                        completableFuture.join();
+                        completableFutures.add(prefilterEvent(event, types));
                     } catch (Exception e) {
                         this.logger.warn("Failed to pre filter event with id [{}]: {}", event.getId(),
                             ExceptionUtils.getRootCauseMessage(e));
                         // Remember the failed event to not query it again
                         failedEvents.add(event.getId());
                     }
+                }
+                // Wait for all events to be written before performing a new search.
+                for (CompletableFuture<?> completableFuture : completableFutures) {
+                    completableFuture.join();
                 }
             }
         } while (true);
@@ -222,7 +226,6 @@ public class UserEventDispatcher
 
     private CompletableFuture<?> dispatchInContext(Event event)
     {
-        CompletableFuture<?> result = new CompletableFuture<>();
         WikiReference eventWiki = event.getWiki();
 
         if (CollectionUtils.isNotEmpty(event.getTarget())) {
@@ -249,77 +252,67 @@ public class UserEventDispatcher
                         ExceptionUtils.getRootCauseMessage(e));
                 }
             }
-
-            // Remember we are done pre filtering this event
-            result = this.events.prefilterEvent(event);
         } else {
             // Try to find users listening to this event
 
             // Associated event with event's wiki users
-            result = dispatch(event, this.userCache.getUsers(eventWiki, true));
+            dispatch(event, this.userCache.getUsers(eventWiki, true));
 
             // Also take into account global users (main wiki users) if the event is on a subwiki
             if (!this.wikiManager.isMainWiki(eventWiki.getName())) {
                 List<DocumentReference> userList =
                     this.userCache.getUsers(new WikiReference(this.wikiManager.getMainWikiId()), true);
-                result = dispatch(event, userList);
+                dispatch(event, userList);
             }
         }
-        return result;
+
+        // Remember we are done pre-filtering this event
+        return this.events.prefilterEvent(event);
     }
 
-    private CompletableFuture<?> dispatch(Event event, DocumentReference user, boolean mailEnabled)
+    private void dispatch(Event event, DocumentReference user, boolean mailEnabled)
     {
         // Get the entity id
         String entityId = this.entityReferenceSerializer.serialize(user);
-        CompletableFuture<?> result = new CompletableFuture<>();
 
         // Make sure the event is not already pre filtered
         // Make sure the user asked to be alerted about this event
-        if (!isStatusPrefiltered(event, entityId)
-            && this.userEventManager.isListening(event, user, NotificationFormat.ALERT)) {
+        if (this.userEventManager.isListening(event, user, NotificationFormat.ALERT)
+            // The only case where this would prevent saving the status is when an event is pre-filtered again (e.g.,
+            // due to a restart in the middle of pre-filtering) and the event was already marked as read by the user.
+            // If the event hasn't been marked as read by the user, the atomic operation would already prevent saving
+            // the status again. It also only prevents saving again if the marking as read was already committed to
+            // the store.
+            && !isStatusPrefiltered(event, entityId)) {
             // Associate the event with the user
-            result = saveEventStatus(event, entityId);
+            saveEventStatus(event, entityId);
         }
 
         // Make sure the notification module is allowed to send mails
-        // Make sure the event is not already pre filtered
         // Make sure the user asked to receive mails about this event
-        if (mailEnabled && !isMailPrefiltered(event, entityId)
-            && this.userEventManager.isListening(event, user, NotificationFormat.EMAIL)) {
+        // TODO: when the event is pre-filtered again and the email was already sent, we're currently sending it again.
+        // We could avoid this by:
+        // - only sending the email for fully pre-filtered events
+        // - adding a list of users for which the email was already sent
+        // - only saving the mail entity event at the end of the pre-filtering, making sure that the status isn't
+        // committed before the event is marked as pre-filtered
+        if (mailEnabled && this.userEventManager.isListening(event, user, NotificationFormat.EMAIL)) {
             // Associate the event with the user
-            result = saveMailEntityEvent(event, entityId);
+            saveMailEntityEvent(event, entityId);
         }
 
         // FIXME: reuse constant from EventType once it's moved (see https://jira.xwiki.org/browse/XWIKI-21669)
         if (StringUtils.equals(event.getType(), "delete")) {
             this.cleanUpFilterProcessingQueue.addCleanUpTask(user, event.getDocument());
         }
-
-        return result;
     }
 
     private boolean isStatusPrefiltered(Event event, String entityId)
     {
-        return isPrefiltered(event, entityId, false);
-    }
-
-    private boolean isMailPrefiltered(Event event, String entityId)
-    {
-        return isPrefiltered(event, entityId, true);
-    }
-
-    private boolean isPrefiltered(Event event, String entityId, boolean mail)
-    {
         SimpleEventQuery eventQuery = new SimpleEventQuery(0, 0);
 
         eventQuery.eq(Event.FIELD_ID, event.getId());
-
-        if (mail) {
-            eventQuery.withMail(entityId);
-        } else {
-            eventQuery.withStatus(entityId);
-        }
+        eventQuery.withStatus(entityId);
 
         try (EventSearchResult result = this.events.search(eventQuery)) {
             return result.getTotalHits() > 0;
@@ -330,25 +323,22 @@ public class UserEventDispatcher
         }
     }
 
-    private CompletableFuture<?> dispatch(Event event, List<DocumentReference> users)
+    private void dispatch(Event event, List<DocumentReference> users)
     {
         boolean mailEnabled = this.notificationConfiguration.areEmailsEnabled();
 
         for (DocumentReference user : users) {
             dispatch(event, user, mailEnabled);
         }
-
-        // Remember we are done pre filtering this event
-        return this.events.prefilterEvent(event);
     }
 
-    private CompletableFuture<?> saveEventStatus(Event event, String entityId)
+    private void saveEventStatus(Event event, String entityId)
     {
-        return this.events.saveEventStatus(new DefaultEventStatus(event, entityId, false));
+        this.events.saveEventStatus(new DefaultEventStatus(event, entityId, false));
     }
 
-    private CompletableFuture<?> saveMailEntityEvent(Event event, String entityId)
+    private void saveMailEntityEvent(Event event, String entityId)
     {
-        return this.events.saveMailEntityEvent(new DefaultEntityEvent(event, entityId));
+        this.events.saveMailEntityEvent(new DefaultEntityEvent(event, entityId));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/test/java/org/xwiki/notifications/notifiers/internal/UserEventDispatcherTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/test/java/org/xwiki/notifications/notifiers/internal/UserEventDispatcherTest.java
@@ -217,10 +217,6 @@ class UserEventDispatcherTest
         when(this.userEventManager.isListening(event2Result1, mainUserFoo, NotificationFormat.ALERT)).thenReturn(true);
         // verify(this.events).saveEventStatus(new DefaultEventStatus(event2Result1, mainUserFooStr, false))
 
-        SimpleEventQuery queryMailE2R1 = new SimpleEventQuery(0, 0)
-            .eq(Event.FIELD_ID, event2Result1Id)
-            .withMail(mainUserFooStr);
-        when(this.events.search(queryMailE2R1)).thenReturn(searchResult0Hit);
         when(this.userEventManager.isListening(event2Result1, mainUserFoo, NotificationFormat.EMAIL)).thenReturn(true);
         // verify(this.events).saveMailEntityEvent(new DefaultEventStatus(event2Result1, mainUserFooStr))
 
@@ -233,11 +229,6 @@ class UserEventDispatcherTest
 
         // verify(this.userEventManager, never()).isListening(event2Result1, mainUserBar, NotificationFormat.ALERT)
         // verify(this.events, never()).saveEventStatus(new DefaultEventStatus(event2Result1, mainUserBarStr, false))
-
-        SimpleEventQuery queryMailE2R1Bar = new SimpleEventQuery(0, 0)
-            .eq(Event.FIELD_ID, event2Result1Id)
-            .withMail(mainUserBarStr);
-        when(this.events.search(queryMailE2R1Bar)).thenReturn(searchResultHits);
 
         // verify(this.userEventManager, never()).isListening(event2Result1, mainUserBar, NotificationFormat.EMAIL)
         // verify(this.events, never()).saveMailEntityEvent(new DefaultEventStatus(event2Result1, mainUserBarStr))
@@ -259,10 +250,6 @@ class UserEventDispatcherTest
         when(this.userEventManager.isListening(event3Result1, mainUserFoo, NotificationFormat.ALERT)).thenReturn(false);
         // verify(this.events, never()).saveEventStatus(new DefaultEventStatus(event3Result1, mainUserFooStr, false))
 
-        SimpleEventQuery queryMailE3R1 = new SimpleEventQuery(0, 0)
-            .eq(Event.FIELD_ID, event3Result1Id)
-            .withMail(mainUserFooStr);
-        when(this.events.search(queryMailE3R1)).thenReturn(searchResult0Hit);
         when(this.userEventManager.isListening(event3Result1, mainUserFoo, NotificationFormat.EMAIL)).thenReturn(false);
         // verify(this.events, never()).saveMailEntityEvent(new DefaultEventStatus(event3Result1, mainUserFooStr))
 
@@ -273,10 +260,6 @@ class UserEventDispatcherTest
         when(this.userEventManager.isListening(event3Result1, mainUserBar, NotificationFormat.ALERT)).thenReturn(true);
         // verify(this.events).saveEventStatus(new DefaultEventStatus(event3Result1, mainUserBarStr, false))
 
-        SimpleEventQuery queryMailE3R1Bar = new SimpleEventQuery(0, 0)
-            .eq(Event.FIELD_ID, event3Result1Id)
-            .withMail(mainUserBarStr);
-        when(this.events.search(queryMailE3R1Bar)).thenReturn(searchResult0Hit);
         when(this.userEventManager.isListening(event3Result1, mainUserBar, NotificationFormat.EMAIL)).thenReturn(true);
         // verify(this.events).saveMailEntityEvent(new DefaultEventStatus(event3Result1, mainUserBarStr))
 
@@ -350,9 +333,9 @@ class UserEventDispatcherTest
 
         verify(this.events).saveEventStatus(new DefaultEventStatus(event2Result1, mainUserFooStr, false));
         verify(this.events).saveMailEntityEvent(new DefaultEntityEvent(event2Result1, mainUserFooStr));
-        verify(this.userEventManager, never()).isListening(event2Result1, mainUserBar, NotificationFormat.ALERT);
+        verify(this.userEventManager).isListening(event2Result1, mainUserBar, NotificationFormat.ALERT);
         verify(this.events, never()).saveEventStatus(new DefaultEventStatus(event2Result1, mainUserBarStr, false));
-        verify(this.userEventManager, never()).isListening(event2Result1, mainUserBar, NotificationFormat.EMAIL);
+        verify(this.userEventManager).isListening(event2Result1, mainUserBar, NotificationFormat.EMAIL);
         verify(this.events, never()).saveMailEntityEvent(new DefaultEntityEvent(event2Result1, mainUserBarStr));
         verify(this.events).prefilterEvent(event2Result1);
         verify(futureE2R1).join();
@@ -366,7 +349,7 @@ class UserEventDispatcherTest
 
         verify(this.events, never()).search(queryStatusE1R2);
         verify(this.events, never()).search(queryMailE1R2);
-        verify(this.userEventManager, never()).isListening(event1Result2, mainUserBar, NotificationFormat.ALERT);
+        verify(this.userEventManager).isListening(event1Result2, mainUserBar, NotificationFormat.ALERT);
         verify(this.events, never()).saveEventStatus(new DefaultEventStatus(event1Result2, mainUserBarStr, false));
         verify(this.events).saveMailEntityEvent(new DefaultEntityEvent(event1Result2, mainUserBarStr));
         verify(this.events).prefilterEvent(event1Result2);


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-23419

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Don't ever check if mails are pre-filtered as this just duplicates the logic of the atomic update that we already use.
* Only check for notification statuses when a user is actually listening to an event.
* Remove unused futures.
* Don't mark an event as pre-filtered after filtering for the users on the subwiki before filtering for the main wiki users.
* Wait for all events of the batch at once, don't wait for every event to be committed.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* It's unfortunately super difficult to test if this actually improves notification performance as this would require quite a complicated test setup - so I can't tell if this actually improves performance, but it seems very likely.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Built the changed module with quality profile.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-17.4.x.
  * stable-16.10.x