### PR TITLE
XWIKI-22983: Focus highlight is not sufficient on topbar notifications button

### DIFF
--- a/xwiki-platform-core/xwiki-platform-bootstrap/src/main/less/dropdowns.less
+++ b/xwiki-platform-core/xwiki-platform-bootstrap/src/main/less/dropdowns.less
@@ -22,8 +22,8 @@
 }
 
 // Prevent the focus on the dropdown toggle when closing dropdowns
-// This specific style got overridden twice already, if it poses more issues we should consider changing this default.
-// See NotificationsDisplayerUIX.xml and breadcrumbs.less
+// This specific style got overridden thrice already, if it poses more issues we should consider changing this default.
+// See NotificationsDisplayerUIX.xml, breadcrumbs.less and buttons.less
 .dropdown-toggle:focus {
   outline: 0;
 }

--- a/xwiki-platform-core/xwiki-platform-bootstrap/src/main/less/dropdowns.less
+++ b/xwiki-platform-core/xwiki-platform-bootstrap/src/main/less/dropdowns.less
@@ -22,6 +22,8 @@
 }
 
 // Prevent the focus on the dropdown toggle when closing dropdowns
+// This specific style got overridden twice already, if it poses more issues we should consider changing this default.
+// See NotificationsDisplayerUIX.xml and breadcrumbs.less
 .dropdown-toggle:focus {
   outline: 0;
 }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsDisplayerUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsDisplayerUIX.xml
@@ -569,6 +569,7 @@ Get the actual notifications.
     }
     &amp;:hover,
     &amp;:focus {
+      outline: revert;
       background-color: @navbar-default-link-hover-bg;
       color: @navbar-default-link-hover-color;
     }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22983

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Overridden the outline for focus of the notification toggle.
* Added a comment to keep track of this

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* See comment on https://jira.xwiki.org/browse/XWIKI-22983 

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
With the changes in the PR applied:
<img width="2560" height="1324" alt="Screenshot from 2025-07-30 12-16-04" src="https://github.com/user-attachments/assets/2e1f79f9-1291-44af-abec-adb66941c34d" />

We can see that the outline is displayed as expected.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Manual test only (see above), this is a minor style change so it doesn't impact docker tests.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 17.4.X