### PR TITLE
XWIKI-17431: Page menus should not hide if the user clicks on their headers or on separators

### DIFF
--- a/xwiki-platform-core/xwiki-platform-bootstrap/src/main/js/dropdown.js
+++ b/xwiki-platform-core/xwiki-platform-bootstrap/src/main/js/dropdown.js
@@ -44,7 +44,7 @@
 
       if (!$parent.hasClass('open')) return
 
-      if (e && e.type == 'click' && $.contains($parent[0], e.target)) return
+      if (e && e.type === 'click' && !/^(?:a|button)$/i.test(e.target.tagName) && $.contains($parent[0], e.target)) return
 
       $parent.trigger(e = $.Event('hide.bs.dropdown', relatedTarget))
 


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-17431

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Removed the condition on the nature of the clicked child to keep the dropdown open.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* `clearMenus` is called on the event `click.bs.dropdown.data-api`. 
* The dropdown used to stay opened if the event is a click AND the target is either a textarea or an input AND the target is a child of the current dropdown. This second condition barely makes sense given how we use it (mostly with links and buttons...). It's not common sense: user feedback highlighted that the dropdown closed as soon as we click on it was unexpected. 

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
We can see on the video that clicking on the dropdown separator and section titles no longer close it anymore. 
In addition, clicking on the links inside it does not close it immediately anymore. IMO it's positive, so I didn't bother finding a solution without this difference.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests, see above. I build the bootstrap jar for these with `mvn clean install -f xwiki-platform-core/xwiki-platform-bootstrap -Pquality`.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, this could have relatively important repercussions on uses of bootstrap dropdowns I didn't account for, I'd rather be safe and merge this only on master so that it's safer when it gets into the LTS :)