### PR TITLE
XWIKI-20909: Code macro scroll controls are not keyboard accessible

### DIFF
--- a/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-test/xwiki-platform-export-pdf-test-docker/src/test/it/org/xwiki/export/pdf/test/ui/PDFExportIT.java
+++ b/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-test/xwiki-platform-export-pdf-test-docker/src/test/it/org/xwiki/export/pdf/test/ui/PDFExportIT.java
@@ -804,7 +804,15 @@ class PDFExportIT
     @Order(12)
     void codeMacro(TestUtils setup) throws Exception
     {
+        boolean wcagEnabled = setup.getWCAGUtils().getWCAGContext().isWCAGEnabled();
+        // We always disable WCAG validation.
+        // Here, the test `scrollable-region-focusable` fails while this is now a browser feature in Chrome.
+        // The docker tests run on Chrome.
+        // See https://github.com/dequelabs/axe-core/issues/4788
+        setup.getWCAGUtils().getWCAGContext().setWCAGEnabled(false);
         ViewPage viewPage = setup.gotoPage(new LocalDocumentReference("PDFExportIT", "CodeMacro"));
+        // We set back the WCAG validation in the state it was in before this BasePage initialization.
+        setup.getWCAGUtils().getWCAGContext().setWCAGEnabled(wcagEnabled);
         PDFExportOptionsModal exportOptions = PDFExportOptionsModal.open(viewPage);
 
         try (PDFDocument pdf = export(exportOptions)) {

--- a/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-test/xwiki-platform-export-pdf-test-docker/src/test/it/org/xwiki/export/pdf/test/ui/PDFExportIT.java
+++ b/xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-test/xwiki-platform-export-pdf-test-docker/src/test/it/org/xwiki/export/pdf/test/ui/PDFExportIT.java
@@ -805,13 +805,13 @@ class PDFExportIT
     void codeMacro(TestUtils setup) throws Exception
     {
         boolean wcagEnabled = setup.getWCAGUtils().getWCAGContext().isWCAGEnabled();
-        // We always disable WCAG validation.
+        // We disable WCAG validation.
         // Here, the test `scrollable-region-focusable` fails while this is now a browser feature in Chrome.
         // The docker tests run on Chrome.
-        // See https://github.com/dequelabs/axe-core/issues/4788
+        // Once https://github.com/dequelabs/axe-core/issues/4788 is fixed, we might be able to remove this workaround.
         setup.getWCAGUtils().getWCAGContext().setWCAGEnabled(false);
         ViewPage viewPage = setup.gotoPage(new LocalDocumentReference("PDFExportIT", "CodeMacro"));
-        // We set back the WCAG validation in the state it was in before this BasePage initialization.
+        // We set back the WCAG validation in the state it was in before this BasePage instantiation.
         setup.getWCAGUtils().getWCAGContext().setWCAGEnabled(wcagEnabled);
         PDFExportOptionsModal exportOptions = PDFExportOptionsModal.open(viewPage);
 
@@ -1652,6 +1652,14 @@ class PDFExportIT
     @Order(34)
     void autoScaleTable(TestUtils setup) throws Exception
     {
+        boolean wcagEnabled = setup.getWCAGUtils().getWCAGContext().isWCAGEnabled();
+        // We disable WCAG validation.
+        // Here, the test `scrollable-region-focusable` fails while this is now a browser feature in Chrome.
+        // The docker tests run on Chrome.
+        // Once https://github.com/dequelabs/axe-core/issues/4788 is fixed, we might be able to remove this workaround.
+        setup.getWCAGUtils().getWCAGContext().setWCAGEnabled(false);
+        // We set back the WCAG validation in the state it was in before this BasePage instantiation.
+        setup.getWCAGUtils().getWCAGContext().setWCAGEnabled(wcagEnabled);
         ViewPage viewPage = setup.gotoPage(new LocalDocumentReference("PDFExportIT", "AutoScaleTable"));
         PDFExportOptionsModal exportOptions = PDFExportOptionsModal.open(viewPage);
 


### PR DESCRIPTION

# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-20909

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Removed the WCAG test for the failing page initialization.
* Added comments to explain why.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* See the jira ticket for details...
* In a few words, the solution to improve accessibility (without making things worst in other use cases) is both complex and costly in computing. It's IMO not worth the trouble at all, since the use case to hit this accessibility problem is very specific:
  * User tries to view a box with a long line inside. This happens typically when there's a code box.
  * User does not use a mouse.
  * User relies on the visual presentation to get information (no screen readers).
  * User accesses the page using Safari.

If ALL of those conditions are fulfilled, then the reported issue corresponds to an actual problem in the user experience.

* This is the last violation of the nature `scrollable-region-focusable` in the full set of WCAG tests done on XS. Once this PR is merged and its result can be confirmed on CI, we can update https://github.com/xwiki/xwiki-platform/blob/d701b8be6d5967a4482022f5e1795532d8a3e654/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/WCAGContext.java#L126 :)

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
None, test change only.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Unfortunately, the test completely failed if I didn't run previous tests before, so I could not use a precise pattern. I ran
`mvn clean install -f xwiki-platform-core/xwiki-platform-export/xwiki-platform-export-pdf/xwiki-platform-export-pdf-test/xwiki-platform-export-pdf-test-docker -Pdocker -Dxwiki.test.ui.wcag=true -Dit.test="PDFExportIT"` and it succeeded. Contrary to before the changes, there was no WCAGWarning found by the tests, only incompletes and passes (both are fine to keep in the build).



# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 17.4.X, 16.10.X , low scope test only changes.