### PR TITLE
XWIKI-21782: Incentivize use of header rows for the WYSIWYG editor tables

### DIFF
--- a/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/TableIT.java
+++ b/xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker/src/test/it/org/xwiki/ckeditor/test/ui/TableIT.java
@@ -84,6 +84,7 @@ class TableIT extends AbstractCKEditorIT
         textArea.sendKeys("three", Keys.BACK_SPACE);
 
         // Check the result.
-        assertSourceEquals("|(((\none\n\ntwo\n)))| \n|thre| \n| | \n| | \n\n ");
+        assertSourceEquals("|=(((\none\n\ntwo\n)))|= \n|=(% scope=\"col\" %) |= \n"
+            + "| | \n|thre| \n\n ");
     }
 }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-21782

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Updated the test to fit the new default for tables.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The new default tables added with CKEditor have a title row. The change in the result of adding a table via CKEditor spotted on CI makes sense in this context.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
None, test change only.
# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
I was able to reproduce the failure spotted on CI at https://ci.xwiki.org/job/XWiki%20Environment%20Tests/job/xwiki-platform/job/master/980/testReport/junit/org.xwiki.ckeditor.test.ui/AllIT$NestedTableIT/MariaDB_latest__Jetty_12_jdk21__Firefox___Docker_tests_for_xwiki_platform_ckeditor___Build_for_MariaDB_latest__Jetty_12_jdk21__Firefox___Docker_tests_for_xwiki_platform_ckeditor___backspaceAfterInsertRow_TestUtils__TestReference_/

After applying the changes proposed in this PR, this build for tests successfully:
`mvn clean install -f xwiki-platform-core/xwiki-platform-ckeditor/xwiki-platform-ckeditor-test/xwiki-platform-ckeditor-test-docker -Pdocker`

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, same as https://github.com/xwiki/xwiki-platform/pull/3310