### PR TITLE
XWIKI-23451: Configuration of CustomNotificationFilterPreferences livedata cannot be overridden

### DIFF
--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-api/src/main/java/org/xwiki/extension/security/internal/livedata/ExtensionSecurityLiveDataConfigurationResolver.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-security/xwiki-platform-extension-security-api/src/main/java/org/xwiki/extension/security/internal/livedata/ExtensionSecurityLiveDataConfigurationResolver.java
@@ -25,9 +25,8 @@ import javax.inject.Provider;
 import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
+import org.xwiki.livedata.AbstractLiveDataConfigurationResolver;
 import org.xwiki.livedata.LiveDataConfiguration;
-import org.xwiki.livedata.LiveDataConfigurationResolver;
-import org.xwiki.livedata.internal.JSONMerge;
 
 /**
  * Adds missing live data configuration values specific to the extension security source.
@@ -38,16 +37,15 @@ import org.xwiki.livedata.internal.JSONMerge;
 @Component
 @Singleton
 @Named(ExtensionSecurityLiveDataSource.ID)
-public class ExtensionSecurityLiveDataConfigurationResolver
-    implements LiveDataConfigurationResolver<LiveDataConfiguration>
+public class ExtensionSecurityLiveDataConfigurationResolver extends AbstractLiveDataConfigurationResolver
 {
     @Inject
     @Named(ExtensionSecurityLiveDataSource.ID)
     private Provider<LiveDataConfiguration> extensionSecurityLiveDataProvider;
 
     @Override
-    public LiveDataConfiguration resolve(LiveDataConfiguration input)
+    protected LiveDataConfiguration getDefaultConfiguration(LiveDataConfiguration input)
     {
-        return new JSONMerge().merge(input, this.extensionSecurityLiveDataProvider.get());
+        return this.extensionSecurityLiveDataProvider.get();
     }
 }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/AbstractLiveDataConfigurationResolver.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/AbstractLiveDataConfigurationResolver.java
@@ -29,7 +29,7 @@ import org.xwiki.stability.Unstable;
  *
  * @version $Id$
  * @since 17.7.0RC1
- * @since 17.4.3
+ * @since 17.4.4
  * @since 16.10.11
  */
 @Unstable

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/AbstractLiveDataConfigurationResolver.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/AbstractLiveDataConfigurationResolver.java
@@ -1,0 +1,61 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.livedata;
+
+import org.xwiki.livedata.internal.JSONMerge;
+import org.xwiki.stability.Unstable;
+
+/**
+ * Abstract implementation of {@link LiveDataConfigurationResolver} taking a {@link LiveDataConfiguration}.
+ * This implementation ensure to resolve the configuration by performing a merge with the given configuration,
+ * after first setting properly the identifier for having a proper merge.
+ *
+ * @version $Id$
+ * @since 17.7.0RC1
+ * @since 17.4.3
+ * @since 16.10.11
+ */
+@Unstable
+public abstract class AbstractLiveDataConfigurationResolver implements
+    LiveDataConfigurationResolver<LiveDataConfiguration>
+{
+    /**
+     * Used to merge the default configuration with the provided configuration.
+     */
+    protected JSONMerge jsonMerge = new JSONMerge();
+
+    /**
+     * Retrieve the default configuration to use for performing the merge.
+     * @param input the input if needed to get the default configuration.
+     * @return the configuration to use for performing the merge.
+     * @throws LiveDataException in case of problem to retrieve the configuration.
+     */
+    protected abstract LiveDataConfiguration getDefaultConfiguration(LiveDataConfiguration input)
+        throws LiveDataException;
+
+    @Override
+    public LiveDataConfiguration resolve(LiveDataConfiguration input) throws LiveDataException
+    {
+        LiveDataConfiguration defaultConfiguration = getDefaultConfiguration(input);
+        defaultConfiguration.setId(input.getId());
+
+        return this.jsonMerge.merge(defaultConfiguration, input);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/internal/JSONMerge.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/internal/JSONMerge.java
@@ -41,6 +41,9 @@ public class JSONMerge
 
     /**
      * Deep merge the given objects.
+     * Note that the right element always have priority over the left element in case of conflict when merging. Also
+     * the merge of object nodes happens only if both objects have an {@code id} key containing the same value. If
+     * it's not the case the object will be treated as simple elements without performing deep analysis.
      * 
      * @param objects the objects to merge
      * @param <T> the type of objects to merge

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/DefaultLiveDataConfigurationResolver.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/DefaultLiveDataConfigurationResolver.java
@@ -34,9 +34,9 @@ import javax.inject.Singleton;
 
 import org.apache.commons.lang3.StringUtils;
 import org.xwiki.component.annotation.Component;
+import org.xwiki.livedata.AbstractLiveDataConfigurationResolver;
 import org.xwiki.livedata.LiveDataActionDescriptor;
 import org.xwiki.livedata.LiveDataConfiguration;
-import org.xwiki.livedata.LiveDataConfigurationResolver;
 import org.xwiki.livedata.LiveDataException;
 import org.xwiki.livedata.LiveDataMeta;
 import org.xwiki.livedata.LiveDataPropertyDescriptor;
@@ -58,7 +58,7 @@ import org.xwiki.localization.ContextualLocalizationManager;
 @Component
 @Named("liveTable")
 @Singleton
-public class DefaultLiveDataConfigurationResolver implements LiveDataConfigurationResolver<LiveDataConfiguration>
+public class DefaultLiveDataConfigurationResolver extends AbstractLiveDataConfigurationResolver
 {
     /**
      * Used to translate the live data property names using the translation prefix specified by the live date source.
@@ -78,20 +78,13 @@ public class DefaultLiveDataConfigurationResolver implements LiveDataConfigurati
     @Named("liveTable")
     private Provider<LiveDataConfiguration> defaultConfigProvider;
 
-    /**
-     * Used to merge the default configuration with the provided configuration.
-     */
+
     private final JSONMerge jsonMerge = new JSONMerge();
 
     @Override
     public LiveDataConfiguration resolve(LiveDataConfiguration config) throws LiveDataException
     {
-        LiveDataConfiguration defaultConfig = getDefaultConfiguration(config);
-
-        // Make sure both configurations have the same id so that they are properly merged.
-        defaultConfig.setId(config.getId());
-
-        LiveDataConfiguration mergedConfig = this.jsonMerge.merge(defaultConfig, config);
+        LiveDataConfiguration mergedConfig = super.resolve(config);
 
         // We don't set the default sort on the default configuration (before the merge) because the sort is not easy to
         // merge automatically (the sort entry doesn't have an "id" property). We need to do the merge manually because
@@ -103,7 +96,8 @@ public class DefaultLiveDataConfigurationResolver implements LiveDataConfigurati
         return translate(mergedConfig, config);
     }
 
-    private LiveDataConfiguration getDefaultConfiguration(LiveDataConfiguration config) throws LiveDataException
+    @Override
+    protected LiveDataConfiguration getDefaultConfiguration(LiveDataConfiguration config) throws LiveDataException
     {
         LiveDataConfiguration defaultConfig = this.defaultConfigProvider.get();
 

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/DefaultLiveDataConfigurationResolver.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/DefaultLiveDataConfigurationResolver.java
@@ -45,7 +45,6 @@ import org.xwiki.livedata.LiveDataQuery;
 import org.xwiki.livedata.LiveDataQuery.SortEntry;
 import org.xwiki.livedata.LiveDataQuery.Source;
 import org.xwiki.livedata.WithParameters;
-import org.xwiki.livedata.internal.JSONMerge;
 import org.xwiki.localization.ContextualLocalizationManager;
 
 /**
@@ -77,9 +76,6 @@ public class DefaultLiveDataConfigurationResolver extends AbstractLiveDataConfig
     @Inject
     @Named("liveTable")
     private Provider<LiveDataConfiguration> defaultConfigProvider;
-
-
-    private final JSONMerge jsonMerge = new JSONMerge();
 
     @Override
     public LiveDataConfiguration resolve(LiveDataConfiguration config) throws LiveDataException

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersLiveDataConfigurationResolver.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersLiveDataConfigurationResolver.java
@@ -25,30 +25,27 @@ import javax.inject.Provider;
 import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
+import org.xwiki.livedata.AbstractLiveDataConfigurationResolver;
 import org.xwiki.livedata.LiveDataConfiguration;
-import org.xwiki.livedata.LiveDataConfigurationResolver;
-import org.xwiki.livedata.LiveDataException;
-import org.xwiki.livedata.internal.JSONMerge;
 
 /**
  * Needed component for the live data configuration.
  *
- * @since 16.3.0RC1
  * @version $Id$
+ * @since 16.3.0RC1
  */
 @Component
 @Singleton
 @Named(NotificationCustomFiltersLiveDataSource.NAME)
-public class NotificationCustomFiltersLiveDataConfigurationResolver implements
-    LiveDataConfigurationResolver<LiveDataConfiguration>
+public class NotificationCustomFiltersLiveDataConfigurationResolver extends AbstractLiveDataConfigurationResolver
 {
     @Inject
     @Named(NotificationCustomFiltersLiveDataSource.NAME)
     private Provider<LiveDataConfiguration> notificationFiltersLiveDataConfigurationProvider;
 
     @Override
-    public LiveDataConfiguration resolve(LiveDataConfiguration input) throws LiveDataException
+    protected LiveDataConfiguration getDefaultConfiguration(LiveDataConfiguration input)
     {
-        return new JSONMerge().merge(input, this.notificationFiltersLiveDataConfigurationProvider.get());
+        return this.notificationFiltersLiveDataConfigurationProvider.get();
     }
 }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/livedata/system/NotificationSystemFiltersLiveDataConfigurationResolver.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/livedata/system/NotificationSystemFiltersLiveDataConfigurationResolver.java
@@ -25,10 +25,8 @@ import javax.inject.Provider;
 import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
+import org.xwiki.livedata.AbstractLiveDataConfigurationResolver;
 import org.xwiki.livedata.LiveDataConfiguration;
-import org.xwiki.livedata.LiveDataConfigurationResolver;
-import org.xwiki.livedata.LiveDataException;
-import org.xwiki.livedata.internal.JSONMerge;
 
 /**
  * Needed component for the live data configuration.
@@ -39,16 +37,15 @@ import org.xwiki.livedata.internal.JSONMerge;
 @Component
 @Singleton
 @Named(NotificationSystemFiltersLiveDataSource.NAME)
-public class NotificationSystemFiltersLiveDataConfigurationResolver implements
-    LiveDataConfigurationResolver<LiveDataConfiguration>
+public class NotificationSystemFiltersLiveDataConfigurationResolver extends AbstractLiveDataConfigurationResolver
 {
     @Inject
     @Named(NotificationSystemFiltersLiveDataSource.NAME)
     private Provider<LiveDataConfiguration> notificationFiltersLiveDataConfigurationProvider;
 
     @Override
-    public LiveDataConfiguration resolve(LiveDataConfiguration input) throws LiveDataException
+    protected LiveDataConfiguration getDefaultConfiguration(LiveDataConfiguration input)
     {
-        return new JSONMerge().merge(input, this.notificationFiltersLiveDataConfigurationProvider.get());
+        return this.notificationFiltersLiveDataConfigurationProvider.get();
     }
 }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22130

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
  * Define a common abstraction for all LiveDataConfigurationResolvers that are using LiveDataConfiguration to ensure that the ID is properly set and that the merge is used in the right way
  * Use that new common abstraction in all existing resolvers

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

`mvn clean install -Pquality,integration-tests,docker` on `xwiki-platform-livedata`, `xwiki-platform-notifications`. Manual test performed to change the configuration of CustomNotificationFilterPreferences like illustrated in the ticket.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 16.10.x
  * 17.4.x
  * 17.7.x