### PR TITLE
XWIKI-20630: Improve usability of the "Change Password" page

### DIFF
--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-test/xwiki-platform-user-profile-test-docker/src/test/it/org/xwiki/user/test/ui/UserChangePasswordIT.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-test/xwiki-platform-user-profile-test-docker/src/test/it/org/xwiki/user/test/ui/UserChangePasswordIT.java
@@ -161,7 +161,7 @@ class UserChangePasswordIT
         ChangePasswordPage changePasswordPage = preferencesPage.changePassword();
         changePasswordPage.changePassword("badPassword", PASSWORD_1, PASSWORD_1);
         changePasswordPage = changePasswordPage.submit();
-        changePasswordPage.assertErrorMessage("Current password is invalid.");
+        changePasswordPage.assertErrorMessage("Error\nThe field \"Current password\" was incorrect.");
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-test/xwiki-platform-user-profile-test-pageobjects/src/main/java/org/xwiki/user/test/po/ChangePasswordPage.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-test/xwiki-platform-user-profile-test-pageobjects/src/main/java/org/xwiki/user/test/po/ChangePasswordPage.java
@@ -34,7 +34,7 @@ import org.xwiki.test.ui.po.BasePage;
  */
 public class ChangePasswordPage extends BasePage
 {
-    private static final String ERROR_MESSAGE_SELECTOR = "span.box.errormessage";
+    private static final String ERROR_MESSAGE_SELECTOR = "div.box.errormessage";
 
     private static final String VALIDATION_ERROR_MESSAGE_SELECTOR = "span.LV_validation_message.LV_invalid";
 


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-20630

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Fixed the pageobject and the docker test that was failing.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* This is a fix for https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/stable-17.7.x/3/testReport/org.xwiki.user.test.ui/AllIT$NestedUserChangePasswordIT/Platform_Builds___main___integration_tests___IT_for_xwiki_platform_core_xwiki_platform_user_xwiki_platform_user_profile_xwiki_platform_user_profile_test_xwiki_platform_user_profile_test_docker___Build_for_IT_for_xwiki_platform_core_xwiki_platform_user_xwiki_platform_user_profile_xwiki_platform_user_profile_test_xwiki_platform_user_profile_test_docker___changePasswordWithWrongOriginalPassword/


# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
None, test changes only

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Built the changes with:
* `mvn clean install -f xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-test/xwiki-platform-user-profile-test-pageobjects`

and ran successfully the test with:
* `mvn clean install -f xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-test/xwiki-platform-user-profile-test-docker`


# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, same as github.com/xwiki/xwiki-platform/pull/4188