### PR TITLE
XWIKI-18718: Additional unnecessary characters displayed in warning message when editing a subwiki descriptor from Administration

### DIFF
--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-common/src/main/resources/WikiManager/CommonTranslations.xml
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-common/src/main/resources/WikiManager/CommonTranslations.xml
@@ -40,7 +40,7 @@
 admin.wikis.descriptor=Descriptor
 admin.wikis.descriptor.description=Configure the wiki descriptor
 admin.wiki.description=Describe your wiki (pretty name and description) and set its owner and homepage.
-platform.wiki.admin.wiki.ownerProblemConfirmation=The new owner's user does not exist or it may come from a different wiki.\\nAre you sure you want to use it and continue with the save operation?
+platform.wiki.admin.wiki.ownerProblemConfirmation=The new owner's user does not exist or it may come from a different wiki.\nAre you sure you want to use it and continue with the save operation?
 platform.wiki.admin.wiki.csrfInvalidError=Invalid security (CSRF) token. Please refresh the page and try again.
 platform.wiki.admin.wiki.requiredFieldsError=The 'Homepage' field cannot be empty.
 platform.wiki.admin.wiki.ownerWarning=Warning: Once you change this, the previous owner will lose their owner rights. If that is you, make sure you do not lock yourself out of the wiki. If that happens by mistake, you will need to contact the main wiki's administrators or use the superadmin account.


### PR DESCRIPTION
# Jira URL

[XWIKI-18718](https://jira.xwiki.org/browse/XWIKI-18718)

# Changes

## Description

* remove extra slash

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<img width="2035" height="1650" alt="before translation fix" src="https://github.com/user-attachments/assets/cfe90f6f-666f-48a6-8e52-c704a53627d9" />

<img width="2029" height="1654" alt="after translation fix" src="https://github.com/user-attachments/assets/87afe072-d257-49f2-bab8-0eee38510cc7" />


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 