### PR TITLE
XWIKI-17011: Maximize link should be placed on the upper-right corner of a textarea

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/fullScreen.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/fullScreen.css
@@ -22,7 +22,7 @@
 
 /* Matches the style of the new object editor */
 #xwikiobjects .fullScreenEditLinkContainer, #xwikiclassproperties .fullScreenEditLinkContainer {
-  margin-right: 10%;
+  margin-right: 0;
 }
 
 .fullScreenWrapper .fullScreenEditLinkContainer {


### PR DESCRIPTION
# Jira URL

[XWIKI-17011](https://jira.xwiki.org/browse/XWIKI-17011)

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* reset to 0 `margin-right`

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

![with right margin](https://github.com/user-attachments/assets/8f098f16-bbf6-4ec8-8906-316f0ed8f8d6)

![zero right margin](https://github.com/user-attachments/assets/e5a59c4d-1384-4a6b-8e9c-1a371c00a850)


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Built with `mvn clean install xwiki-platform\xwiki-platform-core\xwiki-platform-web\xwiki-platform-web-war>` and tested manually with `fullScreen.css` and `fullScreen.min.css` on demo XWiki.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 