### PR TITLE
XWIKI-23463: Errors with DocumentTreeMacroIT with Mysql UTF-8

### DIFF
--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-docker/src/test/it/org/xwiki/index/test/ui/docker/DynamicTestConfigurationExtension.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-test/xwiki-platform-index-test-docker/src/test/it/org/xwiki/index/test/ui/docker/DynamicTestConfigurationExtension.java
@@ -22,7 +22,6 @@ package org.xwiki.index.test.ui.docker;
 import java.util.Objects;
 import java.util.Properties;
 
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.xwiki.test.docker.internal.junit5.DockerTestUtils;
@@ -40,7 +39,6 @@ public class DynamicTestConfigurationExtension implements BeforeAllCallback
     @Override
     public void beforeAll(ExtensionContext extensionContext)
     {
-
         // Get the already loaded configuration to get the used database engine.
         TestConfiguration loadedConfiguration = DockerTestUtils.getTestConfiguration(extensionContext);
 


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-23463

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Compute the right mysql collation when forcing it to german for test purpose

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
 - [x] initially failing case (lts mysql with utf8mb3) `mvn install -Dit.test=DocumentTreeMacroIT -Dxwiki.test.ui.database=mysql -Dxwiki.test.ui.databaseTag=lts -Dxwiki.test.ui.database.commands.character-set-server=utf8 -Dxwiki.test.ui.database.commands.collation-server=utf8_bin`
- [x] lts mysql with uf8mb4 `mvn install -Dit.test=DocumentTreeMacroIT -Dxwiki.test.ui.database=mysql -Dxwiki.test.ui.databaseTag=lts`
- [x] latest mysql with utf8mb4 `mvn install -Dit.test=DocumentTreeMacroIT -Dxwiki.test.ui.database=mysql -Dxwiki.test.ui.databaseTag=9.2`
- [x] latest mariadb with utf8mb4 `mvn install -Dit.test=DocumentTreeMacroIT -Dxwiki.test.ui.database=mariadb`

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-17.7.x