### PR TITLE
XWIKI-23100: When using the TOUR, page elements can be accessed by a mouse but not a keyboard

### DIFF
--- a/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui/src/main/resources/TourCode/TourJS.xml
+++ b/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui/src/main/resources/TourCode/TourJS.xml
@@ -607,21 +607,20 @@ require(['jquery', 'xwiki-meta'], function ($, xm) {
   right: 5px;
 }
 
-.popover[class*="tour-"] {
-  &amp;::before {
-    background: transparent;
-    position: fixed;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    content: "";
-  }
+#contentcontainer:has(.popover[class*="tour-"])::before {
+  background: transparent;
+  z-index: 1;
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  content: "";
+}
 
-  &amp; .popover-navigation:not(.row) {
-    padding-right: 0;
-    padding-left: 0;
-  }
+.popover[class*="tour-"] .popover-navigation:not(.row) {
+  padding-right: 0;
+  padding-left: 0;
 }
 </code>
     </property>

--- a/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui/src/main/resources/TourCode/TourJS.xml
+++ b/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui/src/main/resources/TourCode/TourJS.xml
@@ -607,9 +607,21 @@ require(['jquery', 'xwiki-meta'], function ($, xm) {
   right: 5px;
 }
 
-.popover[class*="tour-"] .popover-navigation:not(.row) {
-  padding-right: 0;
-  padding-left: 0;
+.popover[class*="tour-"] {
+  &amp;::before {
+    background: transparent;
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    content: "";
+  }
+
+  &amp; .popover-navigation:not(.row) {
+    padding-right: 0;
+    padding-left: 0;
+  }
 }
 </code>
     </property>

--- a/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui/src/main/resources/TourCode/TourJS.xml
+++ b/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui/src/main/resources/TourCode/TourJS.xml
@@ -609,7 +609,7 @@ require(['jquery', 'xwiki-meta'], function ($, xm) {
 
 #contentcontainer:has(.popover[class*="tour-"])::before {
   background: transparent;
-  z-index: 1;
+  z-index: 1101;
   position: fixed;
   top: 0;
   right: 0;


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-23100

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Used a pseudo element to "hide" everything that is not inside the tour popup.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Using pseudo elements is usually bad for accessibility. Here we use it purely for technical reasons, it does not convey any meaning but helps us align the mouse experience to the keyboard one.
* IMO it's alright to disable every other interaction for users in the tour. This could be considered a regression but I don't think many tours were made expecting the user to interact with one element. If that was the case, those tours would very much be not accessible because the keyboard only users could not get the focus out of the modal.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Here is a video demo of the changes in action:

https://github.com/user-attachments/assets/c9228979-f2f2-4c4c-a69f-5626caa605a1

We can see that the mouse user cannot interact with the highlighted elements anymore.

On this screenshot, I changed the color of the backdrop from completely transparent to a semi transparent red to highlight the areas that were "shadowed" by the cover:
<img width="2555" height="1107" alt="image" src="https://github.com/user-attachments/assets/d4c4d98d-15b3-4575-a956-d31dc8fbacc5" />

We can see that the whole modal is in front of the cover, while everything else is behind. This ensures that we catch all the click events.


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests, see above.
Built changes with `mvn clean install -f xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui -Pquality`
Then successfully passed the tests: `mvn clean install -f xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-test/xwiki-platform-tour-test-docker/`

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None