### PR TITLE
XWIKI-22996: The contentmenu list of buttons should be coded as a list

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_content.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/menus_content.vm
@@ -132,7 +132,7 @@
 ## Display the submenu modals next to the list. Note that those could be pretty much anywhere but in the ul for HTML
 ## correctness sake.
 #if ("$!notificationsWatchModal" != "")$notificationsWatchModal#end
-#exportModal()
+#if ("#exportModal()" != '#exportModal()')#exportModal()#end
 #end
 
 #**


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22996

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Fixed the case when the exportModal vm macro is not defined.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* A regression was introduced yesterday in https://github.com/xwiki/xwiki-platform/pull/4397/ : The export modal would be added to the DOM even if the macro didn't exist. In this case, velocity falls back by adding the macro name itself. When on non existing pages, the export feature is not available, the export modal macro is never loaded but the bar is still here.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Before the PR:
<img width="1991" height="547" alt="image" src="https://github.com/user-attachments/assets/183cc533-81a5-4576-86e1-70fb226569c5" />
After the PR:
<img width="1991" height="547" alt="image" src="https://github.com/user-attachments/assets/7078c1fb-ecdd-4ae4-9944-a0f08720771b" />


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests only. This regression was not caught by automated tests AFAIK, so it shouldn't have any impact on automated test to fix it.
# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, same as https://github.com/xwiki/xwiki-platform/pull/4397/