### PR TITLE
XWIKI-23413: Separators in navigation tree dropdown

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/LivedataDropdownMenu.vue
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar/src/main/vue/LivedataDropdownMenu.vue
@@ -172,12 +172,12 @@ export default {
 .livedata-dropdown-menu .dropdown-menu {
   /* Dividers within the dropdown with an improved semantic representation */
   li:has(> ul) + li:has(> ul) {
-    padding-top: calc(.5lh - 1px);
+    padding-top: ((@line-height-computed / 2) - 1);
     border-top: solid 1px @dropdown-divider-bg;
   }
 
   li:has(> ul):has(+ li > ul) {
-    margin-bottom: calc(.5lh - 1px);
+    margin-bottom: ((@line-height-computed / 2) - 1);
   }
 }
 


### PR DESCRIPTION

# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-23413

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Updated the variable used in the LESS style block
* Changed the calculation back to what it was in LESS. The "new" way did not work on 16.10.X because some changes did not get backported (probably ones related to CSS variables :) ).

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* There's a compilation error because I added a CSS variable use in a LESS compiled file. The Vue style blocks are native CSS in 17.X. I didn't notice back then that using a CSS variable on a 16.10 backport is wrong anyways. But here it makes the whole style compilation fail so it's very bad.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

I built the Livedata webjar and used it on my locale instance:
<img width="2545" height="715" alt="Screenshot from 2025-08-25 14-21-30" src="https://github.com/user-attachments/assets/8751f882-9556-4fd8-b6a7-233b0aa3346d" />

On the screenshot, we can see that unlike the 16.10.X tests (and what I got when starting my fresh 16.10.10-SNAPSHOT instance), the livedata has appropriate styles.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

I built the changes successfully with `mvn clean install -f xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-webjar -Pquality`
then tested with ` mvn clean install -f xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/ -Dit.test="LiveDataIT#livedataLivetableTableLayout"`. The test passed. Before the changes, I could reproduce the fail found on CI.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, apply only on 16.10.X

/!\ On merge, the commit message might use the wrong ticket reference, since my commits on the branch from which I'm proposing the PR have wrong descriptions.