### PR TITLE
XWIKI-22602: Provide a UI to easily customize the logo alternative text from the colorTheme

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/companylogo.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/companylogo.vm
@@ -30,7 +30,9 @@
 #set($themeObj = $themeDoc.getObject('FlamingoThemesCode.ThemeClass'))
 #if($themeObj)
   #set($logoname = $themeObj.getValue('logo'))
+  #set($logoalt = $themeObj.getValue('logo-description'))
 #else
+  ## Retrieve the value from the old color theme used.
   #set($themeObj = $themeDoc.getObject('ColorThemes.ColorThemeClass'))
   #set($logoname = $themeObj.getValue('logoImage'))
 #end
@@ -45,12 +47,15 @@
     #set($logourl = $prefdoc.getAttachmentURL($logo.filename))
   #end
 #end
+#if("$!{logoalt}" == '')
+  #set($logoalt = $services.localization.render('core.document.header.logo.image.text'))
+#end
 <div id="companylogo">
   <a href="$!xwiki.getURL($services.wiki.currentWikiDescriptor.mainPageReference)" rel="home" ##
     title="$escapetool.xml($services.localization.render('core.document.header.logo.anchor.text'))" ##
     #if(!$displayPageHeader)class="navbar-brand"#end>##
     <span class="sr-only">$services.localization.render('core.document.header.logo.anchor.text')</span>
     <img src="$!logourl" ##
-      alt="$escapetool.xml($services.localization.render('core.document.header.logo.image.text'))"/>##
+      alt="$escapetool.xml($logoalt)"/>##
   </a>
 </div>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/ThemeClass.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/ThemeClass.xml
@@ -644,6 +644,19 @@
       <validationRegExp/>
       <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
     </logo>
+    <logo-description>
+      <customDisplay/>
+      <disabled>0</disabled>
+      <name>logo-description</name>
+      <number>64</number>
+      <picker>0</picker>
+      <prettyName>logo description</prettyName>
+      <size>100</size>
+      <unmodifiable>0</unmodifiable>
+      <validationMessage/>
+      <validationRegExp/>
+      <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+    </logo-description>
     <navbar-default-bg>
       <customDisplay/>
       <disabled>0</disabled>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/ThemeClass.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/ThemeClass.xml
@@ -648,7 +648,7 @@
       <customDisplay/>
       <disabled>0</disabled>
       <name>logo-description</name>
-      <number>64</number>
+      <number>63</number>
       <picker>0</picker>
       <prettyName>logo-description</prettyName>
       <size>100</size>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/ThemeClass.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/ThemeClass.xml
@@ -650,7 +650,7 @@
       <name>logo-description</name>
       <number>64</number>
       <picker>0</picker>
-      <prettyName>logo description</prettyName>
+      <prettyName>logo-description</prettyName>
       <size>100</size>
       <unmodifiable>0</unmodifiable>
       <validationMessage/>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/ThemeSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/ThemeSheet.xml
@@ -52,7 +52,8 @@
 ############################
 #set($variables = {
   "logos": {
-    "logo": "image"
+    "logo": "image",
+    "logo-description": "text"
   },
   "base-colors": {
     "text-color": "color",

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/ThemeSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/ThemeSheet.xml
@@ -758,7 +758,7 @@ require(['jquery', 'xwiki-l10n!xwiki-flamingo-theme-messages', 'bootstrap'], fun
 
 /* When reworking the DOM of this form, use the standard vertical form structure to avoid hard-coding styles like 
 this. */
-.xHint {
+#panel-theme-variables .xHint {
   color: $theme.textSecondaryColor;
   font-size: smaller;
   margin: 0.3em 0;

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/ThemeSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/ThemeSheet.xml
@@ -756,6 +756,8 @@ require(['jquery', 'xwiki-l10n!xwiki-flamingo-theme-messages', 'bootstrap'], fun
   height: 400px;
 }
 
+/* When reworking the DOM of this form, use the standard vertical form structure to avoid hard-coding styles like 
+this. */
 .xHint {
   color: $theme.textSecondaryColor;
   font-size: smaller;

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/ThemeSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/ThemeSheet.xml
@@ -236,8 +236,16 @@
       #foreach($var in $catVar.keySet())
         #set($varName = $var)
         #set($varType = $catVar.get($varName))
+        #set($hintKey = "${obj.xWikiClass.name}_${varName}.hint")
+        #set($hint = $services.localization.render($hintKey))
+        #if($hint == $hintKey)
+          #set($hint = $NULL)
+        #end
         &lt;div class="form-group"&gt;
           &lt;label for="var-$varName" class="col-xs-12"&gt;@$varName&lt;/label&gt;
+          #if ($hint)
+            &lt;span class="col-xs-12 xHint"&gt;$escapetool.xml($hint)&lt;/span&gt;
+          #end
           &lt;div class="col-xs-12"&gt;
             #if($varType == 'image')
               #fieldImage($varName, $obj)
@@ -746,6 +754,12 @@ require(['jquery', 'xwiki-l10n!xwiki-flamingo-theme-messages', 'bootstrap'], fun
 
 #iframe {
   height: 400px;
+}
+
+.xHint {
+  color: $theme.textSecondaryColor;
+  font-size: smaller;
+  margin: 0.3em 0;
 }</code>
     </property>
     <property>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/Translations.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/Translations.xml
@@ -108,6 +108,7 @@ platform.flamingo.themes.defaultvalue=Default
 platform.flamingo.themes.lessCode.description=In this field, you can directly write LESS code which will be added into the skin.
 platform.flamingo.themes.local=Local
 platform.flamingo.themes.global=Global
+FlamingoThemesCode.ThemeClass_logo-description.hint=Alternative text to the logo. It should describe the logo's meaning. Default: "Logo of the wiki"
 
 ###############################################################################
 ## Deprecated

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/Translations.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/Translations.xml
@@ -108,7 +108,7 @@ platform.flamingo.themes.defaultvalue=Default
 platform.flamingo.themes.lessCode.description=In this field, you can directly write LESS code which will be added into the skin.
 platform.flamingo.themes.local=Local
 platform.flamingo.themes.global=Global
-FlamingoThemesCode.ThemeClass_logo-description.hint=Alternative text to the logo. It should describe the logo's meaning. Default: "Logo of the wiki"
+FlamingoThemesCode.ThemeClass_logo-description.hint=Alternative text for the logo. It should describe the logo's meaning. The localized value associated to the key `core.document.header.logo.image.text` is used by default.
 
 ###############################################################################
 ## Deprecated

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/Translations.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/Translations.xml
@@ -108,7 +108,7 @@ platform.flamingo.themes.defaultvalue=Default
 platform.flamingo.themes.lessCode.description=In this field, you can directly write LESS code which will be added into the skin.
 platform.flamingo.themes.local=Local
 platform.flamingo.themes.global=Global
-FlamingoThemesCode.ThemeClass_logo-description.hint=Alternative text for the logo. It should describe the logo's meaning. The localized value associated to the key `core.document.header.logo.image.text` is used by default.
+FlamingoThemesCode.ThemeClass_logo-description.hint=Alternative text for the logo. It should describe the logo's meaning. The localized value associated to the key "core.document.header.logo.image.text" is used by default.
 
 ###############################################################################
 ## Deprecated


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22602

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Updated the flamingo theme class to add a text alternative
* Updated the theme editor
* Used the new variable in the template (default is the value used previously)

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Note that AFAIK this has no impact for sighted users. When hovering the picture, since it's part of the anchor with a title, the title of the anchor is shown ("Home"). However it's useful information for screen reader users and any assistive tech users :)
* I just took the first unused number for the `logo-description` field of the theme class. This means that in the class editor it's far from the `logo` field, but since this class has a custom editor it doesn't matter much. I'd rather do that than increment the numbers of all the fields after `logo`...

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Here is a view of the generated DOM with the changes applied and the value `Organization Name` set as the logo description:
<img width="2555" height="1323" alt="image" src="https://github.com/user-attachments/assets/bd1803af-2479-4b4a-8c00-8f53c3e64cce" />

We can see that the tooltip on hover just displays "Home", but the image has the proper text alternative.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Built changes successfully with `mvn clean install -f xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources -Pquality` and `mvn clean install -f xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui -Pquality`
Tested the change on my local instance, it worked as expected (see above).

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, this is a change to a pretty sensitive class.