### PR TITLE
XWIKI-15166: SOLR reindexation job cause serious perfomance issues on large database

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/job/AbstractDocumentIterator.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/job/AbstractDocumentIterator.java
@@ -45,15 +45,15 @@ public abstract class AbstractDocumentIterator<T> implements DocumentIterator<T>
      */
     public static class DocumentIteratorEntry
     {
-        private final WikiReference reference;
+        private final WikiReference wiki;
 
         private final long docId;
 
         private final String version;
 
-        protected DocumentIteratorEntry(WikiReference reference, long docId, String version)
+        protected DocumentIteratorEntry(WikiReference wiki, long docId, String version)
         {
-            this.reference = reference;
+            this.wiki = wiki;
             this.docId = docId;
             this.version = version;
         }
@@ -63,7 +63,7 @@ public abstract class AbstractDocumentIterator<T> implements DocumentIterator<T>
          */
         public WikiReference getWiki()
         {
-            return reference;
+            return wiki;
         }
 
         /**

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/job/AbstractDocumentIterator.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/job/AbstractDocumentIterator.java
@@ -21,8 +21,12 @@ package org.xwiki.search.solr.internal.job;
 
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.xwiki.model.reference.EntityReference;
+import org.xwiki.model.reference.WikiReference;
 import org.xwiki.search.solr.internal.api.SolrConfiguration;
+import org.xwiki.text.XWikiToStringBuilder;
 
 /**
  * Base class for {@link DocumentIterator}s.
@@ -33,6 +37,96 @@ import org.xwiki.search.solr.internal.api.SolrConfiguration;
  */
 public abstract class AbstractDocumentIterator<T> implements DocumentIterator<T>
 {
+    /**
+     * A document related entry.
+     * 
+     * @version $Id$
+     * @since 17.8.0RC1
+     */
+    public static class DocumentIteratorEntry
+    {
+        private final WikiReference reference;
+
+        private final long docId;
+
+        private final String version;
+
+        protected DocumentIteratorEntry(WikiReference reference, long docId, String version)
+        {
+            this.reference = reference;
+            this.docId = docId;
+            this.version = version;
+        }
+
+        /**
+         * @return the reference
+         */
+        public WikiReference getWiki()
+        {
+            return reference;
+        }
+
+        /**
+         * @return the docId
+         */
+        public long getDocId()
+        {
+            return docId;
+        }
+
+        /**
+         * @return the version
+         */
+        public String getVersion()
+        {
+            return version;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            HashCodeBuilder builder = new HashCodeBuilder();
+
+            builder.append(getWiki());
+            builder.append(getDocId());
+            builder.append(getVersion());
+
+            return builder.build();
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (obj instanceof DocumentIteratorEntry otherEntry) {
+                if (obj == this) {
+                    return true;
+                }
+
+                EqualsBuilder builder = new EqualsBuilder();
+
+                builder.append(getWiki(), otherEntry.getWiki());
+                builder.append(getDocId(), otherEntry.getDocId());
+                builder.append(getVersion(), otherEntry.getVersion());
+
+                return builder.build();
+            }
+
+            return false;
+        }
+
+        @Override
+        public String toString()
+        {
+            XWikiToStringBuilder builder = new XWikiToStringBuilder(this);
+
+            builder.append("wiki", getWiki());
+            builder.append("docId", getDocId());
+            builder.append("version", getVersion());
+
+            return builder.build();
+        }
+    }
+
     /**
      * Specifies the root entity whose documents are iterated. If {@code null} then all the documents are iterated.
      */

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/job/IndexerJob.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/job/IndexerJob.java
@@ -42,6 +42,7 @@ import org.xwiki.search.solr.internal.api.FieldUtils;
 import org.xwiki.search.solr.internal.api.SolrIndexer;
 import org.xwiki.search.solr.internal.api.SolrIndexerException;
 import org.xwiki.search.solr.internal.api.SolrInstance;
+import org.xwiki.search.solr.internal.job.AbstractDocumentIterator.DocumentIteratorEntry;
 import org.xwiki.search.solr.internal.job.DiffDocumentIterator.Action;
 import org.xwiki.search.solr.internal.reference.SolrReferenceResolver;
 
@@ -74,11 +75,11 @@ public class IndexerJob extends AbstractJob<IndexerRequest, DefaultJobStatus<Ind
 
     @Inject
     @Named("database")
-    private transient DocumentIterator<String> databaseIterator;
+    private transient DocumentIterator<DocumentIteratorEntry> databaseIterator;
 
     @Inject
     @Named("solr")
-    private transient DocumentIterator<String> solrIterator;
+    private transient DocumentIterator<DocumentIteratorEntry> solrIterator;
 
     @Inject
     private EntityReferenceSerializer<String> entityReferenceSerializer;
@@ -125,7 +126,7 @@ public class IndexerJob extends AbstractJob<IndexerRequest, DefaultJobStatus<Ind
      */
     private void updateSolrIndex() throws Exception
     {
-        DiffDocumentIterator<String> iterator = new DiffDocumentIterator<>(this.solrIterator, this.databaseIterator);
+        DiffDocumentIterator iterator = new DiffDocumentIterator(this.solrIterator, this.databaseIterator);
         iterator.setRootReference(getRequest().getRootReference());
 
         this.progressManager.pushLevelProgress(2, this);
@@ -147,7 +148,7 @@ public class IndexerJob extends AbstractJob<IndexerRequest, DefaultJobStatus<Ind
         }
     }
 
-    private void updateSolrIndex(int progressSize, DiffDocumentIterator<String> iterator) throws Exception
+    private void updateSolrIndex(int progressSize, DiffDocumentIterator iterator) throws Exception
     {
         this.progressManager.pushLevelProgress(progressSize, this);
 

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/job/SolrDocumentIterator.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/job/SolrDocumentIterator.java
@@ -149,7 +149,7 @@ public class SolrDocumentIterator extends AbstractDocumentIterator<DocumentItera
         if (query == null) {
             query = new SolrQuery(solrReferenceResolver.getQuery(rootReference));
             query.setFields(FieldUtils.WIKI, FieldUtils.SPACES, FieldUtils.NAME, FieldUtils.DOCUMENT_LOCALE,
-                FieldUtils.VERSION);
+                FieldUtils.VERSION, FieldUtils.DOC_ID);
             query.addFilterQuery(FieldUtils.TYPE + ':' + EntityType.DOCUMENT.name());
             // Make sure to skip invalid documents, they will be re-indexed
             query.addFilterQuery(FieldUtils.WIKI + ':' + SOLR_ANYVALUE);

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/job/SolrDocumentIterator.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/job/SolrDocumentIterator.java
@@ -42,6 +42,7 @@ import org.xwiki.model.reference.DocumentReferenceResolver;
 import org.xwiki.search.solr.internal.api.FieldUtils;
 import org.xwiki.search.solr.internal.api.SolrIndexerException;
 import org.xwiki.search.solr.internal.api.SolrInstance;
+import org.xwiki.search.solr.internal.job.AbstractDocumentIterator.DocumentIteratorEntry;
 import org.xwiki.search.solr.internal.reference.SolrReferenceResolver;
 
 /**
@@ -53,7 +54,7 @@ import org.xwiki.search.solr.internal.reference.SolrReferenceResolver;
 @Component
 @InstantiationStrategy(ComponentInstantiationStrategy.PER_LOOKUP)
 @Named("solr")
-public class SolrDocumentIterator extends AbstractDocumentIterator<String>
+public class SolrDocumentIterator extends AbstractDocumentIterator<DocumentIteratorEntry>
 {
     private static final String SOLR_ANYVALUE = "[* TO *]";
 
@@ -94,12 +95,16 @@ public class SolrDocumentIterator extends AbstractDocumentIterator<String>
     }
 
     @Override
-    public Pair<DocumentReference, String> next()
+    public Pair<DocumentReference, DocumentIteratorEntry> next()
     {
-        SolrDocument result = getResults().get(index++);
+        SolrDocument result = getResults().get(this.index++);
+
         DocumentReference documentReference = this.solrDocumentReferenceResolver.resolve(result);
+        long docId = (long) result.getFieldValue(FieldUtils.DOC_ID);
         String version = (String) result.get(FieldUtils.VERSION);
-        return new ImmutablePair<DocumentReference, String>(documentReference, version);
+
+        return new ImmutablePair<>(documentReference,
+            new DocumentIteratorEntry(documentReference.getWikiReference(), docId, version));
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/test/java/org/xwiki/search/solr/internal/job/DatabaseDocumentIteratorTest.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/test/java/org/xwiki/search/solr/internal/job/DatabaseDocumentIteratorTest.java
@@ -43,6 +43,7 @@ import org.xwiki.query.QueryException;
 import org.xwiki.query.QueryFilter;
 import org.xwiki.query.QueryManager;
 import org.xwiki.search.solr.internal.api.SolrConfiguration;
+import org.xwiki.search.solr.internal.job.AbstractDocumentIterator.DocumentIteratorEntry;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
@@ -92,6 +93,14 @@ class DatabaseDocumentIteratorTest
     @InjectMockComponents
     private DatabaseDocumentIterator databaseIterator;
 
+
+    private ImmutablePair<DocumentReference, DocumentIteratorEntry> entry(DocumentReference reference, long docId,
+        String version)
+    {
+        return new ImmutablePair<DocumentReference, DocumentIteratorEntry>(reference,
+            new DocumentIteratorEntry(reference.getWikiReference(), docId, version));
+    }
+
     @BeforeEach
     void configure() throws Exception
     {
@@ -119,8 +128,8 @@ class DatabaseDocumentIteratorTest
         Query chessQuery = mock(Query.class);
         when(chessQuery.setOffset(0)).thenReturn(chessQuery);
         when(chessQuery.setOffset(batchSize)).thenReturn(emptyQuery);
-        when(chessQuery.execute()).thenReturn(Arrays.asList(new Object[] { "Blog.Code", "WebHome", "", "3.2" },
-            new Object[] { "Main", "Welcome", "en", "1.1" }, new Object[] { "XWiki.Syntax", "Links", "fr", "2.5" }));
+        when(chessQuery.execute()).thenReturn(Arrays.asList(new Object[] { "Blog.Code", "WebHome", "", "3.2", 1L },
+            new Object[] { "Main", "Welcome", "en", "1.1", 2L }, new Object[] { "XWiki.Syntax", "Links", "fr", "2.5", 3L }));
 
         DocumentReference chessBlogCodeWebHome =
             createDocumentReference("chess", Arrays.asList("Blog", "Code"), "WebHome", null);
@@ -132,8 +141,8 @@ class DatabaseDocumentIteratorTest
         Query tennisQuery = mock(Query.class);
         when(tennisQuery.setOffset(0)).thenReturn(tennisQuery);
         when(tennisQuery.setOffset(batchSize)).thenReturn(emptyQuery);
-        when(tennisQuery.execute()).thenReturn(Arrays.asList(new Object[] { "Main", "Welcome", "en", "2.1" },
-            new Object[] { "XWiki.Syntax", "Links", "fr", "1.3" }));
+        when(tennisQuery.execute()).thenReturn(Arrays.asList(new Object[] { "Main", "Welcome", "en", "2.1", 1L },
+            new Object[] { "XWiki.Syntax", "Links", "fr", "1.3", 2L }));
 
         DocumentReference tennisMainWelcome =
             createDocumentReference("tennis", Arrays.asList("Main"), "Welcome", Locale.ENGLISH);
@@ -162,21 +171,21 @@ class DatabaseDocumentIteratorTest
             Query.HQL)).thenReturn(query);
         when(this.queryManager.createQuery("", Query.HQL)).thenReturn(countQuery);
 
-        DocumentIterator<String> iterator = this.databaseIterator;
+        DocumentIterator<DocumentIteratorEntry> iterator = this.databaseIterator;
 
         assertEquals(5L, iterator.size());
 
-        List<Pair<DocumentReference, String>> actualResults = new ArrayList<>();
+        List<Pair<DocumentReference, DocumentIteratorEntry>> actualResults = new ArrayList<>();
         while (iterator.hasNext()) {
             actualResults.add(iterator.next());
         }
 
-        List<Pair<DocumentReference, String>> expectedResults = new ArrayList<>();
-        expectedResults.add(new ImmutablePair<>(chessBlogCodeWebHome, "3.2"));
-        expectedResults.add(new ImmutablePair<>(chessMainWelcome, "1.1"));
-        expectedResults.add(new ImmutablePair<>(chessXWikiSyntaxLinks, "2.5"));
-        expectedResults.add(new ImmutablePair<>(tennisMainWelcome, "2.1"));
-        expectedResults.add(new ImmutablePair<>(tennisXWikiSyntaxLinks, "1.3"));
+        List<Pair<DocumentReference, DocumentIteratorEntry>> expectedResults = new ArrayList<>();
+        expectedResults.add(entry(chessBlogCodeWebHome, 1, "3.2"));
+        expectedResults.add(entry(chessMainWelcome, 2, "1.1"));
+        expectedResults.add(entry(chessXWikiSyntaxLinks, 3, "2.5"));
+        expectedResults.add(entry(tennisMainWelcome, 1, "2.1"));
+        expectedResults.add(entry(tennisXWikiSyntaxLinks, 2, "1.3"));
 
         assertEquals(expectedResults, actualResults);
     }
@@ -196,9 +205,9 @@ class DatabaseDocumentIteratorTest
         when(query.setWiki(rootReference.getWikiReference().getName())).thenReturn(query);
         when(query.setOffset(0)).thenReturn(query);
         when(query.setOffset(batchSize)).thenReturn(emptyQuery);
-        when(query.execute()).thenReturn(Collections.singletonList(new Object[] { "A.B", "C", "de", "3.1" }));
+        when(query.execute()).thenReturn(Collections.singletonList(new Object[] { "A.B", "C", "de", "3.1", 1L }));
 
-        Map<String, Object> namedParameters = new HashMap();
+        Map<String, Object> namedParameters = new HashMap<>();
         namedParameters.put("space", "A.B");
         namedParameters.put("name", "C");
         when(query.getNamedParameters()).thenReturn(namedParameters);
@@ -212,16 +221,16 @@ class DatabaseDocumentIteratorTest
                 + whereClause + ORDER_CLAUSE, Query.HQL)).thenReturn(query);
         when(this.queryManager.createQuery(whereClause, Query.HQL)).thenReturn(countQuery);
 
-        DocumentIterator<String> iterator = this.databaseIterator;
+        DocumentIterator<DocumentIteratorEntry> iterator = this.databaseIterator;
         iterator.setRootReference(rootReference);
 
-        List<Pair<DocumentReference, String>> actualResults = new ArrayList<>();
+        List<Pair<DocumentReference, DocumentIteratorEntry>> actualResults = new ArrayList<>();
         while (iterator.hasNext()) {
             actualResults.add(iterator.next());
         }
 
-        List<Pair<DocumentReference, String>> expectedResults = new ArrayList<>();
-        expectedResults.add(new ImmutablePair<>(new DocumentReference(rootReference, Locale.GERMAN), "3.1"));
+        List<Pair<DocumentReference, DocumentIteratorEntry>> expectedResults = new ArrayList<>();
+        expectedResults.add(entry(new DocumentReference(rootReference, Locale.GERMAN), 1, "3.1"));
 
         assertEquals(expectedResults, actualResults);
 

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-test/xwiki-platform-search-test-docker/src/test/it/org/xwiki/search/test/ui/SolrIndexerIT.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-test/xwiki-platform-search-test-docker/src/test/it/org/xwiki/search/test/ui/SolrIndexerIT.java
@@ -66,12 +66,13 @@ class SolrIndexerIT
         import org.xwiki.search.solr.internal.job.DiffDocumentIterator
         import org.xwiki.search.solr.internal.job.DocumentIterator
         import org.xwiki.velocity.tools.JSONTool
-        
+        import org.xwiki.search.solr.internal.job.AbstractDocumentIterator.DocumentIteratorEntry;
+
         if (xcontext.action == "get") {
             ParameterizedType documentIterator =
-                new DefaultParameterizedType(null, DocumentIterator.class, String.class)
-            DocumentIterator<String> databaseIterator = services.component.getInstance(documentIterator, "database")
-            DocumentIterator<String> solrIterator = services.component.getInstance(documentIterator, "solr")
+                new DefaultParameterizedType(null, DocumentIterator.class, DocumentIteratorEntry.class)
+            DocumentIterator<DocumentIteratorEntry> databaseIterator = services.component.getInstance(documentIterator, "database")
+            DocumentIterator<DocumentIteratorEntry> solrIterator = services.component.getInstance(documentIterator, "solr")
         
             // Store both iterators converted to list for the output.
             def outputData = [
@@ -106,8 +107,8 @@ class SolrIndexerIT
             while (iterator.hasNext()) {
                 def pair = iterator.next()
                 int comparison = -1
-                if (previous != null) {
-                    comparison = comparator.compare(previous.getLeft(), pair.getLeft())
+                if (previous != null && previous.getRight() instanceof DocumentIteratorEntry) {
+                    comparison = comparator.compare(previous.getRight(), pair.getRight())
                 }
                 previous = pair
                 list.add([pair.getLeft().toString(), pair.getRight().toString(), String.valueOf(comparison)])


### PR DESCRIPTION
@michitux noticed a problem in how the ordering of missing entries was handled in the diff iterator from https://github.com/xwiki/xwiki-platform/pull/4298, so here is an attempt to fix that

# Jira URL

https://jira.xwiki.org/browse/XWIKI-15166

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

Since we need the docId to properly compare entries, I had to change what the iterators expose to also provide the docId. 
## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

`DocumentIteratorEntry#wiki`:
I could have used the wiki reference from the DocumentReference, but I wanted to be able to sort with only the DocumentIteratorEntry to make the code simpler. 

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Mainly updated already existing tests.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches: no backport