### PR TITLE
XWIKI-23516: Notification watch status cannot be retrieved in Tag tests

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsWatchUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsWatchUIX.xml
@@ -501,7 +501,16 @@
 #if (!$isGuest)
 #set($discard = $xwiki.ssx.use('XWiki.Notifications.Code.NotificationsWatchUIX'))
 #set($discard = $xwiki.jsx.use('XWiki.Notifications.Code.NotificationsWatchUIX'))
+#try()
 #set ($watchedStatus = $services.notification.watch.getLocationWatchedStatus($doc))
+#end
+#if ("$!exception" != '')
+{{html clean='false'}}
+&lt;li&gt;
+  #displayException('Could not get the watched status', $exception)
+&lt;/li&gt;
+{{/html}}
+#else
 ## If the watched status informs that the filter is about children it means it's a filter for the space,
 ## so we should look for ancestor of the space.
 #set ($refForAncestorFirstFilter = $doc.getDocumentReference())
@@ -686,6 +695,7 @@
     &lt;/div&gt;&lt;!-- /.modal-dialog --&gt;
   &lt;/div&gt;&lt;!-- /.modal --&gt;
   #end
+#end
 #end
 {{/velocity}}</content>
     </property>


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-23516

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added a try clause around the failing call.

## Clarification
* This does not fix the root issue that the Notification related Component is missing in the Tag tests, but it makes it so that it does not break WCAG validation anymore. I have no clue why this notification component `DefaultNotificationFilterPreference` is missing only in this specific test suite. AFAIK this is an issue that only impacts our tests and we did not get user feedback about any incompatibility between the tag extension and the `DefaultNotificationFilterPreference` component.
 
<img width="2555" height="519" alt="image" src="https://github.com/user-attachments/assets/a5bbd2b9-16da-4814-8676-6250c6086615" />

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Built the changes with 
* `mvn clean install -f xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui`
* `mvn clean install -f xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-webjar`

Then I ran the tests failing on CI with:
`mvn clean install -f xwiki-platform-core/xwiki-platform-tag/xwiki-platform-tag-test/xwiki-platform-tag-test-docker/ -Dxwiki.test.ui.wcag=true`
I was first able to reproduce the results found on CI, but the tests passed without any WCAG warning after the changes from this PR were applied. 

Note that it was a hassle to debug. The instance created during the Tag dockertests was not reusable (fails when trying to restart it after the tests). The WCAG tests themselves did not output what was interesting, which is the content of the generated block. My solution was to connect to the instance during the tests and try to reproduce the test conditions before the tests ended so that I could get the content of the error message.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, XWIKI-22996 which is the cause for this validation fail is only on 17.7.0