### PR TITLE
XWIKI-11250: FlamingoThemes space doesn't display any panels

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemes/WebPreferences.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemes/WebPreferences.xml
@@ -1333,10 +1333,10 @@
       <rightPanelsWidth>---</rightPanelsWidth>
     </property>
     <property>
-      <showLeftPanels>0</showLeftPanels>
+      <showLeftPanels/>
     </property>
     <property>
-      <showRightPanels>0</showRightPanels>
+      <showRightPanels/>
     </property>
     <property>
       <showannotations/>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/ThemeSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/main/resources/FlamingoThemesCode/ThemeSheet.xml
@@ -322,6 +322,10 @@
 &lt;div class="row"&gt;
   #if($isEdit)
     #displayVariablesPanel()
+    ## Always hide both side panel columns
+    #set($showLeftPanels = "0")
+    #set($showRightPanels = "0")
+    &lt;script&gt;document.getElementById("body").classList.add("hidelefthideright");&lt;/script&gt;
   #else
     #displayHiddenVariables()
   #end


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-11250

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Removed the special Preferences regarding panels in the colortheme section
* Added a few lines to disable the panels specifically when there's the preview in edit mode.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The body class is updated via javascript because the velocity variable is used on that body element before reaching the place where we update it depending on the viewmode in the content. For 

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

Here are what the colortheme pages look like after applying the changes:
<img width="2555" height="1361" alt="Screenshot from 2025-09-11 16-28-04" src="https://github.com/user-attachments/assets/f596fb0b-609b-4fff-b8ae-89ab0223df2a" />
<img width="2555" height="1361" alt="Screenshot from 2025-09-11 16-27-52" src="https://github.com/user-attachments/assets/91a1343a-748c-4199-abcf-cbecb594f37d" />
<img width="2555" height="1361" alt="Screenshot from 2025-09-11 16-27-21" src="https://github.com/user-attachments/assets/0fecf7b9-496d-446b-898b-5474e817142a" />


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Built the changes with `mvn clean install -f xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui -Pquality` and then tested them with `mvn clean install -f xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-test/xwiki-platform-flamingo-theme-test-docker`

Tested the changes locally.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None