### PR TITLE
XWIKI-23529: Translated pages sometimes aren't indexed during extension installation

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/SolrIndexEventListener.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/SolrIndexEventListener.java
@@ -121,14 +121,14 @@ public class SolrIndexEventListener implements EventListener
             } else if (event instanceof DocumentCreatedEvent) {
                 XWikiDocument document = (XWikiDocument) source;
 
-                if (!Locale.ROOT.equals(document.getLocale())) {
-                    // If a new translation is added to a document reindex the whole document (could be optimized a bit
-                    // by reindexing only the parent locales but that would always include objects and attachments
-                    // anyway)
-                    indexTranslations(document, (XWikiContext) data);
-                } else {
-                    this.solrIndexer.get().index(document.getDocumentReferenceWithLocale(), false);
-                }
+                // Always re-index all the translations of a document when a document is created.
+                // If a new translation is added to a document, we need to re-index the parent locales. This could be
+                // optimized a bit by reindexing only the parent locales, but that would always include objects and
+                // attachments anyway.
+                // When the default translation is created, then there could also be existing translations that need
+                // to be re-indexed as indexing operations before that failed due to the missing default translation.
+                // This second case can happen during extension installations.
+                indexTranslations(document, (XWikiContext) data);
             } else if (event instanceof DocumentDeletedEvent) {
                 XWikiDocument document = ((XWikiDocument) source).getOriginalDocument();
 

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/test/java/org/xwiki/search/solr/internal/SolrIndexEventListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/test/java/org/xwiki/search/solr/internal/SolrIndexEventListenerTest.java
@@ -23,6 +23,9 @@ import java.util.Arrays;
 import java.util.Locale;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.xwiki.bridge.event.DocumentCreatedEvent;
 import org.xwiki.bridge.event.DocumentDeletedEvent;
 import org.xwiki.bridge.event.DocumentUpdatedEvent;
 import org.xwiki.mail.GeneralMailConfigurationUpdatedEvent;
@@ -102,6 +105,32 @@ class SolrIndexEventListenerTest
         when(document.getDocumentReference()).thenReturn(documentReference);
 
         this.listener.onEvent(new DocumentUpdatedEvent(), document, xcontext);
+
+        verify(this.indexer, times(3)).index(any(EntityReference.class), any(Boolean.class));
+        verify(this.indexer).index(documentReference, false);
+        verify(this.indexer).index(new DocumentReference(documentReference, Locale.FRENCH), false);
+        verify(this.indexer).index(new DocumentReference(documentReference, Locale.GERMAN), false);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    void onDocumentCreated(boolean isDefaultTranslation) throws Exception
+    {
+        XWikiContext xcontext = mock();
+
+        XWikiDocument document = mock();
+        if (isDefaultTranslation) {
+            when(document.getLocale()).thenReturn(Locale.ROOT);
+        } else {
+            when(document.getLocale()).thenReturn(Locale.FRENCH);
+        }
+
+        when(document.getTranslationLocales(xcontext)).thenReturn(Arrays.asList(Locale.FRENCH, Locale.GERMAN));
+
+        DocumentReference documentReference = new DocumentReference("wiki", "Path", "Page");
+        when(document.getDocumentReference()).thenReturn(documentReference);
+
+        this.listener.onEvent(new DocumentCreatedEvent(), document, xcontext);
 
         verify(this.indexer, times(3)).index(any(EntityReference.class), any(Boolean.class));
         verify(this.indexer).index(documentReference, false);


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-23529

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Always index all translations when a document is created.
* Add a unit test.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* I'm not sure if this is the right fix, i.e., if we're ever supposed to be in the situation where a translation exists without the root locale document.
* It is not clear to me when this started, I couldn't find any test failures on 16.10.x even though the test is part of that branch.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

* built the changed module with the quality profile
* executed `xwiki-platform-search-test-docker` with the changes and some debug logs in the configuration with MySQL in which I previously reproduced the failure. The debug logs and the test confirm that now the document is indexed correctly.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-16.10.x
  * stable-17.4.x
  * stable-17.8.x