### PR TITLE
XWIKI-12646: Page name out of bound for Document Tree, Activity Stream, Space Index and on Children viewer

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-macro/xwiki-platform-notifications-macro-ui/src/main/resources/XWiki/Notifications/Code/Macro/NotificationsMacro.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-macro/xwiki-platform-notifications-macro-ui/src/main/resources/XWiki/Notifications/Code/Macro/NotificationsMacro.xml
@@ -792,6 +792,7 @@ require(['jquery', 'XWikiAsyncNotificationsMacro', 'xwiki-events-bridge'], funct
 .notification-event {
   border: 1px dashed var(--xwiki-border-color);
   padding: 1em;
+  overflow-wrap: break-word;
 }
 
 .notification-event-unread {

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/dashboard/dashboard.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/dashboard/dashboard.css
@@ -35,6 +35,10 @@
   border-radius: 7px;
 }
 
+.gadget .gadget-content {
+  overflow: hidden;
+}
+
 .panels .gadget .gadget-content, .dashboard-edit .gadget .gadget-content {
   background-color: $theme.panelBackgroundColor;
   color: $theme.panelTextColor;


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-12646

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Added a couple style rules to make sure the Activity Stream and Pages widgets behave when there's unexpectedly long page names.

## Clarifications

* There might be alternative compromises, but this one works well IMO. 
  * We want all gadget content to not overflow their space. This stops page names from overflowing but also prevents other unexpected situations that might arise depending on the gadget. This is the equivalent of what was done for panels.
  * The notification box has a `overflow-wrap` policy that will break large words if needed. https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap#break-word

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Here is a screenshot of my dashboard after applying the styles. We can see that on all the elements, a page with a very long title (both regular word-length and one very long word in it) is displayed somewhat successfully. 
<img width="2559" height="1357" alt="Screenshot from 2025-10-02 17-34-29" src="https://github.com/user-attachments/assets/3d77eceb-6f33-4a4c-8b5d-dfe513bfaa64" />

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Style changes only, I only performed manual tests on my local instance. Given the content of the changes, I don't expect any possible regression.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A, small bug fix.