### PR TITLE
XWIKI-22982: WatchModal tooltip icons do not have any text alternative

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsWatchUIX.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/NotificationsWatchUIX.xml
@@ -542,8 +542,11 @@
         &lt;div class="panel-title" id="title-$attributeName"&gt;
           $services.icon.renderHTML("$iconName") 
           &lt;label for="option-$attributeName"&gt;$services.localization.render("notifications.watch.modal.option.${translationSuffix}.title", 'html/5.0', [])&lt;/label&gt;
-          &lt;a role="button" data-toggle="collapse" data-parent="#watch-options-accordion" href="#xhint-$attributeName" aria-controls="xhint-$attributeName"&gt;
+          &lt;a role="button" data-toggle="collapse" data-parent="#watch-options-accordion" 
+            href="#xhint-$attributeName" aria-controls="xhint-$attributeName" 
+            title="$escapetool.xml($services.localization.render('notifications.watch.modal.option.hint.toggle'))"&gt;
             &lt;span class="help-icon"&gt;$services.icon.renderHTML('question')&lt;/span&gt;
+            &lt;span class="sr-only"&gt;$escapetool.xml($services.localization.render('notifications.watch.modal.option.hint.toggle'))&lt;/span&gt;
           &lt;/a&gt;
         &lt;/div&gt;
     &lt;/div&gt;&lt;!-- end panel heading --&gt;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/Translations.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/main/resources/XWiki/Notifications/Code/Translations.xml
@@ -275,6 +275,7 @@ notifications.watch.modal.description.BLOCKED_WITH_CHILDREN_FOR_ALL_EVENTS_AND_F
 
 notifications.watch.modal.title.CUSTOM=Custom watch settings
 notifications.watch.modal.description.CUSTOM=You are using custom notification settings for this page: you might be following or blocking specific events for the page or you might target only specific channels for the notifications. We invite you to review your notification settings from your profile.
+notifications.watch.modal.option.hint.toggle=Toggle details about this option
 
 notifications.watch.modal.option.watchpage.title=Follow current page
 notifications.watch.modal.option.watchpage.hint=You will receive notifications for that page only.


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22982

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added an alternative text to this icon and the associated translation.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Added a few line breaks in the HTML to make it more palatable.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Here is the DOM and how it'd typically be rendered by the browser after the changes proposed in this PR:
<img width="2559" height="1188" alt="Screenshot from 2025-10-03 11-25-18" src="https://github.com/user-attachments/assets/cb1f08db-2f76-4194-916e-9a7443986122" />

We can see on this screenshot that except for the added tooltip on the icon, everything looks the same as before. In the DOM, there's now a `sr-only` description of the anchor with the same content as the tooltip.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests on my local instance. Axe-core in the browser did not find any WCAG failure related to the change.

Successfully built the changes and the associated docker tests:
* `mvn clean install -f xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui -Pquality`
* `mvn clean install -f xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/`
# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 17.4.X , small scope and pretty safe change for a WCAG error on a new UI.