### PR TITLE
XWIKI-23577: Extension Sheet buttons have their icon displayed next to the button

### DIFF
--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-ui/src/main/resources/ExtensionCode/ExtensionSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-ui/src/main/resources/ExtensionCode/ExtensionSheet.xml
@@ -496,6 +496,11 @@
   display: block;
 }
 
+.floatinginfobox .wikiexternallink {
+  background: none;
+  padding: 0;
+}
+
 .main .extensionInfo {
   margin: 0;
 }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-23577

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Reverted the regressing change done in the context of XCOMMONS-3051

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* See `https://github.com/xwiki/xwiki-platform/commit/c91ee943a20ac60f65de2c3901e8a7fc6cdc6167#r167248772`

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

None

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

The archive and current state of extension.xwiki.org shows that there's a regression. Adding this style back into the sheet locally fixed that regression.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 17.4.X, 16.10.X