### PR TITLE
XWIKI-21417: BaseObject#set always set the metadata dirty flag of the owner doc to true

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/output/PropertyClassOutputFilterStream.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/output/PropertyClassOutputFilterStream.java
@@ -112,8 +112,6 @@ public class PropertyClassOutputFilterStream extends AbstractEntityOutputFilterS
 
             this.entity.setName(name);
             this.entity.setObject(this.currentXClass);
-            // The object should not be dirty there.
-            this.entity.setDirty(false);
         }
     }
 
@@ -163,8 +161,6 @@ public class PropertyClassOutputFilterStream extends AbstractEntityOutputFilterS
             }
 
             this.entity.safeput(name, field);
-            // The object should not be dirty there.
-            this.entity.setDirty(false);
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
@@ -1116,7 +1116,7 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
                     if (cxml != null) {
                         bclass.fromXML(cxml);
                         doc.setXClass(bclass);
-                        bclass.setDirty(false);
+                        bclass.setDirty(false, true);
                     }
 
                     // Store this XWikiClass in the context so that we can use it in case of recursive usage
@@ -1175,7 +1175,7 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
                             }
                             doc.setXObject(object.getNumber(), object);
                             // The object just been loaded so make sure it's considered clean
-                            object.setDirty(false);
+                            object.setDirty(false, true);
                         }
 
                         // AFAICT this was added as an emergency patch because loading of objects has proven
@@ -1205,7 +1205,7 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
                                 ((BaseProperty<?>) obj.getField("member")).setDirty(false);
                                 doc.setXObject(obj.getNumber(), obj);
                                 // The object just been loaded so make sure it's considered clean
-                                obj.setDirty(false);
+                                obj.setDirty(false, true);
                             }
                         }
                     }
@@ -1514,7 +1514,7 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
                     }
                 }
 
-                object.setDirty(false);
+                object.setDirty(false, true);
 
                 if (bTransaction) {
                     endTransaction(context, true);
@@ -1610,8 +1610,6 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
                                     handledProps.add(prop);
                                 }
                             }
-                            // The object should never be dirty after being loaded from the DB.
-                            object.setDirty(false, true);
                         }
                     } catch (HibernateException e) {
                         this.logger.error("Failed loading custom mapping for doc [{}], class [{}], nb [{}]",


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-21417

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Ensure to remove the dirty flag when loading data from the DB or from filter stream

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 