### PR TITLE
XWIKI-22845: Introduce a S3 storage support for attachment content, history and deleted attachments and documents

### DIFF
--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/pom.xml
@@ -31,7 +31,7 @@
   <name>XWiki Platform - Store - Filesystem - Old Core</name>
   <description>Implement various oldcore store APIs based on filesystem.</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.41</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.39</xwiki.jacoco.instructionRatio>
     <!-- Old names of this module used for retro compatibility when resolving dependencies of old extensions -->
     <xwiki.extension.features>org.xwiki.platform:xwiki-platform-store-filesystem-attachments</xwiki.extension.features>
   </properties>

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/pom.xml
@@ -45,6 +45,11 @@
       <artifactId>xwiki-commons-component-api</artifactId>
       <version>${commons.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-store-blob-filesystem</artifactId>
+      <version>${commons.version}</version>
+    </dependency>
     <!-- Needed for DocumentReferenceSerializer implementation. -->
     <dependency>
       <groupId>org.xwiki.platform</groupId>

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/AttachmentFileProvider.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/AttachmentFileProvider.java
@@ -19,7 +19,8 @@
  */
 package org.xwiki.store.filesystem.internal;
 
-import java.io.File;
+import org.xwiki.store.blob.Blob;
+import org.xwiki.store.blob.BlobStoreException;
 
 /**
  * A means of getting files for storing information about a given attachment.
@@ -30,23 +31,23 @@ import java.io.File;
 public interface AttachmentFileProvider
 {
     /**
-     * @return the File for storing the latest version of the attachment's content.
+     * @return the Blob for storing the latest version of the attachment's content.
      */
-    File getAttachmentContentFile();
+    Blob getAttachmentContentFile() throws BlobStoreException;
 
     /**
-     * Get the meta file for the attachment. The meta file contains information about each version of the attachment
+     * Get the meta blob for the attachment. The meta file contains information about each version of the attachment
      * such as who saved it.
      *
-     * @return the File for storing meta data for each version of an attachment.
+     * @return the Blob for storing meta data for each version of an attachment.
      */
-    File getAttachmentVersioningMetaFile();
+    Blob getAttachmentVersioningMetaFile() throws BlobStoreException;
 
     /**
-     * Get a uniquely named file for storing a particular version of the attachment.
+     * Get a uniquely named Blob for storing a particular version of the attachment.
      *
      * @param versionName the name of the version of the attachment eg: "1.1" or "1.2"
-     * @return the File for storing the content of a particular version of the attachment.
+     * @return the Blob for storing the content of a particular version of the attachment.
      */
-    File getAttachmentVersionContentFile(String versionName);
+    Blob getAttachmentVersionContentFile(String versionName) throws BlobStoreException;
 }

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/DefaultAttachmentFileProvider.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/DefaultAttachmentFileProvider.java
@@ -19,7 +19,10 @@
  */
 package org.xwiki.store.filesystem.internal;
 
-import java.io.File;
+import org.xwiki.store.blob.Blob;
+import org.xwiki.store.blob.BlobPath;
+import org.xwiki.store.blob.BlobStore;
+import org.xwiki.store.blob.BlobStoreException;
 
 /**
  * A means of getting files for storing information about a given attachment.
@@ -37,9 +40,14 @@ public class DefaultAttachmentFileProvider implements AttachmentFileProvider
     private static final String ATTACH_ARCHIVE_META_FILENAME = "~METADATA.xml";
 
     /**
+     * The blob store where the attachment information is stored.
+     */
+    protected final BlobStore store;
+
+    /**
      * The directory where all information about this attachment resides.
      */
-    private final File attachmentDir;
+    private final BlobPath attachmentDir;
 
     /**
      * The name of the attached file.
@@ -49,11 +57,13 @@ public class DefaultAttachmentFileProvider implements AttachmentFileProvider
     /**
      * The Constructor.
      *
+     * @param store the blob store where the attachment information is stored.
      * @param attachmentDir a directory where all information about this attachment is stored.
      * @param fileName the name of the attachment file.
      */
-    public DefaultAttachmentFileProvider(final File attachmentDir, final String fileName)
+    public DefaultAttachmentFileProvider(BlobStore store, final BlobPath attachmentDir, final String fileName)
     {
+        this.store = store;
         this.attachmentDir = attachmentDir;
         this.attachmentFileName = fileName;
     }
@@ -61,7 +71,7 @@ public class DefaultAttachmentFileProvider implements AttachmentFileProvider
     /**
      * @return the directory where information about this attachment is stored.
      */
-    protected File getAttachmentDir()
+    protected BlobPath getAttachmentDir()
     {
         return this.attachmentDir;
     }
@@ -75,20 +85,22 @@ public class DefaultAttachmentFileProvider implements AttachmentFileProvider
     }
 
     @Override
-    public File getAttachmentContentFile()
+    public Blob getAttachmentContentFile() throws BlobStoreException
     {
-        return new File(this.attachmentDir, StoreFileUtils.getStoredFilename(this.attachmentFileName, null));
+        return this.store.getBlob(
+            this.attachmentDir.resolve(StoreFileUtils.getStoredFilename(this.attachmentFileName, null)));
     }
 
     @Override
-    public File getAttachmentVersioningMetaFile()
+    public Blob getAttachmentVersioningMetaFile() throws BlobStoreException
     {
-        return new File(this.attachmentDir, ATTACH_ARCHIVE_META_FILENAME);
+        return this.store.getBlob(this.attachmentDir.resolve(ATTACH_ARCHIVE_META_FILENAME));
     }
 
     @Override
-    public File getAttachmentVersionContentFile(final String versionName)
+    public Blob getAttachmentVersionContentFile(final String versionName) throws BlobStoreException
     {
-        return new File(this.attachmentDir, StoreFileUtils.getStoredFilename(this.attachmentFileName, versionName));
+        return this.store.getBlob(
+            this.attachmentDir.resolve(StoreFileUtils.getStoredFilename(this.attachmentFileName, versionName)));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/DefaultDeletedAttachmentFileProvider.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/DefaultDeletedAttachmentFileProvider.java
@@ -19,7 +19,12 @@
  */
 package org.xwiki.store.filesystem.internal;
 
-import java.io.File;
+import org.xwiki.store.blob.Blob;
+import org.xwiki.store.blob.BlobPath;
+import org.xwiki.store.blob.BlobStore;
+import org.xwiki.store.blob.BlobStoreException;
+
+import com.xpn.xwiki.doc.XWikiAttachment;
 
 /**
  * A means of getting files for storing information about a given deleted attachment.
@@ -40,17 +45,18 @@ public class DefaultDeletedAttachmentFileProvider extends DefaultAttachmentFileP
     /**
      * The Constructor.
      *
+     * @param store the blob store where the attachment information is stored.
      * @param attachmentDir the location where the information about the deleted attachment will be stored.
      * @param fileName the name of the attachment file.
      */
-    public DefaultDeletedAttachmentFileProvider(final File attachmentDir, final String fileName)
+    public DefaultDeletedAttachmentFileProvider(BlobStore store, final BlobPath attachmentDir, final String fileName)
     {
-        super(attachmentDir, fileName);
+        super(store, attachmentDir, fileName);
     }
 
     @Override
-    public File getDeletedAttachmentMetaFile()
+    public Blob getDeletedAttachmentMetaFile() throws BlobStoreException
     {
-        return new File(this.getAttachmentDir(), DELETED_ATTACH_META_FILENAME);
+        return this.store.getBlob(this.getAttachmentDir().resolve(DELETED_ATTACH_META_FILENAME));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/DefaultDeletedDocumentContentFileProvider.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/DefaultDeletedDocumentContentFileProvider.java
@@ -19,7 +19,10 @@
  */
 package org.xwiki.store.filesystem.internal;
 
-import java.io.File;
+import org.xwiki.store.blob.Blob;
+import org.xwiki.store.blob.BlobPath;
+import org.xwiki.store.blob.BlobStore;
+import org.xwiki.store.blob.BlobStoreException;
 
 /**
  * A means of getting files for storing information about a given deleted document.
@@ -35,21 +38,28 @@ public class DefaultDeletedDocumentContentFileProvider implements DeletedDocumen
     private static final String DELETED_DOCUMENT_FILE_NAME = "content.xml";
 
     /**
-     * The directory where all information about this deleted document resides.
+     * The blob store where the document information is stored.
      */
-    private final File deletedDocumentDir;
+    protected final BlobStore store;
 
     /**
+     * The directory where all information about this deleted document resides.
+     */
+    private final BlobPath deletedDocumentDir;
+
+    /**
+     * @param store the blob store where the document information is stored.
      * @param deletedDocumentDir the location where the information about the deleted document will be stored.
      */
-    public DefaultDeletedDocumentContentFileProvider(final File deletedDocumentDir)
+    public DefaultDeletedDocumentContentFileProvider(BlobStore store, final BlobPath deletedDocumentDir)
     {
+        this.store = store;
         this.deletedDocumentDir = deletedDocumentDir;
     }
 
     @Override
-    public File getDeletedDocumentContentFile()
+    public Blob getDeletedDocumentContentFile() throws BlobStoreException
     {
-        return new File(this.deletedDocumentDir, DELETED_DOCUMENT_FILE_NAME);
+        return this.store.getBlob(this.deletedDocumentDir.resolve(DELETED_DOCUMENT_FILE_NAME));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/DeletedAttachmentFileProvider.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/DeletedAttachmentFileProvider.java
@@ -19,7 +19,8 @@
  */
 package org.xwiki.store.filesystem.internal;
 
-import java.io.File;
+import org.xwiki.store.blob.Blob;
+import org.xwiki.store.blob.BlobStoreException;
 
 /**
  * A means of getting files for storing information about a given attachment.
@@ -30,7 +31,7 @@ import java.io.File;
 public interface DeletedAttachmentFileProvider extends AttachmentFileProvider
 {
     /**
-     * @return the File for storing the information about the deleted attachment such as who deleted it.
+     * @return the Blob for storing the information about the deleted attachment such as who deleted it.
      */
-    File getDeletedAttachmentMetaFile();
+    Blob getDeletedAttachmentMetaFile() throws BlobStoreException;
 }

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/DeletedDocumentContentFileProvider.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/DeletedDocumentContentFileProvider.java
@@ -19,7 +19,8 @@
  */
 package org.xwiki.store.filesystem.internal;
 
-import java.io.File;
+import org.xwiki.store.blob.Blob;
+import org.xwiki.store.blob.BlobStoreException;
 
 /**
  * A means of getting files for storing information about a given deleted document.
@@ -30,7 +31,7 @@ import java.io.File;
 public interface DeletedDocumentContentFileProvider
 {
     /**
-     * @return the File for storing the content of the deleted document.
+     * @return the Blob for storing the content of the deleted document.
      */
-    File getDeletedDocumentContentFile();
+    Blob getDeletedDocumentContentFile() throws BlobStoreException;
 }

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/FilesystemStoreTools.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/FilesystemStoreTools.java
@@ -20,7 +20,7 @@
 package org.xwiki.store.filesystem.internal;
 
 import java.io.File;
-import java.io.IOException;
+import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.locks.ReadWriteLock;
 
@@ -30,15 +30,17 @@ import javax.inject.Singleton;
 
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.phase.Initializable;
 import org.xwiki.component.phase.InitializationException;
-import org.xwiki.environment.Environment;
 import org.xwiki.model.internal.reference.LocalUidStringEntityReferenceSerializer;
 import org.xwiki.model.reference.AttachmentReference;
 import org.xwiki.model.reference.DocumentReference;
-import org.xwiki.store.internal.FileSystemStoreUtils;
+import org.xwiki.store.blob.Blob;
+import org.xwiki.store.blob.BlobPath;
+import org.xwiki.store.blob.BlobStore;
+import org.xwiki.store.blob.BlobStoreException;
+import org.xwiki.store.blob.BlobStoreManager;
 import org.xwiki.store.locks.LockProvider;
 
 import com.xpn.xwiki.doc.XWikiAttachment;
@@ -96,9 +98,6 @@ public class FilesystemStoreTools implements Initializable
      */
     private static final String TEMP_FILE_SUFFIX = "~tmp";
 
-    @Inject
-    private FilesystemAttachmentsConfiguration config;
-
     /**
      * A means of acquiring locks for attachments. Because the attachments temp files are randomly named and rename is
      * atomic, locks are not needed. DummyLockProvider provides fake locks.
@@ -108,93 +107,27 @@ public class FilesystemStoreTools implements Initializable
     private LockProvider lockProvider;
 
     @Inject
-    private Logger logger;
+    private BlobStoreManager blobStoreManager;
 
-    /**
-     * Used to get store directory.
-     */
-    @Inject
-    private Environment environment;
-
-    /**
-     * This is the root directory of the stored data.
-     */
-    private File storeRootDirectory;
-
-    /**
-     * Testing Constructor.
-     *
-     * @param storageDir the directory to store the content in.
-     * @param lockProvider a means of getting locks for making sure only one thread accesses an attachment at a time.
-     */
-    public FilesystemStoreTools(final File storageDir, final LockProvider lockProvider)
-    {
-        this.storeRootDirectory = storageDir;
-        this.lockProvider = lockProvider;
-    }
-
-    /**
-     * Constructor for component manager.
-     */
-    public FilesystemStoreTools()
-    {
-    }
+    private BlobStore store;
 
     @Override
     public void initialize() throws InitializationException
     {
-        File fileStorageDirectory = this.config.getDirectory();
-
-        if (fileStorageDirectory == null) {
-            // General location when filesystem based stored put data
-            File storeDirectory = new File(this.environment.getPermanentDirectory(), "store");
-            // Specific location for file component
-            fileStorageDirectory = new File(storeDirectory, FileSystemStoreUtils.HINT);
-        }
-
         try {
-            this.storeRootDirectory = fileStorageDirectory.getCanonicalFile();
-        } catch (IOException e) {
-            throw new InitializationException("Invalid permanent directory", e);
-        }
-
-        this.logger.info("Using filesystem store directory [{}]", this.storeRootDirectory);
-
-        // TODO: make this useless (by cleaning empty directories as soon as they appear)
-        if (this.config.cleanOnStartup()) {
-            final File dir = this.storeRootDirectory;
-
-            new Thread(() -> deleteEmptyDirs(dir, 0)).start();
+            this.store = this.blobStoreManager.getBlobStore(XWikiFileSystemBlobStoreManager.NAME);
+        } catch (BlobStoreException e) {
+            throw new InitializationException("Failed to initialize attachments blob store.", e);
         }
     }
 
     /**
-     * Delete all empty directories under the given directory. A directory which contains only empty directories is also
-     * considered an empty ditectory. This function will not delete *location* unless depth is non-zero.
-     *
-     * @param location a directory to delete.
-     * @param depth used for recursion, should always be zero.
-     * @return true if the directory existed, was empty and was deleted.
+     * @return the store for file system attachment blobs
+     * @since 17.8.0RC1
      */
-    private static boolean deleteEmptyDirs(final File location, int depth)
+    public BlobStore getStore()
     {
-        if (location != null && location.exists() && location.isDirectory()) {
-            final File[] dirs = location.listFiles();
-            boolean empty = true;
-            for (int i = 0; i < dirs.length; i++) {
-                if (!deleteEmptyDirs(dirs[i], depth + 1)) {
-                    empty = false;
-                }
-            }
-
-            if (empty && depth != 0) {
-                location.delete();
-
-                return true;
-            }
-        }
-
-        return false;
+        return this.store;
     }
 
     /**
@@ -204,13 +137,12 @@ public class FilesystemStoreTools implements Initializable
      * @param storageFile the file to get a backup file for.
      * @return a backup file with a name based on the name of the given file.
      */
-    public File getBackupFile(final File storageFile)
+    public BlobPath getBackupFile(final BlobPath storageFile)
     {
         // We pad our file names with random alphanumeric characters so that multiple operations on the same
         // file in the same transaction do not collide, the set of all capital and lower case letters
         // and numbers has 62 possibilities and 62^8 = 218340105584896 between 2^47 and 2^48.
-        return new File(storageFile.getAbsolutePath() + BACKUP_FILE_SUFFIX
-            + RandomStringUtils.secure().nextAlphanumeric(8));
+        return storageFile.appendSuffix(BACKUP_FILE_SUFFIX + RandomStringUtils.secure().nextAlphanumeric(8));
     }
 
     /**
@@ -220,10 +152,9 @@ public class FilesystemStoreTools implements Initializable
      * @param storageFile the file to get a temporary file for.
      * @return a temporary file with a name based on the name of the given file.
      */
-    public File getTempFile(final File storageFile)
+    public BlobPath getTempFile(final BlobPath storageFile)
     {
-        return new File(storageFile.getAbsolutePath() + TEMP_FILE_SUFFIX
-            + RandomStringUtils.secure().nextAlphanumeric(8));
+        return storageFile.appendSuffix(TEMP_FILE_SUFFIX + RandomStringUtils.secure().nextAlphanumeric(8));
     }
 
     /**
@@ -238,7 +169,7 @@ public class FilesystemStoreTools implements Initializable
     public DeletedAttachmentFileProvider getDeletedAttachmentFileProvider(final AttachmentReference attachment,
         final long index)
     {
-        return new DefaultDeletedAttachmentFileProvider(getDeletedAttachmentDir(attachment, index),
+        return new DefaultDeletedAttachmentFileProvider(getStore(), getDeletedAttachmentDir(attachment, index),
             attachment.getName());
     }
 
@@ -254,16 +185,8 @@ public class FilesystemStoreTools implements Initializable
     public DeletedDocumentContentFileProvider getDeletedDocumentFileProvider(DocumentReference documentReference,
         long index)
     {
-        return new DefaultDeletedDocumentContentFileProvider(getDeletedDocumentContentDir(documentReference, index));
-    }
-
-    /**
-     * @return the absolute path to the directory where the files are stored.
-     * @since 11.0
-     */
-    public File getStoreRootDirectory()
-    {
-        return this.storeRootDirectory;
+        return new DefaultDeletedDocumentContentFileProvider(getStore(), getDeletedDocumentContentDir(documentReference,
+            index));
     }
 
     /**
@@ -276,7 +199,8 @@ public class FilesystemStoreTools implements Initializable
      */
     public AttachmentFileProvider getAttachmentFileProvider(final AttachmentReference attachmentReference)
     {
-        return new DefaultAttachmentFileProvider(getAttachmentDir(attachmentReference), attachmentReference.getName());
+        return new DefaultAttachmentFileProvider(getStore(), getAttachmentDir(attachmentReference),
+            attachmentReference.getName());
     }
 
     /**
@@ -284,13 +208,16 @@ public class FilesystemStoreTools implements Initializable
      * @return the content of the link file
      * @since 16.4.0
      */
-    public String getLinkContent(XWikiAttachment attachment)
+    public String getLinkContent(XWikiAttachment attachment) throws BlobStoreException
     {
         AttachmentFileProvider provider = getAttachmentFileProvider(attachment.getReference());
-        File defaultFile = provider.getAttachmentContentFile();
-        File versionFile = provider.getAttachmentVersionContentFile(attachment.getVersion());
+        Blob defaultFile = provider.getAttachmentContentFile();
+        Blob versionFile = provider.getAttachmentVersionContentFile(attachment.getVersion());
 
-        return StoreFileUtils.getLinkContent(defaultFile.getParentFile(), versionFile);
+        // TODO: implement this in a cleaner way. We shouldn't rely on both files being in the same directory.
+        assert defaultFile.getPath().getParent().equals(versionFile.getPath().getParent());
+        List<String> segments = versionFile.getPath().getSegments();
+        return segments.get(segments.size() - 1);
     }
 
     /**
@@ -298,12 +225,12 @@ public class FilesystemStoreTools implements Initializable
      * @return the attachment directory
      * @since 11.0
      */
-    public File getAttachmentDir(final AttachmentReference attachmentReference)
+    public BlobPath getAttachmentDir(final AttachmentReference attachmentReference)
     {
-        final File docDir = getDocumentContentDir(attachmentReference.getDocumentReference());
-        final File attachmentsDir = new File(docDir, ATTACHMENTS_DIR_NAME);
+        final BlobPath docDir = getDocumentContentDir(attachmentReference.getDocumentReference());
+        BlobPath attachmentsPath = docDir.resolve(ATTACHMENTS_DIR_NAME);
 
-        return hashDirectory(attachmentsDir, attachmentReference.getName());
+        return hashDirectory(attachmentsPath, attachmentReference.getName());
     }
 
     /**
@@ -316,14 +243,14 @@ public class FilesystemStoreTools implements Initializable
      * @return a directory which will be repeatable only with the same inputs.
      * @since 11.0
      */
-    public File getDeletedAttachmentDir(final AttachmentReference attachment, final long index)
+    public BlobPath getDeletedAttachmentDir(final AttachmentReference attachment, final long index)
     {
         final DocumentReference doc = attachment.getDocumentReference();
-        final File docDir = getDocumentContentDir(doc);
-        final File deletedAttachmentsDir = new File(docDir, DELETED_ATTACHMENTS_DIR_NAME);
-        final File deletedAttachmentDir = hashDirectory(deletedAttachmentsDir, attachment.getName());
+        final BlobPath docDir = getDocumentContentDir(doc);
+        final BlobPath deletedAttachmentsDir = docDir.resolve(DELETED_ATTACHMENTS_DIR_NAME);
+        final BlobPath deletedAttachmentDir = hashDirectory(deletedAttachmentsDir, attachment.getName());
 
-        return new File(deletedAttachmentDir, String.valueOf(index));
+        return deletedAttachmentDir.resolve(String.valueOf(index));
     }
 
     /**
@@ -335,12 +262,9 @@ public class FilesystemStoreTools implements Initializable
      * @return a directory which will be repeatable only with the same inputs.
      * @since 11.0
      */
-    public File getDeletedDocumentContentDir(final DocumentReference documentReference, final long index)
+    public BlobPath getDeletedDocumentContentDir(final DocumentReference documentReference, final long index)
     {
-        final File docDir = getDocumentContentDir(documentReference);
-        final File deletedDocumentContentsDir = new File(docDir, DELETED_DOCUMENTS_DIR_NAME);
-
-        return new File(deletedDocumentContentsDir, String.valueOf(index));
+        return getDocumentContentDir(documentReference).resolve(DELETED_DOCUMENTS_DIR_NAME, String.valueOf(index));
     }
 
     /**
@@ -348,21 +272,19 @@ public class FilesystemStoreTools implements Initializable
      * @return the {@link File} corresponding to the passed wiki identifier
      * @since 10.1RC1
      */
-    public File getWikiDir(String wikiId)
+    public BlobPath getWikiDir(String wikiId)
     {
-        return new File(this.storeRootDirectory, wikiId);
+        return BlobPath.of(List.of(wikiId));
     }
 
-    private File hashDirectory(File parent, String name)
+    private BlobPath hashDirectory(BlobPath parent, String name)
     {
         String md5 = DigestUtils.md5Hex(name);
 
         // Avoid having too many files in one folder because some filesystems don't perform well with large numbers of
         // files in one folder
-        File documentDir1 = new File(parent, String.valueOf(md5.charAt(0)));
-        File documentDir2 = new File(documentDir1, String.valueOf(md5.charAt(1)));
-
-        return new File(documentDir2, String.valueOf(md5.substring(2)));
+        return parent.resolve(String.valueOf(md5.charAt(0)), String.valueOf(md5.charAt(1)),
+            md5.substring(2));
     }
 
     /**
@@ -373,9 +295,9 @@ public class FilesystemStoreTools implements Initializable
      *         be safe.
      * @since 11.0
      */
-    public File getDocumentContentDir(final DocumentReference documentReference)
+    public BlobPath getDocumentContentDir(final DocumentReference documentReference)
     {
-        File wikiDir = getWikiDir(documentReference.getWikiReference().getName());
+        BlobPath wikiDir = getWikiDir(documentReference.getWikiReference().getName());
 
         String localKey =
             LocalUidStringEntityReferenceSerializer.INSTANCE.serialize(documentReference.getLocale() != null
@@ -384,18 +306,16 @@ public class FilesystemStoreTools implements Initializable
 
         // Avoid having too many files in one folder because some filesystems don't perform well with large numbers of
         // files in one folder
-        File documentDir1 = new File(wikiDir, String.valueOf(md5.charAt(0)));
-        File documentDir2 = new File(documentDir1, String.valueOf(md5.charAt(1)));
-        File documentDirFinal = new File(documentDir2, String.valueOf(md5.substring(2)));
+        BlobPath documentDirPath = wikiDir.resolve(String.valueOf(md5.charAt(0)),
+            String.valueOf(md5.charAt(1)), md5.substring(2));
 
         // Add the locale (if any)
         Locale documentLocale = documentReference.getLocale();
         if (documentLocale != null && !documentLocale.equals(Locale.ROOT)) {
-            File documentLocalesDir = new File(documentDirFinal, DOCUMENT_LOCALES_DIR_NAME);
-            documentDirFinal = new File(documentLocalesDir, documentLocale.toString());
+            documentDirPath = documentDirPath.resolve(DOCUMENT_LOCALES_DIR_NAME, documentLocale.toString());
         }
 
-        return documentDirFinal;
+        return documentDirPath;
     }
 
     /**
@@ -405,7 +325,7 @@ public class FilesystemStoreTools implements Initializable
      * @param toLock the file to get a lock for.
      * @return a lock for the given file.
      */
-    public ReadWriteLock getLockForFile(final File toLock)
+    public ReadWriteLock getLockForFile(final BlobPath toLock)
     {
         return this.lockProvider.getLock(toLock);
     }

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/FilesystemStoreTools.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/FilesystemStoreTools.java
@@ -111,6 +111,27 @@ public class FilesystemStoreTools implements Initializable
 
     private BlobStore store;
 
+    /**
+     * Default constructor.
+     */
+    public FilesystemStoreTools()
+    {
+        // Nothing to do
+    }
+
+    /**
+     * Constructor used for testing.
+     *
+     * @param blobStore the blob store to use
+     * @param lockProvider the lock provider to use
+     * @since 17.9.0RC1
+     */
+    public FilesystemStoreTools(BlobStore blobStore, LockProvider lockProvider)
+    {
+        this.store = blobStore;
+        this.lockProvider = lockProvider;
+    }
+
     @Override
     public void initialize() throws InitializationException
     {

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/FilesystemStoreTools.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/FilesystemStoreTools.java
@@ -137,12 +137,14 @@ public class FilesystemStoreTools implements Initializable
      * @param storageFile the file to get a backup file for.
      * @return a backup file with a name based on the name of the given file.
      */
-    public BlobPath getBackupFile(final BlobPath storageFile)
+    public Blob getBackupFile(final Blob storageFile) throws BlobStoreException
     {
         // We pad our file names with random alphanumeric characters so that multiple operations on the same
         // file in the same transaction do not collide, the set of all capital and lower case letters
         // and numbers has 62 possibilities and 62^8 = 218340105584896 between 2^47 and 2^48.
-        return storageFile.appendSuffix(BACKUP_FILE_SUFFIX + RandomStringUtils.secure().nextAlphanumeric(8));
+        BlobPath path =
+            storageFile.getPath().appendSuffix(BACKUP_FILE_SUFFIX + RandomStringUtils.secure().nextAlphanumeric(8));
+        return storageFile.getStore().getBlob(path);
     }
 
     /**
@@ -152,9 +154,11 @@ public class FilesystemStoreTools implements Initializable
      * @param storageFile the file to get a temporary file for.
      * @return a temporary file with a name based on the name of the given file.
      */
-    public BlobPath getTempFile(final BlobPath storageFile)
+    public Blob getTempFile(final Blob storageFile) throws BlobStoreException
     {
-        return storageFile.appendSuffix(TEMP_FILE_SUFFIX + RandomStringUtils.secure().nextAlphanumeric(8));
+        BlobPath path =
+            storageFile.getPath().appendSuffix(TEMP_FILE_SUFFIX + RandomStringUtils.secure().nextAlphanumeric(8));
+        return storageFile.getStore().getBlob(path);
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/StoreFileUtils.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/StoreFileUtils.java
@@ -20,6 +20,7 @@
 package org.xwiki.store.filesystem.internal;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
@@ -78,10 +79,11 @@ public final class StoreFileUtils
      * @param targetFile the target file
      * @param followLinks true if links should be followed
      * @return the resolved file
-     * @throws Exception when failing to resolve the link
+     * @throws BlobStoreException when failing to resolve the link
+     * @throws IOException when failing to read the link file
      * @since 16.4.0RC1
      */
-    public static Blob resolve(Blob targetFile, boolean followLinks) throws Exception
+    public static Blob resolve(Blob targetFile, boolean followLinks) throws BlobStoreException, IOException
     {
         // Return the target file by default
         Blob file = targetFile;

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/WikiDeletedListener.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/WikiDeletedListener.java
@@ -19,19 +19,17 @@
  */
 package org.xwiki.store.filesystem.internal;
 
-import java.io.File;
-import java.io.IOException;
-
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.xwiki.bridge.event.WikiDeletedEvent;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.observation.AbstractEventListener;
 import org.xwiki.observation.event.Event;
+import org.xwiki.store.blob.BlobPath;
+import org.xwiki.store.blob.BlobStoreException;
 
 /**
  * Automatically delete store corresponding to deleted wiki.
@@ -68,14 +66,12 @@ public class WikiDeletedListener extends AbstractEventListener
     {
         String wikiId = ((WikiDeletedEvent) event).getWikiId();
 
-        File directory = this.store.getWikiDir(wikiId);
+        BlobPath directory = this.store.getWikiDir(wikiId);
 
-        if (directory.exists() && directory.isDirectory()) {
-            try {
-                FileUtils.deleteDirectory(directory);
-            } catch (IOException e) {
-                this.logger.error("Failed to delete storage for the wiki [{}]", wikiId, e);
-            }
+        try {
+            this.store.getStore().deleteBlobs(directory);
+        } catch (BlobStoreException e) {
+            this.logger.error("Failed to delete blobs for the wiki [{}]", wikiId, e);
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/XWikiFileSystemBlobStoreManager.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/XWikiFileSystemBlobStoreManager.java
@@ -30,7 +30,6 @@ import jakarta.inject.Singleton;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.environment.Environment;
-import org.xwiki.store.blob.BlobStore;
 import org.xwiki.store.blob.BlobStoreException;
 import org.xwiki.store.blob.BlobStoreManager;
 import org.xwiki.store.blob.internal.FileSystemBlobStore;
@@ -62,7 +61,7 @@ public class XWikiFileSystemBlobStoreManager implements BlobStoreManager
     private Logger logger;
 
     @Override
-    public BlobStore getBlobStore(String name) throws BlobStoreException
+    public FileSystemBlobStore getBlobStore(String name) throws BlobStoreException
     {
         File fileStorageDirectory = this.config.getDirectory();
 

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/XWikiFileSystemBlobStoreManager.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/XWikiFileSystemBlobStoreManager.java
@@ -1,0 +1,123 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.store.filesystem.internal;
+
+import java.io.File;
+import java.io.IOException;
+
+import javax.inject.Inject;
+
+import jakarta.inject.Named;
+import jakarta.inject.Singleton;
+
+import org.slf4j.Logger;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.environment.Environment;
+import org.xwiki.store.blob.BlobStore;
+import org.xwiki.store.blob.BlobStoreException;
+import org.xwiki.store.blob.BlobStoreManager;
+import org.xwiki.store.blob.internal.FileSystemBlobStore;
+import org.xwiki.store.internal.FileSystemStoreUtils;
+
+/**
+ * Specialized implementation of {@link BlobStoreManager} to consider the configured storage directory for attachments.
+ *
+ * @version $Id$
+ * @since 17.8.0RC1
+ */
+@Component
+@Singleton
+@Named("filesystem/" + XWikiFileSystemBlobStoreManager.NAME)
+public class XWikiFileSystemBlobStoreManager implements BlobStoreManager
+{
+    /**
+     * The name of the XWiki file system store.
+     */
+    public static final String NAME = "store/" + FileSystemStoreUtils.HINT;
+
+    @Inject
+    private FilesystemAttachmentsConfiguration config;
+
+    @Inject
+    private Environment environment;
+
+    @Inject
+    private Logger logger;
+
+    @Override
+    public BlobStore getBlobStore(String name) throws BlobStoreException
+    {
+        File fileStorageDirectory = this.config.getDirectory();
+
+        if (fileStorageDirectory == null) {
+            // General location when filesystem based stored put data
+            File storeDirectory = new File(this.environment.getPermanentDirectory(), "store");
+            // Specific location for file component
+            fileStorageDirectory = new File(storeDirectory, FileSystemStoreUtils.HINT);
+        }
+
+        try {
+            fileStorageDirectory = fileStorageDirectory.getCanonicalFile();
+        } catch (IOException e) {
+            throw new BlobStoreException("Invalid permanent directory", e);
+        }
+
+        this.logger.info("Using filesystem store directory [{}]", fileStorageDirectory);
+
+        // TODO: make this useless (by cleaning empty directories as soon as they appear)
+        // TODO: this could actually be handled by the blob store itself.
+        if (this.config.cleanOnStartup()) {
+            final File dir = fileStorageDirectory;
+
+            new Thread(() -> deleteEmptyDirs(dir, 0)).start();
+        }
+
+        return new FileSystemBlobStore(NAME, fileStorageDirectory.toPath());
+    }
+
+    /**
+     * Delete all empty directories under the given directory. A directory which contains only empty directories is also
+     * considered an empty ditectory. This function will not delete *location* unless depth is non-zero.
+     *
+     * @param location a directory to delete.
+     * @param depth used for recursion, should always be zero.
+     * @return true if the directory existed, was empty and was deleted.
+     */
+    private static boolean deleteEmptyDirs(final File location, int depth)
+    {
+        if (location != null && location.exists() && location.isDirectory()) {
+            final File[] dirs = location.listFiles();
+            boolean empty = true;
+            for (File dir : dirs) {
+                if (!deleteEmptyDirs(dir, depth + 1)) {
+                    empty = false;
+                }
+            }
+
+            if (empty && depth != 0) {
+                location.delete();
+
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/migration/AbstractFileStoreDataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/migration/AbstractFileStoreDataMigration.java
@@ -75,15 +75,17 @@ public abstract class AbstractFileStoreDataMigration extends AbstractHibernateDa
 
     protected FileSystemBlobStore pre11BlobStore;
 
+    protected File pre11StoreDirectory;
+
     protected BlobStore blobStore;
 
     @Override
     public void initialize() throws InitializationException
     {
         String pre11StoreName = "storage";
-        File pre11StoreDirectory = new File(this.environment.getPermanentDirectory(), pre11StoreName);
+        this.pre11StoreDirectory = new File(this.environment.getPermanentDirectory(), pre11StoreName);
 
-        this.pre11BlobStore = new FileSystemBlobStore(pre11StoreName, pre11StoreDirectory.toPath());
+        this.pre11BlobStore = new FileSystemBlobStore(pre11StoreName, this.pre11StoreDirectory.toPath());
 
         if (getVersion().getVersion() < R1100000XWIKI15620DataMigration.VERSION) {
             this.blobStore = this.pre11BlobStore;
@@ -92,7 +94,7 @@ public abstract class AbstractFileStoreDataMigration extends AbstractHibernateDa
         }
     }
 
-    protected BlobStore getPre11BlobStore()
+    protected FileSystemBlobStore getPre11BlobStore()
     {
         return this.pre11BlobStore;
     }

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/migration/AbstractXWIKI14697DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/migration/AbstractXWIKI14697DataMigration.java
@@ -20,21 +20,20 @@
 
 package org.xwiki.store.filesystem.internal.migration;
 
-import java.io.File;
-import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Locale;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 
-import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.xwiki.configuration.ConfigurationSource;
 import org.xwiki.model.reference.AttachmentReference;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReferenceSerializer;
+import org.xwiki.store.blob.BlobPath;
 import org.xwiki.store.filesystem.internal.FilesystemStoreTools;
 
 import com.xpn.xwiki.internal.XWikiCfgConfigurationSource;
@@ -79,32 +78,28 @@ public abstract class AbstractXWIKI14697DataMigration extends AbstractStoreTypeD
         }
     }
 
-    protected File getDocumentDir(final DocumentReference docRef)
+    protected BlobPath getDocumentDir(final DocumentReference docRef)
     {
-        final File path = new File(getPre11StoreRootDirectory(), this.pathSerializer.serialize(docRef, false));
-        File docDir = new File(path, THIS_DIR_NAME);
+        final BlobPath path = BlobPath.from(this.pathSerializer.serialize(docRef, false));
+        BlobPath docDir = path.resolve(THIS_DIR_NAME);
 
         // Add the locale
         Locale docLocale = docRef.getLocale();
         if (docLocale != null) {
-            final File docLocalesDir = new File(docDir, FilesystemStoreTools.DOCUMENT_LOCALES_DIR_NAME);
-            final File docLocaleDir = new File(docLocalesDir,
+            final BlobPath docLocalesDir = docDir.resolve(FilesystemStoreTools.DOCUMENT_LOCALES_DIR_NAME);
+            final BlobPath docLocaleDir = docLocalesDir.resolve(
                 docLocale.equals(Locale.ROOT) ? DOCUMENT_LOCALE_ROOT_NAME : docLocale.toString());
-            docDir = new File(docLocaleDir, THIS_DIR_NAME);
+            docDir = docLocaleDir.resolve(THIS_DIR_NAME);
         }
 
         return docDir;
     }
 
-    protected File getAttachmentDir(final AttachmentReference attachmentReference)
+    protected BlobPath getAttachmentDir(final AttachmentReference attachmentReference)
     {
-        final File docDir = getDocumentDir(attachmentReference.getDocumentReference());
-        final File attachmentsDir = new File(docDir, FilesystemStoreTools.ATTACHMENTS_DIR_NAME);
+        final BlobPath docDir = getDocumentDir(attachmentReference.getDocumentReference());
+        final BlobPath attachmentsDir = docDir.resolve(FilesystemStoreTools.ATTACHMENTS_DIR_NAME);
 
-        try {
-            return new File(attachmentsDir, URLEncoder.encode(attachmentReference.getName(), "UTF8"));
-        } catch (UnsupportedEncodingException e) {
-            throw new HibernateException("UTF8 is unknown", e);
-        }
+        return attachmentsDir.resolve(URLEncoder.encode(attachmentReference.getName(), StandardCharsets.UTF_8));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/migration/AbstractXWIKI15249DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/migration/AbstractXWIKI15249DataMigration.java
@@ -20,7 +20,6 @@
 
 package org.xwiki.store.filesystem.internal.migration;
 
-import java.io.File;
 import java.util.Locale;
 
 import javax.inject.Inject;
@@ -29,6 +28,7 @@ import javax.inject.Named;
 import org.xwiki.model.reference.AttachmentReference;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReferenceSerializer;
+import org.xwiki.store.blob.BlobPath;
 import org.xwiki.store.filesystem.internal.FilesystemStoreTools;
 import org.xwiki.store.internal.FileSystemStoreUtils;
 
@@ -68,30 +68,29 @@ public abstract class AbstractXWIKI15249DataMigration extends AbstractStoreTypeD
         }
     }
 
-    protected File getDocumentContentDir(final DocumentReference documentReference)
+    protected BlobPath getDocumentContentDir(final DocumentReference documentReference)
     {
-        File documentDir =
-            new File(getPre11StoreRootDirectory(), this.fileEntitySerializer.serialize(documentReference, true));
-        File documentContentDir = new File(documentDir, THIS_DIR_NAME);
+        BlobPath basePath = BlobPath.from(this.fileEntitySerializer.serialize(documentReference, true));
+        BlobPath documentContentDir = basePath.resolve(THIS_DIR_NAME);
 
         // Add the locale
         Locale documentLocale = documentReference.getLocale();
         if (documentLocale != null) {
-            final File documentLocalesDir =
-                new File(documentContentDir, FilesystemStoreTools.DOCUMENT_LOCALES_DIR_NAME);
-            final File documentLocaleDir = new File(documentLocalesDir,
+            final BlobPath documentLocalesDir =
+                documentContentDir.resolve(FilesystemStoreTools.DOCUMENT_LOCALES_DIR_NAME);
+            final BlobPath documentLocaleDir = documentLocalesDir.resolve(
                 documentLocale.equals(Locale.ROOT) ? DOCUMENT_LOCALE_ROOT_NAME : documentLocale.toString());
-            documentContentDir = new File(documentLocaleDir, THIS_DIR_NAME);
+            documentContentDir = documentLocaleDir.resolve(THIS_DIR_NAME);
         }
 
         return documentContentDir;
     }
 
-    protected File getAttachmentDir(final AttachmentReference attachmentReference)
+    protected BlobPath getAttachmentDir(final AttachmentReference attachmentReference)
     {
-        File docDir = getDocumentContentDir(attachmentReference.getDocumentReference());
-        File attachmentsDir = new File(docDir, FilesystemStoreTools.ATTACHMENTS_DIR_NAME);
+        BlobPath docDir = getDocumentContentDir(attachmentReference.getDocumentReference());
+        BlobPath attachmentsDir = docDir.resolve(FilesystemStoreTools.ATTACHMENTS_DIR_NAME);
 
-        return new File(attachmentsDir, FileSystemStoreUtils.encode(attachmentReference.getName(), true));
+        return attachmentsDir.resolve(FileSystemStoreUtils.encode(attachmentReference.getName(), true));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/migration/R1004000XWIKI15249DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/migration/R1004000XWIKI15249DataMigration.java
@@ -23,8 +23,10 @@ package org.xwiki.store.filesystem.internal.migration;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.hibernate.HibernateException;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.AttachmentReference;
+import org.xwiki.store.blob.BlobStoreException;
 import org.xwiki.store.filesystem.internal.DefaultAttachmentFileProvider;
 
 import com.xpn.xwiki.store.migration.XWikiDBVersion;
@@ -63,7 +65,12 @@ public class R1004000XWIKI15249DataMigration extends AbstractXWIKI15249DataMigra
     @Override
     protected boolean isFile(AttachmentReference attachmentReference)
     {
-        return new DefaultAttachmentFileProvider(getAttachmentDir(attachmentReference), attachmentReference.getName())
-            .getAttachmentContentFile().exists();
+        try {
+            return new DefaultAttachmentFileProvider(getBlobStore(), getAttachmentDir(attachmentReference),
+                attachmentReference.getName())
+                .getAttachmentContentFile().exists();
+        } catch (BlobStoreException e) {
+            throw new HibernateException("Error checking if attachment file exists.", e);
+        }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/migration/R1004001XWIKI15249DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/migration/R1004001XWIKI15249DataMigration.java
@@ -23,8 +23,10 @@ package org.xwiki.store.filesystem.internal.migration;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.hibernate.HibernateException;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.AttachmentReference;
+import org.xwiki.store.blob.BlobStoreException;
 import org.xwiki.store.filesystem.internal.DefaultAttachmentFileProvider;
 
 import com.xpn.xwiki.store.migration.XWikiDBVersion;
@@ -63,7 +65,11 @@ public class R1004001XWIKI15249DataMigration extends AbstractXWIKI15249DataMigra
     @Override
     protected boolean isFile(AttachmentReference attachmentReference)
     {
-        return new DefaultAttachmentFileProvider(getAttachmentDir(attachmentReference), attachmentReference.getName())
-            .getAttachmentVersioningMetaFile().exists();
+        try {
+            return new DefaultAttachmentFileProvider(getBlobStore(), getAttachmentDir(attachmentReference),
+                attachmentReference.getName()).getAttachmentVersioningMetaFile().exists();
+        } catch (BlobStoreException e) {
+            throw new HibernateException("Error checking if attachment versioning meta file exists.", e);
+        }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/migration/R910000XWIKI14697DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/migration/R910000XWIKI14697DataMigration.java
@@ -22,15 +22,15 @@ package org.xwiki.store.filesystem.internal.migration;
 
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.hibernate.HibernateException;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.AttachmentReference;
 import org.xwiki.store.blob.BlobPath;
-import org.xwiki.store.blob.BlobStoreException;
 
 import com.xpn.xwiki.store.migration.XWikiDBVersion;
 
@@ -70,12 +70,9 @@ public class R910000XWIKI14697DataMigration extends AbstractXWIKI14697DataMigrat
     {
         BlobPath attachmentFolder = getAttachmentDir(attachmentReference);
 
-        try {
-            String urlEncodedName = URLEncoder.encode(attachmentReference.getName(), StandardCharsets.UTF_8);
-            BlobPath attachmentBlobPath = attachmentFolder.resolve(urlEncodedName);
-            return this.pre11BlobStore.getBlob(attachmentBlobPath).exists();
-        } catch (BlobStoreException e) {
-            throw new HibernateException("Error checking if the attachment exists.", e);
-        }
+        Path attachmentFolderPath = this.pre11BlobStore.getBlobFilePath(attachmentFolder);
+
+        return Files.exists(attachmentFolderPath.resolve(URLEncoder.encode(attachmentReference.getName(),
+            StandardCharsets.UTF_8)));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/migration/R910001XWIKI14697DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/migration/R910001XWIKI14697DataMigration.java
@@ -23,8 +23,10 @@ package org.xwiki.store.filesystem.internal.migration;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.hibernate.HibernateException;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.AttachmentReference;
+import org.xwiki.store.blob.BlobStoreException;
 import org.xwiki.store.filesystem.internal.DefaultAttachmentFileProvider;
 
 import com.xpn.xwiki.store.migration.XWikiDBVersion;
@@ -63,7 +65,11 @@ public class R910001XWIKI14697DataMigration extends AbstractXWIKI14697DataMigrat
     @Override
     protected boolean isFile(AttachmentReference attachmentReference)
     {
-        return new DefaultAttachmentFileProvider(getAttachmentDir(attachmentReference), attachmentReference.getName())
-            .getAttachmentVersioningMetaFile().exists();
+        try {
+            return new DefaultAttachmentFileProvider(this.pre11BlobStore, getAttachmentDir(attachmentReference),
+                attachmentReference.getName()).getAttachmentVersioningMetaFile().exists();
+        } catch (BlobStoreException e) {
+            throw new HibernateException("Error checking if attachment versioning meta file exists.", e);
+        }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/migration/R910100XWIKI14871DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/migration/R910100XWIKI14871DataMigration.java
@@ -21,14 +21,12 @@
 package org.xwiki.store.filesystem.internal.migration;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.nio.file.Path;
 import java.util.Date;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -54,10 +52,6 @@ import org.xwiki.component.annotation.Component;
 import org.xwiki.configuration.ConfigurationSource;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReferenceSerializer;
-import org.xwiki.store.blob.Blob;
-import org.xwiki.store.blob.BlobPath;
-import org.xwiki.store.blob.BlobStoreException;
-import org.xwiki.store.blob.internal.FileSystemBlobStore;
 import org.xwiki.store.internal.FileSystemStoreUtils;
 
 import com.xpn.xwiki.XWikiException;
@@ -121,102 +115,79 @@ public class R910100XWIKI14871DataMigration extends AbstractFileStoreDataMigrati
     private void migrateMetadatas(Session session) throws IOException, XMLStreamException, FactoryConfigurationError,
         ParserConfigurationException, SAXException, DataMigrationException
     {
-        FileSystemBlobStore pre11BlobStore = getPre11BlobStore();
+        File storageLocationFile = getPre11StoreRootDirectory();
 
-        this.logger.info("Migrating filesystem attachment metadatas stored in [{}]", pre11BlobStore.getName());
+        this.logger.info("Migrating filesystem attachment metadatas stored in [{}]", storageLocationFile);
 
-        try {
-            Blob pathByIdStoreBlob =
-                pre11BlobStore.getBlob(BlobPath.of(List.of("~GLOBAL_DELETED_ATTACHMENT_ID_MAPPINGS.xml")));
-            if (pathByIdStoreBlob.exists()) {
-                try (InputStream stream = pathByIdStoreBlob.getStream()) {
-                    // No need to protect against XXE attacks since the XML file is controlled.
-                    // Note that if a user were able to change that XML file content, and modify the <path> element then
-                    // it would be possible to access any local file content since the path is displayed in the logs below.
-                    // That would still need server access though.
-                    XMLStreamReader xmlReader = XMLInputFactory.newInstance().createXMLStreamReader(stream);
+        File pathByIdStore = new File(storageLocationFile, "~GLOBAL_DELETED_ATTACHMENT_ID_MAPPINGS.xml");
+        if (pathByIdStore.exists()) {
+            try (FileInputStream stream = new FileInputStream(pathByIdStore)) {
+                // No need to protect against XXE attacks since the XML file is controlled.
+                // Note that if a user were able to change that XML file content, and modify the <path> element then
+                // it would be possible to access any local file content since the path is displayed in the logs below.
+                // That would still need server access though.
+                XMLStreamReader xmlReader = XMLInputFactory.newInstance().createXMLStreamReader(stream);
 
-                    // <deletedattachmentids>
+                // <deletedattachmentids>
+                xmlReader.nextTag();
+
+                for (xmlReader.nextTag(); xmlReader.isStartElement(); xmlReader.nextTag()) {
+                    // <entry>
                     xmlReader.nextTag();
 
-                    for (xmlReader.nextTag(); xmlReader.isStartElement(); xmlReader.nextTag()) {
-                        // <entry>
-                        xmlReader.nextTag();
+                    String value1 = xmlReader.getElementText();
+                    xmlReader.nextTag();
+                    String value2 = xmlReader.getElementText();
 
-                        String value1 = xmlReader.getElementText();
-                        xmlReader.nextTag();
-                        String value2 = xmlReader.getElementText();
+                    String path;
+                    if (xmlReader.getLocalName().equals("path")) {
+                        path = value2;
+                    } else {
+                        path = value1;
+                    }
 
-                        String path;
-                        if (xmlReader.getLocalName().equals("path")) {
-                            path = value2;
-                        } else {
-                            path = value1;
+                    // </entry>
+                    xmlReader.nextTag();
+
+                    if (!this.migratedDeletedAttachment.contains(path)) {
+                        File directory = new File(path);
+                        if (!directory.getCanonicalPath().startsWith(storageLocationFile.getCanonicalPath())) {
+                            this.logger.warn("[{}] is the wrong path, trying to find the new location", directory);
+
+                            directory = findNewPath(path);
+
+                            if (directory == null) {
+                                this.logger.warn("Could not find the deleted attachment in any other location");
+
+                                // Remember that this attachment could not be migrated
+                                this.migratedDeletedAttachment.add(path);
+
+                                continue;
+                            } else {
+                                this.logger.info("Found deleted attachment on [{}]", directory);
+                            }
                         }
 
-                        // </entry>
-                        xmlReader.nextTag();
+                        if (!directory.isDirectory()) {
+                            this.logger.warn("[{}] is not a directory", directory);
 
-                        handlePath(session, path);
+                            continue;
+                        }
+
+                        // Find document reference
+                        File documentDirectory = directory.getParentFile().getParentFile().getParentFile();
+                        DocumentReference documentReference = getPre11DocumentReference(documentDirectory);
+
+                        if (getXWikiContext().getWikiReference().equals(documentReference.getWikiReference())) {
+                            storeDeletedAttachment(directory, documentReference, session);
+
+                            // Remember which path we already migrated
+                            this.migratedDeletedAttachment.add(path);
+                        }
                     }
                 }
             }
-        } catch (BlobStoreException e) {
-            throw new DataMigrationException("Failed to access the deleted attachment id mappings file", e);
         }
-    }
-
-    private void handlePath(Session session, String path)
-        throws IOException, DataMigrationException, ParserConfigurationException, SAXException
-    {
-        if (!this.migratedDeletedAttachment.contains(path)) {
-            File directory = new File(path);
-            if (!directory.getCanonicalPath().startsWith(this.pre11StoreDirectory.getCanonicalPath())) {
-                this.logger.warn("[{}] is the wrong path, trying to find the new location", directory);
-
-                directory = findNewPath(path);
-
-                if (directory == null) {
-                    this.logger.warn("Could not find the deleted attachment in any other location");
-
-                    // Remember that this attachment could not be migrated
-                    this.migratedDeletedAttachment.add(path);
-
-                    return;
-                } else {
-                    this.logger.info("Found deleted attachment on [{}]", directory);
-                }
-            }
-
-            if (!directory.isDirectory()) {
-                this.logger.warn("[{}] is not a directory", directory);
-
-                return;
-            }
-
-            // Find document reference
-            BlobPath documentBlobPath = getDocumentBlobPath(directory);
-            DocumentReference documentReference = getPre11DocumentReference(documentBlobPath);
-
-            if (getXWikiContext().getWikiReference().equals(documentReference.getWikiReference())) {
-                storeDeletedAttachment(directory, documentReference, session);
-
-                // Remember which path we already migrated
-                this.migratedDeletedAttachment.add(path);
-            }
-        }
-    }
-
-    private BlobPath getDocumentBlobPath(File attachmentDirectory)
-    {
-        File documentDirectory = attachmentDirectory.getParentFile().getParentFile().getParentFile();
-        // Get the relative path from the store directory and construct a BlobPath based on that.
-        Path relativePath = this.pre11StoreDirectory.toPath().relativize(documentDirectory.toPath());
-        List<String> pathParts = new java.util.ArrayList<>();
-        for (Path p : relativePath) {
-            pathParts.add(p.toString());
-        }
-        return BlobPath.of(pathParts);
     }
 
     private File findNewPath(String path)
@@ -226,7 +197,7 @@ public class R910100XWIKI14871DataMigration extends AbstractFileStoreDataMigrati
         if (matcher.find()) {
             String relative = path.substring(matcher.end());
 
-            File newPath = new File(this.pre11StoreDirectory, relative);
+            File newPath = new File(getStoreRootDirectory(), relative);
             if (newPath.exists()) {
                 return newPath;
             }

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/doc/internal/FilesystemAttachmentContent.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/doc/internal/FilesystemAttachmentContent.java
@@ -19,14 +19,13 @@
  */
 package org.xwiki.store.legacy.doc.internal;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.AutoCloseInputStream;
 import org.xwiki.store.UnexpectedException;
+import org.xwiki.store.blob.Blob;
 
 import com.xpn.xwiki.doc.XWikiAttachment;
 import com.xpn.xwiki.doc.XWikiAttachmentContent;
@@ -43,18 +42,18 @@ public class FilesystemAttachmentContent extends XWikiAttachmentContent
     /**
      * The underlying storage mechanism.
      */
-    private final File storageFile;
+    private final Blob storageBlob;
 
     /**
      * The Constructor.
      *
-     * @param storage the file where the data is stored.
+     * @param storage the blob where the data is stored.
      * @param attachment the attachment to associate this content with.
      */
-    public FilesystemAttachmentContent(final File storage, final XWikiAttachment attachment)
+    public FilesystemAttachmentContent(final Blob storage, final XWikiAttachment attachment)
     {
         super(attachment, null);
-        this.storageFile = storage;
+        this.storageBlob = storage;
     }
 
     /**
@@ -64,10 +63,10 @@ public class FilesystemAttachmentContent extends XWikiAttachmentContent
      * @param storage the file where the data is stored.
      * @since 4.4RC1
      */
-    public FilesystemAttachmentContent(final File storage)
+    public FilesystemAttachmentContent(final Blob storage)
     {
         super(null, null);
-        this.storageFile = storage;
+        this.storageBlob = storage;
     }
 
     /**
@@ -81,7 +80,7 @@ public class FilesystemAttachmentContent extends XWikiAttachmentContent
     {
         super(filesystemAttachmentContent);
 
-        this.storageFile = filesystemAttachmentContent.storageFile;
+        this.storageBlob = filesystemAttachmentContent.storageBlob;
     }
 
     @Override
@@ -93,7 +92,7 @@ public class FilesystemAttachmentContent extends XWikiAttachmentContent
     @Override
     public boolean exists()
     {
-        return this.storageFile.exists();
+        return this.storageBlob.exists();
     }
 
     @Override
@@ -122,8 +121,8 @@ public class FilesystemAttachmentContent extends XWikiAttachmentContent
         }
 
         try {
-            return new AutoCloseInputStream(new FileInputStream(this.storageFile));
-        } catch (IOException e) {
+            return AutoCloseInputStream.builder().setInputStream(this.storageBlob.getStream()).get();
+        } catch (Exception e) {
             throw new UnexpectedException("Failed to get InputStream", e);
         }
     }
@@ -135,6 +134,10 @@ public class FilesystemAttachmentContent extends XWikiAttachmentContent
             return super.getLongSize();
         }
 
-        return this.storageFile.length();
+        try {
+            return this.storageBlob.getSize();
+        } catch (Exception e) {
+            throw new UnexpectedException("Failed to get size", e);
+        }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/doc/internal/FilesystemAttachmentContent.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/doc/internal/FilesystemAttachmentContent.java
@@ -26,6 +26,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.AutoCloseInputStream;
 import org.xwiki.store.UnexpectedException;
 import org.xwiki.store.blob.Blob;
+import org.xwiki.store.blob.BlobStoreException;
 
 import com.xpn.xwiki.doc.XWikiAttachment;
 import com.xpn.xwiki.doc.XWikiAttachmentContent;
@@ -92,7 +93,11 @@ public class FilesystemAttachmentContent extends XWikiAttachmentContent
     @Override
     public boolean exists()
     {
-        return this.storageBlob.exists();
+        try {
+            return this.storageBlob.exists();
+        } catch (BlobStoreException e) {
+            throw new UnexpectedException("Failed to check if attachment content exists", e);
+        }
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/AttachmentArchiveDeleteRunnable.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/AttachmentArchiveDeleteRunnable.java
@@ -58,7 +58,7 @@ public class AttachmentArchiveDeleteRunnable extends StartableTransactionRunnabl
         }
 
         for (Blob file : toDelete) {
-            new BlobDeleteTransactionRunnable(file, file.getStore().getBlob(fileTools.getBackupFile(file.getPath())),
+            new BlobDeleteTransactionRunnable(file, fileTools.getBackupFile(file),
                 fileTools.getLockForFile(file.getPath()))
                 .runIn(this);
         }

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/AttachmentArchiveDeleteRunnable.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/AttachmentArchiveDeleteRunnable.java
@@ -19,15 +19,16 @@
  */
 package org.xwiki.store.legacy.store.internal;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.suigeneris.jrcs.rcs.Version;
-import org.xwiki.store.FileDeleteTransactionRunnable;
 import org.xwiki.store.StartableTransactionRunnable;
+import org.xwiki.store.blob.Blob;
+import org.xwiki.store.blob.BlobStoreException;
 import org.xwiki.store.filesystem.internal.AttachmentFileProvider;
 import org.xwiki.store.filesystem.internal.FilesystemStoreTools;
+import org.xwiki.store.internal.BlobDeleteTransactionRunnable;
 
 import com.xpn.xwiki.doc.XWikiAttachmentArchive;
 
@@ -46,9 +47,9 @@ public class AttachmentArchiveDeleteRunnable extends StartableTransactionRunnabl
      * @param provider the file provider for gettign the files to delete.
      */
     public AttachmentArchiveDeleteRunnable(final XWikiAttachmentArchive archive, final FilesystemStoreTools fileTools,
-        final AttachmentFileProvider provider)
+        final AttachmentFileProvider provider) throws BlobStoreException
     {
-        final List<File> toDelete = new ArrayList<>();
+        final List<Blob> toDelete = new ArrayList<>();
         toDelete.add(provider.getAttachmentVersioningMetaFile());
 
         final Version[] versions = archive.getVersions();
@@ -56,8 +57,9 @@ public class AttachmentArchiveDeleteRunnable extends StartableTransactionRunnabl
             toDelete.add(provider.getAttachmentVersionContentFile(versions[i].toString()));
         }
 
-        for (File file : toDelete) {
-            new FileDeleteTransactionRunnable(file, fileTools.getBackupFile(file), fileTools.getLockForFile(file))
+        for (Blob file : toDelete) {
+            new BlobDeleteTransactionRunnable(file, file.getStore().getBlob(fileTools.getBackupFile(file.getPath())),
+                fileTools.getLockForFile(file.getPath()))
                 .runIn(this);
         }
     }

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/AttachmentArchiveSaveRunnable.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/AttachmentArchiveSaveRunnable.java
@@ -19,24 +19,25 @@
  */
 package org.xwiki.store.legacy.store.internal;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.xpn.xwiki.doc.XWikiAttachment;
-import com.xpn.xwiki.doc.XWikiAttachmentArchive;
-import com.xpn.xwiki.XWikiContext;
-import com.xpn.xwiki.XWikiException;
-import com.xpn.xwiki.store.VoidAttachmentVersioningStore;
-
 import org.suigeneris.jrcs.rcs.Version;
-import org.xwiki.store.FileSaveTransactionRunnable;
 import org.xwiki.store.StartableTransactionRunnable;
 import org.xwiki.store.StreamProvider;
+import org.xwiki.store.blob.Blob;
+import org.xwiki.store.blob.BlobStoreException;
 import org.xwiki.store.filesystem.internal.AttachmentFileProvider;
 import org.xwiki.store.filesystem.internal.FilesystemStoreTools;
+import org.xwiki.store.internal.BlobSaveTransactionRunnable;
 import org.xwiki.store.serialization.SerializationStreamProvider;
 import org.xwiki.store.serialization.Serializer;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiAttachment;
+import com.xpn.xwiki.doc.XWikiAttachmentArchive;
+import com.xpn.xwiki.store.VoidAttachmentVersioningStore;
 
 /**
  * A TransactionRunnable for saving attachment archives.
@@ -67,7 +68,7 @@ public class AttachmentArchiveSaveRunnable extends StartableTransactionRunnable
         final Serializer<List<XWikiAttachment>,
             List<XWikiAttachment>> serializer,
         final XWikiContext context)
-        throws XWikiException
+        throws XWikiException, BlobStoreException
     {
         if (archive instanceof VoidAttachmentVersioningStore.VoidAttachmentArchive) {
             return;
@@ -112,12 +113,10 @@ public class AttachmentArchiveSaveRunnable extends StartableTransactionRunnable
      */
     private void addSaver(final StreamProvider provider,
         final FilesystemStoreTools fileTools,
-        final File saveHere)
+        final Blob saveHere) throws BlobStoreException
     {
-        new FileSaveTransactionRunnable(saveHere,
-            fileTools.getTempFile(saveHere),
-            fileTools.getBackupFile(saveHere),
-            fileTools.getLockForFile(saveHere),
+        new BlobSaveTransactionRunnable(saveHere, fileTools.getTempFile(saveHere), fileTools.getBackupFile(saveHere),
+            fileTools.getLockForFile(saveHere.getPath()),
             provider).runIn(this);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/DeletedDocumentContentFileSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/DeletedDocumentContentFileSerializer.java
@@ -27,9 +27,10 @@ import org.xwiki.component.annotation.Component;
 import org.xwiki.component.annotation.InstantiationStrategy;
 import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
 import org.xwiki.filter.instance.input.DocumentInstanceInputProperties;
-import org.xwiki.filter.output.DefaultFileOutputTarget;
+import org.xwiki.filter.output.DefaultBlobOutputTarget;
 import org.xwiki.filter.xar.output.XAROutputProperties;
-import org.xwiki.store.FileSerializer;
+import org.xwiki.store.BlobSerializer;
+import org.xwiki.store.blob.Blob;
 
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiDocument;
@@ -43,7 +44,7 @@ import com.xpn.xwiki.internal.filter.XWikiDocumentFilterUtils;
  */
 @Component(roles = DeletedDocumentContentFileSerializer.class)
 @InstantiationStrategy(ComponentInstantiationStrategy.PER_LOOKUP)
-public class DeletedDocumentContentFileSerializer implements FileSerializer
+public class DeletedDocumentContentFileSerializer implements BlobSerializer
 {
     @Inject
     private XWikiDocumentFilterUtils serializer;
@@ -63,7 +64,7 @@ public class DeletedDocumentContentFileSerializer implements FileSerializer
     }
 
     @Override
-    public void serialize(File file) throws Exception
+    public void serialize(Blob blob) throws Exception
     {
         // Input
         DocumentInstanceInputProperties documentProperties = new DocumentInstanceInputProperties();
@@ -82,7 +83,7 @@ public class DeletedDocumentContentFileSerializer implements FileSerializer
         xarProperties.setFormat(true);
 
         try {
-            this.serializer.exportEntity(this.document, new DefaultFileOutputTarget(file), xarProperties,
+            this.serializer.exportEntity(this.document, new DefaultBlobOutputTarget(blob), xarProperties,
                 documentProperties);
         } catch (Exception e) {
             throw new XWikiException(XWikiException.MODULE_XWIKI_DOC, XWikiException.ERROR_DOC_XML_PARSING,

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/FilesystemAttachmentRecycleBinContentStore.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/FilesystemAttachmentRecycleBinContentStore.java
@@ -141,16 +141,12 @@ public class FilesystemAttachmentRecycleBinContentStore implements AttachmentRec
         Blob attachmentMetaBlob = provider.getDeletedAttachmentMetaFile();
         try (Stream<Blob> blobStream =
                  attachmentMetaBlob.getStore().listBlobs(attachmentMetaBlob.getPath().getParent())) {
-            blobStream.forEach(blob -> {
-                try {
-                    new BlobDeleteTransactionRunnable(blob,
-                        this.fileTools.getBackupFile(blob),
-                        this.fileTools.getLockForFile(blob.getPath()))
-                        .runIn(out);
-                } catch (BlobStoreException e) {
-                    throw new RuntimeException(e);
-                }
-            });
+            for (Blob blob : (Iterable<Blob>) blobStream::iterator) {
+                new BlobDeleteTransactionRunnable(blob,
+                    this.fileTools.getBackupFile(blob),
+                    this.fileTools.getLockForFile(blob.getPath()))
+                    .runIn(out);
+            }
         }
 
         return out;

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/FilesystemAttachmentStore.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/FilesystemAttachmentStore.java
@@ -66,6 +66,8 @@ import com.xpn.xwiki.store.XWikiStoreInterface;
 @Singleton
 public class FilesystemAttachmentStore implements XWikiAttachmentStoreInterface
 {
+    private static final String ATTACHMENT_SAVE_ERROR_MESSAGE = "Exception while saving attachment.";
+
     /**
      * Tools for getting files to store given content in.
      */
@@ -125,7 +127,7 @@ public class FilesystemAttachmentStore implements XWikiAttachmentStoreInterface
             transaction.start();
         } catch (Exception e) {
             throw new XWikiException(XWikiException.MODULE_XWIKI_STORE,
-                XWikiException.ERROR_XWIKI_STORE_HIBERNATE_SAVING_ATTACHMENT, "Exception while saving attachment.", e);
+                XWikiException.ERROR_XWIKI_STORE_HIBERNATE_SAVING_ATTACHMENT, ATTACHMENT_SAVE_ERROR_MESSAGE, e);
         }
     }
 
@@ -159,7 +161,7 @@ public class FilesystemAttachmentStore implements XWikiAttachmentStoreInterface
         } catch (BlobStoreException e) {
             throw new XWikiException(XWikiException.MODULE_XWIKI_STORE,
                 XWikiException.ERROR_XWIKI_STORE_HIBERNATE_SAVING_ATTACHMENT,
-                "Exception while saving attachment.", e);
+                ATTACHMENT_SAVE_ERROR_MESSAGE, e);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/FilesystemAttachmentStore.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/FilesystemAttachmentStore.java
@@ -38,6 +38,7 @@ import org.xwiki.store.FileSaveTransactionRunnable;
 import org.xwiki.store.StreamProvider;
 import org.xwiki.store.StringStreamProvider;
 import org.xwiki.store.TransactionRunnable;
+import org.xwiki.store.blob.BlobStoreException;
 import org.xwiki.store.filesystem.internal.FilesystemStoreTools;
 import org.xwiki.store.filesystem.internal.StoreFileUtils;
 import org.xwiki.store.internal.FileSystemStoreUtils;
@@ -435,7 +436,7 @@ public class FilesystemAttachmentStore implements XWikiAttachmentStoreInterface
          * @throws XWikiException if unable to load the archive for the attachment to delete.
          */
         AttachmentDeleteTransactionRunnable(final XWikiAttachment attachment, final boolean updateDocument,
-            final XWikiContext context, final File attachFile) throws XWikiException
+            final XWikiContext context, final File attachFile) throws XWikiException, BlobStoreException
         {
             // Delete both the standard and link location
             File linkAtachFile = StoreFileUtils.getLinkFile(attachFile);

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/FilesystemAttachmentVersioningStore.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/FilesystemAttachmentVersioningStore.java
@@ -32,6 +32,7 @@ import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
 import org.xwiki.store.StartableTransactionRunnable;
+import org.xwiki.store.blob.BlobStoreException;
 import org.xwiki.store.filesystem.internal.AttachmentFileProvider;
 import org.xwiki.store.filesystem.internal.FilesystemStoreTools;
 import org.xwiki.store.internal.FileSystemStoreUtils;
@@ -231,6 +232,7 @@ public class FilesystemAttachmentVersioningStore implements AttachmentVersioning
      * @return a StartableTransactionRunnable for deleting the attachment archive.
      */
     public StartableTransactionRunnable getArchiveDeleteRunnable(final XWikiAttachmentArchive archive)
+        throws BlobStoreException
     {
         if (archive == null) {
             throw new NullPointerException("The archive to delete cannot be null.");

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/FilesystemRecycleBinContentStore.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/FilesystemRecycleBinContentStore.java
@@ -19,7 +19,6 @@
  */
 package org.xwiki.store.legacy.store.internal;
 
-import java.io.File;
 import java.nio.charset.StandardCharsets;
 
 import javax.inject.Inject;
@@ -29,9 +28,10 @@ import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.reference.DocumentReference;
-import org.xwiki.store.FileDeleteTransactionRunnable;
-import org.xwiki.store.FileSaveTransactionRunnable;
+import org.xwiki.store.blob.Blob;
 import org.xwiki.store.filesystem.internal.FilesystemStoreTools;
+import org.xwiki.store.internal.BlobDeleteTransactionRunnable;
+import org.xwiki.store.internal.BlobSaveTransactionRunnable;
 import org.xwiki.store.internal.FileSystemStoreUtils;
 
 import com.xpn.xwiki.XWikiContext;
@@ -76,15 +76,16 @@ public class FilesystemRecycleBinContentStore implements XWikiRecycleBinContentS
 
         final XWikiHibernateTransaction transaction = new XWikiHibernateTransaction(xcontext);
 
-        final File contentFile =
-            this.fileTools.getDeletedDocumentFileProvider(document.getDocumentReferenceWithLocale(), index)
-                .getDeletedDocumentContentFile();
-        DeletedDocumentContentFileSerializer serializer = this.serializerProvider.get();
-        serializer.init(document, StandardCharsets.UTF_8.name());
-        new FileSaveTransactionRunnable(contentFile, fileTools.getTempFile(contentFile),
-            fileTools.getBackupFile(contentFile), fileTools.getLockForFile(contentFile), serializer).runIn(transaction);
-
         try {
+            final Blob contentFile =
+                this.fileTools.getDeletedDocumentFileProvider(document.getDocumentReferenceWithLocale(), index)
+                    .getDeletedDocumentContentFile();
+            DeletedDocumentContentFileSerializer serializer = this.serializerProvider.get();
+            serializer.init(document, StandardCharsets.UTF_8.name());
+            new BlobSaveTransactionRunnable(contentFile, this.fileTools.getTempFile(contentFile),
+                this.fileTools.getBackupFile(contentFile),
+                this.fileTools.getLockForFile(contentFile.getPath()), serializer).runIn(transaction);
+
             transaction.start();
         } catch (Exception e) {
             throw new XWikiException(XWikiException.MODULE_XWIKI_STORE,
@@ -97,11 +98,17 @@ public class FilesystemRecycleBinContentStore implements XWikiRecycleBinContentS
     public XWikiDeletedDocumentContent get(DocumentReference reference, long index, boolean bTransaction)
         throws XWikiException
     {
-        final File contentFile =
-            this.fileTools.getDeletedDocumentFileProvider(reference, index).getDeletedDocumentContentFile();
+        try {
+            final Blob contentFile =
+                this.fileTools.getDeletedDocumentFileProvider(reference, index).getDeletedDocumentContentFile();
 
-        if (contentFile.exists()) {
-            return new XWikiFileDeletedDocumentContent(contentFile, StandardCharsets.UTF_8);
+            if (contentFile.exists()) {
+                return new XWikiFileDeletedDocumentContent(contentFile, StandardCharsets.UTF_8);
+            }
+        } catch (Exception e) {
+            throw new XWikiException(XWikiException.MODULE_XWIKI_STORE,
+                XWikiException.ERROR_XWIKI_STORE_HIBERNATE_LOADING_ATTACHMENT,
+                "Exception while loading deleted document content.", e);
         }
 
         return null;
@@ -114,16 +121,16 @@ public class FilesystemRecycleBinContentStore implements XWikiRecycleBinContentS
 
         final XWikiHibernateTransaction transaction = new XWikiHibernateTransaction(xcontext);
 
-        final File contentFile =
-            this.fileTools.getDeletedDocumentFileProvider(reference, index).getDeletedDocumentContentFile();
-        new FileDeleteTransactionRunnable(contentFile, this.fileTools.getBackupFile(contentFile),
-            this.fileTools.getLockForFile(contentFile)).runIn(transaction);
-
         try {
+            final Blob contentFile =
+                this.fileTools.getDeletedDocumentFileProvider(reference, index).getDeletedDocumentContentFile();
+            new BlobDeleteTransactionRunnable(contentFile, this.fileTools.getBackupFile(contentFile),
+                this.fileTools.getLockForFile(contentFile.getPath())).runIn(transaction);
+
             transaction.start();
         } catch (Exception e) {
             throw new XWikiException(XWikiException.MODULE_XWIKI_STORE,
-                XWikiException.ERROR_XWIKI_STORE_HIBERNATE_SAVING_ATTACHMENT,
+                XWikiException.ERROR_XWIKI_STORE_HIBERNATE_LOADING_ATTACHMENT,
                 "Exception while deleting deleted document content.", e);
         }
     }

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/XWikiFileDeletedDocumentContent.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/legacy/store/internal/XWikiFileDeletedDocumentContent.java
@@ -19,12 +19,12 @@
  */
 package org.xwiki.store.legacy.store.internal;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 
-import org.apache.commons.io.FileUtils;
-import org.xwiki.filter.input.DefaultFileInputSource;
+import org.apache.commons.io.IOUtils;
+import org.xwiki.filter.input.DefaultStreamProviderInputSource;
+import org.xwiki.store.blob.Blob;
 
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiDeletedDocumentContent;
@@ -38,7 +38,7 @@ import com.xpn.xwiki.doc.XWikiDocument;
  */
 public class XWikiFileDeletedDocumentContent implements XWikiDeletedDocumentContent
 {
-    private final File content;
+    private final Blob content;
 
     private final Charset charset;
 
@@ -46,7 +46,7 @@ public class XWikiFileDeletedDocumentContent implements XWikiDeletedDocumentCont
      * @param file the serialized document as XML
      * @param charset the charset of the file
      */
-    public XWikiFileDeletedDocumentContent(File file, Charset charset)
+    public XWikiFileDeletedDocumentContent(Blob file, Charset charset)
     {
         this.content = file;
         this.charset = charset;
@@ -55,7 +55,13 @@ public class XWikiFileDeletedDocumentContent implements XWikiDeletedDocumentCont
     @Override
     public String getContentAsString() throws IOException
     {
-        return FileUtils.readFileToString(this.content, this.charset);
+        try {
+            return IOUtils.toString(this.content.getStream(), this.charset);
+        } catch (IOException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IOException("Failed to read the deleted document content.", e);
+        }
     }
 
     @Override
@@ -66,7 +72,7 @@ public class XWikiFileDeletedDocumentContent implements XWikiDeletedDocumentCont
             result = new XWikiDocument();
         }
 
-        result.fromXML(new DefaultFileInputSource(this.content), true);
+        result.fromXML(new DefaultStreamProviderInputSource(this.content), true);
 
         return result;
     }

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/resources/META-INF/components.txt
@@ -19,4 +19,5 @@ org.xwiki.store.serialization.xml.internal.AttachmentListMetadataSerializer
 org.xwiki.store.serialization.xml.internal.AttachmentMetadataSerializer
 org.xwiki.store.serialization.xml.internal.DeletedAttachmentMetadataSerializer
 org.xwiki.store.filesystem.internal.DefaultTemporaryAttachmentSessionsManager
+org.xwiki.store.filesystem.internal.XWikiFileSystemBlobStoreManager
 org.xwiki.store.script.TemporaryAttachmentsScriptService

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/test/java/org/xwiki/store/filesystem/internal/StoreFileUtilsTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/test/java/org/xwiki/store/filesystem/internal/StoreFileUtilsTest.java
@@ -20,9 +20,17 @@
 package org.xwiki.store.filesystem.internal;
 
 import java.io.File;
-import java.io.IOException;
+import java.util.List;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.xwiki.store.blob.Blob;
+import org.xwiki.store.blob.BlobPath;
+import org.xwiki.store.blob.BlobStore;
+import org.xwiki.store.blob.internal.FileSystemBlobStore;
+import org.xwiki.test.junit5.XWikiTempDir;
+import org.xwiki.test.junit5.XWikiTempDirExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -33,27 +41,39 @@ import static org.junit.jupiter.api.Assertions.assertSame;
  * 
  * @version $Id$
  */
+@ExtendWith(XWikiTempDirExtension.class)
 class StoreFileUtilsTest
 {
-    @Test
-    void resolveNotExistingFile() throws IOException
+    @XWikiTempDir
+    private File tempDir;
+
+    private BlobStore blobStore;
+
+    @BeforeEach
+    void setUp()
     {
-        File file = new File("does not exist");
-
-        assertFalse(file.exists());
-
-        File foundFile = StoreFileUtils.resolve(file, true);
-
-        assertSame(file, foundFile);
+        this.blobStore = new FileSystemBlobStore("Test", this.tempDir.toPath());
     }
 
     @Test
-    void getLinkFile() throws IOException
+    void resolveNotExistingFile() throws Exception
     {
-        File file = new File("folder/file.ext");
+        Blob blob = this.blobStore.getBlob(BlobPath.of(List.of("does not exist")));
 
-        File linkFile = StoreFileUtils.getLinkFile(file);
+        assertFalse(blob.exists());
 
-        assertEquals("folder/file.ext.lnk", linkFile.getPath());
+        Blob foundBlob = StoreFileUtils.resolve(blob, true);
+
+        assertSame(blob, foundBlob);
+    }
+
+    @Test
+    void getLinkFile() throws Exception
+    {
+        Blob blob = this.blobStore.getBlob(BlobPath.of(List.of("folder", "file.ext")));
+
+        Blob linkFile = StoreFileUtils.getLinkFile(blob);
+
+        assertEquals("folder/file.ext.lnk", linkFile.getPath().toString());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/test/java/org/xwiki/store/filesystem/internal/XWikiFileSystemBlobStoreManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/test/java/org/xwiki/store/filesystem/internal/XWikiFileSystemBlobStoreManagerTest.java
@@ -20,13 +20,14 @@
 package org.xwiki.store.filesystem.internal;
 
 import java.io.File;
-import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.xwiki.component.phase.InitializationException;
 import org.xwiki.environment.Environment;
+import org.xwiki.store.blob.BlobPath;
+import org.xwiki.store.blob.internal.FileSystemBlobStore;
 import org.xwiki.test.LogLevel;
 import org.xwiki.test.junit5.LogCaptureExtension;
 import org.xwiki.test.junit5.XWikiTempDir;
@@ -40,15 +41,17 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * Unit tests for {@link FilesystemStoreTools}.
+ * Unit tests for {@link XWikiFileSystemBlobStoreManager}.
  *
  * @version $Id$
  */
 @ComponentTest
-public class FilesystemStoreToolsTest
+class XWikiFileSystemBlobStoreManagerTest
 {
+    private static final String LOG_MESSAGE = "Using filesystem store directory [%s]";
+
     @InjectMockComponents
-    private FilesystemStoreTools filesystemStoreTools;
+    private XWikiFileSystemBlobStoreManager fileSystemBlobStoreManager;
 
     @MockComponent
     private FilesystemAttachmentsConfiguration config;
@@ -60,35 +63,25 @@ public class FilesystemStoreToolsTest
     private static LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.INFO);
 
     @Test
-    void initialize(@XWikiTempDir File configDirectory) throws IOException, InitializationException
+    void getBlobStore(@XWikiTempDir File configDirectory) throws Exception
     {
         // Use Case 1: Null store directory and cleanOnStartup = false
-        // Note: FilesystemStoreTools.initialize() method is first triggered by the test framework when injecting the
-        // component.
-
-        assertEquals(new File(new File("."), "store/file").getCanonicalFile(),
-            filesystemStoreTools.getStoreRootDirectory());
+        FileSystemBlobStore blobStore = this.fileSystemBlobStoreManager.getBlobStore("store/file");
+        Path expectedPath = Path.of("store", "file").toAbsolutePath();
+        assertEquals(expectedPath, blobStore.getBlobFilePath(BlobPath.of(List.of())));
         verify(this.environment, times(1)).getPermanentDirectory();
+        assertEquals(String.format(LOG_MESSAGE, expectedPath), logCapture.getMessage(0));
 
         // Use Case 2: Non-null store directory and cleanOnStartup = true
 
         when(config.getDirectory()).thenReturn(configDirectory);
         when(config.cleanOnStartup()).thenReturn(true);
 
-        filesystemStoreTools.initialize();
+        blobStore = this.fileSystemBlobStoreManager.getBlobStore("store/file");
 
-        assertEquals(configDirectory, filesystemStoreTools.getStoreRootDirectory());
+        assertEquals(configDirectory, blobStore.getBlobFilePath(BlobPath.of(List.of())).toFile());
         verify(this.environment, times(1)).getPermanentDirectory();
         verify(this.config, times(2)).cleanOnStartup();
-        assertEquals(String.format("Using filesystem store directory [%s]", configDirectory.toString()),
-            logCapture.getMessage(1));
-    }
-
-    @AfterAll
-    static void verifyLog() throws Exception
-    {
-        // Assert log happening in the first initialize() call.
-        assertEquals(String.format("Using filesystem store directory [%s]",
-            new File(new File("."), "store/file").getCanonicalFile()), logCapture.getMessage(0));
+        assertEquals(String.format(LOG_MESSAGE, configDirectory.toString()), logCapture.getMessage(1));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/test/java/org/xwiki/store/legacy/store/internal/FilesystemAttachmentStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/test/java/org/xwiki/store/legacy/store/internal/FilesystemAttachmentStoreTest.java
@@ -22,16 +22,13 @@ package org.xwiki.store.legacy.store.internal;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.hibernate.Session;
@@ -45,6 +42,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.xwiki.model.reference.AttachmentReference;
 import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.store.blob.Blob;
+import org.xwiki.store.blob.BlobStoreException;
+import org.xwiki.store.blob.internal.FileSystemBlobStore;
 import org.xwiki.store.filesystem.internal.FilesystemStoreTools;
 import org.xwiki.store.legacy.doc.internal.FilesystemAttachmentContent;
 import org.xwiki.store.locks.dummy.internal.DummyLockProvider;
@@ -97,7 +97,7 @@ public class FilesystemAttachmentStoreTest extends AbstractFilesystemAttachmentS
     /**
      * The file which will hold content for this attachment.
      */
-    private File storeFile;
+    private Blob storeFile;
 
     /**
      * The dir in /tmp/ which we use as our sandbox.
@@ -185,7 +185,9 @@ public class FilesystemAttachmentStoreTest extends AbstractFilesystemAttachmentS
         final File tmpDir = new File(System.getProperty("java.io.tmpdir"));
         this.storageLocation = new File(tmpDir, "test-storage-location");
 
-        this.fileTools = new FilesystemStoreTools(storageLocation, new DummyLockProvider());
+        FileSystemBlobStore blobStore = new FileSystemBlobStore("Test", this.storageLocation.toPath());
+
+        this.fileTools = new FilesystemStoreTools(blobStore, new DummyLockProvider());
 
         this.attachStore = new FilesystemAttachmentStore();
         FieldUtils.writeField(this.attachStore, "fileTools", this.fileTools, true);
@@ -204,7 +206,7 @@ public class FilesystemAttachmentStoreTest extends AbstractFilesystemAttachmentS
     @Test
     public void saveContentTest() throws Exception
     {
-        final File storeFile =
+        final Blob storeFile =
             this.fileTools.getAttachmentFileProvider(this.mockAttachReference).getAttachmentContentFile();
         Assert.assertFalse(this.storeFile.exists());
 
@@ -220,13 +222,13 @@ public class FilesystemAttachmentStoreTest extends AbstractFilesystemAttachmentS
 
         Assert.assertTrue("The attachment file was not created.", this.storeFile.exists());
         Assert.assertEquals("The attachment file contained the wrong content", HELLO,
-            FileUtils.readFileToString(storeFile, StandardCharsets.UTF_8));
+            IOUtils.toString(storeFile.getStream(), StandardCharsets.UTF_8));
     }
 
     @Test
     public void saveTwoOfSameAttachmentInOneTransactionTest() throws Exception
     {
-        final File storeFile =
+        final Blob storeFile =
             this.fileTools.getAttachmentFileProvider(this.mockAttachReference).getAttachmentContentFile();
         Assert.assertFalse(this.storeFile.exists());
 
@@ -246,16 +248,13 @@ public class FilesystemAttachmentStoreTest extends AbstractFilesystemAttachmentS
 
         Assert.assertTrue("The attachment file was not created.", this.storeFile.exists());
         Assert.assertEquals("The attachment file contained the wrong content", HELLO,
-            FileUtils.readFileToString(storeFile, StandardCharsets.UTF_8));
+            IOUtils.toString(storeFile.getStream(), StandardCharsets.UTF_8));
     }
 
     @Test
     public void loadContentTest() throws Exception
     {
-        this.storeFile.getParentFile().mkdirs();
-        OutputStream os = new FileOutputStream(this.storeFile, false);
-        IOUtils.copy(HELLO_STREAM, os);
-        os.close();
+        this.storeFile.writeFromStream(HELLO_STREAM);
 
         getMockery().checking(new Expectations()
         {
@@ -354,12 +353,9 @@ public class FilesystemAttachmentStoreTest extends AbstractFilesystemAttachmentS
 
     /* -------------------- Helpers -------------------- */
 
-    private void createFile() throws IOException
+    private void createFile() throws BlobStoreException
     {
-        this.storeFile.getParentFile().mkdirs();
-        OutputStream os = new FileOutputStream(this.storeFile, false);
-        IOUtils.copy(HELLO_STREAM, os);
-        os.close();
+        this.storeFile.writeFromStream(HELLO_STREAM);
         Assert.assertTrue("The attachment file not created for the test.", this.storeFile.exists());
     }
 

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/test/java/org/xwiki/store/legacy/store/internal/FilesystemAttachmentVersioningStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/test/java/org/xwiki/store/legacy/store/internal/FilesystemAttachmentVersioningStoreTest.java
@@ -32,6 +32,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.store.blob.internal.FileSystemBlobStore;
 import org.xwiki.store.filesystem.internal.AttachmentFileProvider;
 import org.xwiki.store.filesystem.internal.FilesystemStoreTools;
 import org.xwiki.store.locks.dummy.internal.DummyLockProvider;
@@ -74,7 +75,9 @@ public class FilesystemAttachmentVersioningStoreTest extends AbstractFilesystemA
         final File tmpDir = new File(System.getProperty("java.io.tmpdir"));
         this.storageLocation = new File(tmpDir, "test-storage-location");
 
-        this.fileTools = new FilesystemStoreTools(storageLocation, new DummyLockProvider());
+        FileSystemBlobStore blobStore = new FileSystemBlobStore("Test", this.storageLocation.toPath());
+
+        this.fileTools = new FilesystemStoreTools(blobStore, new DummyLockProvider());
         final AttachmentListMetadataSerializer serializer =
             new AttachmentListMetadataSerializer(new AttachmentMetadataSerializer());
         this.versionStore = new FilesystemAttachmentVersioningStore();
@@ -139,7 +142,7 @@ public class FilesystemAttachmentVersioningStoreTest extends AbstractFilesystemA
         // <?xml version="1.0" encoding="UTF-8"?>
         // <attachment-list serializer="attachment-list-meta/1.0">
         // </attachment-list>
-        Assert.assertTrue(this.provider.getAttachmentVersioningMetaFile().length() > 120);
+        Assert.assertTrue(this.provider.getAttachmentVersioningMetaFile().getSize() > 120);
 
         Assert.assertTrue(this.provider.getAttachmentVersionContentFile("1.1").exists());
         Assert.assertTrue(this.provider.getAttachmentVersionContentFile("1.2").exists());

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/pom.xml
@@ -66,6 +66,12 @@
       <version>${commons.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-store-blob-filesystem</artifactId>
+      <version>${commons.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/pom.xml
@@ -35,6 +35,11 @@
     </properties>
   <dependencies>
     <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-store-blob-api</artifactId>
+      <version>${commons.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.xwiki.platform</groupId>
       <artifactId>xwiki-platform-store-api</artifactId>
       <version>${project.version}</version>

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/src/main/java/org/xwiki/store/BlobSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/src/main/java/org/xwiki/store/BlobSerializer.java
@@ -1,0 +1,37 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.store;
+
+import org.xwiki.store.blob.Blob;
+
+/**
+ * An entity that serializes embedded data to a {@link Blob}.
+ *
+ * @version $Id$
+ * @since 17.8.0RC1
+ */
+public interface BlobSerializer
+{
+    /**
+     * @param blob the file to write to
+     * @throws Exception when failing to serialize the data to the passed blob
+     */
+    void serialize(Blob blob) throws Exception;
+}

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/src/main/java/org/xwiki/store/StreamProviderBlobSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/src/main/java/org/xwiki/store/StreamProviderBlobSerializer.java
@@ -1,0 +1,47 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.store;
+
+import org.xwiki.store.blob.Blob;
+
+/**
+ * A {@link BlobSerializer} which uses a {@link StreamProvider} to get the stream to serialize.
+ *
+ * @version $Id$
+ * @since 17.8.0RC1
+ */
+public class StreamProviderBlobSerializer implements BlobSerializer
+{
+    private final StreamProvider streamProvider;
+
+    /**
+     * @param streamProvider the stream provider to read from
+     */
+    public StreamProviderBlobSerializer(StreamProvider streamProvider)
+    {
+        this.streamProvider = streamProvider;
+    }
+
+    @Override
+    public void serialize(Blob blob) throws Exception
+    {
+        blob.writeFromStream(this.streamProvider.getStream());
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/src/main/java/org/xwiki/store/internal/BlobDeleteTransactionRunnable.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/src/main/java/org/xwiki/store/internal/BlobDeleteTransactionRunnable.java
@@ -1,0 +1,196 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.store.internal;
+
+import java.io.IOException;
+import java.util.concurrent.locks.ReadWriteLock;
+
+import org.xwiki.store.StartableTransactionRunnable;
+import org.xwiki.store.TransactionRunnable;
+import org.xwiki.store.blob.Blob;
+import org.xwiki.store.blob.BlobStoreException;
+
+/**
+ * A TransactionRunnable for deleting a blob safely.
+ * The operation can be rolled back even after the onCommit() function is called.
+ * It is only final when the onComplete function is called.
+ *
+ * @version $Id$
+ * @since 17.8.0RC1
+ */
+public class BlobDeleteTransactionRunnable extends StartableTransactionRunnable<TransactionRunnable<?>>
+{
+    /**
+     * The location of the file to sdelete.
+     */
+    private final Blob toDelete;
+
+    /**
+     * The location of the backup file.
+     */
+    private final Blob backupFile;
+
+    /**
+     * A lock to hold while running this TransactionRunnable.
+     */
+    private final ReadWriteLock lock;
+
+    /**
+     * False until preRun() has complete. If false then we know there is nothing to rollback and
+     * more importantly, we do not know if files in the temporary and backup locations are not
+     * from a previous (catastrophically failed) delete or save operation.
+     */
+    private boolean preRunComplete;
+
+    /**
+     * The Constructor.
+     *
+     * @param toDelete the blob to delete.
+     * @param backupFile a temporary blob, this should not contain anything important as it will be deleted
+     * and must not be altered while the operation is running. This will contain whatever
+     * was in the toDelete blob prior, just in case onRollback must be called.
+     * @param lock a ReadWriteLock whose writeLock will be locked as the beginning of the process and
+     * unlocked when complete.
+     */
+    public BlobDeleteTransactionRunnable(final Blob toDelete,
+        final Blob backupFile,
+        final ReadWriteLock lock)
+    {
+        this.toDelete = toDelete;
+        this.backupFile = backupFile;
+        this.lock = lock;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Obtain the lock and make sure the temporary and backup files are deleted.
+     * </p>
+     *
+     * @see StartableTransactionRunnable#onPreRun()
+     */
+    @Override
+    protected void onPreRun() throws BlobStoreException, IOException
+    {
+        this.lock.writeLock().lock();
+        this.clearBackup();
+        this.preRunComplete = true;
+    }
+
+    @Override
+    protected void onRun() throws BlobStoreException
+    {
+        if (this.toDelete.exists()) {
+            this.toDelete.getStore().moveBlob(this.toDelete.getPath(), this.backupFile.getPath());
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * There are a few possibilities. If preRun() has not completed then there may be an old backup from a previous
+     * delete, anyway if preRun() has not completed then we know there is nothing to rollback. Otherwise:
+     * </p>
+     * <ol>
+     * <li>There is a backup file but no main file, it has been renamed, rename it back to the main location.</li>
+     * <li>There is a main file and no backup. Nothing has probably happened, do nothing to rollback.</li>
+     * <li>There are neither backup nor main files, this means we tried to delete a file which didn't exist to begin
+     * with.</li>
+     * <li>There are both main and backup files. AAAAAaaa what do we do?! Throw an exception which will be reported.
+     * </li>
+     * </ol>
+     *
+     * @see StartableTransactionRunnable#onRollback()
+     */
+    @Override
+    protected void onRollback() throws BlobStoreException
+    {
+        // If this is false then we know run() has not yet happened and we know there is nothing to do.
+        if (this.preRunComplete) {
+            boolean isBackupFile = this.backupFile.exists();
+            boolean isMainFile = this.toDelete.exists();
+
+            // 1.
+            if (isBackupFile && !isMainFile) {
+                this.backupFile.getStore().moveBlob(this.backupFile.getPath(), this.toDelete.getPath());
+                return;
+            }
+
+            // 2.
+            if (!isBackupFile && isMainFile) {
+                return;
+            }
+
+            // 3.
+            if (!isBackupFile && !isMainFile) {
+                return;
+            }
+
+            // 4.
+            if (isBackupFile && isMainFile) {
+                throw new IllegalStateException("Tried to rollback the deletion of file "
+                    + this.toDelete.getPath() + " and encountered a "
+                    + "backup and a main file. Since the main file is renamed "
+                    + "to a backup location before deleting, this should never "
+                    + "happen.");
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Once this is called, there is no going back.
+     * Remove backup file and unlock the lock.
+     * </p>
+     *
+     * @see StartableTransactionRunnable#onComplete()
+     */
+    @Override
+    protected void onComplete() throws BlobStoreException, IOException
+    {
+        if (!this.preRunComplete) {
+            throw new IllegalStateException("Deleting file: " + this.toDelete.getPath()
+                + " onPreRun has not been called, maybe the class was extended "
+                + "and it was overridden?");
+        }
+        try {
+            this.clearBackup();
+        } finally {
+            this.lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Remove backup file.
+     *
+     * @throws IOException if removing file fails or file still exists after delete() is called.
+     */
+    private void clearBackup() throws BlobStoreException, IOException
+    {
+        if (this.backupFile.exists()) {
+            this.backupFile.getStore().deleteBlob(this.backupFile.getPath());
+        }
+        if (this.backupFile.exists()) {
+            throw new IOException("Could not remove backup file, cannot proceed.");
+        }
+    }
+
+}

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/src/main/java/org/xwiki/store/internal/BlobSaveTransactionRunnable.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/src/main/java/org/xwiki/store/internal/BlobSaveTransactionRunnable.java
@@ -1,0 +1,318 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.store.internal;
+
+import java.io.IOException;
+import java.util.concurrent.locks.ReadWriteLock;
+
+import org.xwiki.store.BlobSerializer;
+import org.xwiki.store.StartableTransactionRunnable;
+import org.xwiki.store.StreamProvider;
+import org.xwiki.store.StreamProviderBlobSerializer;
+import org.xwiki.store.TransactionRunnable;
+import org.xwiki.store.blob.Blob;
+import org.xwiki.store.blob.BlobStoreException;
+
+/**
+ * A TransactionRunnable for saving a blob safely.
+ * The operation can be rolled back even after the onCommit() function is called.
+ * It is only final when the onComplete function is called.
+ *
+ * @version $Id$
+ * @since 17.8.0RC1
+ */
+public class BlobSaveTransactionRunnable extends StartableTransactionRunnable<TransactionRunnable>
+{
+    /**
+     * The location of the file to save the attachment content in.
+     */
+    private final Blob toSave;
+
+    /**
+     * The location of the temporary file.
+     */
+    private final Blob tempFile;
+
+    /**
+     * The location of the backup file.
+     */
+    private final Blob backupFile;
+
+    /**
+     * A lock to hold while running this TransactionRunnable.
+     */
+    private final ReadWriteLock lock;
+
+    /**
+     * The serializer.
+     */
+    private final BlobSerializer serializer;
+
+    /**
+     * False until run() has complete. If false then we know there is nothing to rollback and
+     * more importantly, we do not know if files in the temporary and backup locations are not
+     * from a previous (catastrophically failed) save operation.
+     */
+    private boolean runComplete;
+
+    /**
+     * The Constructor.
+     *
+     * @param toSave the file to put the content in.
+     * @param tempFile a temporary file, this should not contain anything important as it will be deleted
+     * and must not be altered while the operation is running. This will contain the data
+     * until onCommit when it is renamed to the toSave file.
+     * @param backupFile a temporary file, this should not contain anything important as it will be deleted
+     * and must not be altered while the operation is running. This will contain whatever
+     * was in the toSave file prior, just in case onRollback must be called.
+     * @param lock a ReadWriteLock whose writeLock will be locked as the beginning of the process and
+     * unlocked when complete.
+     * @param provider a StreamProvider to get the data to put into the file.
+     */
+    public BlobSaveTransactionRunnable(final Blob toSave,
+        final Blob tempFile,
+        final Blob backupFile,
+        final ReadWriteLock lock,
+        final StreamProvider provider)
+    {
+        this.toSave = toSave;
+        this.tempFile = tempFile;
+        this.backupFile = backupFile;
+        this.lock = lock;
+        this.serializer = new StreamProviderBlobSerializer(provider);
+    }
+
+    /**
+     * The Constructor.
+     *
+     * @param toSave the blob to put the content in.
+     * @param tempFile a temporary blob, this should not contain anything important as it will be deleted
+     * and must not be altered while the operation is running. This will contain the data
+     * until onCommit when it is renamed to the toSave blob.
+     * @param backupFile a temporary blob, this should not contain anything important as it will be deleted
+     * and must not be altered while the operation is running. This will contain whatever
+     * was in the toSave blob prior, just in case onRollback must be called.
+     * @param lock a ReadWriteLock whose writeLock will be locked at the beginning of the process and
+     * unlocked when complete.
+     * @param serializer a BlobSerializer in charge of serializing what needs to be serialized to the blob.
+     */
+    public BlobSaveTransactionRunnable(final Blob toSave,
+        final Blob tempFile,
+        final Blob backupFile,
+        final ReadWriteLock lock,
+        final BlobSerializer serializer)
+    {
+        this.toSave = toSave;
+        this.tempFile = tempFile;
+        this.backupFile = backupFile;
+        this.lock = lock;
+        this.serializer = serializer;
+    }
+
+
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Obtain the lock and make sure the temporary and backup files are deleted.
+     * </p>
+     *
+     * @see TransactionRunnable#preRun()
+     */
+    @Override
+    protected void onPreRun() throws IOException, BlobStoreException
+    {
+        this.lock.writeLock().lock();
+        this.clearTempAndBackup();
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Write the data from the provider to the temporary file.
+     * </p>
+     *
+     * @see TransactionRunnable#run()
+     */
+    @Override
+    protected void onRun() throws Exception
+    {
+        try {
+            this.serializer.serialize(this.tempFile);
+        } finally {
+            this.runComplete = true;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Move whatever is in the main file location into backup and move
+     * the temp file into the main location.
+     * </p>
+     *
+     * @see TransactionRunnable#onCommit()
+     */
+    @Override
+    protected void onCommit() throws BlobStoreException
+    {
+        if (this.toSave.exists()) {
+            this.toSave.getStore().moveBlob(this.toSave.getPath(), this.backupFile.getPath());
+        }
+        this.tempFile.getStore().moveBlob(this.tempFile.getPath(), this.toSave.getPath());
+    }
+
+    @Override
+    protected void onRollback() throws BlobStoreException
+    {
+        // If this is false then we know run() has not yet happened and we know there is nothing to do.
+        if (this.runComplete) {
+            if (this.tempFile.exists()) {
+                this.onRollbackWithTempFile();
+            } else {
+                this.onRollbackNoTempFile();
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Once this is called, there is no going back.
+     * Remove temporary and backup files and unlock the lock.
+     * </p>
+     *
+     * @see TransactionRunnable#onComplete()
+     */
+    @Override
+    protected void onComplete() throws IOException, BlobStoreException
+    {
+        try {
+            this.clearTempAndBackup();
+        } finally {
+            this.lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Knowing there is no temp file, we can determine that one of 4 possible things happened.
+     *
+     * 1. No backup file and no main file. There was probably no file to begin with
+     * and it failed before anything could be saved in the temp file. Do nothing.
+     *
+     * 2. No backup file but there is a main file, assume onCommit happened successfully but there
+     * was no file here to begin with so there was nothing to back up. Move the main file back
+     * to the temporary location.
+     *
+     * 3. If there is a backup file, but no main file, this is unexpected but since the backup file
+     * should be the previous main file, move it back to the main location and log a warning
+     * that the storage engine encountered an unexpected albeit probably recoverable state.
+     *
+     * 4. If there is a backup file and a main file, onCommit probably went smoothly and a problem
+     * was encountered somewhere else forcing the rollback. Move the main file back to the
+     * temporary location and the backup file back to the main location.
+     */
+    private void onRollbackNoTempFile() throws BlobStoreException
+    {
+        boolean isBackupFile = this.backupFile.exists();
+        boolean isMainFile = this.toSave.exists();
+
+        // 1.
+        if (!isBackupFile && !isMainFile) {
+            return;
+        }
+
+        // 2.
+        if (!isBackupFile) {
+            this.toSave.getStore().moveBlob(this.toSave.getPath(), this.tempFile.getPath());
+            return;
+        }
+
+        // 3.
+        if (!isMainFile) {
+            this.backupFile.getStore().moveBlob(this.backupFile.getPath(), this.toSave.getPath());
+            // TODO log a low severity warning.
+            return;
+        }
+
+        // 4.
+        this.toSave.getStore().moveBlob(this.toSave.getPath(), this.tempFile.getPath());
+        this.backupFile.getStore().moveBlob(this.backupFile.getPath(), this.toSave.getPath());
+    }
+
+    /**
+     * Knowing there is a temp file, one of 3 things might have happened:
+     *
+     * 1. If there is no backup file, assume onCommit did not occur, do nothing regardless
+     * of whether there is or isn't an (existing) main file.
+     *
+     * 2. If there is a backup file but no main file, there must have been a failure half way
+     * through onCommit, it was able to move the existing main file to the backup
+     * location but did not move the temporary file to the main location. Move the backup file
+     * back to the main location.
+     *
+     * 3. If there is a file in each location which should not happen and if it does,
+     * throw an exception which will be printed in the log.
+     */
+    private void onRollbackWithTempFile() throws BlobStoreException
+    {
+        boolean isBackupFile = this.backupFile.exists();
+        boolean isMainFile = this.toSave.exists();
+
+        // 1.
+        if (!isBackupFile) {
+            return;
+        }
+
+        // 2.
+        if (!isMainFile) {
+            this.backupFile.getStore().moveBlob(this.backupFile.getPath(), this.toSave.getPath());
+            return;
+        }
+
+        // 3.
+        throw new IllegalStateException("Tried to rollback the saving of file " + this.toSave.getPath()
+            + " and encountered a backup, a temp file, and a main file. Since any existing "
+            + "main file is renamed to a temp location and the content is saved in the backup location and then "
+            + "renamed to the main location, the existance of all 3 at once should never happen.");
+    }
+
+    /**
+     * Remove temporary and backup files.
+     *
+     * @throws IOException if removing files fails or files still exist after delete() is called.
+     */
+    private void clearTempAndBackup() throws IOException, BlobStoreException
+    {
+        if (this.tempFile.exists()) {
+            this.tempFile.getStore().deleteBlob(this.tempFile.getPath());
+        }
+        if (this.tempFile.exists()) {
+            throw new IOException("Could not remove temporary file, cannot proceed.");
+        }
+        if (this.backupFile.exists()) {
+            this.backupFile.getStore().deleteBlob(this.backupFile.getPath());
+        }
+        if (this.backupFile.exists()) {
+            throw new IOException("Could not remove backup file, cannot proceed.");
+        }
+    }
+
+}

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/src/test/java/org/xwiki/store/internal/BlobDeleteTransactionRunnableTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/src/test/java/org/xwiki/store/internal/BlobDeleteTransactionRunnableTest.java
@@ -1,0 +1,184 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.store.internal;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.xwiki.store.StartableTransactionRunnable;
+import org.xwiki.store.TransactionRunnable;
+import org.xwiki.store.blob.Blob;
+import org.xwiki.store.blob.BlobPath;
+import org.xwiki.store.blob.BlobStore;
+import org.xwiki.store.blob.BlobStoreException;
+import org.xwiki.store.blob.internal.FileSystemBlobStore;
+import org.xwiki.test.junit5.XWikiTempDir;
+import org.xwiki.test.junit5.XWikiTempDirExtension;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link BlobDeleteTransactionRunnable}.
+ *
+ * @version $Id$
+ */
+@ExtendWith(XWikiTempDirExtension.class)
+class BlobDeleteTransactionRunnableTest
+{
+    private static final String[] FILE_PATH = { "path", "to", "file" };
+
+    private Blob location;
+
+    private Blob temp;
+
+    private ReadWriteLock lock;
+
+    private BlobDeleteTransactionRunnable runnable;
+
+    @XWikiTempDir
+    private File tmpDir;
+
+    @BeforeEach
+    void setUp() throws Exception
+    {
+        BlobStore blobStore = new FileSystemBlobStore("Test", this.tmpDir.toPath());
+
+        BlobPath blobPath = BlobPath.of(Arrays.asList(FILE_PATH));
+
+        this.location = blobStore.getBlob(blobPath);
+        this.temp = blobStore.getBlob(blobPath.appendSuffix("~tmp"));
+        IOUtils.write("Delete me!", this.location.getOutputStream(), StandardCharsets.UTF_8);
+        IOUtils.write("HAHA I am here to trip you up!", this.temp.getOutputStream(), StandardCharsets.UTF_8);
+
+        this.lock = new ReentrantReadWriteLock();
+
+        this.runnable = new BlobDeleteTransactionRunnable(this.location, this.temp, this.lock);
+    }
+
+    @Test
+    void simpleTest() throws Exception
+    {
+        assertTrue(this.location.exists());
+        this.runnable.start();
+        assertFalse(this.location.exists());
+        assertFalse(this.temp.exists());
+    }
+
+    @Test
+    void rollbackAfterPreRunTest() throws BlobStoreException
+    {
+        assertTrue(this.location.exists());
+
+        // After preRun(), before run.
+        final TransactionRunnable failRunnable = new TransactionRunnable()
+        {
+            public void onRun() throws Exception
+            {
+                assertFalse(temp.exists());
+                assertTrue(location.exists());
+                throw new Exception("Simulate something going wrong.");
+            }
+        };
+        final StartableTransactionRunnable str = new StartableTransactionRunnable();
+        failRunnable.runIn(str);
+        runnable.runIn(str);
+        this.validateRollback(str);
+    }
+
+    @Test
+    void rollbackAfterRunTest() throws BlobStoreException
+    {
+        assertTrue(this.location.exists());
+
+        // After run() before onCommit()
+        final TransactionRunnable failRunnable = new TransactionRunnable()
+        {
+            public void onRun() throws Exception
+            {
+                assertTrue(temp.exists());
+                assertFalse(location.exists());
+                throw new Exception("Simulate something going wrong.");
+            }
+        };
+        final StartableTransactionRunnable str = new StartableTransactionRunnable();
+        runnable.runIn(str);
+        failRunnable.runIn(str);
+        this.validateRollback(str);
+    }
+
+    @Test
+    void deleteNonexistantTest() throws Exception
+    {
+        this.location.getStore().deleteBlob(this.location.getPath());
+        assertFalse(this.location.exists());
+        this.runnable.start();
+        assertFalse(this.location.exists());
+        assertFalse(this.temp.exists());
+    }
+
+    @Test
+    void rollbackDeleteNonexistantTest() throws BlobStoreException
+    {
+        this.location.getStore().deleteBlob(this.location.getPath());
+        assertFalse(this.location.exists());
+
+        final TransactionRunnable failRunnable = new TransactionRunnable()
+        {
+            public void onRun() throws Exception
+            {
+                assertFalse(temp.exists());
+                assertFalse(location.exists());
+                throw new Exception("Simulate something going wrong.");
+            }
+        };
+
+        assertThrows(Exception.class, () -> {
+            try {
+                final StartableTransactionRunnable str = new StartableTransactionRunnable();
+                runnable.runIn(str);
+                failRunnable.runIn(str);
+                str.start();
+            } catch (Exception e) {
+                assertFalse(this.location.exists());
+                assertFalse(this.temp.exists());
+                throw e;
+            }
+        });
+    }
+
+    private void validateRollback(final StartableTransactionRunnable str) throws BlobStoreException
+    {
+        assertThrows(Exception.class, () -> {
+            str.start();
+        });
+
+        assertTrue(this.location.exists());
+        assertFalse(this.temp.exists());
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/src/test/java/org/xwiki/store/internal/BlobSaveTransactionRunnableTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/src/test/java/org/xwiki/store/internal/BlobSaveTransactionRunnableTest.java
@@ -1,0 +1,235 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.store.internal;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.xwiki.store.StartableTransactionRunnable;
+import org.xwiki.store.StreamProvider;
+import org.xwiki.store.TransactionRunnable;
+import org.xwiki.store.blob.Blob;
+import org.xwiki.store.blob.BlobPath;
+import org.xwiki.store.blob.BlobStore;
+import org.xwiki.store.blob.internal.FileSystemBlobStore;
+import org.xwiki.test.junit5.XWikiTempDir;
+import org.xwiki.test.junit5.XWikiTempDirExtension;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+/**
+ * Tests for {@link BlobSaveTransactionRunnable}.
+ *
+ * @version $Id$
+ */
+@ExtendWith(XWikiTempDirExtension.class)
+class BlobSaveTransactionRunnableTest
+{
+    private static final String[] FILE_PATH = { "path", "to", "file" };
+
+    private static final String CONTENT_VERSION1 = "Version1";
+
+    private static final String CONTENT_VERSION2 = "Version2";
+
+    private Blob toSave;
+
+    private Blob temp;
+
+    private Blob backup;
+
+    private StreamProvider provider;
+
+    private ReadWriteLock lock;
+
+    private BlobSaveTransactionRunnable runnable;
+
+    private BlobStore blobStore;
+
+    @XWikiTempDir
+    private File testDirectory;
+
+    @BeforeEach
+    void beforeEach() throws Exception
+    {
+        File storageLocation = new File(this.testDirectory, "test-storage" + System.identityHashCode(this.getClass()));
+        this.blobStore = spy(new FileSystemBlobStore("test", storageLocation.toPath()));
+
+        BlobPath blobPath = BlobPath.of(Arrays.asList(FILE_PATH));
+        this.toSave = this.blobStore.getBlob(blobPath);
+
+        this.temp = this.blobStore.getBlob(blobPath.appendSuffix("~tmp"));
+        this.backup = this.blobStore.getBlob(blobPath.appendSuffix("~bak"));
+
+        IOUtils.write(CONTENT_VERSION1, this.toSave.getOutputStream(), StandardCharsets.UTF_8);
+        IOUtils.write("HAHA I am here to trip you up!", this.temp.getOutputStream(), StandardCharsets.UTF_8);
+        IOUtils.write("I am also here to trip you up!", this.backup.getOutputStream(), StandardCharsets.UTF_8);
+
+        this.lock = new ReentrantReadWriteLock();
+
+        this.provider = () -> new ByteArrayInputStream(CONTENT_VERSION2.getBytes());
+
+        this.runnable = new BlobSaveTransactionRunnable(this.toSave, this.temp, this.backup, this.lock, this.provider);
+    }
+
+    @Test
+    void simpleTest() throws Exception
+    {
+        assertEquals(CONTENT_VERSION1, IOUtils.toString(this.toSave.getStream(), StandardCharsets.UTF_8));
+
+        this.runnable.start();
+
+        assertFalse(this.backup.exists());
+        assertFalse(this.temp.exists());
+        assertEquals(CONTENT_VERSION2, IOUtils.toString(this.toSave.getStream(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void rollbackAfterPreRunTest() throws Exception
+    {
+        assertEquals(CONTENT_VERSION1, IOUtils.toString(this.toSave.getStream(), StandardCharsets.UTF_8));
+
+        // After preRun(), before run.
+        final TransactionRunnable failRunnable = new TransactionRunnable()
+        {
+            @Override
+            public void onRun() throws Exception
+            {
+                assertFalse(temp.exists(), "Temp file was not cleared in preRun.");
+                assertFalse(backup.exists(), "Backup file was not cleared in preRun.");
+
+                throw new Exception("Simulate something going wrong.");
+            }
+        };
+
+        final StartableTransactionRunnable str = new StartableTransactionRunnable();
+        failRunnable.runIn(str);
+        runnable.runIn(str);
+        this.validateRollback(str);
+
+        assertEquals(CONTENT_VERSION1, IOUtils.toString(this.toSave.getStream(), StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void rollbackAfterRunTest() throws Exception
+    {
+        assertEquals(CONTENT_VERSION1, IOUtils.toString(this.toSave.getStream(), StandardCharsets.UTF_8));
+
+        // After run() before onCommit()
+        final TransactionRunnable failRunnable = new TransactionRunnable()
+        {
+            @Override
+            public void onRun() throws Exception
+            {
+                assertTrue(temp.exists(), "Content was not saved to temp file.");
+
+                throw new Exception("Simulate something going wrong.");
+            }
+        };
+
+        final StartableTransactionRunnable str = new StartableTransactionRunnable();
+        runnable.runIn(str);
+        failRunnable.runIn(str);
+        validateRollback(str);
+    }
+
+    @Test
+    void rollbackAfterFailedCommit() throws Exception
+    {
+        assertEquals(CONTENT_VERSION1, IOUtils.toString(this.toSave.getStream(), StandardCharsets.UTF_8));
+
+        // Make the temp rename fail
+        doThrow(new SecurityException("Simulate failing rename")).when(this.blobStore)
+            .moveBlob(this.temp.getPath(), this.toSave.getPath());
+
+        final StartableTransactionRunnable str = new StartableTransactionRunnable();
+        runnable.runIn(str);
+        validateRollback(str);
+    }
+
+    @Test
+    void saveWithNonexistantOriginalTest() throws Exception
+    {
+        this.toSave.getStore().deleteBlob(this.toSave.getPath());
+        assertFalse(this.toSave.exists());
+
+        this.runnable.start();
+
+        assertTrue(this.toSave.exists());
+        assertEquals(CONTENT_VERSION2, IOUtils.toString(this.toSave.getStream(), StandardCharsets.UTF_8));
+
+        assertFalse(this.temp.exists());
+        assertFalse(this.backup.exists());
+    }
+
+    @Test
+    void rollbackWithNonexistantOriginalTest() throws Exception
+    {
+        this.toSave.getStore().deleteBlob(this.toSave.getPath());
+        assertFalse(this.toSave.exists());
+
+        final TransactionRunnable failRunnable = new TransactionRunnable()
+        {
+            @Override
+            public void onRun() throws Exception
+            {
+                assertFalse(backup.exists());
+                assertTrue(temp.exists());
+                assertFalse(toSave.exists());
+                throw new Exception("Simulate something going wrong.");
+            }
+        };
+
+        final StartableTransactionRunnable str = new StartableTransactionRunnable();
+        runnable.runIn(str);
+        failRunnable.runIn(str);
+        Exception exception = assertThrows(Exception.class, str::start);
+        assertThat(exception.getMessage(), containsString("Simulate something going wrong."));
+
+        assertFalse(this.toSave.exists());
+        assertFalse(this.temp.exists());
+        assertFalse(this.backup.exists());
+    }
+
+    private void validateRollback(final StartableTransactionRunnable tr) throws Exception
+    {
+        assertThrows(Exception.class, tr::start,
+            "TransactionRunnable#start() did not throw the exception thrown by run.");
+
+        assertTrue(this.toSave.exists());
+        assertEquals(CONTENT_VERSION1, IOUtils.toString(this.toSave.getStream(), StandardCharsets.UTF_8));
+        assertFalse(this.temp.exists());
+        assertFalse(this.backup.exists());
+    }
+}

--- a/xwiki-platform-distribution/xwiki-platform-distribution-war-dependencies/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-war-dependencies/pom.xml
@@ -680,5 +680,12 @@
       <version>${project.version}</version>
       <scope>runtime</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-store-blob-s3</artifactId>
+      <version>${commons.version}</version>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22845

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Change the filesystem store to use the blob storage API introduced in xwiki/xwiki-commons#1416.
* Add dependencies to the blob storage implementations.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* I've left the migrations unchanged as much as possible, when upgrading from an older version, it will be necessary to start XWiki with the filesystem store first before starting with S3.
* Some internal classes and methods should probably be renamed to use the term "blob" instead of file.
* Since-versions still need to be updated.
* This depends on xwiki/xwiki-commons#1416.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Built the changed modules with quality profile. Tested manually with MinIO as backened.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None.