### PR TITLE
XWIKI-22257: Hash the superadmin password

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/user/impl/xwiki/XWikiAuthServiceImplTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/user/impl/xwiki/XWikiAuthServiceImplTest.java
@@ -130,6 +130,23 @@ class XWikiAuthServiceImplTest
     }
 
     /**
+     * Test the superadmin password can be hashed with bcrypt.
+     */
+    @Test
+    void authenticateWithSuperAdminWithBcryptPassword() throws Exception
+    {
+        // The password is "pass"
+        this.oldcore.getMockXWikiCfg().setProperty("xwiki.superadminpassword",
+            "$2y$08$2Mel30blRQ7E.XievLW00.AltivcBuU1HEl2mPG2qRGrd7FmWIwB6");
+
+        Principal principal = this.authService.authenticate(XWikiRightService.SUPERADMIN_USER, "pass",
+            this.oldcore.getXWikiContext());
+
+        assertNotNull(principal);
+        assertEquals(XWikiRightService.SUPERADMIN_USER_FULLNAME, principal.getName());
+    }
+
+    /**
      * Test that SomeUser is correctly authenticated as XWiki.SomeUser when xwiki:SomeUser is entered as username.
      */
     @Test

--- a/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.cfg.vm
+++ b/xwiki-platform-tools/xwiki-platform-tool-configuration-resources/src/main/resources/xwiki.cfg.vm
@@ -302,6 +302,8 @@ xwiki.inactiveuser.allowedpages=
 #-# Enable to allow superadmin. It is disabled by default as this could be a
 #-# security breach if it were set and you forgot about it. Should only be enabled
 #-# for recovering the Wiki when the rights are completely messed.
+#-# [Since 17.9.0RC1] Instead of plain text password, you can use a bcrypt-hashed password string that starts with $2,
+#-# e.g., generated using htpasswd -bnBC 10 "" yourpassword | tr -d ':\n'
 #if ($xwikiCfgSuperadminPassword)
 xwiki.superadminpassword=$xwikiCfgSuperadminPassword
 #else


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-22257

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Support bcrypt-encrypted password hashes for superadmin.
* Document bcrypt support in the configuration file.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* I've chosen bcrypt as it is [an acceptable choice for password hashing](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#bcrypt) and supported by [htpasswd](https://httpd.apache.org/docs/current/programs/htpasswd.html), offering an easy way to create the password hash outside of XWiki. More secure options unfortunately aren't supported by htpasswd.
* Having a superadmin password of exactly 60 characters starting with `$2` seems unlikely enough that I don't think there is any issue of treating such a value as a bcrypt hash and not a plain text password.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Built `xwiki-platform-oldcore` with quality profile.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * New feature, but we could consider backporting it as it seems safe to me and a nice security improvement.