### PR TITLE
XWIKI-23602: Error boxes expand, but the markup does not convey this information to AT users

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/messages.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/messages.less
@@ -112,6 +112,10 @@ div.xwikirenderingerror {
   & + .xwikirenderingerrordescription {
     margin-top: -20px;
   }
+  
+  &[role="button"] {
+    cursor: pointer;
+  }
 }
 
 // In every cases, apply the DANGER styling from bootstrap

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/messages.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/messages.less
@@ -112,7 +112,7 @@ div.xwikirenderingerror {
   & + .xwikirenderingerrordescription {
     margin-top: -20px;
   }
-  
+
   &[role="button"] {
     cursor: pointer;
   }

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/compatibility.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/compatibility.js
@@ -496,6 +496,21 @@ Object.extend(XWiki.watchlist, {
 });
 
 /**
+ * Rendering errors are made expandable by default. Trigger the xwiki:dom:updated event on the content you inserted
+ * instead, passing it in the elements property of the event data, which also initializes everything else that content
+ * needs.
+ *
+ * Deprecated since 18.8.0RC1
+ */
+XWiki.makeRenderingErrorsExpandable = function(content) {
+  warn("XWiki.makeRenderingErrorsExpandable is deprecated since XWiki 18.8.0RC1. Rendering errors are made expandable "
+    + "by default, trigger the xwiki:dom:updated event on the new content instead.");
+  require(['jquery'], function($) {
+    $(document).trigger('xwiki:dom:updated', {'elements': $(content || 'body').toArray()});
+  });
+}
+
+/**
  * Add some deprecated <meta> tags in the header of the page so that old script can still work. It is added via the
  * JavaScript since these <meta> tags are invalid with HTML5 and we want to have valid static HTML code.
  *

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/xwiki.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/xwiki.js
@@ -1835,6 +1835,10 @@ require(['jquery'], ($) => {
 });
 
 require(['jquery', 'xwiki-meta', 'bootstrap'], ($, xm) => {
+    // Used to give a unique id to each rendering error and to its description, so that they can reference each
+    // other.
+    let renderingErrorCounter = 0;
+
     function init(rootElement) {
         if (XWiki.docsyntax !== "xwiki/1.0" && XWiki.contextaction === "view" && XWiki.hasEdit) {
             $(rootElement).find('span.wikicreatelink:not(.skipCreatePagePopup) a').on('click', loadCreateModal);
@@ -1878,27 +1882,54 @@ require(['jquery', 'xwiki-meta', 'bootstrap'], ($, xm) => {
      * Otherwise make all the document's body errors expandable.
      */
     function makeRenderingErrorsExpandable(content) {
-        $(content || 'body').find('.xwikirenderingerror').each(function (index) {
-            let error = $(this);
-            let description = error.next(".xwikirenderingerrordescription");
-            if (description.innerHTML !== "" && description.hasClass("xwikirenderingerrordescription")) {
-                error.attr('id', 'xwikirenderingerror-' + index);
-                error.attr('role', 'button');
-                description.attr('id', 'xwikirenderingerrordescription-' + index);
-                error.attr('aria-controls', 'xwikirenderingerrordescription-' + index);
-                error.attr('aria-expanded', false);
-                let buttonDescription = "$escapetool.javascript($services.localization.render('platform.core.rendering.error.readTechnicalInformation'))"
-                error.attr('title', buttonDescription);
-                error.on("click", function () {
-                    // Toggle both the description class and the aria-expanded attribute of the button.
-                    let error = $(this);
-                    let description = error.next('.xwikirenderingerrordescription');
-                    description.toggleClass("hidden");
-                    error.attr('aria-expanded', error.attr('aria-expanded') === 'true' ? 'false' : 'true')
-                });
+        const readTechnicalInformation =
+            "$escapetool.javascript($services.localization.render('platform.core.rendering.error.readTechnicalInformation'))";
+        // Skip the errors that are already expandable, since this initialization is executed again whenever the DOM is
+        // updated, possibly on a part of the DOM that has already been initialized.
+        $(content || 'body').find('.xwikirenderingerror:not([aria-controls])').each(function () {
+            const error = $(this);
+            const description = error.next('.xwikirenderingerrordescription');
+            // Only the errors that come with a description can be expanded.
+            if (!description.html()) {
+                return;
             }
+            const descriptionId = 'xwikirenderingerrordescription-' + renderingErrorCounter;
+            description.attr('id', descriptionId);
+            error.attr({
+                'id': 'xwikirenderingerror-' + renderingErrorCounter,
+                'role': 'button',
+                // A div is not focusable on its own, unlike a real button.
+                'tabindex': 0,
+                'aria-controls': descriptionId,
+                'aria-expanded': false,
+                'title': readTechnicalInformation
+            });
+            renderingErrorCounter++;
+            error.on('click', function () {
+                // Toggle both the visibility of the description and the expanded state of the button.
+                description.toggleClass('hidden');
+                error.attr('aria-expanded', !description.hasClass('hidden'));
+            });
+            error.on('keydown', function (event) {
+                // A div with a button role is not activated by the keyboard on its own, unlike a real button.
+                if (event.key === 'Enter' || event.key === ' ') {
+                    // Prevent the page from scrolling down when the space key is pressed.
+                    event.preventDefault();
+                    error.trigger('click');
+                }
+            });
         });
     }
+
+    /**
+     * @deprecated since 18.8.0RC1, rendering errors are made expandable automatically, trigger the
+     *             xwiki:dom:updated event on the new content instead
+     */
+    XWiki.makeRenderingErrorsExpandable = (content) => {
+        console.warn('XWiki.makeRenderingErrorsExpandable() is deprecated since 18.8.0RC1, trigger the '
+            + 'xwiki:dom:updated event on the new content instead.');
+        makeRenderingErrorsExpandable(content);
+    };
 
     $(document).on('xwiki:dom:updated', (event, data) => {
         const containers = data?.elements || [document.documentElement];

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/xwiki.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/xwiki.js
@@ -319,24 +319,6 @@ Object.extend(XWiki, {
   },
 
   /**
-   * Add click listeners on all rendering error messages to let the user read the detailed error description.
-   * If a content is passed, add click listener for errors reported in this content (useful for AJAX requests response)
-   * Otherwise make all the document's body errors expandable.
-   */
-  makeRenderingErrorsExpandable: function(content) {
-    $(content || 'body').select(".xwikirenderingerror").each(function(error) {
-        var description = error.next(".xwikirenderingerrordescription");
-        if(description.innerHTML !== "" && description.hasClassName("xwikirenderingerrordescription")) {
-            error.style.cursor="pointer";
-            error.title = "$escapetool.javascript($services.localization.render('platform.core.rendering.error.readTechnicalInformation'))";
-            Event.observe(error, "click", function(event){
-                   event.element().closest(".xwikirenderingerror").next(".xwikirenderingerrordescription").toggleClassName("hidden");
-            });
-        }
-    });
-  },
-
-  /**
    * Make links marked with rel="external" in an external window and sets the target attribute to any
    * rel attribute starting with "_". Note that We need to do this in Javascript
    * as opposed to using target="_blank" since the target attribute is not valid XHTML.
@@ -561,7 +543,6 @@ Object.extend(XWiki, {
   _addBehaviour: function(container) {
     container = container || $('body');
 
-    this.makeRenderingErrorsExpandable(container);
     this.fixLinksTargetAttribute(container);
     this.insertSectionEditLinks(container);
     this.registerPanelToggle(container);
@@ -1858,6 +1839,7 @@ require(['jquery', 'xwiki-meta', 'bootstrap'], ($, xm) => {
         if (XWiki.docsyntax !== "xwiki/1.0" && XWiki.contextaction === "view" && XWiki.hasEdit) {
             $(rootElement).find('span.wikicreatelink:not(.skipCreatePagePopup) a').on('click', loadCreateModal);
         }
+        makeRenderingErrorsExpandable(rootElement);
     }
 
     function loadCreateModal(event) {
@@ -1888,6 +1870,34 @@ require(['jquery', 'xwiki-meta', 'bootstrap'], ($, xm) => {
         }).fail(function (data) {
             notification.replace(new XWiki.widgets.Notification("$escapetool.javascript($services.localization.render('core.create.ajax.error'))", 'error', {inactive: true}));
         })
+    }
+
+    /**
+     * Add click listeners on all rendering error messages to let the user read the detailed error description.
+     * If a content is passed, add click listener for errors reported in this content (useful for AJAX requests response)
+     * Otherwise make all the document's body errors expandable.
+     */
+    function makeRenderingErrorsExpandable(content) {
+        $(content || 'body').find('.xwikirenderingerror').each(function (index) {
+            let error = $(this);
+            let description = error.next(".xwikirenderingerrordescription");
+            if (description.innerHTML !== "" && description.hasClass("xwikirenderingerrordescription")) {
+                error.attr('id', 'xwikirenderingerror-' + index);
+                error.attr('role', 'button');
+                description.attr('id', 'xwikirenderingerrordescription-' + index);
+                error.attr('aria-controls', 'xwikirenderingerrordescription-' + index);
+                error.attr('aria-expanded', false);
+                let buttonDescription = "$escapetool.javascript($services.localization.render('platform.core.rendering.error.readTechnicalInformation'))"
+                error.attr('title', buttonDescription);
+                error.on("click", function () {
+                    // Toggle both the description class and the aria-expanded attribute of the button.
+                    let error = $(this);
+                    let description = error.next('.xwikirenderingerrordescription');
+                    description.toggleClass("hidden");
+                    error.attr('aria-expanded', error.attr('aria-expanded') === 'true' ? 'false' : 'true')
+                });
+            }
+        });
     }
 
     $(document).on('xwiki:dom:updated', (event, data) => {

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/xwiki.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/xwiki.js
@@ -1841,7 +1841,8 @@ require(['jquery', 'xwiki-meta', 'bootstrap'], ($, xm) => {
 
     function init(rootElement) {
         if (XWiki.docsyntax !== "xwiki/1.0" && XWiki.contextaction === "view" && XWiki.hasEdit) {
-            $(rootElement).find('span.wikicreatelink:not(.skipCreatePagePopup) a').on('click', loadCreateModal);
+            $(rootElement).find('span.wikicreatelink:not(.skipCreatePagePopup) a')
+                .off('click.xwikiCreateModal').on('click.xwikiCreateModal', loadCreateModal);
         }
         _makeRenderingErrorsExpandable(rootElement);
     }
@@ -1920,16 +1921,6 @@ require(['jquery', 'xwiki-meta', 'bootstrap'], ($, xm) => {
             });
         });
     }
-
-    /**
-     * @deprecated since 18.8.0RC1, rendering errors are made expandable by default, trigger the
-     *             xwiki:dom:updated event on the new content instead
-     */
-    XWiki.makeRenderingErrorsExpandable = (content) => {
-        console.warn('XWiki.makeRenderingErrorsExpandable() is deprecated since 18.8.0RC1, rendering errors are '
-            + 'made expandable by default, trigger the xwiki:dom:updated event on the new content instead.');
-        _makeRenderingErrorsExpandable(content);
-    };
 
     $(document).on('xwiki:dom:updated', (event, data) => {
         const containers = data?.elements || [document.documentElement];

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/xwiki.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/xwiki.js
@@ -1843,7 +1843,7 @@ require(['jquery', 'xwiki-meta', 'bootstrap'], ($, xm) => {
         if (XWiki.docsyntax !== "xwiki/1.0" && XWiki.contextaction === "view" && XWiki.hasEdit) {
             $(rootElement).find('span.wikicreatelink:not(.skipCreatePagePopup) a').on('click', loadCreateModal);
         }
-        makeRenderingErrorsExpandable(rootElement);
+        _makeRenderingErrorsExpandable(rootElement);
     }
 
     function loadCreateModal(event) {
@@ -1881,7 +1881,7 @@ require(['jquery', 'xwiki-meta', 'bootstrap'], ($, xm) => {
      * If a content is passed, add click listener for errors reported in this content (useful for AJAX requests response)
      * Otherwise make all the document's body errors expandable.
      */
-    function makeRenderingErrorsExpandable(content) {
+    function _makeRenderingErrorsExpandable(content) {
         const readTechnicalInformation =
             "$escapetool.javascript($services.localization.render('platform.core.rendering.error.readTechnicalInformation'))";
         // Skip the errors that are already expandable, since this initialization is executed again whenever the DOM is
@@ -1922,13 +1922,13 @@ require(['jquery', 'xwiki-meta', 'bootstrap'], ($, xm) => {
     }
 
     /**
-     * @deprecated since 18.8.0RC1, rendering errors are made expandable automatically, trigger the
+     * @deprecated since 18.8.0RC1, rendering errors are made expandable by default, trigger the
      *             xwiki:dom:updated event on the new content instead
      */
     XWiki.makeRenderingErrorsExpandable = (content) => {
-        console.warn('XWiki.makeRenderingErrorsExpandable() is deprecated since 18.8.0RC1, trigger the '
-            + 'xwiki:dom:updated event on the new content instead.');
-        makeRenderingErrorsExpandable(content);
+        console.warn('XWiki.makeRenderingErrorsExpandable() is deprecated since 18.8.0RC1, rendering errors are '
+            + 'made expandable by default, trigger the xwiki:dom:updated event on the new content instead.');
+        _makeRenderingErrorsExpandable(content);
     };
 
     $(document).on('xwiki:dom:updated', (event, data) => {


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-23602

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Converted makeRenderingErrorsExpandable to a jquery based function instead of one relying on prototype.
* Added the appropriate markup for a extend/collapse pattern.
* Moved an inline style to its block in messages.less

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* I reused the structure already implemented by @surli in  https://github.com/xwiki/xwiki-platform/commit/0d91409d433c2df6a5c13cec761d913342235b2c after realizing it was exactly the same as what I needed ^^'
* In order to make sure I wouldn't forget anything, I followed the pattern at https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/examples/disclosure-faq/

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Here is a look at the UI and DOM after the changes proposed here were applied on my local instance:
<img width="2256" height="1130" alt="image" src="https://github.com/user-attachments/assets/7d85f36e-292c-4023-b9cc-02127f266f59" />

We can see that the UI in itself does not change at all. However the DOM contains the appropriate info in aria attributes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests, see above.
Checked WCAG validity with the description collapsed and expanded, using the axe browser extension. It did not report any failure.
I couldn't get SonarQube to run on `xwiki.js`, it's probably having a bit of trouble with the 2000 lines of mostly low quality code by today's project standards.
As far as I can see, the exact DOM of the error message isn't used in any docker test validation. It's used in `getHTMLExceptionMessage` but AFAICS this util function is just a util in contexts where the regular error messages can't be used.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None. This is a low priority bugfix