### PR TITLE
XWIKI-23790: Search facets numbers background are displayed elongated downwards when the filter name is on two lines

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/Main/SolrSearch.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/Main/SolrSearch.xml
@@ -464,9 +464,7 @@
       <cache>long</cache>
     </property>
     <property>
-      <code>#template('colorThemeInit.vm')
-
-/* Hide the 'Created by', 'Modified by' and 'Tags' document sections. */
+      <code>/* Hide the 'Created by', 'Modified by' and 'Tags' document sections. */
 .xdocLastModification, #xdocFooter {
   display: none;
 }
@@ -612,7 +610,7 @@ When the box is not checked, we want to hide the second icon. */
 .search-result-language,
 .search-result-uploader,
 .search-result-mediaType {
-  color: $theme.textSecondaryColor;
+  color: var(--text-muted);
 }
 
 .search-result-location,
@@ -658,7 +656,7 @@ blockquote.search-result-highlight {
 }
 
 .search-text-highlight {
-  background-color: $theme.highlightColor;
+  background-color: var(--nav-link-hover-bg);
   font-weight: bold;
 }
 
@@ -731,7 +729,7 @@ dl.search-result-highlights.preview dd:first-of-type blockquote:first-of-type {
 }
 
 .search-facet-header label {
-  color: $theme.titleColor;
+  color: var(--headings-color);
   cursor: pointer;
   display: flex;
   justify-content: space-between;
@@ -795,7 +793,7 @@ dl.search-result-highlights.preview dd:first-of-type blockquote:first-of-type {
 }
 
 .search-facet-body ul, .search-facet-body ul.users {
-  color: $theme.textSecondaryColor;
+  color: var(--text-muted);
   list-style: none;
   display: block;
   padding: 0;
@@ -830,13 +828,13 @@ body.preference-underlining-only-inline-links #xwikicontent .search-facet-body .
 .search-facet-body .facet-value-toggle,
 .search-facet-body .more {
   /* Remove link styling */
-  color: $theme.textColor;
+  color: var(--text-color);
   text-decoration: none;
 }
 
 .search-facet-body .itemName.empty,
 .search-facet-body .more {
-  color: $theme.textSecondaryColor;
+  color: var(--text-muted);
 }
 
 /* In case the JavaScript is disabled. */
@@ -845,6 +843,8 @@ body.preference-underlining-only-inline-links #xwikicontent .search-facet-body .
 }
 
 .search-facet-body .itemCount {
+  /* The YUI CSS compressor removes spaces incorrectly in this operator. We use a workaround to still make it work. */
+  max-height: calc(1lh - -.2em);
   padding: .1em .5em;
   margin-left: auto;
   background-color: var(--nav-link-hover-bg);
@@ -873,7 +873,7 @@ body.preference-underlining-only-inline-links #xwikicontent .search-facet-body .
  */
 
 .search-results-left .paginationFilter {
-  border-top: 1px solid $theme.borderColor;
+  border-top: 1px solid var(--xwiki-border-color);
   padding-left: 0;
 }
 </code>
@@ -885,7 +885,7 @@ body.preference-underlining-only-inline-links #xwikicontent .search-facet-body .
       <name/>
     </property>
     <property>
-      <parse>1</parse>
+      <parse>0</parse>
     </property>
     <property>
       <use>onDemand</use>


### PR DESCRIPTION

# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-23790

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Fixed the error in style on L862.
* Updated the SSX to use CSS variables instead of colibri colortheme ones.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* I used the mappings from the colibri colortheme to LESS in `colorThemeMappingOutput.vm` to figure out what variable contained the same value. Except for colibri colortheme level customizations, this should have no impact on the final style.
* Updating the style variable system allows to save time parsing the SSX content  and another load of colorThemeInit :)

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
After the PR is updated, we can see that the entry count pill on the right doesn't extend vertically when there's space:

<img width="2560" height="1360" alt="image" src="https://github.com/user-attachments/assets/f6988c2e-8dc8-46a5-9b68-875b8ea5b53b" />

The screenshot also highlights that the workaround found to avoid the YUI compressor messing the CSS compilation works.


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests on my local instance.
I successfully built quality tests: `mvn clean install -f xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui -Pquality`.
I did not run any docker tests because this is a minor style only change.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 17.10.X, minor bug fix.