### PR TITLE
XWIKI-18330: Search facets values are truncated

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/Main/SolrSearch.xml
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui/src/main/resources/Main/SolrSearch.xml
@@ -181,6 +181,11 @@
     $(this).before(checkBox)
   };
 
+  var addFacetTitle = function() {
+    let facetPrettyNameText = $(this).text();
+    $(this).attr('title', facetPrettyNameText);
+  }
+
   var enhanceSearchFacets = function() {
     var facetsContainer = $(this);
 
@@ -202,7 +207,8 @@
     // Add a check box before each facet value. We do this from JavaScript because the behaviour of a check box inside
     // a link is not consistent across different browsers (some follow the link when the check box is clicked, others
     // don't) and having the check box outside the facet value link requires JavaScript to synchronize them.
-    facetsContainer.find('.search-facet-body a.itemName').each(addFacetValueCheckbox);
+    // Add a title on the facet. We do this from JS because the pretty name can contain custom HTML.
+    facetsContainer.find('.search-facet-body a.itemName').each(addFacetValueCheckbox).each(addFacetTitle);
   };
 
   var getQueryString = function(url) {


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-18330

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added a title on the facet link.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* AFAIU there's no way to make this cleanly directly in the template. With jquery it's pretty trivial :)

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Here is a demo on my local instance of how the title works:
<img width="804" height="208" alt="Screenshot From 2025-12-12 15-09-02" src="https://github.com/user-attachments/assets/85bad13c-c5e5-4435-9f2f-c73a36eacb75" />
<img width="2334" height="1124" alt="image" src="https://github.com/user-attachments/assets/6d852162-1cb5-488c-a135-a5adab2ffcf0" />


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Built successfully the changes with `mvn clean install -f xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-ui -Pquality`

Passed the docker tests: `mvn clean install -f xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-test/xwiki-platform-search-test-docker/`

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None.