### PR TITLE
XWIKI-23869: HTML5 validation outline error: heading level skipped on the image style code page

### DIFF
--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/xwiki-platform-image-style-ui/src/main/resources/Image/Style/Code/Administration.xml
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/xwiki-platform-image-style-ui/src/main/resources/Image/Style/Code/Administration.xml
@@ -126,7 +126,7 @@
 {{/velocity}}
 
 (% id='HImageStyles' %)
-=== {{translation key="image.style.administration.imageStyleList.heading"/}} ===
+== {{translation key="image.style.administration.imageStyleList.heading"/}} ==
 
 {{liveData
   id='imageStyles'

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/xwiki-platform-image-style-ui/src/main/resources/Image/Style/Code/Configuration.xml
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/xwiki-platform-image-style-ui/src/main/resources/Image/Style/Code/Configuration.xml
@@ -325,7 +325,7 @@
       <displayInSection>image.style</displayInSection>
     </property>
     <property>
-      <heading>$services.localization.render('image.style.admin.heading')</heading>
+      <heading/>
     </property>
     <property>
       <iconAttachment/>


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-23869

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Updated the heading level.
* Removed a repetitive heading on the image style configuration sheet.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* This has two impacts:
  * Fix the outline on the Administration page where this section is by itself (what is intended to solve the ticket).
  * Change slightly the semantics on the whole Image Style page. The semantics of the first h2 before the change "Image Style Administration" was repetitive with the page h1. The page outline would have made especially little sense after moving the only h3 to be a h2 next to this one.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Before the PR:
<img width="2557" height="1018" alt="image" src="https://github.com/user-attachments/assets/6f10a9fb-5cc2-46a5-b999-7e7c99711fae" />
<img width="2557" height="1018" alt="Screenshot From 2026-01-08 17-00-40" src="https://github.com/user-attachments/assets/79aef706-8ec9-4d10-b19e-db4c85127857" />
After the PR:
<img width="2557" height="1018" alt="Screenshot From 2026-01-08 17-02-16" src="https://github.com/user-attachments/assets/95e8a869-2786-4028-8bfa-6996a477fed7" />
<img width="2557" height="1018" alt="image" src="https://github.com/user-attachments/assets/ea4f9212-3c81-4e03-8d10-a236ef5fee39" />


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests on my local instance, see above.,
Built the changes successfully with `mvn clean install -f xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/xwiki-platform-image-style-ui -Pquality`.
# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None.