### PR TITLE
XWIKI-23862: Add support for subscript and superscript in UniAst

### DIFF
--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/fn-utils/etc/platform-fn-utils.api.md
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/fn-utils/etc/platform-fn-utils.api.md
@@ -17,6 +17,12 @@ export function escapeHtml(str: string): string;
 export function filterMap<T, U>(array: T[], filterMap: (value: T, index: number) => U | null | undefined): U[];
 
 // @beta
+export function findWithIndex<T>(array: T[], predicate: (value: T) => boolean): [T, number] | null;
+
+// @beta
+export function findWithIndexTypePredicate<T, U extends T>(array: T[], predicate: (value: T) => value is U): [U, number] | null;
+
+// @beta
 export function objectEntries<O extends Record<string, unknown>>(obj: O): Array<[keyof O & string, O[keyof O]]>;
 
 // @beta

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/fn-utils/src/index.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/fn-utils/src/index.ts
@@ -265,6 +265,56 @@ function escapeHtml(str: string): string {
 }
 
 /**
+ * Find an item inside an array and return its index along the value itself
+ *
+ * @param array - The array to search in
+ * @param predicate - The predicate to find the value
+ *
+ * @returns - The found value and its index, or `null` if no value was found
+ *
+ * @since 18.0.0RC1
+ * @beta
+ */
+function findWithIndex<T>(
+  array: T[],
+  predicate: (value: T) => boolean,
+): [T, number] | null {
+  for (let i = 0; i < array.length; i++) {
+    if (predicate(array[i])) {
+      return [array[i], i];
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Find an item inside an array and return its index along the value itself, with a type predicate
+ *
+ * @param array - The array to search in
+ * @param predicate - The predicate to find the value and assert the value's type
+ *
+ * @returns - The found value and its index, or `null` if no value was found
+ *
+ * @since 18.0.0RC1
+ * @beta
+ */
+function findWithIndexTypePredicate<T, U extends T>(
+  array: T[],
+  predicate: (value: T) => value is U,
+): [U, number] | null {
+  for (let i = 0; i < array.length; i++) {
+    const value = array[i];
+
+    if (predicate(value)) {
+      return [value, i];
+    }
+  }
+
+  return null;
+}
+
+/**
  * Generic tree structure type.
  * @since 18.0.0RC1
  * @beta
@@ -278,6 +328,8 @@ export {
   assertUnreachable,
   escapeHtml,
   filterMap,
+  findWithIndex,
+  findWithIndexTypePredicate,
   objectEntries,
   produceHtmlEl,
   provideTypeInference,

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/uniast/uniast-api/etc/platform-uniast-api.api.md
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/uniast/uniast-api/etc/platform-uniast-api.api.md
@@ -88,6 +88,7 @@ export type InlineContent = ({
 | {
     type: "subscript";
     content: string;
+    styles: TextStyles;
 }
 /**
 * @since 18.0.0RC1
@@ -96,6 +97,7 @@ export type InlineContent = ({
 | {
     type: "superscript";
     content: string;
+    styles: TextStyles;
 };
 
 // @beta (undocumented)

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/uniast/uniast-api/etc/platform-uniast-api.api.md
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/uniast/uniast-api/etc/platform-uniast-api.api.md
@@ -72,9 +72,30 @@ export type InlineContent = ({
     type: "image";
 } & Image_2) | ({
     type: "link";
-} & Link) | {
+} & Link)
+/**
+* @since 18.0.0RC1
+* @beta
+*/
+| {
     type: "inlineMacro";
     call: MacroInvocation;
+}
+/**
+* @since 18.0.0RC1
+* @beta
+*/
+| {
+    type: "subscript";
+    content: string;
+}
+/**
+* @since 18.0.0RC1
+* @beta
+*/
+| {
+    type: "superscript";
+    content: string;
 };
 
 // @beta (undocumented)

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/uniast/uniast-api/src/ast.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/uniast/uniast-api/src/ast.ts
@@ -165,18 +165,31 @@ type InlineContent =
   | ({ type: "text" } & Text)
   | ({ type: "image" } & Image)
   | ({ type: "link" } & Link)
+  /**
+   * @since 18.0.0RC1
+   * @beta
+   */
   | {
-      /**
-       * @since 18.0.0RC1
-       * @beta
-       */
       type: "inlineMacro";
-
-      /**
-       * @since 18.0.0RC1
-       * @beta
-       */
       call: MacroInvocation;
+    }
+  /**
+   * @since 18.0.0RC1
+   * @beta
+   */
+  | {
+      type: "subscript";
+      content: string;
+      styles: TextStyles;
+    }
+  /**
+   * @since 18.0.0RC1
+   * @beta
+   */
+  | {
+      type: "superscript";
+      content: string;
+      styles: TextStyles;
     };
 
 /**

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/uniast/uniast-markdown/src/__tests__/converters.test.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/uniast/uniast-markdown/src/__tests__/converters.test.ts
@@ -168,9 +168,9 @@ describe("MarkdownToUniAstConverter", () => {
   test("parse some text styling", async () => {
     await testTwoWayConversion({
       startingFrom:
-        "Normal **Bold** *Italic1* _Italic2_ ~~Strikethrough~~ __Underline__ `Code` **_~~wow!~~_**",
+        "Normal **Bold** *Italic1* _Italic2_ ~~Strikethrough~~ __Underline__ `Code` **_~~wow!~~_** <sup>superscript</sup> <sub>subscript</sub>",
       convertsBackTo:
-        "Normal **Bold** _Italic1_ _Italic2_ ~~Strikethrough~~ **Underline** Code ~~_**wow!**_~~",
+        "Normal **Bold** _Italic1_ _Italic2_ ~~Strikethrough~~ **Underline** Code ~~_**wow!**_~~ <sup>superscript</sup> <sub>subscript</sub>",
       withUniAst: {
         blocks: [
           {
@@ -258,6 +258,26 @@ describe("MarkdownToUniAstConverter", () => {
                   strikethrough: true,
                 },
                 type: "text",
+              },
+              {
+                content: " ",
+                styles: {},
+                type: "text",
+              },
+              {
+                content: "superscript",
+                styles: {},
+                type: "superscript",
+              },
+              {
+                content: " ",
+                styles: {},
+                type: "text",
+              },
+              {
+                content: "subscript",
+                styles: {},
+                type: "subscript",
               },
             ],
             styles: {},

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/uniast/uniast-markdown/src/markdown/default-uni-ast-to-markdown-converter.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/uniast/uniast-markdown/src/markdown/default-uni-ast-to-markdown-converter.ts
@@ -29,7 +29,7 @@ import type {
   ListItem,
   MacroInvocation,
   TableCell,
-  Text,
+  TextStyles,
   UniAst,
 } from "@xwiki/platform-uniast-api";
 
@@ -189,13 +189,22 @@ export class DefaultUniAstToMarkdownConverter
   async convertInlineContent(inlineContent: InlineContent): Promise<string> {
     switch (inlineContent.type) {
       case "text":
-        return this.convertText(inlineContent);
+        return this.convertText(inlineContent.content, inlineContent.styles);
+
       case "image":
         return this.convertImage(inlineContent);
+
       case "link":
         return this.convertLink(inlineContent);
+
       case "inlineMacro":
         return this.convertMacro(inlineContent.call);
+
+      case "subscript":
+        return `<sub>${this.convertText(inlineContent.content, inlineContent.styles)}</sub>`;
+
+      case "superscript":
+        return `<sup>${this.convertText(inlineContent.content, inlineContent.styles)}</sup>`;
     }
   }
 
@@ -250,9 +259,7 @@ export class DefaultUniAstToMarkdownConverter
   }
 
   // eslint-disable-next-line max-statements
-  private convertText(text: Text): string {
-    const { content, styles } = text;
-
+  private convertText(content: string, styles: TextStyles): string {
     const { bold, italic, strikethrough, code } = styles;
 
     const surroundings = [];

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-headless/src/uniast/bn-to-uniast.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-headless/src/uniast/bn-to-uniast.ts
@@ -460,9 +460,11 @@ export class BlockNoteToUniAstConverter {
         };
 
       case "subscript": {
-        if (inlineContent.content.length !== 1) {
+        if (inlineContent.content.length === 0) {
+          return { type: "subscript", content: "", styles: {} };
+        } else if (inlineContent.content.length !== 1) {
           throw new Error(
-            "Expected exactly one inline content in BlockNote subscript",
+            "Expected at most one inline content in BlockNote subscript",
           );
         }
 
@@ -474,9 +476,11 @@ export class BlockNoteToUniAstConverter {
       }
 
       case "superscript": {
-        if (inlineContent.content.length !== 1) {
+        if (inlineContent.content.length === 0) {
+          return { type: "subscript", content: "", styles: {} };
+        } else if (inlineContent.content.length > 1) {
           throw new Error(
-            "Expected exactly one inline content in BlockNote superscript",
+            "Expected at most one inline content in BlockNote superscript",
           );
         }
 

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/etc/platform-editors-blocknote-react.api.md
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/etc/platform-editors-blocknote-react.api.md
@@ -224,6 +224,16 @@ default: "default";
 };
 }, "table">;
 }>, InlineContentSchemaFromSpecs<    {
+subscript: InlineContentSpec<    {
+readonly type: "subscript";
+readonly content: "styled";
+readonly propSchema: {};
+}>;
+superscript: InlineContentSpec<    {
+readonly type: "superscript";
+readonly content: "styled";
+readonly propSchema: {};
+}>;
 text: {
 config: "text";
 implementation: any;
@@ -330,7 +340,7 @@ export function createCustomInlineContentSpec<const I extends CustomInlineConten
         aliases?: string[];
         group: string;
         icon: ReactNode;
-        default: () => PartialInlineContent<Record<I["type"], I>, S>;
+        default: () => Exclude<PartialInlineContent<Record<I["type"], I>, S>, string>[number];
     };
     customToolbar: (() => ReactNode) | null;
 }): {
@@ -694,7 +704,7 @@ export type EditorStyleSchema = EditorSchema extends BlockNoteSchema<infer _, in
 export type EditorType = BlockNoteEditor<EditorBlockSchema, EditorInlineContentSchema, EditorStyleSchema>;
 
 // @beta
-export function extractMacroRawContent(content: InlineContent<DefaultInlineContentSchema, DefaultStyleSchema>[]): string;
+export function extractMacroRawContent(content: InlineContentType[]): string;
 
 // @beta
 export type InlineContentType = InlineContent<EditorInlineContentSchema, EditorStyleSchema>;

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/blocknote/inlineContents/SubScript.tsx
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/blocknote/inlineContents/SubScript.tsx
@@ -32,7 +32,12 @@ export const SubScript = createCustomInlineContentSpec({
   },
   customToolbar: null,
   slashMenu: {
-    default: () => ({ type: "subscript" as const }),
+    default: () => ({
+      type: "subscript" as const,
+      // TODO: Currently required as the element would be invisible and un-editable if it was empty
+      // Tracking issue: https://github.com/TypeCellOS/BlockNote/issues/2359
+      content: [{ type: "text" as const, text: "subscript", styles: {} }],
+    }),
     group: "Others",
     title: "SubScript",
     icon: "S",

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/blocknote/inlineContents/SubScript.tsx
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/blocknote/inlineContents/SubScript.tsx
@@ -1,0 +1,40 @@
+/**
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+import { createCustomInlineContentSpec } from "../utils";
+
+export const SubScript = createCustomInlineContentSpec({
+  config: {
+    type: "subscript",
+    content: "styled",
+    propSchema: {},
+  },
+  implementation: {
+    render: ({ contentRef }) => {
+      return <sub ref={contentRef} />;
+    },
+  },
+  customToolbar: null,
+  slashMenu: {
+    default: () => ({ type: "subscript" as const }),
+    group: "Others",
+    title: "SubScript",
+    icon: "S",
+  },
+});

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/blocknote/inlineContents/SuperScript.tsx
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/blocknote/inlineContents/SuperScript.tsx
@@ -32,7 +32,12 @@ export const SuperScript = createCustomInlineContentSpec({
   },
   customToolbar: null,
   slashMenu: {
-    default: () => ({ type: "superscript" as const }),
+    default: () => ({
+      type: "superscript" as const,
+      // TODO: Currently required as the element would be invisible and un-editable if it was empty
+      // Tracking issue: https://github.com/TypeCellOS/BlockNote/issues/2359
+      content: [{ type: "text" as const, text: "superscript", styles: {} }],
+    }),
     group: "Others",
     title: "SuperScript",
     icon: "S",

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/blocknote/inlineContents/SuperScript.tsx
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/blocknote/inlineContents/SuperScript.tsx
@@ -1,0 +1,40 @@
+/**
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+import { createCustomInlineContentSpec } from "../utils";
+
+export const SuperScript = createCustomInlineContentSpec({
+  config: {
+    type: "superscript",
+    content: "styled",
+    propSchema: {},
+  },
+  implementation: {
+    render: ({ contentRef }) => {
+      return <sub ref={contentRef} />;
+    },
+  },
+  customToolbar: null,
+  slashMenu: {
+    default: () => ({ type: "superscript" as const }),
+    group: "Others",
+    title: "SuperScript",
+    icon: "S",
+  },
+});

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/blocknote/utils.tsx
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/blocknote/utils.tsx
@@ -24,6 +24,7 @@ import {
   createReactInlineContentSpec,
 } from "@blocknote/react";
 import { assertUnreachable, objectEntries } from "@xwiki/platform-fn-utils";
+import type { InlineContentType } from ".";
 import type {
   BlockConfig,
   CustomInlineContentConfig,
@@ -139,7 +140,11 @@ function createCustomInlineContentSpec<
         aliases?: string[];
         group: string;
         icon: ReactNode;
-        default: () => PartialInlineContent<Record<I["type"], I>, S>;
+        // TODO: change to `PartialInlineContentElement` instead of that `Exclude` mess once https://github.com/TypeCellOS/BlockNote/issues/2352 is resolved
+        default: () => Exclude<
+          PartialInlineContent<Record<I["type"], I>, S>,
+          string
+        >[number];
       };
   customToolbar: (() => ReactNode) | null;
 }) {
@@ -386,10 +391,9 @@ function adaptMacroForBlockNote(
                 ),
             },
             slashMenu: getSlashMenu((getDefaultValue) => ({
-              default: () => [
+              default: () =>
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 getDefaultValue() as any,
-              ],
             })),
             // TODO: allow macros to define their own toolbar, using a set of provided UI components (buttons, ...)
             // Tracking issue: https://jira.xwiki.org/browse/CRISTAL-708
@@ -412,9 +416,7 @@ function adaptMacroForBlockNote(
  * @since 18.0.0RC1
  * @beta
  */
-function extractMacroRawContent(
-  content: InlineContent<DefaultInlineContentSchema, DefaultStyleSchema>[],
-): string {
+function extractMacroRawContent(content: InlineContentType[]): string {
   if (content.length !== 1) {
     throw new Error(
       "Internal error: raw-body macro does not have precisely 1 inline content",


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-23862

Requires https://github.com/xwiki-contrib/cristal/pull/1517 in `cristal` to be merged with this one.

# Changes

## Description

* Add support for subscript and superscript in UniAst and BlockNote

## Clarifications

* BlockNote does not natively support subscript and superscript, so custom inline contents have been made
* Due to BlockNote limitations, only plain text is supported inside these
* Neither CommonMark  nor GFM support subscript and superscript, so the `<sub>` and `<sup>` HTML elements are being used here
* Due to the CommonMark specification stating that HTML elements should be pass-through-ed instead of parsed, a custom HTML elements detector has been added
* HTML conversion is performed via the `<sub>` and `<sup>` elements
* Inline contents without borders are invisible and un-editable by default, so subscripts and superscripts elements are filled with a placeholder text when inserted in BlockNote (see https://github.com/TypeCellOS/BlockNote/issues/2359)

# Screenshots & Video

<img width="313" height="83" alt="image" src="https://github.com/user-attachments/assets/08a3bb1d-c208-42c4-bdef-4f9ba1dbe4f1" />

# Executed Tests

* Tests have been updated to ensure these two new elements are parsed and stringified correctly

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 