### PR TITLE
XWIKI-24683: Factorize the duplicated user-with-avatar display macro in likers.vm and getusers.vm

### DIFF
--- a/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-api/src/main/resources/templates/likers.vm
+++ b/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-api/src/main/resources/templates/likers.vm
@@ -18,15 +18,6 @@
 ## 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 ## ---------------------------------------------------------------------------
 #if ($request.livetable == "true")
-    #macro (displayUserAliasWithAvatar $userReference $disabled)
-    <div class="user#if ($disabled) disabled#end" data-reference="$escapetool.xml($userReference)">
-    <span class="user-avatar-wrapper">
-      #getUserAvatarURL($userReference $avatarURL 120)
-      <img class="user-avatar" src="$escapetool.xml($avatarURL.url)" alt="" />
-    </span>
-      <a href="$xwiki.getURL($userReference)">$escapetool.xml($userReference.name)</a>
-    </div>
-    #end
     $response.setContentType('application/json')
     #set ($documentReference = $doc.documentReference)
     ##==============================
@@ -66,7 +57,7 @@
                 'doc_wiki': $userDoc.wiki,
                 'doc_url': $userDoc.getURL(),
                 'doc_viewable': true,
-                'name': "#displayUserAliasWithAvatar($userDoc.documentReference $disabled)",
+                'name': "#_displayUserAliasWithAvatar($userDoc.documentReference $disabled)",
                 'first_name': $userProperties.firstName,
                 'last_name': $userProperties.lastName
             })

--- a/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-api/src/main/resources/templates/likers.vm
+++ b/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-api/src/main/resources/templates/likers.vm
@@ -18,15 +18,6 @@
 ## 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 ## ---------------------------------------------------------------------------
 #if ($request.livetable == "true")
-    #macro (displayUserAliasWithAvatar $userReference $disabled)
-    <div class="user#if ($disabled) disabled#end" data-reference="$escapetool.xml($userReference)">
-    <span class="user-avatar-wrapper">
-      #getUserAvatarURL($userReference $avatarURL 120)
-      <img class="user-avatar" src="$escapetool.xml($avatarURL.url)" alt="" />
-    </span>
-      <a href="$xwiki.getURL($userReference)">$escapetool.xml($userReference.name)</a>
-    </div>
-    #end
     $response.setContentType('application/json')
     #set ($documentReference = $doc.documentReference)
     ##==============================
@@ -65,7 +56,7 @@
                 'doc_wiki': $userDoc.wiki,
                 'doc_url': $userDoc.getURL(),
                 'doc_viewable': true,
-                'name': "#displayUserAliasWithAvatar($userDoc.documentReference $disabled)",
+                'name': "#_displayUserAliasWithAvatar($userDoc.documentReference $disabled)",
                 'first_name': $userProperties.firstName,
                 'last_name': $userProperties.lastName
             })

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/getusers.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/getusers.vm
@@ -17,16 +17,6 @@
 ## Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 ## 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 ## ---------------------------------------------------------------------------
-#macro (displayUserAliasWithAvatar $userReference $disabled)
-  <div class="user#if ($disabled) disabled#end" data-reference="$escapetool.xml($userReference)">
-    <span class="user-avatar-wrapper">
-      #getUserAvatarURL($userReference $avatarURL 120)
-      <img class="user-avatar" src="$escapetool.xml($avatarURL.url)" alt="" />
-    </span>
-    <a href="$xwiki.getURL($userReference)">$escapetool.xml($userReference.name)</a>
-  </div>
-#end
-
 #set ($userClassName = 'XWiki.XWikiUsers')
 #set ($userClass = $xwiki.getDocument($userClassName).xWikiClass)
 #set ($docProps = ['fullName', 'name'])
@@ -141,7 +131,7 @@
         'userId': $user.documentReference,
         'csrf': $services.csrf.token
       })),
-      'name': "#displayUserAliasWithAvatar($user.documentReference $disabled)",
+      'name': "#_displayUserAliasWithAvatar($user.documentReference $disabled)",
       'first_name': $userObject.getValue('first_name'),
       'last_name': $userObject.getValue('last_name'),
       'scope': $services.localization.render("xe.admin.groups.$scope")

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -242,6 +242,7 @@ $xwiki.getUserName("xwiki:${username}")
  *   useInlineHTML: false, // whether to use in-line HTML elements to display the user or not
  *   wrapAvatar: false // whether to wrap the avatar image with a span or not
  *   displayLink: true // @since 15.9 ; whether to wrap the user name in a link to the user profile
+ *   disabled: false // @since 18.1.0 whether to show or not that the user got removed.
  * }
  *#
 #macro (displayUser $arg $options)
@@ -258,7 +259,8 @@ $xwiki.getUserName("xwiki:${username}")
     'showAlias': false,
     'useInlineHTML': false,
     'wrapAvatar': false,
-    'displayLink': true
+    'displayLink': true,
+    'disabled': false
   })
   #if ($options.entrySet())
     #set ($discard = $macro.options.putAll($options))
@@ -315,9 +317,13 @@ $xwiki.getUserName("xwiki:${username}")
     #else
       #set($userNameTag = 'span')
     #end
+    #set($userClasses = $type)
+    #if($macro.options.disabled)
+      #set($userClasses = "${userClasses} disabled")
+    #end
     ## We avoid the whitespace because the users are displayed as inline blocks.
     #set ($discard = $output.addAll([
-      "<$userTag class=""$type"" data-reference=""$escapetool.xml($userReference)"">",
+      "<$userTag class=""$userClasses"" data-reference=""$escapetool.xml($userReference)"">",
         "<$userNameTag $userNameTagAttributes>",
         $avatarWrapperStart,
           "<img class=""${type}-avatar"" src=""$escapetool.xml($avatarURL.url)"" alt="""" />",
@@ -348,6 +354,14 @@ $xwiki.getUserName("xwiki:${username}")
  *#
 #macro (displayGroup $arg $options)
   #displayUser($arg $options)
+#end
+
+#**
+ * Util macro used to display users a specific way in a couple places in XWiki Standard.
+ * This is not an API, avoid relying on it.
+ *#
+#macro (_displayUserAliasWithAvatar $userReference $disabled)
+  #displayUser($userReference {'useInlineHTML': true, 'wrapAvatar': true, 'disabled': $disabled})
 #end
 
 

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/macros.vm
@@ -323,7 +323,7 @@ $xwiki.getUserName("xwiki:${username}")
     #end
     ## We avoid the whitespace because the users are displayed as inline blocks.
     #set ($discard = $output.addAll([
-      "<$userTag class=""$userClasses"" data-reference=""$escapetool.xml($userReference)"">",
+      "<$userTag class=""$escapetool.xml($userClasses)"" data-reference=""$escapetool.xml($userReference)"">",
         "<$userNameTag $userNameTagAttributes>",
         $avatarWrapperStart,
           "<img class=""${type}-avatar"" src=""$escapetool.xml($avatarURL.url)"" alt="""" />",


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-24683

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Removed the two custom macro definitions from likers.vm and getusers.vm
* Introduced a (non API) alternative directly in the global velocity macros in macros.vm
* Added an option to the displayUser macro to account for the one thing that was missing.

## Clarifications
* The like template doesn't even use the "$disabled" parameter... I left it in because it doesn't hurt and it allows to factorize the velocity macro with getusers.
# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
After the PR:
The `getusers.vm` template still works as intended.
<img width="725" height="714" alt="Screenshot From 2026-01-16 11-27-58" src="https://github.com/user-attachments/assets/5eeb3752-52eb-4d71-967f-9658aa065f96" />

I liked the page with two accounts. The administrator sees both as expected, and the users that doesn't have rights sees "Guest user" with links pointing towards the pages they don't have access to. This is the standard way to handle user display when the current user doesn't have view permission (IMO it could be better, but it's not the point of the ticket.)
<img width="2560" height="888" alt="Screenshot From 2026-01-16 11-28-26" src="https://github.com/user-attachments/assets/a7a8d126-b842-4b80-9a06-249e66a11655" />


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests on local instance, see above.
Successfully built changes with:
* `mvn clean install -f xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-api -Pquality`
* `mvn clean install -f xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates -Pquality`

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None.