### PR TITLE
XWIKI-23978: Improve lists handling in UniAst

### DIFF
--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/macros/macros-api/src/ast.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/macros/macros-api/src/ast.ts
@@ -105,11 +105,10 @@ type MacroListType =
  * @beta
  */
 type MacroListItem = {
-  content: MacroInlineContent[];
-  styles: MacroBlockStyles;
-
   /** Is the item checked? (only applicable for lists with the `checkable` type) */
   checked?: boolean;
+  content: MacroInlineContent[];
+  styles: MacroBlockStyles;
 };
 
 /**

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/macros/macros-api/src/ast.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/macros/macros-api/src/ast.ts
@@ -38,7 +38,7 @@ type MacroBlock =
     }
   | {
       type: "list";
-      numbered?: boolean;
+      listType: MacroListType;
       items: MacroListItem[];
       styles: MacroBlockStyles;
     }
@@ -88,15 +88,28 @@ type MacroBlockStyles = {
 type MacroAlignment = "left" | "center" | "right" | "justify";
 
 /**
+ * Type of a `MacroBlock` list
+ *
+ * @since 18.1.0RC1
+ * @beta
+ */
+type MacroListType =
+  | { type: "unordered" }
+  | { type: "ordered"; firstIndex: number | null }
+  | { type: "checkable" };
+
+/**
  * Item that's part of a `MacroBlock` list
  *
  * @since 18.0.0RC1
  * @beta
  */
 type MacroListItem = {
-  checked?: boolean;
   content: MacroInlineContent[];
   styles: MacroBlockStyles;
+
+  /** Is the item checked? (only applicable for lists with the `checkable` type) */
+  checked?: boolean;
 };
 
 /**
@@ -216,6 +229,7 @@ export type {
   MacroLink,
   MacroLinkTarget,
   MacroListItem,
+  MacroListType,
   MacroTableCell,
   MacroTableColumn,
   MacroText,

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/macros/macros-api/src/index.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/macros/macros-api/src/index.ts
@@ -273,6 +273,7 @@ export type {
   MacroLink,
   MacroLinkTarget,
   MacroListItem,
+  MacroListType,
   MacroTableCell,
   MacroTableColumn,
   MacroText,

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/macros/macros-ast-react-jsx/src/converter.tsx
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/macros/macros-ast-react-jsx/src/converter.tsx
@@ -182,18 +182,25 @@ export class MacrosAstToReactJsxConverter {
         );
 
       case "list":
-        const ListTag = block.numbered ? "ol" : "ul";
+        const ListTag = block.listType.type === "ordered" ? "ol" : "ul";
+
+        const domProps =
+          block.listType.type === "ordered" &&
+          block.listType.firstIndex !== null
+            ? { start: block.listType.firstIndex }
+            : {};
 
         return (
-          <ListTag {...this.convertBlockStyles(block.styles)}>
+          <ListTag {...this.convertBlockStyles(block.styles)} {...domProps}>
             {block.items.map((item, i) => {
               const childKey = `${key}.${i}`;
 
               return (
                 <li key={childKey}>
-                  {item.checked !== undefined && (
-                    <input type="checkbox" checked={item.checked} readOnly />
-                  )}
+                  {block.listType.type === "checkable" &&
+                    item.checked !== undefined && (
+                      <input type="checkbox" checked={item.checked} readOnly />
+                    )}
                   {this.convertInlineContents(
                     item.content,
                     editableZoneRef,

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/uniast/uniast-api/src/ast.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/uniast/uniast-api/src/ast.ts
@@ -40,6 +40,7 @@ type Block =
     }
   | {
       type: "list";
+      listType: ListType;
       items: ListItem[];
       styles: BlockStyles;
     }
@@ -86,11 +87,19 @@ type BlockStyles = {
 type Alignment = "left" | "center" | "right" | "justify";
 
 /**
+ * @since 18.1.0RC1
+ * @beta
+ */
+type ListType =
+  | { type: "unordered" }
+  | { type: "ordered"; firstIndex: number | null }
+  | { type: "checkable" };
+
+/**
  * @since 18.0.0RC1
  * @beta
  */
 type ListItem = {
-  number?: number;
   checked?: boolean;
   content: Block[];
   styles: BlockStyles;
@@ -236,6 +245,7 @@ export type {
   Link,
   LinkTarget,
   ListItem,
+  ListType,
   MacroInvocation,
   TableCell,
   TableColumn,

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/uniast/uniast-api/src/ast.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/uniast/uniast-api/src/ast.ts
@@ -100,6 +100,7 @@ type ListType =
  * @beta
  */
 type ListItem = {
+  /** Is the item checked? (only applicable for lists with the `checkable` type) */
   checked?: boolean;
   content: Block[];
   styles: BlockStyles;

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/uniast/uniast-api/src/index.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/uniast/uniast-api/src/index.ts
@@ -26,6 +26,7 @@ export type {
   Link,
   LinkTarget,
   ListItem,
+  ListType,
   MacroInvocation,
   TableCell,
   TableColumn,

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-headless/src/uniast/bn-to-uniast.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-headless/src/uniast/bn-to-uniast.ts
@@ -120,8 +120,6 @@ export class BlockNoteToUniAstConverter {
               ? { type: "checkable" }
               : { type: "unordered" };
 
-        console.log({ listType });
-
         out.push({
           type: "list",
           items: [listItem],


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-23978

Cristal PR: https://github.com/xwiki-contrib/cristal/pull/1547

# Changes

## Description

* Improve typing of lists in UniAst

## Clarifications

* UniAst currently uses some pretty dirty typing, that made sense during conception but is eventually becoming a bother given the limitations of BlockNote, the XWiki syntax and the Markdown syntax.

cc @mflorea, if you can give me some feedback on the new types

# Screenshots & Video

N/A

# Executed Tests

N/A

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 