### PR TITLE
XWIKI-23828: extend setWikiPreference to update several preferences a…

### DIFF
--- a/xwiki-platform-core/xwiki-platform-edit/xwiki-platform-edit-test/xwiki-platform-edit-test-docker/src/test/it/org/xwiki/edit/test/ui/InplaceTranslateIT.java
+++ b/xwiki-platform-core/xwiki-platform-edit/xwiki-platform-edit-test/xwiki-platform-edit-test-docker/src/test/it/org/xwiki/edit/test/ui/InplaceTranslateIT.java
@@ -22,6 +22,7 @@ package org.xwiki.edit.test.ui;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Locale;
+import java.util.Map;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,6 +34,7 @@ import org.xwiki.test.docker.junit5.UITest;
 import org.xwiki.test.ui.TestUtils;
 import org.xwiki.test.ui.po.InformationPane;
 
+import static java.util.Map.entry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -51,9 +53,11 @@ class InplaceTranslateIT
     void setup(TestUtils setup, TestReference testReference) throws Exception
     {
         setup.loginAsSuperAdmin();
-        setup.setWikiPreference("multilingual", "true");
-        setup.setWikiPreference("languages", "de,en,fr,it");
-        setup.setWikiPreference("default_language", "en");
+        setup.setWikiPreferences(Map.ofEntries(
+            entry("multilingual", "true"), 
+            entry("languages", "de,en,fr,it"),
+            entry("default_language", "en")
+        ));
 
         setup.createUserAndLogin("alice", "pa$$word", "editor", "Wysiwyg");
         // Make sure we create the page with English as default locale.
@@ -66,8 +70,7 @@ class InplaceTranslateIT
     void tearDown(TestUtils setup) throws Exception
     {
         setup.loginAsSuperAdmin();
-        setup.setWikiPreference("multilingual", "false");
-        setup.setWikiPreference("languages", "en");
+        setup.setWikiPreferences(Map.ofEntries(entry("multilingual", "false"), entry("languages", "en")));
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/DeletePageIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/DeletePageIT.java
@@ -55,6 +55,7 @@ import org.xwiki.test.ui.po.ViewPage;
 import org.xwiki.tree.test.po.TreeElement;
 import org.xwiki.tree.test.po.TreeNodeElement;
 
+import static java.util.Map.entry;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -650,8 +651,7 @@ class DeletePageIT
         setup.addObject(objectReference, classReference.toString(), Collections.singletonMap("Foo", "Bar"));
 
         // switch the wiki to multilingual
-        setup.setWikiPreference("multilingual", "true");
-        setup.setWikiPreference("languages", "en,fr");
+        setup.setWikiPreferences(Map.ofEntries(entry("multilingual", "true"), entry("languages", "en,fr")));
 
         DocumentReference frenchXClassTranslation = new DocumentReference(classReference, Locale.FRENCH);
         setup.createPage(frenchXClassTranslation, "French XClass page content", classPageName);

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/TestUtils.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/TestUtils.java
@@ -2414,6 +2414,19 @@ public class TestUtils
     }
 
     /**
+     * Sets the value of existing properties of XWiki.XWikiPreferences.
+     *
+     * @param properties a map of the name and value for the properties to set.
+     * @since 18.1.0
+     */
+    public void setWikiPreferences(Map<String, String> properties) throws Exception
+    {
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+            setWikiPreference(entry.getKey(), entry.getValue());
+        }
+    }
+
+    /**
      * @since 7.3M1
      */
     public static void assertStatuses(int actualCode, int... expectedCodes)

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/TestUtils.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/TestUtils.java
@@ -2417,7 +2417,7 @@ public class TestUtils
      * Sets the value of existing properties of XWiki.XWikiPreferences.
      *
      * @param properties a map of the name and value for the properties to set.
-     * @since 18.1.0
+     * @since 18.8.0RC1
      */
     public void setWikiPreferences(Map<String, String> properties) throws Exception
     {


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Added the new util method.
* Updated two tests to use it instead of multiple calls to setWikiPreference

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The two test updates are not needed to solve the ticket, but it's a good way to check that the new util actually works.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
None, test change only.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Built the main change with `mvn clean install -f xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui -Pquality` successfully.
After that, I updated some docker tests where using this new util would make sense and ran them:
* `mvn clean install -f xwiki-platform-core/xwiki-platform-edit/xwiki-platform-edit-test/xwiki-platform-edit-test-docker`
* `mvn clean install -f xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker -Dit.test=DeletePageIT`

Both docker test builds passed successfully even with the changes.


# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 17.10.X. This is a test only change, it does not have any impact on the distribution.