### PR TITLE
XWIKI-23694: Add warning about temporary logging level changes

### DIFF
--- a/xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-ui/src/main/resources/XWiki/Logging/Code/Translations.xml
+++ b/xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-ui/src/main/resources/XWiki/Logging/Code/Translations.xml
@@ -38,7 +38,8 @@
   <hidden>true</hidden>
   <content>logging.admin.unsetLevel.success=Logger "{0}" level has been unset.
 logging.admin.setLevel.success=Logger "{0}" level has been set to "{1}".
-logging.admin.setLevel.error=Failed to set log level: the logger "{0}" doesn't exist.</content>
+logging.admin.setLevel.error=Failed to set log level: the logger "{0}" doesn't exist.
+logging.admin.temporary.warning=**Note:** Changes to logging levels are temporary and will be lost when the server restarts. For permanent changes, please modify the logging configuration file.</content>
   <object>
     <name>XWiki.Logging.Code.Translations</name>
     <number>0</number>

--- a/xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-ui/src/main/resources/XWiki/LoggingAdmin.xml
+++ b/xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-ui/src/main/resources/XWiki/LoggingAdmin.xml
@@ -39,6 +39,11 @@
   <content>(% class="noitems" %)
 {{translation key="logging.admin.intro" /}}
 
+{{info}}
+{{translation key="logging.admin.temporary.warning" /}}
+{{/info}}
+
+
 {{velocity}}
 #set($logging = $services.logging)
 ##


### PR DESCRIPTION
## Description
Fixes [XWIKI-23694](https://jira.xwiki.org/browse/XWIKI-23694)

Added an informational message box to the Logging Administration page to explicitly warn users that logging level changes are temporary and will be lost on server restart.

## Changes Made
- Added info box in `LoggingAdmin.xml` to display warning message
- Added new translation key `logging.admin.temporary.warning` to `Translations.xml`
- Warning message informs users that changes are not persisted and directs them to modify the configuration file for permanent changes

## Testing
Manual testing performed to verify:
- Info box displays correctly on the Logging Administration page
- Translation key is properly referenced
- Message is clear and helpful to users

## Notes
This PR is part of a SOEN 6431 Case Study #1 assignment.
