### PR TITLE
XWIKI-22981: Navigation Panel Focus contrast is too low

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/misc.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/misc.less
@@ -503,6 +503,7 @@ a.html-diff-context-toggle {
     border-style: solid;
     box-shadow: none;
     border-color: transparent;
+    transition: border-color ease-in-out .15s;
   }
 
   & .jstree-clicked {

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/misc.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/misc.less
@@ -494,14 +494,30 @@ a.html-diff-context-toggle {
   padding: (@line-height-computed / 2);
 }
 
-// Tree Webjar (XWIKI-15089) ---------------------------------------------------
-.skin-flamingo .jstree-xwiki .jstree-clicked {
-  background-color: @nav-link-hover-bg; /* $theme.highlightColor */
-  border-radius: @border-radius-small;
-}
+// Tree Webjar ---------------------------------------------------
+.skin-flamingo .jstree-xwiki {
+  & .jstree-anchor {
+    border-width: 2px; /* We want to add this border consistently to avoid flickers when interacting. */ 
+    line-height: 20px; /* Without this line height change from 24px, the border missaligns the text and the icon ocl. */
+    border-radius: @border-radius-small;
+    border-style: solid;
+    box-shadow: none;
+    border-color: transparent;
+  }
 
-.skin-flamingo .jstree-xwiki .jstree-anchor:hover {
-  border-radius: @border-radius-small;
+  & .jstree-clicked {
+    background-color: @btn-default-bg;
+    border-color: @btn-default-border;
+    color: @btn-default-color;
+  }
+
+  & .jstree-hovered {
+    /* The default link colors should look good on the generic background. */
+    background-color: transparent;
+    border-color: @link-hover-color;
+    color: @link-hover-color;
+  }
+
 }
 
 .previewdiff-diff-options {


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22981

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Added the xwiki tree customizations to improve contrast.
* Cleaned up the comments.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Color choices explanations:
 * the "clicked" is the current page for the navigation tree. This used to be colored with `@nav-link-hover-bg` (highlight color). I changed it to follow the btn-default colors, which are kind of similar and variables that are meant to be generic. Since these specific bootstrap variables do not have enough variations for our use case, I decided to rely on the generic ones.
 * the "hovered" is just the regular link highlight color. The main difference with any other link is that we highlight it with a border instead of an underline. Since it was okay to highlight the active link with a box, I assumed it was okay to use box to highlight the hovered link too.
 * I noticed the icon and text are not centered anymore when hovering the choices for the link target. IMO it's an alright side-change.


# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Here are a few screenshots showing how the changes work in different places:
<img width="2559" height="1323" alt="Screenshot From 2026-02-26 10-15-36" src="https://github.com/user-attachments/assets/6618ca7a-1b03-46d8-8fa0-e3a4f48866e8" />
<img width="2559" height="1323" alt="Screenshot From 2026-02-26 10-15-31" src="https://github.com/user-attachments/assets/57494485-afda-4ca5-937f-8ecf4af667e9" />
<img width="2559" height="1323" alt="Screenshot From 2026-02-26 10-15-13" src="https://github.com/user-attachments/assets/95ba3819-a38a-4140-b20b-940544ee1c21" />
<img width="2559" height="1301" alt="image" src="https://github.com/user-attachments/assets/c08fe99f-7cb2-4313-b772-d6d027091e81" />

Here is what the UI looked like before, for reference:
<img width="2559" height="1301" alt="image" src="https://github.com/user-attachments/assets/59ca1e50-c61b-4957-bb5d-c370ce5e7566" />
<img width="2559" height="1301" alt="image" src="https://github.com/user-attachments/assets/781d7b06-db6d-4978-bd61-04789c341495" />


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests on my local instance, see above.
I built the changes in the CSS successfully with `mvn clean install -f xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin -Pquality`

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 17.10.X