### PR TITLE
XWIKI-24071: Warnings for annotations that could not be loaded

### DIFF
--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Script.xml
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Script.xml
@@ -1915,7 +1915,7 @@ require(['jquery', 'xwiki-text-offset-updater', 'xwiki-events-bridge'], function
   $(function() {
     // Load the annotations only in view mode, if the document content is displayed
     // (the document content is not displayed when viewer=history for instance).
-    if (XWiki.contextaction != 'view' || !$('xwikicontent')) {
+    if (XWiki.contextaction != 'view' || !$('#xwikicontent')[0]) {
       return;
     }
 


### PR DESCRIPTION
# Jira URL
https://jira.xwiki.org/browse/XWIKI-24071

# Changes
* fix initial check for document content for annotations

## Description
The initial check for the #xwikicontent div in the Annotation Application was broken for some time. The jQuery element class selector for classes was previously used instead of the id selector. This showed the warning `Annotations could not be loaded because the content is not available` when opening a deleted page or the page viewer 'Information'/'Comments'/'Attachments'/'History'/'Likes' with the option `Display annotations by default` enabled.

# Executed Tests

I changed the JavaScript code attached to the page AnnotationCode.Script and refreshed the cache. The warning (see Jira issue for reproduction steps) was gone.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches: