### PR TITLE
XWIKI-24084: Tour button popover tip still targetable after page refresh

### DIFF
--- a/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui/src/main/resources/TourCode/TourJS.xml
+++ b/xwiki-platform-core/xwiki-platform-tour/xwiki-platform-tour-ui/src/main/resources/TourCode/TourJS.xml
@@ -181,7 +181,7 @@ require(['jquery', 'xwiki-meta'], function ($, xm) {
       button.removeAttr('hidden');
       popover.attr('open','open');
     } else {
-      buttonContainer.addClass('closed');
+      buttonContainer.addClass('hint-closed');
     }
 
     button.on('click', function() {


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24084

# Changes

* use the correct CSS class to make the tour button popover tooltip not targetable after page load

## Clarifications

The new CSS class "hint-closed" was introduced as a fix for XWIKI-24022: https://github.com/xwiki/xwiki-platform/pull/5198
Just missed one case of replacing "closed" with "hint-closed"

# Executed Tests

I changed the JavaScript code attached to the page TourCode.TourJS and refreshed the cache. The popover content tooltip was now also not targetable after page load, as expected.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * 17.10.x
  * 18.1.x