### PR TITLE
XWIKI-17010: Code viewer doesn't allow to copy blank lines

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/code.vm
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/code.vm
@@ -104,6 +104,9 @@ $xwiki.ssfx.use('uicomponents/viewers/code.css', true)##
     #end
 
     #set ($lineNumber = $foreach.count)
+    #if("$el.element" == '')
+      #set($el.element = $util.getNewline())
+    #end
 
     #if ($startNewGroup)
       </tbody>
@@ -122,6 +125,9 @@ $xwiki.ssfx.use('uicomponents/viewers/code.css', true)##
     #set ($lines = $content.split('\n'))
     #foreach ($line in $lines)
       #set ($lineNumber = $foreach.count)
+      #if("$line" == '')
+        #set($line = $util.getNewline())
+      #end
       <tr class="line" id="$lineNumber">
         ## Even though empty we still need the first 2 TD to make the HTML valid
         <td class="author avatar_16 hidden"></td>


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-17010

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Replaced the "empty" lines with a single newline character.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The empty lines did not have any text content so they are not kept in the clipboard at all. However, the clipboard adds a newline in between two separate nodes in the copied text. By making sure there's at least a newline character in the "empty line" node, we make sure the clipboard registers it. I don't have sources backing my logic, but in my manual tests it worked well.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests on my local instance (both with and without author blame).
Built the change with `mvn clean install -f xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources -Pquality`. Since this is a very niche use case and was quite badly broken, I suppose none of our tests ever relied on copying code from this viewer (in addition, a WCAG scan on the page shows that there's a WCAG contrast error on this UI, it'd have been found by CI if we had any automated test passing on this viewer).

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 17.10.X (small scope bugfix)