### PR TITLE
XWIKI-24268: Hibernate attachment versioning store loses the initial 1.1 version when an attachment is first updated

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateAttachmentStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateAttachmentStore.java
@@ -36,6 +36,7 @@ import com.xpn.xwiki.XWiki;
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiAttachment;
+import com.xpn.xwiki.doc.XWikiAttachmentArchive;
 import com.xpn.xwiki.doc.XWikiAttachmentContent;
 import com.xpn.xwiki.doc.XWikiDocument;
 
@@ -145,8 +146,18 @@ public class XWikiHibernateAttachmentStore extends XWikiHibernateBaseStore imple
                         attachment.loadArchive(context);
                     }
 
+                    // If the archive has no history yet, seed it with the current attachment so that the initial
+                    // version (typically 1.1) is not lost when the attachment is later updated. Without this seed,
+                    // the second upload increments to 1.2 and creates a fresh archive at 1.2, making 1.1
+                    // unrecoverable. This mirrors the seeding done in AttachmentArchiveSaveRunnable for the
+                    // filesystem store.
+                    XWikiAttachmentArchive archive = attachment.getAttachment_archive();
+                    if (archive != null && archive.getArchiveAsString().isEmpty()) {
+                        archive.addCurrentAttachment(context);
+                    }
+
                     // The archive has been updated in XWikiHibernateStore.saveAttachment()
-                    store.saveArchive(attachment.getAttachment_archive(), context, false);
+                    store.saveArchive(archive, context, false);
 
                     if (parentUpdate) {
                         context.getWiki().getStore().saveXWikiDoc(attachment.getDoc(), context, true);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/XWikiHibernateAttachmentStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/XWikiHibernateAttachmentStoreTest.java
@@ -1,0 +1,116 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xpn.xwiki.store;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.query.Query;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.suigeneris.jrcs.rcs.Archive;
+import com.xpn.xwiki.internal.store.hibernate.HibernateStore;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+
+import com.xpn.xwiki.doc.XWikiAttachment;
+import com.xpn.xwiki.doc.XWikiAttachmentArchive;
+import com.xpn.xwiki.doc.XWikiAttachmentContent;
+import com.xpn.xwiki.test.MockitoOldcore;
+import com.xpn.xwiki.test.junit5.mockito.InjectMockitoOldcore;
+import com.xpn.xwiki.test.junit5.mockito.OldcoreTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link XWikiHibernateAttachmentStore}.
+ *
+ * @version $Id$
+ */
+@OldcoreTest
+class XWikiHibernateAttachmentStoreTest
+{
+    @InjectMockitoOldcore
+    private MockitoOldcore oldcore;
+
+    @InjectMockComponents
+    private XWikiHibernateAttachmentStore store;
+
+    private Session mockSession;
+
+    @BeforeEach
+    void setup() throws Exception
+    {
+        HibernateStore mockHibernateStore = this.oldcore.getMocker().getInstance(HibernateStore.class);
+        this.mockSession = mock(Session.class);
+        when(mockHibernateStore.getCurrentSession()).thenReturn(this.mockSession);
+        when(mockHibernateStore.getSessionFactory()).thenReturn(mock(SessionFactory.class));
+
+        @SuppressWarnings("unchecked")
+        Query<Long> mockQuery = mock(Query.class);
+        when(this.mockSession.createQuery(anyString(), eq(Long.class))).thenReturn(mockQuery);
+        when(mockQuery.setParameter(anyString(), any())).thenReturn(mockQuery);
+        when(mockQuery.uniqueResult()).thenReturn(null);
+    }
+
+    private XWikiAttachment createAttachment(XWikiAttachmentArchive archive) throws Exception
+    {
+        XWikiAttachment attachment = mock(XWikiAttachment.class);
+        XWikiAttachmentContent content = mock(XWikiAttachmentContent.class);
+        when(attachment.getAttachment_content()).thenReturn(content);
+        when(attachment.getAttachment_archive()).thenReturn(archive);
+        when(attachment.getReference()).thenReturn(null);
+        when(attachment.toStringXML(anyBoolean(), anyBoolean(), any())).thenReturn("<attachment/>");
+        when(attachment.getFilename()).thenReturn("test.txt");
+        when(attachment.getVersion()).thenReturn("1.1");
+        archive.setAttachment(attachment);
+        return attachment;
+    }
+
+    @Test
+    void saveAttachmentContentSeedsEmptyArchive() throws Exception
+    {
+        XWikiAttachmentArchive archive = new XWikiAttachmentArchive();
+        XWikiAttachment attachment = createAttachment(archive);
+
+        this.store.saveAttachmentContent(attachment, false, this.oldcore.getXWikiContext(), false);
+
+        assertFalse(archive.getArchiveAsString().isEmpty());
+    }
+
+    @Test
+    void saveAttachmentContentDoesNotSeedWhenArchiveAlreadyHasHistory() throws Exception
+    {
+        XWikiAttachmentArchive archive = new XWikiAttachmentArchive();
+        archive.setRCSArchive(new Archive(new Object[] {"content"}, "test.txt", "1.2"));
+        String originalArchiveContent = archive.getArchiveAsString();
+
+        XWikiAttachment attachment = createAttachment(archive);
+
+        this.store.saveAttachmentContent(attachment, false, this.oldcore.getXWikiContext(), false);
+
+        assertEquals(originalArchiveContent, archive.getArchiveAsString());
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/XWikiHibernateAttachmentStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/XWikiHibernateAttachmentStoreTest.java
@@ -68,8 +68,7 @@ class XWikiHibernateAttachmentStoreTest
         when(mockHibernateStore.getCurrentSession()).thenReturn(this.mockSession);
         when(mockHibernateStore.getSessionFactory()).thenReturn(mock(SessionFactory.class));
 
-        @SuppressWarnings("unchecked")
-        Query<Long> mockQuery = mock(Query.class);
+        Query<Long> mockQuery = mock();
         when(this.mockSession.createQuery(anyString(), eq(Long.class))).thenReturn(mockQuery);
         when(mockQuery.setParameter(anyString(), any())).thenReturn(mockQuery);
         when(mockQuery.uniqueResult()).thenReturn(null);


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24268

# Changes

See https://jira.xwiki.org/browse/XWIKI-24268

# Executed Tests

* New unit test
* Manually tested by adding twice the same attachment and clicking on the revision link. Verify the 2 attachment revisions can be seen. All this after configuring XWiki as mentioned on the forum, i.e.:

```
xwiki.store.recyclebin.content.hint=hibernate
xwiki.store.attachment.hint=hibernate
xwiki.store.attachment.versioning.hint=hibernate
xwiki.store.attachment.recyclebin.content.hint=hibernate

xwiki.store.main.hint=hibernate
xwiki.store.versioning.hint=hibernate
xwiki.store.recyclebin.hint=hibernate
xwiki.store.attachment.recyclebin.hint=hibernate
xwiki.store.migration.manager.hint=hibernate

xwiki.recyclebin=1
storage.attachment.recyclebin=1
xwiki.store.versioning=1
xwiki.store.attachment.versioning=1
xwiki.store.rollbackattachmentwithdocuments=1
```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * To be defined, ideally on all branches if the fix is ok