### PR TITLE
XWIKI-24145: Wrong behavior when deleting a page with its children

### DIFF
--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/resources/ApplicationResources.properties
@@ -92,7 +92,7 @@ job.question.ExtensionBreakingQuestion.confirm=Do you wish to continue?
 job.question.ExtensionBreakingQuestion.tree.selectAll=select all
 job.question.ExtensionBreakingQuestion.tree.selectNone=none
 job.question.ExtensionBreakingQuestion.tree.paginationNode={0} more....
-job.question.ExtensionBreakingQuestion.tree.freePages=Pages that do not belong to any extension
+job.question.ExtensionBreakingQuestion.tree.freePages=Pages that are not mandatory for any extension
 
 job.question.ExtensionBreakingQuestion.refactoring/delete.title=You are about to delete pages that belong to extensions.
 job.question.ExtensionBreakingQuestion.refactoring/delete.explanation=If you delete these pages, the extensions might not work anymore.

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/job/question/ExtensionBreakingQuestion.data.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/job/question/ExtensionBreakingQuestion.data.vm
@@ -76,7 +76,8 @@ $response.setContentType("application/json")
     #set ($pageReference = $page.entityReference)
     #if ($foreach.count > $offset + $limit)
       #set ($howMany = $pages.size() - $foreach.count + 1)
-      #paginationNode($data, $howMany, $foreach.count)
+      #set ($newOffset = $foreach.count - 1)
+      #paginationNode($data, $howMany, $newOffset)
       #break
     #end
     #if ($foreach.count > $offset)

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/job_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/job_macros.vm
@@ -47,13 +47,13 @@ $services.template.execute('logging_macros.vm')
   <dl class="xform">
     ## Collapse the job log if the job is waiting for user input (leave more space for the job question).
     <dt>
-      <label class="collapse-toggle#if ($collapsed || $status.state == 'WAITING') collapsed#end"
+      <button class="btn btn-default btn-xs collapse-toggle#if ($collapsed || $status.state == 'WAITING') collapsed#end"
           data-target-xpath="parent::*/following-sibling::*">
         <span class="icon-closed">$services.icon.renderHTML('caret-right')</span>
         <span class="icon-opened">$services.icon.renderHTML('caret-down')</span>
         #set ($jobType = $status.jobType)
         $services.localization.render(["job.log.label.$jobType", 'job.log.label'])
-      </label>
+      </button>
     </dt>
     <dd>#printStatusLog($status)</dd>
   </dl>


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-24145

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Updated an imprecise translation
* Fixed an offset error
* Fixed the node nature of the log toggle.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The change in `job_macros.vm` is not necessary to solve the ticket but it was an easy fix close to the UI that needed to be updated. The button is slightly different, it now has borders.
* The ticket description mentions three problems:
1. The tree of children misses an entry
2. The logs are incorrect (same as missing entry)
3. One translation is imprecise
 
Solving 1. also fixed 2., my guess is that the incorrect state of the tree created the second problem. I decided to not provide anything for 2. , a safer (but more complex) option would have been to provide a safeguard.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Here is what the UI looks like after the changes (except for the translation change):
<img width="1043" height="456" alt="Screenshot From 2026-04-24 12-40-21" src="https://github.com/user-attachments/assets/2288db02-880b-4c6e-ac8e-cc3e626ac2e0" />
<img width="1011" height="983" alt="Screenshot From 2026-04-24 12-42-23" src="https://github.com/user-attachments/assets/518acea2-5dbd-43bd-add2-fd8cf02371ae" />
<img width="1011" height="791" alt="Screenshot From 2026-04-24 12-42-14" src="https://github.com/user-attachments/assets/4e4ff6a9-8ee7-4873-8620-cce40e34ba4c" />
<img width="1018" height="1245" alt="Screenshot From 2026-04-24 12-43-29" src="https://github.com/user-attachments/assets/b7d89297-5635-4755-b519-a211fd5e0e5a" />


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
I tested on my local instance (see screenshots) and could not reproduce any of the three issues pointed out in the ticket description.
____

First, I built the changes successfully with:
* `mvn clean install -f xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/ -Pquality`
* `mvn clean install -f xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar -Pquality`

Then I ran the "Delete action" tests with `mvn clean install -f xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker -Dit.test=DeletePageIT`. After a few minutes of docker tests, the build succeeded. 

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 17.10.X