### PR TITLE
XWIKI-24200: Improve header handling for downloading attachments

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Attachment.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Attachment.java
@@ -30,6 +30,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.suigeneris.jrcs.rcs.Version;
 import org.xwiki.model.reference.AttachmentReference;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.stability.Unstable;
 
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
@@ -110,6 +112,18 @@ public class Attachment extends Api
     public String getAuthor()
     {
         return this.attachment.getAuthor();
+    }
+
+    /**
+     * @return the reference of the author of the attachment.
+     * @see XWikiAttachment#getAuthorReference()
+     * @since 17.10.9
+     * @since 18.4.0RC1
+     */
+    @Unstable
+    public DocumentReference getAuthorReference()
+    {
+        return this.attachment.getAuthorReference();
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/DownloadAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/DownloadAction.java
@@ -46,6 +46,7 @@ import org.xwiki.component.annotation.Component;
 import org.xwiki.configuration.ConfigurationSource;
 import org.xwiki.context.Execution;
 import org.xwiki.context.ExecutionContext;
+import org.xwiki.internal.attachment.XWikiAttachmentSecurityManager;
 import org.xwiki.model.EntityType;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.EntityReference;
@@ -477,17 +478,10 @@ public class DownloadAction extends XWikiAction
         // Save dialog box (exe, zip, xar, etc).
         String dispType = "inline";
 
-        // Determine whether the user who attached the file has Programming Rights or not.
-        boolean hasPR = false;
-        String author = attachment.getAuthor();
-        try {
-            hasPR = context.getWiki().getRightService().hasAccessLevel("programming", author, "XWiki.XWikiPreferences",
-                context);
-        } catch (Exception e) {
-            hasPR = false;
-        }
+        XWikiAttachmentSecurityManager attachmentSecurityManager =
+            Utils.getComponent(XWikiAttachmentSecurityManager.class);
         // If the mimetype is not authorized to be displayed inline, let's force its content disposition to download.
-        if (shouldBeDownloaded(hasPR, request, mimetype)) {
+        if (attachmentSecurityManager.shouldBeDownloaded(attachment)) {
             dispType = ATTACHMENT;
         }
         // Use RFC 2231 for encoding filenames, since the normal HTTP headers only allows ASCII characters.
@@ -516,50 +510,5 @@ public class DownloadAction extends XWikiAction
             return false;
         }
         return start == null || end == null || end >= start;
-    }
-
-    /**
-     * Check if an attachment should be downloaded or can be displayed inline.
-     * Attachments should be downloaded if:
-     * <ul>
-     *     <li>the request contains a force-download parameter with the value 1</li>
-     *     <li>or the mimetype is part of the forceDownload property list</li>
-     *     <li>or no custom whitelist exists and a custom blacklist exists and contains the mimetype and the attachment
-     *     has not been added by a user with programming rights</li>
-     *     <li>or the whitelist (default or custom) does not contains the mimetype and the attachment has not been added
-     *     by a user with programming rights</li>
-     * </ul>
-     *
-     * Note that in the case of the request does not contain a force-downloaded parameter with the value 1 and the
-     * mimetype is not part of the forceDownload property list, but the attachment has been added by a user with
-     * programming right, then the attachment is always displayed inline.
-     *
-     * @param hasPR a boolean indicating if the attachment has been added by someone with programming rights.
-     * @param request the current download request.
-     * @param mimeType the mimetype of the attachment.
-     * @return {@code true} if the attachment should be downloaded, and {@code false} if it can be displayed inline.
-     */
-    private boolean shouldBeDownloaded(boolean hasPR, XWikiRequest request, String mimeType)
-    {
-        boolean result;
-        ConfigurationSource configuration = Utils.getComponent(ConfigurationSource.class, "xwikiproperties");
-
-        boolean whiteListExists = configuration.containsKey(WHITELIST_PROPERTY);
-        boolean blackListExists = configuration.containsKey(BLACKLIST_PROPERTY);
-        List<String> blackList = configuration.getProperty(BLACKLIST_PROPERTY, Collections.emptyList());
-        List<String> whiteList = configuration.getProperty(WHITELIST_PROPERTY, MIMETYPE_WHITELIST);
-        List<String> forceDownloadList = configuration.getProperty(FORCE_DOWNLOAD_PROPERTY, Collections.emptyList());
-
-        if ("1".equals(request.getParameter("force-download")) || forceDownloadList.contains(mimeType)) {
-            result = true;
-        } else if (hasPR) {
-            result = false;
-        } else if (blackListExists && !whiteListExists) {
-            result = blackList.contains(mimeType);
-        } else {
-            result = !whiteList.contains(mimeType);
-        }
-
-        return result;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/internal/attachment/XWikiAttachmentSecurityManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/internal/attachment/XWikiAttachmentSecurityManager.java
@@ -1,0 +1,134 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.internal.attachment;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.configuration.ConfigurationSource;
+import org.xwiki.container.Container;
+import org.xwiki.container.Request;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.security.authorization.AuthorizationManager;
+import org.xwiki.security.authorization.Right;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.doc.XWikiAttachment;
+import com.xpn.xwiki.web.DownloadAction;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Provider;
+import jakarta.inject.Singleton;
+
+/**
+ * Generic check to define if an attachment can be provided inline or if it needs to be downloaded.
+ *
+ * @version $Id$
+ * @since 18.4.0RC1
+ */
+@Component(roles = XWikiAttachmentSecurityManager.class)
+@Singleton
+public class XWikiAttachmentSecurityManager
+{
+    @Inject
+    @Named("xwikiproperties")
+    private ConfigurationSource configuration;
+
+    @Inject
+    private AuthorizationManager authorizationManager;
+
+    @Inject
+    private Container container;
+
+    @Inject
+    private Provider<XWikiContext> contextProvider;
+
+    /**
+     * Check if an attachment should be downloaded or can be displayed inline.
+     * Attachments should be downloaded if:
+     * <ul>
+     *     <li>the request contains a force-download parameter with the value 1</li>
+     *     <li>or the mimetype is part of the forceDownload property list</li>
+     *     <li>or no custom whitelist exists and a custom blacklist exists and contains the mimetype and the attachment
+     *     has not been added by a user with programming rights</li>
+     *     <li>or the whitelist (default or custom) does not contains the mimetype and the attachment has not been added
+     *     by a user with programming rights</li>
+     * </ul>
+     *
+     * Note that in the case of the request does not contain a force-downloaded parameter with the value 1 and the
+     * mimetype is not part of the forceDownload property list, but the attachment has been added by a user with
+     * programming right, then the attachment is always displayed inline.
+     *
+     * @param attachment the attachment to check if it should be downloaded or provided inline.
+     * @return {@code true} if the attachment should be downloaded, and {@code false} if it can be displayed inline.
+     */
+    public boolean shouldBeDownloaded(XWikiAttachment attachment)
+    {
+        DocumentReference authorReference = attachment.getAuthorReference();
+        boolean hasPR = this.authorizationManager.hasAccess(Right.PROGRAM, authorReference,
+            this.contextProvider.get().getWikiReference());
+        String mimeType = attachment.getMimeType(this.contextProvider.get());
+        return shouldBeDownloaded(mimeType, hasPR);
+    }
+
+    private boolean shouldBeDownloaded(String mimeType, boolean hasPR)
+    {
+        boolean result;
+        Request request = this.container.getRequest();
+        boolean whiteListExists = configuration.containsKey(DownloadAction.WHITELIST_PROPERTY);
+        boolean blackListExists = configuration.containsKey(DownloadAction.BLACKLIST_PROPERTY);
+        List<String> blackList = configuration.getProperty(DownloadAction.BLACKLIST_PROPERTY, Collections.emptyList());
+        List<String> whiteList =
+            configuration.getProperty(DownloadAction.WHITELIST_PROPERTY, DownloadAction.MIMETYPE_WHITELIST);
+        List<String> forceDownloadList =
+            configuration.getProperty(DownloadAction.FORCE_DOWNLOAD_PROPERTY, Collections.emptyList());
+
+        if ("1".equals(request.getParameter("force-download")) || forceDownloadList.contains(mimeType)) {
+            result = true;
+        } else if (hasPR) {
+            result = false;
+        } else if (blackListExists && !whiteListExists) {
+            result = blackList.contains(mimeType);
+        } else {
+            result = !whiteList.contains(mimeType);
+        }
+        return result;
+    }
+
+    /**
+     * Check if a resource with a given mimetype should be downloaded or can be displayed inline.
+     * Attachments should be downloaded if:
+     * <ul>
+     *     <li>the request contains a force-download parameter with the value 1</li>
+     *     <li>or the mimetype is part of the forceDownload property list</li>
+     *     <li>or no custom whitelist exists and a custom blacklist exists and contains the mimetype</li>
+     *     <li>or the whitelist (default or custom) does not contains the mimetype</li>
+     * </ul>
+     *
+     * @param mimeType the mimetype of the resource to check if it should be downloaded or provided inline.
+     * @return {@code true} if the resource should be downloaded, and {@code false} if it can be displayed inline.
+     */
+    public boolean shouldBeDownloaded(String mimeType)
+    {
+        return shouldBeDownloaded(mimeType, false);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/internal/attachment/XWikiAttachmentSecurityManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/internal/attachment/XWikiAttachmentSecurityManager.java
@@ -31,6 +31,8 @@ import org.xwiki.security.authorization.AuthorizationManager;
 import org.xwiki.security.authorization.Right;
 
 import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.api.Attachment;
+import com.xpn.xwiki.api.Document;
 import com.xpn.xwiki.doc.XWikiAttachment;
 import com.xpn.xwiki.web.DownloadAction;
 
@@ -81,13 +83,35 @@ public class XWikiAttachmentSecurityManager
      * @param attachment the attachment to check if it should be downloaded or provided inline.
      * @return {@code true} if the attachment should be downloaded, and {@code false} if it can be displayed inline.
      */
+    public boolean shouldBeDownloaded(Attachment attachment)
+    {
+        if (attachment != null) {
+            DocumentReference authorReference = attachment.getAuthorReference();
+            boolean hasPR = this.authorizationManager.hasAccess(Right.PROGRAM, authorReference,
+                this.contextProvider.get().getWikiReference());
+            String mimeType = attachment.getMimeType();
+            return shouldBeDownloaded(mimeType, hasPR);
+        } else {
+            return true;
+        }
+    }
+
+    /**
+     * Same as {@link #shouldBeDownloaded(Attachment)}: wrap the given attachment to call it.
+     *
+     * @param attachment the attachment to test if it should be downloaded or displayed inline.
+     * @return {@code true} if the attachment should be downloaded, and {@code false} if it can be displayed inline.
+     * @see #shouldBeDownloaded(Attachment)
+     */
     public boolean shouldBeDownloaded(XWikiAttachment attachment)
     {
-        DocumentReference authorReference = attachment.getAuthorReference();
-        boolean hasPR = this.authorizationManager.hasAccess(Right.PROGRAM, authorReference,
-            this.contextProvider.get().getWikiReference());
-        String mimeType = attachment.getMimeType(this.contextProvider.get());
-        return shouldBeDownloaded(mimeType, hasPR);
+        if (attachment != null) {
+            XWikiContext context = this.contextProvider.get();
+            Document attachmentDoc = new Document(attachment.getDoc(), context);
+            return shouldBeDownloaded(new Attachment(attachmentDoc, attachment, context));
+        } else {
+            return true;
+        }
     }
 
     private boolean shouldBeDownloaded(String mimeType, boolean hasPR)

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/META-INF/components.txt
@@ -279,6 +279,7 @@ org.xwiki.security.authservice.script.AuthServiceScriptService
 org.xwiki.model.validation.edit.XWikiDocumentLockEditConfirmationChecker
 org.xwiki.evaluation.internal.DefaultObjectEvaluator
 org.xwiki.evaluation.internal.VelocityObjectPropertyEvaluator
+org.xwiki.internal.attachment.XWikiAttachmentSecurityManager
 org.xwiki.internal.authentication.LoginLinkUIExtension
 org.xwiki.internal.authentication.RegisterLinkUIExtension
 org.xwiki.internal.filter.Importer

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/DownloadActionTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/DownloadActionTest.java
@@ -37,6 +37,7 @@ import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
 import org.xwiki.context.ExecutionContext;
 import org.xwiki.context.ExecutionContextManager;
+import org.xwiki.internal.attachment.XWikiAttachmentSecurityManager;
 import org.xwiki.model.reference.AttachmentReference;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.resource.ResourceReference;
@@ -116,6 +117,9 @@ class DownloadActionTest
     @MockComponent
     private ResourceReferenceManager resourceReferenceManager;
 
+    @MockComponent
+    private XWikiAttachmentSecurityManager attachmentSecurityManager;
+
     private DocumentReference documentReference;
 
     /**
@@ -150,12 +154,13 @@ class DownloadActionTest
     }
 
     // Helpers for the tests
-    private void createAttachment(Date d, String name) throws IOException
+    private XWikiAttachment createAttachment(Date d, String name) throws IOException
     {
         XWikiAttachment filetxt = new XWikiAttachment(this.document, name);
         filetxt.setContent(new ByteArrayInputStream(this.fileContent));
         filetxt.setDate(d);
         this.document.getAttachmentList().add(filetxt);
+        return filetxt;
     }
 
     private void setRequestExpectations(String uri, String id, String forceDownload, String range, long modifiedSince,
@@ -371,114 +376,6 @@ class DownloadActionTest
     }
 
     @Test
-    void downloadWhenForce() throws XWikiException, IOException
-    {
-        Date d = new Date();
-        createAttachment(d, DEFAULT_FILE_NAME);
-        setRequestExpectations(DEFAULT_URI, null, "1", null, -1l, DEFAULT_FILE_NAME);
-
-        assertNull(this.action.render(this.oldcore.getXWikiContext()));
-
-        verifyResponseExpectations(d.getTime(), this.fileContent.length, "text/plain",
-            "attachment; filename*=utf-8''file.txt");
-        verifyOutputExpectations(0, this.fileContent.length);
-    }
-
-    @Test
-    void downloadWhenMimeTypeBlacklisted() throws Exception
-    {
-        Date d = new Date();
-        createAttachment(d, "file.png");
-        when(this.engineContext.getMimeType("file.png")).thenReturn("image/png");
-        setRequestExpectations("/xwiki/bin/download/space/page/file.png", null, null, null, -1l, "file.png");
-        this.oldcore.getConfigurationSource().setProperty(DownloadAction.BLACKLIST_PROPERTY,
-            Arrays.asList("application/x-bzip", "image/png"));
-
-        assertNull(this.action.render(this.oldcore.getXWikiContext()));
-
-        verifyResponseExpectations(d.getTime(), this.fileContent.length, "image/png",
-            "attachment; filename*=utf-8''file.png");
-        verifyOutputExpectations(0, this.fileContent.length);
-    }
-
-    @Test
-    void downloadWhenMimeTypeBlacklistedAndAttachmentAddedByPRUser() throws Exception
-    {
-        Date d = new Date();
-        createAttachment(d, "file.png");
-        when(this.engineContext.getMimeType("file.png")).thenReturn("image/png");
-        setRequestExpectations("/xwiki/bin/download/space/page/file.png", null, null, null, -1l, "file.png");
-        this.oldcore.getConfigurationSource().setProperty(DownloadAction.BLACKLIST_PROPERTY,
-            Arrays.asList("application/x-bzip", "image/png"));
-        // Consider PR rights
-        when(this.oldcore.getMockRightService().hasAccessLevel(eq("programming"), any(), any(),
-            any(XWikiContext.class))).thenReturn(true);
-
-        assertNull(this.action.render(this.oldcore.getXWikiContext()));
-
-        verifyResponseExpectations(d.getTime(), this.fileContent.length, "image/png",
-            "inline; filename*=utf-8''file.png");
-        verifyOutputExpectations(0, this.fileContent.length);
-    }
-
-    @Test
-    void downloadWhenMimeTypeForcedDownloadAndAttachmentAddedByPRUser() throws Exception
-    {
-        Date d = new Date();
-        createAttachment(d, "file.png");
-        when(this.engineContext.getMimeType("file.png")).thenReturn("image/png");
-        setRequestExpectations("/xwiki/bin/download/space/page/file.png", null, null, null, -1l, "file.png");
-        this.oldcore.getConfigurationSource().setProperty(DownloadAction.FORCE_DOWNLOAD_PROPERTY,
-            Arrays.asList("application/x-bzip", "image/png"));
-        // Consider PR rights
-        when(this.oldcore.getMockRightService().hasAccessLevel(eq("programming"), any(), any(),
-            any(XWikiContext.class))).thenReturn(true);
-
-        assertNull(this.action.render(this.oldcore.getXWikiContext()));
-
-        verifyResponseExpectations(d.getTime(), this.fileContent.length, "image/png",
-            "attachment; filename*=utf-8''file.png");
-        verifyOutputExpectations(0, this.fileContent.length);
-    }
-
-    @Test
-    void downloadWhenMimeTypeNotWhitelisted() throws Exception
-    {
-        Date d = new Date();
-        createAttachment(d, "file.png");
-        when(this.engineContext.getMimeType("file.png")).thenReturn("image/png");
-        setRequestExpectations("/xwiki/bin/download/space/page/file.png", null, null, null, -1l, "file.png");
-        this.oldcore.getConfigurationSource().setProperty(DownloadAction.WHITELIST_PROPERTY,
-            Collections.singletonList("application/x-bzip"));
-
-        assertNull(this.action.render(this.oldcore.getXWikiContext()));
-
-        verifyResponseExpectations(d.getTime(), this.fileContent.length, "image/png",
-            "attachment; filename*=utf-8''file.png");
-        verifyOutputExpectations(0, this.fileContent.length);
-    }
-
-    @Test
-    void downloadWhenMimeTypeNotWhitelistedButAddedByPRUser() throws Exception
-    {
-        Date d = new Date();
-        createAttachment(d, "file.png");
-        when(this.engineContext.getMimeType("file.png")).thenReturn("image/png");
-        setRequestExpectations("/xwiki/bin/download/space/page/file.png", null, null, null, -1l, "file.png");
-        this.oldcore.getConfigurationSource().setProperty(DownloadAction.WHITELIST_PROPERTY,
-            Collections.singletonList("application/x-bzip"));
-        // Consider PR rights
-        when(this.oldcore.getMockRightService().hasAccessLevel(eq("programming"), any(), any(),
-            any(XWikiContext.class))).thenReturn(true);
-
-        assertNull(this.action.render(this.oldcore.getXWikiContext()));
-
-        verifyResponseExpectations(d.getTime(), this.fileContent.length, "image/png",
-            "inline; filename*=utf-8''file.png");
-        verifyOutputExpectations(0, this.fileContent.length);
-    }
-
-    @Test
     void downloadWithRealDate() throws XWikiException, IOException
     {
         Date d = new Date(411757300000l);
@@ -510,10 +407,10 @@ class DownloadActionTest
     void downloadWhenNameWithSpacesEncodedWithPercent() throws XWikiException, IOException
     {
         Date d = new Date();
-        createAttachment(d, "file name.txt");
+        XWikiAttachment attachment = createAttachment(d, "file name.txt");
         when(this.engineContext.getMimeType("file name.txt")).thenReturn("text/plain");
         setRequestExpectations("/xwiki/bin/download/space/page/file%20name.txt", null, "1", null, -1l, "file name.txt");
-
+        when(this.attachmentSecurityManager.shouldBeDownloaded(attachment)).thenReturn(true);
         assertNull(this.action.render(this.oldcore.getXWikiContext()));
 
         verifyResponseExpectations(d.getTime(), this.fileContent.length, "text/plain",
@@ -525,11 +422,11 @@ class DownloadActionTest
     void downloadWhenNameWithNonAsciiChars() throws XWikiException, IOException
     {
         Date d = new Date();
-        createAttachment(d, "file\u021B.txt");
+        XWikiAttachment attachment = createAttachment(d, "file\u021B.txt");
 
         when(this.engineContext.getMimeType("file\u021B.txt")).thenReturn("text/plain");
         setRequestExpectations("/xwiki/bin/download/space/page/file%C8%9B.txt", null, "1", null, -1l, "file\u021B.txt");
-
+        when(this.attachmentSecurityManager.shouldBeDownloaded(attachment)).thenReturn(true);
         assertNull(this.action.render(this.oldcore.getXWikiContext()));
 
         verifyResponseExpectations(d.getTime(), this.fileContent.length, "text/plain",
@@ -816,7 +713,7 @@ class DownloadActionTest
             new DocumentReference("wiki", Arrays.asList("space1", "space2"), "page")), EntityResourceAction.VIEW));
 
         // Note: we don't give PR and the attachment is not an authorized mime type.
-
+        when(attachmentSecurityManager.shouldBeDownloaded(attachment)).thenReturn(true);
         assertNull(action.render(xcontext));
 
         // This is the test, we verify what is set in the response
@@ -882,6 +779,7 @@ class DownloadActionTest
         XWikiPluginManager pluginManager = mock(XWikiPluginManager.class);
         when(pluginManager.downloadAttachment(attachment, xcontext)).thenReturn(attachment);
         doReturn(pluginManager).when(this.oldcore.getSpyXWiki()).getPluginManager();
+        when(this.attachmentSecurityManager.shouldBeDownloaded(attachment)).thenReturn(true);
 
         assertNull(action.render(xcontext));
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/internal/attachment/XWikiAttachmentSecurityManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/internal/attachment/XWikiAttachmentSecurityManagerTest.java
@@ -1,0 +1,178 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.internal.attachment;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.xwiki.container.Container;
+import org.xwiki.container.Request;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.WikiReference;
+import org.xwiki.security.authorization.AuthorizationManager;
+import org.xwiki.security.authorization.Right;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiAttachment;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.test.MockitoOldcore;
+import com.xpn.xwiki.test.junit5.mockito.InjectMockitoOldcore;
+import com.xpn.xwiki.test.junit5.mockito.OldcoreTest;
+import com.xpn.xwiki.web.DownloadAction;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Provider;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@OldcoreTest
+class XWikiAttachmentSecurityManagerTest
+{
+    @InjectMockComponents
+    private XWikiAttachmentSecurityManager securityManager;
+
+    @InjectMockitoOldcore
+    private MockitoOldcore oldcore;
+
+    @MockComponent
+    private Container container;
+
+    @MockComponent
+    private Provider<XWikiContext> contextProvider;
+
+    @Inject
+    private AuthorizationManager authorizationManager;
+
+    @Mock
+    private Request request;
+
+    @Mock
+    private XWikiContext context;
+
+    @BeforeEach
+    void setup()
+    {
+        when(this.container.getRequest()).thenReturn(request);
+        when(this.contextProvider.get()).thenReturn(context);
+    }
+
+    // Helpers for the tests
+    private XWikiAttachment createAttachment() throws IOException
+    {
+        DocumentReference documentReference = new DocumentReference("wiki", "space", "page");
+        XWikiDocument document = new XWikiDocument(documentReference);
+        XWikiAttachment filetxt = new XWikiAttachment(document, "file");
+        filetxt.setContent(new ByteArrayInputStream("any content".getBytes(StandardCharsets.UTF_8)));
+        filetxt.setDate(new Date());
+        document.getAttachmentList().add(filetxt);
+        return filetxt;
+    }
+
+    @Test
+    void downloadWhenForce() throws XWikiException, IOException
+    {
+        XWikiAttachment attachment = createAttachment();
+        when(this.request.getParameter("force-download")).thenReturn("1");
+        assertTrue(this.securityManager.shouldBeDownloaded(attachment));
+    }
+
+    @Test
+    void downloadWhenMimeTypeBlacklisted() throws Exception
+    {
+        XWikiAttachment attachment = createAttachment();
+        attachment.setMimeType("image/png");
+        this.oldcore.getConfigurationSource().setProperty(DownloadAction.BLACKLIST_PROPERTY,
+            List.of("application/x-bzip", "image/png"));
+        assertTrue(this.securityManager.shouldBeDownloaded(attachment));
+    }
+
+    @Test
+    void downloadWhenMimeTypeBlacklistedAndAttachmentAddedByPRUser() throws Exception
+    {
+        XWikiAttachment attachment = createAttachment();
+        attachment.setMimeType("image/png");
+        DocumentReference prUser = new DocumentReference("xwiki", "XWiki", "PRUser");
+        attachment.setAuthorReference(prUser);
+        WikiReference wikiReference = new WikiReference("foo");
+        when(context.getWikiReference()).thenReturn(wikiReference);
+
+        this.oldcore.getConfigurationSource().setProperty(DownloadAction.BLACKLIST_PROPERTY,
+            List.of("application/x-bzip", "image/png"));
+        // Consider PR rights
+        when(this.authorizationManager.hasAccess(Right.PROGRAM, prUser, wikiReference)).thenReturn(true);
+        assertFalse(this.securityManager.shouldBeDownloaded(attachment));
+    }
+
+    @Test
+    void downloadWhenMimeTypeForcedDownloadAndAttachmentAddedByPRUser() throws Exception
+    {
+        when(this.request.getParameter("force-download")).thenReturn("1");
+        XWikiAttachment attachment = createAttachment();
+        attachment.setMimeType("image/png");
+        DocumentReference prUser = new DocumentReference("xwiki", "XWiki", "PRUser");
+        attachment.setAuthorReference(prUser);
+        WikiReference wikiReference = new WikiReference("foo");
+        when(context.getWikiReference()).thenReturn(wikiReference);
+
+        this.oldcore.getConfigurationSource().setProperty(DownloadAction.BLACKLIST_PROPERTY,
+            Arrays.asList("application/x-bzip", "image/png"));
+        // Consider PR rights
+        when(this.authorizationManager.hasAccess(Right.PROGRAM, prUser, wikiReference)).thenReturn(true);
+        assertTrue(this.securityManager.shouldBeDownloaded(attachment));
+    }
+
+    @Test
+    void downloadWhenMimeTypeNotWhitelisted() throws Exception
+    {
+        XWikiAttachment attachment = createAttachment();
+        attachment.setMimeType("image/png");
+        this.oldcore.getConfigurationSource().setProperty(DownloadAction.WHITELIST_PROPERTY,
+            List.of("application/x-bzip"));
+        assertTrue(this.securityManager.shouldBeDownloaded(attachment));
+    }
+
+    @Test
+    void downloadWhenMimeTypeNotWhitelistedButAddedByPRUser() throws Exception
+    {
+        XWikiAttachment attachment = createAttachment();
+        attachment.setMimeType("image/png");
+        DocumentReference prUser = new DocumentReference("xwiki", "XWiki", "PRUser");
+        attachment.setAuthorReference(prUser);
+        WikiReference wikiReference = new WikiReference("foo");
+        when(context.getWikiReference()).thenReturn(wikiReference);
+
+        this.oldcore.getConfigurationSource().setProperty(DownloadAction.WHITELIST_PROPERTY,
+            List.of("application/x-bzip"));
+        // Consider PR rights
+        when(this.authorizationManager.hasAccess(Right.PROGRAM, prUser, wikiReference)).thenReturn(true);
+        assertFalse(this.securityManager.shouldBeDownloaded(attachment));
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/attachments/AttachmentResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/attachments/AttachmentResourceImpl.java
@@ -75,7 +75,7 @@ public class AttachmentResourceImpl extends BaseAttachmentsResource implements A
             String dispType = "inline";
             // If the mimetype is not authorized to be displayed inline,
             // let's force its content disposition to download.
-            if (attachmentSecurityManager.shouldBeDownloaded(xwikiAttachment.getAttachment())) {
+            if (attachmentSecurityManager.shouldBeDownloaded(xwikiAttachment)) {
                 dispType = "attachment";
             }
             return Response

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/attachments/AttachmentResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/attachments/AttachmentResourceImpl.java
@@ -29,6 +29,7 @@ import javax.ws.rs.core.Response.Status;
 
 import org.xwiki.attachment.validation.AttachmentValidationException;
 import org.xwiki.component.annotation.Component;
+import org.xwiki.internal.attachment.XWikiAttachmentSecurityManager;
 import org.xwiki.rest.XWikiRestException;
 import org.xwiki.rest.internal.resources.BaseAttachmentsResource;
 import org.xwiki.rest.resources.attachments.AttachmentResource;
@@ -37,6 +38,9 @@ import org.xwiki.security.authorization.Right;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.api.Attachment;
 import com.xpn.xwiki.api.Document;
+import com.xpn.xwiki.util.Util;
+
+import jakarta.inject.Inject;
 
 /**
  * @version $Id$
@@ -45,6 +49,9 @@ import com.xpn.xwiki.api.Document;
 @Named("org.xwiki.rest.internal.resources.attachments.AttachmentResourceImpl")
 public class AttachmentResourceImpl extends BaseAttachmentsResource implements AttachmentResource
 {
+    @Inject
+    private XWikiAttachmentSecurityManager attachmentSecurityManager;
+
     @Override
     public Response getAttachment(String wikiName, String spaceName, String pageName, String attachmentName)
         throws XWikiRestException
@@ -58,7 +65,25 @@ public class AttachmentResourceImpl extends BaseAttachmentsResource implements A
                 throw new WebApplicationException(Status.NOT_FOUND);
             }
 
-            return Response.ok().type(xwikiAttachment.getMimeType()).entity(xwikiAttachment.getContent()).build();
+            String ofilename = Util.encodeURI(xwikiAttachment.getFilename(), getXWikiContext())
+                .replaceAll("\\+", "%20");
+            // The inline attribute of Content-Disposition tells the browser that they should display
+            // the downloaded file in the page (see http://www.ietf.org/rfc/rfc1806.txt for more
+            // details). We do this so that JPG, GIF, PNG, etc are displayed without prompting a Save
+            // dialog box. However, all mime types that cannot be displayed by the browser do prompt a
+            // Save dialog box (exe, zip, xar, etc).
+            String dispType = "inline";
+            // If the mimetype is not authorized to be displayed inline,
+            // let's force its content disposition to download.
+            if (attachmentSecurityManager.shouldBeDownloaded(xwikiAttachment.getAttachment())) {
+                dispType = "attachment";
+            }
+            return Response
+                .ok()
+                .type(xwikiAttachment.getMimeType())
+                .entity(xwikiAttachment.getContent())
+                .header("Content-Disposition", dispType + "; filename*=utf-8''" + ofilename)
+                .build();
         } catch (XWikiException e) {
             throw new XWikiRestException(e);
         }

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/AbstractContentResourceReferenceHandler.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/AbstractContentResourceReferenceHandler.java
@@ -27,6 +27,7 @@ import javax.inject.Inject;
 import org.apache.commons.io.IOUtils;
 import org.xwiki.container.Container;
 import org.xwiki.container.Response;
+import org.xwiki.internal.attachment.XWikiAttachmentSecurityManager;
 import org.xwiki.resource.AbstractResourceReferenceHandler;
 import org.xwiki.resource.ResourceReferenceHandlerException;
 import org.xwiki.resource.ResourceType;
@@ -43,6 +44,9 @@ public abstract class AbstractContentResourceReferenceHandler extends AbstractRe
 {
     @Inject
     private Container container;
+
+    @Inject
+    private XWikiAttachmentSecurityManager attachmentSecurityManager;
 
     protected void serveResource(String resourceName, InputStream resourceStream)
         throws ResourceReferenceHandlerException
@@ -64,12 +68,26 @@ public abstract class AbstractContentResourceReferenceHandler extends AbstractRe
         try {
             Response response = this.container.getResponse();
 
+            String actualContentType = (contentType != null) ? contentType
+                : TikaUtils.detect(markResetSupportingStream, resourceName);
             // Set the content type
-            if (contentType != null) {
-                response.setContentType(contentType);
-            } else {
-                response.setContentType(TikaUtils.detect(markResetSupportingStream, resourceName));
+            response.setContentType(actualContentType);
+
+            // The inline attribute of Content-Disposition tells the browser that they should display
+            // the downloaded file in the page (see http://www.ietf.org/rfc/rfc1806.txt for more
+            // details). We do this so that JPG, GIF, PNG, etc are displayed without prompting a Save
+            // dialog box. However, all mime types that cannot be displayed by the browser do prompt a
+            // Save dialog box (exe, zip, xar, etc).
+            String dispType = "inline";
+
+            // If the mimetype is not authorized to be displayed inline,
+            // let's force its content disposition to download.
+            if (attachmentSecurityManager.shouldBeDownloaded(actualContentType)) {
+                dispType = "attachment";
             }
+            // Use RFC 2231 for encoding filenames, since the normal HTTP headers only allows ASCII characters.
+            // See http://tools.ietf.org/html/rfc2231 for more details.
+            response.addHeader("Content-disposition", dispType + "; filename*=utf-8''" + resourceName);
 
             IOUtils.copy(markResetSupportingStream, response.getOutputStream());
         } catch (Exception e) {

--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/VfsResourceReferenceHandler.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/VfsResourceReferenceHandler.java
@@ -28,11 +28,9 @@ import java.util.List;
 
 import javax.inject.Inject;
 import javax.inject.Named;
-import javax.inject.Provider;
 import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
-import org.xwiki.component.manager.ComponentManager;
 import org.xwiki.resource.ResourceReference;
 import org.xwiki.resource.ResourceReferenceHandlerChain;
 import org.xwiki.resource.ResourceReferenceHandlerException;
@@ -60,10 +58,6 @@ import net.java.truevfs.access.TPath;
 @Authenticate
 public class VfsResourceReferenceHandler extends AbstractContentResourceReferenceHandler
 {
-    @Inject
-    @Named("context")
-    private Provider<ComponentManager> componentManagerProvider;
-
     @Inject
     @Named("cascading")
     private VfsPermissionChecker permissionChecker;


### PR DESCRIPTION


(cherry picked from commit 7472126ffada28b1a443b98ef0f6ec1ab7ccdba9) (cherry picked from commit e795561fe570eef2b37a84ef3ada55667f607445)

# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->



# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* XWIKI-24200: Improve header handling for downloading attachments
* XWIKI-24235: Improve header handling for VFS

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 