### PR TITLE
XWIKI-16811: 100 scaled image => OutOfMemory

### DIFF
--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -162,6 +162,21 @@
                 </item>
               </differences>
             </revapi.differences>
+
+            <revapi.differences>
+              <justification>
+                Knowing the raw image size before loading it in memory is important to be able to reject unreasonable
+                image processing requests. Since it'a an operation done on an image, it fits ImageProcessor.
+              </justification>
+              <criticality>highlight</criticality>
+              <differences>
+                <item>
+                  <code>java.method.addedToInterface</code>
+                  <fullQualifiedClassName>com.xpn.xwiki.plugin.image.ImageProcessor</fullQualifiedClassName>
+                  <new>method long com.xpn.xwiki.plugin.image.ImageProcessor::estimateImageRawSize(java.io.InputStream) throws java.io.IOException</new>
+                </item>
+              </differences>
+            </revapi.differences>
           </analysisConfiguration>
         </configuration>
       </plugin>

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-api/src/main/java/com/xpn/xwiki/internal/plugin/image/DefaultImageProcessor.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-api/src/main/java/com/xpn/xwiki/internal/plugin/image/DefaultImageProcessor.java
@@ -32,9 +32,12 @@ import java.util.Iterator;
 
 import javax.imageio.IIOImage;
 import javax.imageio.ImageIO;
+import javax.imageio.ImageReader;
+import javax.imageio.ImageTypeSpecifier;
 import javax.imageio.ImageWriteParam;
 import javax.imageio.ImageWriter;
 import javax.imageio.plugins.jpeg.JPEGImageWriteParam;
+import javax.imageio.stream.ImageInputStream;
 import javax.imageio.stream.ImageOutputStream;
 import javax.inject.Singleton;
 
@@ -112,6 +115,27 @@ public class DefaultImageProcessor implements ImageProcessor
         } catch (NoClassDefFoundError e) {
             // Happens on certain systems where the javax.imageio package is not available.
             return false;
+        }
+    }
+
+    @Override
+    public long estimateImageRawSize(InputStream inputStream) throws IOException
+    {
+        try (ImageInputStream iis = ImageIO.createImageInputStream(inputStream)) {
+            ImageReader imageReader = ImageIO.getImageReaders(iis).next();
+
+            try {
+                imageReader.setInput(iis);
+                int width = imageReader.getWidth(0);
+                int height = imageReader.getHeight(0);
+
+                ImageTypeSpecifier imageTypeSpecifier = imageReader.getImageTypes(0).next();
+                int bitsPerPixel = imageTypeSpecifier.getColorModel().getPixelSize();
+
+                return ((long) width) * height * bitsPerPixel / 8;
+            } finally {
+                imageReader.dispose();
+            }
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-api/src/main/java/com/xpn/xwiki/plugin/image/ImageProcessor.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-api/src/main/java/com/xpn/xwiki/plugin/image/ImageProcessor.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 import org.xwiki.component.annotation.Role;
+import org.xwiki.stability.Unstable;
 
 /**
  * Component used to process images.
@@ -73,4 +74,16 @@ public interface ImageProcessor
      * @return {@code true} if the given mime type is supported, {@code false} otherwise
      */
     boolean isMimeTypeSupported(String mimeType);
+
+    /**
+     * Attempts to compute the raw size (in bytes) of the given image from an input stream,
+     * without fully loading it in memory.
+     *
+     * @param inputStream the input stream to read the image metadata from
+     * @return the raw image size in bytes
+     * @throws IOException if reading the image metadata fails
+     * @since 18.4.0RC1
+     */
+    @Unstable
+    long estimateImageRawSize(InputStream inputStream) throws IOException;
 }

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-plugin/src/main/java/com/xpn/xwiki/plugin/image/ImagePlugin.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-processing/xwiki-platform-image-processing-plugin/src/main/java/com/xpn/xwiki/plugin/image/ImagePlugin.java
@@ -22,12 +22,14 @@ package com.xpn.xwiki.plugin.image;
 import java.awt.Image;
 import java.awt.image.RenderedImage;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Arrays;
+import java.util.concurrent.Semaphore;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xwiki.cache.Cache;
@@ -64,6 +66,8 @@ public class ImagePlugin extends XWikiDefaultPlugin
 
     private static final String DEFAULT_QUALITY_PARAM = "xwiki.plugin.image.defaultQuality";
 
+    private static final String PROCESSING_POOL_SIZE = "xwiki.plugin.image.processingPoolSizeMB";
+
     /**
      * Cache for already served images.
      */
@@ -80,9 +84,19 @@ public class ImagePlugin extends XWikiDefaultPlugin
     private float defaultQuality = 0.5f;
 
     /**
+     * Default available pool size to perform image processing, in MB.
+     */
+    private int processingPoolSizeMB = 200;
+
+    /**
      * The object used to process images.
      */
     private ImageProcessor imageProcessor;
+
+    /**
+     * Semaphore to handle access to the memory pool for image processing.
+     */
+    private Semaphore imageProcessorSemaphore;
 
     /**
      * Creates a new instance of this plugin.
@@ -130,6 +144,19 @@ public class ImagePlugin extends XWikiDefaultPlugin
                     DEFAULT_QUALITY_PARAM, this.defaultQuality);
             }
         }
+
+        String defaultProcessingPoolSize = context.getWiki().Param(PROCESSING_POOL_SIZE);
+        if (!StringUtils.isBlank(defaultProcessingPoolSize)) {
+            try {
+                this.processingPoolSizeMB =
+                    Math.max(0, Integer.parseInt(defaultProcessingPoolSize.trim()));
+            } catch (NumberFormatException e) {
+                LOG.warn("Failed to parse [{}] configuration parameter. Using [{}] as the image processing pool size.",
+                    PROCESSING_POOL_SIZE, this.processingPoolSizeMB);
+            }
+        }
+        this.imageProcessorSemaphore = new Semaphore(
+            (int) Math.min(this.processingPoolSizeMB * 1_000_000L, Integer.MAX_VALUE));
     }
 
     /**
@@ -313,39 +340,60 @@ public class ImagePlugin extends XWikiDefaultPlugin
     private XWikiAttachment shrinkImage(XWikiAttachment attachment, int requestedWidth, int requestedHeight,
         boolean keepAspectRatio, float requestedQuality, XWikiContext context) throws Exception
     {
-        Image image = this.imageProcessor.readImage(attachment.getContentInputStream(context));
-
-        // Compute the new image dimension.
-        int currentWidth = image.getWidth(null);
-        int currentHeight = image.getHeight(null);
-        int[] dimensions =
-            reduceImageDimensions(currentWidth, currentHeight, requestedWidth, requestedHeight, keepAspectRatio);
-
-        float quality = requestedQuality;
-        if (quality < 0) {
-            // If no scaling is needed and the quality parameter is not specified, return the original image.
-            if (dimensions[0] == currentWidth && dimensions[1] == currentHeight) {
-                return attachment;
-            }
-            quality = this.defaultQuality;
+        // Before processing the image, which would load a raw representation in memory, we check we have enough
+        // available space. The permits we acquire here corresponds to the raw image size in bytes.
+        long requiredPermits;
+        try (InputStream attachmentInputStream = attachment.getContentInputStream(context)) {
+            requiredPermits = this.imageProcessor.estimateImageRawSize(attachmentInputStream);
         }
 
-        // Scale the image to the new dimensions.
-        RenderedImage shrunkImage = this.imageProcessor.scaleImage(image, dimensions[0], dimensions[1]);
+        // We skip image processing for any image whose raw size exceeds half the total pool size.
+        if (requiredPermits > this.processingPoolSizeMB * 500_000L) {
+            LOG.warn("Skipping image processing for attachment [{}]. "
+                    + "Its estimated raw size is [{}] bytes which exceeds 50% of the image processing pool of [{}MB]. "
+                    + "Returning unprocessed image.",
+                attachment.getFilename(), requiredPermits, this.processingPoolSizeMB);
+            return attachment;
+        }
+        this.imageProcessorSemaphore.acquire((int) requiredPermits);
 
-        // Create an image attachment for the shrunk image.
-        XWikiAttachment thumbnail = attachment.clone();
-        thumbnail.loadAttachmentContent(context);
+        try {
+            Image image = this.imageProcessor.readImage(attachment.getContentInputStream(context));
 
-        OutputStream acos = thumbnail.getAttachment_content().getContentOutputStream();
-        this.imageProcessor.writeImage(shrunkImage,
-            attachment.getMimeType(context),
-            quality,
-            acos);
+            // Compute the new image dimension.
+            int currentWidth = image.getWidth(null);
+            int currentHeight = image.getHeight(null);
+            int[] dimensions =
+                reduceImageDimensions(currentWidth, currentHeight, requestedWidth, requestedHeight, keepAspectRatio);
 
-        IOUtils.closeQuietly(acos);
+            float quality = requestedQuality;
+            if (quality < 0) {
+                // If no scaling is needed and the quality parameter is not specified, return the original image.
+                if (dimensions[0] == currentWidth && dimensions[1] == currentHeight) {
+                    return attachment;
+                }
+                quality = this.defaultQuality;
+            }
 
-        return thumbnail;
+            // Scale the image to the new dimensions.
+            RenderedImage shrunkImage = this.imageProcessor.scaleImage(image, dimensions[0], dimensions[1]);
+
+            // Create an image attachment for the shrunk image.
+            XWikiAttachment thumbnail = attachment.clone();
+            thumbnail.loadAttachmentContent(context);
+
+            OutputStream acos = thumbnail.getAttachment_content().getContentOutputStream();
+            this.imageProcessor.writeImage(shrunkImage,
+                attachment.getMimeType(context),
+                quality,
+                acos);
+
+            IOUtils.closeQuietly(acos);
+
+            return thumbnail;
+        } finally {
+            this.imageProcessorSemaphore.release((int) requiredPermits);
+        }
     }
 
     /**


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-16811

# Changes

## Description

With this PR, a semaphore now handles a "processing memory pool". Whenever a request for an image processing comes in the ImagePlugin, we start by first computing an estimate of the image size without fully loading it in memory. If there is enough available space in the pool, the processing will go through, or it will either wait or be skipped entirely if the image is too large.

## Clarifications

The choice to use a semaphore instead of a simple ThreadPool came from the fact the ThreadPool added way too much overhead for small images.
The current default size for the memory pool is 200MB, which from my own testing seems to be the maximum that can be safely allotted using XWiki's recommended heap size (1024MB)

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Tested manually to fetch 1000 different resizes in parallel for a 3840x5760 jpg image. No OOM was reported during this test.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A