### PR TITLE
XWIKI-24312: confirmationText is not handled as plain text in Confirm…

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/confirmationBox.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/confirmationBox.js
@@ -97,8 +97,15 @@ if(typeof(XWiki) == "undefined" || typeof(XWiki.widgets) == "undefined" || typeo
       }
     }
   });
+
   /**
-   * @return {string} the expected format of the textContent property
+   * Indicates how the textContent parameter is interpreted by XWiki.widgets.ConfirmationBox.
+   * Callers can check for the presence of this method to decide whether to escape their input:
+   * When this method is available, the textContent parameter is treated as plain text and must not be escaped.
+   * When this method is missing (before 18.4.0RC1/17.10.9), the textContent parameter is interpreted as HTML and may
+   * need to be escaped.
+   * The returned value is always the "plain" string.
+   * @return {string} the expected format of the text property
    * @since 18.4.0RC1
    * @since 17.10.9
    */

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/confirmationBox.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/confirmationBox.js
@@ -23,6 +23,39 @@ if(typeof(XWiki) == "undefined" || typeof(XWiki.widgets) == "undefined" || typeo
     console.warn("[ConfirmationBox widget] Required class missing: XWiki.widgets.ModalPopup");
   }
 } else {
+  /**
+   * A general purpose modal confirmation dialog widget for requesting user confirmation on an action.
+   * Features:
+   * <ul>
+   * <li>Displays a confirmation question with customizable text.</li>
+   * <li>Multiple action buttons: Yes, No, and optional Cancel.</li>
+   * <li>Customizable callbacks for Yes, No, and Cancel actions.</li>
+   * </ul>
+   * To display a confirmation dialog, create a new XWiki.widgets.ConfirmationBox object. Constructor parameters:
+   * <dl>
+   *   <dt>behavior (optional)</dt>
+   *   <dd>An object containing callback functions:
+   *   <ul>
+   *     <li><tt>onYes</tt>: callback when the user picks the Yes option</li>
+   *     <li><tt>onNo</tt>: callback when the user picks the No option</li>
+   *     <li><tt>onCancel</tt>: callback when the user picks the Cancel option</li>
+   *   </ul>
+   *   </dd>
+   *   <dt>interactionParameters (optional)</dt>
+   *   <dd>Configuration options:
+   *   <ul>
+   *     <li><tt>confirmationText</tt>: the question or message to display (defaults to a localized message). Since
+   *     18.4.0RC1 and 17.10.9, its values is used as plain text. Before, it was used as HTML content. You can check for
+   *     the presence of the ConfirmationBox.textContentFormat static method to know which behavior applies at runtime.
+   *     </li>
+   *     <li><tt>yesButtonText</tt>: text for the Yes button (defaults to localized "Yes")</li>
+   *     <li><tt>noButtonText</tt>: text for the No button (defaults to localized "No")</li>
+   *     <li><tt>cancelButtonText</tt>: text for the Cancel button (defaults to localized "Cancel")</li>
+   *     <li><tt>showCancelButton</tt>: boolean to show/hide the Cancel button (defaults to false)</li>
+   *   </ul>
+   *   </dd>
+   * </dl>
+   */
   XWiki.widgets.ConfirmationBox = Class.create(XWiki.widgets.ModalPopup, {
     /** Default displayed texts */
     defaultInteractionParameters : {

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/confirmationBox.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/confirmationBox.js
@@ -60,7 +60,8 @@ if(typeof(XWiki) == "undefined" || typeof(XWiki.widgets) == "undefined" || typeo
     },
     /** Create the content of the confirmation dialog: icon + question text, buttons */
     createContent : function (data) {
-      var question = new Element("div", {"class" : "question"}).update(data.confirmationText);
+      var question = new Element("div", {"class" : "question"});
+      question.textContent = data.confirmationText;
       var buttons = new Element("div", {"class" : "buttons"});
       var yesButton = this.createButton("button", data.yesButtonText, "(Enter)", "");
       Event.observe(yesButton, "click", this.onYes.bindAsEventListener(this));
@@ -96,4 +97,10 @@ if(typeof(XWiki) == "undefined" || typeof(XWiki.widgets) == "undefined" || typeo
       }
     }
   });
+  /**
+   * @return {string} the expected format of the textContent property
+   * @since 18.4.0RC1
+   * @since 17.10.9
+   */
+  XWiki.widgets.ConfirmationBox.textContentFormat = () => "plain";
 } // if the parent widget is defined


### PR DESCRIPTION
…ationBox

# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-24312

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* use `textContent` as plain text
* introduce `XWiki.widgets.ConfirmationBox.textContentFormat` to get the expected format of the `textContent` property

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-17.10.x