### PR TITLE
XWIKI-24313: text is not handled as plain text in Notification

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/notification.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/notification.js
@@ -35,7 +35,9 @@ var widgets = XWiki.widgets = XWiki.widgets || {};
  * To display a notification, it suffices to create a new XWiki.widgets.Notification object. Constructor parameters:
  * <dl>
  *   <dt>text</dt>
- *   <dd>The notification text</dd>
+ *   <dd>The notification text. Since 18.4.0RC1 and 17.10.9, its values is used as plain text. Before, it was used
+ *   as HTML content. You can check for the presence of the Notification.textFormat static method to know which
+ *   behavior applies at runtime.</dd>
  *   <dt>type (optional)</dt>
  *   <dd>The notification type, one of <tt>plain</tt>, <tt>info</tt>, <tt>warning</tt>, <tt>error</tt>, <tt>inprogress</tt>,
  *    <tt>done</tt>. If an unknown or no type is passed, <tt>plain</tt> is used by default.</dd>

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/notification.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/notification.js
@@ -163,6 +163,13 @@ widgets.Notification = Class.create({
 widgets.Notification.container = null;
 
 /**
+ *
+ * Indicates how the text parameter is interpreted by XWiki.widgets.Notification.
+ * Callers can check for the presence of this method to decide whether to escape their input:
+ * When this method is available, the text parameter is treated as plain text and must not be escaped.
+ * When this method is missing (before 18.4.0RC1/17.10.9), the text parameter is interpreted as HTML and may need to be
+ * escaped.
+ * The returned value is always the "plain" string.
  * @return {string} the expected format of the text property
  * @since 18.4.0RC1
  * @since 17.10.9

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/notification.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/notification.js
@@ -108,7 +108,8 @@ widgets.Notification = Class.create({
   createElement : function() {
     if (!this.element) {
       // The notification container is already an ARIA "alert", those notifications do not need extra semantics.
-      this.element = new Element("div", {"class" : "xnotification xnotification-" + this.type}).update(this.text);
+      this.element = new Element("div", {"class" : "xnotification xnotification-" + this.type});
+      this.element.textContent = this.text;
       if (this.options.icon) {
         this.element.setStyle({backgroundImage : this.options.icon, paddingLeft : "22px"});
       }
@@ -160,6 +161,13 @@ widgets.Notification = Class.create({
 
 /** The container for all the notifications. */
 widgets.Notification.container = null;
+
+/**
+ * @return {string} the expected format of the text property
+ * @since 18.4.0RC1
+ * @since 17.10.9
+ */
+widgets.Notification.textFormat = () => "plain"
 
 /** Returns the container for all the notifications. The container is created the first time this function is called. */
 widgets.Notification.getContainer = function() {


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-24313

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* use `text` as plain text
* introduce `XWiki.widgets.ConfirmationBox.textContentFormat` to provide the format of the `text` property

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-17.10.x