### PR TITLE
[Misc] Convert ExtensionIT to a docker-based test

### DIFF
--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/pom.xml
@@ -42,4 +42,12 @@
     <module>xwiki-platform-extension-test-pageobjects</module>
     <module>xwiki-platform-extension-test-utils</module>
   </modules>
+  <profiles>
+    <profile>
+      <id>docker</id>
+      <modules>
+        <module>xwiki-platform-extension-test-docker</module>
+      </modules>
+    </profile>
+  </profiles>
 </project>

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/pom.xml
@@ -1,0 +1,215 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.xwiki.platform</groupId>
+    <artifactId>xwiki-platform-extension-test</artifactId>
+    <version>18.4.0-SNAPSHOT</version>
+  </parent>
+  <name>XWiki Platform - Extension - Test - Functional Docker Tests</name>
+  <artifactId>xwiki-platform-extension-test-docker</artifactId>
+  <description>XWiki Platform - Extension - Test - Functional Docker Tests</description>
+  <properties>
+    <!-- Functional tests are allowed to output content to the console -->
+    <xwiki.surefire.captureconsole.skip>true</xwiki.surefire.captureconsole.skip>
+  </properties>
+  <dependencies>
+    <!-- ================================
+         Runtime dependencies
+         ================================ -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-extension-ui</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+      <type>xar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-repository-server-ui</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+      <type>xar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-panels-ui</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+      <type>xar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-icon-default</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-extension-repository-maven</artifactId>
+      <version>${commons.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-extension-repository-xwiki</artifactId>
+      <version>${commons.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-extension-handler-jar</artifactId>
+      <version>${commons.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-extension-handler-xar</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-rendering-macro-groovy</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-component-script</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-diff-script</artifactId>
+      <version>${commons.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-search-solr-embedded</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+
+    <!-- ================================
+         Test only dependencies
+         ================================ -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-test-docker</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-extension-test-utils</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-repository-test-utils</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-extension-test-pageobjects</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-repository-test-pageobjects</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-panels-test-pageobjects</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.rendering</groupId>
+      <artifactId>xwiki-rendering-transformation-macro</artifactId>
+      <version>${rendering.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <testSourceDirectory>src/test/it</testSourceDirectory>
+    <plugins>
+      <!-- We need to explicitly include the failsafe plugin since it's not part of the default maven lifecycle -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+  <profiles>
+    <profile>
+      <id>clover</id>
+      <!-- Add the Clover JAR to the WAR so that it's available at runtime when XWiki executes.
+           It's needed because instrumented jars in the WAR will call Clover APIs at runtime when they execute. -->
+      <dependencies>
+        <dependency>
+          <groupId>org.openclover</groupId>
+          <artifactId>clover</artifactId>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <systemPropertyVariables>
+                <!-- Tell the Docker-based test to activate the Clover profile so that the Clover JAR is added to
+                     WEB-INF/lib -->
+                <xwiki.test.ui.profiles>clover</xwiki.test.ui.profiles>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+          <!-- Add the Clover JAR to the Packager plugin runtime classpath since the Packager plugin uses java classes
+               that have been instrumented with Clover (XWiki oldcore for example) -->
+          <plugin>
+            <groupId>org.xwiki.platform</groupId>
+            <artifactId>xwiki-platform-tool-packager-plugin</artifactId>
+            <version>${project.version}</version>
+            <dependencies>
+              <dependency>
+                <groupId>org.openclover</groupId>
+                <artifactId>clover</artifactId>
+                <version>${clover.version}</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/it/org/xwiki/extension/test/docker/AllIT.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/it/org/xwiki/extension/test/docker/AllIT.java
@@ -1,0 +1,38 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.extension.test.docker;
+
+import org.junit.jupiter.api.Nested;
+import org.xwiki.test.docker.junit5.UITest;
+
+/**
+ * Main test class for the extension manager functional tests.
+ *
+ * @version $Id$
+ * @since 18.4.0RC1
+ */
+@UITest
+public class AllIT
+{
+    @Nested
+    class NestedExtensionIT extends ExtensionIT
+    {
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/it/org/xwiki/extension/test/docker/ExtensionIT.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/it/org/xwiki/extension/test/docker/ExtensionIT.java
@@ -17,7 +17,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.xwiki.test.ui.extension;
+package org.xwiki.extension.test.docker;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -29,7 +29,10 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.RandomUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.Select;
 import org.xwiki.administration.test.po.AdministrationPage;
@@ -44,6 +47,7 @@ import org.xwiki.extension.DefaultExtensionSupporter;
 import org.xwiki.extension.ExtensionId;
 import org.xwiki.extension.ExtensionLicense;
 import org.xwiki.extension.repository.xwiki.model.jaxb.ExtensionsSearchResult;
+import org.xwiki.extension.test.RepositoryUtils;
 import org.xwiki.extension.test.po.AdvancedSearchPane;
 import org.xwiki.extension.test.po.DependencyPane;
 import org.xwiki.extension.test.po.ExtensionAdministrationPage;
@@ -59,57 +63,99 @@ import org.xwiki.extension.test.po.SearchResultsPane;
 import org.xwiki.extension.test.po.SimpleSearchPane;
 import org.xwiki.extension.test.po.UnusedPagesPane;
 import org.xwiki.extension.version.internal.DefaultVersionConstraint;
+import org.xwiki.repository.test.RepositoryTestUtils;
+import org.xwiki.repository.test.SolrTestUtils;
 import org.xwiki.repository.test.TestExtension;
-import org.xwiki.test.ui.AbstractExtensionAdminAuthenticatedIT;
+import org.xwiki.test.docker.junit5.TestReference;
+import org.xwiki.test.docker.junit5.UITest;
+import org.xwiki.test.ui.TestUtils;
 import org.xwiki.test.ui.po.ViewPage;
 import org.xwiki.test.ui.po.diff.EntityDiff;
 import org.xwiki.test.ui.po.diff.RawChanges;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Functional tests for the Extension Manager user interface.
- * 
+ *
  * @version $Id$
- * @since 4.2M1
+ * @since 18.4.0RC1
  */
-public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
+@UITest(
+    // - xwiki-commons-extension-repository-xwiki provides the XWikiExtensionRepositoryFactory component needed
+    // to support the "xwiki" repository type used for self:xwiki. It must be in WEB-INF/lib at startup.
+    // - xwiki-platform-extension-index provides the Solr-backed extension index (required for keyword search).
+    extraJARs = {
+        "org.xwiki.commons:xwiki-commons-extension-repository-xwiki",
+        "org.xwiki.platform:xwiki-platform-extension-index"
+    },
+    // - Disable core extension resolve because Jetty is not ready when it starts
+    // - Exclude the ExtensionTest.Service page created by the test so that the PR checker doesn't check it since
+    // the test creates this page with Groovy code and thus requires PR FTM.
+    // - Put self and Maven as extensions repository
+    properties = {
+        "xwikiPropertiesAdditionalProperties=extension.core.resolve=false\n"
+            + "test.prchecker.excludePattern=.*:ExtensionTest\\.Service\n"
+            + "extension.repositories = self:xwiki:http://localhost:8080/xwiki/rest"
+    }
+)
+class ExtensionIT
 {
-    @Override
-    public void setUp() throws Exception
+    private static RepositoryUtils repositoryUtils;
+
+    private static RepositoryTestUtils repositoryTestUtils;
+
+    private static org.xwiki.extension.test.junit5.ExtensionTestUtils extensionTestUtils;
+
+    @BeforeAll
+    static void beforeAll(TestUtils setup) throws Exception
     {
-        super.setUp();
+        repositoryUtils = new RepositoryUtils();
 
-        // Make sure the extensions we are playing with are not already installed.
-        getExtensionTestUtils().finishCurrentJob();
-        getExtensionTestUtils().uninstall("alice-xar-extension");
-        getExtensionTestUtils().uninstall("bob-xar-extension");
-        getExtensionTestUtils().uninstall("scriptServiceJarExtension");
+        setup.loginAsSuperAdmin();
+        setup.recacheSecretToken();
+        setup.setDefaultCredentials(TestUtils.SUPER_ADMIN_CREDENTIALS);
 
-        // Delete the pages that are provided by the XAR extensions we use in tests.
-        getUtil().rest().deletePage("ExtensionTest", "Alice");
-        assertFalse(getUtil().pageExists("ExtensionTest", "Alice"));
-        getUtil().rest().deletePage("ExtensionTest", "Bob");
-        assertFalse(getUtil().pageExists("ExtensionTest", "Bob"));
+        repositoryTestUtils =
+            new RepositoryTestUtils(setup, repositoryUtils, new SolrTestUtils(setup));
+        // init() calls repositoryUtils.setup() which generates the test extension files
+        repositoryTestUtils.init();
+        extensionTestUtils = new org.xwiki.extension.test.junit5.ExtensionTestUtils(setup);
+    }
 
-        // Delete from the repository the XAR extensions we use in tests.
-        // The extension page name is either the extension name, if specified, or the extension id. Most of the tests
-        // don't set the extension name but some do and we end up with two extensions (two pages) with the same id.
-        getRepositoryTestUtils().deleteExtension("Alice Wiki Macro");
-        getRepositoryTestUtils().deleteExtension("Bob Wiki Macro");
-        getRepositoryTestUtils().deleteExtension("alice-xar-extension");
-        getRepositoryTestUtils().deleteExtension("bob-xar-extension");
-        getRepositoryTestUtils().deleteExtension("scriptServiceJarExtension");
+    @BeforeEach
+    void setUp(TestUtils setup) throws Exception
+    {
+        setup.loginAsSuperAdmin();
+        setup.recacheSecretToken();
+        setup.setDefaultCredentials(TestUtils.SUPER_ADMIN_CREDENTIALS);
 
-        getRepositoryTestUtils().waitUntilReady();
+        extensionTestUtils.finishCurrentJob();
+        extensionTestUtils.uninstall("alice-xar-extension");
+        extensionTestUtils.uninstall("bob-xar-extension");
+        extensionTestUtils.uninstall("scriptServiceJarExtension");
 
-        // Double check that the XWiki Extension Repository is empty.
+        setup.rest().deletePage("ExtensionTest", "Alice");
+        assertFalse(setup.pageExists("ExtensionTest", "Alice"));
+        setup.rest().deletePage("ExtensionTest", "Bob");
+        assertFalse(setup.pageExists("ExtensionTest", "Bob"));
+
+        repositoryTestUtils.deleteExtension("Alice Wiki Macro");
+        repositoryTestUtils.deleteExtension("Bob Wiki Macro");
+        repositoryTestUtils.deleteExtension("alice-xar-extension");
+        repositoryTestUtils.deleteExtension("bob-xar-extension");
+        repositoryTestUtils.deleteExtension("scriptServiceJarExtension");
+        repositoryTestUtils.deleteExtension("XWiki Commons - Diff API");
+        repositoryTestUtils.deleteExtension("XWiki Platform - Display API");
+
+        repositoryTestUtils.waitUntilReady();
+
         ExtensionsSearchResult searchResult =
-            getUtil().rest().getResource("repository/search", Collections.singletonMap("number", new Object[] {1}));
+            setup.rest().getResource("repository/search", Collections.singletonMap("number", new Object[] {1}));
         assertEquals(0, searchResult.getTotalHits());
     }
 
@@ -117,7 +163,8 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
      * The extension search results pagination.
      */
     @Test
-    public void testPagination()
+    @Order(1)
+    void testPagination()
     {
         ExtensionAdministrationPage adminPage = ExtensionAdministrationPage.gotoCoreExtensions();
 
@@ -172,7 +219,8 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
      * Tests the simple search form.
      */
     @Test
-    public void testSimpleSearch()
+    @Order(2)
+    void testSimpleSearch()
     {
         ExtensionAdministrationPage adminPage = ExtensionAdministrationPage.gotoCoreExtensions();
         int coreExtensionCount = adminPage.getSearchResults().getPagination().getResultsCount();
@@ -196,11 +244,11 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
         for (int i = 0; i < searchResults.getPagination().getPageCount(); i++) {
             ExtensionPane extension = searchResults.getExtension(i);
             assertTrue(
-                "Can't find [commons] in the summary/id/name parts of extension [" + extension.getId() + "] ("
-                    + extension.getSummary() + ")",
                 extension.getSummary().toLowerCase().contains("commons")
                     || extension.getId().getId().toLowerCase().contains("commons")
-                    || extension.getName().toLowerCase().contains("commons"));
+                    || extension.getName().toLowerCase().contains("commons"),
+                "Can't find [commons] in the summary/id/name parts of extension [" + extension.getId() + "] ("
+                    + extension.getSummary() + ")");
             assertEquals("core", extension.getStatus());
         }
 
@@ -216,19 +264,21 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
         searchResults = searchBar.search("groovy");
         assertNull(searchResults.getNoResultsMessage());
         assertNull(searchResults.getPagination());
-        assertTrue(searchResults.getDisplayedResultsCount() > 1);
+        assertTrue(searchResults.getDisplayedResultsCount() >= 1);
 
         ExtensionPane extension = searchResults.getExtension(0);
         assertEquals("core", extension.getStatus());
-        assertTrue("Can't find [groovy] in the name of the extension [" + extension.getId() + "] ("
-            + extension.getName() + ")", extension.getName().toLowerCase().contains("groovy"));
+        assertTrue(extension.getName().toLowerCase().contains("groovy"),
+            "Can't find [groovy] in the name of the extension [" + extension.getId() + "] ("
+                + extension.getName() + ")");
     }
 
     /**
      * Tests the advanced search form.
      */
     @Test
-    public void testAdvancedSearch()
+    @Order(3)
+    void testAdvancedSearch()
     {
         ExtensionAdministrationPage adminPage = ExtensionAdministrationPage.gotoCoreExtensions();
 
@@ -263,7 +313,8 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
      * Tests how core extensions are displayed.
      */
     @Test
-    public void testCoreExtensions()
+    @Order(4)
+    void testCoreExtensions()
     {
         ExtensionAdministrationPage adminPage = ExtensionAdministrationPage.gotoCoreExtensions();
 
@@ -278,7 +329,6 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
         assertNull(extension.getUninstallButton());
         assertNull(extension.getUpgradeButton());
         assertNull(extension.getDowngradeButton());
-        // Just test that the button to show the extension details is present.
         assertEquals("core", extension.showDetails().getStatus());
     }
 
@@ -286,13 +336,14 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
      * Tests the extension repository selector (all, core, installed, local).
      */
     @Test
-    public void testRepositorySelector() throws Exception
+    @Order(5)
+    void testRepositorySelector(TestUtils setup) throws Exception
     {
         // Setup the extension.
         ExtensionId extensionId = new ExtensionId("alice-xar-extension", "1.3");
-        TestExtension extension = getRepositoryTestUtils().getTestExtension(extensionId, "xar");
-        getRepositoryTestUtils().addExtension(extension);
-        getRepositoryTestUtils().waitUntilReady();
+        TestExtension extension = repositoryTestUtils.getTestExtension(extensionId, "xar");
+        repositoryTestUtils.addExtension(extension);
+        repositoryTestUtils.waitUntilReady();
 
         // Check that the Supported Extensions are displayed by default.
         ExtensionAdministrationPage adminPage = ExtensionAdministrationPage.gotoPage();
@@ -314,7 +365,7 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
         assertNull(new SimpleSearchPane().selectRepository("local").getExtension(extensionId));
 
         // Check that an installed extension appears also in "Installed Extensions" and "Local Extensions".
-        getExtensionTestUtils().install(extensionId);
+        extensionTestUtils.install(extensionId);
         adminPage = ExtensionAdministrationPage.gotoPage();
         adminPage.getSearchBar().selectRepository("installed");
         searchResults = adminPage.getSearchBar().search("alice");
@@ -328,7 +379,7 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
         assertNotNull(adminPage.getSearchBar().selectRepository("").getExtension(extensionId));
 
         // Check local extension.
-        getExtensionTestUtils().uninstall(extensionId.getId(), true);
+        extensionTestUtils.uninstall(extensionId.getId(), true);
         adminPage = ExtensionAdministrationPage.gotoPage();
         adminPage.getSearchBar().selectRepository("installed");
         searchResults = adminPage.getSearchBar().search("alice");
@@ -346,11 +397,12 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
      * Tests the extension details (license, web site).
      */
     @Test
-    public void testShowDetails() throws Exception
+    @Order(6)
+    void testShowDetails(TestUtils setup) throws Exception
     {
         // Setup the extension.
         ExtensionId extensionId = new ExtensionId("alice-xar-extension", "1.3");
-        TestExtension extension = getRepositoryTestUtils().getTestExtension(extensionId, "xar");
+        TestExtension extension = repositoryTestUtils.getTestExtension(extensionId, "xar");
         extension.setName("Alice Wiki Macro");
         extension.setSummary("A **useless** macro");
         extension.addAuthor(new DefaultExtensionAuthor("Thomas", (String) null));
@@ -363,7 +415,7 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
             new DefaultExtensionScmConnection("git", "git:git@github.com:xwiki-contrib/alice-xar-extension.git")));
         extension
             .setIssueManagement(new DefaultExtensionIssueManagement("jira", "https://jira.xwiki.org/browse/ALICE"));
-        getRepositoryTestUtils().addExtension(extension);
+        repositoryTestUtils.addExtension(extension);
 
         // Search the extension and assert the displayed information.
         ExtensionAdministrationPage adminPage = ExtensionAdministrationPage.gotoPage();
@@ -383,7 +435,7 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
         ExtensionDescriptionPane descriptionPane = extensionPane.openDescriptionSection();
         assertEquals(extension.getLicenses().iterator().next().getName(), descriptionPane.getLicense());
         assertEquals(extension.getId().getId(), descriptionPane.getId());
-        assertEquals(extension.getFeatures().iterator().next(), descriptionPane.getFeatures().get(0));
+        assertEquals(extension.getFeatures().iterator().next(), descriptionPane.getFeatures().getFirst());
         assertEquals(extension.getType(), descriptionPane.getType());
 
         WebElement webSiteLink = descriptionPane.getWebSite();
@@ -398,30 +450,44 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
         List<String> namespaces = descriptionPane.getNamespaces();
         assertEquals(1, namespaces.size());
         String prefix = "Home, by superadmin on ";
-        assertTrue(namespaces.get(0).startsWith(prefix));
-        Date installDate = new SimpleDateFormat("yyyy/MM/dd HH:mm").parse(namespaces.get(0).substring(prefix.length()));
+        assertTrue(namespaces.getFirst().startsWith(prefix));
+        Date installDate =
+            new SimpleDateFormat("yyyy/MM/dd HH:mm").parse(namespaces.getFirst().substring(prefix.length()));
         // Ignore the seconds as they are not displayed.
-        assertTrue(String.format("Install date [%s] should be after [%s].", installDate, beforeInstall),
-            installDate.getTime() / 60000 >= beforeInstall.getTime() / 60000);
-        assertTrue(String.format("Install date [%s] should be before [%s].", installDate, afterInstall),
-            installDate.before(afterInstall));
+        assertTrue(installDate.getTime() / 60000 >= beforeInstall.getTime() / 60000,
+            String.format("Install date [%s] should be after [%s].", installDate, beforeInstall));
+        assertTrue(installDate.before(afterInstall),
+            String.format("Install date [%s] should be before [%s].", installDate, afterInstall));
     }
 
     /**
      * Tests how extension dependencies are displayed (both direct and backward dependencies).
      */
     @Test
-    public void testDependencies() throws Exception
+    @Order(7)
+    void testDependencies(TestUtils setup) throws Exception
     {
+        // Add fake remote versions of core extensions to test remote-core and remote-core-incompatible statuses.
+        // These must exist in the self:xwiki repository so the extension manager can resolve them.
+        TestExtension diffApiExtension = repositoryTestUtils.getTestExtension(
+            new ExtensionId("org.xwiki.commons:xwiki-commons-diff-api", "2.7"), "jar");
+        diffApiExtension.setName("XWiki Commons - Diff API");
+        repositoryTestUtils.addExtension(diffApiExtension);
+
+        TestExtension displayApiExtension = repositoryTestUtils.getTestExtension(
+            new ExtensionId("org.xwiki.platform:xwiki-platform-display-api", "100.1"), "jar");
+        displayApiExtension.setName("XWiki Platform - Display API");
+        repositoryTestUtils.addExtension(displayApiExtension);
+
         // Setup the extension and its dependencies.
         ExtensionId dependencyId = new ExtensionId("bob-xar-extension", "2.5-milestone-2");
-        TestExtension dependency = getRepositoryTestUtils().getTestExtension(dependencyId, "xar");
+        TestExtension dependency = repositoryTestUtils.getTestExtension(dependencyId, "xar");
         dependency.setName("Bob Wiki Macro");
         dependency.setSummary("Required by Alice");
-        getRepositoryTestUtils().addExtension(dependency);
+        repositoryTestUtils.addExtension(dependency);
 
         ExtensionId extensionId = new ExtensionId("alice-xar-extension", "1.3");
-        TestExtension extension = getRepositoryTestUtils().getTestExtension(extensionId, "xar");
+        TestExtension extension = repositoryTestUtils.getTestExtension(extensionId, "xar");
         extension.addDependency(new DefaultExtensionDependency(dependencyId.getId(),
             new DefaultVersionConstraint(dependencyId.getVersion().getValue())));
         extension
@@ -432,7 +498,8 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
             new DefaultVersionConstraint("2.7")));
         extension.addDependency(new DefaultExtensionDependency("org.xwiki.platform:xwiki-platform-display-api",
             new DefaultVersionConstraint("100.1")));
-        getRepositoryTestUtils().addExtension(extension);
+        repositoryTestUtils.addExtension(extension);
+        repositoryTestUtils.waitUntilReady();
 
         // Search the extension and assert the list of dependencies.
         ExtensionAdministrationPage adminPage = ExtensionAdministrationPage.gotoPage();
@@ -489,20 +556,21 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
      * Tests how an extension is installed.
      */
     @Test
-    public void testInstall() throws Exception
+    @Order(8)
+    void testInstall(TestUtils setup, TestReference testReference) throws Exception
     {
         // Setup the extension and its dependencies.
         ExtensionId extensionId = new ExtensionId("alice-xar-extension", "1.3");
-        TestExtension extension = getRepositoryTestUtils().getTestExtension(extensionId, "xar");
+        TestExtension extension = repositoryTestUtils.getTestExtension(extensionId, "xar");
 
         ExtensionId dependencyId = new ExtensionId("bob-xar-extension", "2.5-milestone-2");
-        getRepositoryTestUtils().addExtension(getRepositoryTestUtils().getTestExtension(dependencyId, "xar"));
+        repositoryTestUtils.addExtension(repositoryTestUtils.getTestExtension(dependencyId, "xar"));
         extension.addDependency(new DefaultExtensionDependency(dependencyId.getId(),
             new DefaultVersionConstraint(dependencyId.getVersion().getValue())));
 
         extension.addDependency(new DefaultExtensionDependency("org.xwiki.platform:xwiki-platform-sheet-api",
             new DefaultVersionConstraint("[3.2,)")));
-        getRepositoryTestUtils().addExtension(extension);
+        repositoryTestUtils.addExtension(extension);
 
         // Search the extension and install it.
         ExtensionAdministrationPage adminPage = ExtensionAdministrationPage.gotoPage();
@@ -530,7 +598,7 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
             log.get(logSize - 1).getMessage());
 
         // Test that both extensions are usable.
-        ViewPage viewPage = getUtil().createPage(getTestClassName(), getTestMethodName(), "{{alice/}}\n\n{{bob/}}", "");
+        ViewPage viewPage = setup.createPage(testReference, "{{alice/}}\n\n{{bob/}}", "");
         String content = viewPage.getContent();
         assertTrue(content.contains("Alice says hello!"));
         assertTrue(content.contains("Bob says hi!"));
@@ -588,24 +656,25 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
      * Tests how an extension is uninstalled.
      */
     @Test
-    public void testUninstall() throws Exception
+    @Order(9)
+    void testUninstall(TestUtils setup) throws Exception
     {
         // Setup the extension and its dependencies.
         ExtensionId dependencyId = new ExtensionId("bob-xar-extension", "2.5-milestone-2");
-        getRepositoryTestUtils().addExtension(getRepositoryTestUtils().getTestExtension(dependencyId, "xar"));
+        repositoryTestUtils.addExtension(repositoryTestUtils.getTestExtension(dependencyId, "xar"));
 
         ExtensionId extensionId = new ExtensionId("alice-xar-extension", "1.3");
-        TestExtension extension = getRepositoryTestUtils().getTestExtension(extensionId, "xar");
+        TestExtension extension = repositoryTestUtils.getTestExtension(extensionId, "xar");
         extension.addDependency(new DefaultExtensionDependency(dependencyId.getId(),
             new DefaultVersionConstraint(dependencyId.getVersion().getValue())));
-        getRepositoryTestUtils().addExtension(extension);
+        repositoryTestUtils.addExtension(extension);
 
         // Install the extensions.
-        getExtensionTestUtils().install(extensionId);
+        extensionTestUtils.install(extensionId);
 
         // Check if the installed pages are present.
-        assertTrue(getUtil().pageExists("ExtensionTest", "Alice"));
-        assertTrue(getUtil().pageExists("ExtensionTest", "Bob"));
+        assertTrue(setup.pageExists("ExtensionTest", "Alice"));
+        assertTrue(setup.pageExists("ExtensionTest", "Bob"));
 
         // Uninstall the dependency.
         ExtensionAdministrationPage adminPage = ExtensionAdministrationPage.gotoInstalledExtensions();
@@ -640,14 +709,14 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
             log.get(2).getMessage());
         assertEquals("info", log.get(log.size() - 1).getLevel());
         assertEquals("Finished job of type [uninstall] with identifier [extension/action/bob-xar-extension/wiki:xwiki]",
-            log.get(log.size() - 1).getMessage());
+            log.getLast().getMessage());
 
         // Check if the uninstalled pages have been deleted.
-        assertFalse(getUtil().pageExists("ExtensionTest", "Alice"));
-        assertFalse(getUtil().pageExists("ExtensionTest", "Bob"));
+        assertFalse(setup.pageExists("ExtensionTest", "Alice"));
+        assertFalse(setup.pageExists("ExtensionTest", "Bob"));
 
         // Install both extension again and uninstall only the one with the dependency.
-        getExtensionTestUtils().install(extensionId);
+        extensionTestUtils.install(extensionId);
 
         adminPage = ExtensionAdministrationPage.gotoInstalledExtensions();
         extensionPane = adminPage.getSearchBar().clickAdvancedSearch().search(extensionId).getExtension(0);
@@ -656,7 +725,7 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
         // Check the uninstall plan. Only one extension should be included.
         uninstallPlan = extensionPane.openProgressSection().getJobPlan();
         assertEquals(1, uninstallPlan.size());
-        assertEquals(extensionId, uninstallPlan.get(0).getId());
+        assertEquals(extensionId, uninstallPlan.getFirst().getId());
 
         // Check the confirmation to delete the unused wiki pages.
         extensionPane = extensionPane.confirm();
@@ -669,14 +738,14 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
         assertTrue(log.size() > 2);
         assertEquals("info", log.get(2).getLevel());
         assertEquals("Resolving extension [alice-xar-extension 1.3] from namespace [Home]", log.get(2).getMessage());
-        assertEquals("info", log.get(log.size() - 1).getLevel());
+        assertEquals("info", log.getLast().getLevel());
         assertEquals(
             "Finished job of type [uninstall] with identifier [extension/action/alice-xar-extension/wiki:xwiki]",
-            log.get(log.size() - 1).getMessage());
+            log.getLast().getMessage());
 
         // Check if the uninstalled pages have been deleted.
-        assertFalse(getUtil().pageExists("ExtensionTest", "Alice"));
-        assertTrue(getUtil().pageExists("ExtensionTest", "Bob"));
+        assertFalse(setup.pageExists("ExtensionTest", "Alice"));
+        assertTrue(setup.pageExists("ExtensionTest", "Bob"));
 
         // Check the list of installed extensions. It should contain only the second extension.
         adminPage = ExtensionAdministrationPage.gotoInstalledExtensions();
@@ -695,11 +764,12 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
      * Tests that an extension can be installed and uninstalled without reloading the extension manager UI.
      */
     @Test
-    public void testInstallAndUninstallWithoutReload() throws Exception
+    @Order(10)
+    void testInstallAndUninstallWithoutReload(TestUtils setup) throws Exception
     {
         // Setup the extension.
         ExtensionId extensionId = new ExtensionId("alice-xar-extension", "1.3");
-        getRepositoryTestUtils().addExtension(getRepositoryTestUtils().getTestExtension(extensionId, "xar"));
+        repositoryTestUtils.addExtension(repositoryTestUtils.getTestExtension(extensionId, "xar"));
 
         // Search the extension to install.
         ExtensionAdministrationPage adminPage = ExtensionAdministrationPage.gotoPage();
@@ -715,23 +785,24 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
      * Tests how an extension is upgraded.
      */
     @Test
-    public void testUpgrade() throws Exception
+    @Order(11)
+    void testUpgrade(TestUtils setup) throws Exception
     {
         // Setup the extension.
         String extensionId = "alice-xar-extension";
         String oldVersion = "1.3";
         String newVersion = "2.1.4";
         TestExtension oldExtension =
-            getRepositoryTestUtils().getTestExtension(new ExtensionId(extensionId, oldVersion), "xar");
-        getRepositoryTestUtils().addExtension(oldExtension);
+            repositoryTestUtils.getTestExtension(new ExtensionId(extensionId, oldVersion), "xar");
+        repositoryTestUtils.addExtension(oldExtension);
         TestExtension newExtension =
-            getRepositoryTestUtils().getTestExtension(new ExtensionId(extensionId, newVersion), "xar");
-        getRepositoryTestUtils().attachFile(newExtension);
-        getRepositoryTestUtils().addVersionObject(newExtension, newVersion,
+            repositoryTestUtils.getTestExtension(new ExtensionId(extensionId, newVersion), "xar");
+        repositoryTestUtils.attachFile(newExtension);
+        repositoryTestUtils.addVersionObject(newExtension, newVersion,
             "attach:" + newExtension.getFile().getName());
 
         // Make sure the old version is installed.
-        getExtensionTestUtils().install(new ExtensionId(extensionId, oldVersion));
+        extensionTestUtils.install(new ExtensionId(extensionId, oldVersion));
 
         // Upgrade the extension.
         ExtensionAdministrationPage adminPage = ExtensionAdministrationPage.gotoPage();
@@ -746,10 +817,10 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
         // Check the upgrade plan.
         List<DependencyPane> upgradePlan = extensionPane.openProgressSection().getJobPlan();
         assertEquals(1, upgradePlan.size());
-        assertEquals(extensionId, upgradePlan.get(0).getName());
-        assertEquals(newVersion, upgradePlan.get(0).getVersion());
-        assertEquals("remote-installed", upgradePlan.get(0).getStatus());
-        assertEquals("Version 1.3 is installed", upgradePlan.get(0).getStatusMessage());
+        assertEquals(extensionId, upgradePlan.getFirst().getName());
+        assertEquals(newVersion, upgradePlan.getFirst().getVersion());
+        assertEquals("remote-installed", upgradePlan.getFirst().getStatus());
+        assertEquals("Version 1.3 is installed", upgradePlan.getFirst().getStatusMessage());
 
         // Finish the upgrade and check the upgrade log.
         extensionPane = extensionPane.confirm();
@@ -759,13 +830,13 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
         assertTrue(log.size() > 2);
         assertEquals("info", log.get(2).getLevel());
         assertEquals("Resolving extension [alice-xar-extension 2.1.4] on namespace [Home]", log.get(2).getMessage());
-        assertEquals("info", log.get(log.size() - 1).getLevel());
+        assertEquals("info", log.getLast().getLevel());
         assertEquals(
             "Finished job of type [install] with identifier " + "[extension/action/alice-xar-extension/wiki:xwiki]",
-            log.get(log.size() - 1).getMessage());
+            log.getLast().getMessage());
 
         // Assert the changes.
-        ViewPage viewPage = getUtil().gotoPage("ExtensionTest", "Alice");
+        ViewPage viewPage = setup.gotoPage("ExtensionTest", "Alice");
         assertEquals("Alice Wiki Macro (upgraded)", viewPage.getDocumentTitle());
         assertTrue(viewPage.getContent().contains("Alice says hi guys!"));
     }
@@ -774,23 +845,23 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
      * Tests how an extension is upgraded when there is a merge conflict.
      */
     @Test
-    public void testUpgradeWithMergeConflict() throws Exception
+    @Order(12)
+    void testUpgradeWithMergeConflict(TestUtils setup) throws Exception
     {
-        // Setup the extension.
         String extensionId = "alice-xar-extension";
         String oldVersion = "1.3";
         String newVersion = "2.1.4";
         TestExtension oldExtension =
-            getRepositoryTestUtils().getTestExtension(new ExtensionId(extensionId, oldVersion), "xar");
-        getRepositoryTestUtils().addExtension(oldExtension);
+            repositoryTestUtils.getTestExtension(new ExtensionId(extensionId, oldVersion), "xar");
+        repositoryTestUtils.addExtension(oldExtension);
         TestExtension newExtension =
-            getRepositoryTestUtils().getTestExtension(new ExtensionId(extensionId, newVersion), "xar");
-        getRepositoryTestUtils().attachFile(newExtension);
-        getRepositoryTestUtils().addVersionObject(newExtension, newVersion,
+            repositoryTestUtils.getTestExtension(new ExtensionId(extensionId, newVersion), "xar");
+        repositoryTestUtils.attachFile(newExtension);
+        repositoryTestUtils.addVersionObject(newExtension, newVersion,
             "attach:" + newExtension.getFile().getName());
 
         // Make sure the old version is installed.
-        getExtensionTestUtils().install(new ExtensionId(extensionId, oldVersion));
+        extensionTestUtils.install(new ExtensionId(extensionId, oldVersion));
 
         // Edit the installed version so that we have a merge conflict.
         Map<String, String> queryParameters = new HashMap<String, String>();
@@ -798,7 +869,7 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
         queryParameters.put("content",
             "== Usage ==\n\n{{code language=\"none\"}}\n" + "{{alice/}}\n{{/code}}\n\n== Output ==\n\n{{alice/}}");
         queryParameters.put("XWiki.WikiMacroClass_0_code", "{{info}}Alice says hello!{{/info}}");
-        getUtil().gotoPage("ExtensionTest", "Alice", "save", queryParameters);
+        setup.gotoPage("ExtensionTest", "Alice", "save", queryParameters);
 
         // Initiate the upgrade process.
         ExtensionAdministrationPage adminPage = ExtensionAdministrationPage.gotoPage();
@@ -883,7 +954,7 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
             lastLogItem.getMessage());
 
         // Check the merge result.
-        ViewPage mergedPage = getUtil().gotoPage("ExtensionTest", "Alice");
+        ViewPage mergedPage = setup.gotoPage("ExtensionTest", "Alice");
         assertEquals("Alice Wiki Macro (upgraded)", mergedPage.getDocumentTitle());
     }
 
@@ -891,23 +962,24 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
      * Tests how an extension is downgraded.
      */
     @Test
-    public void testDowngrade() throws Exception
+    @Order(13)
+    void testDowngrade(TestUtils setup) throws Exception
     {
         // Setup the extension.
         String extensionId = "alice-xar-extension";
         String oldVersion = "1.3";
         String newVersion = "2.1.4";
         TestExtension oldExtension =
-            getRepositoryTestUtils().getTestExtension(new ExtensionId(extensionId, oldVersion), "xar");
-        getRepositoryTestUtils().addExtension(oldExtension);
+            repositoryTestUtils.getTestExtension(new ExtensionId(extensionId, oldVersion), "xar");
+        repositoryTestUtils.addExtension(oldExtension);
         TestExtension newExtension =
-            getRepositoryTestUtils().getTestExtension(new ExtensionId(extensionId, newVersion), "xar");
-        getRepositoryTestUtils().attachFile(newExtension);
-        getRepositoryTestUtils().addVersionObject(newExtension, newVersion,
+            repositoryTestUtils.getTestExtension(new ExtensionId(extensionId, newVersion), "xar");
+        repositoryTestUtils.attachFile(newExtension);
+        repositoryTestUtils.addVersionObject(newExtension, newVersion,
             "attach:" + newExtension.getFile().getName());
 
         // Make sure the new version is installed.
-        getExtensionTestUtils().install(new ExtensionId(extensionId, newVersion));
+        extensionTestUtils.install(new ExtensionId(extensionId, newVersion));
 
         // Downgrade the extension.
         ExtensionAdministrationPage adminPage = ExtensionAdministrationPage.gotoPage();
@@ -922,10 +994,10 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
         // Check the downgrade plan.
         List<DependencyPane> downgradePlan = extensionPane.openProgressSection().getJobPlan();
         assertEquals(1, downgradePlan.size());
-        assertEquals(extensionId, downgradePlan.get(0).getName());
-        assertEquals(oldVersion, downgradePlan.get(0).getVersion());
-        assertEquals("remote-installed", downgradePlan.get(0).getStatus());
-        assertEquals("Version 2.1.4 is installed", downgradePlan.get(0).getStatusMessage());
+        assertEquals(extensionId, downgradePlan.getFirst().getName());
+        assertEquals(oldVersion, downgradePlan.getFirst().getVersion());
+        assertEquals("remote-installed", downgradePlan.getFirst().getStatus());
+        assertEquals("Version 2.1.4 is installed", downgradePlan.getFirst().getStatusMessage());
 
         // Finish the downgrade and check the downgrade log.
         // Using 20s for the timeout since 10s seems to not always be enough
@@ -936,13 +1008,13 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
         assertTrue(log.size() > 2);
         assertEquals("info", log.get(2).getLevel());
         assertEquals("Resolving extension [alice-xar-extension 1.3] on namespace [Home]", log.get(2).getMessage());
-        assertEquals("info", log.get(log.size() - 1).getLevel());
+        assertEquals("info", log.getLast().getLevel());
         assertEquals(
             "Finished job of type [install] with identifier " + "[extension/action/alice-xar-extension/wiki:xwiki]",
-            log.get(log.size() - 1).getMessage());
+            log.getLast().getMessage());
 
         // Assert the changes.
-        ViewPage viewPage = getUtil().gotoPage("ExtensionTest", "Alice");
+        ViewPage viewPage = setup.gotoPage("ExtensionTest", "Alice");
         assertEquals("Alice Macro", viewPage.getDocumentTitle());
         assertTrue(viewPage.getContent().contains("Alice says hello!"));
     }
@@ -951,10 +1023,11 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
      * Tests if a Java component script service is properly installed.
      */
     @Test
-    public void testInstallScriptService() throws Exception
+    @Order(14)
+    void testInstallScriptService(TestUtils setup, TestReference testReference) throws Exception
     {
         // Make sure the script service is not available before the extension is installed.
-        ViewPage viewPage = getUtil().createPage(getTestClassName(), getTestMethodName(),
+        ViewPage viewPage = setup.createPage(testReference,
             "{{velocity}}$services.greeter.greet('world') "
                 + "$services.greeter.greet('XWiki', 'default'){{/velocity}}",
             "");
@@ -962,8 +1035,8 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
 
         // Setup the extension.
         ExtensionId extensionId = new ExtensionId("scriptServiceJarExtension", "4.2-milestone-1");
-        TestExtension extension = getRepositoryTestUtils().getTestExtension(extensionId, "jar");
-        getRepositoryTestUtils().addExtension(extension);
+        TestExtension extension = repositoryTestUtils.getTestExtension(extensionId, "jar");
+        repositoryTestUtils.addExtension(extension);
 
         // Search the extension and install it.
         ExtensionAdministrationPage adminPage = ExtensionAdministrationPage.gotoPage();
@@ -973,31 +1046,32 @@ public class ExtensionIT extends AbstractExtensionAdminAuthenticatedIT
 
         // Check the result.
         assertEquals("Hello world! Hello XWiki!",
-            getUtil().gotoPage(getTestClassName(), getTestMethodName()).getContent());
+            setup.gotoPage(testReference).getContent());
     }
 
     /**
      * Make sure supported extensions are properly filtered.
      */
     @Test
-    public void testFilterSupported() throws Exception
+    @Order(15)
+    void testFilterSupported(TestUtils setup) throws Exception
     {
         // Add supported extension
         ExtensionId supportedExtensionId = new ExtensionId("alice-xar-extension", "1.3");
-        TestExtension supportedExtension = getRepositoryTestUtils().getTestExtension(supportedExtensionId, "xar");
+        TestExtension supportedExtension = repositoryTestUtils.getTestExtension(supportedExtensionId, "xar");
         DefaultExtensionSupporter supporter = new DefaultExtensionSupporter("Supporter", null);
         DefaultExtensionSupportPlan supportPlan =
             new DefaultExtensionSupportPlan(supporter, "Support Plan", null, true);
         supportedExtension.setSupportPlans(new DefaultExtensionSupportPlans(List.of(supportPlan)));
-        getRepositoryTestUtils().addExtension(supportedExtension);
+        repositoryTestUtils.addExtension(supportedExtension);
 
         // Add not supported extension
         ExtensionId notSupportedExtensionId = new ExtensionId("bob-xar-extension", "2.5-milestone-2");
-        TestExtension notSupportedExtension = getRepositoryTestUtils().getTestExtension(notSupportedExtensionId, "xar");
-        getRepositoryTestUtils().addExtension(notSupportedExtension);
+        TestExtension notSupportedExtension = repositoryTestUtils.getTestExtension(notSupportedExtensionId, "xar");
+        repositoryTestUtils.addExtension(notSupportedExtension);
 
         // Make sure everything is ready
-        getRepositoryTestUtils().waitUntilReady();
+        repositoryTestUtils.waitUntilReady();
 
         ExtensionAdministrationPage adminPage = ExtensionAdministrationPage.gotoPage();
 

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/it/packagefile/libjarextension/TestObject.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/it/packagefile/libjarextension/TestObject.java
@@ -1,0 +1,28 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package packagefile.libjarextension;
+
+public class TestObject
+{
+    public String getString()
+    {
+        return "Hello world";
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/it/packagefile/macrojarextension/TestMacro.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/it/packagefile/macrojarextension/TestMacro.java
@@ -1,0 +1,59 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package packagefile.macrojarextension;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.rendering.block.Block;
+import org.xwiki.rendering.block.SpaceBlock;
+import org.xwiki.rendering.block.WordBlock;
+import org.xwiki.rendering.macro.AbstractNoParameterMacro;
+import org.xwiki.rendering.macro.MacroExecutionException;
+import org.xwiki.rendering.transformation.MacroTransformationContext;
+
+//It is a static registration but it's a generated jar
+@Component(staticRegistration = false)
+@Named("macrojarextension")
+@Singleton
+public class TestMacro extends AbstractNoParameterMacro
+{
+    public TestMacro()
+    {
+        super("Macro Jar Extension");
+    }
+
+    @Override
+    public List<Block> execute(Object parameters, String content, MacroTransformationContext context)
+        throws MacroExecutionException
+    {
+        return Arrays.<Block> asList(new WordBlock("test"), new SpaceBlock(), new WordBlock("result"));
+    }
+
+    @Override
+    public boolean supportsInlineMode()
+    {
+        return true;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/it/packagefile/scriptServiceJarExtension/Greeter.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/it/packagefile/scriptServiceJarExtension/Greeter.java
@@ -1,0 +1,37 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package packagefile.scriptServiceJarExtension;
+
+import org.xwiki.component.annotation.Role;
+
+/**
+ * Greets people.
+ */
+@Role
+public interface Greeter
+{
+    /**
+     * Greets the specified person.
+     * 
+     * @param name the name of the person to greet
+     * @return the greet message
+     */
+    String greet(String name);
+}

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/it/packagefile/scriptServiceJarExtension/internal/DefaultGreeter.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/it/packagefile/scriptServiceJarExtension/internal/DefaultGreeter.java
@@ -1,0 +1,41 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package packagefile.scriptServiceJarExtension.internal;
+
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+
+import packagefile.scriptServiceJarExtension.Greeter;
+
+/**
+ * Default {@link Greeter} implementation.
+ */
+//It is a static registration but it's a generated jar
+@Component(staticRegistration = false)
+@Singleton
+public class DefaultGreeter implements Greeter
+{
+    @Override
+    public String greet(String name)
+    {
+        return String.format("Hello %s!", name);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/it/packagefile/scriptServiceJarExtension/internal/script/GreeterScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/it/packagefile/scriptServiceJarExtension/internal/script/GreeterScriptService.java
@@ -1,0 +1,82 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package packagefile.scriptServiceJarExtension.internal.script;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.manager.ComponentLookupException;
+import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.script.service.ScriptService;
+
+import packagefile.scriptServiceJarExtension.Greeter;
+
+/**
+ * Script service for {@link Greeter}.
+ */
+//It is a static registration but it's a generated jar
+@Component(staticRegistration = false)
+@Named("greeter")
+@Singleton
+public class GreeterScriptService implements ScriptService
+{
+    /**
+     * The greeter.
+     */
+    @Inject
+    private Greeter greeter;
+
+    /**
+     * The component manager, used to perform dynamic component lookups.
+     */
+    @Inject
+    private ComponentManager componentManager;
+
+    /**
+     * Greets the specified person.
+     * 
+     * @param name the name of the person to greet
+     * @return the greet message
+     */
+    public String greet(String name)
+    {
+        // Test component injection.
+        return greeter.greet(name);
+    }
+
+    /**
+     * Greets the specified person.
+     * 
+     * @param name the name of the person to greet
+     * @return the greet message
+     */
+    public String greet(String name, String hint)
+    {
+        try {
+            // Test dynamic component lookup.
+            Greeter greeter = componentManager.getInstance(Greeter.class, hint);
+            return greeter.greet(name);
+        } catch (ComponentLookupException e) {
+            return null;
+        }
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/alice-xar-extension-upgrade/ExtensionTest/Alice.xml
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/alice-xar-extension-upgrade/ExtensionTest/Alice.xml
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xwikidoc>
+  <web>ExtensionTest</web>
+  <name>Alice</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <parent>Macros.WebHome</parent>
+  <creator>xwiki:XWiki.Admin</creator>
+  <author>xwiki:XWiki.Admin</author>
+  <customClass/>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <creationDate>1341237176000</creationDate>
+  <date>1341237322000</date>
+  <contentUpdateDate>1341237322000</contentUpdateDate>
+  <version>1.1</version>
+  <title>Alice Wiki Macro (upgraded)</title>
+  <template/>
+  <defaultTemplate/>
+  <validationScript/>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>false</hidden>
+  <object>
+    <class>
+      <name>XWiki.WikiMacroClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <code>
+        <disabled>0</disabled>
+        <name>code</name>
+        <number>9</number>
+        <prettyName>Macro code</prettyName>
+        <rows>20</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </code>
+      <contentDescription>
+        <disabled>0</disabled>
+        <name>contentDescription</name>
+        <number>8</number>
+        <prettyName>Content description (Not applicable for "No content" type)</prettyName>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </contentDescription>
+      <contentType>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>contentType</name>
+        <number>7</number>
+        <prettyName>Macro content type</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator>|</separator>
+        <separators>|</separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>Optional|Mandatory|No content</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </contentType>
+      <defaultCategories>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
+        <name>defaultCategories</name>
+        <number>4</number>
+        <prettyName>Default categories</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values/>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </defaultCategories>
+      <description>
+        <disabled>0</disabled>
+        <name>description</name>
+        <number>3</number>
+        <prettyName>Macro description</prettyName>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </description>
+      <id>
+        <disabled>0</disabled>
+        <name>id</name>
+        <number>1</number>
+        <prettyName>Macro id</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </id>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>2</number>
+        <prettyName>Macro name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <supportsInlineMode>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>supportsInlineMode</name>
+        <number>5</number>
+        <prettyName>Supports inline mode</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </supportsInlineMode>
+      <visibility>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>visibility</name>
+        <number>6</number>
+        <prettyName>Macro visibility</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator>|</separator>
+        <separators>|</separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>Current User|Current Wiki|Global</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </visibility>
+    </class>
+    <name>ExtensionTest.Alice</name>
+    <number>0</number>
+    <className>XWiki.WikiMacroClass</className>
+    <guid>aaf17d70-33e1-4b92-a811-e25f4b490d70</guid>
+    <property>
+      <code>Alice says hi guys!</code>
+    </property>
+    <property>
+      <contentDescription/>
+    </property>
+    <property>
+      <contentType>No content</contentType>
+    </property>
+    <property>
+      <defaultCategories>
+        <value>Content</value>
+      </defaultCategories>
+    </property>
+    <property>
+      <description>A cool macro.</description>
+    </property>
+    <property>
+      <id>alice</id>
+    </property>
+    <property>
+      <name>Alice</name>
+    </property>
+    <property>
+      <supportsInlineMode>1</supportsInlineMode>
+    </property>
+    <property>
+      <visibility>Current User</visibility>
+    </property>
+  </object>
+  <content>== Usage example ==
+
+{{code}}
+{{alice/}}
+{{/code}}
+
+== Output ==
+
+This is what you get:
+
+{{alice/}}</content>
+</xwikidoc>

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/alice-xar-extension-upgrade/package.xml
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/alice-xar-extension-upgrade/package.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package>
+<infos/>
+<name>ExtensionTest.Alice</name>
+<description></description>
+<licence>LGPL</licence>
+<author>XWiki</author>
+<version>1.0.0</version>
+<backupPack>false</backupPack>
+<preserveVersion>false</preserveVersion><files>
+<file defaultAction="0" language="">ExtensionTest.Alice</file></files></package>

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/alice-xar-extension-upgrade/packagefile.properties
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/alice-xar-extension-upgrade/packagefile.properties
@@ -1,0 +1,3 @@
+id=alice-xar-extension
+version=2.1.4
+type=xar

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/alice-xar-extension/ExtensionTest/Alice.xml
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/alice-xar-extension/ExtensionTest/Alice.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xwikidoc>
+  <web>ExtensionTest</web>
+  <name>Alice</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <parent>Main.WebHome</parent>
+  <creator>xwiki:XWiki.Admin</creator>
+  <author>xwiki:XWiki.Admin</author>
+  <customClass/>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <creationDate>1341237176000</creationDate>
+  <date>1341237322000</date>
+  <contentUpdateDate>1341237322000</contentUpdateDate>
+  <version>1.1</version>
+  <title>Alice Macro</title>
+  <template/>
+  <defaultTemplate/>
+  <validationScript/>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>false</hidden>
+  <object>
+    <class>
+      <name>XWiki.WikiMacroClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <code>
+        <disabled>0</disabled>
+        <name>code</name>
+        <number>9</number>
+        <prettyName>Macro code</prettyName>
+        <rows>20</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </code>
+      <contentDescription>
+        <disabled>0</disabled>
+        <name>contentDescription</name>
+        <number>8</number>
+        <prettyName>Content description (Not applicable for "No content" type)</prettyName>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </contentDescription>
+      <contentType>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>contentType</name>
+        <number>7</number>
+        <prettyName>Macro content type</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator>|</separator>
+        <separators>|</separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>Optional|Mandatory|No content</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </contentType>
+      <defaultCategories>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
+        <name>defaultCategories</name>
+        <number>4</number>
+        <prettyName>Default categories</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values/>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </defaultCategories>
+      <description>
+        <disabled>0</disabled>
+        <name>description</name>
+        <number>3</number>
+        <prettyName>Macro description</prettyName>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </description>
+      <id>
+        <disabled>0</disabled>
+        <name>id</name>
+        <number>1</number>
+        <prettyName>Macro id</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </id>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>2</number>
+        <prettyName>Macro name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <supportsInlineMode>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>supportsInlineMode</name>
+        <number>5</number>
+        <prettyName>Supports inline mode</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </supportsInlineMode>
+      <visibility>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>visibility</name>
+        <number>6</number>
+        <prettyName>Macro visibility</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator>|</separator>
+        <separators>|</separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>Current User|Current Wiki|Global</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </visibility>
+    </class>
+    <name>ExtensionTest.Alice</name>
+    <number>0</number>
+    <className>XWiki.WikiMacroClass</className>
+    <guid>aaf17d70-33e1-4b92-a811-e25f4b490d70</guid>
+    <property>
+      <code>Alice says hello!</code>
+    </property>
+    <property>
+      <contentDescription/>
+    </property>
+    <property>
+      <contentType>No content</contentType>
+    </property>
+    <property>
+      <defaultCategories>
+        <value>Content</value>
+      </defaultCategories>
+    </property>
+    <property>
+      <description>Test macro.</description>
+    </property>
+    <property>
+      <id>alice</id>
+    </property>
+    <property>
+      <name>Alice</name>
+    </property>
+    <property>
+      <supportsInlineMode>1</supportsInlineMode>
+    </property>
+    <property>
+      <visibility>Current User</visibility>
+    </property>
+  </object>
+  <content>= Usage =
+
+{{code}}
+{{alice/}}
+{{/code}}
+
+= Result =
+
+{{alice/}}</content>
+</xwikidoc>

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/alice-xar-extension/package.xml
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/alice-xar-extension/package.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package>
+<infos/>
+<name>ExtensionTest.Alice</name>
+<description></description>
+<licence>LGPL</licence>
+<author>XWiki</author>
+<version>1.0.0</version>
+<backupPack>false</backupPack>
+<preserveVersion>false</preserveVersion><files>
+<file defaultAction="0" language="">ExtensionTest.Alice</file></files></package>

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/alice-xar-extension/packagefile.properties
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/alice-xar-extension/packagefile.properties
@@ -1,0 +1,2 @@
+version=1.3
+type=xar

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/bob-xar-extension/ExtensionTest/Bob.xml
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/bob-xar-extension/ExtensionTest/Bob.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xwikidoc>
+  <web>ExtensionTest</web>
+  <name>Bob</name>
+  <language/>
+  <defaultLanguage/>
+  <translation>0</translation>
+  <parent>Main.WebHome</parent>
+  <creator>xwiki:XWiki.Admin</creator>
+  <author>xwiki:XWiki.Admin</author>
+  <customClass/>
+  <contentAuthor>xwiki:XWiki.Admin</contentAuthor>
+  <creationDate>1341301536000</creationDate>
+  <date>1341302135000</date>
+  <contentUpdateDate>1341302135000</contentUpdateDate>
+  <version>1.1</version>
+  <title>Bob Macro</title>
+  <template/>
+  <defaultTemplate/>
+  <validationScript/>
+  <comment/>
+  <minorEdit>false</minorEdit>
+  <syntaxId>xwiki/2.1</syntaxId>
+  <hidden>false</hidden>
+  <object>
+    <class>
+      <name>XWiki.WikiMacroClass</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <code>
+        <disabled>0</disabled>
+        <name>code</name>
+        <number>9</number>
+        <prettyName>Macro code</prettyName>
+        <rows>20</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </code>
+      <contentDescription>
+        <disabled>0</disabled>
+        <name>contentDescription</name>
+        <number>8</number>
+        <prettyName>Content description (Not applicable for "No content" type)</prettyName>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </contentDescription>
+      <contentType>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>contentType</name>
+        <number>7</number>
+        <prettyName>Macro content type</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator>|</separator>
+        <separators>|</separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>Optional|Mandatory|No content</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </contentType>
+      <defaultCategories>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>input</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>1</multiSelect>
+        <name>defaultCategories</name>
+        <number>4</number>
+        <prettyName>Default categories</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values/>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </defaultCategories>
+      <description>
+        <disabled>0</disabled>
+        <name>description</name>
+        <number>3</number>
+        <prettyName>Macro description</prettyName>
+        <rows>5</rows>
+        <size>40</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </description>
+      <id>
+        <disabled>0</disabled>
+        <name>id</name>
+        <number>1</number>
+        <prettyName>Macro id</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </id>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>2</number>
+        <prettyName>Macro name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <supportsInlineMode>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>supportsInlineMode</name>
+        <number>5</number>
+        <prettyName>Supports inline mode</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </supportsInlineMode>
+      <visibility>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <multiSelect>0</multiSelect>
+        <name>visibility</name>
+        <number>6</number>
+        <prettyName>Macro visibility</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator>|</separator>
+        <separators>|</separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>Current User|Current Wiki|Global</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </visibility>
+    </class>
+    <name>ExtensionTest.Bob</name>
+    <number>0</number>
+    <className>XWiki.WikiMacroClass</className>
+    <guid>979b141c-359c-4e7a-bc33-f2a203dd589e</guid>
+    <property>
+      <code>Bob says hi!</code>
+    </property>
+    <property>
+      <contentDescription/>
+    </property>
+    <property>
+      <contentType>No content</contentType>
+    </property>
+    <property>
+      <defaultCategories>
+        <value>Content</value>
+      </defaultCategories>
+    </property>
+    <property>
+      <description>Wiki macro for Extension Manager tests.</description>
+    </property>
+    <property>
+      <id>bob</id>
+    </property>
+    <property>
+      <name>Bob</name>
+    </property>
+    <property>
+      <supportsInlineMode>0</supportsInlineMode>
+    </property>
+    <property>
+      <visibility>Global</visibility>
+    </property>
+  </object>
+  <content>{{bob/}}</content>
+</xwikidoc>

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/bob-xar-extension/package.xml
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/bob-xar-extension/package.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package>
+<infos/>
+<name>ExtensionTest.Bob</name>
+<description></description>
+<licence>LGPL</licence>
+<author>XWiki</author>
+<version>1.0.0</version>
+<backupPack>false</backupPack>
+<preserveVersion>false</preserveVersion><files>
+<file defaultAction="0" language="">ExtensionTest.Bob</file></files></package>

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/bob-xar-extension/packagefile.properties
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/bob-xar-extension/packagefile.properties
@@ -1,0 +1,2 @@
+version=2.5-milestone-2
+type=xar

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/emptyjar/packagefile.properties
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/emptyjar/packagefile.properties
@@ -1,0 +1,1 @@
+type=jar

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/libjarextension/packagefile.properties
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/libjarextension/packagefile.properties
@@ -1,0 +1,2 @@
+version=1.0
+type=jar

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/macrojarextension/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/macrojarextension/META-INF/components.txt
@@ -1,0 +1,2 @@
+packagefile.macrojarextension.TestMacroExtension
+packagefile.macrojarextension.TestScriptServiceExtension

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/macrojarextension/packagefile.properties
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/macrojarextension/packagefile.properties
@@ -1,0 +1,3 @@
+id=prefix-macro-jar-extension
+version=1.0
+type=jar

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/scriptServiceJarExtension/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/scriptServiceJarExtension/META-INF/components.txt
@@ -1,0 +1,2 @@
+packagefile.scriptServiceJarExtension.internal.DefaultGreeter
+packagefile.scriptServiceJarExtension.internal.script.GreeterScriptService

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/scriptServiceJarExtension/packagefile.properties
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/scriptServiceJarExtension/packagefile.properties
@@ -1,0 +1,2 @@
+version=4.2-milestone-1
+type=jar

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/xwiki-commons-diff-api/packagefile.properties
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/xwiki-commons-diff-api/packagefile.properties
@@ -1,0 +1,3 @@
+id=org.xwiki.commons:xwiki-commons-diff-api
+version=2.7
+type=jar

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/xwiki-platform-display-api/packagefile.properties
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker/src/test/resources/packagefile/xwiki-platform-display-api/packagefile.properties
@@ -1,0 +1,3 @@
+id=org.xwiki.platform:xwiki-platform-display-api
+version=100.1
+type=jar

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-pageobjects/src/main/java/org/xwiki/extension/test/po/ExtensionProgressPane.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-pageobjects/src/main/java/org/xwiki/extension/test/po/ExtensionProgressPane.java
@@ -63,7 +63,7 @@ public class ExtensionProgressPane extends BaseElement
      */
     public WebElement getJobLogLabel()
     {
-        String xpath = "//*[@class = 'log']/parent::dd/preceding-sibling::dt[last()]/label";
+        String xpath = "//*[@class = 'log']/parent::dd/preceding-sibling::dt[last()]/button";
         return getDriver().findElementWithoutWaiting(container, By.xpath(xpath));
     }
 

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/job_macros.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/job_macros.vm
@@ -47,7 +47,7 @@ $services.template.execute('logging_macros.vm')
   <dl class="xform">
     ## Collapse the job log if the job is waiting for user input (leave more space for the job question).
     <dt>
-      <button class="btn btn-default btn-xs collapse-toggle#if ($collapsed || $status.state == 'WAITING') collapsed#end"
+      <button type="button" class="btn btn-default btn-xs collapse-toggle#if ($collapsed || $status.state == 'WAITING') collapsed#end"
           data-target-xpath="parent::*/following-sibling::*">
         <span class="icon-closed">$services.icon.renderHTML('caret-right')</span>
         <span class="icon-opened">$services.icon.renderHTML('caret-down')</span>


### PR DESCRIPTION
# Changes

All 15 tests pass: `mvn clean verify -pl xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker -Plegacy,integration-tests,snapshot,docker -Dxwiki.checkstyle.skip=true -Dxwiki.surefire.captureconsole.skip=true -Dxwiki.revapi.skip=true`

## Summary of Changes

### Files Modified

1. **`xwiki-platform-extension-test-docker/src/test/it/.../ExtensionIT.java`** — New JUnit5 Docker test (15 tests)
   - Uses `@UITest` with `extraJARs` for xwiki-commons-extension-repository-xwiki and xwiki-platform-extension-index
   - Uses `xwikiPropertiesAdditionalProperties` to add `self:xwiki` repository
   - `testSimpleSearch`: groovy count assertion changed from `> 1` to `>= 1` (minimal WAR only has `org.apache.groovy:groovy`)

2. **`xwiki-platform-extension-test-docker/pom.xml`** — New Docker test module POM

3. **`xwiki-platform-extension-test-docker/src/test/it/.../AllIT.java`** — Test entry point

4. **`xwiki-platform-extension-test/pom.xml`** — Added `docker` profile activating the new module

5. **`xwiki-platform-extension-test-pageobjects/.../ExtensionProgressPane.java`** — Fixed XPath:
   - `getJobLogLabel()` XPath changed from `/label` to `/button` (commit 891f2b563011 changed `<label>` to `<button>`)

6. **`xwiki-platform-web-templates/templates/job_macros.vm`** — Bug fix:
   - Added `type="button"` to the `collapse-toggle` button in `displayJobStatusLog` macro
   - Without this, the button (being inside a `<form>` without `type="button"`) would submit the extension form on click, causing `StaleElementReferenceException` in `testUpgradeWithMergeConflict`

## Key Technical Findings

- The Docker minimal WAR only contains `org.apache.groovy:groovy` (name "Apache Groovy") as a groovy core extension, not the XWiki groovy wrappers
- The `xwiki-platform-extension-index` extraJAR is required for Solr-backed keyword search (otherwise returns 0 results)
- Commit 891f2b563011 (XWIKI-24145) changed the log toggle from `<label>` to `<button>` but omitted `type="button"`, causing the button to submit the extension form — fixed in job_macros.vm

# Open questions

* Is it ok to add the `type=button`, see https://matrix.to/#/!zdPfnFC0pUfwN5kZ4LKP2dXZ2jC266yFWKNeqgmJd4E/$weHyTv_5-fZx6FVkJj4r0hnX7kyggBDaFgG8qxI-_nY?via=matrix.xwiki.com&via=matrix.org&via=c-base.org
* Is it ok to have  the groovy count assertion changed from `> 1` to `>= 1`? I doesn't change the test much but I'm wondering why it was needed. When I checked manually in the generated distribution I could indeed only see a single result for "groovy". Maybe the generated distribution is different in the docker-based tests from what we had before in the old functional test framework?
* TODO: Check if the -test-tests AllIT needs to be cleaned (i.e. if what is in it is needed or not for the remaining AbstractExtensionAdminAuthenticatedIT test - or maybe that test too, which would be better but I wanted to do it in 2 steps).

