### PR TITLE
[css] Remove invalid CSS property 'sborder' in extension.css

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/extension/extension.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/extension/extension.css
@@ -381,7 +381,6 @@ ul.innerMenu {
 }
 .innerMenu li {
   display: inline-block;
-  sborder: 1px solid red;
   vertical-align: top;
   margin-left: -1px;
 }


### PR DESCRIPTION
## Summary

Fix SonarQube BLOCKER issue [css:S4654](https://rules.sonarsource.com/css/RSPEC-4654/) - "Unexpected unknown property 'sborder'" in `extension.css`.

- Removes the invalid CSS property `sborder: 1px solid red` from the `.innerMenu li` rule in `xwiki-platform-web-war/src/main/webapp/resources/uicomponents/extension/extension.css` (line 384)
- The property `sborder` is not a valid CSS property name and was silently ignored by all browsers, so removing it has **no visual impact**
- The `red` color suggests this was likely leftover debug/development code

## Verification

- Verified the `xwiki-platform-web-war` module builds successfully with `mvn clean verify -Pquality` (BUILD SUCCESS, 0 Checkstyle violations)
- No backward compatibility concerns — browsers never rendered this property

## SonarCloud Issue

- Rule: `css:S4654` (Unexpected unknown property)
- Severity: BLOCKER
- Component: `xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/extension/extension.css`

---
*This fix was produced by a Claude remote session: https://claude.ai/code/session_01RR7AMCt8iTfVBoCtB9hhmT*

---
_Generated by [Claude Code](https://claude.ai/code/session_01RR7AMCt8iTfVBoCtB9hhmT)_