### PR TITLE
[css] Remove leftover debug CSS property 'sborder' in extension.css

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/extension/extension.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/extension/extension.css
@@ -381,7 +381,6 @@ ul.innerMenu {
 }
 .innerMenu li {
   display: inline-block;
-  sborder: 1px solid red;
   vertical-align: top;
   margin-left: -1px;
 }


### PR DESCRIPTION
## What

Removes the invalid CSS property `sborder: 1px solid red;` from the `.innerMenu li` rule in `extension.css`.

## Why

This property is not a recognized CSS standard (`sborder` does not exist). It was clearly a debugging artifact (note the `solid red` value) accidentally left in the code. Browsers silently ignore unknown CSS properties, so this has no visual effect — but it was flagged as a **BLOCKER** issue by SonarCloud (rule [css:S4654](https://rules.sonarsource.com/css/RSPEC-4654/) — Unexpected unknown property).

## SonarCloud Issue

- **Rule**: `css:S4654` — Unexpected unknown property  
- **Severity**: BLOCKER  
- **File**: `xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/extension/extension.css`, line 384

## Verification

The `xwiki-platform-web-war` Maven module was built successfully with `mvn clean verify -Pquality`.

---

*This fix was made in a remote Claude Code session: https://claude.ai/code/session_01G6dRck67gzkiccYiQ9fxja*

---
_Generated by [Claude Code](https://claude.ai/code/session_01G6dRck67gzkiccYiQ9fxja)_