### PR TITLE
[sonar] Fix java:S1845 - Rename fields to avoid case-only clash with static constants in CreateActionRequestHandler

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/CreateActionRequestHandler.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/CreateActionRequestHandler.java
@@ -181,7 +181,7 @@ public class CreateActionRequestHandler
 
     private SpaceReference spaceReference;
 
-    private String name;
+    private String documentName;
 
     private boolean isSpace;
 
@@ -197,7 +197,7 @@ public class CreateActionRequestHandler
 
     private List<Document> recommendedTemplateProviders;
 
-    private String type;
+    private String documentType;
 
     /**
      * Used to convert a proper Document Reference to a string but without the wiki name.
@@ -233,7 +233,7 @@ public class CreateActionRequestHandler
             document.getDocumentReference().getLastSpaceReference(), templateProviderClassReference, context);
 
         // Get the type of document to create
-        type = request.get(TYPE);
+        documentType = request.get(TYPE);
 
         // Since this template can be used for creating a Page or a Space, check the passed "tocreate" parameter
         // which can be either "page" or "space". If no parameter is passed then we default to creating a Page.
@@ -265,7 +265,7 @@ public class CreateActionRequestHandler
                 // Note: We leave the spaceReference variable intentionally null to symbolize a top level space or
                 // non-terminal document.
 
-                name = request.getParameter(NAME);
+                documentName = request.getParameter(NAME);
 
                 // Determine the type of document we are creating (terminal vs non-terminal).
 
@@ -293,19 +293,19 @@ public class CreateActionRequestHandler
     {
         // Current space and page name.
         spaceReference = document.getDocumentReference().getLastSpaceReference();
-        name = document.getDocumentReference().getName();
+        documentName = document.getDocumentReference().getName();
 
         // Determine if the current document is in a top-level space.
         EntityReference parentSpaceReference = spaceReference.getParent();
         boolean isTopLevelSpace = parentSpaceReference.extractReference(EntityType.SPACE) == null;
 
         // Remember this since we might update it below.
-        String originalName = name;
+        String originalName = documentName;
 
         // Since WebHome is a convention, determine the real name and parent of our document.
-        if (WEBHOME.equals(name)) {
+        if (WEBHOME.equals(documentName)) {
             // Determine its name from the space name.
-            name = spaceReference.getName();
+            documentName = spaceReference.getName();
 
             // Determine its space reference by looking at the space's parent.
             if (!isTopLevelSpace) {
@@ -373,14 +373,14 @@ public class CreateActionRequestHandler
         if (isSpace) {
             // Always creating top level spaces in this mode. Adapt to the new implementation.
             spaceReference = null;
-            name = spaceParameter;
+            documentName = spaceParameter;
         } else {
             if (StringUtils.isNotEmpty(spaceParameter)) {
                 // Always creating documents in top level spaces in this mode.
                 spaceReference = new SpaceReference(spaceParameter, document.getDocumentReference().getWikiReference());
             }
 
-            name = request.getParameter(PAGE);
+            documentName = request.getParameter(PAGE);
         }
     }
 
@@ -581,14 +581,14 @@ public class CreateActionRequestHandler
      */
     public DocumentReference getDocumentReference()
     {
-        if (StringUtils.isEmpty(name)) {
+        if (StringUtils.isEmpty(documentName)) {
             // Can`t do anything without a name.
             return null;
         }
 
         // The new values, after the processing needed for ND below, to be used when creating the document reference.
         SpaceReference newSpaceReference = spaceReference;
-        String newName = name;
+        String newName = documentName;
 
         // Special handling for old spaces or new Nested Documents.
         if (isSpace) {
@@ -598,7 +598,7 @@ public class CreateActionRequestHandler
             }
 
             // The new space's reference.
-            newSpaceReference = new SpaceReference(name, parentSpaceReference);
+            newSpaceReference = new SpaceReference(documentName, parentSpaceReference);
 
             // The new document's name set to the new space's homepage. In Nested Documents, this leads to the new ND's
             // reference name.
@@ -666,7 +666,7 @@ public class CreateActionRequestHandler
             if (creationRestrictionsEnforced && !isTemplateProviderAllowedInSpace(templateProvider, spaceReference,
                 TP_CREATION_RESTRICTIONS_PROPERTY)) {
                 // put an exception on the context, for create.vm to know to display an error
-                Object[] args = { templateProvider.getStringValue(TEMPLATE), spaceReference, name };
+                Object[] args = { templateProvider.getStringValue(TEMPLATE), spaceReference, documentName };
                 XWikiException exception = new XWikiException(XWikiException.MODULE_XWIKI_STORE,
                     XWikiException.ERROR_XWIKI_APP_TEMPLATE_NOT_AVAILABLE,
                     "Template {0} cannot be used in space {1} when creating page {2}", null, args);
@@ -855,7 +855,7 @@ public class CreateActionRequestHandler
      */
     public String getName()
     {
-        return name;
+        return documentName;
     }
 
     /**
@@ -897,6 +897,6 @@ public class CreateActionRequestHandler
      */
     public String getType()
     {
-        return type;
+        return documentType;
     }
 }


### PR DESCRIPTION
## Summary

Fix SonarQube BLOCKER issue [java:S1845](https://rules.sonarsource.com/java/RSPEC-1845/) in `CreateActionRequestHandler.java`.

The rule flags fields/methods whose names differ only by capitalization from other members in the same class, which can cause confusion and hard-to-spot bugs.

**Changes:**
- Renamed private instance field `name` → `documentName` (was clashing with `static final String NAME = "name"`)
- Renamed private instance field `type` → `documentType` (was clashing with `static final String TYPE = "type"`)

The public API is **fully preserved**: `getName()` and `getType()` methods remain unchanged, so there is no backward compatibility impact.

**SonarCloud issues fixed:**
- `AW5-S6aq1Yj5qvzeRnWy` - Rename field "name" to prevent any misunderstanding/clash with field "NAME" (line 184)
- `AW5-S6aq1Yj5qvzeRnWz` - Rename field "type" to prevent any misunderstanding/clash with field "TYPE" (line 200)

## Test plan

- [x] Module builds successfully with `mvn clean verify -Pquality` on `xwiki-platform-oldcore`
- [x] No public API changes (only private field renames)
- [x] All existing usages of the fields updated consistently within the class

## Remote session

https://claude.ai/code/session_01QgmnAv2PrGXoB92BAt514b

---
_Generated by [Claude Code](https://claude.ai/code/session_01QgmnAv2PrGXoB92BAt514b)_