### PR TITLE
Fix SonarQube S2387: Rename RightMap.keySet field to avoid shadowing AbstractMap.keySet

### DIFF
--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/RightMap.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/RightMap.java
@@ -53,7 +53,7 @@ public class RightMap<V> extends AbstractMap<Right, V> implements Serializable, 
     private transient List<Object> rights;
 
     /** Cached key set. */
-    private transient Set<Right> keySet;
+    private transient Set<Right> cachedKeySet;
 
     /** Cached value collection. */
     private transient Collection<V> cachedValues;
@@ -260,10 +260,10 @@ public class RightMap<V> extends AbstractMap<Right, V> implements Serializable, 
     @Override
     public Set<Right> keySet()
     {
-        if (keySet == null) {
-            keySet = new RightSet();
+        if (cachedKeySet == null) {
+            cachedKeySet = new RightSet();
         }
-        return keySet;
+        return cachedKeySet;
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes SonarQube BLOCKER issue [S2387 - Child class fields should not shadow parent class fields](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&issues=AW5-S48e1Yj5qvzeRmvr&open=AW5-S48e1Yj5qvzeRmvr).

The private field `keySet` in `RightMap` was shadowing the `keySet` field defined in its parent class `AbstractMap` (`java.util.AbstractMap` has a `transient Set<K> keySet` field). This is flagged as a BLOCKER by SonarQube rule [java:S2387](https://rules.sonarsource.com/java/RSPEC-2387/).

### Change

- Renamed private transient field `keySet` → `cachedKeySet` in `RightMap.java`
- Updated all internal references within the `keySet()` method body
- The public `keySet()` method override is unchanged — no backward compatibility impact

### SonarCloud Issue

https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&issues=AW5-S48e1Yj5qvzeRmvr&open=AW5-S48e1Yj5qvzeRmvr

### Testing

- Built `xwiki-platform-security-authorization-api` with `mvn clean verify -Pquality` — **BUILD SUCCESS**


---
_Generated by [Claude Code](https://claude.ai/code/session_012AtaFRwNqcM6w4eFRtvn2v)_