### PR TITLE
Fix SonarQube S3516: getSuggestions in suggest.js should not always return false

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggest.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggest.js
@@ -338,8 +338,8 @@ var XWiki = (function(XWiki){
       this.container.select('.hide-button-wrapper').invoke('hide');
       this.ajID = setTimeout( function() { pointer.doAjaxRequests(requestId) }, this.options.delay );
 
+      return true;
     }
-    return false;
   },
 
   /**


### PR DESCRIPTION
## Summary

Fixes SonarQube BLOCKER issue [S3516 - Refactor this function to not always return the same value](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&issues=AY1U1sR50GHv9uFD3jjE&open=AY1U1sR50GHv9uFD3jjE).

The `getSuggestions` function in `suggest.js` was always returning `false` regardless of which code path was taken. SonarQube rule [javascript:S3516](https://rules.sonarsource.com/javascript/RSPEC-3516/) flags this as a BLOCKER because a function that unconditionally returns the same value usually signals a bug.

### Change

The function now returns:
- `true` when a new AJAX request is scheduled (the else/new-request branch) — indicating that the input triggered a server request
- `false` in all other cases (input unchanged, input too short, or served from cache)

No callers in the codebase check the return value of `getSuggestions`, so this change has no backward compatibility impact.

### SonarCloud Issue

https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&issues=AY1U1sR50GHv9uFD3jjE&open=AY1U1sR50GHv9uFD3jjE

### Testing

- Built `xwiki-platform-web-war` with `mvn clean verify -Pquality` — **BUILD SUCCESS**


---
_Generated by [Claude Code](https://claude.ai/code/session_012AtaFRwNqcM6w4eFRtvn2v)_