### PR TITLE
XWIKI-24331: Extension page WCAG fails: contrast and text alternative

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -1401,6 +1401,8 @@ core.widgets.confirmationBox.notification.failed=Failed:
 
 core.widgets.ajaxRequest.error.noServer=Server not responding
 
+core.widgets.buttonGroup.dropDown.toggle.hint=More actions
+
 core.widgets.gallery.currentImage=Current image
 core.widgets.gallery.previousImage=Show previous image
 core.widgets.gallery.nextImage=Show next image

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/extension.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/extension.vm
@@ -110,7 +110,7 @@
           #else
             #set ($compatible = true)
           #end
-          <div class="extension-search-more collapse#if($customExtensionFilter) in#end">
+          <div class="extension-search-more collapse#if($customExtensionFilter) in#end" role="tabpanel">
             <div>
               <span class="box">
                 #set($recommendedTooltip = $escapetool.xml($services.localization.render('extensions.search.recommended.tooltip')))
@@ -142,7 +142,7 @@
       </div>
     </form>
     ## Advanced search form.
-    <form action="$xwiki.relativeRequestURL" class="xform extension-search-more collapse#if($customExtensionFilter) in#end">
+    <form action="$xwiki.relativeRequestURL" class="xform extension-search-more collapse#if($customExtensionFilter) in#end" role="tabpanel">
       <fieldset id="extension-search-advanced">
         <legend><a href="#extension-search-advanced-body">$services.localization.render('extensions.advancedSearch.title')</a></legend>
         <div id="extension-search-advanced-body"></div>

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/extension.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/extension.vm
@@ -23,7 +23,7 @@
 #set ($discard = $xwiki.jsfx.use('uicomponents/extension/extension.js', {'forceSkinAction': true, 'version': $environmentVersion}))
 #set ($discard = $xwiki.ssfx.use('uicomponents/viewers/diff.css', {'forceSkinAction': true, 'version': $environmentVersion}))
 #set ($discard = $xwiki.jsfx.use('uicomponents/viewers/diff.js', {'forceSkinAction': true, 'version': $environmentVersion}))
-#set ($discard = $xwiki.ssfx.use('uicomponents/widgets/buttonGroup.css', {'forceSkinAction': true, 'version': $environmentVersion}))
+#set ($discard = $xwiki.ssfx.use('uicomponents/widgets/buttonGroup.css', {'version': $environmentVersion}))
 #set ($discard = $xwiki.jsfx.use('uicomponents/widgets/buttonGroup.js', {'forceSkinAction': true, 'version': $environmentVersion}))
 
 #set($discard = $services.template.execute('job_macros.vm'))
@@ -81,7 +81,7 @@
         ## We don't use #em_submitButton because we want to use <button> instead of <input type="submit">, in order to 
         ## be able to use HTML content inside the text of the button (the search icon and the hidden span for screen readers).
         <span class="buttonwrapper">
-          <button class="btn btn-primary" type="submit" id="extensionSearchButton">$services.icon.renderHTML('search') <span class="hidden">$escapetool.xml($services.localization.render('extensions.advancedSearch.actions.submit'))</span></button>
+          <button class="btn btn-primary" type="submit" id="extensionSearchButton">$services.icon.renderHTML('search') <span class="sr-only">$escapetool.xml($services.localization.render('extensions.advancedSearch.actions.submit'))</span></button>
         </span>
         <button type="button" id="extensionMoreButton" class="btn btn-default" data-toggle="collapse" data-target=".extension-search-more">$escapetool.xml($services.localization.render('extensions.search.more.label'))</button>
       </div>
@@ -1055,10 +1055,10 @@ $namespace##
             </$supporterElementName>
           #else
             <$supporterElementName class="supporter support-multi-plan dropdown">
-              <span class="supporter-name support-multi-name" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <button class="supporter-name support-multi-name" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 $escapetool.xml($extensionSupporter.name)
                 <span class="caret"></span>
-              </span>
+              </button>
               <div class="support-dialog dropdown-menu">
                 $escapetool.xml($extensionSupporter.name) <a href="$escapetool.xml($extensionSupporter.uRL)"> $services.icon.renderHTML('link') </a>
                 <h4>$escapetool.xml($services.localization.render('extensions.info.support.supportPlans'))</h4>

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/extension/extension.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/extension/extension.css
@@ -33,7 +33,7 @@
 }
 
 .extension-item:hover .extension-header {
-  background-color: $theme.highlightColor;
+  background-color: var(--nav-link-hover-bg);
 }
 .extension-header .buttonwrapper {
   margin: 0 0 0 5px;
@@ -42,13 +42,13 @@
 /*Supported By*/
 
 .supported-by {
-  color: $theme.textColor;
+  color: var(--text-color);
 }
 
 .supported-by h3,
 .supported-by h4{
+  color: var(--text-muted);
   font-size: 1.1rem;
-  opacity: .5;
   font-weight: 600;
   text-transform: uppercase;
 }
@@ -64,6 +64,8 @@
 }
 
 .supporter-name {
+  border: none;
+  background: transparent;
   font-weight: 600;
   padding: 0px 6px;
 }
@@ -139,7 +141,7 @@ h2.extension-title .extension-status {
 }
 
 .extension-authors {
-  color: $theme.textSecondaryColor;
+  color: var(--text-muted);
   font-size: .9em;
 }
 
@@ -148,11 +150,11 @@ h2.extension-title .extension-status {
 /* We have to duplicate the selectors to force the style to be applied to extension dependencies, which are nested inside extension display. */
 .extension-item .extension-item-core .extension-status,
 .extension-item .extension-item-installed-dependency .extension-status {
-  color: $theme.textSecondaryColor;
+  color: var(--text-muted);
 }
 .extension-item-installed .extension-status,
 .extension-item .extension-item-installed .extension-status {
-  color: $theme.notificationSuccessColor;
+  color: var(--brand-success);
 }
 .extension-item-remote-core .extension-status,
 .extension-item-remote-installed .extension-status,
@@ -160,13 +162,13 @@ h2.extension-title .extension-status {
 .extension-item .extension-item-remote-core .extension-status,
 .extension-item .extension-item-remote-installed .extension-status,
 .extension-item .extension-item-remote-installed-dependency .extension-status {
-  color: $theme.notificationWarningColor;
+  color: var(--brand-warning);
 }
 .extension-item-installed-invalid .extension-status, .extension-item-remote-installed-invalid .extension-status,
 .extension-item .extension-item-installed-invalid .extension-status, .extension-item .extension-item-remote-installed-invalid .extension-status,
 /* This applies only to dependencies. */
 .extension-item-remote-core-incompatible .extension-status, .extension-item-remote-installed-incompatible .extension-status {
-  color: $theme.notificationErrorColor;
+  color: var(--brand-danger);
 }
 
 .extension-summary {
@@ -178,11 +180,11 @@ h2.extension-title .extension-status {
 
 .extension-recommended {
   margin-top: .5em;
-  color: $theme.notificationSuccessColor
+  color: var(--brand-success);
 }
 
 .extension-body {
-  border: 1px dotted $theme.borderColor;;
+  border: 1px dotted var(--xwiki-border-color);
   padding: 0 .8em .8em 1.8em !important;
   margin: 0 1em 1em;
 }
@@ -209,7 +211,7 @@ dl.extension-body-section,
 }
 dl.extension-body-section > dt,
 .extension-body-section > dl > dt {
-  color: $theme.textSecondaryColor;
+  color: var(--text-muted);
   font-weight: normal;
 }
 dl.extension-body-section > dd + dt,
@@ -235,12 +237,12 @@ ul.dependencies {
   padding: 0;
 }
 ul.dependencies li:hover {
-  background-color: $theme.highlightColor;
+  background-color: var(--nav-link-hover-bg);
 }
 .dependency-item {
   background: transparent none no-repeat left;
   border-bottom: 1px dotted #E8E8E8;
-  border-right: 7px solid $theme.pageContentBackgroundColor;
+  border-right: 7px solid var(--xwiki-page-content-bg);
   padding: 0.3em 0 0.3em 20px;
   position: relative;
 }
@@ -275,19 +277,19 @@ ul.dependencies li:hover {
 
 .extension-item-core,
 .extension-item-installed-dependency {
-  border-right-color: $theme.textSecondaryColor;
+  border-right-color: var(--text-muted);
 }
 .extension-item-installed {
-  border-right-color: $theme.notificationSuccessColor;
+  border-right-color: var(--brand-success);
 }
 .extension-item-remote-installed,
 .extension-item-remote-installed-dependency,
 .extension-item-remote-core {
-  border-right-color: $theme.notificationWarningColor;
+  border-right-color: var(--brand-warning);
 }
 .extension-item-installed-invalid, .extension-item-remote-installed-invalid,
 .extension-item-remote-core-incompatible, .extension-item-remote-installed-incompatible {
-  border-right-color: $theme.notificationErrorColor;
+  border-right-color: var(--brand-danger);
 }
 
 .extension-diff-title {
@@ -297,7 +299,7 @@ ul.dependencies li:hover {
   margin-bottom: .6em;
 }
 .extension-diff-options .label {
-  color: $theme.textColor;
+  color: var(--text-color);
   font-size: 0.85em;
   font-weight: 700;
   margin-right: 0.3em;
@@ -309,11 +311,8 @@ ul.dependencies li:hover {
 }
 
 .extension-search-bar {
-  background-color: $theme.panelCollapsedBackgroundColor;
-  border: 1px solid $theme.borderColor;
-  border-bottom: 0;
-  color: $theme.panelCollapsedTextColor;
-  font-size: .8em;
+  background-color: var(--breadcrumb-bg);
+  border-radius: var(--border-radius-base);
   padding: .3em 1.2em .3em .3em;
   position: relative;
 }
@@ -322,7 +321,7 @@ ul.dependencies li:hover {
   float: left;
 }
 #extensionSearchInput {
-  background: url("$xwiki.getSkinFile('icons/xwiki/search.png')") no-repeat scroll left center $theme.pageContentBackgroundColor;
+  background: url("$xwiki.getSkinFile('icons/xwiki/search.png')") no-repeat scroll left center var(--xwiki-page-content-bg);
   padding-left: 18px;
 }
 
@@ -373,7 +372,7 @@ ul.dependencies li:hover {
 }
 
 ul.innerMenu {
-  color: $theme.textSecondaryColor;
+  color: var(--text-muted);
   font-size: 1em;
   font-size: 0.8em;
   padding: 0 0 .1em;
@@ -387,7 +386,7 @@ ul.innerMenu {
 }
 .innerMenu li a {
   border-radius: 7px 7px 0 0 / 5px 5px 0 0;
-  border-top: 3px solid $theme.borderColor;
+  border-top: 3px solid var(--xwiki-border-color);
   display: inline-block;
   margin: 2px 2em 0 0;
   padding: 6px .5em .2em;
@@ -396,20 +395,20 @@ ul.innerMenu {
 }
 .innerMenu li a:hover {
   border-radius: 8px 8px 0 0;
-  border-top: 5px solid $theme.borderColor;
+  border-top: 5px solid var(--xwiki-border-color);
   margin-top: 0px;
 }
 .innerMenu li a.current {
-  background-color: $theme.panelCollapsedBackgroundColor;
+  background-color: var(--nav-link-hover-bg);
   border: 0 none;
-  border-top: 5px solid $theme.panelCollapsedBackgroundColor;
+  border-top: 5px solid var(--nav-link-hover-bg);
   margin-top: 0;
   border-radius: 0 0 8px 8px;
   box-shadow: 3px;
 }
 .innerMenu li a.current:after {
   border-style: solid;
-  border-color: transparent transparent  $theme.borderColor;
+  border-color: transparent;
   border-width: 0 5px 5px 0;
   width: 0;
   display: block;
@@ -420,7 +419,6 @@ ul.innerMenu {
   right: -5px;
 }
 .innerMenu li a.current {
-  color: $theme.panelCollapsedTextColor;
   text-decoration: none;
 }
 
@@ -441,7 +439,7 @@ ul.innerMenu {
   text-transform: uppercase;
 }
 .xHint {
-  color: $theme.textSecondaryColor;
+  color: var(--text-muted);
   font-size: smaller;
   margin: 0.3em 0;
 }
@@ -465,10 +463,10 @@ ul.document-tree {
   position: relative;
 }
 .document-tree .node:hover {
-  background-color: $theme.highlightColor;
+  background-color: var(--nav-link-hover-bg);
 }
 .document-tree .node .locale {
-  color: $theme.textSecondaryColor;
+  color: var(--text-muted);
   font-style: italic;
   padding-left: .2em;
 }
@@ -542,7 +540,7 @@ ul.collapsible.document-tree {
   vertical-align: middle;
 }
 .selectable.document-tree .selectedCount {
-  color: $theme.textSecondaryColor;
+  color: var(--text-muted);
   font-size: .8em;
   /* Bold is inherited from wiki and space nodes so we need to overwrite it. */
   font-weight: normal;

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/buttonGroup.css
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/buttonGroup.css
@@ -1,29 +1,12 @@
-#template('colorThemeInit.vm')
-
 .button-group {
   /* Required in order to display the drop-down list below the button. */
   position: relative;
 }
 
-#distributionWizard .button-group a.dropdown-toggle > span, 
-#contentcontainer .button-group a.dropdown-toggle > span {
-  /* Draw the down arrow/triangle using the border. */
-  border-left: 4px solid transparent;
-  border-right: 4px solid transparent;
-  border-top: 4px solid $theme.buttonPrimaryTextColor;
-  display: inline-block;
-  vertical-align: middle;
-}
-
-#distributionWizard .button-group a.dropdown-toggle.secondary > span,
-#contentcontainer .button-group a.dropdown-toggle.secondary > span {
-  border-top: 4px solid $theme.buttonSecondaryTextColor;
-}
-
 .button-group > a.dropdown-toggle {
-  /* Left border shadow to separate the toggle from the button. */
-  box-shadow: 1px 0 0 rgba(255, 255, 255, 0.125) inset;
-  margin-left: -1px;
+  /* Left border to separate the toggle from the button. 
+    Most colors are already provided by bootstrap's buttons.less */
+  border-left: var(--border-width) solid var(--btn-default-border);
   padding-left: 6px;
   padding-right: 6px;
 }
@@ -53,8 +36,8 @@
 }
 
 .button-group > .dropdown-menu {
-  background-color: $theme.pageContentBackgroundColor;
-  border: 1px solid $theme.borderColor;
+  background-color: var(--xwiki-page-content-bg);
+  border: 1px solid var(--xwiki-border-color);
   /* Same border radius as the button. */
   border-radius: 5px;
   box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
@@ -89,7 +72,7 @@
   border: 0 none transparent;
   border-radius: 0;
   box-shadow: none;
-  color: $theme.textColor;
+  color: var(--text-color);
   display: block;
   padding: 3px 6px;
   text-align: left;
@@ -108,6 +91,6 @@
 .button-group > .dropdown-menu > input.button:focus,
 .button-group > .dropdown-menu > button:focus,
 .button-group > .dropdown-menu > a:focus {
-  background-color: $theme.highlightColor;
+  background-color: var(--nav-link-hover-bg);
   box-shadow: none;
 }

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/buttonGroup.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/buttonGroup.js
@@ -20,6 +20,12 @@
 var XWiki = (function (XWiki) {
 // Start XWiki augmentation.
 var widgets = XWiki.widgets = XWiki.widgets || {};
+const l10n = {
+  "core.widgets.buttonGroup.dropDown.toggle.hint" : "$!escapetool.javascript($services.localization.render('core.widgets.buttonGroup.dropDown.toggle.hint'))",
+};
+const icons = {
+  'caret-down': "$!escapetool.javascript($services.icon.renderHTML('caret-down'))"
+};
 
 /**
  * A static button group. Both the drop-down toggle and the drop-down menu must be present in the DOM document. This
@@ -152,12 +158,13 @@ widgets.DynamicButtonGroup = Class.create({
     // Initialize the container.
     container.removeClassName('dynamic-button-group').addClassName('buttonwrapper button-group initialized');
 
-    // Insert the drop down menu toggle.
+    // Insert the dropdown menu toggle.
     buttons[0].insert({after: new Element('a', {
       href: '#dropDownMenu',
       'class': 'dropdown-toggle' + (buttons[0].hasClassName('secondary') ? ' secondary' : ''),
       tabindex: 0
-    }).insert(new Element('span'))});
+    }).insert(icons['caret-down'] + " <span class='sr-only'>" 
+      + l10n['core.widgets.buttonGroup.dropDown.toggle.hint'] + "</span>")});
 
     // Insert the drop down menu.
     var dropDownMenu = new Element('span', {'class': 'dropdown-menu'});

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/buttonGroup.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/buttonGroup.js
@@ -163,7 +163,7 @@ widgets.DynamicButtonGroup = Class.create({
       href: '#dropDownMenu',
       'class': 'dropdown-toggle' + (buttons[0].hasClassName('secondary') ? ' secondary' : ''),
       tabindex: 0
-    }).insert(icons['caret-down'] + " <span class='sr-only'>" 
+    }).insert(icons['caret-down'] + "<span class='sr-only'>" 
       + l10n['core.widgets.buttonGroup.dropDown.toggle.hint'] + "</span>")});
 
     // Insert the drop down menu.


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-24331

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

1. Updated the colors of the extension search bar to use standard colors. This fixes the contrast issue the advanced search link had.
1. Updated the button dynamic group widget to use a proper icon and a text alternative.
1. Updated the two CSS sheets to use CSS variables instead of the Colibri colortheme ones.
1. Fixed contrast of the `supported by` sections.
1. Changed the visibility of the text alternative of the search extension button so that it can be useful for SRs.
1. Changed the role of the `.extension-search-more` so that they would accept the `aria-extended` attribute added by the bootstrap collapse.
1. Updated the nature of the multi supporter node to reflect its role as a toggle to display more.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The test failure on CI needs a pretty limited fix: only 1. and 2. . 
* . 3. is just a generic optimization/cleanup of the CSS.
* 4., 5., 6. and 7. are fixes to WCAG issues that popped up on my test instance but were not reported on CI for some reason. Those are not very dangerous or complex so I figured it would be okay to provide them in the same PR.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

Before the PR:
<img width="1720" height="1280" alt="image" src="https://github.com/user-attachments/assets/bf3f0ba0-c60c-49e3-a3e3-7ab675ca602b" />
<img width="2556" height="1280" alt="image" src="https://github.com/user-attachments/assets/04400864-1b9e-4695-8c1a-bdf0318365aa" />
After the PR:
<img width="1705" height="1280" alt="image" src="https://github.com/user-attachments/assets/4e9dc2d9-be1a-495e-8ad6-f2d5984fe0d6" />
<img width="2555" height="1280" alt="image" src="https://github.com/user-attachments/assets/d948ac90-f804-47eb-93d9-0dc8ffd1ed0c" />



# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual testing on my local instance (see screenshots).
After building successfully the changes with `mvn clean install -f xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war -Pquality` and `mvn clean install -f xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates -Pquality`, I ran the docker test that are failing on CI with `mvn clean install -f xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-test/xwiki-platform-extension-test-docker -Dxwiki.test.ui.wcag=true`. The docker tests passed, and the WCAG tests did not find any violation in the test suite anymore.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None. There is quite a few changes and this UI is not critical to upgrade.