### PR TITLE
[SONAR] Fix double-checked locking: make urlFactoryService volatile in XWiki

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
@@ -347,7 +347,7 @@ public class XWiki implements EventListener
 
     private XWikiStatsService statsService;
 
-    private XWikiURLFactoryService urlFactoryService;
+    private volatile XWikiURLFactoryService urlFactoryService;
 
     private XWikiCriteriaService criteriaService;
 


### PR DESCRIPTION
## Summary

Fixes SonarCloud blocker issue [java:S2168 - Remove this dangerous instance of double-checked locking](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AW5-S62m1Yj5qvzeRn1N&open=AW5-S62m1Yj5qvzeRn1N) in `XWiki.java`.

### Problem

The `getURLFactoryService()` method uses the double-checked locking pattern:

```java
if (this.urlFactoryService == null) {         // check outside lock
    synchronized (this.URLFACTORY_SERVICE_LOCK) {
        if (this.urlFactoryService == null) {   // check inside lock
            // ... initialize ...
        }
    }
}
```

Double-checked locking is only safe in Java (since Java 5) when the guarded field is declared `volatile`. Without `volatile`, the JVM's memory model allows instruction reordering: a second thread may read a non-null but partially-initialized `urlFactoryService` reference before the constructor has finished executing.

### Fix

Declare `urlFactoryService` as `volatile`:

```java
private volatile XWikiURLFactoryService urlFactoryService;
```

This is the standard, minimal fix prescribed by the Java Memory Model. It enforces a happens-before relationship so all threads see a fully-initialized object once they observe a non-null reference.

No behaviour change for callers — the public API and return type are unchanged.

## Test plan

- [ ] Build `xwiki-platform-oldcore` with `mvn clean verify -Pquality` — passes.
- [ ] Verify the SonarCloud issue is marked as resolved after the next scan.


---
_Generated by [Claude Code](https://claude.ai/code/session_01M2PjYgcVyNAUJkm83M4LLM)_