### PR TITLE
XWIKI-24313: text is not handled as plain text in Notification

### DIFF
--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-validation/xwiki-platform-attachment-validation-ui/src/main/resources/XWiki/Attachment/Validation/Code/MimetypeValidation.xml
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-validation/xwiki-platform-attachment-validation-ui/src/main/resources/XWiki/Attachment/Validation/Code/MimetypeValidation.xml
@@ -193,7 +193,7 @@ require(['jquery', 'xwiki-l10n!attachment-validation-mimetype-messages', 'xwiki-
       if (hasBlockerMimetypes) {
         localizedMessage += '&lt;br/&gt;' + l10n.get('blockerMimetypes', blockerMimetypes)
       }
-      new XWiki.widgets.Notification(localizedMessage, "error");
+      new XWiki.widgets.Notification(localizedMessage, "error", { textHtml: true });
       event.preventDefault();
     }
   });

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/actionbuttons/actionButtons.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/actionbuttons/actionButtons.js
@@ -224,7 +224,7 @@ var XWiki = (function(XWiki) {
       this.savedBox = new XWiki.widgets.Notification("$escapetool.javascript($services.localization.render('core.editors.saveandcontinue.notification.done'))", "done", {inactive: true});
       this.failedBox = new XWiki.widgets.Notification(
         '$escapetool.javascript($services.localization.render("core.editors.saveandcontinue.notification.error", ["<span id=""ajaxRequestFailureReason""></span>"]))',
-        "error", {inactive: true});
+        "error", {inactive: true, textHtml: true});
       this.progressMessageTemplate = "$escapetool.javascript($services.localization.render('core.editors.savewithprogress.notification'))";
       this.progressBox = new XWiki.widgets.Notification(this.progressMessageTemplate.replace('__PROGRESS__', '0'), "inprogress", {inactive: true});
       this.savedWithMergeBox = new XWiki.widgets.Notification("$escapetool.javascript($services.localization.render('core.editors.saveandcontinue.notification.doneWithMerge'))", "done", {inactive: true});

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/editors/dataeditors.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/editors/dataeditors.js
@@ -556,7 +556,8 @@
               }).fail(function (error) {
                 // FIXME: we should change translation value for action.addClassProperty.error.invalidName
                 let failureReason = error.responseText.replaceAll("&#60;br/&#62;", "<br/>") || 'Server not responding';
-                notification.replace(new XWiki.widgets.Notification(l10n['class.addProperty.failed'] + failureReason, "error"));
+                notification.replace(new XWiki.widgets.Notification(l10n['class.addProperty.failed'] + failureReason,
+                  "error", {textHtml: true}));
               }).always(function () {
                 item.prop('disabled', false);
               });

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggestAttachments.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/suggestAttachments.js
@@ -448,7 +448,8 @@ define('xwiki-suggestAttachments', [
 
   var uploadFileAndShowProgress = function(attachment, selectize) {
     var attachmentName = $('<em></em>').text(attachment.label).prop('outerHTML');
-    var notification = new XWiki.widgets.Notification(l10n.get('uploading', attachmentName), 'inprogress');
+    var notification = new XWiki.widgets.Notification(l10n.get('uploading', attachmentName), 'inprogress',
+      {textHtml: true});
     attachment.data.upload = {
       status: 'pending',
       progress: {
@@ -468,12 +469,14 @@ define('xwiki-suggestAttachments', [
     }).then(attachment => {
       attachment.data.upload = {status: 'done'};
       selectize.updateOption(attachment.value, attachment);
-      notification.replace(new XWiki.widgets.Notification(l10n.get('uploadDone', attachmentName), 'done'));
+      notification.replace(new XWiki.widgets.Notification(l10n.get('uploadDone', attachmentName), 'done',
+        {textHtml: true}));
       return attachment;
     }).catch(() => {
       attachment.data.upload.status = 'failed';
       selectize.updateOption(attachment.value, attachment);
-      notification.replace(new XWiki.widgets.Notification(l10n.get('uploadFailed', attachmentName), 'error'));
+      notification.replace(new XWiki.widgets.Notification(l10n.get('uploadFailed', attachmentName), 'error',
+        {textHtml: true}));
       return Promise.reject();
     });
   };

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/notification.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/notification.js
@@ -35,9 +35,9 @@ var widgets = XWiki.widgets = XWiki.widgets || {};
  * To display a notification, it suffices to create a new XWiki.widgets.Notification object. Constructor parameters:
  * <dl>
  *   <dt>text</dt>
- *   <dd>The notification text. Since 18.4.0RC1 and 17.10.9, its values is used as plain text. Before, it was used
- *   as HTML content. You can check for the presence of the Notification.textFormat static method to know which
- *   behavior applies at runtime.</dd>
+ *   <dd>The notification text. Since 18.4.0RC1 and 17.10.9, its values is used as plain text unless textHtml is true.
+ *   Before, it was used as HTML content. You can check for the presence of the Notification.textFormat static
+ *   method to know which default behavior applies at runtime.</dd>
  *   <dt>type (optional)</dt>
  *   <dd>The notification type, one of <tt>plain</tt>, <tt>info</tt>, <tt>warning</tt>, <tt>error</tt>, <tt>inprogress</tt>,
  *    <tt>done</tt>. If an unknown or no type is passed, <tt>plain</tt> is used by default.</dd>
@@ -49,6 +49,10 @@ var widgets = XWiki.widgets = XWiki.widgets || {};
  *     <li><tt>icon</tt>: a custom image to use</li>
  *     <li><tt>color</tt>: a custom color for the text</li>
  *     <li><tt>backgroundColor</tt>: a custom color for the background</li>
+ *     <li><tt>textHtml</tt> (since 18.4.0RC1): when true, the <tt>text</tt> parameter is interpreted as HTML; when
+ *      false (default), it is used as plain text. <strong>Warning:</strong> setting this to true exposes the
+ *      notification to XSS attacks if the <tt>text</tt> value contains untrusted content; callers are responsible
+ *      for properly escaping any user-provided data before passing it in.</li>
  *   </ul>
  *   </dd>
  * </dl>
@@ -95,7 +99,8 @@ widgets.Notification = Class.create({
     "warning"    : {timeout : 5},
     "error"      : {timeout : 10},
     "inprogress" : {timeout : false},
-    "done"       : {timeout : 2}
+    "done"       : {timeout : 2},
+    textHtml     : false
   },
   initialize : function(text, type, options) {
     this.text = text || this.text;
@@ -111,7 +116,11 @@ widgets.Notification = Class.create({
     if (!this.element) {
       // The notification container is already an ARIA "alert", those notifications do not need extra semantics.
       this.element = new Element("div", {"class" : "xnotification xnotification-" + this.type});
-      this.element.textContent = this.text;
+      if (this.options.textHtml) {
+        this.element.update(this.text);
+      } else {
+        this.element.textContent = this.text;
+      }
       if (this.options.icon) {
         this.element.setStyle({backgroundImage : this.options.icon, paddingLeft : "22px"});
       }

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.js
@@ -331,7 +331,7 @@ var XWiki = (function(XWiki) {
         this.statusUI.FILE_CANCEL.addClassName('hidden');
       }
       this.formData.input.fire('xwiki:html5upload:message', {content: 'UPLOAD_FINISHING', type: 'inprogress', source: this,
-        parameters : {name : this.file.name.escapeHTML()}
+        parameters : {name : this.file.name}
       });
     },
 
@@ -360,7 +360,7 @@ var XWiki = (function(XWiki) {
         }
       }
       this.formData.input.fire('xwiki:html5upload:message', {content: 'UPLOAD_FINISHED', type: 'done', source: this,
-        parameters : {name : this.file.name.escapeHTML(), size : UploadUtils.bytesToSize(this.file.size)}
+        parameters : {name : this.file.name, size : UploadUtils.bytesToSize(this.file.size)}
       });
       this.formData.input.fire('xwiki:html5upload:fileFinished', {source: this});
       clearInterval(this.timer);
@@ -391,7 +391,7 @@ var XWiki = (function(XWiki) {
     abnormalUploadFinish : function (message) {
       clearInterval(this.timer);
       this.formData.input.fire('xwiki:html5upload:message', {content: message, type: 'error', source: this, parameters :
-       {name : this.file.name.escapeHTML()}});
+       {name : this.file.name}});
       this.formData.input.fire('xwiki:html5upload:fileFinished', {source: this});
     }
   });


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-24313

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* see https://forum.xwiki.org/t/handling-of-plain-text-vs-html-in-confirmationbox-and-notification/18446/10?u=mleduc

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Several places are actually using HTML content for legitimate reason, and we need to handle this.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-17.10.x