### PR TITLE
XWIKI-24351: Add support for parent reference to Cristal's ReferenceHandler

### DIFF
--- a/xwiki-platform-core/xwiki-platform-blocknote/xwiki-platform-blocknote-webjar/src/main/node/src/services/container.ts
+++ b/xwiki-platform-core/xwiki-platform-blocknote/xwiki-platform-blocknote-webjar/src/main/node/src/services/container.ts
@@ -65,7 +65,7 @@ DefaultModelReferenceSerializerProvider.bind(container);
 XWikiModelReferenceSerializer.bind(container);
 
 DefaultModelReferenceHandlerProvider.bind(container);
-XWikiModelReferenceHandler.bind(container);
+XWikiModelReferenceHandler.bindComponents(container);
 
 DefaultResourceReferenceParser.bind(container);
 

--- a/xwiki-platform-core/xwiki-platform-blocknote/xwiki-platform-blocknote-webjar/src/main/node/src/services/model/reference/XWikiModelReferenceHandler.ts
+++ b/xwiki-platform-core/xwiki-platform-blocknote/xwiki-platform-blocknote-webjar/src/main/node/src/services/model/reference/XWikiModelReferenceHandler.ts
@@ -23,13 +23,13 @@ import {
   EntityType,
   SpaceReference,
 } from "@xwiki/platform-model-api";
+import { AbstractModelReferenceHandler } from "@xwiki/platform-model-reference-api";
 import { Container, injectable } from "inversify";
 import type { EntityReference } from "@xwiki/platform-model-api";
-import type { ModelReferenceHandler } from "@xwiki/platform-model-reference-api";
 
 @injectable("Singleton")
-export class XWikiModelReferenceHandler implements ModelReferenceHandler {
-  public static bind(container: Container): void {
+export class XWikiModelReferenceHandler extends AbstractModelReferenceHandler {
+  public static override bind(container: Container): void {
     container
       .bind("ModelReferenceHandler")
       .to(XWikiModelReferenceHandler)

--- a/xwiki-platform-core/xwiki-platform-blocknote/xwiki-platform-blocknote-webjar/src/main/node/src/services/model/reference/XWikiModelReferenceHandler.ts
+++ b/xwiki-platform-core/xwiki-platform-blocknote/xwiki-platform-blocknote-webjar/src/main/node/src/services/model/reference/XWikiModelReferenceHandler.ts
@@ -29,7 +29,7 @@ import type { EntityReference } from "@xwiki/platform-model-api";
 
 @injectable("Singleton")
 export class XWikiModelReferenceHandler extends AbstractModelReferenceHandler {
-  public static override bind(container: Container): void {
+  public static bindComponents(container: Container): void {
     container
       .bind("ModelReferenceHandler")
       .to(XWikiModelReferenceHandler)

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/model/model-reference/model-reference-api/etc/platform-model-reference-api.api.md
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/model/model-reference/model-reference-api/etc/platform-model-reference-api.api.md
@@ -10,6 +10,18 @@ import { EntityReference } from '@xwiki/platform-model-api';
 import { EntityType } from '@xwiki/platform-model-api';
 import { SpaceReference } from '@xwiki/platform-model-api';
 
+// @beta
+export abstract class AbstractModelReferenceHandler implements ModelReferenceHandler {
+    // (undocumented)
+    abstract createDocumentReference(name: string, space: SpaceReference): DocumentReference;
+    // (undocumented)
+    getParentDocumentReference(reference: DocumentReference): DocumentReference | undefined;
+    // (undocumented)
+    getParentSpaceReference(reference: SpaceReference): SpaceReference | undefined;
+    // (undocumented)
+    abstract getTitle(reference: EntityReference): string;
+}
+
 // @beta (undocumented)
 export class ComponentInit {
     constructor(container: Container);

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/model/model-reference/model-reference-api/etc/platform-model-reference-api.api.md
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/model/model-reference/model-reference-api/etc/platform-model-reference-api.api.md
@@ -18,6 +18,8 @@ export class ComponentInit {
 // @beta
 export interface ModelReferenceHandler {
     createDocumentReference(name: string, space: SpaceReference): DocumentReference;
+    getParentDocumentReference(reference: DocumentReference): DocumentReference | undefined;
+    getParentSpaceReference(reference: SpaceReference): SpaceReference | undefined;
     getTitle(reference: EntityReference): string;
 }
 

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/model/model-reference/model-reference-api/src/abstractModelReferenceHandler.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/model/model-reference/model-reference-api/src/abstractModelReferenceHandler.ts
@@ -1,0 +1,67 @@
+/**
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+import { DocumentReference, SpaceReference } from "@xwiki/platform-model-api";
+import type { ModelReferenceHandler } from "./modelReferenceHandler";
+import type { EntityReference } from "@xwiki/platform-model-api";
+
+/**
+ * Shared methods implementation for instances of {@link ModelReferenceHandler}.
+ *
+ * @since 18.4.0RC1
+ * @beta
+ */
+abstract class AbstractModelReferenceHandler implements ModelReferenceHandler {
+  abstract createDocumentReference(
+    name: string,
+    space: SpaceReference,
+  ): DocumentReference;
+  abstract getTitle(reference: EntityReference): string;
+
+  getParentDocumentReference(
+    reference: DocumentReference,
+  ): DocumentReference | undefined {
+    const parentSpace = reference.space
+      ? this.getParentSpaceReference(reference.space)
+      : undefined;
+
+    if (parentSpace) {
+      return this.createDocumentReference(
+        reference.space!.names.at(-1)!,
+        parentSpace,
+      );
+    }
+  }
+
+  getParentSpaceReference(
+    reference: SpaceReference,
+  ): SpaceReference | undefined {
+    if (reference.names.length > 0) {
+      return new SpaceReference(
+        reference.wiki,
+        ...reference.names.slice(0, -1),
+      );
+    } else {
+      return undefined;
+    }
+  }
+}
+
+export { AbstractModelReferenceHandler };

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/model/model-reference/model-reference-api/src/defaultModelReferenceHandler.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/model/model-reference/model-reference-api/src/defaultModelReferenceHandler.ts
@@ -18,6 +18,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
+import { AbstractModelReferenceHandler } from "./abstractModelReferenceHandler";
 import {
   AttachmentReference,
   DocumentReference,
@@ -25,7 +26,6 @@ import {
   SpaceReference,
 } from "@xwiki/platform-model-api";
 import { injectable } from "inversify";
-import type { ModelReferenceHandler } from "./modelReferenceHandler";
 import type { EntityReference, WikiReference } from "@xwiki/platform-model-api";
 
 /**
@@ -35,7 +35,7 @@ import type { EntityReference, WikiReference } from "@xwiki/platform-model-api";
  * @beta
  */
 @injectable()
-class DefaultModelReferenceHandler implements ModelReferenceHandler {
+class DefaultModelReferenceHandler extends AbstractModelReferenceHandler {
   createDocumentReference(
     name: string,
     space: SpaceReference,
@@ -53,34 +53,6 @@ class DefaultModelReferenceHandler implements ModelReferenceHandler {
         return (reference as DocumentReference).name;
       case EntityType.ATTACHMENT:
         return (reference as AttachmentReference).name;
-    }
-  }
-
-  getParentDocumentReference(
-    reference: DocumentReference,
-  ): DocumentReference | undefined {
-    const parentSpace = reference.space
-      ? this.getParentSpaceReference(reference.space)
-      : undefined;
-
-    if (parentSpace) {
-      return this.createDocumentReference(
-        reference.space!.names.at(-1)!,
-        parentSpace,
-      );
-    }
-  }
-
-  getParentSpaceReference(
-    reference: SpaceReference,
-  ): SpaceReference | undefined {
-    if (reference.names.length > 0) {
-      return new SpaceReference(
-        reference.wiki,
-        ...reference.names.slice(0, -1),
-      );
-    } else {
-      return undefined;
     }
   }
 }

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/model/model-reference/model-reference-api/src/defaultModelReferenceHandler.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/model/model-reference/model-reference-api/src/defaultModelReferenceHandler.ts
@@ -22,14 +22,11 @@ import {
   AttachmentReference,
   DocumentReference,
   EntityType,
+  SpaceReference,
 } from "@xwiki/platform-model-api";
 import { injectable } from "inversify";
 import type { ModelReferenceHandler } from "./modelReferenceHandler";
-import type {
-  EntityReference,
-  SpaceReference,
-  WikiReference,
-} from "@xwiki/platform-model-api";
+import type { EntityReference, WikiReference } from "@xwiki/platform-model-api";
 
 /**
  * Default implementation for {@link ModelReferenceHandler}.
@@ -52,13 +49,39 @@ class DefaultModelReferenceHandler implements ModelReferenceHandler {
         return (reference as WikiReference).name;
       case EntityType.SPACE:
         return [...(reference as SpaceReference).names].pop()!;
-      case EntityType.DOCUMENT: {
+      case EntityType.DOCUMENT:
         return (reference as DocumentReference).name;
-      }
       case EntityType.ATTACHMENT:
         return (reference as AttachmentReference).name;
     }
-    return "";
+  }
+
+  getParentDocumentReference(
+    reference: DocumentReference,
+  ): DocumentReference | undefined {
+    const parentSpace = reference.space
+      ? this.getParentSpaceReference(reference.space)
+      : undefined;
+
+    if (parentSpace) {
+      return this.createDocumentReference(
+        reference.space!.names.at(-1)!,
+        parentSpace,
+      );
+    }
+  }
+
+  getParentSpaceReference(
+    reference: SpaceReference,
+  ): SpaceReference | undefined {
+    if (reference.names.length > 0) {
+      return new SpaceReference(
+        reference.wiki,
+        ...reference.names.slice(0, -1),
+      );
+    } else {
+      return undefined;
+    }
   }
 }
 

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/model/model-reference/model-reference-api/src/index.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/model/model-reference/model-reference-api/src/index.ts
@@ -18,6 +18,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
+import { AbstractModelReferenceHandler } from "./abstractModelReferenceHandler";
 import { ComponentInit } from "./componentInit";
 import type { ModelReferenceHandler } from "./modelReferenceHandler";
 import type { ModelReferenceHandlerProvider } from "./modelReferenceHandlerProvider";
@@ -27,6 +28,7 @@ import type { ModelReferenceParserProvider } from "./modelReferenceParserProvide
 import type { ModelReferenceSerializer } from "./modelReferenceSerializer";
 import type { ModelReferenceSerializerProvider } from "./modelReferenceSerializerProvider";
 export {
+  AbstractModelReferenceHandler,
   ComponentInit,
   type ModelReferenceHandler,
   type ModelReferenceHandlerProvider,

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/model/model-reference/model-reference-api/src/modelReferenceHandler.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/model/model-reference/model-reference-api/src/modelReferenceHandler.ts
@@ -55,7 +55,6 @@ interface ModelReferenceHandler {
    * the given document reference.
    * @param reference - the reference for which we want the parent
    * @returns the parent for the given reference, undefined if there is none
-
    *
    * @since 18.4.0RC1
    * @beta

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/model/model-reference/model-reference-api/src/modelReferenceHandler.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/model/model-reference/model-reference-api/src/modelReferenceHandler.ts
@@ -54,7 +54,8 @@ interface ModelReferenceHandler {
    * Returns the {@link DocumentReference} considered as the direct parent of
    * the given document reference.
    * @param reference - the reference for which we want the parent
-   * @returns the parent for the given reference
+   * @returns the parent for the given reference, undefined if there is none
+
    *
    * @since 18.4.0RC1
    * @beta
@@ -67,7 +68,7 @@ interface ModelReferenceHandler {
    * Returns the {@link SpaceReference} considered as the direct parent of
    * the given space reference.
    * @param reference - the reference for which we want the parent
-   * @returns the parent for the given reference
+   * @returns the parent for the given reference, undefined if there is none
    *
    * @since 18.4.0RC1
    * @beta

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/model/model-reference/model-reference-api/src/modelReferenceHandler.ts
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/model/model-reference/model-reference-api/src/modelReferenceHandler.ts
@@ -49,6 +49,32 @@ interface ModelReferenceHandler {
    * Return the title of a reference
    */
   getTitle(reference: EntityReference): string;
+
+  /**
+   * Returns the {@link DocumentReference} considered as the direct parent of
+   * the given document reference.
+   * @param reference - the reference for which we want the parent
+   * @returns the parent for the given reference
+   *
+   * @since 18.4.0RC1
+   * @beta
+   */
+  getParentDocumentReference(
+    reference: DocumentReference,
+  ): DocumentReference | undefined;
+
+  /**
+   * Returns the {@link SpaceReference} considered as the direct parent of
+   * the given space reference.
+   * @param reference - the reference for which we want the parent
+   * @returns the parent for the given reference
+   *
+   * @since 18.4.0RC1
+   * @beta
+   */
+  getParentSpaceReference(
+    reference: SpaceReference,
+  ): SpaceReference | undefined;
 }
 
 export type { ModelReferenceHandler };


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-24351

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
This PR adds two methods to Cristal's ReferenceHandler: `getParentDocumentReference` and `getParentSpaceReference`. It also includes default implementations that should work for all current Cristal's supported backends.

While I was at it, I also cleaned up a few issues in the rest of the files.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

This is a required PR for https://github.com/xwiki-contrib/cristal/pull/1635

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
N/A

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches: N/A