### PR TITLE
XWIKI-24113: Tomcat cache warnings when starting XWiki 18.0.0+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
     <rssreader.version>3.12.0</rssreader.version>
 
     <!-- The default Tomcat cache size  -->
-    <xwiki.tomcat.cacheMaxSize>100176</xwiki.tomcat.cacheMaxSize>
+    <xwiki.tomcat.cacheMaxSize>120176</xwiki.tomcat.cacheMaxSize>
 
     <!-- Versions of other software we need in our functional tests -->
     <!-- The LO version must point to the latest version from "Still" branch (LTS). When upgrading the version make


### PR DESCRIPTION
https://jira.xwiki.org/browse/XWIKI-24113

# Jira URL

https://jira.xwiki.org/browse/XWIKI-24113

# Changes

## Description

Increase cache value from 100176 to 120176

# Executed Tests

Manual tests with Tomcat 11.0.22

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * stable-17.10.x