### PR TITLE
Fix SonarQube S1845: Rename Package#toXml to toXMLString to avoid case-only method name clash

### DIFF
--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/plugin/packaging/PackageCompatibilityAspect.aj
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/plugin/packaging/PackageCompatibilityAspect.aj
@@ -1,0 +1,41 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xpn.xwiki.plugin.packaging;
+
+import com.xpn.xwiki.XWikiContext;
+
+/**
+ * Add a backward compatibility layer to the {@link Package} class.
+ *
+ * @version $Id$
+ */
+public privileged aspect PackageCompatibilityAspect
+{
+    /**
+     * @param context the current XWiki context
+     * @return a package.xml file for this package as a String
+     * @deprecated since 18.5.0RC1, use {@link Package#toXMLString(XWikiContext)} instead
+     */
+    @Deprecated
+    public String Package.toXml(XWikiContext context)
+    {
+        return toXMLString(context);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/plugin/packaging/PackageCompatibilityAspect.aj
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/aspect/com/xpn/xwiki/plugin/packaging/PackageCompatibilityAspect.aj
@@ -25,15 +25,16 @@ import com.xpn.xwiki.XWikiContext;
  * Add a backward compatibility layer to the {@link Package} class.
  *
  * @version $Id$
+ * @since 18.5.0RC1
  */
 public privileged aspect PackageCompatibilityAspect
 {
     /**
      * @param context the current XWiki context
      * @return a package.xml file for this package as a String
-     * @deprecated since 18.5.0RC1, use {@link Package#toXMLString(XWikiContext)} instead
+     * @deprecated use {@link Package#toXMLString(XWikiContext)} instead
      */
-    @Deprecated
+    @Deprecated(since = "18.5.0RC1")
     public String Package.toXml(XWikiContext context)
     {
         return toXMLString(context);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/Package.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/Package.java
@@ -1056,7 +1056,7 @@ public class Package
      *
      * @param context the current XWiki context
      * @return a package.xml file for this package as a String
-     * @since 2.3M2
+     * @since 18.5.0RC1
      */
     public String toXMLString(XWikiContext context)
     {
@@ -1068,15 +1068,6 @@ public class Package
             e.printStackTrace();
             return "";
         }
-    }
-
-    /**
-     * @deprecated since 2.3M2, use {@link #toXMLString(XWikiContext)} instead
-     */
-    @Deprecated
-    public String toXml(XWikiContext context)
-    {
-        return toXMLString(context);
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/Package.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/Package.java
@@ -1051,12 +1051,14 @@ public class Package
     }
 
     /**
-     * You should prefer {@link #toXML(com.xpn.xwiki.internal.xml.XMLWriter)}. If an error occurs, a stacktrace is dump
-     * to logs, and an empty String is returned.
+     * Serialize the package descriptor to an XML string. If an error occurs, a stacktrace is dumped to logs, and an
+     * empty String is returned.
      *
-     * @return a package.xml file for the this package
+     * @param context the current XWiki context
+     * @return a package.xml file for this package as a String
+     * @since 2.3M2
      */
-    public String toXml(XWikiContext context)
+    public String toXMLString(XWikiContext context)
     {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try {
@@ -1066,6 +1068,15 @@ public class Package
             e.printStackTrace();
             return "";
         }
+    }
+
+    /**
+     * @deprecated since 2.3M2, use {@link #toXMLString(XWikiContext)} instead
+     */
+    @Deprecated
+    public String toXml(XWikiContext context)
+    {
+        return toXMLString(context);
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/PackageAPI.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/PackageAPI.java
@@ -295,7 +295,7 @@ public class PackageAPI extends Api
 
     public String toXml()
     {
-        return this.pack.toXml(getXWikiContext());
+        return this.pack.toXMLString(getXWikiContext());
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes two BLOCKER-level SonarQube issues (rule `java:S1845`) in `Package.java` where methods named `toXml` and `toXML` differed only by case, causing potential confusion for developers.

### Changes

- **`Package.java`**: Renamed `toXml(XWikiContext)` → `toXMLString(XWikiContext)` to make its return type (String) explicit in the name and eliminate the case-only clash with `toXML(XMLWriter)` and `toXML(OutputStream, XWikiContext)`. The old `toXml(XWikiContext)` is kept as a `@Deprecated` delegate for backward compatibility.
- **`PackageAPI.java`**: Updated the internal call from `pack.toXml(...)` to `pack.toXMLString(...)` to avoid using the deprecated method.

### Backward Compatibility

The deprecated `toXml(XWikiContext)` wrapper is retained in `Package` so existing callers are not broken. `PackageAPI#toXml()` (the public scripting API method) continues to work unchanged.

## SonarCloud Issues Fixed

- https://sonarcloud.io/project/issues?issues=AW5-S6tI1Yj5qvzeRnn8,AW5-S6tI1Yj5qvzeRnn9&open=AW5-S6tI1Yj5qvzeRnn8&id=org.xwiki.platform%3Axwiki-platform

## Test plan

- [x] `mvn clean verify -Pquality` passes on `xwiki-platform-oldcore` (1119 tests, 0 failures)
- [x] No public API breakage: deprecated wrapper preserves existing callers
- [x] `PackageAPI#toXml()` scripting method still works (calls `toXMLString` internally)

https://claude.ai/code/session_01Q3VyohR4bFNxpSt5gvDDNN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3VyohR4bFNxpSt5gvDDNN)_