### PR TITLE
Fix SonarQube S5361: Replace replaceAll() with replace() in AttachmentResourceImpl

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/attachments/AttachmentResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/attachments/AttachmentResourceImpl.java
@@ -66,7 +66,7 @@ public class AttachmentResourceImpl extends BaseAttachmentsResource implements A
             }
 
             String ofilename = Util.encodeURI(xwikiAttachment.getFilename(), getXWikiContext())
-                .replaceAll("\\+", "%20");
+                .replace("+", "%20");
             // The inline attribute of Content-Disposition tells the browser that they should display
             // the downloaded file in the page (see http://www.ietf.org/rfc/rfc1806.txt for more
             // details). We do this so that JPG, GIF, PNG, etc are displayed without prompting a Save


### PR DESCRIPTION
## Summary

Replace the regex-based `replaceAll("\\+", "%20")` with the literal string `replace("+", "%20")` in `AttachmentResourceImpl.java`. Since the pattern `+` contains no regex metacharacters, using `replaceAll()` is unnecessary — `replace()` is clearer and more efficient.

This fixes the SonarQube rule [java:S5361](https://rules.sonarsource.com/java/RSPEC-5361/): *"Replace this call to `replaceAll()` by a call to the `replace()` method."*

## SonarCloud Issue

https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AZ3Qk1YpGYAMZSw7Wia8&open=AZ3Qk1YpGYAMZSw7Wia8

## Files Changed

- `xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/attachments/AttachmentResourceImpl.java` — line 69: `replaceAll("\\+", "%20")` → `replace("+", "%20")`

## Test plan

- [x] Module builds successfully with `mvn clean verify -Pquality`
- [x] No behavioral change: `String.replace(CharSequence, CharSequence)` does literal string replacement, identical semantics to `replaceAll("\\+", ...)` with a literal-only regex pattern


---
_Generated by [Claude Code](https://claude.ai/code/session_016skjQmUhwn1nznuYJpi1N1)_