### PR TITLE
[Misc] Use PROPERTY_TYPE constant instead of duplicating literals in BooleanClass and StringClass

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BooleanClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BooleanClass.java
@@ -59,7 +59,7 @@ public class BooleanClass extends PropertyClass
     
     public BooleanClass(PropertyMetaClass wclass)
     {
-        super(XCLASSNAME, "Boolean", wclass);
+        super(XCLASSNAME, PROPERTY_TYPE, wclass);
     }
 
     public BooleanClass()

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/StringClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/StringClass.java
@@ -60,7 +60,7 @@ public class StringClass extends PropertyClass
 
     public StringClass(PropertyMetaClass wclass)
     {
-        this(XCLASSNAME, "String", wclass);
+        this(XCLASSNAME, PROPERTY_TYPE, wclass);
     }
 
     public StringClass()


### PR DESCRIPTION
## Summary

Replace hardcoded `"Boolean"` and `"String"` string literals in constructor calls with the already-defined `PROPERTY_TYPE` constants to eliminate duplicate literals flagged by SonarCloud.

### Changes

- `BooleanClass.java`: Replace `"Boolean"` literal with `PROPERTY_TYPE` constant in `super()` call
- `StringClass.java`: Replace `"String"` literal with `PROPERTY_TYPE` constant in `this()` call

### SonarCloud Issues Fixed

- [AZzGqNeoXFD7Ud6sqSQN - BooleanClass: Use already-defined constant 'PROPERTY_TYPE'](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&open=AZzGqNeoXFD7Ud6sqSQN)
- [AZzGqNhnXFD7Ud6sqSQO - StringClass: Use already-defined constant 'PROPERTY_TYPE'](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&open=AZzGqNhnXFD7Ud6sqSQO)

### Backward Compatibility

No behavior change — `PROPERTY_TYPE` holds the exact same value as the duplicated literals (`"Boolean"` and `"String"` respectively). This is a pure code quality improvement.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPpJfyHfWMuTbyHRHYWXeC)_