### PR TITLE
XWIKI-24331: Extension page WCAG fails: contrast and text alternative

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/extension.vm
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-templates/src/main/resources/templates/extension.vm
@@ -142,27 +142,29 @@
       </div>
     </form>
     ## Advanced search form.
-    <form action="$xwiki.relativeRequestURL" class="xform extension-search-more collapse#if($customExtensionFilter) in#end" role="tabpanel">
-      <fieldset id="extension-search-advanced">
-        <legend><a href="#extension-search-advanced-body">$services.localization.render('extensions.advancedSearch.title')</a></legend>
-        <div id="extension-search-advanced-body"></div>
-        <div class="plainmessage extension-search-advanced-popup hidden">
-          #if ($request.section)
-            <input type="hidden" name="section" value="$escapetool.xml($request.section)" />
-          #end
-          <dl>
-            <dt><label for="advancedExtensionSearch-id">$services.localization.render('extensions.advancedSearch.id.label')</label></dt>
-            <dd><input type="text" name="extensionId" id="advancedExtensionSearch-id" value="" /></dd>
-            <dt><label for="advancedExtensionSearch-version">$services.localization.render('extensions.advancedSearch.version.label')</label></dt>
-            <dd><input type="text" name="extensionVersion" id="advancedExtensionSearch-version" value="" /></dd>
-          </dl>
-          <p>
-            #em_submitButton('extensions.advancedSearch.actions.submit')
-            #em_linkButton('#extension-search-simple' 'extensions.advancedSearch.actions.cancel' 'actionCancel')
-          </p>
-        </div>
-      </fieldset>
-    </form>
+    <div class="extension-search-more collapse#if($customExtensionFilter) in#end" role="tabpanel">
+      <form action="$xwiki.relativeRequestURL" class="xform">
+        <fieldset id="extension-search-advanced">
+          <legend><a href="#extension-search-advanced-body">$services.localization.render('extensions.advancedSearch.title')</a></legend>
+          <div id="extension-search-advanced-body"></div>
+          <div class="plainmessage extension-search-advanced-popup hidden">
+            #if ($request.section)
+              <input type="hidden" name="section" value="$escapetool.xml($request.section)" />
+            #end
+            <dl>
+              <dt><label for="advancedExtensionSearch-id">$services.localization.render('extensions.advancedSearch.id.label')</label></dt>
+              <dd><input type="text" name="extensionId" id="advancedExtensionSearch-id" value="" /></dd>
+              <dt><label for="advancedExtensionSearch-version">$services.localization.render('extensions.advancedSearch.version.label')</label></dt>
+              <dd><input type="text" name="extensionVersion" id="advancedExtensionSearch-version" value="" /></dd>
+            </dl>
+            <p>
+              #em_submitButton('extensions.advancedSearch.actions.submit')
+              #em_linkButton('#extension-search-simple' 'extensions.advancedSearch.actions.cancel' 'actionCancel')
+            </p>
+          </div>
+        </fieldset>
+      </form>
+    </div>
     <div class="clearfloats"></div>
   </div>
 #end


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-24331

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Separated the form and collapsible panel nodes to solve a webstandard issue

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* The tabpanel role is what makes sense with the collapse pattern from bootstrap. This used to be applied directly on the form, but it ends up in incorrect HTML. Separating both roles in two nodes makes the HTML clearer.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
After the PR changes:
<img width="2560" height="1322" alt="image" src="https://github.com/user-attachments/assets/964c8784-ccff-4b78-a66d-1d7457eecfc3" />


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
I tested the changed DOM quickly on my local instance (see screenshot above). Both style and functionality looked unchanged.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 18.4.x (same as https://github.com/xwiki/xwiki-platform/pull/5486)