### PR TITLE
[SONAR] Replace replaceAll() with replace() in SkinAction for literal string replacement

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SkinAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SkinAction.java
@@ -508,7 +508,7 @@ public class SkinAction extends XWikiAction
                 setupHeaders(response, mimetype, attachment.getDate(), attachment.getContentLongSize(context));
                 String contentDisposition = (attachmentSecurityManager.shouldBeDownloaded(attachment))
                     ? "attachment" : "inline";
-                String ofilename = Util.encodeURI(filename, context).replaceAll("\\+", "%20");
+                String ofilename = Util.encodeURI(filename, context).replace("+", "%20");
                 response.setHeader("Content-Disposition",
                     String.format("%s; filename*=utf-8''%s", contentDisposition, ofilename));
                 try (InputStream input = attachment.getContentInputStream(context)) {


### PR DESCRIPTION
## Summary

Replace `String.replaceAll("\\+", "%20")` with `String.replace("+", "%20")` in `SkinAction.java` since the pattern is a plain literal string, not a regular expression.

## Details

- Using `replaceAll()` with a literal string unnecessarily compiles a regex pattern at runtime
- Using `replace()` with a `CharSequence` is more efficient and makes the intent clearer
- This fixes SonarQube rule [java:S5361](https://rules.sonarsource.com/java/RSPEC-5361/): "String.replaceAll() should not be used when String.replace() suffices"

## SonarCloud Issue

https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AZ4957U8pF59qXp1mDf2&open=AZ4957U8pF59qXp1mDf2

## Test plan

- [x] The modified module `xwiki-platform-oldcore` builds successfully with `mvn clean verify -Pquality`
- [x] No behavioral change: `replace("+", "%20")` and `replaceAll("\\+", "%20")` produce identical results for all inputs

https://claude.ai/code/session_01R4auBxxSKJh4yhL1xzLJZa

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4auBxxSKJh4yhL1xzLJZa)_