### PR TITLE
Improve engine class handling in CaptchaServiceManager

### DIFF
--- a/xwiki-platform-core/xwiki-platform-captcha/xwiki-platform-captcha-api/src/main/java/org/xwiki/captcha/CaptchaException.java
+++ b/xwiki-platform-core/xwiki-platform-captcha/xwiki-platform-captcha-api/src/main/java/org/xwiki/captcha/CaptchaException.java
@@ -33,6 +33,17 @@ public class CaptchaException extends Exception
      * Constructor.
      *
      * @param message the detail message
+     * @since 18.5.0RC1
+     */
+    public CaptchaException(String message)
+    {
+        super(message);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param message the detail message
      * @param cause the cause of this exception
      */
     public CaptchaException(String message, Throwable cause)

--- a/xwiki-platform-core/xwiki-platform-captcha/xwiki-platform-captcha-jcaptcha/xwiki-platform-captcha-jcaptcha-api/src/main/java/org/xwiki/captcha/internal/CaptchaServiceManager.java
+++ b/xwiki-platform-core/xwiki-platform-captcha/xwiki-platform-captcha-jcaptcha/xwiki-platform-captcha-jcaptcha-api/src/main/java/org/xwiki/captcha/internal/CaptchaServiceManager.java
@@ -67,19 +67,20 @@ public class CaptchaServiceManager implements Initializable
      */
     public CaptchaService getCaptchaService(String engine) throws CaptchaException
     {
-        CaptchaService result = null;
-
-        CaptchaEngine captchaEngine = null;
+        CaptchaEngine captchaEngine;
 
         try {
-            Class<CaptchaEngine> engineClass = (Class<CaptchaEngine>) Class.forName(engine);
-            captchaEngine = engineClass.getConstructor(null).newInstance(null);
+            Class<?> engineClass = Class.forName(engine);
+            if (!CaptchaEngine.class.isAssignableFrom(engineClass)) {
+                throw new CaptchaException(String.format("Invalid engine [%s]: not a CaptchaEngine", engine));
+            }
+            captchaEngine = (CaptchaEngine) engineClass.getDeclaredConstructor().newInstance();
+        } catch (CaptchaException e) {
+            throw e;
         } catch (Exception e) {
             throw new CaptchaException(String.format("Invalid engine [%s]", engine), e);
         }
 
-        result = new GenericManageableCaptchaService(captchaStore, captchaEngine, 180, 100000, 75000);
-
-        return result;
+        return new GenericManageableCaptchaService(captchaStore, captchaEngine, 180, 100000, 75000);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-captcha/xwiki-platform-captcha-jcaptcha/xwiki-platform-captcha-jcaptcha-api/src/test/java/org/xwiki/captcha/internal/CaptchaServiceManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-captcha/xwiki-platform-captcha-jcaptcha/xwiki-platform-captcha-jcaptcha-api/src/test/java/org/xwiki/captcha/internal/CaptchaServiceManagerTest.java
@@ -1,0 +1,69 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.captcha.internal;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xwiki.captcha.CaptchaException;
+import org.xwiki.component.phase.InitializationException;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Validate the behaviour of {@link CaptchaServiceManager}.
+ *
+ * @version $Id$
+ * @since 18.5.0RC1
+ */
+class CaptchaServiceManagerTest
+{
+    private CaptchaServiceManager captchaServiceManager;
+
+    @BeforeEach
+    void setUp() throws InitializationException
+    {
+        captchaServiceManager = new CaptchaServiceManager();
+        captchaServiceManager.initialize();
+    }
+
+    @Test
+    void getCaptchaStoreIsNotNull()
+    {
+        assertNotNull(captchaServiceManager.getCaptchaStore());
+    }
+
+    @Test
+    void getCaptchaServiceWithNonExistentClass()
+    {
+        CaptchaException exception = assertThrows(CaptchaException.class,
+            () -> captchaServiceManager.getCaptchaService("com.example.NonExistentEngine"));
+        assertTrue(exception.getMessage().contains("com.example.NonExistentEngine"));
+    }
+
+    @Test
+    void getCaptchaServiceWithNonEngineClass()
+    {
+        CaptchaException exception = assertThrows(CaptchaException.class,
+            () -> captchaServiceManager.getCaptchaService("java.lang.String"));
+        assertTrue(exception.getMessage().contains("not a CaptchaEngine"));
+    }
+}


### PR DESCRIPTION
## Summary

- Validate that the engine class is assignable to `CaptchaEngine` before instantiating it in `CaptchaServiceManager.getCaptchaService()`
- Replace deprecated `getConstructor(null).newInstance(null)` with `getDeclaredConstructor().newInstance()`
- Add a message-only constructor to `CaptchaException` (previously only a two-argument constructor existed)
- Add `CaptchaServiceManagerTest` covering the engine class validation logic

## Test plan

- [x] New `CaptchaServiceManagerTest` passes: verifies that non-`CaptchaEngine` classes and non-existent class names are rejected with a `CaptchaException`
- [x] `mvn clean verify -Pquality` passes on the `xwiki-platform-captcha` module (all 16 tests pass, coverage above threshold)