### PR TITLE
XWIKI-24340: Annotations cannot be added one after another on the same line anymore in some conditions

### DIFF
--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Script.xml
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Script.xml
@@ -415,6 +415,8 @@ XWiki.Selection = Class.create({
       subLeft = left.substring(left.length - leftExpansion, left.length);
     }
     this.selectionContext = subLeft + this.selectionText + subRight;
+    this.selectionContext.replaceAll(
+        "$escapetool.xml($services.localization.render('annotations.annotated.highlight.toggle.hint'))", '');
     this.selectionOffset = Math.max(subLeft.length, 0);
   },
 

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Script.xml
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Script.xml
@@ -150,6 +150,14 @@ XWiki.Selection = Class.create({
     }
     this.container = container;
   },
+  
+  // This method should only be used internally.
+  // Filter a string to remove all occurrences of the annotation text alternative.
+  // This allows to get the same result from the content picked on the page whether annotations are shown or not.
+  filterText : function(text) {
+    return text.replaceAll(
+      "$escapetool.xml($services.localization.render('annotations.annotated.highlight.toggle.hint'))",'');
+  },
 
   computeSelection : function () {
     // reset the selection state
@@ -171,8 +179,7 @@ XWiki.Selection = Class.create({
       return;
     }
     this.selectionText = this.range.toString();
-    this.selectionText = this.selectionText.replaceAll(
-        "$escapetool.xml($services.localization.render('annotations.annotated.highlight.toggle.hint'))",'')
+    this.selectionText = this.filterText(this.selectionText);
     if (this.selectionText.strip() == '') {
       this.selectionText = false;
     }
@@ -396,10 +403,10 @@ XWiki.Selection = Class.create({
 
   computeContextFF : function() {
     var left = this.getLeftDocument(this.range.startContainer) + this.range.startContainer.textContent.substring(0, this.range.startOffset);
-    left = left.replaceAll("$escapetool.xml($services.localization.render('annotations.annotated.highlight.toggle.hint'))", '');
+    left = this.filterText(left);
     var subLeft = '';
     var right = this.range.endContainer.textContent.substring(this.range.endOffset, this.range.endContainer.textContent.length) + this.getRightDocument(this.range.endContainer);
-    right = right.replaceAll("$escapetool.xml($services.localization.render('annotations.annotated.highlight.toggle.hint'))", '');
+    right = this.filterText(right);
     var subRight = '';
     var offset = 0;
     var context = this.range.toString();

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Script.xml
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Script.xml
@@ -396,8 +396,10 @@ XWiki.Selection = Class.create({
 
   computeContextFF : function() {
     var left = this.getLeftDocument(this.range.startContainer) + this.range.startContainer.textContent.substring(0, this.range.startOffset);
+    left = left.replaceAll("$escapetool.xml($services.localization.render('annotations.annotated.highlight.toggle.hint'))", '');
     var subLeft = '';
     var right = this.range.endContainer.textContent.substring(this.range.endOffset, this.range.endContainer.textContent.length) + this.getRightDocument(this.range.endContainer);
+    right = right.replaceAll("$escapetool.xml($services.localization.render('annotations.annotated.highlight.toggle.hint'))", '');
     var subRight = '';
     var offset = 0;
     var context = this.range.toString();
@@ -415,8 +417,6 @@ XWiki.Selection = Class.create({
       subLeft = left.substring(left.length - leftExpansion, left.length);
     }
     this.selectionContext = subLeft + this.selectionText + subRight;
-    this.selectionContext.replaceAll(
-        "$escapetool.xml($services.localization.render('annotations.annotated.highlight.toggle.hint'))", '');
     this.selectionOffset = Math.max(subLeft.length, 0);
   },
 


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-24340

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Filtered the annotation context to remove the text alternative of the buttons for other annotations.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* There was filtering already done on the content itself at https://github.com/xwiki/xwiki-platform/blob/895dad437d6e154a03af95c88bd76b6f96c7df31/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Script.xml#L1040
* We need to filter directly `left` and `right` so that the computed `selectionOffset` is correct. `selectionOffset` is computed from `subLeft` and not the context itself.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
After the PR:
<img width="2560" height="1322" alt="image" src="https://github.com/user-attachments/assets/2568f513-a615-426a-9035-0047136d9f0e" />

We can see on this screenshot that the `selectionContext` does not contain any "hidden" annotation bubble toggle alternative text. In addition, the number in `selectionOffset` matches this string.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests. 
This PR only proposes changes to the logic of the `AnnotationCode.Script` JSX, there is no change in the DOM.
I followed the process described in the ticket description and cannot reproduce the result anymore.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 18.4.X