### PR TITLE
XWIKI-24339: Annotated words that were modified are not differentiated anymore

### DIFF
--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Script.xml
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Script.xml
@@ -1052,6 +1052,7 @@ XWiki.Annotation = Class.create({
     var wrapper = document.createElement('mark');
     wrapper.addClassName('annotation');
     wrapper.addClassName('ID' + ann.annotationId);
+    wrapper.addClassName(ann.state.toLowerCase());
     var parentNode = markedNode.parentElement;
     parentNode.replaceChild(wrapper, markedNode);
     wrapper.appendChild(markedNode);

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Style.xml
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Style.xml
@@ -272,11 +272,11 @@
   cursor: pointer;
 
   &amp;.updated {
-  background-color: var(--mark-updated-bg);
+    background-color: var(--mark-updated-bg);
   }
 
   &amp;.altered {
-  background-color: var(--mark-altered-bg);
+    background-color: var(--mark-altered-bg);
   }
   
   &amp;.hovered,

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Style.xml
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui/src/main/resources/AnnotationCode/Style.xml
@@ -270,6 +270,15 @@
      The highlights can happen in the middle of words, and it would look odd. */
   padding: 0;
   cursor: pointer;
+
+  &amp;.updated {
+  background-color: var(--mark-updated-bg);
+  }
+
+  &amp;.altered {
+  background-color: var(--mark-altered-bg);
+  }
+  
   &amp;.hovered,
   &amp;.hovered .annotation-highlight, &amp;.hovered .selection-highlight {
     /* We want to increase the accent on the element when hovered. 
@@ -422,12 +431,10 @@ mark.annotation:not(.annotation-highlight) {
   background: transparent #attImgURL('notesmall') left 4px no-repeat;
   text-align: justify;
 }
-#allAnnotations .UPDATED .annotationText, #xwikicontent .UPDATED {
-  ##background-image: #imgURL('note_error');
+#allAnnotations .UPDATED .annotationText {
   background-image: #attImgURL('notesmallorange');
 }
-#allAnnotations .ALTERED annotationText, #xwikicontent .ALTERED {
-  ##background-image: #imgURL('note_delete');
+#allAnnotations .ALTERED annotationText {
   background-image: #attImgURL('notesmallred');
 }
 

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/cssVariablesInit.css
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/cssVariablesInit.css
@@ -46,6 +46,8 @@
 "font-weight-semibold": 700,
 "font-weight-bold": "900",
 "mark-bg": "color-mix(in srgb, var(--btn-warning-bg), white)",
+"mark-updated-bg": "color-mix(in srgb, var(--btn-warning-bg), var(--btn-danger-bg) 20%, white)",
+"mark-altered-bg": "color-mix(in srgb, var(--btn-danger-bg), white)",
 "mark-highlighted-bg": "var(--btn-warning-bg)"
 })
 


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-24339

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added two new variables for the background of special status annotations (orangish and brand-danger variation)
* Added the state information back on the mark wrapper.
* Updated the style to use this info and the new variables and make the state visible again.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* At https://github.com/xwiki/xwiki-platform/commit/9534b9f1d07ab817e86e67ae5d5d6b17641efa2c#diff-6fae9d69c9935f88c56cf7c9fde0f2f98b2cee09a3810b706400d3c1b007f437L988 I removed the old marker for annotations. I did not notice that the `ann.state` class contained in there was meaningful.
* I decided to add the color variables directly in the flamingo skin. We could have decided those are too specific and only define them in the annotation module.
* I blended the danger and warning colors so that the result would be a orange that works well with the other colors in the Icerberg colortheme. It might not result in such a neat middle ground for other colorthemes, but it's better than hard-coding things.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
After the PR was applied, on my local instance:
<img width="2560" height="1322" alt="Screenshot From 2026-05-20 11-48-28" src="https://github.com/user-attachments/assets/6dcba1ff-99c5-49f2-83bb-03f302b78c6a" />

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests (see above). Note that I couldn't find a way to reliably get an annotation in the `altered` state, so I added the class myself in the debugger on one annotation just to display the style. The `updated ` state works exactly the same and everything ran as expected.

Built the changes with `mvn clean install -f xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-ui -Pquality `. Successfully passed the docker tests: `mvn clean install -f xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-test/xwiki-platform-annotation-test-docker`. Note that the feature regression did not trigger an automated test failure, so I doubt adding it back would do much. In any case the changes are very localized and low risk (addition of one class on one element purely for styling purposes).

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 18.4.X