### PR TITLE
XWIKI-24233: Fix lightbox caption

### DIFF
--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-docker/src/test/it/org/xwiki/image/lightbox/test/ui/LightboxIT.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-docker/src/test/it/org/xwiki/image/lightbox/test/ui/LightboxIT.java
@@ -68,9 +68,9 @@ class LightboxIT
     private static final List<String> IMAGES = Arrays.asList("image1.png", "image2.png", "missingImage.png");
 
     /**
-     * Alt text containing HTML that would trigger XSS if lightbox doesn't escape it.
+     * Caption text containing HTML that would trigger XSS if lightbox doesn't escape it.
      */
-    private static final String XSS_ALT = "<b id=xss-alt>XSSAlt</b>";
+    private static final String XSS_CAPTION = "<b id=xss-caption>XSSCaption</b>";
 
     @BeforeAll
     void beforeAll(TestUtils testUtils)
@@ -464,14 +464,14 @@ class LightboxIT
     {
         enableLightbox(testUtils, true);
 
-        testUtils.createPage(testReference, this.getImageWithAlt(IMAGES.get(0), XSS_ALT));
+        testUtils.createPage(testReference, this.getImageWithAlt(IMAGES.get(0), XSS_CAPTION));
         LightboxPage lightboxPage = new LightboxPage();
 
         // Make sure that the images are displayed.
         lightboxPage.reloadPage();
         Lightbox lightbox = lightboxPage.openLightboxAtImage(0);
 
-        assertEquals(XSS_ALT, lightbox.getCaption());
+        assertEquals(XSS_CAPTION, lightbox.getCaption());
     }
 
     private void setTimezone(TestUtils testUtils, String timezoneValue) throws Exception

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-docker/src/test/it/org/xwiki/image/lightbox/test/ui/LightboxIT.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-docker/src/test/it/org/xwiki/image/lightbox/test/ui/LightboxIT.java
@@ -67,6 +67,11 @@ class LightboxIT
 
     private static final List<String> IMAGES = Arrays.asList("image1.png", "image2.png", "missingImage.png");
 
+    /**
+     * Alt text containing HTML that would trigger XSS if lightbox doesn't escape it.
+     */
+    private static final String XSS_ALT = "<b id=xss-alt>XSSAlt</b>";
+
     @BeforeAll
     void beforeAll(TestUtils testUtils)
     {
@@ -453,6 +458,22 @@ class LightboxIT
         assertEquals(lastUploadDate, lightbox.getDate());
     }
 
+    @Test
+    @Order(15)
+    void testXSSInCaption(TestUtils testUtils, TestReference testReference, TestConfiguration testConfiguration)
+    {
+        enableLightbox(testUtils, true);
+
+        testUtils.createPage(testReference, this.getImageWithAlt(IMAGES.get(0), XSS_ALT));
+        LightboxPage lightboxPage = new LightboxPage();
+
+        // Make sure that the images are displayed.
+        lightboxPage.reloadPage();
+        Lightbox lightbox = lightboxPage.openLightboxAtImage(0);
+
+        assertEquals(XSS_ALT, lightbox.getCaption());
+    }
+
     private void setTimezone(TestUtils testUtils, String timezoneValue) throws Exception
     {
         Object userObject = testUtils.rest().object(new LocalDocumentReference("XWiki", USER_NAME), "XWiki.XWikiUsers");
@@ -479,11 +500,18 @@ class LightboxIT
 
     private String getImageWithAlt(String image)
     {
+        return getImageWithAlt(image, "Alternative text");
+    }
+    
+    private String getImageWithAlt(String image, String alt)
+    {
         StringBuilder sb = new StringBuilder();
 
         sb.append("[[image:");
         sb.append(image);
-        sb.append("||alt=\"Alternative text\" width=120 height=120]]\n\n");
+        sb.append("||alt=\"");
+        sb.append(alt);
+        sb.append("\" width=120 height=120]]\n\n");
 
         return sb.toString();
     }

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/lightbox.js
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/lightbox.js
@@ -68,17 +68,13 @@ define('xwiki-lightbox-description', [
   var updateDescriptionCaption = function(imageData, attachmentData) {
     if (imageData?.caption) {
       $('.lightboxDescription .caption').html(imageData.caption);
-      return;
     } else if (imageData) {
       // Verify to not display the url as caption, since this is the default value for alt.
       let alt = imageData.alt == decodeURIComponent(imageData.href) ? '' : imageData.alt;
       $('.lightboxDescription .caption').text(alt || imageData.title || '');
-      return;
-    }
-
-    if (attachmentData && attachmentData.name) {
+    } else if ($('.lightboxDescription .caption').is(':empty') && attachmentData?.name) {
       $('.lightboxDescription .caption').text(attachmentData.name);
-    } else if (imageData && imageData.fileName) {
+    } else if ($('.lightboxDescription .caption').is(':empty') && imageData?.fileName) {
       $('.lightboxDescription .caption').text(imageData.fileName);
     }
   };

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/lightbox.js
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar/src/main/webjar/lightbox.js
@@ -66,20 +66,20 @@ define('xwiki-lightbox-description', [
   };
 
   var updateDescriptionCaption = function(imageData, attachmentData) {
-    if (imageData) {
+    if (imageData?.caption) {
+      $('.lightboxDescription .caption').html(imageData.caption);
+      return;
+    } else if (imageData) {
       // Verify to not display the url as caption, since this is the default value for alt.
-      var alt = imageData.alt == decodeURIComponent(imageData.href) ? '' : imageData.alt;
-      $('.lightboxDescription .caption').html(imageData.caption || alt || imageData.title);
-    }
-
-    if (!$('.lightboxDescription .caption').is(':empty')) {
+      let alt = imageData.alt == decodeURIComponent(imageData.href) ? '' : imageData.alt;
+      $('.lightboxDescription .caption').text(alt || imageData.title || '');
       return;
     }
 
     if (attachmentData && attachmentData.name) {
-      $('.lightboxDescription .caption').html(attachmentData.name);
+      $('.lightboxDescription .caption').text(attachmentData.name);
     } else if (imageData && imageData.fileName) {
-      $('.lightboxDescription .caption').html(imageData.fileName);
+      $('.lightboxDescription .caption').text(imageData.fileName);
     }
   };
 


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-24233

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Fixed the caption
* Kept cyclomatic complexity of `updateDescriptionCaption` at 10
* Added a test to avoid a regression

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
None

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests on my local instance.
Successfully passed the new test with `mvn clean install -f xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-test/xwiki-platform-image-lightbox-test-docker` only after building the changes with `mvn clean install -f xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-lightbox/xwiki-platform-image-lightbox-webjar -Pquality`.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 17.10.X