### PR TITLE
XWIKI-2445: Cannot set a custom role hint priority for a wiki component

### DIFF
--- a/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/DefaultWikiComponent.java
+++ b/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/main/java/org/xwiki/component/wiki/internal/DefaultWikiComponent.java
@@ -250,7 +250,7 @@ public class DefaultWikiComponent implements WikiComponent
     @Override
     public int getRoleHintPriority()
     {
-        return this.roleTypePriority;
+        return this.roleHintPriority;
     }
 
     /**


### PR DESCRIPTION
## Summary

Fix a copy-paste bug in `DefaultWikiComponent` where `getRoleHintPriority()` was returning `this.roleTypePriority` instead of `this.roleHintPriority`. This caused role hint priority to always mirror the role type priority value, regardless of what was set via `setRoleHintPriority()`.

The fix is a one-line change:
```java
// Before (bug)
return this.roleTypePriority;

// After (fix)
return this.roleHintPriority;
```

Jira issue: https://jira.xwiki.org/browse/XWIKI-2445
SonarCloud issue: https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AYeluzB7Py-JUaC8vYL6

## Test plan

- [x] Build passes: `mvn clean verify -Pquality` on `xwiki-platform-component-wiki` module — BUILD SUCCESS
- [ ] Verify that wiki components with different `roleTypePriority` and `roleHintPriority` values now correctly return the respective priorities from their getters