### PR TITLE
[Misc] Globally fix typo 'an class' to 'a class'

### DIFF
--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/LocalUidStringEntityReferenceSerializerTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/LocalUidStringEntityReferenceSerializerTest.java
@@ -136,7 +136,7 @@ public class LocalUidStringEntityReferenceSerializerTest
     }
 
     /**
-     * Tests resolving and re-serializing an class property reference.
+     * Tests resolving and re-serializing a class property reference.
      */
     @Test
     public void serializeClassPropertyReference()

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/UidStringEntityReferenceSerializerTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/UidStringEntityReferenceSerializerTest.java
@@ -147,7 +147,7 @@ public class UidStringEntityReferenceSerializerTest
     }
 
     /**
-     * Tests resolving and re-serializing an class property reference.
+     * Tests resolving and re-serializing a class property reference.
      */
     @Test
     public void serializeClassPropertyReference()

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/event/XClassPropertyAddedEvent.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/event/XClassPropertyAddedEvent.java
@@ -22,7 +22,7 @@ package com.xpn.xwiki.internal.event;
 import org.xwiki.model.reference.EntityReference;
 
 /**
- * An event triggered when an class property is added.
+ * An event triggered when a class property is added.
  * <p>
  * The event also send the following parameters:
  * </p>

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/event/XClassPropertyDeletedEvent.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/event/XClassPropertyDeletedEvent.java
@@ -22,7 +22,7 @@ package com.xpn.xwiki.internal.event;
 import org.xwiki.model.reference.EntityReference;
 
 /**
- * An event triggered when an class property is deleted.
+ * An event triggered when a class property is deleted.
  * <p>
  * The event also send the following parameters:
  * </p>

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/event/XClassPropertyUpdatedEvent.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/event/XClassPropertyUpdatedEvent.java
@@ -22,7 +22,7 @@ package com.xpn.xwiki.internal.event;
 import org.xwiki.model.reference.EntityReference;
 
 /**
- * An event triggered when an class property is modified.
+ * An event triggered when a class property is modified.
  * <p>
  * The event also send the following parameters:
  * </p>


### PR DESCRIPTION
# Changes

an class -> a class in JavaDoc