### PR TITLE
XWIKI-24421: LiveData User List filter stuck after `(empty)` selection

### DIFF
--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/src/test/it/org/xwiki/livedata/test/ui/LiveDataIT.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-test/xwiki-platform-livedata-test-docker/src/test/it/org/xwiki/livedata/test/ui/LiveDataIT.java
@@ -851,6 +851,42 @@ class LiveDataIT
         assertThat(viewPage.getContent(), containsString(velocityError));
     }
 
+    /**
+     * Non-regression test (see XWIKI-24421). Makes sure that, for a selectize filter in the header of a column, moving
+     * from the (empty) filter to another value actually update the filters to the new value.
+     */
+    @Test
+    @Order(10)
+    void filterListSwitchFromEmptyToValue(TestUtils testUtils, TestReference testReference) throws Exception
+    {
+        testUtils.loginAsSuperAdmin();
+        testUtils.deletePage(testReference, true);
+
+        // The user filter suggestions are built from the existing users, so make sure they exist.
+        testUtils.createUser("U1", "U1", null);
+        testUtils.createUser("U2", "U2", null);
+
+        // Reuse the shared class/objects: O1 has user U1, O2 has user U2 and O3 has an empty user.
+        List<String> properties = List.of(NAME_COLUMN, USER_COLUMN);
+        createClassNameLiveDataPage(testUtils, testReference, properties, "");
+        createXClass(testUtils, testReference);
+        createXObjects(testUtils, testReference);
+
+        testUtils.gotoPage(testReference);
+        TableLayoutElement tableLayout = new LiveDataElement("test").getTableLayout();
+        tableLayout.waitUntilRowCountEqualsTo(3);
+
+        // Filter the user list column by (empty): only the entry with Nikolay is expected.
+        tableLayout.filterColumn(USER_COLUMN, CHOICE_EMPTY, true, PICK_FROM_SUGGESTIONS);
+        tableLayout.waitUntilRowCountEqualsTo(1);
+        tableLayout.assertRow(NAME_COLUMN, NAME_NIKOLAY);
+
+        // Switch the filter from (empty) to an U1:  only the entry with Lynda is expected.
+        tableLayout.filterColumn(USER_COLUMN, "U1");
+        tableLayout.waitUntilRowCountEqualsTo(1);
+        tableLayout.assertRow(NAME_COLUMN, NAME_LYNDA);
+    }
+
     private void initLocalization(TestUtils testUtils, DocumentReference testReference) throws Exception
     {
         DocumentReference translationDocumentReference =

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/filters/FilterList.test.js
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/filters/FilterList.test.js
@@ -142,6 +142,39 @@ describe("FilterList.vue", () => {
     expect(wrapper.vm.$refs.input.value).toBe(",");
   });
 
+  it("Applies the default operator when switching from the empty filter to a value", async () => {
+    const filter = vi.fn();
+    const wrapper = initWrapper({
+      props: { index: 0, propertyId: "user1" },
+      global: {
+        provide: {
+          logic: {
+            getFilterDefaultOperator() {
+              return "equals";
+            },
+            filter,
+          },
+        },
+      },
+    });
+    await flushPromises();
+    // Simulate a selectize widget with one selected (non-empty) value.
+    wrapper.vm.$refs.input.selectize = { items: ["U1"] };
+    // Simulate the user selecting a non-empty value while the empty operator is active.
+    wrapper.vm.selectizeSettings.onChange("U1");
+
+    // Make sure the filter is called with the right value.
+    expect(filter).toHaveBeenCalledWith(
+      "user1",
+      0,
+      { value: "U1" },
+      {
+        filterOperator: "equals",
+        skipFetch: false,
+      },
+    );
+  });
+
   it("Render the filter list when Empty filter and advanced", async () => {
     const wrapper = initWrapper({
       props: { index: 0, isAdvanced: true },

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/filters/FilterList.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/filters/FilterList.vue
@@ -96,9 +96,17 @@ export default {
             // Note that this imply that any filter list descriptor needs to have an empty operator defined.
             if (value === "") {
               this.applyFilter(value, "empty");
-            } else {
-              // Fallback on default operator.
+            } else if (this.isAdvanced) {
+              // In the advanced filtering panel the operator is selected separately, so keep the current operator.
               this.applyFilter(value);
+            } else {
+              // In the top filter, selecting a value always uses the default operator. Passing it explicitly is
+              // required so that switching away from the "empty" operator resets to the default operator instead of
+              // keeping the "empty" operator (which would make the backend ignore the value).
+              this.applyFilter(
+                value,
+                this.logic.getFilterDefaultOperator(this.propertyId),
+              );
             }
           }
         },

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/filters/FilterList.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/filters/FilterList.vue
@@ -100,7 +100,7 @@ export default {
               // In the advanced filtering panel the operator is selected separately, so keep the current operator.
               this.applyFilter(value);
             } else {
-              // In the top filter, selecting a value always uses the default operator. Passing it explicitly is
+              // In a column filter, selecting a value always uses the default operator. Passing it explicitly is
               // required so that switching away from the "empty" operator resets to the default operator instead of
               // keeping the "empty" operator (which would make the backend ignore the value).
               this.applyFilter(


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-24421

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->


## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
mvn clean install -pl :xwiki-platform-node,:xwiki-platform-livedata-node-ui,:xwiki-platform-livedata-test-docker -Pintegration-tests,docker,quality
```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-18.4.x
  * stable-17.10.x