### PR TITLE
XWIKI-24455: Header and advanced panel selectize filters can be desynchronized

### DIFF
--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/filters/FilterList.test.js
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/filters/FilterList.test.js
@@ -23,6 +23,7 @@ import flushPromises from "flush-promises";
 import $ from "jquery";
 import _ from "lodash-es";
 import { describe, expect, it, vi } from "vitest";
+import { reactive } from "vue";
 
 vi.mock("../../services/require.js", () => {
   return {
@@ -108,6 +109,37 @@ describe("FilterList.vue", () => {
     expect(wrapper.find("span").html()).toBe(
       '<span><input class="filter-list livedata-filter" aria-label="livedata.filter.list.label"></span>',
     );
+  });
+
+  it("Displays the empty option when the operator is switched to empty externally", async () => {
+    // Reactive filter group so that mutating the operator (as the advanced filtering panel does) triggers the
+    // component reactivity.
+    const filterGroup = reactive({
+      constraints: [{ value: "U1", operator: "contains" }],
+    });
+    const wrapper = initWrapper({
+      props: { index: 0, propertyId: "user1" },
+      global: {
+        provide: {
+          logic: {
+            getQueryFilterGroup() {
+              return filterGroup;
+            },
+          },
+        },
+      },
+    });
+    await flushPromises();
+    // The column filter initially displays the selected value.
+    expect(wrapper.vm.$refs.input.value).toBe("U1");
+
+    // Simulate selecting the "empty" operator in the advanced filtering panel.
+    filterGroup.constraints[0].operator = "empty";
+    await wrapper.vm.$nextTick();
+
+    // Verify the value is the empty operator (the comma is the convention used to display the empty
+    // option).
+    expect(wrapper.vm.$refs.input.value).toBe(",");
   });
 
   it("Render the filter list when Empty filter and advanced", async () => {

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/filters/FilterList.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/filters/FilterList.vue
@@ -187,16 +187,16 @@ export default {
         return;
       }
       const input = this.jQuery(this.$refs.input);
+      let value = this.value;
       if (this.filterEntry?.operator === "empty") {
         // Make sure the empty option exists so the widget can display its label even when the operator was switched
         // to empty after the widget creation (e.g., from the advanced filtering panel).
         this.$refs.input.selectize?.addOption(this.getDefaultEmptyOption());
         // The empty string is ignored by default. We change the value to empty string plus a comma value separator to
         // take it into account.
-        input.val(",").trigger("change");
-      } else {
-        input.val(this.value).trigger("change");
+        value = ",";
       }
+      input.val(value).trigger("change");
     },
   },
 
@@ -216,6 +216,8 @@ export default {
         // selectize to be able to enhance it.
         await this.$nextTick();
         this.jQuery(this.$refs.input).xwikiSelectize(this.selectizeSettings);
+        // For non-empty operators, selectize picks up the initial value from the HTML input attribute. For the empty
+        // operator, selectize ignores empty string values, so we must sync explicitly after widget creation.
         if (this.filterEntry?.operator === "empty") {
           this.syncSelectizeValue();
         }

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/filters/FilterList.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/filters/FilterList.vue
@@ -178,24 +178,46 @@ export default {
         label: this.$t("livedata.filter.list.emptyLabel"),
       };
     },
+
+    // Synchronize the selectize widget display with the current filter entry (value and operator). This is needed
+    // because the filter entry can be updated outside of this widget (e.g., from the advanced filtering panel).
+    syncSelectizeValue() {
+      if (!this.$refs.input) {
+        // The input might not be in the DOM yet (e.g., an external filter change while the widget is still loading).
+        return;
+      }
+      const input = this.jQuery(this.$refs.input);
+      if (this.filterEntry?.operator === "empty") {
+        // Make sure the empty option exists so the widget can display its label even when the operator was switched
+        // to empty after the widget creation (e.g., from the advanced filtering panel).
+        this.$refs.input.selectize?.addOption(this.getDefaultEmptyOption());
+        // The empty string is ignored by default. We change the value to empty string plus a comma value separator to
+        // take it into account.
+        input.val(",").trigger("change");
+      } else {
+        input.val(this.value).trigger("change");
+      }
+    },
   },
 
-  // Update the selectize widget whenever the filter value changes.
+  // Update the selectize widget whenever the filter entry changes.
   watch: {
-    value(newValue) {
-      this.jQuery(this.$refs.input).val(newValue).trigger("change");
+    value() {
+      this.syncSelectizeValue();
+    },
+    // The operator can be changed outside of this widget (e.g., from the advanced filtering panel), so the displayed
+    // value must be kept consistent with the active operator.
+    "filterEntry.operator"() {
+      this.syncSelectizeValue();
     },
     async fullyReady(isReady) {
       if (isReady) {
         // It is important to wait for the next tick to be sure that the input reference is available in the dom, for
         // selectize to be able to enhance it.
         await this.$nextTick();
-        const $ = this.jQuery;
-        $(this.$refs.input).xwikiSelectize(this.selectizeSettings);
+        this.jQuery(this.$refs.input).xwikiSelectize(this.selectizeSettings);
         if (this.filterEntry?.operator === "empty") {
-          // The empty string is ignored by default. We change the value to empty string plus a coma value separator to
-          // take it into account.
-          $(this.$refs.input).val(",").trigger("change");
+          this.syncSelectizeValue();
         }
       }
     },


### PR DESCRIPTION
…chronized

# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-24455

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

*

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

*

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

```
mvn clean install -pl :xwiki-platform-node,:xwiki-platform-livedata-node-ui,:xwiki-platform-livedata-test-docker -Pintegration-tests,docker,quality
```

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-17.10.x
  * stable-18.4.x