### PR TITLE
XWIKI-24457: Apply all the changes in one go when migrating objects of a modified XClass

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/event/AbstractEntityEvent.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/event/AbstractEntityEvent.java
@@ -19,8 +19,9 @@
  */
 package com.xpn.xwiki.internal.event;
 
-import org.apache.commons.lang3.ObjectUtils;
 import org.xwiki.model.reference.EntityReference;
+
+import java.util.Objects;
 
 /**
  * Base class for all entity {@link org.xwiki.observation.event.Event events}.
@@ -84,7 +85,7 @@ public abstract class AbstractEntityEvent implements EntityEvent
             return true;
         }
 
-        return getClass() == obj.getClass() && ObjectUtils.equals(this.reference, ((EntityEvent) obj).getReference());
+        return getClass() == obj.getClass() && Objects.equals(this.reference, ((EntityEvent) obj).getReference());
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/event/XClassPropertyEventGeneratorListener.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/event/XClassPropertyEventGeneratorListener.java
@@ -19,6 +19,7 @@
  */
 package com.xpn.xwiki.internal.event;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -96,9 +97,13 @@ public class XClassPropertyEventGeneratorListener implements EventListener
      */
     private void onDocumentCreatedEvent(XWikiDocument originalDoc, XWikiDocument doc, XWikiContext context)
     {
-        for (PropertyInterface property : (Collection<PropertyInterface>) doc.getXClass().getFieldList()) {
+        Collection<PropertyInterface> fieldList = doc.getXClass().getFieldList();
+        Collection<PropertyInterface[]> updatedProperties = new ArrayList<>(fieldList.size());
+        for (PropertyInterface property : fieldList) {
+            updatedProperties.add(new PropertyInterface[] {null, property});
             this.observation.notify(new XClassPropertyAddedEvent(property.getReference()), doc, context);
         }
+        notifyClassUpdate(doc, context, updatedProperties);
     }
 
     /**
@@ -108,9 +113,13 @@ public class XClassPropertyEventGeneratorListener implements EventListener
      */
     private void onDocumentDeletedEvent(XWikiDocument originalDoc, XWikiDocument doc, XWikiContext context)
     {
-        for (PropertyInterface property : (Collection<PropertyInterface>) originalDoc.getXClass().getFieldList()) {
+        Collection<PropertyInterface> fieldList = originalDoc.getXClass().getFieldList();
+        Collection<PropertyInterface[]> updatedProperties = new ArrayList<>(fieldList.size());
+        for (PropertyInterface property : fieldList) {
+            updatedProperties.add(new PropertyInterface[] {property, null});
             this.observation.notify(new XClassPropertyDeletedEvent(property.getReference()), doc, context);
         }
+        notifyClassUpdate(doc, context, updatedProperties);
     }
 
     /**
@@ -122,11 +131,13 @@ public class XClassPropertyEventGeneratorListener implements EventListener
     {
         BaseClass baseClass = doc.getXClass();
         BaseClass baseClassOriginal = originalDoc.getXClass();
+        Collection<PropertyInterface[]> updatedProperties = new ArrayList<>();
 
         for (List<ObjectDiff> objectChanges : doc.getClassDiff(originalDoc, doc, context)) {
             for (ObjectDiff diff : objectChanges) {
                 PropertyInterface property = baseClass.getField(diff.getPropName());
                 PropertyInterface propertyOriginal = baseClassOriginal.getField(diff.getPropName());
+                updatedProperties.add(new PropertyInterface[] { propertyOriginal, property});
 
                 if (ObjectDiff.ACTION_PROPERTYREMOVED.equals(diff.getAction())) {
                     this.observation.notify(
@@ -137,6 +148,14 @@ public class XClassPropertyEventGeneratorListener implements EventListener
                     this.observation.notify(new XClassPropertyUpdatedEvent(property.getReference()), doc, context);
                 }
             }
+        }
+        notifyClassUpdate(doc, context, updatedProperties);
+    }
+
+    private void notifyClassUpdate(XWikiDocument doc, XWikiContext context, Collection<PropertyInterface[]> props)
+    {
+        if (!props.isEmpty()) {
+            this.observation.notify(new XClassUpdatedEvent(doc.getDocumentReference(), props), doc, context);
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/event/XClassPropertyEventGeneratorListener.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/event/XClassPropertyEventGeneratorListener.java
@@ -28,7 +28,6 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.xwiki.bridge.event.DocumentCreatedEvent;
 import org.xwiki.bridge.event.DocumentDeletedEvent;
 import org.xwiki.bridge.event.DocumentUpdatedEvent;
@@ -99,12 +98,12 @@ public class XClassPropertyEventGeneratorListener implements EventListener
     private void onDocumentCreatedEvent(XWikiDocument originalDoc, XWikiDocument doc, XWikiContext context)
     {
         Collection<PropertyInterface> fieldList = doc.getXClass().getFieldList();
-        Collection<Pair<PropertyInterface, PropertyInterface>> updatedProperties = new ArrayList<>(fieldList.size());
+        Collection<XClassUpdatedEvent.PropertyUpdate> updatedProperties = new ArrayList<>(fieldList.size());
         for (PropertyInterface property : fieldList) {
-            updatedProperties.add(Pair.of(null, property));
+            updatedProperties.add(new XClassUpdatedEvent.PropertyUpdate(null, property));
             this.observation.notify(new XClassPropertyAddedEvent(property.getReference()), doc, context);
         }
-        notifyClassUpdate(doc, context, updatedProperties);
+        notifyClassUpdate(doc, updatedProperties);
     }
 
     /**
@@ -115,12 +114,12 @@ public class XClassPropertyEventGeneratorListener implements EventListener
     private void onDocumentDeletedEvent(XWikiDocument originalDoc, XWikiDocument doc, XWikiContext context)
     {
         Collection<PropertyInterface> fieldList = originalDoc.getXClass().getFieldList();
-        Collection<Pair<PropertyInterface, PropertyInterface>> updatedProperties = new ArrayList<>(fieldList.size());
+        Collection<XClassUpdatedEvent.PropertyUpdate> updatedProperties = new ArrayList<>(fieldList.size());
         for (PropertyInterface property : fieldList) {
-            updatedProperties.add(Pair.of(property, null));
+            updatedProperties.add(new XClassUpdatedEvent.PropertyUpdate(property, null));
             this.observation.notify(new XClassPropertyDeletedEvent(property.getReference()), doc, context);
         }
-        notifyClassUpdate(doc, context, updatedProperties);
+        notifyClassUpdate(doc, updatedProperties);
     }
 
     /**
@@ -132,13 +131,13 @@ public class XClassPropertyEventGeneratorListener implements EventListener
     {
         BaseClass baseClass = doc.getXClass();
         BaseClass baseClassOriginal = originalDoc.getXClass();
-        Collection<Pair<PropertyInterface, PropertyInterface>> updatedProperties = new ArrayList<>();
+        Collection<XClassUpdatedEvent.PropertyUpdate> updatedProperties = new ArrayList<>();
 
         for (List<ObjectDiff> objectChanges : doc.getClassDiff(originalDoc, doc, context)) {
             for (ObjectDiff diff : objectChanges) {
                 PropertyInterface property = baseClass.getField(diff.getPropName());
                 PropertyInterface propertyOriginal = baseClassOriginal.getField(diff.getPropName());
-                updatedProperties.add(Pair.of(propertyOriginal, property));
+                updatedProperties.add(new XClassUpdatedEvent.PropertyUpdate(propertyOriginal, property));
 
                 if (ObjectDiff.ACTION_PROPERTYREMOVED.equals(diff.getAction())) {
                     this.observation.notify(
@@ -150,14 +149,13 @@ public class XClassPropertyEventGeneratorListener implements EventListener
                 }
             }
         }
-        notifyClassUpdate(doc, context, updatedProperties);
+        notifyClassUpdate(doc, updatedProperties);
     }
 
-    private void notifyClassUpdate(XWikiDocument doc, XWikiContext context,
-            Collection<Pair<PropertyInterface, PropertyInterface>> props)
+    private void notifyClassUpdate(XWikiDocument doc, Collection<XClassUpdatedEvent.PropertyUpdate> props)
     {
         if (!props.isEmpty()) {
-            this.observation.notify(new XClassUpdatedEvent(doc.getDocumentReference(), props), doc, context);
+            this.observation.notify(new XClassUpdatedEvent(doc.getDocumentReference()), doc, props);
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/event/XClassPropertyEventGeneratorListener.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/event/XClassPropertyEventGeneratorListener.java
@@ -28,6 +28,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.xwiki.bridge.event.DocumentCreatedEvent;
 import org.xwiki.bridge.event.DocumentDeletedEvent;
 import org.xwiki.bridge.event.DocumentUpdatedEvent;
@@ -98,9 +99,9 @@ public class XClassPropertyEventGeneratorListener implements EventListener
     private void onDocumentCreatedEvent(XWikiDocument originalDoc, XWikiDocument doc, XWikiContext context)
     {
         Collection<PropertyInterface> fieldList = doc.getXClass().getFieldList();
-        Collection<PropertyInterface[]> updatedProperties = new ArrayList<>(fieldList.size());
+        Collection<Pair<PropertyInterface, PropertyInterface>> updatedProperties = new ArrayList<>(fieldList.size());
         for (PropertyInterface property : fieldList) {
-            updatedProperties.add(new PropertyInterface[] {null, property});
+            updatedProperties.add(Pair.of(null, property));
             this.observation.notify(new XClassPropertyAddedEvent(property.getReference()), doc, context);
         }
         notifyClassUpdate(doc, context, updatedProperties);
@@ -114,9 +115,9 @@ public class XClassPropertyEventGeneratorListener implements EventListener
     private void onDocumentDeletedEvent(XWikiDocument originalDoc, XWikiDocument doc, XWikiContext context)
     {
         Collection<PropertyInterface> fieldList = originalDoc.getXClass().getFieldList();
-        Collection<PropertyInterface[]> updatedProperties = new ArrayList<>(fieldList.size());
+        Collection<Pair<PropertyInterface, PropertyInterface>> updatedProperties = new ArrayList<>(fieldList.size());
         for (PropertyInterface property : fieldList) {
-            updatedProperties.add(new PropertyInterface[] {property, null});
+            updatedProperties.add(Pair.of(property, null));
             this.observation.notify(new XClassPropertyDeletedEvent(property.getReference()), doc, context);
         }
         notifyClassUpdate(doc, context, updatedProperties);
@@ -131,13 +132,13 @@ public class XClassPropertyEventGeneratorListener implements EventListener
     {
         BaseClass baseClass = doc.getXClass();
         BaseClass baseClassOriginal = originalDoc.getXClass();
-        Collection<PropertyInterface[]> updatedProperties = new ArrayList<>();
+        Collection<Pair<PropertyInterface, PropertyInterface>> updatedProperties = new ArrayList<>();
 
         for (List<ObjectDiff> objectChanges : doc.getClassDiff(originalDoc, doc, context)) {
             for (ObjectDiff diff : objectChanges) {
                 PropertyInterface property = baseClass.getField(diff.getPropName());
                 PropertyInterface propertyOriginal = baseClassOriginal.getField(diff.getPropName());
-                updatedProperties.add(new PropertyInterface[] { propertyOriginal, property});
+                updatedProperties.add(Pair.of(propertyOriginal, property));
 
                 if (ObjectDiff.ACTION_PROPERTYREMOVED.equals(diff.getAction())) {
                     this.observation.notify(
@@ -152,7 +153,8 @@ public class XClassPropertyEventGeneratorListener implements EventListener
         notifyClassUpdate(doc, context, updatedProperties);
     }
 
-    private void notifyClassUpdate(XWikiDocument doc, XWikiContext context, Collection<PropertyInterface[]> props)
+    private void notifyClassUpdate(XWikiDocument doc, XWikiContext context,
+            Collection<Pair<PropertyInterface, PropertyInterface>> props)
     {
         if (!props.isEmpty()) {
             this.observation.notify(new XClassUpdatedEvent(doc.getDocumentReference(), props), doc, context);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/event/XClassUpdatedEvent.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/event/XClassUpdatedEvent.java
@@ -20,19 +20,28 @@
 package com.xpn.xwiki.internal.event;
 
 import com.xpn.xwiki.objects.PropertyInterface;
+import org.apache.commons.lang3.tuple.Pair;
 import org.xwiki.model.reference.DocumentReference;
-import org.xwiki.model.reference.EntityReference;
 
 import java.util.Collection;
+import java.util.Objects;
 
 /**
  * Class updated entity event. The entity is the class reference.
+ * <p>
+ * The following parameters get sent:
+ * </p>
+ * <ul>
+ * <li>source: the current {com.xpn.xwiki.doc.XWikiDocument} instance from which you can get the "original" document
+ * (the version before all the modifications)</li>
+ * <li>data: the current {com.xpn.xwiki.XWikiContext} instance</li>
+ * </ul>
  * @since 18.5.0
  * @version $Id$
  */
 public class XClassUpdatedEvent extends AbstractEntityEvent
 {
-    private final Collection<PropertyInterface[]> updatedProperties;
+    private final Collection<Pair<PropertyInterface, PropertyInterface>> updatedProperties;
 
     /**
      * Default constructor. Matches any {@link XClassUpdatedEvent}.
@@ -47,7 +56,8 @@ public class XClassUpdatedEvent extends AbstractEntityEvent
      * @param updatedProperties the pairs of [old, new] property updates.
      *                          old is null for new properties and new is null for removed properties
      */
-    public XClassUpdatedEvent(DocumentReference classReference, Collection<PropertyInterface[]> updatedProperties)
+    public XClassUpdatedEvent(DocumentReference classReference,
+            Collection<Pair<PropertyInterface, PropertyInterface>> updatedProperties)
     {
         super(classReference);
         this.updatedProperties = updatedProperties;
@@ -63,8 +73,25 @@ public class XClassUpdatedEvent extends AbstractEntityEvent
      * @return the pairs of [old, new] property updates.
      *         old is null for new properties and new is null for removed properties
      */
-    public Collection<PropertyInterface[]> getUpdatedProperties()
+    public Collection<Pair<PropertyInterface, PropertyInterface>> getUpdatedProperties()
     {
         return this.updatedProperties;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (super.equals(obj)) {
+            return true;
+        }
+
+        return getClass() == obj.getClass()
+                && Objects.equals(this.updatedProperties, ((XClassUpdatedEvent) obj).getUpdatedProperties());
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return 3 * super.hashCode() + (updatedProperties == null ? 0 : 5 * updatedProperties.hashCode());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/event/XClassUpdatedEvent.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/event/XClassUpdatedEvent.java
@@ -20,11 +20,8 @@
 package com.xpn.xwiki.internal.event;
 
 import com.xpn.xwiki.objects.PropertyInterface;
-import org.apache.commons.lang3.tuple.Pair;
 import org.xwiki.model.reference.DocumentReference;
 
-import java.util.Collection;
-import java.util.Objects;
 
 /**
  * Class updated entity event. The entity is the class reference.
@@ -34,64 +31,38 @@ import java.util.Objects;
  * <ul>
  * <li>source: the current {com.xpn.xwiki.doc.XWikiDocument} instance from which you can get the "original" document
  * (the version before all the modifications)</li>
- * <li>data: the current {com.xpn.xwiki.XWikiContext} instance</li>
+ * <li>data: the collection of property updates ({@code Collection<PropertyUpdate>})</li>
  * </ul>
  * @since 18.5.0
  * @version $Id$
  */
 public class XClassUpdatedEvent extends AbstractEntityEvent
 {
-    private final Collection<Pair<PropertyInterface, PropertyInterface>> updatedProperties;
+    /**
+     * @param oldProperty the property before the document update, null if the document is new
+     * @param newProperty the property after the document update, null if it was removed
+     */
+    public record PropertyUpdate(PropertyInterface oldProperty, PropertyInterface newProperty) { }
 
     /**
      * Default constructor. Matches any {@link XClassUpdatedEvent}.
      */
     public XClassUpdatedEvent()
     {
-        updatedProperties = null;
+        // Nothing to do
     }
 
     /**
      * @param classReference the class reference
-     * @param updatedProperties the pairs of [old, new] property updates.
-     *                          old is null for new properties and new is null for removed properties
      */
-    public XClassUpdatedEvent(DocumentReference classReference,
-            Collection<Pair<PropertyInterface, PropertyInterface>> updatedProperties)
+    public XClassUpdatedEvent(DocumentReference classReference)
     {
         super(classReference);
-        this.updatedProperties = updatedProperties;
     }
 
     @Override
     public DocumentReference getReference()
     {
         return (DocumentReference) super.getReference();
-    }
-
-    /**
-     * @return the pairs of [old, new] property updates.
-     *         old is null for new properties and new is null for removed properties
-     */
-    public Collection<Pair<PropertyInterface, PropertyInterface>> getUpdatedProperties()
-    {
-        return this.updatedProperties;
-    }
-
-    @Override
-    public boolean equals(Object obj)
-    {
-        if (super.equals(obj)) {
-            return true;
-        }
-
-        return getClass() == obj.getClass()
-                && Objects.equals(this.updatedProperties, ((XClassUpdatedEvent) obj).getUpdatedProperties());
-    }
-
-    @Override
-    public int hashCode()
-    {
-        return 3 * super.hashCode() + (updatedProperties == null ? 0 : 5 * updatedProperties.hashCode());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/event/XClassUpdatedEvent.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/event/XClassUpdatedEvent.java
@@ -1,0 +1,70 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xpn.xwiki.internal.event;
+
+import com.xpn.xwiki.objects.PropertyInterface;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.EntityReference;
+
+import java.util.Collection;
+
+/**
+ * Class updated entity event. The entity is the class reference.
+ * @since 18.5.0
+ * @version $Id$
+ */
+public class XClassUpdatedEvent extends AbstractEntityEvent
+{
+    private final Collection<PropertyInterface[]> updatedProperties;
+
+    /**
+     * Default constructor. Matches any {@link XClassUpdatedEvent}.
+     */
+    public XClassUpdatedEvent()
+    {
+        updatedProperties = null;
+    }
+
+    /**
+     * @param classReference the class reference
+     * @param updatedProperties the pairs of [old, new] property updates.
+     *                          old is null for new properties and new is null for removed properties
+     */
+    public XClassUpdatedEvent(DocumentReference classReference, Collection<PropertyInterface[]> updatedProperties)
+    {
+        super(classReference);
+        this.updatedProperties = updatedProperties;
+    }
+
+    @Override
+    public DocumentReference getReference()
+    {
+        return (DocumentReference) super.getReference();
+    }
+
+    /**
+     * @return the pairs of [old, new] property updates.
+     *         old is null for new properties and new is null for removed properties
+     */
+    public Collection<PropertyInterface[]> getUpdatedProperties()
+    {
+        return this.updatedProperties;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/event/XClassUpdatedEvent.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/event/XClassUpdatedEvent.java
@@ -33,7 +33,7 @@ import org.xwiki.model.reference.DocumentReference;
  * (the version before all the modifications)</li>
  * <li>data: the collection of property updates ({@code Collection<PropertyUpdate>})</li>
  * </ul>
- * @since 18.5.0
+ * @since 18.6.0RC1
  * @version $Id$
  */
 public class XClassUpdatedEvent extends AbstractEntityEvent

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/XClassMigratorListener.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/XClassMigratorListener.java
@@ -31,7 +31,6 @@ import javax.inject.Singleton;
 import com.xpn.xwiki.XWiki;
 import com.xpn.xwiki.internal.event.XClassUpdatedEvent;
 import com.xpn.xwiki.objects.PropertyInterface;
-import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.EntityType;
@@ -53,6 +52,8 @@ import com.xpn.xwiki.internal.store.PropertyConverter;
 import com.xpn.xwiki.objects.BaseObject;
 import com.xpn.xwiki.objects.BaseProperty;
 import com.xpn.xwiki.objects.classes.PropertyClass;
+
+import static com.xpn.xwiki.internal.event.XClassUpdatedEvent.PropertyUpdate;
 
 /**
  * Listen to classes modifications and automatically update objects accordingly when needed.
@@ -104,19 +105,30 @@ public class XClassMigratorListener extends AbstractEventListener
     public void onEvent(Event event, Object source, Object data)
     {
         if (event instanceof XClassUpdatedEvent ev) {
-            Collection<Pair<PropertyInterface, PropertyInterface>> updatedProperties = ev.getUpdatedProperties();
-            List<PropertyToUpdate> propertiesToUpdate = new ArrayList<>(updatedProperties.size());
-            for (Pair<PropertyInterface, PropertyInterface> p : updatedProperties) {
-                PropertyInterface oldProp = p.getLeft();
-                PropertyInterface newProp = p.getRight();
-                if ((oldProp instanceof PropertyClass || oldProp == null)
-                        &&  (newProp instanceof PropertyClass || newProp == null)
-                ) {
-                    maybeAddPropertyToUpdate((PropertyClass) newProp, (PropertyClass) oldProp, propertiesToUpdate);
+            if (data instanceof Collection<?> updatedProperties) {
+                List<PropertyToUpdate> propertiesToUpdate = new ArrayList<>(updatedProperties.size());
+                for (Object p : updatedProperties) {
+                    if (p instanceof PropertyUpdate(PropertyInterface oldProp, PropertyInterface newProp)) {
+                        if ((oldProp instanceof PropertyClass || oldProp == null)
+                                    && (newProp instanceof PropertyClass || newProp == null)
+                        ) {
+                            maybeAddPropertyToUpdate((PropertyClass) newProp, (PropertyClass) oldProp, propertiesToUpdate);
+                        }
+                    } else {
+                        logger.error("Unexpected entry of type [{}], this should not happen",
+                                p == null ? null : p.getClass());
+                        return;
+                    }
                 }
-            }
 
-            updateProperties(ev.getReference(), propertiesToUpdate);
+                updateProperties(ev.getReference(), propertiesToUpdate);
+            } else {
+                logger.error("Unexpected data of type [{}], this should not happen",
+                        data == null ? null : data.getClass());
+            }
+        } else {
+            logger.error("Unexpected event of type [{}], this should not happen",
+                    event == null ? null : event.getClass());
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/XClassMigratorListener.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/XClassMigratorListener.java
@@ -29,14 +29,10 @@ import javax.inject.Provider;
 import javax.inject.Singleton;
 
 import com.xpn.xwiki.XWiki;
-import com.xpn.xwiki.api.Document;
 import com.xpn.xwiki.internal.event.XClassUpdatedEvent;
-import com.xpn.xwiki.objects.ObjectDiff;
 import com.xpn.xwiki.objects.PropertyInterface;
-import com.xpn.xwiki.objects.classes.BaseClass;
+import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
-import org.xwiki.bridge.event.DocumentCreatedEvent;
-import org.xwiki.bridge.event.DocumentUpdatedEvent;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.EntityType;
 import org.xwiki.model.reference.ClassPropertyReference;
@@ -107,19 +103,20 @@ public class XClassMigratorListener extends AbstractEventListener
     @Override
     public void onEvent(Event event, Object source, Object data)
     {
-        if (event instanceof XClassUpdatedEvent xClassUpdatedEvent) {
-            Collection<PropertyInterface[]> updatedProperties = xClassUpdatedEvent.getUpdatedProperties();
+        if (event instanceof XClassUpdatedEvent ev) {
+            Collection<Pair<PropertyInterface, PropertyInterface>> updatedProperties = ev.getUpdatedProperties();
             List<PropertyToUpdate> propertiesToUpdate = new ArrayList<>(updatedProperties.size());
-            for (PropertyInterface[] p : updatedProperties) {
-                if (p.length == 2
-                    && (p[0] instanceof PropertyClass || p[0] == null)
-                    && (p[1] instanceof PropertyClass || p[1] == null)
+            for (Pair<PropertyInterface, PropertyInterface> p : updatedProperties) {
+                PropertyInterface oldProp = p.getLeft();
+                PropertyInterface newProp = p.getRight();
+                if ((oldProp instanceof PropertyClass || oldProp == null)
+                        &&  (newProp instanceof PropertyClass || newProp == null)
                 ) {
-                    maybeAddPropertyToUpdate((PropertyClass) p[1], (PropertyClass) p[0], propertiesToUpdate);
+                    maybeAddPropertyToUpdate((PropertyClass) newProp, (PropertyClass) oldProp, propertiesToUpdate);
                 }
             }
 
-            updateProperties(xClassUpdatedEvent.getReference(), propertiesToUpdate);
+            updateProperties(ev.getReference(), propertiesToUpdate);
         }
     }
 
@@ -157,14 +154,9 @@ public class XClassMigratorListener extends AbstractEventListener
 
         // Get all the documents containing at least one object of the modified class
         List<String> documents;
-        XWikiContext context = xcontextProvider.get();
-        XWiki wiki = context.getWiki();
         String className = this.localSerializer.serialize(classReference);
         String wikiName = classReference.getWikiReference().getName();
         this.logger.info("Migrating objects in the [{}] wiki after the update of the [{}] class", wikiName, className);
-        String currentWikiId = context.getWikiId();
-        // Switch to class wiki to be safer
-        context.setWikiId(wikiName);
         try {
             Query query = this.queryManager.createQuery(
                     "select distinct obj.name from BaseObject as obj where obj.className = :className", Query.HQL);
@@ -177,8 +169,25 @@ public class XClassMigratorListener extends AbstractEventListener
             } else {
                 this.logger.info("[{}] documents will be migrated in the [{}] wiki after the [{}] class update",
                         documents.size(), wikiName, className);
+                migrateDocuments(documents, propertiesToUpdate, classReference);
+                this.logger.info("Migration of the [{}] class finished in the [{}] wiki", className, wikiName);
             }
+        } catch (QueryException e) {
+            this.logger.error("Failed to get the documents to migrate after the update of class [{}] in the [{}] wiki",
+                    className, wikiName, e);
+        }
+    }
 
+    private void migrateDocuments(List<String> documents, List<PropertyToUpdate> propertiesToUpdate,
+            DocumentReference classReference)
+    {
+        XWikiContext context = xcontextProvider.get();
+        XWiki wiki = context.getWiki();
+        String currentWikiId = context.getWikiId();
+        String className = this.localSerializer.serialize(classReference);
+        try {
+            // Switch to class wiki to be safer
+            context.setWikiId(classReference.getWikiReference().getName());
             for (String documentName : documents) {
                 try {
                     DocumentReference ref = this.resolver.resolve(documentName, classReference);
@@ -193,10 +202,6 @@ public class XClassMigratorListener extends AbstractEventListener
                             documentName, className, e);
                 }
             }
-            this.logger.info("Migration of the [{}] class finished in the [{}] wiki", className, wikiName);
-        } catch (QueryException e) {
-            this.logger.error("Failed to get the documents to migrate after the update of class [{}] in the [{}] wiki",
-                    className, wiki, e);
         } finally {
             // Restore context wiki
             context.setWikiId(currentWikiId);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/XClassMigratorListener.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/XClassMigratorListener.java
@@ -104,32 +104,32 @@ public class XClassMigratorListener extends AbstractEventListener
     @Override
     public void onEvent(Event event, Object source, Object data)
     {
-        if (event instanceof XClassUpdatedEvent ev) {
-            if (data instanceof Collection<?> updatedProperties) {
-                List<PropertyToUpdate> propertiesToUpdate = new ArrayList<>(updatedProperties.size());
-                for (Object p : updatedProperties) {
-                    if (p instanceof PropertyUpdate(PropertyInterface oldProp, PropertyInterface newProp)) {
-                        if ((oldProp instanceof PropertyClass || oldProp == null)
-                                    && (newProp instanceof PropertyClass || newProp == null)
-                        ) {
-                            maybeAddPropertyToUpdate((PropertyClass) newProp, (PropertyClass) oldProp, propertiesToUpdate);
-                        }
-                    } else {
-                        logger.error("Unexpected entry of type [{}], this should not happen",
-                                p == null ? null : p.getClass());
-                        return;
-                    }
-                }
-
-                updateProperties(ev.getReference(), propertiesToUpdate);
-            } else {
-                logger.error("Unexpected data of type [{}], this should not happen",
-                        data == null ? null : data.getClass());
-            }
+        if (event instanceof XClassUpdatedEvent ev && data instanceof Collection<?> updatedProperties) {
+            onEvent(ev, updatedProperties);
         } else {
-            logger.error("Unexpected event of type [{}], this should not happen",
-                    event == null ? null : event.getClass());
+            logger.error("Unexpected event of type [{}] or unexpected data of type [{}], this should not happen",
+                    event == null ? null : event.getClass(), data == null ? null : data.getClass());
         }
+    }
+
+    private void onEvent(XClassUpdatedEvent ev, Collection<?> updatedProperties)
+    {
+        List<PropertyToUpdate> propertiesToUpdate = new ArrayList<>(updatedProperties.size());
+        for (Object p : updatedProperties) {
+            if (p instanceof PropertyUpdate(PropertyInterface oldProp, PropertyInterface newProp)) {
+                if ((oldProp instanceof PropertyClass || oldProp == null)
+                            && (newProp instanceof PropertyClass || newProp == null)
+                ) {
+                    maybeAddPropertyToUpdate((PropertyClass) newProp, (PropertyClass) oldProp, propertiesToUpdate);
+                }
+            } else {
+                logger.error("Unexpected entry of type [{}], this should not happen",
+                        p == null ? null : p.getClass());
+                return;
+            }
+        }
+
+        updateProperties(ev.getReference(), propertiesToUpdate);
     }
 
     private void maybeAddPropertyToUpdate(PropertyClass newPropertyClass, PropertyClass previousPropertyClass,

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/XClassMigratorListener.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/XClassMigratorListener.java
@@ -19,6 +19,8 @@
  */
 package com.xpn.xwiki.internal.objects.classes;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import javax.inject.Inject;
@@ -26,10 +28,17 @@ import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
+import com.xpn.xwiki.XWiki;
+import com.xpn.xwiki.objects.ObjectDiff;
+import com.xpn.xwiki.objects.PropertyInterface;
+import com.xpn.xwiki.objects.classes.BaseClass;
 import org.slf4j.Logger;
+import org.xwiki.bridge.event.DocumentCreatedEvent;
+import org.xwiki.bridge.event.DocumentUpdatedEvent;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.EntityType;
 import org.xwiki.model.reference.ClassPropertyReference;
+import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.DocumentReferenceResolver;
 import org.xwiki.model.reference.EntityReference;
 import org.xwiki.model.reference.EntityReferenceSerializer;
@@ -42,9 +51,6 @@ import org.xwiki.query.QueryManager;
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiDocument;
-import com.xpn.xwiki.internal.event.AbstractXClassPropertyEvent;
-import com.xpn.xwiki.internal.event.XClassPropertyAddedEvent;
-import com.xpn.xwiki.internal.event.XClassPropertyUpdatedEvent;
 import com.xpn.xwiki.internal.store.PropertyConverter;
 import com.xpn.xwiki.objects.BaseObject;
 import com.xpn.xwiki.objects.BaseProperty;
@@ -58,11 +64,10 @@ import com.xpn.xwiki.objects.classes.PropertyClass;
  * @version $Id$
  * @since 7.1RC1
  */
-// TODO: could be optimized a bit by listening to XClassUpdatedEvent and redoing the comparison between the two
-// classes in case there is several changes to the class
 @Component
 @Singleton
 @Named("XClassMigratorListener")
+@SuppressWarnings("ClassFanOutComplexity")
 public class XClassMigratorListener extends AbstractEventListener
 {
     @Inject
@@ -87,26 +92,70 @@ public class XClassMigratorListener extends AbstractEventListener
     @Inject
     private Logger logger;
 
+    private record PropertyToUpdate(PropertyClass newPropertyClass, BaseProperty<?> newProperty) { };
+
     /**
-     * Setup the listener.
+     * Set up the listener.
      */
     public XClassMigratorListener()
     {
-        super(XClassMigratorListener.class.getName(), new XClassPropertyUpdatedEvent(), new XClassPropertyAddedEvent());
+        super(XClassMigratorListener.class.getName(), new DocumentCreatedEvent(), new DocumentUpdatedEvent());
     }
 
     @Override
     public void onEvent(Event event, Object source, Object data)
     {
-        AbstractXClassPropertyEvent propertyEvent = (AbstractXClassPropertyEvent) event;
-        XWikiDocument newDocument = (XWikiDocument) source;
-        XWikiDocument previousDocument = newDocument.getOriginalDocument();
+        XWikiDocument doc = (XWikiDocument) source;
+        if (event instanceof DocumentUpdatedEvent) {
+            onDocumentUpdatedEvent(doc.getOriginalDocument(), doc);
+        } else if (event instanceof DocumentCreatedEvent) {
+            onDocumentCreatedEvent(doc);
+        }
+    }
 
-        PropertyClass newPropertyClass =
-            (PropertyClass) newDocument.getXClass().getField(propertyEvent.getReference().getName());
-        PropertyClass previousPropertyClass =
-            (PropertyClass) previousDocument.getXClass().getField(propertyEvent.getReference().getName());
+    /**
+     * @param doc the new version of the document
+     */
+    private void onDocumentCreatedEvent(XWikiDocument doc)
+    {
+        BaseClass baseClass = doc.getXClass();
+        Collection<PropertyInterface> fieldList = baseClass.getFieldList();
+        List<PropertyToUpdate> propertiesToUpdate = new ArrayList<>(fieldList.size());
+        for (PropertyInterface property : fieldList) {
+            maybeAddPropertyToUpdate((PropertyClass) property, null, propertiesToUpdate);
+        }
 
+        if (propertiesToUpdate.isEmpty()) {
+            // the class wasn't modified
+            return;
+        }
+
+        updateProperties(baseClass.getReference(), propertiesToUpdate);
+    }
+
+    /**
+     * @param originalDoc the previous version of the document
+     * @param doc the new version of the document
+     */
+    private void onDocumentUpdatedEvent(XWikiDocument originalDoc, XWikiDocument doc)
+    {
+        BaseClass baseClass = doc.getXClass();
+        BaseClass baseClassOriginal = originalDoc.getXClass();
+
+        List<PropertyToUpdate> propertiesToUpdate = new ArrayList<>();
+        for (List<ObjectDiff> objectChanges : doc.getClassDiff(originalDoc, doc, xcontextProvider.get())) {
+            for (ObjectDiff diff : objectChanges) {
+                PropertyClass property = (PropertyClass) baseClass.getField(diff.getPropName());
+                PropertyClass propertyOriginal = (PropertyClass) baseClassOriginal.getField(diff.getPropName());
+                maybeAddPropertyToUpdate(property, propertyOriginal, propertiesToUpdate);
+            }
+        }
+        updateProperties(baseClass.getReference(), propertiesToUpdate);
+    }
+
+    private void maybeAddPropertyToUpdate(PropertyClass newPropertyClass, PropertyClass previousPropertyClass,
+        List<PropertyToUpdate> propertiesToUpdate)
+    {
         boolean migrate = false;
         if (newPropertyClass != null) {
             BaseProperty<?> newProperty = newPropertyClass.newProperty();
@@ -123,86 +172,106 @@ public class XClassMigratorListener extends AbstractEventListener
             }
 
             if (migrate) {
-                try {
-                    migrate(newPropertyClass, newProperty);
-                } catch (QueryException e) {
-                    this.logger.error("Failed to migrate XClass property [{}]", newPropertyClass.getReference(), e);
-                }
+                propertiesToUpdate.add(new PropertyToUpdate(newPropertyClass, newProperty));
             }
         }
     }
 
-    private void migrate(PropertyClass newPropertyClass, BaseProperty<?> newProperty) throws QueryException
+    private void updateProperties(DocumentReference classReference, List<PropertyToUpdate> propertiesToUpdate)
     {
-        ClassPropertyReference propertyReference = newPropertyClass.getReference();
-        EntityReference classReference = propertyReference.extractReference(EntityType.DOCUMENT);
-        EntityReference wikiReference = propertyReference.extractReference(EntityType.WIKI);
+        if (propertiesToUpdate.isEmpty()) {
+            // to property to update in the end
+            return;
+        }
 
         // Get all the documents containing at least one object of the modified class
-        Query query = this.queryManager
-            .createQuery("select distinct obj.name from BaseObject as obj where obj.className = :className", Query.HQL);
-        query.bindValue("className", this.localSerializer.serialize(classReference));
-        query.setWiki(wikiReference.getName());
+        List<String> documents;
+        XWikiContext context = xcontextProvider.get();
+        XWiki wiki = context.getWiki();
+        String className = this.localSerializer.serialize(classReference);
+        String wikiName = classReference.getWikiReference().getName();
+        this.logger.info("Migrating objects in the [{}] wiki after the update of the [{}] class", wikiName, className);
+        String currentWikiId = context.getWikiId();
+        // Switch to class wiki to be safer
+        context.setWikiId(wikiName);
+        try {
+            Query query = this.queryManager.createQuery(
+                    "select distinct obj.name from BaseObject as obj where obj.className = :className", Query.HQL);
+            query.bindValue("className", className);
+            query.setWiki(wikiName);
+            documents = query.execute();
+            if (documents.isEmpty()) {
+                this.logger.info("No documents to migrate after the update of class [{}] in the [{}] wiki",
+                        className, wikiName);
+            } else {
+                this.logger.info("[{}] documents will be migrated in the [{}] wiki after the [{}] class update",
+                        documents.size(), wikiName, className);
+            }
 
-        List<String> documents = query.execute();
-
-        if (!documents.isEmpty()) {
-            XWikiContext xcontext = this.xcontextProvider.get();
-
-            String currentWikiId = xcontext.getWikiId();
-            try {
-                // Switch to class wiki to be safer
-                xcontext.setWikiId(wikiReference.getName());
-
-                for (String documentName : documents) {
-                    try {
-                        migrate(newPropertyClass, newProperty, documentName, xcontext);
-                    } catch (XWikiException e) {
-                        this.logger.error("Failed to migrate property [{}] in document [{}]", propertyReference,
-                            documentName);
+            for (String documentName : documents) {
+                try {
+                    DocumentReference ref = this.resolver.resolve(documentName, classReference);
+                    XWikiDocument document = wiki.getDocument(ref, context);
+                    if (!document.isNew()) {
+                        // Avoid modifying the cached document
+                        document = document.clone();
+                        migrate(document, propertiesToUpdate, className);
                     }
+                } catch (XWikiException e) {
+                    this.logger.error("Failed to get document [{}] to apply the update of class [{}]",
+                            documentName, className, e);
                 }
-            } finally {
-                // Restore context wiki
-                xcontext.setWikiId(currentWikiId);
+            }
+            this.logger.info("Migration of the [{}] class finished in the [{}] wiki", className, wikiName);
+        } catch (QueryException e) {
+            this.logger.error("Failed to get the documents to migrate after the update of class [{}] in the [{}] wiki",
+                    className, wiki, e);
+        } finally {
+            // Restore context wiki
+            context.setWikiId(currentWikiId);
+        }
+    }
+
+    void migrate(XWikiDocument document, List<PropertyToUpdate> propertiesToUpdate, String className)
+    {
+        boolean modified = false;
+        for (PropertyToUpdate p : propertiesToUpdate) {
+            modified = updateProperty(document, p.newPropertyClass, p.newProperty) || modified;
+        }
+
+        if (modified) {
+            XWikiContext context = xcontextProvider.get();
+            try {
+                context.getWiki().saveDocument(document, "Migrated class [" + className + "]", context);
+            } catch (XWikiException e) {
+                this.logger.error("Failed to migrate document [{}] after update of class [{}]",
+                        document.getDocumentReference(), className, e);
             }
         }
     }
 
-    private void migrate(PropertyClass newPropertyClass, BaseProperty<?> newProperty, String documentName,
-        XWikiContext xcontext) throws XWikiException
+    private boolean updateProperty(XWikiDocument document, PropertyClass newPropertyClass,
+        BaseProperty<?> newProperty)
     {
         ClassPropertyReference propertyReference = newPropertyClass.getReference();
         EntityReference classReference = propertyReference.extractReference(EntityType.DOCUMENT);
 
-        XWikiDocument document =
-            xcontext.getWiki().getDocument(this.resolver.resolve(documentName, classReference), xcontext);
+        boolean modified = false;
 
-        if (!document.isNew()) {
-            boolean modified = false;
+        for (BaseObject xobject : document.getXObjects(classReference)) {
+            if (xobject != null) {
+                BaseProperty<?> property = (BaseProperty<?>) xobject.getField(propertyReference.getName());
 
-            // Avoid modifying the cached document
-            document = document.clone();
-
-            for (BaseObject xobject : document.getXObjects(classReference)) {
-                if (xobject != null) {
-                    BaseProperty<?> property = (BaseProperty<?>) xobject.getField(propertyReference.getName());
-
-                    // If the existing field is of different kind than what is produced by the new class property
-                    if (property != null) {
-                        modified = convert(xobject, property, newProperty, newPropertyClass);
-                    } else {
-                        modified = add(xobject, newPropertyClass);
-                    }
+                // If the existing field is of different kind than what is produced by the new class property
+                if (property != null) {
+                    modified = convert(xobject, property, newProperty, newPropertyClass);
+                } else {
+                    modified = add(xobject, newPropertyClass);
                 }
             }
-
-            // If anything changed save the document
-            if (modified) {
-                xcontext.getWiki().saveDocument(document, "Migrated property [" + propertyReference.getName()
-                    + "] from class [" + this.localSerializer.serialize(classReference) + "]", xcontext);
-            }
         }
+
+        return modified;
     }
 
     private boolean add(BaseObject xobject, PropertyClass newPropertyClass)

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/XClassMigratorListener.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/XClassMigratorListener.java
@@ -29,6 +29,8 @@ import javax.inject.Provider;
 import javax.inject.Singleton;
 
 import com.xpn.xwiki.XWiki;
+import com.xpn.xwiki.api.Document;
+import com.xpn.xwiki.internal.event.XClassUpdatedEvent;
 import com.xpn.xwiki.objects.ObjectDiff;
 import com.xpn.xwiki.objects.PropertyInterface;
 import com.xpn.xwiki.objects.classes.BaseClass;
@@ -99,58 +101,26 @@ public class XClassMigratorListener extends AbstractEventListener
      */
     public XClassMigratorListener()
     {
-        super(XClassMigratorListener.class.getName(), new DocumentCreatedEvent(), new DocumentUpdatedEvent());
+        super(XClassMigratorListener.class.getName(), new XClassUpdatedEvent());
     }
 
     @Override
     public void onEvent(Event event, Object source, Object data)
     {
-        XWikiDocument doc = (XWikiDocument) source;
-        if (event instanceof DocumentUpdatedEvent) {
-            onDocumentUpdatedEvent(doc.getOriginalDocument(), doc);
-        } else if (event instanceof DocumentCreatedEvent) {
-            onDocumentCreatedEvent(doc);
-        }
-    }
-
-    /**
-     * @param doc the new version of the document
-     */
-    private void onDocumentCreatedEvent(XWikiDocument doc)
-    {
-        BaseClass baseClass = doc.getXClass();
-        Collection<PropertyInterface> fieldList = baseClass.getFieldList();
-        List<PropertyToUpdate> propertiesToUpdate = new ArrayList<>(fieldList.size());
-        for (PropertyInterface property : fieldList) {
-            maybeAddPropertyToUpdate((PropertyClass) property, null, propertiesToUpdate);
-        }
-
-        if (propertiesToUpdate.isEmpty()) {
-            // the class wasn't modified
-            return;
-        }
-
-        updateProperties(baseClass.getReference(), propertiesToUpdate);
-    }
-
-    /**
-     * @param originalDoc the previous version of the document
-     * @param doc the new version of the document
-     */
-    private void onDocumentUpdatedEvent(XWikiDocument originalDoc, XWikiDocument doc)
-    {
-        BaseClass baseClass = doc.getXClass();
-        BaseClass baseClassOriginal = originalDoc.getXClass();
-
-        List<PropertyToUpdate> propertiesToUpdate = new ArrayList<>();
-        for (List<ObjectDiff> objectChanges : doc.getClassDiff(originalDoc, doc, xcontextProvider.get())) {
-            for (ObjectDiff diff : objectChanges) {
-                PropertyClass property = (PropertyClass) baseClass.getField(diff.getPropName());
-                PropertyClass propertyOriginal = (PropertyClass) baseClassOriginal.getField(diff.getPropName());
-                maybeAddPropertyToUpdate(property, propertyOriginal, propertiesToUpdate);
+        if (event instanceof XClassUpdatedEvent xClassUpdatedEvent) {
+            Collection<PropertyInterface[]> updatedProperties = xClassUpdatedEvent.getUpdatedProperties();
+            List<PropertyToUpdate> propertiesToUpdate = new ArrayList<>(updatedProperties.size());
+            for (PropertyInterface[] p : updatedProperties) {
+                if (p.length == 2
+                    && (p[0] instanceof PropertyClass || p[0] == null)
+                    && (p[1] instanceof PropertyClass || p[1] == null)
+                ) {
+                    maybeAddPropertyToUpdate((PropertyClass) p[1], (PropertyClass) p[0], propertiesToUpdate);
+                }
             }
+
+            updateProperties(xClassUpdatedEvent.getReference(), propertiesToUpdate);
         }
-        updateProperties(baseClass.getReference(), propertiesToUpdate);
     }
 
     private void maybeAddPropertyToUpdate(PropertyClass newPropertyClass, PropertyClass previousPropertyClass,
@@ -180,7 +150,8 @@ public class XClassMigratorListener extends AbstractEventListener
     private void updateProperties(DocumentReference classReference, List<PropertyToUpdate> propertiesToUpdate)
     {
         if (propertiesToUpdate.isEmpty()) {
-            // to property to update in the end
+            // no property to update in the end
+            // this happens for property deletions for instance
             return;
         }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/event/XClassPropertyEventGeneratorListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/event/XClassPropertyEventGeneratorListenerTest.java
@@ -19,8 +19,10 @@
  */
 package com.xpn.xwiki.internal.event;
 
+import com.xpn.xwiki.objects.PropertyInterface;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 import org.xwiki.bridge.event.DocumentCreatedEvent;
 import org.xwiki.bridge.event.DocumentDeletedEvent;
 import org.xwiki.bridge.event.DocumentUpdatedEvent;
@@ -37,8 +39,13 @@ import com.xpn.xwiki.test.junit5.mockito.InjectMockitoOldcore;
 import com.xpn.xwiki.test.junit5.mockito.OldcoreTest;
 import com.xpn.xwiki.test.reference.ReferenceComponentList;
 
+import java.util.Collection;
+import java.util.List;
+
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -83,15 +90,26 @@ class XClassPropertyEventGeneratorListenerTest
     {
         this.xclass.addTextField("property", "Property", 30);
 
-        final Event event = new XClassPropertyAddedEvent(this.xclass.getField("property").getReference());
-        final Event classEvent = new XClassUpdatedEvent(this.document.getDocumentReference());
+        PropertyInterface newProp = this.xclass.getField("property");
+        final Event propertyEvent = new XClassPropertyAddedEvent(newProp.getReference());
 
         this.listener.onEvent(new DocumentCreatedEvent(this.document.getDocumentReference()),
             this.document, this.oldcore.getXWikiContext());
 
+        // We verify in order because it makes it easier to debug the test, but I suppose triggering XClassUpdatedEvent
+        // before the PropertyAddedEvent would be fine.
+        // Although a behavior change could theoretically be a subtle API breakage I suppose.
+        InOrder inOrder = inOrder(this.observationManager);
+
         // Make sure the listener generated a property added event
-        verify(this.observationManager).notify(eq(event), same(this.document), same(this.oldcore.getXWikiContext()));
-        verify(this.observationManager).notify(eq(classEvent), same(this.document), same(this.oldcore.getXWikiContext()));
+        inOrder.verify(this.observationManager).notify(eq(propertyEvent), same(this.document), same(this.oldcore.getXWikiContext()));
+
+        // Make sure the listener generated a class updated event
+        final Event classEvent = new XClassUpdatedEvent(this.document.getDocumentReference());
+        Collection<XClassUpdatedEvent.PropertyUpdate> propertyUpdates = List.of(
+                new XClassUpdatedEvent.PropertyUpdate(null, newProp)
+        );
+        inOrder.verify(this.observationManager).notify(eq(classEvent), same(this.document), eq(propertyUpdates));
     }
 
     @Test
@@ -99,15 +117,24 @@ class XClassPropertyEventGeneratorListenerTest
     {
         this.xclassOrigin.addTextField("property", "Property", 30);
 
-        final Event event = new XClassPropertyDeletedEvent(this.xclassOrigin.getField("property").getReference());
-        final Event classEvent = new XClassUpdatedEvent(this.document.getDocumentReference());
+        PropertyInterface oldProp = this.xclassOrigin.getField("property");
+        final Event event = new XClassPropertyDeletedEvent(oldProp.getReference());
 
         this.listener.onEvent(new DocumentDeletedEvent(this.document.getDocumentReference()),
             this.document, this.oldcore.getXWikiContext());
 
+        // See the previous comment about verifying in order
+        InOrder inOrder = inOrder(this.observationManager);
+
         // Make sure the listener generated a property deleted event
-        verify(this.observationManager).notify(eq(event), same(this.document), same(this.oldcore.getXWikiContext()));
-        verify(this.observationManager).notify(eq(classEvent), same(this.document), same(this.oldcore.getXWikiContext()));
+        inOrder.verify(this.observationManager).notify(eq(event), same(this.document), same(this.oldcore.getXWikiContext()));
+
+        // Make sure the listener generated a class updated event
+        final Event classEvent = new XClassUpdatedEvent(this.document.getDocumentReference());
+        Collection<XClassUpdatedEvent.PropertyUpdate> propertyUpdates = List.of(
+                new XClassUpdatedEvent.PropertyUpdate(oldProp, null)
+        );
+        inOrder.verify(this.observationManager).notify(eq(classEvent), same(this.document), eq(propertyUpdates));
     }
 
     @Test
@@ -115,15 +142,24 @@ class XClassPropertyEventGeneratorListenerTest
     {
         this.xclass.addTextField("property", "Property", 30);
 
-        final Event event = new XClassPropertyAddedEvent(this.xclass.getField("property").getReference());
-        final Event classEvent = new XClassUpdatedEvent(this.document.getDocumentReference());
+        PropertyInterface newProp = this.xclass.getField("property");
+        final Event event = new XClassPropertyAddedEvent(newProp.getReference());
 
         this.listener.onEvent(new DocumentUpdatedEvent(this.document.getDocumentReference()),
             this.document, this.oldcore.getXWikiContext());
 
-        // Make sure the listener generated a property added event
-        verify(this.observationManager).notify(eq(event), same(this.document), same(this.oldcore.getXWikiContext()));
-        verify(this.observationManager).notify(eq(classEvent), same(this.document), same(this.oldcore.getXWikiContext()));
+        // See the previous comment about verifying in order
+        InOrder inOrder = inOrder(this.observationManager);
+
+        // Make sure the listener generated a property deleted event
+        inOrder.verify(this.observationManager).notify(eq(event), same(this.document), same(this.oldcore.getXWikiContext()));
+
+        // Make sure the listener generated a class updated event
+        final Event classEvent = new XClassUpdatedEvent(this.document.getDocumentReference());
+        Collection<XClassUpdatedEvent.PropertyUpdate> propertyUpdates = List.of(
+                new XClassUpdatedEvent.PropertyUpdate(null, newProp)
+        );
+        inOrder.verify(this.observationManager).notify(eq(classEvent), same(this.document), eq(propertyUpdates));
     }
 
     @Test
@@ -131,31 +167,50 @@ class XClassPropertyEventGeneratorListenerTest
     {
         this.xclassOrigin.addTextField("property", "Property", 30);
 
-        final Event event = new XClassPropertyDeletedEvent(this.xclassOrigin.getField("property").getReference());
-        final Event classEvent = new XClassUpdatedEvent(this.document.getDocumentReference());
+        PropertyInterface oldProp = this.xclassOrigin.getField("property");
+        final Event event = new XClassPropertyDeletedEvent(oldProp.getReference());
 
         this.listener.onEvent(new DocumentUpdatedEvent(this.document.getDocumentReference()),
             this.document, this.oldcore.getXWikiContext());
 
+        // See the previous comment about verifying in order
+        InOrder inOrder = inOrder(this.observationManager);
+
         // Make sure the listener generated a property deleted event
-        verify(this.observationManager).notify(eq(event), same(this.document), same(this.oldcore.getXWikiContext()));
-        verify(this.observationManager).notify(eq(classEvent), same(this.document), same(this.oldcore.getXWikiContext()));
+        inOrder.verify(this.observationManager).notify(eq(event), same(this.document), same(this.oldcore.getXWikiContext()));
+
+        // Make sure the listener generated a class updated event
+        final Event classEvent = new XClassUpdatedEvent(this.document.getDocumentReference());
+        Collection<XClassUpdatedEvent.PropertyUpdate> propertyUpdates = List.of(
+                new XClassUpdatedEvent.PropertyUpdate(oldProp, null)
+        );
+        inOrder.verify(this.observationManager).notify(eq(classEvent), same(this.document), eq(propertyUpdates));
     }
 
     @Test
     void modifiedDocumentXClassPropertyModified()
     {
         this.xclassOrigin.addTextField("property", "Property", 30);
+        PropertyInterface oldProp = this.xclassOrigin.getField("property");
         this.xclass.addTextField("property", "New Property", 30);
+        PropertyInterface newProp = this.xclass.getField("property");
 
         final Event event = new XClassPropertyUpdatedEvent(this.xclassOrigin.getField("property").getReference());
-        final Event classEvent = new XClassUpdatedEvent(this.document.getDocumentReference());
 
         this.listener.onEvent(new DocumentUpdatedEvent(this.document.getDocumentReference()),
             this.document, this.oldcore.getXWikiContext());
 
-        // Make sure the listener generated a xobject added event
-        verify(this.observationManager).notify(eq(event), same(this.document), same(this.oldcore.getXWikiContext()));
-        verify(this.observationManager).notify(eq(classEvent), same(this.document), same(this.oldcore.getXWikiContext()));
+        // See the previous comment about verifying in order
+        InOrder inOrder = inOrder(this.observationManager);
+
+        // Make sure the listener generated a property updated event
+        inOrder.verify(this.observationManager).notify(eq(event), same(this.document), same(this.oldcore.getXWikiContext()));
+
+        // Make sure the listener generated a class updated event
+        final Event classEvent = new XClassUpdatedEvent(this.document.getDocumentReference());
+        Collection<XClassUpdatedEvent.PropertyUpdate> propertyUpdates = List.of(
+                new XClassUpdatedEvent.PropertyUpdate(oldProp, newProp)
+        );
+        inOrder.verify(this.observationManager).notify(eq(classEvent), same(this.document), eq(propertyUpdates));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/event/XClassPropertyEventGeneratorListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/event/XClassPropertyEventGeneratorListenerTest.java
@@ -84,7 +84,7 @@ class XClassPropertyEventGeneratorListenerTest
         this.xclass.addTextField("property", "Property", 30);
 
         final Event event = new XClassPropertyAddedEvent(this.xclass.getField("property").getReference());
-        final Event classEvent = new XClassUpdatedEvent(this.document.getDocumentReference(), null);
+        final Event classEvent = new XClassUpdatedEvent(this.document.getDocumentReference());
 
         this.listener.onEvent(new DocumentCreatedEvent(this.document.getDocumentReference()),
             this.document, this.oldcore.getXWikiContext());
@@ -100,7 +100,7 @@ class XClassPropertyEventGeneratorListenerTest
         this.xclassOrigin.addTextField("property", "Property", 30);
 
         final Event event = new XClassPropertyDeletedEvent(this.xclassOrigin.getField("property").getReference());
-        final Event classEvent = new XClassUpdatedEvent(this.document.getDocumentReference(), null);
+        final Event classEvent = new XClassUpdatedEvent(this.document.getDocumentReference());
 
         this.listener.onEvent(new DocumentDeletedEvent(this.document.getDocumentReference()),
             this.document, this.oldcore.getXWikiContext());
@@ -116,7 +116,7 @@ class XClassPropertyEventGeneratorListenerTest
         this.xclass.addTextField("property", "Property", 30);
 
         final Event event = new XClassPropertyAddedEvent(this.xclass.getField("property").getReference());
-        final Event classEvent = new XClassUpdatedEvent(this.document.getDocumentReference(), null);
+        final Event classEvent = new XClassUpdatedEvent(this.document.getDocumentReference());
 
         this.listener.onEvent(new DocumentUpdatedEvent(this.document.getDocumentReference()),
             this.document, this.oldcore.getXWikiContext());
@@ -132,7 +132,7 @@ class XClassPropertyEventGeneratorListenerTest
         this.xclassOrigin.addTextField("property", "Property", 30);
 
         final Event event = new XClassPropertyDeletedEvent(this.xclassOrigin.getField("property").getReference());
-        final Event classEvent = new XClassUpdatedEvent(this.document.getDocumentReference(), null);
+        final Event classEvent = new XClassUpdatedEvent(this.document.getDocumentReference());
 
         this.listener.onEvent(new DocumentUpdatedEvent(this.document.getDocumentReference()),
             this.document, this.oldcore.getXWikiContext());
@@ -149,7 +149,7 @@ class XClassPropertyEventGeneratorListenerTest
         this.xclass.addTextField("property", "New Property", 30);
 
         final Event event = new XClassPropertyUpdatedEvent(this.xclassOrigin.getField("property").getReference());
-        final Event classEvent = new XClassUpdatedEvent(this.document.getDocumentReference(), null);
+        final Event classEvent = new XClassUpdatedEvent(this.document.getDocumentReference());
 
         this.listener.onEvent(new DocumentUpdatedEvent(this.document.getDocumentReference()),
             this.document, this.oldcore.getXWikiContext());

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/event/XClassPropertyEventGeneratorListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/event/XClassPropertyEventGeneratorListenerTest.java
@@ -84,12 +84,14 @@ class XClassPropertyEventGeneratorListenerTest
         this.xclass.addTextField("property", "Property", 30);
 
         final Event event = new XClassPropertyAddedEvent(this.xclass.getField("property").getReference());
+        final Event classEvent = new XClassUpdatedEvent(this.document.getDocumentReference(), null);
 
         this.listener.onEvent(new DocumentCreatedEvent(this.document.getDocumentReference()),
             this.document, this.oldcore.getXWikiContext());
 
-        // Make sure the listener generated a xobject added event
+        // Make sure the listener generated a property added event
         verify(this.observationManager).notify(eq(event), same(this.document), same(this.oldcore.getXWikiContext()));
+        verify(this.observationManager).notify(eq(classEvent), same(this.document), same(this.oldcore.getXWikiContext()));
     }
 
     @Test
@@ -98,12 +100,14 @@ class XClassPropertyEventGeneratorListenerTest
         this.xclassOrigin.addTextField("property", "Property", 30);
 
         final Event event = new XClassPropertyDeletedEvent(this.xclassOrigin.getField("property").getReference());
+        final Event classEvent = new XClassUpdatedEvent(this.document.getDocumentReference(), null);
 
         this.listener.onEvent(new DocumentDeletedEvent(this.document.getDocumentReference()),
             this.document, this.oldcore.getXWikiContext());
 
-        // Make sure the listener generated a xobject added event
+        // Make sure the listener generated a property deleted event
         verify(this.observationManager).notify(eq(event), same(this.document), same(this.oldcore.getXWikiContext()));
+        verify(this.observationManager).notify(eq(classEvent), same(this.document), same(this.oldcore.getXWikiContext()));
     }
 
     @Test
@@ -112,12 +116,14 @@ class XClassPropertyEventGeneratorListenerTest
         this.xclass.addTextField("property", "Property", 30);
 
         final Event event = new XClassPropertyAddedEvent(this.xclass.getField("property").getReference());
+        final Event classEvent = new XClassUpdatedEvent(this.document.getDocumentReference(), null);
 
         this.listener.onEvent(new DocumentUpdatedEvent(this.document.getDocumentReference()),
             this.document, this.oldcore.getXWikiContext());
 
-        // Make sure the listener generated a xobject added event
+        // Make sure the listener generated a property added event
         verify(this.observationManager).notify(eq(event), same(this.document), same(this.oldcore.getXWikiContext()));
+        verify(this.observationManager).notify(eq(classEvent), same(this.document), same(this.oldcore.getXWikiContext()));
     }
 
     @Test
@@ -126,12 +132,14 @@ class XClassPropertyEventGeneratorListenerTest
         this.xclassOrigin.addTextField("property", "Property", 30);
 
         final Event event = new XClassPropertyDeletedEvent(this.xclassOrigin.getField("property").getReference());
+        final Event classEvent = new XClassUpdatedEvent(this.document.getDocumentReference(), null);
 
         this.listener.onEvent(new DocumentUpdatedEvent(this.document.getDocumentReference()),
             this.document, this.oldcore.getXWikiContext());
 
-        // Make sure the listener generated a xobject added event
+        // Make sure the listener generated a property deleted event
         verify(this.observationManager).notify(eq(event), same(this.document), same(this.oldcore.getXWikiContext()));
+        verify(this.observationManager).notify(eq(classEvent), same(this.document), same(this.oldcore.getXWikiContext()));
     }
 
     @Test
@@ -141,11 +149,13 @@ class XClassPropertyEventGeneratorListenerTest
         this.xclass.addTextField("property", "New Property", 30);
 
         final Event event = new XClassPropertyUpdatedEvent(this.xclassOrigin.getField("property").getReference());
+        final Event classEvent = new XClassUpdatedEvent(this.document.getDocumentReference(), null);
 
         this.listener.onEvent(new DocumentUpdatedEvent(this.document.getDocumentReference()),
             this.document, this.oldcore.getXWikiContext());
 
         // Make sure the listener generated a xobject added event
         verify(this.observationManager).notify(eq(event), same(this.document), same(this.oldcore.getXWikiContext()));
+        verify(this.observationManager).notify(eq(classEvent), same(this.document), same(this.oldcore.getXWikiContext()));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/objects/classes/XClassMigratorListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/objects/classes/XClassMigratorListenerTest.java
@@ -21,6 +21,7 @@ package com.xpn.xwiki.internal.objects.classes;
 
 import java.util.Arrays;
 
+import com.xpn.xwiki.internal.event.XClassPropertyEventGeneratorListener;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.xwiki.model.reference.DocumentReference;
@@ -54,7 +55,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @OldcoreTest
-@ComponentList({ DefaultObservationManager.class, PropertyConverter.class })
+@ComponentList({ DefaultObservationManager.class, PropertyConverter.class, XClassPropertyEventGeneratorListener.class })
 @ReferenceComponentList
 public class XClassMigratorListenerTest
 {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/objects/classes/XClassMigratorListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/objects/classes/XClassMigratorListenerTest.java
@@ -34,7 +34,6 @@ import org.xwiki.test.junit5.mockito.MockComponent;
 
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiDocument;
-import com.xpn.xwiki.internal.event.XClassPropertyEventGeneratorListener;
 import com.xpn.xwiki.internal.store.PropertyConverter;
 import com.xpn.xwiki.objects.BaseObject;
 import com.xpn.xwiki.objects.BaseProperty;
@@ -55,7 +54,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @OldcoreTest
-@ComponentList({ DefaultObservationManager.class, PropertyConverter.class, XClassPropertyEventGeneratorListener.class })
+@ComponentList({ DefaultObservationManager.class, PropertyConverter.class })
 @ReferenceComponentList
 public class XClassMigratorListenerTest
 {
@@ -108,14 +107,18 @@ public class XClassMigratorListenerTest
     public void migrateProperty() throws Exception
     {
         this.xclassDocument.getXClass().addTextField("property", "property", 30);
+        this.xclassDocument.getXClass().addNumberField("property2", "property2", 30, "integer");
         saveXClassDocument();
 
         this.xobjectDocument.setStringValue(this.xclassDocument.getDocumentReference(), "property", "42");
+        this.xobjectDocument.setIntValue(this.xclassDocument.getDocumentReference(), "property2", 1337);
         this.oldcore.getSpyXWiki().saveDocument(this.xobjectDocument, this.oldcore.getXWikiContext());
 
         // Modify the class
         this.xclassDocument.getXClass().removeField("property");
         this.xclassDocument.getXClass().addNumberField("property", "property", 30, "integer");
+        this.xclassDocument.getXClass().removeField("property2");
+        this.xclassDocument.getXClass().addTextField("property2", "property2", 30);
         saveXClassDocument();
 
         // Verify the document has been modified
@@ -125,6 +128,9 @@ public class XClassMigratorListenerTest
         assertEquals(42,
             ((BaseProperty) this.xobjectDocument.getXObject(this.xclassDocument.getDocumentReference()).get("property"))
                 .getValue());
+        assertEquals("1337",
+            ((BaseProperty) this.xobjectDocument.getXObject(this.xclassDocument.getDocumentReference()).get("property2"))
+                    .getValue());
     }
 
     @Test


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24457

# Changes

## Description

* Make the xclass migrator compute the field changes and apply all the property changes at once for each document

## Clarifications

* This is take 2 of https://github.com/xwiki/xwiki-platform/pull/5557 but:
   * instead of looping over all the property changes, and then a list of `XWikiDocuments`, we loop over the documents and apply the property changes to each document. This way, we don't keep potentially thousands of documents in memory
   * we keep the XClassProperty* events (but we don't use them anymore in the class migrator
* This change will help move the class migrator into a task consumer to make the whole process asynchronous

# Executed Tests

The XClassMigratorListenerTest test was executed (with a small modification to make it modify two properties instead of only one)

# Todo

- [x] Try running xwiki-platform-distribution-flavor-test-upgrade

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches: none
