### PR TITLE
Prevent exception masking when closing XMLStreamReader in XarUtils

### DIFF
--- a/xwiki-platform-core/xwiki-platform-xar/xwiki-platform-xar-model/src/main/java/org/xwiki/xar/internal/XarUtils.java
+++ b/xwiki-platform-core/xwiki-platform-xar/xwiki-platform-xar-model/src/main/java/org/xwiki/xar/internal/XarUtils.java
@@ -31,8 +31,6 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
 import org.apache.commons.lang3.LocaleUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.xwiki.model.EntityType;
 import org.xwiki.model.internal.reference.DefaultSymbolScheme;
 import org.xwiki.model.internal.reference.RelativeStringEntityReferenceResolver;
@@ -48,8 +46,6 @@ import org.xwiki.xml.stax.StAXUtils;
  */
 public final class XarUtils
 {
-    private static final Logger LOGGER = LoggerFactory.getLogger(XarUtils.class);
-
     public static final RelativeStringEntityReferenceResolver RESOLVER =
         new RelativeStringEntityReferenceResolver(new DefaultSymbolScheme());
 
@@ -101,6 +97,9 @@ public final class XarUtils
 
         String legacySpace = null;
         String legacyPage = null;
+
+        XarException parseException = null;
+        XarException closeException = null;
 
         try {
             // <xwikidoc>
@@ -169,13 +168,25 @@ public final class XarUtils
                 }
             }
         } catch (XMLStreamException e) {
-            throw new XarException("Failed to parse document", e);
+            parseException = new XarException("Failed to parse document", e);
         } finally {
             try {
                 xmlReader.close();
             } catch (XMLStreamException e) {
-                LOGGER.warn("Failed to close XML reader", e);
+                closeException = new XarException("Failed to close XML reader", e);
             }
+        }
+
+        // Propagate exceptions outside the finally block so neither masks the other.
+        // Mirrors the suppression semantics of try-with-resources for non-AutoCloseable resources.
+        if (parseException != null) {
+            if (closeException != null) {
+                parseException.addSuppressed(closeException);
+            }
+            throw parseException;
+        }
+        if (closeException != null) {
+            throw closeException;
         }
 
         if (reference == null) {

--- a/xwiki-platform-core/xwiki-platform-xar/xwiki-platform-xar-model/src/main/java/org/xwiki/xar/internal/XarUtils.java
+++ b/xwiki-platform-core/xwiki-platform-xar/xwiki-platform-xar-model/src/main/java/org/xwiki/xar/internal/XarUtils.java
@@ -31,6 +31,8 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
 import org.apache.commons.lang3.LocaleUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xwiki.model.EntityType;
 import org.xwiki.model.internal.reference.DefaultSymbolScheme;
 import org.xwiki.model.internal.reference.RelativeStringEntityReferenceResolver;
@@ -46,6 +48,8 @@ import org.xwiki.xml.stax.StAXUtils;
  */
 public final class XarUtils
 {
+    private static final Logger LOGGER = LoggerFactory.getLogger(XarUtils.class);
+
     public static final RelativeStringEntityReferenceResolver RESOLVER =
         new RelativeStringEntityReferenceResolver(new DefaultSymbolScheme());
 
@@ -89,7 +93,7 @@ public final class XarUtils
         try {
             xmlReader = XML_INPUT_FACTORY.createXMLStreamReader(documentStream);
         } catch (XMLStreamException e) {
-            throw new XarException("Failed to create a XML read", e);
+            throw new XarException("Failed to create a XML reader", e);
         }
 
         EntityReference reference = null;
@@ -170,7 +174,7 @@ public final class XarUtils
             try {
                 xmlReader.close();
             } catch (XMLStreamException e) {
-                throw new XarException("Failed to close XML reader", e);
+                LOGGER.warn("Failed to close XML reader", e);
             }
         }
 


### PR DESCRIPTION
## What

Replace the `throw` statement inside the `finally` block of `XarUtils.getReference(InputStream)` with a warning log via SLF4J.

## Why

Throwing an exception from a `finally` block silently discards any exception already being propagated from the `try` block. If parsing fails and the subsequent `close()` also fails, the original parsing exception is lost entirely, making debugging very difficult. The correct approach is to log the close failure without masking the primary exception.

## SonarCloud issue

https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&issues=AW5-S-OZ1Yj5qvzeRozH

## Changes

- Added `LOGGER` field to `XarUtils` (SLF4J, consistent with `XarPackage` in the same module)
- Changed the `finally` block in `getReference(InputStream)` to log a warning instead of throwing, preventing exception masking


---
_Generated by [Claude Code](https://claude.ai/code/session_01KLG8YY32tZev2UjuWmHuRB)_