### PR TITLE
[Misc] Simplify chart image writing to fix SonarQube resource-handling issue

### DIFF
--- a/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/main/java/org/xwiki/rendering/internal/macro/chart/TemporaryChartImageWriter.java
+++ b/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/main/java/org/xwiki/rendering/internal/macro/chart/TemporaryChartImageWriter.java
@@ -20,7 +20,6 @@
 package org.xwiki.rendering.internal.macro.chart;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URLEncoder;
 
@@ -28,7 +27,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.FileUtils;
 import org.xwiki.bridge.DocumentAccessBridge;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.environment.Environment;
@@ -94,15 +93,10 @@ public class TemporaryChartImageWriter implements ChartImageWriter
     {
         File imageFile = getStorageLocation(imageId);
 
-        FileOutputStream fos = null;
         try {
-            fos = new FileOutputStream(imageFile);
-            fos.write(imageData);
-            fos.close();
+            FileUtils.writeByteArrayToFile(imageFile, imageData);
         } catch (IOException e) {
             throw new MacroExecutionException("Failed to write the generated chart image", e);
-        } finally {
-            IOUtils.closeQuietly(fos);
         }
     }
 


### PR DESCRIPTION
## Description

This fixes a SonarQube issue in `TemporaryChartImageWriter` where the chart image was written using a manual `FileOutputStream` wrapped in a `try`/`finally` block with `IOUtils.closeQuietly`.

The code is replaced with commons-io's `FileUtils.writeByteArrayToFile`, which:
* closes the underlying stream automatically (no more manual resource handling), resolving SonarQube rule `java:S2093` ("`try`" should be a try-with-resources);
* removes the boilerplate (one line instead of an 8-line `try`/`finally`).

The behavior is unchanged: the byte array is written to the target file and an `IOException` is still wrapped into a `MacroExecutionException`. No public API is affected, so there is no backward-compatibility impact.

## SonarQube issue

https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&open=AW5-S8Qb1Yj5qvzeRoF9&issues=AW5-S8Qb1Yj5qvzeRoF9

## Verification

Built the modified module with:

```
mvn clean verify -Pquality -pl xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro -am
```

→ `BUILD SUCCESS` (Checkstyle and all quality checks pass).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XXfaWhSXjLtKVBYQuDwXzJ)_