### PR TITLE
[Misc] Define a constant for the duplicated Solr range query literal in SolrEventStore

### DIFF
--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/main/java/org/xwiki/eventstream/store/solr/internal/SolrEventStore.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/main/java/org/xwiki/eventstream/store/solr/internal/SolrEventStore.java
@@ -98,6 +98,11 @@ public class SolrEventStore extends AbstractAsynchronousEventStore
 {
     private static final Map<String, SearchFieldMapping> SEARCH_FIELD_MAPPING = new HashMap<>();
 
+    /**
+     * Solr range query matching any value, i.e. used to check that a field exists.
+     */
+    private static final String SOLR_RANGE_ALL = "[* TO *]";
+
     private static class SearchFieldMapping
     {
         String solrFieldName;
@@ -579,11 +584,11 @@ public class SolrEventStore extends AbstractAsynchronousEventStore
                 builder.append('(');
                 builder.append(EventsSolrCoreInitializer.SOLR_FIELD_READLISTENERS);
                 builder.append(':');
-                builder.append("[* TO *]");
+                builder.append(SOLR_RANGE_ALL);
                 builder.append(" OR ");
                 builder.append(EventsSolrCoreInitializer.SOLR_FIELD_UNREADLISTENERS);
                 builder.append(':');
-                builder.append("[* TO *]");
+                builder.append(SOLR_RANGE_ALL);
                 builder.append(')');
             }
 
@@ -635,7 +640,7 @@ public class SolrEventStore extends AbstractAsynchronousEventStore
         builder.append(':');
 
         if (values.isEmpty()) {
-            builder.append("[* TO *]");
+            builder.append(SOLR_RANGE_ALL);
 
             return "(-" + builder.toString() + ')';
         } else {


### PR DESCRIPTION
## Description

SonarQube rule [`java:S1192`](https://rules.sonarsource.com/java/RuleType/CodeSmell/RSPEC-1192) (CRITICAL) flagged the string literal `"[* TO *]"` being duplicated 3 times in `SolrEventStore`. This literal is a Solr range query used to check that a field exists.

This change extracts the literal into a single `SOLR_RANGE_ALL` constant and reuses it for the three occurrences. There is no behavior change and no impact on backward compatibility (the constant is `private`).

## SonarCloud issue

https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&issues=AX6xicLKaDqRkOGosnr1&open=AX6xicLKaDqRkOGosnr1

(issue key `AX6xicLKaDqRkOGosnr1`, rule `java:S1192`)

## Verification

Built the modified module with `mvn clean verify -Pquality` — `XWiki Platform - Event Stream - Store - Solr` builds successfully.

---
_Tokens used so far: ~160,000._
