### PR TITLE
[Misc] Make the translationParameters field transient to fix a SonarQube issue

### DIFF
--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-validation/xwiki-platform-attachment-validation-api/src/main/java/org/xwiki/attachment/validation/AttachmentValidationException.java
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-validation/xwiki-platform-attachment-validation-api/src/main/java/org/xwiki/attachment/validation/AttachmentValidationException.java
@@ -36,7 +36,7 @@ public class AttachmentValidationException extends Exception
 
     private final String translationKey;
 
-    private final List<Object> translationParameters;
+    private final transient List<Object> translationParameters;
 
     private final String contextMessage;
 
@@ -135,6 +135,8 @@ public class AttachmentValidationException extends Exception
      */
     public List<Object> getTranslationParameters()
     {
-        return this.translationParameters;
+        // The field is transient, so it can be null after deserialization. Always return a non-null list to preserve
+        // the contract expected by the callers.
+        return this.translationParameters == null ? List.of() : this.translationParameters;
     }
 }


### PR DESCRIPTION
## Description

SonarQube rule [`java:S1948`](https://rules.sonarsource.com/java/RSPEC-1948) (HIGH / MAINTAINABILITY) flagged the `translationParameters` field of `AttachmentValidationException`. The class extends `Exception` and is therefore `Serializable`, but the field is declared with the non-serializable `List` interface type, which is neither `transient` nor guaranteed serializable.

This change:
* marks the `translationParameters` field as `transient`, which is the recommended remediation for this rule;
* keeps `getTranslationParameters()` null-safe so it still returns a non-null (empty) list after deserialization, since a `final transient` field defaults to `null`.

There is no impact on backward compatibility: the field is `private`, the public API (constructors and getters) is unchanged, and the `serialVersionUID` is preserved.

## SonarCloud issue

https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&open=AYSGdGyFy5DkguhPufKo&issues=AYSGdGyFy5DkguhPufKo

(issue key `AYSGdGyFy5DkguhPufKo`, rule `java:S1948`)

## Verification

Built the modified module with `mvn clean verify -Pquality`:

```
mvn clean verify -Pquality -pl xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-validation/xwiki-platform-attachment-validation-api
```

→ `BUILD SUCCESS` (Checkstyle and all quality checks pass).

---
### Token usage so far
* Finding an issue to fix: ~60,000 tokens
* Fixing the issue: ~35,000 tokens
* Work after fixing the issue: ~10,000 tokens


---
_Generated by [Claude Code](https://claude.ai/code/session_01L45gtv6grkBTpvSJFsCajB)_