### PR TITLE
Close Reader in code

### DIFF
--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-default/src/test/java/org/xwiki/icon/internal/DefaultIconSetLoaderTest.java
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-default/src/test/java/org/xwiki/icon/internal/DefaultIconSetLoaderTest.java
@@ -105,14 +105,15 @@ class DefaultIconSetLoaderTest
     @Test
     void loadIconSet() throws Exception
     {
-        Reader content = new InputStreamReader(getClass().getResourceAsStream("/test.iconset"));
+        try (Reader content = new InputStreamReader(getClass().getResourceAsStream("/test.iconset"))) {
 
-        // Test
-        IconSet result = this.iconSetLoader.loadIconSet(content, "FontAwesome");
+            // Test
+            IconSet result = this.iconSetLoader.loadIconSet(content, "FontAwesome");
 
-        // Verify
-        verifies(result);
-        assertEquals("FontAwesome", result.getName());
+            // Verify
+            verifies(result);
+            assertEquals("FontAwesome", result.getName());
+        }
     }
 
     @Test


### PR DESCRIPTION
code is close — The resource opened there can leak if code exits on an error path. this patch moves the allocation into try-with-resources so cleanup happens on every exit path. Happy to drop this if it doesn’t fit.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.