### PR TITLE
[Misc] Fix an unsafe type cast in DocumentReference#getSpaceReferences reported by SonarQube

### DIFF
--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/reference/DocumentReference.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/reference/DocumentReference.java
@@ -315,7 +315,7 @@ public class DocumentReference extends AbstractLocalizedEntityReference
         EntityReference reference = this;
         while (reference != null) {
             if (reference.getType() == EntityType.SPACE) {
-                references.add((SpaceReference) reference);
+                references.add(new SpaceReference(reference));
             }
             reference = reference.getParent();
         }


### PR DESCRIPTION
## Description

SonarQube rule [`javabugs:S6320`](https://rules.sonarsource.com/java/RSPEC-6320/) (CRITICAL / BUG) flagged an illegal type cast in `DocumentReference#getSpaceReferences()`.

While walking the parent chain, each element is statically typed as `EntityReference` and is reassigned via `getParent()`. These elements are **not guaranteed** to be `SpaceReference` instances — for example when a `DocumentReference` is built from a generic `EntityReference` whose `SPACE`-typed parents are plain `EntityReference` objects. In that case the cast `(SpaceReference) reference` throws a `ClassCastException`.

This change builds the `SpaceReference` from the `EntityReference` using the existing `SpaceReference(EntityReference)` constructor instead of casting:

```java
references.add(new SpaceReference(reference));
```

This is safe in all cases (it works whether or not the element already is a `SpaceReference`) and preserves equality, so the returned list is unchanged for the existing scenarios.

### Backward compatibility

No impact: the method signature is unchanged and the returned `SpaceReference` objects are `equals()` to the previously returned ones in all cases that did not already throw.

## SonarCloud issue

https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&open=AZmpv0y4UdISPbk2SXOn&issues=AZmpv0y4UdISPbk2SXOn

(issue key `AZmpv0y4UdISPbk2SXOn`, rule `javabugs:S6320`)

## Verification

Built the modified module with the quality profile:

```
mvn clean verify -Pquality -pl xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api
```

→ `BUILD SUCCESS` (all tests pass, Checkstyle and other quality checks pass).

---
### Token usage so far
* Finding an issue to fix: ~95,000 tokens
* Fixing the issue: ~40,000 tokens
* Work after fixing the issue: ~10,000 tokens

---
_Generated by [Claude Code](https://claude.ai/code/session_01UwG6XEFYfV26bcpZV3Xbfy)_