### PR TITLE
[Misc] Use String.replace() instead of String.replaceAll() in UIExtensionScriptService to fix a SonarQube issue

### DIFF
--- a/xwiki-platform-core/xwiki-platform-uiextension/xwiki-platform-uiextension-api/src/main/java/org/xwiki/uiextension/script/UIExtensionScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-uiextension/xwiki-platform-uiextension-api/src/main/java/org/xwiki/uiextension/script/UIExtensionScriptService.java
@@ -77,7 +77,7 @@ public class UIExtensionScriptService implements ScriptService
      */
     private String[] parseFilterParameters(String nameList)
     {
-        return nameList.replaceAll(" ", "").split(",");
+        return nameList.replace(" ", "").split(",");
     }
 
     /**


### PR DESCRIPTION
## Description

This fixes the SonarQube issue [`java:S5361`](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&issues=AW5-S5lE1Yj5qvzeRm3N&open=AW5-S5lE1Yj5qvzeRm3N&organization=xwiki) reported on `UIExtensionScriptService#parseFilterParameters`.

The private helper method used `nameList.replaceAll(" ", "")`. The argument passed to `String.replaceAll()` is a plain literal (a single space) and contains no regular expression syntax. `replaceAll()` compiles a regular expression on each call, which is unnecessary overhead here. Switching to `String.replace(" ", "")` produces the exact same result, is clearer about the intent, and avoids the regex compilation.

The change is confined to the body of a `private` method, so there is **no impact on backward compatibility** (no public API signature or behaviour change).

## SonarCloud issue

https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&issues=AW5-S5lE1Yj5qvzeRm3N&open=AW5-S5lE1Yj5qvzeRm3N&organization=xwiki

## Verification

Built the modified module with the quality profile:

```
mvn clean verify -Pquality -pl xwiki-platform-core/xwiki-platform-uiextension/xwiki-platform-uiextension-api -am
```

Result: `BUILD SUCCESS` — 0 Checkstyle violations, JaCoCo coverage checks met, Spoon checks passed.

---

### Token usage (approximate)

| Phase | Tokens |
|-------|--------|
| Finding an issue to fix | ~155k |
| Fixing the issue | ~12k |
| Work after fixing (build, commit, PR) | ~25k |


---
_Generated by [Claude Code](https://claude.ai/code/session_016dhzGudmQiegDY22TMj2Vk)_