### PR TITLE
[Misc] Define a constant for the duplicated "space" literal in DatabaseKeywordSearchSource

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/DatabaseKeywordSearchSource.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/DatabaseKeywordSearchSource.java
@@ -83,6 +83,11 @@ import static org.xwiki.rest.internal.resources.KeywordSearchScope.TITLE;
 @Named("database")
 public class DatabaseKeywordSearchSource implements KeywordSearchSource
 {
+    /**
+     * The {@code space} literal, used as an order field name, as a query parameter name and as a search result type.
+     */
+    private static final String SPACE = "space";
+
     @Inject
     protected ContextualAuthorizationManager authorizationManager;
 
@@ -175,8 +180,8 @@ public class DatabaseKeywordSearchSource implements KeywordSearchSource
             String addColumn = "";
             if (!StringUtils.isBlank(orderField)) {
                 addColumn =
-                    (orderField.isEmpty() || "fullName".equals(orderField) || "name".equals(orderField) || "space"
-                        .equals(orderField)) ? "" : ", doc." + orderField;
+                    (orderField.isEmpty() || "fullName".equals(orderField) || "name".equals(orderField)
+                        || SPACE.equals(orderField)) ? "" : ", doc." + orderField;
             }
 
             String addSpace = "";
@@ -269,7 +274,7 @@ public class DatabaseKeywordSearchSource implements KeywordSearchSource
                 .setLimit(options.number() * 2);
 
             if (options.space() != null) {
-                query.bindValue("space", options.space());
+                query.bindValue(SPACE, options.space());
             }
 
             if (options.searchScopes().contains(NAME)) {
@@ -421,7 +426,7 @@ public class DatabaseKeywordSearchSource implements KeywordSearchSource
                 Document spaceDoc = xwikiApi.getDocument(spaceReference);
 
                 SearchResult searchResult = objectFactory.createSearchResult();
-                searchResult.setType("space");
+                searchResult.setType(SPACE);
                 searchResult.setId(spaceId);
                 searchResult.setWiki(wikiName);
                 searchResult.setSpace(spaceId);
@@ -478,8 +483,8 @@ public class DatabaseKeywordSearchSource implements KeywordSearchSource
              * select clause.
              */
             String addColumn =
-                (orderField.isEmpty() || "fullName".equals(orderField) || "name".equals(orderField) || "space"
-                    .equals(orderField)) ? "" : ", doc." + orderField;
+                (orderField.isEmpty() || "fullName".equals(orderField) || "name".equals(orderField)
+                    || SPACE.equals(orderField)) ? "" : ", doc." + orderField;
 
             if (options.space() != null) {
                 f.format("select distinct doc.fullName, doc.space, doc.name, obj.className, obj.number");
@@ -529,7 +534,7 @@ public class DatabaseKeywordSearchSource implements KeywordSearchSource
                 queryResult =
                     finalQueryManager.createQuery(query, Query.XWQL)
                         .bindValue("keywords", String.format("%%%s%%", keywords.toUpperCase()))
-                        .bindValue("space", options.space()).setLimit(options.number()).execute();
+                        .bindValue(SPACE, options.space()).setLimit(options.number()).execute();
             } else {
                 queryResult =
                     finalQueryManager.createQuery(query, Query.XWQL)


### PR DESCRIPTION
## Summary

Fixes the SonarQube issue [java:S1192](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AZ0ozLiw3af-gOVdekEi&open=AZ0ozLiw3af-gOVdekEi) (CRITICAL) in `DatabaseKeywordSearchSource`: the string literal `"space"` was duplicated 5 times.

### Change

- Introduced a private `SPACE` constant and reused it for:
  - the order field comparison (`SPACE.equals(orderField)`, twice),
  - the HQL query parameter name (`bindValue(SPACE, ...)`, twice),
  - the search result type (`setType(SPACE)`).

No behavior change — the literal value is unchanged, only factored into a constant. No public API is affected (backward compatibility preserved, verified by RevAPI).

## SonarCloud Issue

https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AZ0ozLiw3af-gOVdekEi&open=AZ0ozLiw3af-gOVdekEi

## Test plan

- [x] `mvn clean verify -Pquality` passes on `xwiki-platform-rest-server` (Checkstyle: 0 violations, RevAPI: no API breakage, JaCoCo: coverage met, tests green).

## Token usage (approximate)

- Finding an issue to fix: ~28k tokens
- Fixing the issue: ~22k tokens
- Work after fixing (commit, PR, SonarCloud transition): ~12k tokens

---
_Generated by [Claude Code](https://claude.ai/code/session_01N87L66gd2suE9qhhoo847f)_