### PR TITLE
[Misc] Document the empty store() method in StopStatsRegisterObject

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/stats/impl/xwiki/StopStatsRegisterObject.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/stats/impl/xwiki/StopStatsRegisterObject.java
@@ -37,5 +37,8 @@ class StopStatsRegisterObject implements XWikiStatsStoreItem
     @Override
     public void store(List<XWikiStatsStoreItem> register)
     {
+        // Intentionally empty: this item is only a marker used to signal that the statistics storing must stop.
+        // It never carries any statistics to store and it's recognized through an "instanceof" check before "store"
+        // would ever be called, so there's nothing to do here.
     }
 }


### PR DESCRIPTION
## Summary

Fixes a SonarQube **CRITICAL** issue (rule `java:S1186` — "Methods should not be empty") in `StopStatsRegisterObject.java`.

### Problem

The `store(List<XWikiStatsStoreItem>)` method had an empty body with no explanation, which SonarQube flags because an empty method can be a sign of a missing implementation.

### Fix

`StopStatsRegisterObject` is only a *marker* (poison-pill) item: it is enqueued in `XWikiStatsStoreService` to signal that the statistics storing thread must stop, and it is recognized through an `instanceof` check before `store()` would ever be invoked. The method therefore has nothing to do by design. Added an explanatory comment documenting why the body is intentionally left empty, which is the resolution recommended by the rule. No behavioral change and no impact on backward compatibility.

## SonarCloud Issue

https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AZ0l7WFzhkAMMveQw34z&open=AZ0l7WFzhkAMMveQw34z

## Test plan

- [x] `mvn clean verify -Pquality` passes on `xwiki-platform-oldcore` (1119 tests, 0 failures, Checkstyle clean)

## Token usage

- Finding an issue to fix: ~45k tokens
- Fixing the issue: ~30k tokens
- Work after fixing the issue (commit, push, PR, issue transition): ~10k tokens

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rzef37twU8AX2LPx66NPui)_