### PR TITLE
Improve group filtering (XWIKI-22764, XWIKI-24466, XWIKI-22765)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-events/xwiki-platform-filter-event-user/src/main/java/org/xwiki/filter/event/user/GroupFilter.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-events/xwiki-platform-filter-event-user/src/main/java/org/xwiki/filter/event/user/GroupFilter.java
@@ -44,6 +44,12 @@ public interface GroupFilter
      */
     String PARAMETER_REVISION_DATE = "revision_date";
 
+    /**
+     * @type {@link java.lang.Boolean}
+     * @since 18.5.0
+     */
+    String PARAMETER_APPEND = "append";
+
     // Events
 
     /**

--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-events/xwiki-platform-filter-event-user/src/main/java/org/xwiki/filter/event/user/GroupFilter.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-events/xwiki-platform-filter-event-user/src/main/java/org/xwiki/filter/event/user/GroupFilter.java
@@ -46,7 +46,7 @@ public interface GroupFilter
 
     /**
      * @type {@link java.lang.Boolean}
-     * @since 18.5.0
+     * @since 18.6.0RC1
      */
     String PARAMETER_OVERWRITE = "overwrite";
 

--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-events/xwiki-platform-filter-event-user/src/main/java/org/xwiki/filter/event/user/GroupFilter.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-events/xwiki-platform-filter-event-user/src/main/java/org/xwiki/filter/event/user/GroupFilter.java
@@ -48,7 +48,7 @@ public interface GroupFilter
      * @type {@link java.lang.Boolean}
      * @since 18.5.0
      */
-    String PARAMETER_APPEND = "append";
+    String PARAMETER_OVERWRITE = "overwrite";
 
     // Events
 

--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-instance/xwiki-platform-filter-instance-document/src/main/java/org/xwiki/filter/instance/output/EntityInstanceOutputProperties.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-instance/xwiki-platform-filter-instance-document/src/main/java/org/xwiki/filter/instance/output/EntityInstanceOutputProperties.java
@@ -102,7 +102,7 @@ public class EntityInstanceOutputProperties extends InstanceOutputProperties
      * @return Indicate if the version related information coming from the events should be kept
      */
     @PropertyName("Preserve version")
-    @PropertyDescription("Indicate if the versions related informations coming from the events should be kept")
+    @PropertyDescription("Indicate if the versions related data coming from the events should be kept")
     public boolean isVersionPreserved()
     {
         return this.versionPreserved;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
@@ -2177,7 +2177,7 @@ public class XWiki implements EventListener
             context.setWikiId(doc.getDocumentReference().getWikiReference().getName());
 
             try {
-                // Indicate the the async context manipulated documents
+                // Indicate the async context manipulated documents
                 getAsyncContext().useEntity(doc.getDocumentReferenceWithLocale());
             } catch (Exception e) {
                 // If the AsyncContext component does not work then we are not in an asynchronous context anyway

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/output/UserInstanceOutputFilterStream.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/output/UserInstanceOutputFilterStream.java
@@ -21,13 +21,14 @@ package com.xpn.xwiki.internal.filter.output;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
+import java.util.ArrayDeque;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.Queue;
+import java.util.TreeSet;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -71,6 +72,7 @@ public class UserInstanceOutputFilterStream extends AbstractBeanOutputFilterStre
     implements UserInstanceOutputFilter
 {
     private static final EntityReference DEFAULT_SPACE = new EntityReference("XWiki", EntityType.SPACE);
+    private static final String MEMBER = "member";
 
     @Inject
     @Named("relative")
@@ -94,7 +96,7 @@ public class UserInstanceOutputFilterStream extends AbstractBeanOutputFilterStre
 
     private String currentWiki;
 
-    private List<String> members;
+    private Collection<String> membersToAdd;
 
     @Override
     public void close() throws IOException
@@ -171,11 +173,6 @@ public class UserInstanceOutputFilterStream extends AbstractBeanOutputFilterStre
         XWikiDocument groupDoc = xcontext.getWiki().getDocument(getGroupDocumentReference(id), xcontext);
         if (groupDoc.isNew()) {
             return groupDoc;
-        }
-
-        if (TRUE.equals(parameters.get(PARAMETER_OVERWRITE))) {
-            xcontext.getWiki().deleteDocument(groupDoc, false, xcontext);
-            return getGroupDocument(id, parameters);
         }
 
         // Don't modify any cached document abusively
@@ -316,20 +313,24 @@ public class UserInstanceOutputFilterStream extends AbstractBeanOutputFilterStre
     public void beginGroupContainer(String name, FilterEventParameters parameters) throws FilterException
     {
         // Init members
-        this.members = new ArrayList<>();
+        this.membersToAdd = new TreeSet<>();
     }
 
     private void addMember(String member, XWikiDocument groupDocument, DocumentReference groupClass,
-            XWikiContext xcontext) throws FilterException
+            Queue<BaseObject> toOverwrite, XWikiContext xcontext) throws FilterException
     {
         BaseObject memberObject;
         try {
-            memberObject = groupDocument.newXObject(groupClass, xcontext);
+            // We take an existing object to overwrite, or we create a new one if there isn't any
+            memberObject = toOverwrite.poll();
+            if (memberObject == null) {
+                memberObject = groupDocument.newXObject(groupClass, xcontext);
+            }
         } catch (XWikiException e) {
             throw new FilterException("Failed to add a group member object", e);
         }
 
-        memberObject.setStringValue("member", member);
+        memberObject.setStringValue(MEMBER, member);
     }
 
     @Override
@@ -364,21 +365,40 @@ public class UserInstanceOutputFilterStream extends AbstractBeanOutputFilterStre
             xcontext.setWikiId(originalWikiId);
         }
 
-        Set<String> existingMembers = groupDocument.getXObjects(groupClass)
-                .stream()
-                .map(obj -> obj.getStringValue("member"))
-                .collect(Collectors.toSet());
-        if (this.members.isEmpty() && existingMembers.isEmpty()) {
-            // Put an empty member so that the document is "marked" as group
-            addMember("", groupDocument, groupClass, xcontext);
-        } else {
-            this.members.removeAll(existingMembers);
-            for (String member : this.members) {
-                addMember(member, groupDocument, groupClass, xcontext);
+        boolean overwrite = TRUE.equals(parameters.get(PARAMETER_OVERWRITE));
+
+        List<BaseObject> existingObjects = groupDocument.getXObjects(groupClass);
+        Queue<BaseObject> membersToDrop = new ArrayDeque<>();
+
+        // We determine which members to add are already there and which members to remove
+        // The objects of members to remove will be reused to add the new members and then deleted if there are
+        // remaining ones.
+        // Doing this helps limit the number of database operations (deletes) and works around issues related to
+        // inserting objects with the same index than already existing objects (that we are deleting)
+
+        for (BaseObject existingObject : existingObjects) {
+            String existingMember = existingObject.getStringValue(MEMBER);
+            // we remove existing members from the list of members to add
+            boolean keepThisExistingMember = this.membersToAdd.remove(existingMember);
+            if (overwrite && !keepThisExistingMember) {
+                membersToDrop.add(existingObject);
             }
         }
 
-        // Save
+        boolean allExistingMembersAreDropped = existingObjects.size() == membersToDrop.size();
+        if (this.membersToAdd.isEmpty() && allExistingMembersAreDropped) {
+            // Put an empty member in this empty group so that the document is "marked" as group
+            addMember("", groupDocument, groupClass, membersToDrop, xcontext);
+        } else {
+            for (String member : this.membersToAdd) {
+                addMember(member, groupDocument, groupClass, membersToDrop, xcontext);
+            }
+        }
+
+        for (BaseObject memberToDrop : membersToDrop) {
+            groupDocument.removeXObject(memberToDrop);
+        }
+
         try {
             if (groupDocument.isNew() && this.properties.isVersionPreserved()) {
                 maybeSetDates(parameters, groupDocument, GroupFilter.PARAMETER_CREATION_DATE, GroupFilter.PARAMETER_REVISION_DATE);
@@ -393,14 +413,14 @@ public class UserInstanceOutputFilterStream extends AbstractBeanOutputFilterStre
         }
 
         // Reset members
-        this.members = null;
+        this.membersToAdd = null;
     }
 
     private void addMember(String name)
     {
         EntityReference memberReference = this.relativeResolver.resolve(name, EntityType.DOCUMENT, DEFAULT_SPACE);
 
-        this.members.add(this.serializer.serialize(memberReference));
+        this.membersToAdd.add(this.serializer.serialize(memberReference));
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/output/UserInstanceOutputFilterStream.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/output/UserInstanceOutputFilterStream.java
@@ -191,12 +191,12 @@ public class UserInstanceOutputFilterStream extends AbstractBeanOutputFilterStre
     @Override
     public void beginUser(String name, FilterEventParameters parameters) throws FilterException
     {
-        XWikiDocument userDocument;
+        XWikiDocument userDoc;
         try {
-            userDocument = getUserDocument(name);
+            userDoc = getUserDocument(name);
 
             // Safer to clone for thread safety and in case the save fail
-            userDocument = userDocument.clone();
+            userDoc = userDoc.clone();
         } catch (XWikiException e) {
             throw new FilterException("Failed to get an XWikiDocument for user name [" + name + "]", e);
         }
@@ -223,10 +223,37 @@ public class UserInstanceOutputFilterStream extends AbstractBeanOutputFilterStre
 
         XWikiContext xcontext = this.xcontextProvider.get();
 
+        createOrUpdateUserObject(xcontext, userDoc, map);
+
+        if (userDoc.isNew()) {
+            // Authors
+            userDoc.setCreatorReference(userDoc.getDocumentReference());
+            userDoc.setAuthorReference(userDoc.getDocumentReference());
+            userDoc.setContentAuthorReference(userDoc.getDocumentReference());
+
+            // Dates
+            maybeSetDates(parameters, userDoc, UserFilter.PARAMETER_CREATION_DATE, UserFilter.PARAMETER_REVISION_DATE);
+
+            // Set false to force the date and authors we want
+            userDoc.setMetaDataDirty(false);
+            userDoc.setContentDirty(false);
+        }
+
+        // Save
+        try {
+            xcontext.getWiki().saveDocument(userDoc, this.properties.getSaveComment(), xcontext);
+        } catch (XWikiException e) {
+            throw new FilterException("Failed to save user document", e);
+        }
+    }
+
+    private static void createOrUpdateUserObject(XWikiContext xcontext, XWikiDocument userDoc, Map<String, Object> map)
+            throws FilterException
+    {
         BaseClass userClass;
         String originalWikiId = xcontext.getWikiId();
         // Make sure we get the group class from the same wiki as the imported user
-        xcontext.setWikiId(userDocument.getDocumentReference().getWikiReference().getName());
+        xcontext.setWikiId(userDoc.getDocumentReference().getWikiReference().getName());
         try {
             userClass = xcontext.getWiki().getUserClass(xcontext);
         } catch (XWikiException e) {
@@ -235,18 +262,18 @@ public class UserInstanceOutputFilterStream extends AbstractBeanOutputFilterStre
             xcontext.setWikiId(originalWikiId);
         }
 
-        BaseObject userObject = userDocument.getXObject(userClass.getReference());
+        BaseObject userObject = userDoc.getXObject(userClass.getReference());
         if (userObject == null) {
             // Create object
             try {
-                userObject = userDocument.newXObject(userClass.getReference(), xcontext);
+                userObject = userDoc.newXObject(userClass.getReference(), xcontext);
             } catch (XWikiException e) {
                 throw new FilterException("Failed to create user object", e);
             }
 
             // Setup right on user profile
             try {
-                xcontext.getWiki().protectUserPage(userDocument.getFullName(), "edit", userDocument, xcontext);
+                xcontext.getWiki().protectUserPage(userDoc.getFullName(), "edit", userDoc, xcontext);
             } catch (XWikiException e) {
                 throw new FilterException("Failed to initialize user", e);
             }
@@ -254,31 +281,10 @@ public class UserInstanceOutputFilterStream extends AbstractBeanOutputFilterStre
 
         // Update user properties
         userClass.fromValueMap(map, userObject);
-
-        if (userDocument.isNew()) {
-            // Authors
-            userDocument.setCreatorReference(userDocument.getDocumentReference());
-            userDocument.setAuthorReference(userDocument.getDocumentReference());
-            userDocument.setContentAuthorReference(userDocument.getDocumentReference());
-
-            // Dates
-            maybeSetDates(parameters, userDocument, UserFilter.PARAMETER_CREATION_DATE, UserFilter.PARAMETER_REVISION_DATE);
-
-            // Set false to force the date and authors we want
-            userDocument.setMetaDataDirty(false);
-            userDocument.setContentDirty(false);
-        }
-
-        // Save
-        try {
-            xcontext.getWiki().saveDocument(userDocument, this.properties.getSaveComment(), xcontext);
-        } catch (XWikiException e) {
-            throw new FilterException("Failed to save user document", e);
-        }
     }
 
     private void maybeSetDates(FilterEventParameters parameters, XWikiDocument doc, String creationField,
-       String revisionField)
+        String revisionField)
     {
         if (this.properties.isVersionPreserved()) {
             if (parameters.containsKey(creationField)) {
@@ -360,8 +366,31 @@ public class UserInstanceOutputFilterStream extends AbstractBeanOutputFilterStre
             xcontext.setWikiId(originalWikiId);
         }
 
-        boolean overwrite = TRUE.equals(parameters.get(PARAMETER_OVERWRITE));
+        boolean overwrite = TRUE.equals(parameters.get(GroupFilter.PARAMETER_OVERWRITE));
 
+        updateGroupObjects(groupDocument, groupClass, overwrite, xcontext);
+
+        try {
+            if (groupDocument.isNew() && this.properties.isVersionPreserved()) {
+                maybeSetDates(parameters, groupDocument, GroupFilter.PARAMETER_CREATION_DATE,
+                        GroupFilter.PARAMETER_REVISION_DATE);
+
+                // Make sure the dates won't be overwritten when saving
+                groupDocument.setMetaDataDirty(false);
+                groupDocument.setContentDirty(false);
+            }
+            wiki.saveDocument(groupDocument, this.properties.getSaveComment(), xcontext);
+        } catch (XWikiException e) {
+            throw new FilterException("Failed to save group document", e);
+        }
+
+        // Reset members
+        this.membersToAdd = null;
+    }
+
+    private void updateGroupObjects(XWikiDocument groupDocument, DocumentReference groupClass, boolean overwrite,
+            XWikiContext xcontext) throws FilterException
+    {
         List<BaseObject> existingObjects = groupDocument.getXObjects(groupClass);
         Queue<BaseObject> membersToDrop = new ArrayDeque<>();
 
@@ -393,22 +422,6 @@ public class UserInstanceOutputFilterStream extends AbstractBeanOutputFilterStre
         for (BaseObject memberToDrop : membersToDrop) {
             groupDocument.removeXObject(memberToDrop);
         }
-
-        try {
-            if (groupDocument.isNew() && this.properties.isVersionPreserved()) {
-                maybeSetDates(parameters, groupDocument, GroupFilter.PARAMETER_CREATION_DATE, GroupFilter.PARAMETER_REVISION_DATE);
-
-                // Make sure the dates won't be overwritten when saving
-                groupDocument.setMetaDataDirty(false);
-                groupDocument.setContentDirty(false);
-            }
-            wiki.saveDocument(groupDocument, this.properties.getSaveComment(), xcontext);
-        } catch (XWikiException e) {
-            throw new FilterException("Failed to save group document", e);
-        }
-
-        // Reset members
-        this.membersToAdd = null;
     }
 
     private void addMember(String name)

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/output/UserInstanceOutputFilterStream.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/output/UserInstanceOutputFilterStream.java
@@ -173,7 +173,7 @@ public class UserInstanceOutputFilterStream extends AbstractBeanOutputFilterStre
             return groupDoc;
         }
 
-         if (!TRUE.equals(parameters.get(PARAMETER_APPEND))) {
+        if (TRUE.equals(parameters.get(PARAMETER_OVERWRITE))) {
             xcontext.getWiki().deleteDocument(groupDoc, false, xcontext);
             return getGroupDocument(id, parameters);
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/output/UserInstanceOutputFilterStream.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/output/UserInstanceOutputFilterStream.java
@@ -39,7 +39,6 @@ import org.apache.commons.lang3.reflect.TypeUtils;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.annotation.InstantiationStrategy;
 import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
-import org.xwiki.component.manager.ComponentManager;
 import org.xwiki.filter.FilterEventParameters;
 import org.xwiki.filter.FilterException;
 import org.xwiki.filter.event.user.GroupFilter;
@@ -89,10 +88,6 @@ public class UserInstanceOutputFilterStream extends AbstractBeanOutputFilterStre
 
     @Inject
     private ConverterManager converter;
-
-    @Inject
-    @Named("context")
-    private Provider<ComponentManager> componentManagerProvider;
 
     private String currentWiki;
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/output/UserInstanceOutputFilterStream.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/output/UserInstanceOutputFilterStream.java
@@ -26,11 +26,14 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Provider;
 
+import com.xpn.xwiki.XWiki;
 import org.apache.commons.lang3.reflect.TypeUtils;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.annotation.InstantiationStrategy;
@@ -38,6 +41,7 @@ import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
 import org.xwiki.component.manager.ComponentManager;
 import org.xwiki.filter.FilterEventParameters;
 import org.xwiki.filter.FilterException;
+import org.xwiki.filter.event.user.GroupFilter;
 import org.xwiki.filter.event.user.UserFilter;
 import org.xwiki.filter.output.AbstractBeanOutputFilterStream;
 import org.xwiki.model.EntityType;
@@ -53,6 +57,8 @@ import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.objects.BaseObject;
 import com.xpn.xwiki.objects.classes.BaseClass;
+
+import static java.lang.Boolean.TRUE;
 
 /**
  * @version $Id$
@@ -158,11 +164,22 @@ public class UserInstanceOutputFilterStream extends AbstractBeanOutputFilterStre
         return new DocumentReference(getCurrentWiki(), DEFAULT_SPACE.getName(), id);
     }
 
-    private XWikiDocument getGroupDocument(String id) throws XWikiException
+    private XWikiDocument getGroupDocument(String id, FilterEventParameters parameters) throws XWikiException
     {
         XWikiContext xcontext = this.xcontextProvider.get();
 
-        return xcontext.getWiki().getDocument(getGroupDocumentReference(id), xcontext);
+        XWikiDocument groupDoc = xcontext.getWiki().getDocument(getGroupDocumentReference(id), xcontext);
+        if (groupDoc.isNew()) {
+            return groupDoc;
+        }
+
+         if (!TRUE.equals(parameters.get(PARAMETER_APPEND))) {
+            xcontext.getWiki().deleteDocument(groupDoc, false, xcontext);
+            return getGroupDocument(id, parameters);
+        }
+
+        // Don't modify any cached document abusively
+        return groupDoc.clone();
     }
 
     // Events
@@ -215,10 +232,15 @@ public class UserInstanceOutputFilterStream extends AbstractBeanOutputFilterStre
         XWikiContext xcontext = this.xcontextProvider.get();
 
         BaseClass userClass;
+        String originalWikiId = xcontext.getWikiId();
+        // Make sure we get the group class from the same wiki as the imported user
+        xcontext.setWikiId(userDocument.getDocumentReference().getWikiReference().getName());
         try {
             userClass = xcontext.getWiki().getUserClass(xcontext);
         } catch (XWikiException e) {
             throw new FilterException("Failed to get user class", e);
+        } finally {
+            xcontext.setWikiId(originalWikiId);
         }
 
         BaseObject userObject = userDocument.getXObject(userClass.getReference());
@@ -248,16 +270,7 @@ public class UserInstanceOutputFilterStream extends AbstractBeanOutputFilterStre
             userDocument.setContentAuthorReference(userDocument.getDocumentReference());
 
             // Dates
-            if (this.properties.isVersionPreserved()) {
-                if (parameters.containsKey(UserFilter.PARAMETER_CREATION_DATE)) {
-                    userDocument.setCreationDate(getDate(UserFilter.PARAMETER_CREATION_DATE, parameters, new Date()));
-                }
-                if (parameters.containsKey(UserFilter.PARAMETER_REVISION_DATE)) {
-                    userDocument.setDate(getDate(UserFilter.PARAMETER_REVISION_DATE, parameters, new Date()));
-                    userDocument
-                        .setContentUpdateDate(getDate(UserFilter.PARAMETER_REVISION_DATE, parameters, new Date()));
-                }
-            }
+            maybeSetDates(parameters, userDocument, UserFilter.PARAMETER_CREATION_DATE, UserFilter.PARAMETER_REVISION_DATE);
 
             // Set false to force the date and authors we want
             userDocument.setMetaDataDirty(false);
@@ -269,6 +282,20 @@ public class UserInstanceOutputFilterStream extends AbstractBeanOutputFilterStre
             xcontext.getWiki().saveDocument(userDocument, this.properties.getSaveComment(), xcontext);
         } catch (XWikiException e) {
             throw new FilterException("Failed to save user document", e);
+        }
+    }
+
+    private void maybeSetDates(FilterEventParameters parameters, XWikiDocument doc, String creationField,
+       String revisionField)
+    {
+        if (this.properties.isVersionPreserved()) {
+            if (parameters.containsKey(creationField)) {
+                doc.setCreationDate(getDate(creationField, parameters, new Date()));
+            }
+            if (parameters.containsKey(revisionField)) {
+                doc.setDate(getDate(revisionField, parameters, new Date()));
+                doc.setContentUpdateDate(getDate(revisionField, parameters, new Date()));
+            }
         }
     }
 
@@ -292,12 +319,12 @@ public class UserInstanceOutputFilterStream extends AbstractBeanOutputFilterStre
         this.members = new ArrayList<>();
     }
 
-    private void addMember(String member, XWikiDocument groupDocument, BaseClass groupClass, XWikiContext xcontext)
-        throws FilterException
+    private void addMember(String member, XWikiDocument groupDocument, DocumentReference groupClass,
+            XWikiContext xcontext) throws FilterException
     {
         BaseObject memberObject;
         try {
-            memberObject = groupDocument.newXObject(groupClass.getReference(), xcontext);
+            memberObject = groupDocument.newXObject(groupClass, xcontext);
         } catch (XWikiException e) {
             throw new FilterException("Failed to add a group member object", e);
         }
@@ -319,22 +346,33 @@ public class UserInstanceOutputFilterStream extends AbstractBeanOutputFilterStre
 
         XWikiDocument groupDocument;
         try {
-            groupDocument = getGroupDocument(name);
+            groupDocument = getGroupDocument(name, parameters);
         } catch (XWikiException e) {
             throw new FilterException("Failed to get an XWikiDocument for group name [" + name + "]", e);
         }
 
-        BaseClass groupClass;
+        DocumentReference groupClass;
+        String originalWikiId = xcontext.getWikiId();
+        // Make sure we get the group class from the same wiki as the imported group
+        xcontext.setWikiId(groupDocument.getDocumentReference().getWikiReference().getName());
+        XWiki wiki = xcontext.getWiki();
         try {
-            groupClass = xcontext.getWiki().getGroupClass(xcontext);
+            groupClass = wiki.getGroupClass(xcontext).getReference();
         } catch (XWikiException e) {
             throw new FilterException("Failed to get group class", e);
+        } finally {
+            xcontext.setWikiId(originalWikiId);
         }
 
-        if (this.members.isEmpty()) {
+        Set<String> existingMembers = groupDocument.getXObjects(groupClass)
+                .stream()
+                .map(obj -> obj.getStringValue("member"))
+                .collect(Collectors.toSet());
+        if (this.members.isEmpty() && existingMembers.isEmpty()) {
             // Put an empty member so that the document is "marked" as group
             addMember("", groupDocument, groupClass, xcontext);
         } else {
+            this.members.removeAll(existingMembers);
             for (String member : this.members) {
                 addMember(member, groupDocument, groupClass, xcontext);
             }
@@ -342,7 +380,14 @@ public class UserInstanceOutputFilterStream extends AbstractBeanOutputFilterStre
 
         // Save
         try {
-            xcontext.getWiki().saveDocument(groupDocument, this.properties.getSaveComment(), xcontext);
+            if (groupDocument.isNew() && this.properties.isVersionPreserved()) {
+                maybeSetDates(parameters, groupDocument, GroupFilter.PARAMETER_CREATION_DATE, GroupFilter.PARAMETER_REVISION_DATE);
+
+                // Make sure the dates won't be overwritten when saving
+                groupDocument.setMetaDataDirty(false);
+                groupDocument.setContentDirty(false);
+            }
+            wiki.saveDocument(groupDocument, this.properties.getSaveComment(), xcontext);
         } catch (XWikiException e) {
             throw new FilterException("Failed to save group document", e);
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/filter/output/UserInstanceOutputFilterStreamTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/filter/output/UserInstanceOutputFilterStreamTest.java
@@ -21,6 +21,8 @@ package com.xpn.xwiki.internal.filter.output;
 
 import java.text.ParseException;
 
+import com.xpn.xwiki.XWiki;
+import com.xpn.xwiki.XWikiContext;
 import org.junit.jupiter.api.Test;
 import org.xwiki.filter.FilterException;
 import org.xwiki.model.reference.DocumentReference;
@@ -33,6 +35,7 @@ import com.xpn.xwiki.test.MockitoOldcoreRule;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Validate {@link UserInstanceOutputFilterStream}.
@@ -41,6 +44,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  */
 class UserInstanceOutputFilterStreamTest extends AbstractInstanceFilterStreamTest
 {
+    private static final DocumentReference GROUP1 = new DocumentReference("wiki1", "XWiki", "group1");
+
     // Tests
 
     @Test
@@ -101,15 +106,15 @@ class UserInstanceOutputFilterStreamTest extends AbstractInstanceFilterStreamTes
 
         // XWiki.group1
 
-        XWikiDocument groupDocument = this.oldcore.getSpyXWiki()
-            .getDocument(new DocumentReference("wiki1", "XWiki", "group1"), this.oldcore.getXWikiContext());
-
+        XWikiDocument groupDocument = this.oldcore.getSpyXWiki().getDocument(GROUP1, this.oldcore.getXWikiContext());
         assertFalse(groupDocument.isNew());
 
         BaseObject groupMemberObject0 = groupDocument.getXObject(MockitoOldcoreRule.GROUP_CLASS, 0);
         assertEquals("XWiki.user1", groupMemberObject0.getStringValue("member"));
         BaseObject groupMemberObject1 = groupDocument.getXObject(MockitoOldcoreRule.GROUP_CLASS, 1);
         assertEquals("XWiki.user2", groupMemberObject1.getStringValue("member"));
+
+        assertEquals(2, groupDocument.getXObjects(MockitoOldcoreRule.GROUP_CLASS).size());
 
         // XWiki.group2
 
@@ -165,4 +170,47 @@ class UserInstanceOutputFilterStreamTest extends AbstractInstanceFilterStreamTes
         assertEquals("user1@email.ext", userObject.getStringValue("email"));
         assertEquals(1, userObject.getIntValue("active"));
     }
+
+    @Test
+    void importOverExistingGroupKeepsExistingMembersAndDoesNotAddDuplication() throws FilterException, XWikiException
+    {
+        // Ensure group1 is empty
+        XWiki wiki = this.oldcore.getSpyXWiki();
+        XWikiContext context = this.oldcore.getXWikiContext();
+        XWikiDocument groupDocument = wiki.getDocument(GROUP1, context).clone();
+        groupDocument.removeXObjects(MockitoOldcoreRule.GROUP_CLASS);
+        wiki.saveDocument(groupDocument, "Empty group1", context);
+
+        // Add user1
+        groupDocument = wiki.getDocument(GROUP1, context).clone();
+        BaseObject user1Member = groupDocument.newXObject(MockitoOldcoreRule.GROUP_CLASS, context);
+        user1Member.setStringValue("member", "XWiki.user1");
+        wiki.saveDocument(groupDocument, "Add user1 to group1", context);
+
+        // Add user0
+        groupDocument = wiki.getDocument(GROUP1, context).clone();
+        BaseObject user0Member = groupDocument.newXObject(MockitoOldcoreRule.GROUP_CLASS, context);
+        user0Member.setStringValue("member", "XWiki.user0");
+
+        // Catch abusive modifications
+        groupDocument.setCached(true);
+
+        wiki.saveDocument(groupDocument, "Add user0 to group1", context);
+
+        // Import user1 and user2
+        importFromXML("user1");
+
+        XWikiDocument groupDocument1 = this.oldcore.getSpyXWiki().getDocument(GROUP1, this.oldcore.getXWikiContext());
+        assertFalse(groupDocument1.isNew());
+
+        BaseObject groupMemberObject0 = groupDocument1.getXObject(MockitoOldcoreRule.GROUP_CLASS, 0);
+        assertEquals("XWiki.user1", groupMemberObject0.getStringValue("member"));
+        BaseObject groupMemberObject1 = groupDocument1.getXObject(MockitoOldcoreRule.GROUP_CLASS, 1);
+        assertEquals("XWiki.user0", groupMemberObject1.getStringValue("member"));
+        BaseObject groupMemberObject2 = groupDocument1.getXObject(MockitoOldcoreRule.GROUP_CLASS, 2);
+        assertEquals("XWiki.user2", groupMemberObject2.getStringValue("member"));
+
+        assertEquals(3, groupDocument1.getXObjects(MockitoOldcoreRule.GROUP_CLASS).size());
+    }
+
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/resources/filter/user1.xml
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/resources/filter/user1.xml
@@ -62,10 +62,38 @@
     </p>
   </user>
   <groupContainer name="group1">
+    <p>
+      <parameters>
+        <entry>
+          <string>creation_date</string>
+          <date>2000-01-20 00:00:00.0 UTC</date>
+        </entry>
+        <entry>
+          <string>revision_date</string>
+          <date>2000-01-21 00:00:00.0 UTC</date>
+        </entry>
+        <entry>
+          <string>append</string>
+          <boolean>true</boolean>
+        </entry>
+      </parameters>
+    </p>
     <groupMemberUser name="user1" />
     <groupMemberUser name="user2" />
   </groupContainer>
   <groupContainer name="group2">
+    <p>
+      <parameters>
+        <entry>
+          <string>creation_date</string>
+          <date>2000-01-20 00:00:00.0 UTC</date>
+        </entry>
+        <entry>
+          <string>revision_date</string>
+          <date>2000-01-21 00:00:00.0 UTC</date>
+        </entry>
+      </parameters>
+    </p>
     <groupMemberGroup name="group1" />
   </groupContainer>
   <groupContainer name="emptygroup" />

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/resources/filter/user1.xml
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/resources/filter/user1.xml
@@ -72,10 +72,6 @@
           <string>revision_date</string>
           <date>2000-01-21 00:00:00.0 UTC</date>
         </entry>
-        <entry>
-          <string>append</string>
-          <boolean>true</boolean>
-        </entry>
       </parameters>
     </p>
     <groupMemberUser name="user1" />
@@ -84,6 +80,10 @@
   <groupContainer name="group2">
     <p>
       <parameters>
+        <entry>
+          <string>overwrite</string>
+          <boolean>true</boolean>
+        </entry>
         <entry>
           <string>creation_date</string>
           <date>2000-01-20 00:00:00.0 UTC</date>


### PR DESCRIPTION

# Jira URL

https://jira.xwiki.org/browse/XWIKI-22764 - Allow updating groups instead of overwriting
https://jira.xwiki.org/browse/XWIKI-24466 - Take creation and revision dates in account for group filtering when versions should be preserved 
https://jira.xwiki.org/browse/XWIKI-22765 - The user output can fail to save if the group already exists

# Changes

## Description

- Creation and revision dates are taken in account when creating a new group when versions should be preserved
- When the group already exists, use .clone()
- add a parameter to update instead of overwriting groups
  - overwriting is currently implemented by removing the original document

- [x] Should we overwrite by updating member objects instead of removing the original document?
- [ ] Should updating groups be done by default instead of overwriting?
 
## Clarifications

-

# Executed Tests

Updated the automated tests, and tried importing an XWikiAdminGroup with Confluence (but this was done with updating being on by default)

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 