### PR TITLE
[Misc] Access static nested class through its declaring class in XAR filter

### DIFF
--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/DocumentLocaleReader.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/DocumentLocaleReader.java
@@ -77,7 +77,7 @@ public class DocumentLocaleReader extends AbstractReader
     private XARXMLReader<WikiObjectReader.WikiObject> objectReader;
 
     @Inject
-    private XARXMLReader<WikiObjectPropertyReader.WikiObjectProperty> objectPropertyReader;
+    private XARXMLReader<AbstractWikiObjectPropertyReader.WikiObjectProperty> objectPropertyReader;
 
     @Inject
     private XARXMLReader<ClassReader.WikiClass> classReader;


### PR DESCRIPTION
## Summary

Fixes a SonarQube CRITICAL issue (rule `java:S3252` — "Static members should be accessed statically") in `DocumentLocaleReader.java`.

The `objectPropertyReader` field was typed as `XARXMLReader<WikiObjectPropertyReader.WikiObjectProperty>`, accessing the `WikiObjectProperty` static nested class through the `WikiObjectPropertyReader` subclass. That class is actually declared in the parent `AbstractWikiObjectPropertyReader`, so SonarQube flags the access as misleading (it suggests `WikiObjectProperty` is defined in `WikiObjectPropertyReader`).

### Change

- **`DocumentLocaleReader.java`**: Reference the nested class through its declaring class, i.e. `AbstractWikiObjectPropertyReader.WikiObjectProperty`. Both classes live in the same package, so no new import is needed.

### Backward Compatibility

No API change — this only affects a `private` field's generic type parameter, which resolves to the exact same nested class. Behaviour is identical.

## SonarCloud Issue

https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AZzDryJzAHaDflByRxXT&open=AZzDryJzAHaDflByRxXT

## Test plan

- [x] `mvn clean verify -Pquality` passes on `xwiki-platform-filter-stream-xar` (BUILD SUCCESS)

## Token usage (approximate)

- Finding an issue to fix: ~40k tokens
- Fixing the issue (incl. Maven build/verify output): ~55k tokens
- Work after fixing (commit, push, PR, SonarCloud transition): ~15k tokens

---
_Generated by [Claude Code](https://claude.ai/code/session_012C5kCYu2GwbwXvy3QB7cgv)_