### PR TITLE
[Misc] Fix SonarQube static access issue in WikiObjectPropertyReader

### DIFF
--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/WikiObjectPropertyReader.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/WikiObjectPropertyReader.java
@@ -34,7 +34,7 @@ import org.xwiki.filter.xar.input.XARInputProperties;
 @Component
 @Singleton
 public class WikiObjectPropertyReader extends AbstractWikiObjectPropertyReader
-    implements XARXMLReader<WikiObjectPropertyReader.WikiObjectProperty>
+    implements XARXMLReader<AbstractWikiObjectPropertyReader.WikiObjectProperty>
 {
     @Override
     public WikiObjectProperty read(XMLStreamReader xmlReader, XARInputProperties properties)


### PR DESCRIPTION
## Summary

Fixes the SonarCloud issue [java:S3252 - Use static access with "AbstractWikiObjectPropertyReader" for "WikiObjectProperty"](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AZzDryLYAHaDflByRxXd&open=AZzDryLYAHaDflByRxXd) in `WikiObjectPropertyReader.java`.

### Problem

`WikiObjectProperty` is a `static` nested class declared in the superclass `AbstractWikiObjectPropertyReader`, but it was being referenced through the subclass (`WikiObjectPropertyReader.WikiObjectProperty`) in the `XARXMLReader` generic type parameter. Accessing a static member through a subclass rather than its declaring class is misleading and is flagged by SonarQube (rule java:S3252).

### Fix

- Reference the nested `WikiObjectProperty` class directly through its declaring class `AbstractWikiObjectPropertyReader`. This is consistent with the existing usage in `DocumentLocaleReader.java`, which already declares `XARXMLReader<AbstractWikiObjectPropertyReader.WikiObjectProperty>`.

This is a purely cosmetic, behavior-preserving change in an `internal` package, so there is no backward-compatibility impact.

## Test plan

- [x] Build the `xwiki-platform-filter-stream-xar` module with `mvn clean verify -Pquality` — **BUILD SUCCESS**.
- [ ] Verify the SonarCloud issue is marked as resolved after the next scan.

## Token usage

- Cost in tokens for finding an issue to fix: ~50k tokens
- Cost in tokens for fixing the issue: ~25k tokens
- Cost in tokens for the work after fixing the issue: ~15k tokens

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gf5XnUE165vZwo1CERRXaJ)_