### PR TITLE
XWIKI-24356: Navigation panel keyboard focus should look similar to `:focus-visible`

### DIFF
--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/main.less
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/main.less
@@ -8,6 +8,7 @@
 	// .jstree-hovered { background:@hovered-bg-color; border-radius:2px; box-shadow:inset 0 0 1px @hovered-shadow-color; }
 	// .jstree-context { background:@hovered-bg-color; border-radius:2px; box-shadow:inset 0 0 1px @hovered-shadow-color; }
 	// .jstree-clicked { background:@clicked-bg-color; border-radius:2px; box-shadow:inset 0 0 1px @clicked-shadow-color; }
+	.jstree-hovered:hover { background:@hovered-bg-color; border-radius:3px; box-shadow:inset 0 0 1px @hovered-shadow-color; outline: revert;}
 	// We create a focus ring to make it look similar to :focus-visible styles. Two rules for cross browser compatibility.
 	.jstree-hovered {
 		outline: 5px auto Highlight;

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/main.less
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/main.less
@@ -9,7 +9,8 @@
 	// .jstree-context { background:@hovered-bg-color; border-radius:2px; box-shadow:inset 0 0 1px @hovered-shadow-color; }
 	// .jstree-clicked { background:@clicked-bg-color; border-radius:2px; box-shadow:inset 0 0 1px @clicked-shadow-color; }
 	.jstree-hovered:hover { background:@hovered-bg-color; box-shadow:inset 0 0 1px @hovered-shadow-color; outline: revert;}
-	// We create a focus ring to make it look similar to :focus-visible styles. Two rules for cross browser compatibility.
+	// We create a focus ring to make keyboard navigation look similar to :focus-visible styles. 
+	// Two rules are needed for cross browser compatibility.
 	.jstree-hovered {
 		outline: 5px auto Highlight;
 		outline: 5px auto -webkit-focus-ring-color;

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/main.less
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/main.less
@@ -8,7 +8,11 @@
 	// .jstree-hovered { background:@hovered-bg-color; border-radius:2px; box-shadow:inset 0 0 1px @hovered-shadow-color; }
 	// .jstree-context { background:@hovered-bg-color; border-radius:2px; box-shadow:inset 0 0 1px @hovered-shadow-color; }
 	// .jstree-clicked { background:@clicked-bg-color; border-radius:2px; box-shadow:inset 0 0 1px @clicked-shadow-color; }
-	.jstree-hovered { background:@hovered-bg-color; border-radius:3px; box-shadow:inset 0 0 1px @hovered-shadow-color; }
+	// We create a focus ring to make it look similar to :focus-visible styles. Two rules for cross browser compatibility.
+	.jstree-hovered {
+		outline: 5px auto Highlight;
+		outline: 5px auto -webkit-focus-ring-color;
+	}
 	.jstree-context { background:@hovered-bg-color; border-radius:3px; box-shadow:inset 0 0 1px @hovered-shadow-color; }
 	.jstree-clicked { background:@clicked-bg-color; border-radius:3px; box-shadow:inset 0 0 1px @clicked-shadow-color; }
 	// XWiki customization end

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/main.less
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/jstree/main.less
@@ -3,19 +3,19 @@
 	.jstree-icon { background-repeat:no-repeat; background-color:transparent; }
 	.jstree-anchor,
 	.jstree-animated,
-	.jstree-wholerow { transition:background-color 0.15s, box-shadow 0.15s; }
+	.jstree-wholerow { transition:background-color 0.15s, box-shadow 0.15s; border-radius: @border-radius-small; }
 	// XWiki customization start
 	// .jstree-hovered { background:@hovered-bg-color; border-radius:2px; box-shadow:inset 0 0 1px @hovered-shadow-color; }
 	// .jstree-context { background:@hovered-bg-color; border-radius:2px; box-shadow:inset 0 0 1px @hovered-shadow-color; }
 	// .jstree-clicked { background:@clicked-bg-color; border-radius:2px; box-shadow:inset 0 0 1px @clicked-shadow-color; }
-	.jstree-hovered:hover { background:@hovered-bg-color; border-radius:3px; box-shadow:inset 0 0 1px @hovered-shadow-color; outline: revert;}
+	.jstree-hovered:hover { background:@hovered-bg-color; box-shadow:inset 0 0 1px @hovered-shadow-color; outline: revert;}
 	// We create a focus ring to make it look similar to :focus-visible styles. Two rules for cross browser compatibility.
 	.jstree-hovered {
 		outline: 5px auto Highlight;
 		outline: 5px auto -webkit-focus-ring-color;
 	}
-	.jstree-context { background:@hovered-bg-color; border-radius:3px; box-shadow:inset 0 0 1px @hovered-shadow-color; }
-	.jstree-clicked { background:@clicked-bg-color; border-radius:3px; box-shadow:inset 0 0 1px @clicked-shadow-color; }
+	.jstree-context { background:@hovered-bg-color; box-shadow:inset 0 0 1px @hovered-shadow-color; }
+	.jstree-clicked { background:@clicked-bg-color; box-shadow:inset 0 0 1px @clicked-shadow-color; }
 	// XWiki customization end
 	.jstree-no-icons .jstree-anchor > .jstree-themeicon { display:none; }
 	.jstree-disabled {

--- a/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/tree.less
+++ b/xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar/src/main/less/tree.less
@@ -19,6 +19,7 @@
 @responsive: true;
 @image-path: "$!services.webjars.url('org.xwiki.platform:xwiki-platform-tree-webjar', '')";
 @base-height: 40px;
+@border-radius-small: 3px;
 
 // We use FontAwesome for the open/close/leaf icons.
 .fontAwesome() {


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-24356

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Updated the CSS for XWiki's special styles of this keyboard focused element.


## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* This solution is based on the info shared at https://css-tricks.com/copy-the-browsers-native-focus-styles/ . I assumed this was a correct source of info and didn't check the browser docs further.
* As a side improvement, I decided to change a bit how `border-radius` style is done on tree items. Instead of applying it in pretty much all the situations where there's a border, it's now always there. This might apply to some elements I didn't test, but small border-radius can only make an element fit better in today's XWiki UI (where we decided to have border radius on all boxes). This side improvement allows to avoid a weird interaction where the only "round" outline would be the one on the selected item, while all the others were square.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Here are a couple screenshots of the highlighting styles. For the sake of the screenshot, I added the class manually and set `:focus-visible` on another element of the page. Note how similar both outlines look on both browsers.
<img width="3834" height="1914" alt="Screenshot From 2026-06-10 15-49-13" src="https://github.com/user-attachments/assets/db8e9049-f4c8-4bf5-bf5c-af67e81366f7" />
<img width="3834" height="1914" alt="Screenshot From 2026-06-10 15-48-12" src="https://github.com/user-attachments/assets/dafd4f4b-fa4b-4ded-8b41-64685f9fcc17" />

Here is a video recording of the fix in action:

https://github.com/user-attachments/assets/4b90cfa6-8d14-45d6-9cb3-aebb2c1bd21b

We can notice that the style on mouse hover is the same as it used to be, but the style when navigating the tree with a keyboard is the one that was described in the ticket.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests on my local instance, see above.
Built successfully the changes with the quality profile: `mvn clean install -f xwiki-platform-core/xwiki-platform-tree/xwiki-platform-tree-webjar -Pquality`.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None. This is a very noticeable style change.