### PR TITLE
XWIKI-24472: Annotations on words that are modified are not visible in Chrome and Edge anymore

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/cssVariablesInit.css
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/cssVariablesInit.css
@@ -46,7 +46,7 @@
 "font-weight-semibold": 700,
 "font-weight-bold": "900",
 "mark-bg": "color-mix(in srgb, var(--btn-warning-bg), white)",
-"mark-updated-bg": "color-mix(in srgb, var(--btn-warning-bg), var(--btn-danger-bg) 20%, white)",
+"mark-updated-bg": "color-mix(in srgb, color-mix(in srgb, var(--btn-warning-bg), var(--btn-danger-bg) 35%), white)",
 "mark-altered-bg": "color-mix(in srgb, var(--btn-danger-bg), white)",
 "mark-highlighted-bg": "var(--btn-warning-bg)"
 })


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-24472

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Fixed the formula for color calculation to make it work without the experimental feature.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* I checked MDN docs and it wasn't clear to me that color-mix with more than two colors was still experimental.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Here is what it looks like in Chrome:
<img width="3834" height="1914" alt="Screenshot From 2026-06-10 17-21-22" src="https://github.com/user-attachments/assets/b0b1ecae-eb2b-4704-9ca7-f7b024385a81" />

On Firefox, this looks very similar to what was before:
<img width="3834" height="1914" alt="image" src="https://github.com/user-attachments/assets/ad2b8b7e-3a82-40f3-82bd-7c17e851375c" />



# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests, see above.
Built the change with ` mvn clean install -f xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources -Pquality`.

This is a style change only, to solve a bug that was found only in manual testing, so I doubt there'd be any impact on any automated test. 

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 18.4.X ,same as https://github.com/xwiki/xwiki-platform/pull/5519