### PR TITLE
[Misc] Reduce cognitive complexity of AttachmentReader.read() (SonarQube)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/AttachmentReader.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/AttachmentReader.java
@@ -216,39 +216,43 @@ public class AttachmentReader extends AbstractReader implements XARXMLReader<Att
 
         try {
             for (xmlReader.nextTag(); xmlReader.isStartElement(); xmlReader.nextTag()) {
-                String elementName = xmlReader.getLocalName();
-
-                EventParameter parameter = XARAttachmentModel.ATTACHMENT_PARAMETERS.get(elementName);
-
-                if (parameter != null) {
-                    Object wsValue = convert(parameter.type, xmlReader.getElementText());
-                    if (wsValue != null) {
-                        wikiAttachmentSource.parameters.put(parameter.name, wsValue);
-                    }
-                } else {
-                    if (XARAttachmentModel.ELEMENT_NAME.equals(elementName)) {
-                        wikiAttachmentSource.name = xmlReader.getElementText();
-                    } else if (XARAttachmentModel.ELEMENT_CONTENT_SIZE.equals(elementName)) {
-                        wikiAttachmentSource.size = Long.valueOf(xmlReader.getElementText());
-                    } else if (XARAttachmentModel.ELEMENT_CONTENT.equals(elementName)) {
-                        readContent(xmlReader, wikiAttachmentSource);
-                    } else if (XARAttachmentModel.ELEMENT_REVISIONS.equals(elementName)) {
-                        // Skip revisions if history is disabled
-                        if (properties.isWithHistory()) {
-                            readRevisions(xmlReader, wikiAttachmentSource);
-                        } else {
-                            StAXUtils.skipElement(xmlReader);
-                        }
-                    } else {
-                        unknownElement(xmlReader);
-                    }
-                }
+                readAttachmentElement(xmlReader, properties, wikiAttachmentSource);
             }
 
             return wikiAttachmentSource;
         } catch (Exception e) {
             IOUtils.closeQuietly(wikiAttachmentSource);
             throw e;
+        }
+    }
+
+    private void readAttachmentElement(XMLStreamReader xmlReader, XARInputProperties properties,
+        WikiAttachmentInputSource wikiAttachmentSource) throws XMLStreamException, FilterException
+    {
+        String elementName = xmlReader.getLocalName();
+
+        EventParameter parameter = XARAttachmentModel.ATTACHMENT_PARAMETERS.get(elementName);
+
+        if (parameter != null) {
+            Object wsValue = convert(parameter.type, xmlReader.getElementText());
+            if (wsValue != null) {
+                wikiAttachmentSource.parameters.put(parameter.name, wsValue);
+            }
+        } else if (XARAttachmentModel.ELEMENT_NAME.equals(elementName)) {
+            wikiAttachmentSource.name = xmlReader.getElementText();
+        } else if (XARAttachmentModel.ELEMENT_CONTENT_SIZE.equals(elementName)) {
+            wikiAttachmentSource.size = Long.valueOf(xmlReader.getElementText());
+        } else if (XARAttachmentModel.ELEMENT_CONTENT.equals(elementName)) {
+            readContent(xmlReader, wikiAttachmentSource);
+        } else if (XARAttachmentModel.ELEMENT_REVISIONS.equals(elementName)) {
+            // Skip revisions if history is disabled
+            if (properties.isWithHistory()) {
+                readRevisions(xmlReader, wikiAttachmentSource);
+            } else {
+                StAXUtils.skipElement(xmlReader);
+            }
+        } else {
+            unknownElement(xmlReader);
         }
     }
 


### PR DESCRIPTION
## Summary

This fixes a SonarQube `java:S3776` issue (severity: CRITICAL) reported on
`AttachmentReader.read()` in the XAR filter stream module. The method had a
cognitive complexity of 20, above the allowed threshold of 15.

The per-element handling of the attachment-reading loop was extracted into a
dedicated private method (`readAttachmentElement`) and the nested `else { if ... }`
block was flattened into an `else if` chain. This is a pure, behavior-preserving
refactor — no functional change.

## Verification

* `mvn clean verify -Pquality` on the modified module
  (`xwiki-platform-filter-stream-xar`) passes, including Checkstyle and all 42 tests.

## SonarQube issue

https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&issues=AZzDryKKAHaDflByRxXb&open=AZzDryKKAHaDflByRxXb

## Token usage

* Finding an issue to fix: ~35K tokens
* Fixing the issue: ~25K tokens
* Work after fixing the issue (build verification, commit, PR): ~30K tokens
