### PR TITLE
XWIKI-22081: Add automated test for "See The Logging Page"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-ui/src/main/resources/XWiki/Logging/Code/Translations.xml
+++ b/xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-ui/src/main/resources/XWiki/Logging/Code/Translations.xml
@@ -38,7 +38,8 @@
   <hidden>true</hidden>
   <content>logging.admin.unsetLevel.success=Logger "{0}" level has been unset.
 logging.admin.setLevel.success=Logger "{0}" level has been set to "{1}".
-logging.admin.setLevel.error=Failed to set log level: the logger "{0}" doesn't exist.</content>
+logging.admin.setLevel.error=Failed to set log level: the logger "{0}" doesn't exist.
+logging.admin.livetable.actions.select.hint=Action for the "{0}" logger.</content>
   <object>
     <name>XWiki.Logging.Code.Translations</name>
     <number>0</number>

--- a/xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-ui/src/main/resources/XWiki/LoggingAdminTableJson.xml
+++ b/xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-ui/src/main/resources/XWiki/LoggingAdminTableJson.xml
@@ -144,7 +144,7 @@
       "actions" : "${escapetool.javascript("&lt;form action='' method='post'&gt;
         &lt;fieldset&gt;
           &lt;input name='logger_name' value='$logger.key' type='hidden'/&gt;
-          &lt;select name='logger_level'&gt;
+          &lt;select name='logger_level' aria-label='${escapetool.xml($services.localization.render('logging.admin.livetable.actions.select.hint', $logger.key))}'&gt;
             #if ($loggLevelName != 'TRACE')
               &lt;option label='TRACE' value='TRACE'&gt;TRACE&lt;/option&gt;
             #end


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-22081

The solution to this ticket highlighted a WCAG violation that failed on CI:
https://ge.xwiki.org/s/bjuvxhrtofvwc/tests/goal/org.xwiki.platform:xwiki-platform-logging-test-docker:failsafe:integration-test@functional-tests/details/org.xwiki.logging.test.ui.docker.AllIT?top-execution=1

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added a missing text alternative to the select that's now going through WCAG tests.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Since the issue and the fix are minor, and the cause is not yet released, I figured it was okay to use the same ticket as the cause.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

Here are two screenshots of the PR applied on my instance:
<img width="2560" height="1319" alt="Screenshot From 2026-06-11 15-07-15" src="https://github.com/user-attachments/assets/a859d815-4cd0-41dc-aaa8-72aa02021740" />
<img width="2560" height="1319" alt="Screenshot From 2026-06-11 15-06-58" src="https://github.com/user-attachments/assets/37fad52c-1f65-4e5f-8db5-03cb54ba2c6a" />


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests (see above).
Successfully ran the quality build: `mvn clean install -f xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-ui -Pquality`.
Successfully passed the docker tests with WCAG checks and 0 WCAG fail or warning:
`mvn clean install -f xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-test/xwiki-platform-logging-test-docker -Dxwiki.test.ui.wcag=true` .

Checking the string `logger_level` int he project, it seems like the only place where it's used in tests is in the quality tests of `xwiki-platform-logging-ui` and in the new docker tests.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None, same as https://github.com/xwiki/xwiki-platform/commit/4bb573afb3cbcbdaba96f10a70111a65c25e8273