### PR TITLE
[Misc] Use static access for inherited XAR attachment model constants

### DIFF
--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/AttachmentReader.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/AttachmentReader.java
@@ -44,6 +44,7 @@ import org.xwiki.filter.input.InputSource;
 import org.xwiki.filter.xar.input.XARInputProperties;
 import org.xwiki.filter.xar.internal.XARAttachmentModel;
 import org.xwiki.filter.xar.internal.XARFilterUtils.EventParameter;
+import org.xwiki.xar.internal.model.XarAttachmentModel;
 import org.xwiki.xml.stax.StAXUtils;
 
 /**
@@ -238,13 +239,13 @@ public class AttachmentReader extends AbstractReader implements XARXMLReader<Att
             if (wsValue != null) {
                 wikiAttachmentSource.parameters.put(parameter.name, wsValue);
             }
-        } else if (XARAttachmentModel.ELEMENT_NAME.equals(elementName)) {
+        } else if (XarAttachmentModel.ELEMENT_NAME.equals(elementName)) {
             wikiAttachmentSource.name = xmlReader.getElementText();
-        } else if (XARAttachmentModel.ELEMENT_CONTENT_SIZE.equals(elementName)) {
+        } else if (XarAttachmentModel.ELEMENT_CONTENT_SIZE.equals(elementName)) {
             wikiAttachmentSource.size = Long.valueOf(xmlReader.getElementText());
-        } else if (XARAttachmentModel.ELEMENT_CONTENT.equals(elementName)) {
+        } else if (XarAttachmentModel.ELEMENT_CONTENT.equals(elementName)) {
             readContent(xmlReader, wikiAttachmentSource);
-        } else if (XARAttachmentModel.ELEMENT_REVISIONS.equals(elementName)) {
+        } else if (XarAttachmentModel.ELEMENT_REVISIONS.equals(elementName)) {
             // Skip revisions if history is disabled
             if (properties.isWithHistory()) {
                 readRevisions(xmlReader, wikiAttachmentSource);
@@ -262,7 +263,7 @@ public class AttachmentReader extends AbstractReader implements XARXMLReader<Att
         for (xmlReader.nextTag(); xmlReader.isStartElement(); xmlReader.nextTag()) {
             String elementName = xmlReader.getLocalName();
 
-            if (XARAttachmentModel.ELEMENT_REVISION.equals(elementName)) {
+            if (XarAttachmentModel.ELEMENT_REVISION.equals(elementName)) {
                 wikiAttachment.revisions.add(readRevision(xmlReader));
             }
         }
@@ -284,11 +285,11 @@ public class AttachmentReader extends AbstractReader implements XARXMLReader<Att
                         wikiAttachmentRevisionSource.parameters.put(parameter.name, wsValue);
                     }
                 } else {
-                    if (XARAttachmentModel.ELEMENT_REVISION.equals(elementName)) {
+                    if (XarAttachmentModel.ELEMENT_REVISION.equals(elementName)) {
                         wikiAttachmentRevisionSource.version = xmlReader.getElementText();
-                    } else if (XARAttachmentModel.ELEMENT_CONTENT_SIZE.equals(elementName)) {
+                    } else if (XarAttachmentModel.ELEMENT_CONTENT_SIZE.equals(elementName)) {
                         wikiAttachmentRevisionSource.size = Long.valueOf(xmlReader.getElementText());
-                    } else if (XARAttachmentModel.ELEMENT_CONTENT.equals(elementName)) {
+                    } else if (XarAttachmentModel.ELEMENT_CONTENT.equals(elementName)) {
                         readContent(xmlReader, wikiAttachmentRevisionSource);
                     } else {
                         unknownElement(xmlReader);


### PR DESCRIPTION
## Description

[SonarQube](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&open=AZ66iqBNMaZnG_u2c2zT) reports a CRITICAL issue (rule `java:S3252`) in `AttachmentReader` where the inherited static constant `ELEMENT_NAME` (and a few sibling `ELEMENT_*` constants) are accessed through the `XARAttachmentModel` subclass instead of through `XarAttachmentModel`, the class that actually declares them.

This change references the declaring class directly for those constants, which removes the ambiguity flagged by the rule. The `ATTACHMENT_PARAMETERS` constant, which is genuinely declared in `XARAttachmentModel`, keeps using that class.

No behavior change and no API change — purely an internal readability/static-access cleanup.

SonarQube issue: https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&open=AZ66iqBNMaZnG_u2c2zT

## Verification

`mvn clean verify -Pquality` was run on the `xwiki-platform-filter-stream-xar` module and passed (including Checkstyle).

## Token usage

- Cost in tokens for finding an issue to fix: ~40k tokens
- Cost in tokens for fixing the issue: ~75k tokens
- Cost in tokens for the work after fixing the issue: ~20k tokens
