### PR TITLE
[Misc] Use static access for StringUtils.isNotBlank in CompositeEvent

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/src/main/java/org/xwiki/notifications/CompositeEvent.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/src/main/java/org/xwiki/notifications/CompositeEvent.java
@@ -27,12 +27,12 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.xwiki.eventstream.DocumentEventType;
 import org.xwiki.eventstream.Event;
 import org.xwiki.model.reference.DocumentReference;
-import org.xwiki.text.StringUtils;
 
 /**
  * A group of similar events that compose a "composite" event.


### PR DESCRIPTION
## Summary

Fixes SonarCloud issue [java:S3252 - Use static access with "org.apache.commons.lang3.StringUtils" for "isNotBlank"](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AYxotEGkHHfsI57D8VtW&open=AYxotEGkHHfsI57D8VtW) in `CompositeEvent.java`.

### Problem

`CompositeEvent#getType()` calls `StringUtils.isNotBlank(...)` through an import of `org.xwiki.text.StringUtils`. That class extends `org.apache.commons.lang3.StringUtils` and does **not** declare `isNotBlank` itself — the method is inherited from the Apache Commons Lang class. Accessing an inherited static member through a subclass is confusing (rule S3252), since it hides where the member is actually defined.

### Fix

- Import `org.apache.commons.lang3.StringUtils` (the class that actually declares `isNotBlank`) and drop the unused `org.xwiki.text.StringUtils` import.
- The call site is unchanged (`StringUtils.isNotBlank(...)`), so there is no behavioral or API change. Apache Commons Lang 3 is already a direct dependency of the module (the same file already imports `EqualsBuilder`/`HashCodeBuilder` from it).

## Test plan

- [x] `mvn clean verify -Pquality` passes on the `xwiki-platform-notifications-api` module (Checkstyle + quality checks green).

## Token usage

- Cost in tokens for finding an issue to fix: ~50k tokens
- Cost in tokens for fixing the issue: ~40k tokens
- Cost in tokens for the work after fixing the issue: ~10k tokens

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ke2L47c4UteRuMYmr9JHk8)_