### PR TITLE
[Misc] Reduce cognitive complexity of ImportmapMojo.execute()

### DIFF
--- a/xwiki-platform-tools/xwiki-platform-tool-importmap-plugin/src/main/java/org/xwiki/tool/importmap/ImportmapMojo.java
+++ b/xwiki-platform-tools/xwiki-platform-tool-importmap-plugin/src/main/java/org/xwiki/tool/importmap/ImportmapMojo.java
@@ -25,10 +25,12 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.jar.JarFile;
 import java.util.zip.ZipEntry;
 
 import org.apache.maven.artifact.Artifact;
+import org.apache.maven.model.Model;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -75,43 +77,49 @@ public class ImportmapMojo extends AbstractMojo
             var importMap = new JavascriptImportmapParser().parse(property);
             var dependencies = this.project.getArtifacts();
             for (Map.Entry<String, ImportmapPathDescriptor> entry : importMap.entrySet()) {
-                var key = entry.getKey();
-                var value = entry.getValue();
-                var descriptor = value.descriptor();
-                var webjarId = descriptor.webjarId().split(":", 2);
-                var groupIdWebjar = webjarId[0];
-                var artifactIdWebjar = webjarId[1];
-                var path = descriptor.path();
-                getLog().debug("Checking key [%s] for webjar reference [%s]".formatted(key, value));
-                var isSelf =
-                    areDependenciesEquals(model.getGroupId(), model.getArtifactId(), groupIdWebjar, artifactIdWebjar);
-                if (isSelf) {
-                    if (!checkPathInSelf(this.project, computeFullPathInJar(artifactIdWebjar,
-                        this.project.getVersion(), path)))
-                    {
-                        throw new MojoExecutionException(
-                            "Unable to find path [%s] in the current module".formatted(path));
-                    }
-                    continue;
-                }
-                boolean dependencyNotFound = true;
-                for (var dependency : dependencies) {
-                    if (areDependenciesEquals(dependency.getGroupId(), dependency.getArtifactId(),
-                        groupIdWebjar, artifactIdWebjar))
-                    {
-                        dependencyNotFound = false;
-                        checkIfPathExistsInDependency(dependency, artifactIdWebjar, path);
-                        break;
-                    }
-                }
-                if (dependencyNotFound) {
-                    throw new MojoExecutionException(
-                        "Unable to find a declared dependency for [%s]".formatted(descriptor.webjarId()));
-                }
+                verifyImportmapEntry(model, dependencies, entry);
             }
         } catch (JavascriptImportmapException e) {
             throw new MojoExecutionException(
                 "Failed to parse the [%s] property".formatted(JAVASCRIPT_IMPORTMAP_PROPERTY), e);
+        }
+    }
+
+    private void verifyImportmapEntry(Model model, Set<Artifact> dependencies,
+        Map.Entry<String, ImportmapPathDescriptor> entry) throws MojoExecutionException
+    {
+        var key = entry.getKey();
+        var value = entry.getValue();
+        var descriptor = value.descriptor();
+        var webjarId = descriptor.webjarId().split(":", 2);
+        var groupIdWebjar = webjarId[0];
+        var artifactIdWebjar = webjarId[1];
+        var path = descriptor.path();
+        getLog().debug("Checking key [%s] for webjar reference [%s]".formatted(key, value));
+        var isSelf =
+            areDependenciesEquals(model.getGroupId(), model.getArtifactId(), groupIdWebjar, artifactIdWebjar);
+        if (isSelf) {
+            if (!checkPathInSelf(this.project, computeFullPathInJar(artifactIdWebjar,
+                this.project.getVersion(), path)))
+            {
+                throw new MojoExecutionException(
+                    "Unable to find path [%s] in the current module".formatted(path));
+            }
+            return;
+        }
+        boolean dependencyNotFound = true;
+        for (var dependency : dependencies) {
+            if (areDependenciesEquals(dependency.getGroupId(), dependency.getArtifactId(),
+                groupIdWebjar, artifactIdWebjar))
+            {
+                dependencyNotFound = false;
+                checkIfPathExistsInDependency(dependency, artifactIdWebjar, path);
+                break;
+            }
+        }
+        if (dependencyNotFound) {
+            throw new MojoExecutionException(
+                "Unable to find a declared dependency for [%s]".formatted(descriptor.webjarId()));
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes the SonarCloud issue [java:S3776 - Refactor this method to reduce its Cognitive Complexity from 16 to the 15 allowed](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AZwsr4tdhbQyUzZ8Bchu&open=AZwsr4tdhbQyUzZ8Bchu) in `ImportmapMojo.java`.

### Problem

The `execute()` method of the `importmap` Maven plugin had a cognitive complexity of 16, just above the allowed threshold of 15. The nesting (the entries loop containing the `isSelf` branch plus the inner dependency-search loop) made the method harder to read than necessary.

### Fix

- Extracted the per-entry verification logic out of the `execute()` loop into a dedicated private `verifyImportmapEntry()` method.
- `execute()` now only handles the skip/property checks and iterates over the import map entries, delegating each entry's validation to the new method.
- This is a pure refactoring with no behavior change; the existing unit test (`ImportmapMojoTest`) continues to pass.

## Test plan

- [x] `mvn clean verify -Pquality` on `xwiki-platform-tools/xwiki-platform-tool-importmap-plugin` — passes (Checkstyle, JaCoCo coverage, Spoon).
- [ ] Verify the SonarCloud issue is marked as resolved after the next scan.

---

### Token usage

- Cost in tokens for finding an issue to fix: ~30k tokens
- Cost in tokens for fixing the issue: ~20k tokens
- Cost in tokens for the work after fixing the issue: ~15k tokens

_Generated by Claude Code._

---
_Generated by [Claude Code](https://claude.ai/code/session_016vLSrVKCDkx3qf7o5Mrfmk)_