### PR TITLE
[Misc] Reduce cognitive complexity of ExtensionSupportProtectionListener.onEvent

### DIFF
--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/ExtensionSupportProtectionListener.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/ExtensionSupportProtectionListener.java
@@ -90,58 +90,60 @@ public class ExtensionSupportProtectionListener extends AbstractEventListener im
         BaseObject nextExtensionObject = nextDocument.getXObject(XWikiRepositoryModel.EXTENSION_CLASSREFERENCE);
 
         // If the extension object was removed we cannot really filter anything
-        if (nextExtensionObject != null) {
-            // Get the new support plans
-            List<String> nextSupportPlans =
-                nextExtensionObject.getListValue(XWikiRepositoryModel.PROP_EXTENSION_SUPPORTPLANS);
+        if (nextExtensionObject == null) {
+            return;
+        }
 
-            // Get the previous support plans
-            List<String> previousSupportPlans;
-            if (previousExtensionObject != null) {
-                previousSupportPlans =
-                    previousExtensionObject.getListValue(XWikiRepositoryModel.PROP_EXTENSION_SUPPORTPLANS);
-            } else {
-                previousSupportPlans = List.of();
+        // Get the new support plans
+        List<String> nextSupportPlans =
+            nextExtensionObject.getListValue(XWikiRepositoryModel.PROP_EXTENSION_SUPPORTPLANS);
+
+        // Get the previous support plans
+        List<String> previousSupportPlans;
+        if (previousExtensionObject != null) {
+            previousSupportPlans =
+                previousExtensionObject.getListValue(XWikiRepositoryModel.PROP_EXTENSION_SUPPORTPLANS);
+        } else {
+            previousSupportPlans = List.of();
+        }
+
+        DocumentReference extensionReference = nextDocument.getDocumentReference();
+        DocumentReference userReference = ((UserEvent) event).getUserReference();
+
+        // Make sure the list is modifiable
+        nextSupportPlans = new ArrayList<>(nextSupportPlans);
+        boolean updated = false;
+
+        // Remove all the plans the current user is not allowed to add
+        List<String> addedSupportPlans = ListUtils.subtract(nextSupportPlans, previousSupportPlans);
+        for (String supportPlan : addedSupportPlans) {
+            if (!isAllowed(userReference, supportPlan, extensionReference)) {
+                this.logger.warn("The user [{}] tried to add the support plan [{}] to extension [{}]. Reverted.",
+                    userReference, supportPlan, extensionReference);
+
+                // Remove the support plan
+                nextSupportPlans.remove(supportPlan);
+                updated = true;
             }
+        }
 
-            DocumentReference extensionReference = nextDocument.getDocumentReference();
-            DocumentReference userReference = ((UserEvent) event).getUserReference();
+        // Restore all the plans the current user is not allowed to remove
+        List<String> removedSupportPlans = ListUtils.subtract(previousSupportPlans, nextSupportPlans);
+        for (String supportPlan : removedSupportPlans) {
+            if (!isAllowed(userReference, supportPlan, extensionReference)) {
+                this.logger.warn(
+                    "The user [{}] tried to remove the support plan [{}] from extension [{}]. Reverted.",
+                    userReference, supportPlan, extensionReference);
 
-            // Make sure the list is modifiable
-            nextSupportPlans = new ArrayList<>(nextSupportPlans);
-            boolean updated = false;
-
-            // Remove all the plans the current user is not allowed to add
-            List<String> addedSupportPlans = ListUtils.subtract(nextSupportPlans, previousSupportPlans);
-            for (String supportPlan : addedSupportPlans) {
-                if (!isAllowed(userReference, supportPlan, extensionReference)) {
-                    this.logger.warn("The user [{}] tried to add the support plan [{}] to extension [{}]. Reverted.",
-                        userReference, supportPlan, extensionReference);
-
-                    // Remove the support plan
-                    nextSupportPlans.remove(supportPlan);
-                    updated = true;
-                }
+                // Add back the support plan
+                nextSupportPlans.add(supportPlan);
+                updated = true;
             }
+        }
 
-            // Restore all the plans the current user is not allowed to remove
-            List<String> removedSupportPlans = ListUtils.subtract(previousSupportPlans, nextSupportPlans);
-            for (String supportPlan : removedSupportPlans) {
-                if (!isAllowed(userReference, supportPlan, extensionReference)) {
-                    this.logger.warn(
-                        "The user [{}] tried to remove the support plan [{}] from extension [{}]. Reverted.",
-                        userReference, supportPlan, extensionReference);
-
-                    // Add back the support plan
-                    nextSupportPlans.add(supportPlan);
-                    updated = true;
-                }
-            }
-
-            if (updated) {
-                nextExtensionObject.setStringListValue(XWikiRepositoryModel.PROP_EXTENSION_SUPPORTPLANS,
-                    nextSupportPlans);
-            }
+        if (updated) {
+            nextExtensionObject.setStringListValue(XWikiRepositoryModel.PROP_EXTENSION_SUPPORTPLANS,
+                nextSupportPlans);
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes SonarCloud issue [java:S3776 - Refactor this method to reduce its Cognitive Complexity from 16 to the 15 allowed](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AZGaG1cEPhpr_P5DN48P&open=AZGaG1cEPhpr_P5DN48P) in `ExtensionSupportProtectionListener.java`.

### Problem

The whole body of the `onEvent` method was wrapped in a single `if (nextExtensionObject != null)` block. That extra nesting level pushed the method's cognitive complexity to 16, above the SonarQube threshold of 15.

### Fix

- Replaced the outer `if (nextExtensionObject != null)` wrapper with an early-return guard clause (`if (nextExtensionObject == null) { return; }`).
- De-indented the remaining body by one level. This removes a nesting level for the inner loops and conditions, bringing the cognitive complexity comfortably below the threshold.

No behavior change: when the extension object is `null` the method still does nothing, exactly as before. No public API is affected (the change is internal to the method body).

## Test plan

- [x] Build the `xwiki-platform-repository-server-api` module with `mvn clean verify -Pquality` — passes.
- [ ] Verify the SonarCloud issue is marked as resolved after the next scan.

## Token usage

- Cost in tokens for finding an issue to fix: ~70k tokens
- Cost in tokens for fixing the issue: ~25k tokens
- Cost in tokens for the work after fixing the issue: ~15k tokens

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHZHTG7HUxDqstgbkRp7ci)_