### PR TITLE
XWIKI-24482: Side buttons from Distribution Wizard are not displayed properly anymore

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/buttonGroup.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/buttonGroup.js
@@ -160,7 +160,7 @@ widgets.DynamicButtonGroup = Class.create({
       href: '#dropDownMenu',
       'class': 'dropdown-toggle' + (buttons[0].hasClassName('secondary') ? ' secondary' : ''),
       tabindex: 0
-    }).insert("<span class='caret'></span>" + "<span class='sr-only'>" 
+    }).insert("<span class='caret'></span><span class='sr-only'>" 
       + l10n['core.widgets.buttonGroup.dropDown.toggle.hint'] + "</span>")});
 
     // Insert the drop down menu.

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/buttonGroup.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/buttonGroup.js
@@ -23,9 +23,6 @@ var widgets = XWiki.widgets = XWiki.widgets || {};
 const l10n = {
   "core.widgets.buttonGroup.dropDown.toggle.hint" : "$!escapetool.javascript($services.localization.render('core.widgets.buttonGroup.dropDown.toggle.hint'))",
 };
-const icons = {
-  'caret-down': "$!escapetool.javascript($services.icon.renderHTML('caret-down'))"
-};
 
 /**
  * A static button group. Both the drop-down toggle and the drop-down menu must be present in the DOM document. This
@@ -163,7 +160,7 @@ widgets.DynamicButtonGroup = Class.create({
       href: '#dropDownMenu',
       'class': 'dropdown-toggle' + (buttons[0].hasClassName('secondary') ? ' secondary' : ''),
       tabindex: 0
-    }).insert(icons['caret-down'] + "<span class='sr-only'>" 
+    }).insert("<span class='caret'></span>" + "<span class='sr-only'>" 
       + l10n['core.widgets.buttonGroup.dropDown.toggle.hint'] + "</span>")});
 
     // Insert the drop down menu.


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-24482

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Removed the use of the iconTheme to use the same icon as the advanced edit dropdown instead.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Because the velocity script previously used did not update the sources, in some situations the icon would be missing from the button and end up in a weird looking UI.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
With the PR applied:
<img width="978" height="383" alt="Screenshot From 2026-06-15 11-32-45" src="https://github.com/user-attachments/assets/b8f9728a-41f6-495b-ab0d-47ada75d7a27" />
<img width="2290" height="1241" alt="image" src="https://github.com/user-attachments/assets/a4d24e56-85bc-4ec0-9043-cd5d5679aab2" />


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual tests, see above.
Successfully built `mvn clean install -f xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war -Pquality`.
# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * Solution for 18.4.X only. Ideally for 18.5.0-rc1 we make buttonGroup use requirejs instead of prototype and use the new API.