### PR TITLE
XWIKI-24237: Provide a button on the context toolbar to edit the selected macro

### DIFF
--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/components/BlockNoteViewWrapper.tsx
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/components/BlockNoteViewWrapper.tsx
@@ -341,7 +341,8 @@ const BlockNoteViewWrapper: React.FC<BlockNoteViewWrapperProps> = ({
                 builtMacros,
                 (built) => built.dropdownTransformItem,
               )}
-              ctxForMacros={macros ? macros.ctx : false}
+              macros={macros}
+              imageEditionOverrideFn={overrides?.imageEdition}
             />
           )}
         />

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/components/BlockNoteViewWrapper.tsx
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/components/BlockNoteViewWrapper.tsx
@@ -342,7 +342,6 @@ const BlockNoteViewWrapper: React.FC<BlockNoteViewWrapperProps> = ({
                 (built) => built.dropdownTransformItem,
               )}
               macros={macros}
-              imageEditionOverrideFn={overrides?.imageEdition}
             />
           )}
         />

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/components/CustomFormattingToolbar.tsx
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/components/CustomFormattingToolbar.tsx
@@ -21,6 +21,7 @@
 import { CustomImageToolbar } from "./images/CustomImageToolbar";
 import { CustomCreateLinkButton } from "./links/CustomCreateLinkButton";
 import { CustomInsertMacroButton } from "./links/CustomInsertMacroButton";
+import { CustomMacroEditButton } from "./links/CustomMacroEditButton";
 import { useEditor } from "../hooks";
 import {
   AddCommentButton,
@@ -44,17 +45,19 @@ import {
 } from "@blocknote/react";
 import type { ImageEditionOverrideFn } from "./images/CustomImageToolbar";
 import type { ContextForMacros } from "../blocknote/utils";
+import type { LinkEditionContext } from "../misc/linkSuggest";
 import type {
   BlockTypeSelectItem,
   FormattingToolbarProps,
 } from "@blocknote/react";
+import type { MacroWithUnknownParamsType } from "@xwiki/platform-macros-api";
 import type { JSX } from "react";
 
 type CustomFormattingToolbarProps = {
   formattingToolbarProps: FormattingToolbarProps;
   additionalBlockTypes: BlockTypeSelectItem[];
+  macros: { list: MacroWithUnknownParamsType[]; ctx: ContextForMacros } | false;
   imageEditionOverrideFn?: ImageEditionOverrideFn;
-  ctxForMacros: ContextForMacros | false;
 };
 
 export const CustomFormattingToolbar: React.FC<
@@ -63,7 +66,7 @@ export const CustomFormattingToolbar: React.FC<
   formattingToolbarProps,
   additionalBlockTypes,
   imageEditionOverrideFn,
-  ctxForMacros,
+  macros,
 }) => {
   const Components = useComponentsContext()!;
   const dict = useDictionary();
@@ -90,8 +93,8 @@ export const CustomFormattingToolbar: React.FC<
       ) : (
         // For others, simply show the "normal", default toolbar
         getDefaultFormattingToolbarItems(
-          combinedBlockTypeSelectItems,
-          ctxForMacros,
+          formattingToolbarProps.blockTypeSelectItems,
+          macros,
         )
       )}
     </Components.FormattingToolbar.Root>
@@ -100,7 +103,7 @@ export const CustomFormattingToolbar: React.FC<
 
 const getDefaultFormattingToolbarItems = (
   blockTypeSelectItems: BlockTypeSelectItem[] | undefined,
-  ctxForMacros: ContextForMacros | false,
+  macros: { list: MacroWithUnknownParamsType[]; ctx: ContextForMacros } | false,
 ): JSX.Element[] =>
   // NOTE: This should return **exactly** the same items as BlockNote's default toolbar
   // So, when BlockNote updates theirs, we should update ours
@@ -138,11 +141,16 @@ const getDefaultFormattingToolbarItems = (
     <AddCommentButton key={"addCommentButton"} />,
     <AddTiptapCommentButton key={"addTiptapCommentButton"} />,
   ].concat(
-    ctxForMacros
+    macros
       ? [
+          <CustomMacroEditButton
+            key={"macroEditButton"}
+            macrosList={macros.list}
+            ctxForMacros={macros.ctx}
+          />,
           <CustomInsertMacroButton
             key={"insertMacroButton"}
-            openEditor={ctxForMacros.openInsertionEditor}
+            openEditor={macros.ctx.openInsertionEditor}
           />,
         ]
       : [],

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/components/CustomFormattingToolbar.tsx
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/components/CustomFormattingToolbar.tsx
@@ -45,7 +45,6 @@ import {
 } from "@blocknote/react";
 import type { ImageEditionOverrideFn } from "./images/CustomImageToolbar";
 import type { ContextForMacros } from "../blocknote/utils";
-import type { LinkEditionContext } from "../misc/linkSuggest";
 import type {
   BlockTypeSelectItem,
   FormattingToolbarProps,
@@ -92,10 +91,7 @@ export const CustomFormattingToolbar: React.FC<
         />
       ) : (
         // For others, simply show the "normal", default toolbar
-        getDefaultFormattingToolbarItems(
-          formattingToolbarProps.blockTypeSelectItems,
-          macros,
-        )
+        getDefaultFormattingToolbarItems(combinedBlockTypeSelectItems, macros)
       )}
     </Components.FormattingToolbar.Root>
   );

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/components/links/CustomMacroEditButton.tsx
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/components/links/CustomMacroEditButton.tsx
@@ -27,7 +27,6 @@ import type { ContextForMacros } from "../../blocknote/utils";
 import type { MacroWithUnknownParamsType } from "@xwiki/platform-macros-api";
 
 export type CustomMacroEditButtonProps = {
-  // TODO
   macrosList: MacroWithUnknownParamsType[];
   ctxForMacros: ContextForMacros;
 };

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/components/links/CustomMacroEditButton.tsx
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/components/links/CustomMacroEditButton.tsx
@@ -69,7 +69,7 @@ export const CustomMacroEditButton: React.FC<CustomMacroEditButtonProps> = ({
         editor.updateBlock(macroBlock.id, { props: newProps }),
       );
     };
-  }, [selection, macrosList]);
+  }, [selection, macrosList, ctxForMacros, editor]);
 
   return (
     openMacroEditor && (

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/components/links/CustomMacroEditButton.tsx
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/components/links/CustomMacroEditButton.tsx
@@ -75,7 +75,7 @@ export const CustomMacroEditButton: React.FC<CustomMacroEditButtonProps> = ({
     openMacroEditor && (
       <Components.FormattingToolbar.Button
         className={"bn-button"}
-        data-test="createLink"
+        data-test="insertMacroButton"
         label={t("blocknote.linkToolbar.macros.edit.label")}
         mainTooltip={t("blocknote.linkToolbar.macros.edit.tooltip")}
         icon={<RiPencilFill />}

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/components/links/CustomMacroEditButton.tsx
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/components/links/CustomMacroEditButton.tsx
@@ -1,0 +1,87 @@
+/**
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+import { MACRO_NAME_PREFIX } from "../../blocknote/utils";
+import { useEditor } from "../../hooks";
+import { useComponentsContext } from "@blocknote/react";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { RiPencilFill } from "react-icons/ri";
+import type { ContextForMacros } from "../../blocknote/utils";
+import type { MacroWithUnknownParamsType } from "@xwiki/platform-macros-api";
+
+export type CustomMacroEditButtonProps = {
+  // TODO
+  macrosList: MacroWithUnknownParamsType[];
+  ctxForMacros: ContextForMacros;
+};
+
+export const CustomMacroEditButton: React.FC<CustomMacroEditButtonProps> = ({
+  macrosList,
+  ctxForMacros,
+}) => {
+  const Components = useComponentsContext()!;
+  const { t } = useTranslation();
+
+  const editor = useEditor();
+
+  const selection = editor.getSelection();
+
+  const openMacroEditor = useMemo(() => {
+    if (
+      !selection ||
+      selection.blocks.length !== 1 ||
+      !selection.blocks[0].type.startsWith(MACRO_NAME_PREFIX)
+    ) {
+      return null;
+    }
+
+    const macroBlock = selection.blocks[0];
+
+    const macro = macrosList.find(
+      (macro) =>
+        macro.infos.id === macroBlock.type.replace(MACRO_NAME_PREFIX, ""),
+    );
+
+    if (!macro) {
+      throw new Error(
+        "Internal error: macro not found for block: " + macroBlock.type,
+      );
+    }
+
+    return () => {
+      ctxForMacros.openParamsEditor(macro, macroBlock.props, (newProps) =>
+        editor.updateBlock(macroBlock.id, { props: newProps }),
+      );
+    };
+  }, [selection, macrosList]);
+
+  return (
+    openMacroEditor && (
+      <Components.FormattingToolbar.Button
+        className={"bn-button"}
+        data-test="createLink"
+        label={t("blocknote.linkToolbar.macros.edit.label")}
+        mainTooltip={t("blocknote.linkToolbar.macros.edit.tooltip")}
+        icon={<RiPencilFill />}
+        onClick={openMacroEditor}
+      />
+    )
+  );
+};

--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/langs/translation-en.json
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/editors/blocknote-react/src/langs/translation-en.json
@@ -4,6 +4,8 @@
   "blocknote.linkToolbar.buttons.edit": "Edit link",
   "blocknote.linkToolbar.buttons.open": "Open target",
   "blocknote.linkToolbar.buttons.delete": "Delete link",
+  "blocknote.linkToolbar.macros.edit.label": "Edit macro",
+  "blocknote.linkToolbar.macros.edit.tooltip": "Open the macro editor",
   "blocknote.toolbar.unknownBlockType": "Unknown block type",
   "blocknote.toolbar.buttons.insertMacro": "Insert a macro",
   "blocknote.imageSelector.uploadButton": "Upload",


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24237

# Changes

## Description

* When a macro is focused/selected, show an edit button on the formatting toolbar to bring up the modal edition modal

## Clarifications

* The button does not appear if multiple blocks are selected

# Screenshots & Video

<img width="573" height="195" alt="image" src="https://github.com/user-attachments/assets/31d4cb90-706f-4b54-8805-501ba0a20c8a" />

# Executed Tests

N/A

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 