### PR TITLE
XWIKI-24491: The title of  a box macro / code macro is not displayed in a way that is distinguished from the box content

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/messages.less
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources/src/main/resources/flamingo/less/messages.less
@@ -56,6 +56,11 @@ div.successmessage, div.errormessage, div.warningmessage, div.infomessage {
   }
 }
 
+// The box titles should be highlighted even when the structure is simple.
+div.box > .box-title {
+  font-weight: bold;
+}
+
 .box, .plainmessage, // Used by: Code Macro, Success Macro, etc.
 fieldset.xwikimessage { // Used by: Login form, Delete messages
   .well;


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-24491

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added a rule so that simple box titles would be bold too.

## Clarification
* See ticket description -> https://jira.xwiki.org/browse/XWIKI-24491

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
With the PR applied:
<img width="5106" height="2642" alt="image" src="https://github.com/user-attachments/assets/4fee6184-43a3-4b1b-b6c3-e84e949eb958" />
<img width="3360" height="1218" alt="image" src="https://github.com/user-attachments/assets/f3591395-1124-47cf-b151-d9f9ac789e2f" />
In this second example, I tested both how this worked with an image and with extra formatting in the title.


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual test on local instance, see
Built the changes successfully with `mvn clean install -f xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-resources -Pquality`.

Since this is a small scope CSS only change, I didn't build any more test. This CSS change is very safe.
# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 17.10.X , very safe bugfix 