### PR TITLE
[Misc] Use the declaring class for static method access in LocalizationScriptService

### DIFF
--- a/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-script/src/main/java/org/xwiki/localization/script/LocalizationScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-script/src/main/java/org/xwiki/localization/script/LocalizationScriptService.java
@@ -34,6 +34,7 @@ import javax.inject.Singleton;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.LineIterator;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.environment.Environment;
@@ -44,7 +45,6 @@ import org.xwiki.localization.LocalizationManager;
 import org.xwiki.localization.Translation;
 import org.xwiki.rendering.syntax.Syntax;
 import org.xwiki.script.service.ScriptService;
-import org.xwiki.text.StringUtils;
 
 /**
  * Provides Component-specific Scripting APIs.


### PR DESCRIPTION
## Summary

Fixes the SonarCloud issue [java:S3252 - Use static access with "org.apache.commons.lang3.StringUtils" for "isNotBlank"](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AW5-S7Xy1Yj5qvzeRn7V&open=AW5-S7Xy1Yj5qvzeRn7V) in `LocalizationScriptService.java`.

### Problem

The class imported `org.xwiki.text.StringUtils` (a subclass of `org.apache.commons.lang3.StringUtils`) and accessed the inherited static method `isNotBlank` through it. SonarQube (rule `java:S3252`) flags accessing a static member through a subclass rather than the class that actually declares it, since it can be misleading about where the member is defined.

### Fix

- Changed the import to `org.apache.commons.lang3.StringUtils`, which is the class that actually declares the `isNotBlank` method used here. It was the only `StringUtils` member referenced in the file, so no behavior changes.

This is a purely internal change with no impact on the public API, so backward compatibility is preserved.

## Test plan

- [x] `mvn clean verify -Pquality` on `xwiki-platform-localization-script` — passes (BUILD SUCCESS).

---

### Token usage (approximate)

- Finding an issue to fix: ~60k tokens
- Fixing the issue: ~25k tokens
- Work after fixing (build, PR, issue transition): ~15k tokens

_Generated by [Claude Code](https://claude.ai/code/session_01BKLf9u3dtnxKgS1sw8HimJ)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKLf9u3dtnxKgS1sw8HimJ)_