### PR TITLE
[Misc] Use try-with-resources in DefaultTemporaryResourceStore

### DIFF
--- a/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-temporary/src/main/java/org/xwiki/resource/temporary/internal/DefaultTemporaryResourceStore.java
+++ b/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-temporary/src/main/java/org/xwiki/resource/temporary/internal/DefaultTemporaryResourceStore.java
@@ -20,7 +20,6 @@
 package org.xwiki.resource.temporary.internal;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
@@ -33,7 +32,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.phase.Initializable;
@@ -70,11 +69,8 @@ public class DefaultTemporaryResourceStore implements TemporaryResourceStore, In
     public File createTemporaryFile(TemporaryResourceReference reference, InputStream content) throws IOException
     {
         File temporaryFile = getTemporaryFile(reference);
-        // Make sure the parent folders exist.
-        temporaryFile.getParentFile().mkdirs();
-        try (FileOutputStream fos = new FileOutputStream(temporaryFile)) {
-            IOUtils.copy(content, fos);
-        }
+        // FileUtils#copyInputStreamToFile takes care of creating the parent folders and of closing the streams.
+        FileUtils.copyInputStreamToFile(content, temporaryFile);
 
         return temporaryFile;
     }

--- a/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-temporary/src/main/java/org/xwiki/resource/temporary/internal/DefaultTemporaryResourceStore.java
+++ b/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-temporary/src/main/java/org/xwiki/resource/temporary/internal/DefaultTemporaryResourceStore.java
@@ -70,14 +70,10 @@ public class DefaultTemporaryResourceStore implements TemporaryResourceStore, In
     public File createTemporaryFile(TemporaryResourceReference reference, InputStream content) throws IOException
     {
         File temporaryFile = getTemporaryFile(reference);
-        FileOutputStream fos = null;
-        try {
-            // Make sure the parent folders exist.
-            temporaryFile.getParentFile().mkdirs();
-            fos = new FileOutputStream(temporaryFile);
+        // Make sure the parent folders exist.
+        temporaryFile.getParentFile().mkdirs();
+        try (FileOutputStream fos = new FileOutputStream(temporaryFile)) {
             IOUtils.copy(content, fos);
-        } finally {
-            IOUtils.closeQuietly(fos);
         }
 
         return temporaryFile;


### PR DESCRIPTION
## Summary

Fixes the SonarQube issue [java:S2093 - Change this "try" to a try-with-resources](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AW5-S9DS1Yj5qvzeRoTG&open=AW5-S9DS1Yj5qvzeRoTG) reported in `DefaultTemporaryResourceStore.java`.

### Problem

`createTemporaryFile()` opened a `FileOutputStream` and relied on a manual `try`/`finally` block calling `IOUtils.closeQuietly()` to close it. SonarQube flags this pattern because a try-with-resources statement is the recommended, safer way to guarantee that the resource is closed.

### Fix

- Replaced the manual `try`/`finally` + `IOUtils.closeQuietly()` with a try-with-resources block on the `FileOutputStream`.
- Moved the parent folders creation (`mkdirs()`) out of the block since it does not require the stream to be opened.

This is a behaviour-preserving change. A failure to close the stream is now surfaced (the method already declares `throws IOException`) instead of being silently swallowed, which is the intended improvement of the rule.

## Test plan

- `mvn clean verify -Pquality` on the `xwiki-platform-resource-temporary` module — **passes** (including Checkstyle, Spoon and RevAPI; RevAPI reports no backward-compatibility issues).

## SonarCloud issue

https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AW5-S9DS1Yj5qvzeRoTG&open=AW5-S9DS1Yj5qvzeRoTG

## Token usage (approximate)

- Finding an issue to fix: ~75K tokens
- Fixing the issue (read, edit, build/verify): ~45K tokens
- Work after fixing (commit, push, PR, issue transition): ~10K tokens

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QTXLxCd8iwnZZ3PPSY9B1e)_