### PR TITLE
XWIKI-24499: The level select in the logging administration misses a label

### DIFF
--- a/xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-ui/src/main/resources/XWiki/LoggingAdminTableJson.xml
+++ b/xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-ui/src/main/resources/XWiki/LoggingAdminTableJson.xml
@@ -144,7 +144,7 @@
       "actions" : "${escapetool.javascript("&lt;form action='' method='post'&gt;
         &lt;fieldset&gt;
           &lt;input name='logger_name' value='$logger.key' type='hidden'/&gt;
-          &lt;select name='logger_level'&gt;
+          &lt;select name='logger_level' aria-label='${escapetool.xml($services.localization.render('logging.admin.livetable.actions.level.label', [$logger.key]))}'&gt;
             #if ($loggLevelName != 'TRACE')
               &lt;option label='TRACE' value='TRACE'&gt;TRACE&lt;/option&gt;
             #end

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/resources/ApplicationResources.properties
@@ -4015,6 +4015,9 @@ admin.logging=Logging
 admin.logging.description=Review and modify the log level associated to a registered logger.
 logging.admin.intro=Here you can review and modify the log level associated to a registered logger. <default> or empty log level means that the logger inherits from its parent logger which is the package prefix when it's a package or the default level in the logger implementation configuration if there is no parent.
 logging.admin.livetable.actions.set=Set
+# Level refers to the log level (e.g., DEBUG, INFO, WARN, ERROR) and {0} is replaced by the name of the logger for
+# which the level is being set.
+logging.admin.livetable.actions.level.label=Set level of {0}
 logging.admin.livetable.logger=Logger
 logging.admin.livetable.level=Level
 logging.admin.livetable.actions=Actions


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-24499

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Add an aria-label.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* There are also translations in the logging UI module itself, but as the other keys for the table are in oldcore, I think consistency wins where.
* I'm not sure what the best label is.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI change, view of the changed HTML:

<img width="730" height="149" alt="image" src="https://github.com/user-attachments/assets/b65b15f7-2b01-425b-b67d-cdab287d5d66" />

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Manuel test and manually executed axe-core test in Firefox. Built the changed module.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-18.5.x - failing tests because of the missing label
  * stable-18.4.x - low-risk accessibility improvement
  * stable-17.10.x - low-risk accessibility improvement