### PR TITLE
[Misc] Use static access for inherited constants in XAROutputFilterStream

### DIFF
--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/output/XAROutputFilterStream.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/output/XAROutputFilterStream.java
@@ -38,7 +38,9 @@ import org.xwiki.component.annotation.InstantiationStrategy;
 import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
 import org.xwiki.filter.FilterEventParameters;
 import org.xwiki.filter.FilterException;
+import org.xwiki.filter.event.model.WikiAttachmentFilter;
 import org.xwiki.filter.event.model.WikiClassFilter;
+import org.xwiki.filter.event.model.WikiDocumentFilter;
 import org.xwiki.filter.event.model.WikiObjectFilter;
 import org.xwiki.filter.event.model.WikiObjectPropertyFilter;
 import org.xwiki.filter.event.xwiki.XWikiWikiAttachmentFilter;
@@ -64,7 +66,10 @@ import org.xwiki.model.reference.EntityReferenceSerializer;
 import org.xwiki.model.reference.LocalDocumentReference;
 import org.xwiki.rendering.syntax.Syntax;
 import org.xwiki.xar.internal.XarObjectPropertySerializerManager;
+import org.xwiki.xar.internal.model.XarAttachmentModel;
+import org.xwiki.xar.internal.model.XarClassModel;
 import org.xwiki.xar.internal.model.XarDocumentModel;
+import org.xwiki.xar.internal.model.XarObjectPropertyModel;
 
 /**
  * @version $Id$
@@ -288,9 +293,9 @@ public class XAROutputFilterStream extends AbstractBeanOutputFilterStream<XAROut
         this.writer.writeElement(XarDocumentModel.ELEMENT_ISTRANSLATION,
             locale != null && !Locale.ROOT.equals(locale) ? "1" : "0");
 
-        writeElementIfParameterExists(parameters, XWikiWikiDocumentFilter.PARAMETER_CREATION_AUTHOR,
+        writeElementIfParameterExists(parameters, WikiDocumentFilter.PARAMETER_CREATION_AUTHOR,
             XarDocumentModel.ELEMENT_CREATION_AUTHOR);
-        writeElementIfParameterExists(parameters, XWikiWikiDocumentFilter.PARAMETER_CREATION_DATE,
+        writeElementIfParameterExists(parameters, WikiDocumentFilter.PARAMETER_CREATION_DATE,
             XarDocumentModel.ELEMENT_CREATION_DATE);
 
         if (this.properties.isPreserveVersion()) {
@@ -341,42 +346,42 @@ public class XAROutputFilterStream extends AbstractBeanOutputFilterStream<XAROut
         this.currentDocumentVersion = revision;
 
         try {
-            writeElementIfParameterExists(parameters, XWikiWikiDocumentFilter.PARAMETER_PARENT,
+            writeElementIfParameterExists(parameters, WikiDocumentFilter.PARAMETER_PARENT,
                 XarDocumentModel.ELEMENT_PARENT);
             writeElementIfParameterExists(parameters,
-                XWikiWikiDocumentFilter.PARAMETER_REVISION_EFFECTIVEMETADATA_AUTHOR,
+                WikiDocumentFilter.PARAMETER_REVISION_EFFECTIVEMETADATA_AUTHOR,
                 XarDocumentModel.ELEMENT_REVISION_EFFECTIVEMEDATAAUTHOR);
             writeElementIfParameterExists(parameters,
-                XWikiWikiDocumentFilter.PARAMETER_REVISION_ORIGINALMETADATA_AUTHOR,
+                WikiDocumentFilter.PARAMETER_REVISION_ORIGINALMETADATA_AUTHOR,
                 XarDocumentModel.ELEMENT_REVISION_ORIGINALMEDATAAUTHOR);
-            writeElementIfParameterExists(parameters, XWikiWikiDocumentFilter.PARAMETER_CUSTOMCLASS,
+            writeElementIfParameterExists(parameters, WikiDocumentFilter.PARAMETER_CUSTOMCLASS,
                 XarDocumentModel.ELEMENT_CUSTOMCLASS);
             writeElementIfParameterExists(parameters, XWikiWikiDocumentFilter.PARAMETER_CONTENT_AUTHOR,
                 XarDocumentModel.ELEMENT_CONTENT_AUTHOR);
             writeElementIfParameterExists(parameters, XWikiWikiDocumentFilter.PARAMETER_REVISION_DATE,
                 XarDocumentModel.ELEMENT_REVISION_DATE);
-            writeElementIfParameterExists(parameters, XWikiWikiDocumentFilter.PARAMETER_CONTENT_DATE,
+            writeElementIfParameterExists(parameters, WikiDocumentFilter.PARAMETER_CONTENT_DATE,
                 XarDocumentModel.ELEMENT_CONTENT_DATE);
             this.writer.writeElement(XarDocumentModel.ELEMENT_REVISION, this.currentDocumentVersion);
-            writeElementIfParameterExists(parameters, XWikiWikiDocumentFilter.PARAMETER_TITLE,
+            writeElementIfParameterExists(parameters, WikiDocumentFilter.PARAMETER_TITLE,
                 XarDocumentModel.ELEMENT_TITLE);
-            writeElementIfParameterExists(parameters, XWikiWikiDocumentFilter.PARAMETER_DEFAULTTEMPLATE,
+            writeElementIfParameterExists(parameters, WikiDocumentFilter.PARAMETER_DEFAULTTEMPLATE,
                 XarDocumentModel.ELEMENT_DEFAULTTEMPLATE);
-            writeElementIfParameterExists(parameters, XWikiWikiDocumentFilter.PARAMETER_VALIDATIONSCRIPT,
+            writeElementIfParameterExists(parameters, WikiDocumentFilter.PARAMETER_VALIDATIONSCRIPT,
                 XarDocumentModel.ELEMENT_VALIDATIONSCRIPT);
-            writeElementIfParameterExists(parameters, XWikiWikiDocumentFilter.PARAMETER_REVISION_COMMENT,
+            writeElementIfParameterExists(parameters, WikiDocumentFilter.PARAMETER_REVISION_COMMENT,
                 XarDocumentModel.ELEMENT_REVISION_COMMENT);
-            writeElementIfParameterExists(parameters, XWikiWikiDocumentFilter.PARAMETER_REVISION_MINOR,
+            writeElementIfParameterExists(parameters, WikiDocumentFilter.PARAMETER_REVISION_MINOR,
                 XarDocumentModel.ELEMENT_REVISION_MINOR);
-            writeElementIfParameterExists(parameters, XWikiWikiDocumentFilter.PARAMETER_SYNTAX,
+            writeElementIfParameterExists(parameters, WikiDocumentFilter.PARAMETER_SYNTAX,
                 XarDocumentModel.ELEMENT_SYNTAX);
-            writeElementIfParameterExists(parameters, XWikiWikiDocumentFilter.PARAMETER_HIDDEN,
+            writeElementIfParameterExists(parameters, WikiDocumentFilter.PARAMETER_HIDDEN,
                 XarDocumentModel.ELEMENT_HIDDEN);
-            writeElementIfParameterExists(parameters, XWikiWikiDocumentFilter.PARAMETER_ENFORCE_REQUIRED_RIGHTS,
+            writeElementIfParameterExists(parameters, WikiDocumentFilter.PARAMETER_ENFORCE_REQUIRED_RIGHTS,
                 XarDocumentModel.ELEMENT_ENFORCE_REQUIRED_RIGHTS);
-            writeElementIfParameterExists(parameters, XWikiWikiDocumentFilter.PARAMETER_CONTENT,
+            writeElementIfParameterExists(parameters, WikiDocumentFilter.PARAMETER_CONTENT,
                 XarDocumentModel.ELEMENT_CONTENT);
-            writeElementIfParameterExists(parameters, XWikiWikiDocumentFilter.PARAMETER_CONTENT_HTML,
+            writeElementIfParameterExists(parameters, WikiDocumentFilter.PARAMETER_CONTENT_HTML,
                 XarDocumentModel.ELEMENT_CONTENT_HTML);
         } catch (Exception e) {
             throw new FilterException(String.format("Failed to write begin document [%s] with version [%s]",
@@ -418,29 +423,29 @@ public class XAROutputFilterStream extends AbstractBeanOutputFilterStream<XAROut
             this.writer.writeElement(XARAttachmentModel.ELEMENT_NAME, name);
             if (this.properties.isPreserveVersion()) {
                 writeElementIfParameterExists(parameters, XWikiWikiAttachmentFilter.PARAMETER_JRCSREVISIONS,
-                    XARAttachmentModel.ELEMENT_JRCSVERSIONS);
+                    XarAttachmentModel.ELEMENT_JRCSVERSIONS);
             }
 
-            writeElementIfParameterExists(parameters, XWikiWikiAttachmentFilter.PARAMETER_MIMETYPE,
-                XARAttachmentModel.ELEMENT_MIMETYPE);
-            writeElementIfParameterExists(parameters, XWikiWikiAttachmentFilter.PARAMETER_CHARSET,
-                XARAttachmentModel.ELEMENT_CHARSET);
+            writeElementIfParameterExists(parameters, WikiAttachmentFilter.PARAMETER_MIMETYPE,
+                XarAttachmentModel.ELEMENT_MIMETYPE);
+            writeElementIfParameterExists(parameters, WikiAttachmentFilter.PARAMETER_CHARSET,
+                XarAttachmentModel.ELEMENT_CHARSET);
 
             // Author
-            writeElementIfParameterExists(parameters, XWikiWikiAttachmentFilter.PARAMETER_REVISION_AUTHOR,
-                XARAttachmentModel.ELEMENT_REVISION_AUTHOR);
+            writeElementIfParameterExists(parameters, WikiAttachmentFilter.PARAMETER_REVISION_AUTHOR,
+                XarAttachmentModel.ELEMENT_REVISION_AUTHOR);
 
             // Date
-            writeElementIfParameterExists(parameters, XWikiWikiAttachmentFilter.PARAMETER_REVISION_DATE,
-                XARAttachmentModel.ELEMENT_REVISION_DATE);
+            writeElementIfParameterExists(parameters, WikiAttachmentFilter.PARAMETER_REVISION_DATE,
+                XarAttachmentModel.ELEMENT_REVISION_DATE);
 
             // Version
-            writeElementIfParameterExists(parameters, XWikiWikiAttachmentFilter.PARAMETER_REVISION,
-                XARAttachmentModel.ELEMENT_VERSION);
+            writeElementIfParameterExists(parameters, WikiAttachmentFilter.PARAMETER_REVISION,
+                XarAttachmentModel.ELEMENT_VERSION);
 
             // Comment
-            writeElementIfParameterExists(parameters, XWikiWikiAttachmentFilter.PARAMETER_REVISION_COMMENT,
-                XARAttachmentModel.ELEMENT_REVISION_COMMENT);
+            writeElementIfParameterExists(parameters, WikiAttachmentFilter.PARAMETER_REVISION_COMMENT,
+                XarAttachmentModel.ELEMENT_REVISION_COMMENT);
 
             // Content
             writeContent(content, size);
@@ -469,7 +474,7 @@ public class XAROutputFilterStream extends AbstractBeanOutputFilterStream<XAROut
     @Override
     public void beginWikiAttachmentRevisions(FilterEventParameters parameters) throws FilterException
     {
-        this.writer.writeStartElement(XARAttachmentModel.ELEMENT_REVISIONS);
+        this.writer.writeStartElement(XarAttachmentModel.ELEMENT_REVISIONS);
     }
 
     @Override
@@ -482,28 +487,28 @@ public class XAROutputFilterStream extends AbstractBeanOutputFilterStream<XAROut
     public void beginWikiAttachmentRevision(String version, InputSource content, Long size,
         FilterEventParameters parameters) throws FilterException
     {
-        this.writer.writeStartElement(XARAttachmentModel.ELEMENT_REVISION);
+        this.writer.writeStartElement(XarAttachmentModel.ELEMENT_REVISION);
 
         // Author
-        writeElementIfParameterExists(parameters, XWikiWikiAttachmentFilter.PARAMETER_REVISION_AUTHOR,
-            XARAttachmentModel.ELEMENT_REVISION_AUTHOR);
+        writeElementIfParameterExists(parameters, WikiAttachmentFilter.PARAMETER_REVISION_AUTHOR,
+            XarAttachmentModel.ELEMENT_REVISION_AUTHOR);
 
         // Date
-        writeElementIfParameterExists(parameters, XWikiWikiAttachmentFilter.PARAMETER_REVISION_DATE,
-            XARAttachmentModel.ELEMENT_REVISION_DATE);
+        writeElementIfParameterExists(parameters, WikiAttachmentFilter.PARAMETER_REVISION_DATE,
+            XarAttachmentModel.ELEMENT_REVISION_DATE);
 
         // Version
-        writeElementIfParameterExists(parameters, XWikiWikiAttachmentFilter.PARAMETER_REVISION,
-            XARAttachmentModel.ELEMENT_VERSION);
+        writeElementIfParameterExists(parameters, WikiAttachmentFilter.PARAMETER_REVISION,
+            XarAttachmentModel.ELEMENT_VERSION);
 
         // Comment
-        writeElementIfParameterExists(parameters, XWikiWikiAttachmentFilter.PARAMETER_REVISION_COMMENT,
-            XARAttachmentModel.ELEMENT_REVISION_COMMENT);
+        writeElementIfParameterExists(parameters, WikiAttachmentFilter.PARAMETER_REVISION_COMMENT,
+            XarAttachmentModel.ELEMENT_REVISION_COMMENT);
 
         // Revision content storage optimization
-        String contentAlias = (String) parameters.get(XWikiWikiAttachmentFilter.PARAMETER_REVISION_CONTENT_ALIAS);
+        String contentAlias = (String) parameters.get(WikiAttachmentFilter.PARAMETER_REVISION_CONTENT_ALIAS);
         if (contentAlias != null) {
-            this.writer.writeElement(XARAttachmentModel.ELEMENT_REVISION_CONTENT_ALIAS, contentAlias);
+            this.writer.writeElement(XarAttachmentModel.ELEMENT_REVISION_CONTENT_ALIAS, contentAlias);
         }
 
         // Content
@@ -599,19 +604,19 @@ public class XAROutputFilterStream extends AbstractBeanOutputFilterStream<XAROut
             }
 
             writeElementIfParameterExists(parameters, WikiClassFilter.PARAMETER_CUSTOMCLASS,
-                XARClassModel.ELEMENT_CUSTOMCLASS);
+                XarClassModel.ELEMENT_CUSTOMCLASS);
             writeElementIfParameterExists(parameters, WikiClassFilter.PARAMETER_CUSTOMMAPPING,
-                XARClassModel.ELEMENT_CUSTOMMAPPING);
+                XarClassModel.ELEMENT_CUSTOMMAPPING);
             writeElementIfParameterExists(parameters, WikiClassFilter.PARAMETER_SHEET_DEFAULTVIEW,
-                XARClassModel.ELEMENT_SHEET_DEFAULTVIEW);
+                XarClassModel.ELEMENT_SHEET_DEFAULTVIEW);
             writeElementIfParameterExists(parameters, WikiClassFilter.PARAMETER_SHEET_DEFAULTEDIT,
-                XARClassModel.ELEMENT_SHEET_DEFAULTEDIT);
+                XarClassModel.ELEMENT_SHEET_DEFAULTEDIT);
             writeElementIfParameterExists(parameters, WikiClassFilter.PARAMETER_DEFAULTSPACE,
-                XARClassModel.ELEMENT_DEFAULTSPACE);
+                XarClassModel.ELEMENT_DEFAULTSPACE);
             writeElementIfParameterExists(parameters, WikiClassFilter.PARAMETER_NAMEFIELD,
-                XARClassModel.ELEMENT_NAMEFIELD);
+                XarClassModel.ELEMENT_NAMEFIELD);
             writeElementIfParameterExists(parameters, WikiClassFilter.PARAMETER_VALIDATIONSCRIPT,
-                XARClassModel.ELEMENT_VALIDATIONSCRIPT);
+                XarClassModel.ELEMENT_VALIDATIONSCRIPT);
         } catch (Exception e) {
             throw new FilterException(String.format("Failed to write begin xclass [%s] with version [%s]",
                 this.currentDocumentReference, this.currentDocumentVersion), e);
@@ -742,7 +747,7 @@ public class XAROutputFilterStream extends AbstractBeanOutputFilterStream<XAROut
             boolean objectPropertyTypeExists = false;
             if (objectPropertyType instanceof String stringObjectPropertyType
                 && StringUtils.isNotBlank(stringObjectPropertyType)) {
-                this.writer.writeAttribute(XARObjectPropertyModel.ATTRIBUTE_TYPE, stringObjectPropertyType);
+                this.writer.writeAttribute(XarObjectPropertyModel.ATTRIBUTE_TYPE, stringObjectPropertyType);
                 objectPropertyTypeExists = true;
             }
 


### PR DESCRIPTION
## Summary

Fixes the SonarCloud issues reported by rule [`java:S3252` (Classes from "calls to super class methods should not be ambiguous" family — *static members should be accessed statically*)](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&rules=java:S3252&open=AZzDryJKAHaDflByRxWm) in `XAROutputFilterStream`.

Representative issue: https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&open=AZzDryJKAHaDflByRxWm

### Problem

`XAROutputFilterStream` accessed a number of **inherited** static constants through a *subtype* rather than through the type that actually declares them. SonarQube flags this (rule `java:S3252`) because it can be misleading about where the constant is defined. 50 occurrences in this single file were reported.

### Fix

Each flagged reference now uses the declaring type directly:

| Was (subtype) | Now (declaring type) |
|---------------|----------------------|
| `XWikiWikiDocumentFilter.PARAMETER_*` | `WikiDocumentFilter.PARAMETER_*` |
| `XWikiWikiAttachmentFilter.PARAMETER_*` | `WikiAttachmentFilter.PARAMETER_*` |
| `XARAttachmentModel.ELEMENT_*` | `XarAttachmentModel.ELEMENT_*` |
| `XARClassModel.ELEMENT_*` | `XarClassModel.ELEMENT_*` |
| `XARObjectPropertyModel.ATTRIBUTE_TYPE` | `XarObjectPropertyModel.ATTRIBUTE_TYPE` |

Only the constants that SonarQube flagged as inherited were changed. Constants that are genuinely declared in the subtypes (e.g. `XWikiWikiDocumentFilter.PARAMETER_CONTENT_AUTHOR`, `XARAttachmentModel.ELEMENT_NAME`) are intentionally left untouched, so the subtype imports are still required. This is a pure readability change with **no behavioral or API impact** (all classes are `internal`).

## Test plan

- [x] `mvn clean verify -Pquality` on `xwiki-platform-filter-stream-xar` — passes (compilation, Checkstyle and tests green).

## Token usage

- Cost in tokens for finding an issue to fix: ~35k
- Cost in tokens for fixing the issue: ~45k
- Cost in tokens for the work after fixing the issue: ~15k (so far)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QzNkgyJZwGyKgiBXb2QUNd)_