### PR TITLE
[Misc] Use try-with-resources in HTMLCleanerTest

### DIFF
--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/test/java/org/xwiki/wysiwyg/internal/cleaner/HTMLCleanerTest.java
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/test/java/org/xwiki/wysiwyg/internal/cleaner/HTMLCleanerTest.java
@@ -303,8 +303,7 @@ public class HTMLCleanerTest
     private String[] readTestDataFromResource(String testResourceName) throws IOException
     {
         InputStream source = getClass().getResourceAsStream('/' + testResourceName + ".test");
-        BufferedReader reader = new BufferedReader(new InputStreamReader(source));
-        try {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(source))) {
             StringBuilder input = new StringBuilder();
             String line = reader.readLine();
             while (line != null && !INPUT_EXPECTED_SEPARATOR.equals(line)) {
@@ -319,8 +318,6 @@ public class HTMLCleanerTest
                 line = reader.readLine();
             }
             return new String[] {testResourceName, input.toString(), expected.toString()};
-        } finally {
-            reader.close();
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes the SonarCloud issue [`java:S2093` - Change this "try" to a try-with-resources](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&open=AZrl03oOOGUQvg5hQY8L) in `HTMLCleanerTest`.

### Problem

The `readTestDataFromResource` method opened a `BufferedReader` and closed it in a `finally` block. SonarQube recommends a try-with-resources statement instead, which is clearer and guarantees the reader is closed even if an exception is thrown while it is being constructed.

### Fix

Replaced the `try { ... } finally { reader.close(); }` pattern with a try-with-resources statement that declares the `BufferedReader` as a managed resource. This is a test-only, behaviour-preserving change with no API impact.

## Test plan

- [x] `mvn clean verify -Pquality` on `xwiki-platform-wysiwyg-api` — passes (compilation, Checkstyle and tests green).

## Token usage

- Cost in tokens for finding an issue to fix: ~30k
- Cost in tokens for fixing the issue: ~15k
- Cost in tokens for the work after fixing the issue: ~10k (so far)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011PG839yfYhvGh1JU8aWhB2)_