### PR TITLE
XWIKI-20155: Allow downloading a XIP package of any extension in the repository

### DIFF
--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/pom.xml
@@ -76,6 +76,17 @@
       <artifactId>xwiki-commons-cache-api</artifactId>
       <version>${commons.version}</version>
     </dependency>
+    <!-- Used by the XIP export. -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-resource-temporary</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.commons</groupId>
+      <artifactId>xwiki-commons-extension-repository-maven</artifactId>
+      <version>${commons.version}</version>
+    </dependency>
     <dependency>
       <groupId>org.xwiki.platform</groupId>
       <artifactId>xwiki-platform-oldcore</artifactId>

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/job/TemporaryCoreExtensionRepository.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/job/TemporaryCoreExtensionRepository.java
@@ -1,0 +1,55 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.repository.internal.job;
+
+import jakarta.inject.Named;
+
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.annotation.InstantiationStrategy;
+import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
+import org.xwiki.component.phase.InitializationException;
+import org.xwiki.extension.Extension;
+import org.xwiki.extension.repository.internal.core.DefaultCoreExtension;
+import org.xwiki.extension.repository.internal.core.DefaultCoreExtensionRepository;
+
+/**
+ * @version $Id$
+ */
+@Component
+@Named("tmp")
+@InstantiationStrategy(ComponentInstantiationStrategy.PER_LOOKUP)
+public class TemporaryCoreExtensionRepository extends DefaultCoreExtensionRepository
+{
+    @Override
+    public void initialize() throws InitializationException
+    {
+        // Cancel standard DefaultCoreExtensionRepository#initialize() since we don't care about what's in Maven
+        // classloader
+    }
+
+    /**
+     * @param extension the core extension to add
+     */
+    public void addExtension(Extension extension)
+    {
+        addExtension(extension instanceof DefaultCoreExtension coreExtension ? coreExtension
+            : new DefaultCoreExtension(this, null, extension));
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/job/TemporaryLocalExtensionRepository.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/job/TemporaryLocalExtensionRepository.java
@@ -1,0 +1,83 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.repository.internal.job;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+import org.apache.commons.io.FileUtils;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.annotation.InstantiationStrategy;
+import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
+import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.component.phase.InitializationException;
+import org.xwiki.environment.Environment;
+import org.xwiki.extension.repository.internal.local.DefaultLocalExtensionRepository;
+import org.xwiki.extension.repository.internal.local.LocalExtensionStorage;
+
+/**
+ * @version $Id$
+ */
+@Component
+@Named("tmp")
+@InstantiationStrategy(ComponentInstantiationStrategy.PER_LOOKUP)
+public class TemporaryLocalExtensionRepository extends DefaultLocalExtensionRepository
+{
+    @Inject
+    private Environment environment;
+
+    @Inject
+    private ComponentManager componentManager;
+
+    private Path path;
+
+    @Override
+    public void initialize() throws InitializationException
+    {
+        try {
+            this.path = Files.createTempDirectory(this.environment.getTemporaryDirectory().toPath(), "local");
+            this.storage = new LocalExtensionStorage(this, path.toFile(), this.componentManager);
+        } catch (Exception e) {
+            throw new InitializationException("Failed to initialize local extension storage", e);
+        }
+    }
+
+    /**
+     * @return the path
+     */
+    public Path getPath()
+    {
+        return this.path;
+    }
+
+    /**
+     * Dispose.
+     * 
+     * @throws IOException when failing to dispose
+     */
+    public void dispose() throws IOException
+    {
+        FileUtils.deleteDirectory(this.path.toFile());
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/job/XIPExportJob.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/job/XIPExportJob.java
@@ -1,0 +1,425 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.repository.internal.job;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Provider;
+
+import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.Strings;
+import org.codehaus.plexus.PlexusContainer;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.collection.CollectRequest;
+import org.eclipse.aether.collection.CollectResult;
+import org.eclipse.aether.collection.DependencyCollectionException;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.annotation.InstantiationStrategy;
+import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
+import org.xwiki.environment.Environment;
+import org.xwiki.extension.Extension;
+import org.xwiki.extension.ExtensionContext;
+import org.xwiki.extension.ExtensionException;
+import org.xwiki.extension.ExtensionId;
+import org.xwiki.extension.ExtensionManager;
+import org.xwiki.extension.ExtensionSession;
+import org.xwiki.extension.job.InstallRequest;
+import org.xwiki.extension.job.internal.InstallPlanJob;
+import org.xwiki.extension.job.plan.ExtensionPlan;
+import org.xwiki.extension.job.plan.ExtensionPlanAction;
+import org.xwiki.extension.job.plan.ExtensionPlanAction.Action;
+import org.xwiki.extension.repository.CoreExtensionRepository;
+import org.xwiki.extension.repository.ExtensionRepository;
+import org.xwiki.extension.repository.ExtensionRepositoryManager;
+import org.xwiki.extension.repository.LocalExtensionRepository;
+import org.xwiki.extension.repository.aether.internal.AetherExtensionRepository;
+import org.xwiki.extension.repository.aether.internal.XWikiRepositorySystemSession;
+import org.xwiki.job.AbstractJob;
+import org.xwiki.job.Job;
+import org.xwiki.repository.job.XIPExportJobRequest;
+import org.xwiki.repository.job.XIPExportJobStatus;
+import org.xwiki.resource.temporary.TemporaryResourceStore;
+
+/**
+ * Job responsible to export an extension (along with its dependencies) as a XIP package that can be used to install the
+ * extension offline on another XWiki instance.
+ *
+ * @version $Id$
+ * @since 18.5.0RC1
+ */
+@Component
+@Named(XIPExportJob.JOB_TYPE)
+@InstantiationStrategy(ComponentInstantiationStrategy.PER_LOOKUP)
+@SuppressWarnings("checkstyle:ClassFanOutComplexity")
+public class XIPExportJob extends AbstractJob<XIPExportJobRequest, XIPExportJobStatus>
+{
+    /**
+     * The XIP export job type.
+     */
+    public static final String JOB_TYPE = "repository/xip";
+
+    @Inject
+    private ExtensionContext extensionContext;
+
+    @Inject
+    private Environment environment;
+
+    @Inject
+    private Provider<PlexusContainer> plexusProvider;
+
+    @Inject
+    private XWikiRepositorySystemSession systemSession;
+
+    @Inject
+    private ExtensionRepositoryManager extensionRepositoryManager;
+
+    @Inject
+    private ExtensionManager extensionManager;
+
+    @Inject
+    @Named("tmp")
+    private Provider<CoreExtensionRepository> tmpCoreRepositoryProvider;
+
+    @Inject
+    @Named("tmp")
+    private Provider<LocalExtensionRepository> tmpLocalRepositoryProvider;
+
+    @Inject
+    @Named(InstallPlanJob.JOBTYPE)
+    private Provider<Job> installPlanJobProvider;
+
+    @Inject
+    private TemporaryResourceStore temporaryResourceStore;
+
+    private RepositorySystem repositorySystem;
+
+    @Override
+    public String getType()
+    {
+        return JOB_TYPE;
+    }
+
+    @Override
+    protected XIPExportJobStatus createNewStatus(XIPExportJobRequest request)
+    {
+        return new XIPExportJobStatus(getType(), request, this.observationManager, this.loggerManager);
+    }
+
+    @Override
+    protected void runInternal() throws Exception
+    {
+        this.progressManager.pushLevelProgress(5, this);
+
+        ExtensionSession extensionSession = this.extensionContext.pushSession();
+
+        try {
+            this.progressManager.startStep(this);
+            initializeRepositorySystem(extensionSession);
+            this.progressManager.endStep(this);
+
+            if (this.status.isCanceled()) {
+                return;
+            }
+
+            this.progressManager.startStep(this);
+            CoreExtensionRepository repository = resolveCoreExtensions();
+            this.progressManager.endStep(this);
+
+            if (this.status.isCanceled()) {
+                return;
+            }
+
+            this.progressManager.startStep(this);
+            ExtensionPlan plan = getInstallPlan(repository);
+            this.progressManager.endStep(this);
+
+            if (this.status.isCanceled()) {
+                return;
+            }
+
+            this.progressManager.startStep(this);
+            TemporaryLocalExtensionRepository localRepository = serializeInstallPlan(plan);
+            this.progressManager.endStep(this);
+
+            if (this.status.isCanceled()) {
+                return;
+            }
+
+            try {
+                this.progressManager.startStep(this);
+                archiveLocalRepository(localRepository);
+                this.progressManager.endStep(this);
+            } finally {
+                localRepository.dispose();
+            }
+        } finally {
+            this.progressManager.popLevelProgress(this);
+            this.extensionContext.popSession();
+        }
+    }
+
+    private void initializeRepositorySystem(ExtensionSession extensionSession) throws Exception
+    {
+        this.logger.info("Initializing repository system...");
+        PlexusContainer plexusContainer = this.plexusProvider.get();
+        this.repositorySystem = plexusContainer.lookup(RepositorySystem.class);
+
+        Path path = this.environment.getPermanentDirectory().toPath().resolve("cache/repository/xip");
+        this.systemSession.initialize(repositorySystem, path, false);
+        extensionSession.set("maven.systemSession", systemSession);
+    }
+
+    private CoreExtensionRepository resolveCoreExtensions() throws ExtensionException
+    {
+        this.logger.info("Resolving core extensions...");
+        this.progressManager.pushLevelProgress(5, this);
+        try {
+            this.progressManager.startStep(this);
+            Set<Artifact> artifacts = collectCoreArtifacts();
+            this.progressManager.endStep(this);
+
+            if (artifacts.isEmpty() || this.status.isCanceled()) {
+                return null;
+            }
+
+            this.progressManager.startStep(this);
+            CoreExtensionRepository coreExtensionRepository = createCoreExtensionRepository(artifacts);
+            this.progressManager.endStep(this);
+            return coreExtensionRepository;
+        } finally {
+            this.progressManager.popLevelProgress(this);
+        }
+    }
+
+    private Set<Artifact> collectCoreArtifacts() throws ExtensionException
+    {
+        this.logger.info("Collecting core artifacts...");
+        List<Artifact> coreExtensions = getCoreExtensions();
+        if (coreExtensions == null || coreExtensions.isEmpty()) {
+            return Set.of();
+        }
+
+        CollectRequest request = new CollectRequest();
+
+        request.setRepositories(getAllMavenRepositories());
+
+        for (Artifact coreExtension : coreExtensions) {
+            request.addDependency(new Dependency(coreExtension, null));
+        }
+
+        CollectResult collectResult;
+        try {
+            collectResult = this.repositorySystem.collectDependencies(this.systemSession, request);
+        } catch (DependencyCollectionException e) {
+            throw new ExtensionException("Failed to resolve artifacts", e);
+        }
+
+        if (!collectResult.getExceptions().isEmpty()) {
+            throw new ExtensionException(String.format("Failed to resolve artifacts %s", coreExtensions),
+                collectResult.getExceptions().get(0));
+        }
+
+        Set<Artifact> artifacts = new HashSet<>();
+
+        collectResult.getRoot().getChildren().forEach(child -> addNode(child, artifacts));
+        return artifacts;
+    }
+
+    private List<Artifact> getCoreExtensions()
+    {
+        String xwikiVersion = getRequest().getXWikiVersion();
+        return getRequest().getCoreExtensions().stream().<Artifact>map(extensionId -> {
+            String[] parts = extensionId.getId().split(":");
+            if (parts.length == 2) {
+                String groupId = parts[0];
+                String artifactId = parts[1];
+                return new DefaultArtifact(groupId, artifactId, "pom", xwikiVersion);
+            } else {
+                return null;
+            }
+        }).filter(Objects::nonNull).toList();
+    }
+
+    private List<RemoteRepository> getAllMavenRepositories()
+    {
+        Collection<ExtensionRepository> extensionRepositories = this.extensionRepositoryManager.getRepositories();
+
+        List<RemoteRepository> repositories = new ArrayList<>(extensionRepositories.size());
+
+        for (ExtensionRepository extensionRepository : extensionRepositories) {
+            if (extensionRepository instanceof AetherExtensionRepository aetherExtensionRepository) {
+                RemoteRepository repository = aetherExtensionRepository.getRemoteRepository();
+
+                repositories.add(repository);
+            }
+        }
+
+        this.repositorySystem.newResolutionRepositories(this.systemSession, repositories);
+
+        return repositories;
+    }
+
+    private void addNode(DependencyNode node, Collection<Artifact> artifacts)
+    {
+        // TODO: find out why we end up with "system" scope dependency (seems to be specific to jdk.tools:jdk.tools)
+        if (!node.getDependency().getScope().equals("system")) {
+            artifacts.add(node.getArtifact());
+            node.getChildren().forEach(child -> addNode(child, artifacts));
+        }
+    }
+
+    private CoreExtensionRepository createCoreExtensionRepository(Set<Artifact> artifacts) throws ExtensionException
+    {
+        TemporaryCoreExtensionRepository repository =
+            (TemporaryCoreExtensionRepository) this.tmpCoreRepositoryProvider.get();
+
+        this.logger.info("Resolving [{}] core extensions...", artifacts.size());
+        this.progressManager.pushLevelProgress(artifacts.size(), this);
+
+        try {
+            for (Artifact artifact : artifacts) {
+                if (this.status.isCanceled()) {
+                    break;
+                }
+                this.progressManager.startStep(this);
+                this.logger.info("Resolving core extension [{}:{}]...", artifact.getGroupId(),
+                    artifact.getArtifactId());
+                Extension extension = this.extensionManager.resolveExtension(
+                    new ExtensionId(artifact.getGroupId() + ':' + artifact.getArtifactId(), artifact.getVersion()));
+                repository.addExtension(extension);
+                this.progressManager.endStep(this);
+            }
+        } finally {
+            this.progressManager.popLevelProgress(this);
+        }
+
+        return repository;
+    }
+
+    private ExtensionPlan getInstallPlan(CoreExtensionRepository repository) throws ExtensionException
+    {
+        this.logger.info("Computing install plan for [{}]...", this.request.getExtension());
+        InstallRequest planRequest = new InstallRequest();
+        planRequest.addExtension(this.request.getExtension());
+        planRequest.setInstalledIgnored(true);
+        planRequest.setCoreExtensionRepository(repository);
+        planRequest.setVerbose(false);
+        Job installPlanJob = installPlanJobProvider.get();
+        installPlanJob.initialize(planRequest);
+        installPlanJob.run();
+        ExtensionPlan plan = (ExtensionPlan) installPlanJob.getStatus();
+        if (plan.getError() != null) {
+            throw new ExtensionException(
+                "Failed to resolve the install plan for extension [" + this.request.getExtension() + "]",
+                plan.getError());
+        }
+        return plan;
+    }
+
+    private TemporaryLocalExtensionRepository serializeInstallPlan(ExtensionPlan plan) throws ExtensionException
+    {
+        this.logger.info("Downloading extension files...");
+        List<ExtensionPlanAction> installActions =
+            plan.getActions().stream().filter(item -> item.getAction() == Action.INSTALL).toList();
+
+        TemporaryLocalExtensionRepository localRepository =
+            (TemporaryLocalExtensionRepository) this.tmpLocalRepositoryProvider.get();
+
+        this.logger.info("Storing [{}] extensions...", installActions.size());
+        this.progressManager.pushLevelProgress(installActions.size(), this);
+
+        try {
+            for (ExtensionPlanAction action : installActions) {
+                if (this.status.isCanceled()) {
+                    break;
+                }
+                this.progressManager.startStep(this);
+                this.logger.info("Storing extension [{}]...", action.getExtension().getId());
+                localRepository.storeExtension(action.getExtension());
+                this.progressManager.endStep(this);
+            }
+        } finally {
+            this.progressManager.popLevelProgress(this);
+        }
+
+        return localRepository;
+    }
+
+    private void archiveLocalRepository(TemporaryLocalExtensionRepository localRepository) throws IOException
+    {
+        this.logger.info("Creating XIP archive...");
+        String suffix = ".xip";
+        String prefix = Strings.CS.removeEnd(this.status.getXIPFileReference().getResourceName(), suffix);
+        File xip = Files.createTempFile(this.environment.getTemporaryDirectory().toPath(), prefix, suffix).toFile();
+        try {
+            try (ZipArchiveOutputStream zipStream = new ZipArchiveOutputStream(xip)) {
+                zipStream.setEncoding("UTF8");
+                zipFile(localRepository.getPath().toFile(), "", zipStream);
+            }
+            if (!this.status.isCanceled()) {
+                try (FileInputStream xipStream = new FileInputStream(xip)) {
+                    this.temporaryResourceStore.createTemporaryFile(this.status.getXIPFileReference(), xipStream);
+                }
+            }
+        } finally {
+            Files.delete(xip.toPath());
+        }
+    }
+
+    private void zipFile(File file, String path, ZipArchiveOutputStream zipStream) throws IOException
+    {
+        if (this.status.isCanceled()) {
+            return;
+        }
+
+        if (file.isDirectory()) {
+            File[] children = file.listFiles();
+            if (children != null) {
+                for (File childFile : children) {
+                    zipFile(childFile, path + "/" + childFile.getName(), zipStream);
+                }
+            }
+        } else {
+            zipStream.putArchiveEntry(zipStream.createArchiveEntry(file, path));
+            try (FileInputStream inputStream = new FileInputStream(file)) {
+                IOUtils.copy(inputStream, zipStream);
+            }
+            zipStream.closeArchiveEntry();
+        }
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/job/XIPExportJobRequest.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/job/XIPExportJobRequest.java
@@ -1,0 +1,124 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.repository.job;
+
+import java.util.List;
+
+import org.xwiki.extension.ExtensionId;
+import org.xwiki.job.Request;
+import org.xwiki.job.api.AbstractCheckRightsRequest;
+import org.xwiki.stability.Unstable;
+
+/**
+ * Represents a request to export an XWiki extension and its dependencies as a XIP package.
+ * 
+ * @version $Id$
+ * @since 18.5.0RC1
+ */
+@Unstable
+public class XIPExportJobRequest extends AbstractCheckRightsRequest
+{
+    /**
+     * The property that stores the id of the extension to export.
+     */
+    private static final String PROPERTY_EXTENSION = "extension";
+
+    /**
+     * The property that stores the XWiki version where the XIP package is intended to be used.
+     */
+    private static final String PROPERTY_XWIKI_VERSION = "xwikiVersion";
+
+    /**
+     * The property that stores the list of core extensions to exclude from the XIP package. These extensions are
+     * supposed to be provided by the target XWiki instance.
+     */
+    private static final String PROPERTY_CORE_EXTENSIONS = "coreExtensions";
+
+    /**
+     * Default constructor.
+     */
+    public XIPExportJobRequest()
+    {
+    }
+
+    /**
+     * Copy constructor.
+     *
+     * @param request the request to copy
+     */
+    public XIPExportJobRequest(Request request)
+    {
+        super(request);
+    }
+
+    /**
+     * @return the id of the extension to export
+     */
+    public ExtensionId getExtension()
+    {
+        return getProperty(PROPERTY_EXTENSION);
+    }
+
+    /**
+     * Sets the id of the extension to export.
+     *
+     * @param extension the id of the extension to export
+     */
+    public void setExtension(ExtensionId extension)
+    {
+        setProperty(PROPERTY_EXTENSION, extension);
+    }
+
+    /**
+     * @return the XWiki version where the XIP package is intended to be used
+     */
+    public String getXWikiVersion()
+    {
+        return getProperty(PROPERTY_XWIKI_VERSION);
+    }
+
+    /**
+     * Sets the XWiki version where the XIP package is intended to be used.
+     *
+     * @param xwikiVersion the XWiki version where the XIP package is intended to be used
+     */
+    public void setXWikiVersion(String xwikiVersion)
+    {
+        setProperty(PROPERTY_XWIKI_VERSION, xwikiVersion);
+    }
+
+    /**
+     * @return the list of core extensions to excludes from the XIP package
+     */
+    public List<ExtensionId> getCoreExtensions()
+    {
+        return getProperty(PROPERTY_CORE_EXTENSIONS);
+    }
+
+    /**
+     * Sets the list of core extensions to exclude from the XIP package.
+     *
+     * @param coreExtensions the list of core extensions to exclude from the XIP package
+     */
+    public void setCoreExtensions(List<ExtensionId> coreExtensions)
+    {
+        setProperty(PROPERTY_CORE_EXTENSIONS, coreExtensions);
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/job/XIPExportJobStatus.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/job/XIPExportJobStatus.java
@@ -1,0 +1,71 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.repository.job;
+
+import java.util.List;
+
+import org.xwiki.extension.ExtensionId;
+import org.xwiki.job.DefaultJobStatus;
+import org.xwiki.logging.LoggerManager;
+import org.xwiki.observation.ObservationManager;
+import org.xwiki.resource.temporary.TemporaryResourceReference;
+import org.xwiki.stability.Unstable;
+
+/**
+ * The status of the XIP export job.
+ * 
+ * @version $Id$
+ * @since 18.5.0RC1
+ */
+@Unstable
+public class XIPExportJobStatus extends DefaultJobStatus<XIPExportJobRequest>
+{
+    private final TemporaryResourceReference xipFileReference;
+
+    /**
+     * Create a new XIP export job status.
+     * 
+     * @param jobType the job type
+     * @param request the request provided when the job was started
+     * @param observationManager the observation manager
+     * @param loggerManager the logger manager
+     */
+    public XIPExportJobStatus(String jobType, XIPExportJobRequest request, ObservationManager observationManager,
+        LoggerManager loggerManager)
+    {
+        super(jobType, request, null, observationManager, loggerManager);
+
+        setCancelable(true);
+        String idSuffix = request.getId().get(request.getId().size() - 1);
+        this.xipFileReference = new TemporaryResourceReference("repository", List.of("xip", idSuffix + ".xip"),
+            request.getAuthorReference());
+        ExtensionId extensionId = request.getExtension();
+        this.xipFileReference.addParameter("fileName", "%s-%s-xwiki-%s.xip".formatted(extensionId.getId(),
+            extensionId.getVersion().getValue(), request.getXWikiVersion()));
+    }
+
+    /**
+     * @return the reference of the generated temporary XIP file
+     */
+    public TemporaryResourceReference getXIPFileReference()
+    {
+        return this.xipFileReference;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/script/RepositoryScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/script/RepositoryScriptService.java
@@ -20,6 +20,8 @@
 package org.xwiki.repository.script;
 
 import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -29,15 +31,21 @@ import javax.inject.Singleton;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.context.Execution;
 import org.xwiki.extension.ExtensionException;
+import org.xwiki.extension.ExtensionId;
 import org.xwiki.extension.ExtensionSupportPlans;
 import org.xwiki.extension.repository.ExtensionRepository;
 import org.xwiki.extension.repository.ExtensionRepositoryManager;
 import org.xwiki.extension.version.Version;
+import org.xwiki.job.Job;
+import org.xwiki.job.JobExecutor;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.query.QueryException;
 import org.xwiki.repository.internal.ExtensionStore;
 import org.xwiki.repository.internal.RepositoryManager;
+import org.xwiki.repository.internal.job.XIPExportJob;
+import org.xwiki.repository.job.XIPExportJobRequest;
 import org.xwiki.script.service.ScriptService;
+import org.xwiki.stability.Unstable;
 
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
@@ -71,6 +79,12 @@ public class RepositoryScriptService implements ScriptService
 
     @Inject
     private Provider<XWikiContext> contextProvider;
+
+    /**
+     * Used to execute the XIP export jobs.
+     */
+    @Inject
+    private JobExecutor jobExecutor;
 
     /**
      * Store a caught exception in the context, so that it can be later retrieved using {@link #getLastError()}.
@@ -207,5 +221,38 @@ public class RepositoryScriptService implements ScriptService
         XWikiDocument projectVersionDocument =
             this.extensionStore.getProjectVersionDocument(projectDocument, version, context);
         return new Object(this.extensionStore.getProjectVersionObject(projectVersionDocument, version), context);
+    }
+
+    /**
+     * Starts a job that will export the given extension (along with its dependencies) as a XIP package that can be used
+     * to install the extension offline on another XWiki instance with the specified version.
+     *
+     * @param extensionId the extension to export (along with its dependencies) as a XIP package
+     * @param xwikiVersion the XWiki version where the extension needs to be installed offline
+     * @return the XIP export job
+     * @since 18.5.0RC1
+     */
+    @Unstable
+    public Job exportExtension(ExtensionId extensionId, String xwikiVersion)
+    {
+        setError(null);
+
+        XIPExportJobRequest request = new XIPExportJobRequest();
+        request.setId("repository", "xip", UUID.randomUUID().toString());
+        request.setExtension(extensionId);
+        request.setXWikiVersion(xwikiVersion);
+        request.setCoreExtensions(
+            List.of(new ExtensionId("org.xwiki.platform:xwiki-platform-distribution-war-dependencies", xwikiVersion)));
+        request.setCheckRights(true);
+        XWikiContext xcontext = contextProvider.get();
+        request.setUserReference(xcontext.getUserReference());
+        request.setAuthorReference(xcontext.getAuthorReference());
+
+        try {
+            return this.jobExecutor.execute(XIPExportJob.JOB_TYPE, request);
+        } catch (Exception e) {
+            setError(e);
+            return null;
+        }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/resources/META-INF/components.txt
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/resources/META-INF/components.txt
@@ -4,6 +4,9 @@ org.xwiki.repository.internal.ExtensionSupporterProtectionListener
 org.xwiki.repository.internal.ExtensionSupportProtectionListener
 org.xwiki.repository.internal.ExtensionUpdaterListener
 org.xwiki.repository.internal.RepositoryManager
+org.xwiki.repository.internal.job.TemporaryCoreExtensionRepository
+org.xwiki.repository.internal.job.TemporaryLocalExtensionRepository
+org.xwiki.repository.internal.job.XIPExportJob
 org.xwiki.repository.internal.reference.ExtensionResourceReferenceTypeParser
 org.xwiki.repository.internal.resources.ExtensionRESTResource
 org.xwiki.repository.internal.resources.ExtensionsRESTResource

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/test/java/org/xwiki/repository/script/RepositoryScriptServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/test/java/org/xwiki/repository/script/RepositoryScriptServiceTest.java
@@ -1,0 +1,135 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.repository.script;
+
+import java.util.List;
+
+import javax.inject.Provider;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.xwiki.context.Execution;
+import org.xwiki.context.ExecutionContext;
+import org.xwiki.extension.ExtensionId;
+import org.xwiki.job.Job;
+import org.xwiki.job.JobException;
+import org.xwiki.job.JobExecutor;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.repository.internal.job.XIPExportJob;
+import org.xwiki.repository.job.XIPExportJobRequest;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import com.xpn.xwiki.XWikiContext;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link RepositoryScriptService}.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+class RepositoryScriptServiceTest
+{
+    @InjectMockComponents
+    private RepositoryScriptService repositoryScriptService;
+
+    @MockComponent
+    private JobExecutor jobExecutor;
+
+    @MockComponent
+    private Execution execution;
+
+    @MockComponent
+    private Provider<XWikiContext> contextProvider;
+
+    @Mock
+    private XWikiContext xcontext;
+
+    private final ExecutionContext executionContext = new ExecutionContext();
+
+    private ExtensionId extensionId = new ExtensionId("org.xwiki.contrib:my-extension", "1.0");
+
+    private String xwikiVersion = "18.5.0";
+
+    @BeforeEach
+    void setup()
+    {
+        when(this.execution.getContext()).thenReturn(this.executionContext);
+        when(this.contextProvider.get()).thenReturn(this.xcontext);
+    }
+
+    @Test
+    void exportExtension() throws JobException
+    {
+        DocumentReference userReference = new DocumentReference("xwiki", "XWiki", "Alice");
+        DocumentReference authorReference = new DocumentReference("xwiki", "XWiki", "Bob");
+        when(this.xcontext.getUserReference()).thenReturn(userReference);
+        when(this.xcontext.getAuthorReference()).thenReturn(authorReference);
+
+        Job expectedJob = mock(Job.class);
+        when(this.jobExecutor.execute(eq(XIPExportJob.JOB_TYPE), any(XIPExportJobRequest.class)))
+            .thenReturn(expectedJob);
+
+        Job result = this.repositoryScriptService.exportExtension(extensionId, xwikiVersion);
+
+        assertEquals(expectedJob, result);
+        assertNull(this.repositoryScriptService.getLastError());
+
+        ArgumentCaptor<XIPExportJobRequest> requestCaptor = ArgumentCaptor.forClass(XIPExportJobRequest.class);
+        verify(this.jobExecutor).execute(eq(XIPExportJob.JOB_TYPE), requestCaptor.capture());
+        XIPExportJobRequest request = requestCaptor.getValue();
+
+        assertEquals(extensionId, request.getExtension());
+        assertEquals(xwikiVersion, request.getXWikiVersion());
+        assertEquals(
+            List.of(new ExtensionId("org.xwiki.platform:xwiki-platform-distribution-war-dependencies", xwikiVersion)),
+            request.getCoreExtensions());
+        assertTrue(request.isCheckRights());
+        assertEquals(userReference, request.getUserReference());
+        assertEquals(authorReference, request.getAuthorReference());
+        List<String> jobId = request.getId();
+        assertEquals(3, jobId.size());
+        assertEquals("repository", jobId.get(0));
+        assertEquals("xip", jobId.get(1));
+    }
+
+    @Test
+    void exportExtensionWhenJobExecutionFails() throws JobException
+    {
+        JobException expectedException = new JobException("Failed to start XIP export job");
+        when(this.jobExecutor.execute(eq(XIPExportJob.JOB_TYPE), any(XIPExportJobRequest.class)))
+            .thenThrow(expectedException);
+
+        assertNull(this.repositoryScriptService.exportExtension(extensionId, xwikiVersion));
+        assertEquals(expectedException, this.repositoryScriptService.getLastError());
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-ui/src/main/resources/ExtensionCode/ExtensionSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-ui/src/main/resources/ExtensionCode/ExtensionSheet.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.6" reference="ExtensionCode.ExtensionSheet" locale="">
+<xwikidoc version="1.7" reference="ExtensionCode.ExtensionSheet" locale="">
   <web>ExtensionCode</web>
   <name>ExtensionSheet</name>
   <language/>
@@ -83,12 +83,98 @@
 
 #set($proxyExtensionObject = $doc.getObject('ExtensionCode.ExtensionProxyClass'))
 #set($projectReference = $doc.getValue('project'))
+
+#macro (_handleExtensionAction $extension)
+  #if ("$!request.action" != '' &amp;&amp; !$services.csrf.isTokenValid($request.get('form_token')))
+    set ($discard = $response.sendError(401, 'CSRF token verification failed!'))
+  #elseif ($request.data == 'supportedXWikiVersions')
+    #_returnSupportedXWikiVersions($extension)
+  #elseif ($request.data == 'xipJobStatus')
+    #set ($xipExportJobId = $request.jobId.split('/'))
+    #_returnXIPExportJobStatusJSON($xipExportJobId)
+  #elseif ($request.action == 'exportXIP')
+    #set ($extensionId = $services.extension.createExtensionId($request.extensionId, $request.extensionVersion))
+    #set ($xipExportJob = $services.repository.exportExtension($extensionId, $request.xwikiVersion))
+    #_returnXIPExportJobStatusJSON($xipExportJob.request.id)
+  #elseif ($request.action == 'cancelXIP')
+    #set ($xipExportJobId = $request.jobId.split('/'))
+    #set ($xipExportJobStatus = $services.job.getJobStatus($xipExportJobId))
+    #set ($discard = $xipExportJobStatus.cancel())
+    #_returnXIPExportJobStatusJSON($xipExportJobId)
+  #end
+#end
+
+#macro (_returnSupportedXWikiVersions $extension)
+  #set ($xwikiVersions = $collectiontool.linkedList)
+  ## TODO: Find a way to keep only the XWiki versions where the specified extension can be installed.
+  #foreach ($version in $extensionManager.resolveVersions('org.xwiki.platform:xwiki-platform-distribution-war', 0, -1))
+    #if ($version.type == 'STABLE')
+      #set ($discard = $xwikiVersions.push($version.value))
+    #end
+  #end
+  #jsonResponse($xwikiVersions)
+#end
+
+#macro (_returnXIPExportJobStatusJSON $xipExportJobId)
+  #set ($xipExportJobStatusJSON = {})
+  #if ($xipExportJobId)
+    #set ($xipExportJobStatus = $services.job.getJobStatus($xipExportJobId))
+    #if ($xipExportJobStatus)
+      #set ($discard = $xipExportJobStatusJSON.putAll({
+        'id': $xipExportJobStatus.request.id,
+        'state': $xipExportJobStatus.state,
+        'canceled': $xipExportJobStatus.canceled,
+        'progress': {
+          'offset': $xipExportJobStatus.progress.offset
+        }
+      }))
+      #if ($xipExportJobStatus.state == 'FINISHED')
+        #if ($services.resource.temporary.exists($xipExportJobStatus.getXIPFileReference()))
+          #set ($xipExportJobStatusJSON.xipFileURL = $services.resource.temporary.getURL(
+            $xipExportJobStatus.getXIPFileReference()))
+        #end
+        ## Check if the XIP export job failed.
+        #set ($lastError = {'throwable': $xipExportJobStatus.error})
+        #set ($xipExportJobStatusJSON.failed = "$!lastError.throwable" != '')
+        #if (!$xipExportJobStatusJSON.failed)
+          ## The XIP export job log can contain errors even if the job did not fail. Let's extract the last error and warn
+          ## the user because it may justify why the result is not as expected.
+          #set ($lastError = $xipExportJobStatus.logTail.getLastLogEvent('ERROR'))
+        #end
+        ## Extract the error message from the last error.
+        #if ($lastError.throwable)
+          #set ($lastError = $exceptiontool.getRootCauseMessage($lastError.throwable))
+        #else
+          #set ($lastError = $lastError.formattedMessage)
+        #end
+        #set ($xipExportJobStatusJSON.lastError = $lastError)
+      #end
+    #else
+      #set ($xipExportJobStatusJSON.id = $xipExportJobId)
+      #set ($xipExportJobStatusJSON.failed = true)
+      #set ($xipExportJobStatusJSON.lastError = 'XIP export job not found')
+    #end
+  #else
+    #set ($xipExportJobStatusJSON.failed = true)
+    #set ($xipExportJobStatusJSON.lastError = 'XIP export job ID is missing')
+  #end
+  #jsonResponse($xipExportJobStatusJSON)
+#end
 {{/velocity}}
 
 {{velocity}}
-#if ($extension)
+#if ($extension &amp;&amp; $xcontext.action == 'get')
+  ##
+  ## Extension Action
+  ##
+  #_handleExtensionAction($extension)
+#elseif ($extension)
+  ##
+  ## Extension Display
+  ##
   $doc.use("ExtensionCode.ExtensionClass")
   #if ($isViewMode)
+    #set ($discard = $xwiki.jsx.use('ExtensionCode.ExtensionSheet'))
     ##------- Icon &amp; Summary -----------------
     (% class="extensionSummary" %)
     #set($icon = $doc.getValue("icon"))
@@ -198,11 +284,72 @@
             [[$services.icon.render('download') #wikiTranslation('repository.extension.sheet.download', [$version])&gt;&gt;$services.rendering.escape($download, 'xwiki/2.1')||class="btn btn-default"]]##
           #end
         #end
+        ##------- XIP export ------
+        ## Provide the XIP button only if the extension is valid (has an ID and a version) and only for authenticated
+        ## users (to reduce abuse, since generating the XIP can be costly).
+        #set ($extensionId = $extension.getProperty('id').value)
+        #set ($extensionVersion = $lastVersionObject.getProperty('version').value)
+        #if ($extensionId &amp;&amp; $extensionVersion &amp;&amp; $doc.getValue('validExtension') == 1 &amp;&amp; "$!xcontext.userReference" != '')
+          [[$services.icon.render('file-archive') {{translation key="repository.extension.sheet.installOffline"/}}&gt;&gt;||anchor="installOffline" class="btn btn-default" data-toggle="modal" data-target="#installOffline"]]
+        #end
       )))
     {{/box}}
 
     {{box cssClass="toc col-xs-12 col-sm-6"}}(% class="label" %){{translation key="repository.extension.sheet.toc"/}}(%%)((({{toc/}}))){{/box}}
     (%class="clearfix"%)((()))
+
+    ##
+    ## Install Offline (XIP export) Modal
+    ##
+    {{html clean="false"}}
+    &lt;form class="xform modal fade" id="installOffline" tabindex="-1" role="dialog" aria-labelledby="installOfflineLabel"
+        data-keyboard="false"&gt;
+      &lt;div class="modal-dialog" role="document"&gt;
+        &lt;div class="modal-content"&gt;
+          &lt;div class="modal-header"&gt;
+            &lt;button type="button" class="close" data-dismiss="modal"
+              aria-label="$escapetool.xml($services.localization.render('cancel'))"
+              &gt;&lt;span aria-hidden="true"&gt;&amp;times;&lt;/span&gt;&lt;/button&gt;
+            &lt;h4 class="modal-title" id="installOfflineLabel"&gt;
+              $escapetool.xml($services.localization.render('repository.extension.sheet.installOffline'))
+            &lt;/h4&gt;
+          &lt;/div&gt;
+          &lt;div class="modal-body"&gt;
+            &lt;p&gt;$escapetool.xml($services.localization.render('repository.extension.sheet.installOffline.help'))&lt;/p&gt;
+            &lt;dl&gt;
+              &lt;dt&gt;
+                &lt;label&gt;
+                  $escapetool.xml($services.localization.render(
+                    'repository.extension.sheet.installOffline.xwikiVersion'))
+                &lt;/label&gt;
+                &lt;span class="xHint"&gt;
+                  $escapetool.xml($services.localization.render(
+                    'repository.extension.sheet.installOffline.xwikiVersionHint'))
+                &lt;/span&gt;
+              &lt;/dt&gt;
+              &lt;dd&gt;
+                &lt;input type="text" name="xwikiVersion" /&gt;
+              &lt;/dd&gt;
+            &lt;/dl&gt;
+          &lt;/div&gt;
+          &lt;div class="modal-footer"&gt;
+            &lt;div hidden="hidden"&gt;
+              &lt;input type="hidden" name="form_token" value="$escapetool.xml($services.csrf.token)" /&gt;
+              &lt;input type="hidden" name="extensionId" value="$!escapetool.xml($extensionId)" /&gt;
+              &lt;input type="hidden" name="extensionVersion" value="$!escapetool.xml($extensionVersion)" /&gt;
+            &lt;/div&gt;
+            &lt;button type="submit" class="btn btn-primary" name="action" value="exportXIP" disabled="disabled"&gt;
+              $services.icon.renderHTML('download')
+              $escapetool.xml($services.localization.render('repository.extension.sheet.installOffline.exportXIP'))
+            &lt;/button&gt;
+            &lt;button type="button" class="btn btn-default" name="action" value="cancelXIP" data-dismiss="modal"&gt;
+              $escapetool.xml($services.localization.render('cancel'))
+            &lt;/button&gt;
+          &lt;/div&gt;
+        &lt;/div&gt;
+      &lt;/div&gt;
+    &lt;/form&gt;
+    {{/html}}
   #else
     ## Editing
     ##
@@ -264,56 +411,73 @@
     #end
   #end
 
-    ## If there's a website specified, then don't display the Description (since Description is a local documentation).
-    #if (($isViewMode &amp;&amp; "$!website" == '') || !$isViewMode)
-      = {{translation key="repository.extension.sheet.description"/}} =
+  ## If there's a website specified, then don't display the Description (since Description is a local documentation).
+  #if (($isViewMode &amp;&amp; "$!website" == '') || !$isViewMode)
+    = {{translation key="repository.extension.sheet.description"/}} =
+  #end
+  #if ($isViewMode &amp;&amp; "$!website" == '')
+    ## Make sure to resolve reference based on the right document
+    {{context transformationContext="document" restricted=true}}
+      $doc.getValue('description')
+    {{/context}}
+  #elseif (!$isViewMode)
+    (((
+    $doc.display('description')
+    )))
+  #end
+
+  #if ($extensionTypeObject &amp;&amp; $lastVersionObject &amp;&amp; "$!{extension.getProperty('customInstallationOnly').value}" != '1')
+    #set($standardInstallation = "$!{extensionTypeObject.getProperty('installation').value}")
+  #else
+    #set($standardInstallation = '')
+  #end
+  #set($extraInstallation = "$!{doc.getValue('installation')}")
+
+  #if ($isEditMode || $standardInstallation != '' || $extraInstallation != '')
+    = {{translation key="repository.extension.sheet.prerequisites"/}} =
+
+    #if ($isEditMode)
+      ; {{translation key="repository.extension.sheet.customInstallationOnly"/}}
+      : $extension.display('customInstallationOnly', 'edit')
     #end
-    #if ($isViewMode &amp;&amp; "$!website" == '')
-      ## Make sure to resolve reference based on the right document
-      {{context transformationContext="document" restricted=true}}
-        $doc.getValue('description')
-      {{/context}}
-    #elseif (!$isViewMode)
+    ##
+    ## Standard installation
+    #if ($standardInstallation != '')
+      #if ($isEditMode)
+        == {{translation key="repository.extension.sheet.standardInstallationInstructions"/}}
+
+      #end
+      $extensionTypeObject.display('installation', 'view')
+    #end
+    ##
+    ## Extra installation
+    #if ($isEditMode)
+      == {{translation key="repository.extension.sheet.customInstallationInstructions"/}}
+
       (((
-      $doc.display('description')
+      $extension.display('installation', 'edit')
       )))
+    #elseif ($extraInstallation != '')
+      {{context transformationContext="document" restricted=true}}
+        $extraInstallation
+      {{/context}}
     #end
+  #end
 
-    #if ($extensionTypeObject &amp;&amp; $lastVersionObject &amp;&amp; "$!{extension.getProperty('customInstallationOnly').value}" != '1')
-      #set($standardInstallation = "$!{extensionTypeObject.getProperty('installation').value}")
-    #else
-      #set($standardInstallation = '')
-    #end
-    #set($extraInstallation = "$!{doc.getValue('installation')}")
+  ## Only display release notes if there are downloads and release notes
+  #if ($doc.getValue('versionPage') == 1 &amp;&amp; $proxyExtensionObject.getValue('proxyLevel') != 'history')
+    #set ($versionPageRef = $services.model.createEntityReference('Versions', 'page', $doc.pageReference))
+    = {{translation key="repository.extension.sheet.versions"/}} =
 
-    #if ($isEditMode || $standardInstallation != '' || $extraInstallation != '')
-      = {{translation key="repository.extension.sheet.prerequisites"/}} =
-
-      #if ($isEditMode)
-        ; {{translation key="repository.extension.sheet.customInstallationOnly"/}}
-        : $extension.display('customInstallationOnly', 'edit')
-      #end
-      ##
-      ## Standard installation
-      #if ($standardInstallation != '')
-        #if ($isEditMode)
-          == {{translation key="repository.extension.sheet.standardInstallationInstructions"/}}
-
-        #end
-        $extensionTypeObject.display('installation', 'view')
-      #end
-      ##
-      ## Extra installation
-      #if ($isEditMode)
-        == {{translation key="repository.extension.sheet.customInstallationInstructions"/}}
-
-        (((
-        $extension.display('installation', 'edit')
-        )))
-      #elseif ($extraInstallation != '')
-        {{context transformationContext="document" restricted=true}}
-          $extraInstallation
-        {{/context}}
+    {{display page="$services.rendering.escape($services.model.serialize($versionPageRef), 'xwiki/2.1')"/}}
+  #elseif ($lastVersionObject)
+    #set ($releaseNotes = [])
+    #set ($versions = $doc.getObjects("ExtensionCode.ExtensionVersionClass"))
+    #foreach ($versionObject in $versions)
+      #set ($notes = $!{versionObject.display('notes', 'read')})
+      #set ($version = $!{versionObject.getProperty('version').value})
+      #if ("$!notes" != '' &amp;&amp; "$!version" != '')
+        #set ($discard = $releaseNotes.add([$version, $notes]))
       #end
     #end
 
@@ -348,44 +512,45 @@
         #end
       #end
     #end
+  #end
 
-    #set($extensionDependencies = $doc.getObjects('ExtensionCode.ExtensionDependencyClass', 'extensionVersion', $lastVersionObject.getValue('version')))
-    #if ($extensionDependencies.size() &gt; 0)
-      = {{translation key="repository.extension.sheet.dependencies"/}} =
+  #set($extensionDependencies = $doc.getObjects('ExtensionCode.ExtensionDependencyClass', 'extensionVersion', $lastVersionObject.getValue('version')))
+  #if ($extensionDependencies.size() &gt; 0)
+    = {{translation key="repository.extension.sheet.dependencies"/}} =
 
-       $services.rendering.escape($services.localization.render('repository.extension.sheet.dependenciesIntro', ["${extension.getValue('id')} ${doc.getValue('lastVersion')}"]), 'xwiki/2.1')
-       #foreach($extensionDependency in $extensionDependencies)
-        #set($dependencyDocumentName = $null)
-        #set($dependencyDocumentNames = $services.query.xwql('from doc.object(ExtensionCode.ExtensionClass) as extension where extension.id = :id').bindValue("id", $extensionDependency.id).execute())
-        #if (!$dependencyDocumentNames.isEmpty())
-          #set($dependencyDocumentName = $dependencyDocumentNames.get(0))
-        #end
-        #if ($dependencyDocumentName)
-          * [[$services.rendering.escape($services.rendering.escape($extensionDependency.getValue('id'), 'xwiki/2.1'), 'xwiki/2.1')&gt;&gt;$services.rendering.escape($dependencyDocumentName, 'xwiki/2.1')]] $services.rendering.escape($extensionDependency.getValue('constraint'), 'xwiki/2.1')
-        #else
-          * $services.rendering.escape("${extensionDependency.getValue('id')} ${extensionDependency.getValue('constraint')}", 'xwiki/2.1')
-        #end
+    $services.rendering.escape($services.localization.render('repository.extension.sheet.dependenciesIntro', ["${extension.getValue('id')} ${doc.getValue('lastVersion')}"]), 'xwiki/2.1')
+    #foreach($extensionDependency in $extensionDependencies)
+      #set($dependencyDocumentName = $null)
+      #set($dependencyDocumentNames = $services.query.xwql('from doc.object(ExtensionCode.ExtensionClass) as extension where extension.id = :id').bindValue("id", $extensionDependency.id).execute())
+      #if (!$dependencyDocumentNames.isEmpty())
+        #set($dependencyDocumentName = $dependencyDocumentNames.get(0))
+      #end
+      #if ($dependencyDocumentName)
+        * [[$services.rendering.escape($services.rendering.escape($extensionDependency.getValue('id'), 'xwiki/2.1'), 'xwiki/2.1')&gt;&gt;$services.rendering.escape($dependencyDocumentName, 'xwiki/2.1')]] $services.rendering.escape($extensionDependency.getValue('constraint'), 'xwiki/2.1')
+      #else
+        * $services.rendering.escape("${extensionDependency.getValue('id')} ${extensionDependency.getValue('constraint')}", 'xwiki/2.1')
+      #end
+    #end
+  #end
+
+  #if ($isEditMode &amp;&amp; !$proxyExtensionObject)
+    #set($extversions = $doc.getObjects("ExtensionCode.ExtensionVersionClass"))
+    #if($extversions &amp;&amp; $extversions.size()&gt;0)
+      = {{translation key="repository.extension.sheet.currentDownloads"/}} =
+      #foreach($versionobj in $extversions)
+        #set($ok = $doc.use($versionobj))
+        {{html clean="false"}} $xwiki.includeForm("ExtensionCode.ExtensionVersionSheet") {{/html}}
       #end
     #end
 
-    #if ($isEditMode &amp;&amp; !$proxyExtensionObject)
-      #set($extversions = $doc.getObjects("ExtensionCode.ExtensionVersionClass"))
-      #if($extversions &amp;&amp; $extversions.size()&gt;0)
-      = {{translation key="repository.extension.sheet.currentDownloads"/}} =
-         #foreach($versionobj in $extversions)
-            #set($ok = $doc.use($versionobj))
-            {{html clean="false"}} $xwiki.includeForm("ExtensionCode.ExtensionVersionSheet") {{/html}}
-         #end
-      #end
+    = {{translation key="repository.extension.sheet.addDownloads"/}} =
+    #if ($doc.isNew())
+      {{info}}{{translation key="repository.extension.sheet.addDownloadsSaveFirst"/}}{{/info}}
+    #else
+      {{warning}}{{translation key="repository.extension.sheet.addDownloadsWarning"/}}{{/warning}}
 
-      = {{translation key="repository.extension.sheet.addDownloads"/}} =
-      #if ($doc.isNew())
-        {{info}}{{translation key="repository.extension.sheet.addDownloadsSaveFirst"/}}{{/info}}
-      #else
-        {{warning}}{{translation key="repository.extension.sheet.addDownloadsWarning"/}}{{/warning}}
-
-        {{translation key="repository.extension.sheet.addDownloadsProcess"/}}
-        * $services.localization.render('repository.extension.sheet.addDownloadsAttach', ['[[', "&gt;&gt;path:$xwiki.getURL($doc.fullName, 'view', 'viewer=attachments')]]"])
+      {{translation key="repository.extension.sheet.addDownloadsProcess"/}}
+      * $services.localization.render('repository.extension.sheet.addDownloadsAttach', ['[[', "&gt;&gt;path:$xwiki.getURL($doc.fullName, 'view', 'viewer=attachments')]]"])
  
       #set($xredirect = $doc.getURL("edit"))
       #set($addobjecturl = $doc.getURL('objectadd', "classname=ExtensionCode.ExtensionVersionClass&amp;form_token=$!{services.csrf.getToken()}&amp;xredirect=${escapetool.url($xredirect)}"))
@@ -393,27 +558,303 @@
 
       #set($extdeps = $doc.getObjects("ExtensionCode.ExtensionDependencyClass"))
       #if($extdeps &amp;&amp; $extdeps.size()&gt;0)
-      = {{translation key="repository.extension.sheet.currentDependencies"/}} =
-         #foreach($depobj in $extdeps)
-            #set($ok = $doc.use($depobj))
-            {{html clean="false"}} $xwiki.includeForm("ExtensionCode.ExtensionDependencySheet") {{/html}}
-         #end
+        = {{translation key="repository.extension.sheet.currentDependencies"/}} =
+        #foreach($depobj in $extdeps)
+          #set($ok = $doc.use($depobj))
+          {{html clean="false"}}$xwiki.includeForm("ExtensionCode.ExtensionDependencySheet"){{/html}}
+        #end
       #end
 
       = {{translation key="repository.extension.sheet.addDependencies"/}} =
 
       #set($xredirect = $doc.getURL("edit"))
       #set($addobjecturl = $doc.getURL('objectadd', "classname=ExtensionCode.ExtensionDependencyClass&amp;form_token=$!{services.csrf.getToken()}&amp;xredirect=${escapetool.url($xredirect)}"))
-        $services.localization.render('repository.extension.sheet.addDependenciesIntro', ['[[', "&gt;&gt;path:$addobjecturl]]"])
-        * {{translation key="repository.extension.sheet.addDependenciesVersion"/}}
-        * {{translation key="repository.extension.sheet.addDependenciesId"/}}
-        * {{translation key="repository.extension.sheet.addDependenciesConstraint"/}}
-      #end
+      $services.localization.render('repository.extension.sheet.addDependenciesIntro', ['[[', "&gt;&gt;path:$addobjecturl]]"])
+      * {{translation key="repository.extension.sheet.addDependenciesVersion"/}}
+      * {{translation key="repository.extension.sheet.addDependenciesId"/}}
+      * {{translation key="repository.extension.sheet.addDependenciesConstraint"/}}
     #end
+  #end
 #else
   {{translation key="repository.extension.sheet.wrongObject"/}}
 #end
 {{/velocity}}</content>
+  <object>
+    <name>ExtensionCode.ExtensionSheet</name>
+    <number>0</number>
+    <className>XWiki.JavaScriptExtension</className>
+    <guid>5cdfdbd4-bdb9-47ca-b3bc-b0cf042684b8</guid>
+    <class>
+      <name>XWiki.JavaScriptExtension</name>
+      <customClass/>
+      <customMapping/>
+      <defaultViewSheet/>
+      <defaultEditSheet/>
+      <defaultWeb/>
+      <nameField/>
+      <validationScript/>
+      <cache>
+        <cache>0</cache>
+        <defaultValue>long</defaultValue>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>cache</name>
+        <number>5</number>
+        <prettyName>Caching policy</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>long|short|default|forbid</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </cache>
+      <code>
+        <contenttype>PureText</contenttype>
+        <disabled>0</disabled>
+        <editor>PureText</editor>
+        <name>code</name>
+        <number>2</number>
+        <prettyName>Code</prettyName>
+        <rows>20</rows>
+        <size>50</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.TextAreaClass</classType>
+      </code>
+      <name>
+        <disabled>0</disabled>
+        <name>name</name>
+        <number>1</number>
+        <prettyName>Name</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.StringClass</classType>
+      </name>
+      <parse>
+        <disabled>0</disabled>
+        <displayFormType>select</displayFormType>
+        <displayType>yesno</displayType>
+        <name>parse</name>
+        <number>4</number>
+        <prettyName>Parse content</prettyName>
+        <unmodifiable>0</unmodifiable>
+        <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
+      </parse>
+      <use>
+        <cache>0</cache>
+        <disabled>0</disabled>
+        <displayType>select</displayType>
+        <freeText>forbidden</freeText>
+        <largeStorage>0</largeStorage>
+        <multiSelect>0</multiSelect>
+        <name>use</name>
+        <number>3</number>
+        <prettyName>Use this extension</prettyName>
+        <relationalStorage>0</relationalStorage>
+        <separator> </separator>
+        <separators>|, </separators>
+        <size>1</size>
+        <unmodifiable>0</unmodifiable>
+        <values>currentPage|onDemand|always</values>
+        <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
+      </use>
+    </class>
+    <property type="String">
+      <cache>long</cache>
+    </property>
+    <property type="LargeString">
+      <code>//repository.extension.sheet.installOffline
+
+define('xwiki-repository-installOffline-messages', {
+  prefix: 'repository.extension.sheet.installOffline.',
+  keys: [
+    'inProgress',
+    'failed',
+    'canceling',
+    'canceled',
+    'cancelFailed'
+  ]
+});
+
+require([
+  'jquery',
+  'xwiki-l10n!xwiki-repository-installOffline-messages',
+  'xwiki-job-runner',
+  'xwiki-selectize'
+], function($, l10n, JobRunner) {
+  const $installOfflineModal = $('#installOffline');
+  const $xwikiVersionPicker = $installOfflineModal.find('input[name="xwikiVersion"]');
+  const $exportXIPButton = $installOfflineModal.find('button[value="exportXIP"]');
+  const $cancelXIPButton = $installOfflineModal.find('button[value="cancelXIP"]');
+
+  //
+  // XWiki Version Picker
+  //
+
+  $installOfflineModal.on('show.bs.modal', function(event) {
+    maybeInitXWikiVersionPicker();
+  });
+
+  async function maybeInitXWikiVersionPicker() {
+    if (!$xwikiVersionPicker.data('selectize')) {
+      try {
+        const xwikiVersions = await fetchSupportedXWikiVersions();
+        $xwikiVersionPicker.xwikiSelectize({
+          options: xwikiVersions,
+          maxItems: 1
+        }).data('selectize').on('change', function(version) {
+          $exportXIPButton.prop('disabled', !version);
+        });
+      } catch (error) {
+        console.log('Failed to fetch the list of supported XWiki versions: ', error);
+      }
+    }
+  }
+
+  async function fetchSupportedXWikiVersions() {
+    const url = XWiki.currentDocument.getURL('get', 'data=supportedXWikiVersions');
+    try {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`Response status: ${response.status}`);
+      }
+      const versions = await response.json();
+      return versions.map(version =&gt; ({value: version, text: version}));
+    } catch (error) {
+      console.error(error.message);
+    }
+  }
+
+  //
+  // Export XIP
+  //
+
+  $exportXIPButton.on('click', function(event) {
+    event.preventDefault();
+    $('body').css('cursor', 'wait');
+    const notification = new XWiki.widgets.Notification(l10n['inProgress'], 'inprogress');
+    const data = $installOfflineModal.serializeArray();
+    data.push({name: $exportXIPButton.attr('name'), value: $exportXIPButton.val()});
+    // Prevent multiple clicks on the export button.
+    $exportXIPButton.prop('disabled', true);
+    $xwikiVersionPicker.data('selectize').disable();
+    exportXIP(data).then(() =&gt; {
+      // XIP export job finished.
+      notification.hide();
+    }).catch(reason =&gt; {
+      // XIP export job failed.
+      let message = l10n['failed'];
+      if (reason) {
+        message += `: ${reason.message || reason}`;
+      }
+      notification.replace(new XWiki.widgets.Notification(message, 'error'));
+    }).finally(() =&gt; {
+      // Re-enable the XIP export modal.
+      $exportXIPButton.prop('disabled', false);
+      $xwikiVersionPicker.data('selectize').enable();
+      $('body').css('cursor', '');
+    });
+  });
+
+  async function exportXIP(data) {
+    const job = await runXIPExportJob(data);
+    // Remove the exception name from the start of the error message to make it less technical.
+    const lastError = ((job.lastError || '') + '').replace(/^\w+Exception: /, '');
+    if (job.canceled) {
+      // Do nothing.
+    } else if (job.failed) {
+      throw new Error(lastError);
+    } else if (job.xipFileURL) {
+      // The XIP file was generated on the server-side. The user just needs to download it.
+      window.location.href = job.xipFileURL;
+    }
+  }
+
+  // There's no XIP export job started. This promise is used to cancel the XIP export job (the job needs to be started
+  // before we can cancel it).
+  let xipExportJobStarted = false;
+
+  async function runXIPExportJob(data) {
+    let resolveXIPExportJobStarted, rejectXIPExportJobStarted;
+    xipExportJobStarted = new Promise((resolve, reject) =&gt; {
+      resolveXIPExportJobStarted = resolve;
+      rejectXIPExportJobStarted = reject;
+    });
+    try {
+      const jobRunner = new JobRunner({
+        createStatusRequest: function(jobId) {
+          resolveXIPExportJobStarted(jobId);
+          return {
+            url: XWiki.currentDocument.getURL('get'),
+            data: {
+              data: 'xipJobStatus',
+              jobId: jobId.join('/')
+            }
+          };
+        }
+      });
+      const job = await jobRunner.run(XWiki.currentDocument.getURL('get'), data);
+      return job;
+    } catch (error) {
+      // We need to reject any pending cancel requests.
+      rejectXIPExportJobStarted();
+      // But we also need to reject the XIP export itself.
+      throw error;
+    } finally {
+      xipExportJobStarted = false;
+    }
+  }
+
+  //
+  // Cancel XIP
+  //
+
+  $installOfflineModal.on('hide.bs.modal', event =&gt; {
+    if ($cancelXIPButton.prop('disabled')) {
+      // Don't close the modal because there's a pending cancel request.
+      return event.preventDefault();
+    } else if (xipExportJobStarted) {
+      // Cancel the running XIP export job.
+      const notification = new XWiki.widgets.Notification(l10n['canceling'], 'inprogress');
+      // Prevent multiple cancel requests.
+      const $closeModalButton = $installOfflineModal.find('.modal-header button.close');
+      $closeModalButton.prop('disabled', true);
+      $cancelXIPButton.prop('disabled', true);
+      xipExportJobStarted.then(cancelXIPExportJob).then(() =&gt; {
+        notification.replace(new XWiki.widgets.Notification(l10n['canceled'], 'done'));
+      }).catch(() =&gt; {
+        notification.replace(new XWiki.widgets.Notification(l10n['cancelFailed'], 'error'));
+      }).finally(() =&gt; {
+        // Allow the user to retry the cancel (e.g. in case it failed due to some network issue).
+        $closeModalButton.prop('disabled', false);
+        $cancelXIPButton.prop('disabled', false);
+      });
+      // Don't close the modal because the job doesn't finish immediately after being canceled.
+      return event.preventDefault();
+    }
+  });
+
+  async function cancelXIPExportJob(jobId) {
+    const data = $installOfflineModal.serializeArray();
+    data.push({name: $cancelXIPButton.attr('name'), value: $cancelXIPButton.val()});
+    data.push({name: 'jobId', value: jobId.join('/')});
+    return await $.post(XWiki.currentDocument.getURL('get'), data);
+  };
+});</code>
+    </property>
+    <property type="String">
+      <name/>
+    </property>
+    <property type="Integer">
+      <parse>0</parse>
+    </property>
+    <property type="String">
+      <use>onDemand</use>
+    </property>
+  </object>
   <object>
     <name>ExtensionCode.ExtensionSheet</name>
     <number>0</number>
@@ -454,7 +895,6 @@
         <name>code</name>
         <number>2</number>
         <prettyName>Code</prettyName>
-        <restricted>0</restricted>
         <rows>20</rows>
         <size>50</size>
         <unmodifiable>0</unmodifiable>
@@ -516,10 +956,10 @@
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </use>
     </class>
-    <property>
+    <property type="String">
       <cache>long</cache>
     </property>
-    <property>
+    <property type="LargeString">
       <code>#template('colorThemeInit.vm')
 
 .extensionSummary {
@@ -554,16 +994,16 @@
   margin-right: 10px
 }</code>
     </property>
-    <property>
+    <property type="String">
       <contentType>CSS</contentType>
     </property>
-    <property>
+    <property type="String">
       <name>Extension CSS</name>
     </property>
-    <property>
+    <property type="Integer">
       <parse>1</parse>
     </property>
-    <property>
+    <property type="String">
       <use>always</use>
     </property>
   </object>
@@ -607,7 +1047,6 @@
         <name>code</name>
         <number>2</number>
         <prettyName>Code</prettyName>
-        <restricted>0</restricted>
         <rows>20</rows>
         <size>50</size>
         <unmodifiable>0</unmodifiable>
@@ -669,10 +1108,10 @@
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </use>
     </class>
-    <property>
+    <property type="String">
       <cache>long</cache>
     </property>
-    <property>
+    <property type="LargeString">
       <code>.extensionSummary td, /* PROBLEM: General styling reset */
 .extensionInfo td {
   border: 0;
@@ -711,16 +1150,16 @@
   vertical-align: baseline;
 }</code>
     </property>
-    <property>
+    <property type="String">
       <contentType>CSS</contentType>
     </property>
-    <property>
+    <property type="String">
       <name>Junco</name>
     </property>
-    <property>
+    <property type="Integer">
       <parse/>
     </property>
-    <property>
+    <property type="String">
       <use>currentPage</use>
     </property>
   </object>

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-ui/src/main/resources/ExtensionCode/Translations.xml
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-ui/src/main/resources/ExtensionCode/Translations.xml
@@ -20,7 +20,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<xwikidoc version="1.5" reference="ExtensionCode.Translations" locale="">
+<xwikidoc version="1.7" reference="ExtensionCode.Translations" locale="">
   <web>ExtensionCode</web>
   <name>Translations</name>
   <language/>
@@ -104,6 +104,16 @@ repository.extension.sheet.documentation=Documentation
 repository.extension.sheet.sources=Sources
 repository.extension.sheet.issues=Issues
 repository.extension.sheet.download=Download v{0}
+repository.extension.sheet.installOffline=Install Offline
+repository.extension.sheet.installOffline.help=You can use a XIP package to install this extension offline. A XIP is a ZIP file containing XWiki extensions (usually an extension with all its transitive dependencies) formatted like the local XWiki extension repository.
+repository.extension.sheet.installOffline.xwikiVersion=XWiki Version
+repository.extension.sheet.installOffline.xwikiVersionHint=Select the version of the XWiki instance where you want to install the extension.
+repository.extension.sheet.installOffline.exportXIP=Export XIP
+repository.extension.sheet.installOffline.inProgress=Generating XIP package...
+repository.extension.sheet.installOffline.failed=Failed to generate XIP package
+repository.extension.sheet.installOffline.canceling=Canceling XIP export...
+repository.extension.sheet.installOffline.canceled=XIP export canceled
+repository.extension.sheet.installOffline.cancelFailed=Failed to cancel XIP export
 repository.extension.sheet.toc=Table of contents
 repository.extension.sheet.documentationHelp=Documentation Help
 repository.extension.sheet.rulesIntro=Here are some rules to follow when contributing an extension:
@@ -176,7 +186,7 @@ repository.extension.sheet.wrongObject=This class sheet must be applied on a doc
         <classType>com.xpn.xwiki.objects.classes.StaticListClass</classType>
       </scope>
     </class>
-    <property>
+    <property type="String">
       <scope>WIKI</scope>
     </property>
   </object>


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-20155

# Changes

## Description

* Implements a XIP export job (based on @tmortagne's code from feature-xip branch)
* Add an "Install offline" button to the extension sheet to generate and download the XIP

## Clarifications

What can be improved:

* Cache the generated XIPs (currently each job execution generates a new XIP). I suppose this could be done by using a single temporary resource reference per XIP (with some naming convension), but it's owning entity reference needs to be the wiki?
* Are we using the right artifact to resolve core extensions?
* Cache the result of resolving the core extensions for a specific XWiki version. This is the most time-consuming step. Even though we cache the POM files in the ``data/cache/repository/xip``, it still takes a lot of time to resolve the core extensions on two successive executions of the XIP export job for the same extension and the same XWiki version.
* Improve the UI to show the progress, and maybe show the last job log item (so that users understand why it takes so long)
* List only XWiki versions that are supported by the extensions (I'm currently listing all stable versions of ``xwiki-platform-distribution-war``)

# Screenshots & Video

<img width="1217" height="433" alt="image" src="https://github.com/user-attachments/assets/50b263e9-b108-4aa4-a090-67f4de06d756" />

<img width="824" height="473" alt="image" src="https://github.com/user-attachments/assets/8d489855-371f-44aa-a2e8-9e224c47797c" />

# Executed Tests

* ``xwiki-platform-repository-test-docker``

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None