### PR TITLE
[Misc] Define a constant instead of duplicating the "version" literal in RepositoryManager

### DIFF
--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/RepositoryManager.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/RepositoryManager.java
@@ -1199,8 +1199,9 @@ public class RepositoryManager
             }
         }
 
-        BaseObject extensionVersionObject = extensionVersionDocument
-            .getXObject(XWikiRepositoryModel.EXTENSIONVERSION_CLASSREFERENCE, "version", version, false);
+        BaseObject extensionVersionObject = extensionVersionDocument.getXObject(
+            XWikiRepositoryModel.EXTENSIONVERSION_CLASSREFERENCE, XWikiRepositoryModel.PROP_VERSION_VERSION, version,
+            false);
 
         if (extensionVersionObject == null && allowProxying
             && this.extensionStore.isVersionProxyingEnabled(extensionDocument)) {
@@ -1225,8 +1226,9 @@ public class RepositoryManager
             try {
                 XWikiDocument extensionDocumentClone = extensionDocument.clone();
                 updateExtensionVersion(extension, extensionDocumentClone, 0, xcontext);
-                extensionVersionObject = extensionDocumentClone
-                    .getXObject(XWikiRepositoryModel.EXTENSIONVERSION_CLASSREFERENCE, "version", version, false);
+                extensionVersionObject = extensionDocumentClone.getXObject(
+                    XWikiRepositoryModel.EXTENSIONVERSION_CLASSREFERENCE, XWikiRepositoryModel.PROP_VERSION_VERSION,
+                    version, false);
             } catch (XWikiException e) {
                 throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
             }
@@ -1880,8 +1882,8 @@ public class RepositoryManager
 
             // Migrate the release note if it was stored on the main project page
             BaseObject legacyVersionObject =
-                projectDocument.getXObject(XWikiRepositoryModel.PROJECTVERSION_CLASSREFERENCE, "version",
-                    projectVersion.getId().getVersion().getValue(), false);
+                projectDocument.getXObject(XWikiRepositoryModel.PROJECTVERSION_CLASSREFERENCE,
+                    XWikiRepositoryModel.PROP_VERSION_VERSION, projectVersion.getId().getVersion().getValue(), false);
             if (legacyVersionObject != null) {
                 String releaseNote = this.extensionStore.getValue(legacyVersionObject,
                     XWikiRepositoryModel.PROP_VERSION_NOTES, (String) null);


### PR DESCRIPTION
## Summary

Fixes the SonarCloud issue [`java:S1192` - Define a constant instead of duplicating this literal "version" 3 times](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AZ7imjBN8lbwoM_tj_be&open=AZ7imjBN8lbwoM_tj_be) in `RepositoryManager`.

SonarCloud issue: https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&open=AZ7imjBN8lbwoM_tj_bd

### Problem

`RepositoryManager` repeated the string literal `"version"` three times when calling `getXObject(...)` to look up the version property of an extension/project version XObject.

### Fix

The module already declares a dedicated constant for that property name: `XWikiRepositoryModel.PROP_VERSION_VERSION = "version"`. The three duplicated literals now reuse this existing constant. This is a pure readability change with **no behavioral or API impact** (the class is `internal`).

## Test plan

- [x] `mvn clean verify -Pquality` on `xwiki-platform-repository-server-api` — passes (compilation, Checkstyle, Spoon and tests green).

## Token usage

- Cost in tokens for finding an issue to fix: ~40k
- Cost in tokens for fixing the issue: ~25k
- Cost in tokens for the work after fixing the issue: ~10k (so far)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BYE3LvsXjFgmMUK5XwEJkJ)_