### PR TITLE
[Misc] Define a constant instead of duplicating the "version" string literal in RepositoryManager

### DIFF
--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/RepositoryManager.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/RepositoryManager.java
@@ -1199,8 +1199,9 @@ public class RepositoryManager
             }
         }
 
-        BaseObject extensionVersionObject = extensionVersionDocument
-            .getXObject(XWikiRepositoryModel.EXTENSIONVERSION_CLASSREFERENCE, "version", version, false);
+        BaseObject extensionVersionObject = extensionVersionDocument.getXObject(
+            XWikiRepositoryModel.EXTENSIONVERSION_CLASSREFERENCE, XWikiRepositoryModel.PROP_VERSION_VERSION, version,
+            false);
 
         if (extensionVersionObject == null && allowProxying
             && this.extensionStore.isVersionProxyingEnabled(extensionDocument)) {
@@ -1225,8 +1226,9 @@ public class RepositoryManager
             try {
                 XWikiDocument extensionDocumentClone = extensionDocument.clone();
                 updateExtensionVersion(extension, extensionDocumentClone, 0, xcontext);
-                extensionVersionObject = extensionDocumentClone
-                    .getXObject(XWikiRepositoryModel.EXTENSIONVERSION_CLASSREFERENCE, "version", version, false);
+                extensionVersionObject = extensionDocumentClone.getXObject(
+                    XWikiRepositoryModel.EXTENSIONVERSION_CLASSREFERENCE, XWikiRepositoryModel.PROP_VERSION_VERSION,
+                    version, false);
             } catch (XWikiException e) {
                 throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
             }
@@ -1880,8 +1882,8 @@ public class RepositoryManager
 
             // Migrate the release note if it was stored on the main project page
             BaseObject legacyVersionObject =
-                projectDocument.getXObject(XWikiRepositoryModel.PROJECTVERSION_CLASSREFERENCE, "version",
-                    projectVersion.getId().getVersion().getValue(), false);
+                projectDocument.getXObject(XWikiRepositoryModel.PROJECTVERSION_CLASSREFERENCE,
+                    XWikiRepositoryModel.PROP_VERSION_VERSION, projectVersion.getId().getVersion().getValue(), false);
             if (legacyVersionObject != null) {
                 String releaseNote = this.extensionStore.getValue(legacyVersionObject,
                     XWikiRepositoryModel.PROP_VERSION_NOTES, (String) null);


### PR DESCRIPTION
## Description

SonarQube (rule `java:S1192`) reported that the string literal `"version"` was duplicated three times in `RepositoryManager`. This change replaces those duplicated literals with the already-existing public constant `XWikiRepositoryModel.PROP_VERSION_VERSION` (same package, identical semantics — it is the property name of the extension/project version XClass).

* No new constant was introduced: an existing one is reused, removing the duplication while keeping the code DRY.
* No API change and no behavioural change, so this is fully backward compatible.

## Verification

* Built with `mvn clean verify -Pquality` on `xwiki-platform-repository-server-api` → **BUILD SUCCESS** (Checkstyle, Spoon and RevAPI all pass).

## SonarCloud issue

https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AZ7imjBN8lbwoM_tj_bd&open=AZ7imjBN8lbwoM_tj_bd

## Token usage

* Finding an issue to fix: ~20K tokens
* Fixing the issue: ~95K tokens
* Work after fixing the issue (push/PR/diagnostics): ~120K tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)
