### PR TITLE
[Misc] Define a constant instead of duplicating the "version" string literal in RepositoryManager

### DIFF
--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/RepositoryManager.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/RepositoryManager.java
@@ -1199,8 +1199,9 @@ public class RepositoryManager
             }
         }
 
-        BaseObject extensionVersionObject = extensionVersionDocument
-            .getXObject(XWikiRepositoryModel.EXTENSIONVERSION_CLASSREFERENCE, "version", version, false);
+        BaseObject extensionVersionObject = extensionVersionDocument.getXObject(
+            XWikiRepositoryModel.EXTENSIONVERSION_CLASSREFERENCE, XWikiRepositoryModel.PROP_VERSION_VERSION, version,
+            false);
 
         if (extensionVersionObject == null && allowProxying
             && this.extensionStore.isVersionProxyingEnabled(extensionDocument)) {
@@ -1225,8 +1226,9 @@ public class RepositoryManager
             try {
                 XWikiDocument extensionDocumentClone = extensionDocument.clone();
                 updateExtensionVersion(extension, extensionDocumentClone, 0, xcontext);
-                extensionVersionObject = extensionDocumentClone
-                    .getXObject(XWikiRepositoryModel.EXTENSIONVERSION_CLASSREFERENCE, "version", version, false);
+                extensionVersionObject = extensionDocumentClone.getXObject(
+                    XWikiRepositoryModel.EXTENSIONVERSION_CLASSREFERENCE, XWikiRepositoryModel.PROP_VERSION_VERSION,
+                    version, false);
             } catch (XWikiException e) {
                 throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
             }
@@ -1880,8 +1882,8 @@ public class RepositoryManager
 
             // Migrate the release note if it was stored on the main project page
             BaseObject legacyVersionObject =
-                projectDocument.getXObject(XWikiRepositoryModel.PROJECTVERSION_CLASSREFERENCE, "version",
-                    projectVersion.getId().getVersion().getValue(), false);
+                projectDocument.getXObject(XWikiRepositoryModel.PROJECTVERSION_CLASSREFERENCE,
+                    XWikiRepositoryModel.PROP_VERSION_VERSION, projectVersion.getId().getVersion().getValue(), false);
             if (legacyVersionObject != null) {
                 String releaseNote = this.extensionStore.getValue(legacyVersionObject,
                     XWikiRepositoryModel.PROP_VERSION_NOTES, (String) null);


### PR DESCRIPTION
## Description

Fixes a [SonarQube](https://sonarcloud.io/) code smell (`java:S1192`, CRITICAL) reported in `RepositoryManager`:

> Define a constant instead of duplicating this literal "version" 3 times.

The three duplicated `"version"` string literals are replaced by the already-existing
`XWikiRepositoryModel.PROP_VERSION_VERSION` constant (whose value is `"version"`). This is
a pure readability/maintainability change with no behavior change and no impact on
backward compatibility (the code lives in an `internal` package).

SonarCloud issue: https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&open=AZ7imjBN8lbwoM_tj_bd

## Verification

Built the modified module with the quality profile:

```
mvn clean verify -Pquality -pl xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api
```

Result: `BUILD SUCCESS` (unit tests pass, Checkstyle passes).

## Token usage

* Cost in tokens for finding an issue to fix: ~50K tokens
* Cost in tokens for fixing the issue: ~80K tokens
* Cost in tokens for the work after fixing the issue: ~95K tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTw8XKYcwhbpHCzJ2Wpesd
