### PR TITLE
[Misc] Use static access for StringUtils.join in CacheKeyFactory (SonarQube)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/cache/CacheKeyFactory.java
+++ b/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/cache/CacheKeyFactory.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import org.apache.commons.lang3.StringUtils;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.container.Container;
 import org.xwiki.container.Request;
@@ -33,7 +34,6 @@ import org.xwiki.container.servlet.ServletRequest;
 import org.xwiki.lesscss.internal.colortheme.ColorThemeReference;
 import org.xwiki.lesscss.internal.skin.SkinReference;
 import org.xwiki.lesscss.resources.LESSResourceReference;
-import org.xwiki.text.StringUtils;
 
 import com.xpn.xwiki.XWiki;
 


### PR DESCRIPTION
## Description

This fixes a SonarQube issue reported on `CacheKeyFactory`.

SonarQube rule `java:S3252` flagged that the static `join` method was being
accessed through `org.xwiki.text.StringUtils`, which is merely a subclass of
`org.apache.commons.lang3.StringUtils` where the method is actually declared.
The fix imports the Apache Commons class directly so the static member is
accessed through the class that declares it.

No behavior change and no backward-compatibility impact (internal class, no API
signature change). Verified with `mvn clean verify -Pquality` on the
`xwiki-platform-lesscss-default` module (Checkstyle, tests, JaCoCo, RevAPI and
Spoon all pass).

## SonarCloud issue

https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AYK2yKjljX57U6EJhxnR&open=AYK2yKjljX57U6EJhxnR

## Token usage

- Cost in tokens for finding an issue to fix: ~95k tokens
- Cost in tokens for fixing the issue: ~120k tokens
- Cost in tokens for the work after fixing the issue: ~115k tokens
