### PR TITLE
[Misc] Use static access for SOLR_FIELD_ID constant in Solr event migration

### DIFF
--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/main/java/org/xwiki/eventstream/store/solr/internal/migration/SolrDocumentMigration171001000.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/main/java/org/xwiki/eventstream/store/solr/internal/migration/SolrDocumentMigration171001000.java
@@ -36,7 +36,7 @@ import org.apache.solr.common.params.CursorMarkParams;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.eventstream.Event;
-import org.xwiki.eventstream.store.solr.internal.EventsSolrCoreInitializer;
+import org.xwiki.search.solr.AbstractSolrCoreInitializer;
 import org.xwiki.search.solr.SolrException;
 import org.xwiki.search.solr.SolrUtils;
 import org.xwiki.search.solr.XWikiSolrCore;
@@ -126,7 +126,7 @@ public class SolrDocumentMigration171001000
             Date date = this.solrUtils.get(Event.FIELD_DATE, solrDocument);
 
             SolrInputDocument solrInputDocument = new SolrInputDocument();
-            this.solrUtils.set(EventsSolrCoreInitializer.SOLR_FIELD_ID, id, solrInputDocument);
+            this.solrUtils.set(AbstractSolrCoreInitializer.SOLR_FIELD_ID, id, solrInputDocument);
             this.solrUtils.setAtomic(SolrUtils.ATOMIC_UPDATE_MODIFIER_SET, Event.FIELD_PREFILTERING_DATE,
                 date, solrInputDocument);
             documentsToUpdate.add(solrInputDocument);


### PR DESCRIPTION
## Summary

Fixes SonarCloud issue [java:S3252 - Use static access with "org.xwiki.search.solr.AbstractSolrCoreInitializer" for "SOLR_FIELD_ID"](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AZrl02DDOGUQvg5hQY8F&open=AZrl02DDOGUQvg5hQY8F) in `SolrDocumentMigration171001000.java`.

### Problem

The static constant `SOLR_FIELD_ID` is declared in `AbstractSolrCoreInitializer` but was accessed through the subclass `EventsSolrCoreInitializer`. Accessing a static member through a subclass is misleading because it suggests the member belongs to that subclass.

### Fix

- Reference the constant through its declaring class: `AbstractSolrCoreInitializer.SOLR_FIELD_ID`.
- Remove the now-unused `EventsSolrCoreInitializer` import.

This is a purely internal change with no behavioral or API impact (the constant value is unchanged).

## Test plan

- Built the `xwiki-platform-eventstream-store-solr` module with `mvn clean verify -Pquality` — BUILD SUCCESS.

---

### Token usage

- Cost in tokens for finding an issue to fix: ~30k
- Cost in tokens for fixing the issue: ~25k
- Cost in tokens for the work after fixing the issue: ~15k

---
_Generated by [Claude Code](https://claude.ai/code/session_015HdHYXSJGrwQfaMriSG5aZ)_