### PR TITLE
[Misc] Fix SonarQube non-serializable field issues in EmbeddedClient

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-embedded/src/main/java/org/xwiki/search/solr/internal/EmbeddedClient.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-embedded/src/main/java/org/xwiki/search/solr/internal/EmbeddedClient.java
@@ -50,9 +50,9 @@ public class EmbeddedClient extends EmbeddedSolrServer
 {
     private static final long serialVersionUID = 1L;
 
-    private final SolrCore core;
+    private final transient SolrCore core;
 
-    private final SolrRequestParsers parser;
+    private final transient SolrRequestParsers parser;
 
     /**
      * A wrapper around a {@link StreamingResponseCallback} to workaround a bug in Solr. See


### PR DESCRIPTION
## Description

The `EmbeddedClient` class extends `EmbeddedSolrServer` (which is `Serializable`) but declares two non-transient fields whose types are not serializable:
* `private final SolrCore core;`
* `private final SolrRequestParsers parser;`

SonarQube reports these as `java:S1948` ("Make non-static field transient or serializable"). Both fields hold runtime-only state that has no meaning across serialization, so they are now marked `transient`. There is no behavioral or backward-compatibility impact.

## SonarQube issues

* https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&open=AZwedJQk7L5XoT2tQWhO&organization=xwiki
* https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&open=AZwedJQk7L5XoT2tQWhP&organization=xwiki

## Verification

`mvn clean verify -Pquality` run on the `xwiki-platform-search-solr-embedded` module: BUILD SUCCESS.

## Token usage

* Finding an issue to fix: ~70k tokens
* Fixing the issue: ~80k tokens
* Work after fixing the issue: ~25k tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ME1XuekTch1o67H59YKJ3U
