### PR TITLE
[Misc] Use static access for the inherited CONFIGURATIONID constant

### DIFF
--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/ExtensionStore.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/ExtensionStore.java
@@ -39,6 +39,7 @@ import org.xwiki.cache.Cache;
 import org.xwiki.cache.CacheException;
 import org.xwiki.cache.CacheManager;
 import org.xwiki.cache.config.CacheConfiguration;
+import org.xwiki.cache.eviction.EntryEvictionConfiguration;
 import org.xwiki.cache.eviction.LRUEvictionConfiguration;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.manager.ComponentLifecycleException;
@@ -161,7 +162,7 @@ public class ExtensionStore implements Initializable, Disposable
         cacheConfiguration.setConfigurationId("repository.extensionid.documentreference");
         LRUEvictionConfiguration lru = new LRUEvictionConfiguration();
         lru.setMaxEntries(10000);
-        cacheConfiguration.put(LRUEvictionConfiguration.CONFIGURATIONID, lru);
+        cacheConfiguration.put(EntryEvictionConfiguration.CONFIGURATIONID, lru);
 
         try {
             this.documentReferenceCache = this.cacheManager.createNewCache(cacheConfiguration);


### PR DESCRIPTION
## Description

SonarQube (rule `java:S3252`, CRITICAL) reports that, in `ExtensionStore`, the
`CONFIGURATIONID` constant was being accessed statically through the subclass
`LRUEvictionConfiguration`, while it is actually declared in the parent class
`org.xwiki.cache.eviction.EntryEvictionConfiguration`. Accessing a static member
through a subclass is misleading because it suggests the constant belongs to the
subclass.

This change accesses the constant through the class that actually declares it
(`EntryEvictionConfiguration.CONFIGURATIONID`). This is purely a readability fix:
the resolved constant and the runtime behaviour are unchanged, and no public API
is modified (backward compatibility preserved, verified by RevAPI).

SonarCloud issue: https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&open=AZnliIl_CPXKFOTPbKvQ

## Verification

`mvn clean verify -Pquality` was run on the modified module
(`xwiki-platform-repository-server-api`) and completed with **BUILD SUCCESS**
(Checkstyle and RevAPI included).

## Token usage

- Cost in tokens for finding an issue to fix: ~20k
- Cost in tokens for fixing the issue: ~25k
- Cost in tokens for the work after fixing the issue: ~10k

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fo5bYDZwwrkJ8tvMcCk3hv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fo5bYDZwwrkJ8tvMcCk3hv)_