### PR TITLE
XWIKI-24514: LiveData tables always showing a scrollbar

### DIFF
--- a/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/layouts/table/LayoutTableHeaderNames.vue
+++ b/xwiki-platform-core/xwiki-platform-node/src/main/node/core/livedata/livedata-ui/src/components/layouts/table/LayoutTableHeaderNames.vue
@@ -335,6 +335,10 @@ export default {
   z-index: 1;
 }
 
+.layout-table .draggable-item:last-child .resize-handle {
+  right: 0; /* Prevents an always showing horizontal scrollbar below the table */
+}
+
 .layout-table .draggable-item .resize-handle:focus-within,
 .layout-table .draggable-item .resize-handle:hover {
   /* Show the resize handle and increase its width when the column is focused or hovered. */


### PR DESCRIPTION
- Fix for an always present horizontal scrollbar

# Jira URL

https://jira.xwiki.org/browse/XWIKI-24514

# Changes

## Description

* This is providing a specific css class to handle right spacing on a LiveData Table.

## Clarifications

-

# Screenshots & Video

**Before:**

<img width="1082" height="408" alt="Screenshot 2026-06-24 at 08 34 03" src="https://github.com/user-attachments/assets/708901d5-cf15-4f1f-9de6-95388ebfe8f2" />

**After:**

<img width="1079" height="403" alt="Screenshot 2026-06-24 at 08 33 48" src="https://github.com/user-attachments/assets/4dce1aed-288e-4ab1-adda-64b716fc1a82" />



# Executed Tests

`mvn clean install -pl :xwiki-platform-livedata-node-ui,:xwiki-platform-node`

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 