### PR TITLE
[SONAR] Reduce Cognitive Complexity of deleteEmptyDirs in XWikiFilesystemBlobStorePropertiesCustomizer

### DIFF
--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/XWikiFilesystemBlobStorePropertiesCustomizer.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/main/java/org/xwiki/store/filesystem/internal/XWikiFilesystemBlobStorePropertiesCustomizer.java
@@ -88,27 +88,39 @@ public class XWikiFilesystemBlobStorePropertiesCustomizer implements BlobStorePr
 
     private static boolean deleteEmptyDirs(final File location, int depth)
     {
-        if (location != null && location.exists() && location.isDirectory()) {
-            final File[] files = location.listFiles();
-            boolean empty = true;
-            if (files != null) {
-                for (File file : files) {
-                    if (!deleteEmptyDirs(file, depth + 1)) {
-                        empty = false;
-                    }
-                }
-            }
+        if (location == null || !location.exists() || !location.isDirectory()) {
+            return false;
+        }
 
-            if (empty && depth != 0) {
-                try {
-                    Files.delete(location.toPath());
-                    return true;
-                } catch (IOException e) {
-                    return false;
+        if (areChildrenEmpty(location, depth) && depth != 0) {
+            return tryDelete(location);
+        }
+
+        return false;
+    }
+
+    private static boolean areChildrenEmpty(final File location, int depth)
+    {
+        final File[] files = location.listFiles();
+        boolean empty = true;
+        if (files != null) {
+            for (File file : files) {
+                if (!deleteEmptyDirs(file, depth + 1)) {
+                    empty = false;
                 }
             }
         }
 
-        return false;
+        return empty;
+    }
+
+    private static boolean tryDelete(final File location)
+    {
+        try {
+            Files.delete(location.toPath());
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes SonarCloud issue [java:S3776 - Refactor this method to reduce its Cognitive Complexity from 17 to the 15 allowed](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AZp0P6ZJRAQTv1t4zCSP&open=AZp0P6ZJRAQTv1t4zCSP) in `XWikiFilesystemBlobStorePropertiesCustomizer.java`.

### Problem

The recursive `deleteEmptyDirs` method had a Cognitive Complexity of 17 (above the allowed 15), mostly due to deep nesting (a guard `if`, a nested `if`, a `for` loop, another nested `if`, plus a `try/catch`).

### Fix

- Extracted the directory-children iteration into a dedicated private helper method `areChildrenEmpty`.
- Extracted the deletion logic (the `try/catch`) into a dedicated private helper method `tryDelete`.
- Inverted the first condition into a guard clause to flatten the remaining nesting.

This is a pure internal refactoring: the methods involved are all `private static`, so there is no behavioral change and no impact on backward compatibility.

## Test plan

- [x] Build the `xwiki-platform-store-filesystem-oldcore` module with `mvn clean verify -Pquality` — passes (BUILD SUCCESS, including Checkstyle and Spoon).
- [ ] Verify the SonarCloud issue is marked as resolved after the next scan.

---

### Token usage (approximate)

- Cost in tokens for finding an issue to fix: ~28k tokens
- Cost in tokens for fixing the issue: ~22k tokens
- Cost in tokens for the work after fixing the issue: ~12k tokens

---
_Generated by [Claude Code](https://claude.ai/code/session_01NTwEEPJ9N7K8iu2NMyArC8)_