### PR TITLE
[Misc] Reduce cognitive complexity of exclusive filter handling reported by SonarQube

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterLocationStateComputer.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilterLocationStateComputer.java
@@ -209,45 +209,65 @@ public class ScopeNotificationFilterLocationStateComputer
     private Optional<WatchedLocationState> handleExclusiveFilters(EntityReference location,
         ScopeNotificationFilterPreferencesHierarchy preferences, boolean allTypesAndEvents)
     {
-        WatchedLocationState.WatchedState state = null;
-        int deepestLevel = 0;
-        Date startingDate = null;
+        ExclusiveMatch match = new ExclusiveMatch();
 
         Iterator<ScopeNotificationFilterPreference> it = preferences.getExclusiveFiltersThatHasNoParents();
         while (it.hasNext()) {
-            ScopeNotificationFilterPreference pref = it.next();
-
-            int deepLevel = pref.getScopeReference().size();
-            boolean isExactMatch = isExactMatch(pref, location);
-            boolean isParentMatch = isParentMatch(pref, location);
-            boolean isSpaceMatch = isSpaceMatch(pref, location);
-
-            // If the exclusive filter match the event location...
-            if ((isExactMatch || isParentMatch) && deepLevel > deepestLevel) {
-                state = getWatchedState(allTypesAndEvents, isExactMatch, isSpaceMatch, false);
-                startingDate = pref.getStartingDate();
-                deepestLevel = deepLevel;
-
-                // then we watch the location if there is at least an inclusive filter child matching it
-                for (ScopeNotificationFilterPreference child : pref.getChildren()) {
-                    int childDeepLevel = child.getScopeReference().size();
-                    boolean isChildExactMatch = isExactMatch(child, location);
-                    boolean isChildParentMatch = isParentMatch(child, location);
-                    boolean isChildSpaceMatch = isSpaceMatch(child, location);
-                    if ((isChildExactMatch || isChildParentMatch) && childDeepLevel > deepestLevel) {
-                        state = getWatchedState(allTypesAndEvents, isChildExactMatch, isChildSpaceMatch, true);
-                        deepestLevel = childDeepLevel;
-                        startingDate = child.getStartingDate();
-                    }
-                }
-            }
+            handleExclusiveFilter(it.next(), location, allTypesAndEvents, match);
         }
 
-        if (state != null) {
-            return Optional.of(new WatchedLocationState(state, startingDate));
+        if (match.state != null) {
+            return Optional.of(new WatchedLocationState(match.state, match.startingDate));
         } else {
             return Optional.empty();
         }
+    }
+
+    private void handleExclusiveFilter(ScopeNotificationFilterPreference pref, EntityReference location,
+        boolean allTypesAndEvents, ExclusiveMatch match)
+    {
+        int deepLevel = pref.getScopeReference().size();
+        boolean isExactMatch = isExactMatch(pref, location);
+        boolean isParentMatch = isParentMatch(pref, location);
+        boolean isSpaceMatch = isSpaceMatch(pref, location);
+
+        // If the exclusive filter match the event location...
+        if ((isExactMatch || isParentMatch) && deepLevel > match.deepestLevel) {
+            match.state = getWatchedState(allTypesAndEvents, isExactMatch, isSpaceMatch, false);
+            match.startingDate = pref.getStartingDate();
+            match.deepestLevel = deepLevel;
+
+            // then we watch the location if there is at least an inclusive filter child matching it
+            for (ScopeNotificationFilterPreference child : pref.getChildren()) {
+                handleExclusiveChild(child, location, allTypesAndEvents, match);
+            }
+        }
+    }
+
+    private void handleExclusiveChild(ScopeNotificationFilterPreference child, EntityReference location,
+        boolean allTypesAndEvents, ExclusiveMatch match)
+    {
+        int childDeepLevel = child.getScopeReference().size();
+        boolean isChildExactMatch = isExactMatch(child, location);
+        boolean isChildParentMatch = isParentMatch(child, location);
+        boolean isChildSpaceMatch = isSpaceMatch(child, location);
+        if ((isChildExactMatch || isChildParentMatch) && childDeepLevel > match.deepestLevel) {
+            match.state = getWatchedState(allTypesAndEvents, isChildExactMatch, isChildSpaceMatch, true);
+            match.deepestLevel = childDeepLevel;
+            match.startingDate = child.getStartingDate();
+        }
+    }
+
+    /**
+     * Holds the current best match found while iterating over the exclusive filters and their children.
+     */
+    private static final class ExclusiveMatch
+    {
+        private WatchedLocationState.WatchedState state;
+
+        private int deepestLevel;
+
+        private Date startingDate;
     }
 
     private boolean isSpaceMatch(ScopeNotificationFilterPreference pref, EntityReference location)


### PR DESCRIPTION
## Summary

Fixes the SonarCloud CRITICAL issue [java:S3776 - Refactor this method to reduce its Cognitive Complexity from 16 to the 15 allowed](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AZAL3YOfJK9ZeuA5t1--&open=AZAL3YOfJK9ZeuA5t1--) in `ScopeNotificationFilterLocationStateComputer.java`.

### Problem

The private method `handleExclusiveFilters(...)` had a cognitive complexity of 16 (the maximum allowed by SonarQube being 15). The complexity came from a `while` loop containing a nested `if` block which itself contained a nested `for` loop with another nested `if`.

### Fix

- Extracted the body of the outer loop into a new private method `handleExclusiveFilter(...)`.
- Extracted the inner child-handling loop body into a new private method `handleExclusiveChild(...)`.
- Introduced a small private static holder `ExclusiveMatch` to carry the running best match (state, deepest level and starting date) across the iterations.

The change is purely a structural refactoring: the behavior is strictly preserved. This is an `internal` class so there is no public API / backward compatibility impact.

## Test plan

- [x] Build the `xwiki-platform-notifications-filters-api` module with `mvn clean verify -Pquality` — passes (BUILD SUCCESS, including the existing `ScopeNotificationFilterTest` unit tests).
- [ ] Verify the SonarCloud issue is marked as resolved after the next scan.

---

### Token usage

- Cost in tokens for finding an issue to fix: ~50k tokens
- Cost in tokens for fixing the issue: ~35k tokens
- Cost in tokens for the work after fixing the issue: ~15k tokens

---
_Generated by [Claude Code](https://claude.ai/code/session_01VTJc3Gt4NGDwEayK1ZYvck)_