### PR TITLE
[SONAR] Reduce Cognitive Complexity of the SOLR resolver thread in DefaultSolrIndexer

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/DefaultSolrIndexer.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/DefaultSolrIndexer.java
@@ -239,30 +239,7 @@ public class DefaultSolrIndexer implements SolrIndexer, Initializable, Disposabl
                 }
 
                 try {
-                    switch (queueEntry.operation) {
-                        case READY_MARKER:
-                            queueEntry.readyIndicator.switchToIndexQueue();
-                            DefaultSolrIndexer.this.indexQueue.put(new IndexQueueEntry(queueEntry.readyIndicator));
-                            break;
-                        case INDEX:
-                            Iterable<EntityReference> references = retrieveReferences(queueEntry);
-
-                            for (EntityReference reference : references) {
-                                indexQueue.put(new IndexQueueEntry(
-                                    DefaultSolrIndexer.this.entityReferenceFactory.getReference(reference),
-                                    queueEntry.operation));
-                            }
-                            break;
-                        default:
-                            if (queueEntry.recurse) {
-                                indexQueue.put(new IndexQueueEntry(solrRefereceResolver.getQuery(queueEntry.reference),
-                                    queueEntry.operation));
-                            } else if (queueEntry.reference != null) {
-                                indexQueue.put(new IndexQueueEntry(
-                                    DefaultSolrIndexer.this.entityReferenceFactory.getReference(queueEntry.reference),
-                                    queueEntry.operation));
-                            }
-                    }
+                    dispatchQueueEntry(queueEntry);
                 } catch (Throwable e) {
                     logger.warn("Failed to apply operation [{}] on root reference [{}]", queueEntry.operation,
                         queueEntry.reference, e);
@@ -276,6 +253,35 @@ public class DefaultSolrIndexer implements SolrIndexer, Initializable, Disposabl
             }
 
             logger.debug("Stop SOLR resolver thread");
+        }
+
+        private void dispatchQueueEntry(ResolveQueueEntry queueEntry)
+            throws SolrIndexerException, InterruptedException
+        {
+            switch (queueEntry.operation) {
+                case READY_MARKER:
+                    queueEntry.readyIndicator.switchToIndexQueue();
+                    DefaultSolrIndexer.this.indexQueue.put(new IndexQueueEntry(queueEntry.readyIndicator));
+                    break;
+                case INDEX:
+                    Iterable<EntityReference> references = retrieveReferences(queueEntry);
+
+                    for (EntityReference reference : references) {
+                        indexQueue.put(new IndexQueueEntry(
+                            DefaultSolrIndexer.this.entityReferenceFactory.getReference(reference),
+                            queueEntry.operation));
+                    }
+                    break;
+                default:
+                    if (queueEntry.recurse) {
+                        indexQueue.put(new IndexQueueEntry(solrRefereceResolver.getQuery(queueEntry.reference),
+                            queueEntry.operation));
+                    } else if (queueEntry.reference != null) {
+                        indexQueue.put(new IndexQueueEntry(
+                            DefaultSolrIndexer.this.entityReferenceFactory.getReference(queueEntry.reference),
+                            queueEntry.operation));
+                    }
+            }
         }
 
         private Iterable<EntityReference> retrieveReferences(ResolveQueueEntry queueEntry) throws SolrIndexerException


### PR DESCRIPTION
## Summary

Fixes the SonarCloud CRITICAL issue [java:S3776 - Refactor this method to reduce its Cognitive Complexity from 16 to the 15 allowed](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AZ7imeLL8lbwoM_tj_bO&open=AZ7imeLL8lbwoM_tj_bO) in `DefaultSolrIndexer.java`.

### Problem

The `Resolver.runInternal()` method (the SOLR resolver thread loop) had a Cognitive Complexity of 16, one above the allowed threshold of 15. The `switch`/`for`/`if` logic that dispatches each resolve-queue entry was inlined directly in the thread loop, adding nesting on top of the surrounding `while`/`try`/`catch`/`finally`.

### Fix

- Extracted the queue-entry dispatching logic (the `switch` on `queueEntry.operation`) from `runInternal()` into a dedicated private `dispatchQueueEntry()` method.
- `runInternal()` keeps the thread loop, stop handling and the surrounding `try`/`catch`/`finally`, and now simply delegates to `dispatchQueueEntry()`.
- No behavior change: the same operations are performed in the same order, the checked exceptions (`SolrIndexerException`, `InterruptedException`) are still propagated to the existing `catch (Throwable)` handler, and the `finally` accounting is unchanged.

This is purely an internal refactoring of a package-private inner class; no public API is affected (backward compatibility preserved).

## Test plan

- [x] Build the `xwiki-platform-search-solr-api` module with `mvn clean verify -Pquality` — passes (Checkstyle, Spoon, RevAPI all green).
- [ ] Verify the SonarCloud issue is marked as resolved after the next scan.

---

### Token usage

- Cost in tokens for finding an issue to fix: ~35k tokens
- Cost in tokens for fixing the issue: ~55k tokens
- Cost in tokens for the work after fixing the issue: ~20k tokens

---
_Generated by [Claude Code](https://claude.ai/code/session_01M9WeNT5y1vfEyc93sxKQdG)_