### PR TITLE
[Misc] Replace String#replaceAll() with String#replace() in the notification filter displayer

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/DefaultNotificationFilterDisplayer.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/DefaultNotificationFilterDisplayer.java
@@ -60,7 +60,7 @@ public class DefaultNotificationFilterDisplayer extends AbstractNotificationFilt
 
         try {
             // Try to get a template using the filter name; if no template is found, fallback on the default one.
-            String templateName = String.format("notification/filters/%s.vm", filter.getName().replaceAll("\\/", "."));
+            String templateName = String.format("notification/filters/%s.vm", filter.getName().replace("/", "."));
             Template template = templateManager.getTemplate(templateName);
 
             return (template != null) ? templateManager.execute(template)


### PR DESCRIPTION
## Summary

Fixes the SonarQube issue [java:S5361 - Replace this call to "replaceAll()" by a call to the "replace()" method](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&issues=AXnpAd1_DDFOvAKXAQIW&open=AXnpAd1_DDFOvAKXAQIW) in `DefaultNotificationFilterDisplayer`.

### Problem

`DefaultNotificationFilterDisplayer#display()` builds a template name with:

```java
filter.getName().replaceAll("\\/", ".")
```

The first argument of `String#replaceAll()` is interpreted as a regular expression, but `"\\/"` only ever matches the literal `/` character. Using `replaceAll()` here is misleading and pays the cost of compiling a regular expression for a plain literal replacement.

### Fix

- Replaced `replaceAll("\\/", ".")` with `replace("/", ".")`. `String#replace(CharSequence, CharSequence)` also replaces all occurrences but treats both arguments as literals, so the behaviour is strictly identical while being clearer and avoiding the unnecessary regex compilation.

This is a behaviour-preserving change with no backward compatibility impact.

## Test plan

- [x] Built `xwiki-platform-notifications-filters-api` with `mvn clean install -Plegacy,snapshot` — BUILD SUCCESS, 0 Checkstyle violations, unit tests pass.

---

### Token usage (approximate)

- Finding an issue to fix: ~135k tokens
- Fixing the issue: ~20k tokens
- Work after fixing (commit, push, PR, SonarQube update): ~15k tokens

---
_Generated by [Claude Code](https://claude.ai/code/session_015HMajkfMnVJ8UJzb9LQRax)_