### PR TITLE
[Misc] Replace replaceAll() with replace() in DefaultAsyncNotificationRenderer

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/DefaultAsyncNotificationRenderer.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/DefaultAsyncNotificationRenderer.java
@@ -99,7 +99,7 @@ public class DefaultAsyncNotificationRenderer implements AsyncRenderer
         }
         // We need to replace the / from the cachekey so it won't appear encoded in the URL
         // since it not necessarily supported, in particular for Tomcat standard configuration.
-        return Arrays.asList("notifications", queryType, this.cacheKey.replaceAll("/", "_"));
+        return Arrays.asList("notifications", queryType, this.cacheKey.replace("/", "_"));
     }
 
     @Override


### PR DESCRIPTION
## Summary

Fixes SonarCloud issue [java:S5361 - Replace this call to `replaceAll()` by a call to the `replace()` method](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AXFZ784-f_iQWSeutigI&open=AXFZ784-f_iQWSeutigI) in `DefaultAsyncNotificationRenderer.java`.

### Problem

`String.replaceAll(String, String)` compiles its first argument as a regular expression on every call. When the pattern is a plain literal — here `"/"` — this incurs the cost of compiling a regex for no benefit. SonarQube flags this as a performance/clarity issue (`java:S5361`).

### Fix

- Replaced `this.cacheKey.replaceAll("/", "_")` with `this.cacheKey.replace("/", "_")`.
- The first argument is the literal string `"/"` with no regex metacharacters, so `replace()` (literal `CharSequence` replacement of all occurrences) is functionally identical and avoids the regex compilation.

## Test plan

- [x] Build `xwiki-platform-notifications-notifiers-api` with `mvn clean install -Plegacy,snapshot` — passes.
- [ ] Verify the SonarCloud issue is marked resolved after the next scan.

## Token usage

- Cost in tokens for finding an issue to fix: ~30k
- Cost in tokens for fixing the issue: ~15k
- Cost in tokens for the work after fixing the issue: ~10k

---
_Generated by [Claude Code](https://claude.ai/code/session_01BttNzXzjYsDkaCCJfLqCHT)_