### PR TITLE
[Misc] Replace replaceAll() with replace() in DefaultNotificationDisplayer

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/DefaultNotificationDisplayer.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/DefaultNotificationDisplayer.java
@@ -76,7 +76,7 @@ public class DefaultNotificationDisplayer implements NotificationDisplayer
     private Template getSpecificTemplate(CompositeEvent eventNotification)
     {
         String templateName = String.format("notification/%s.vm",
-            eventNotification.getType().replaceAll("\\/", "."));
+            eventNotification.getType().replace("/", "."));
         return this.templateManager.getTemplate(templateName);
     }
 


### PR DESCRIPTION
# Jira URL

N/A — trivial `[Misc]` change, no JIRA issue.

# Changes

## Description

* Fixes SonarCloud issue [java:S5361](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AXnpAeDNDDFOvAKXAQJ2&open=AXnpAeDNDDFOvAKXAQJ2) in `DefaultNotificationDisplayer.getSpecificTemplate()`.
* Replaced `eventNotification.getType().replaceAll("\\/", ".")` with `replace("/", ".")`. The first argument of `replaceAll()` was a regex matching a single literal `/` (no metacharacters), so the non-regex `String.replace()` is equivalent and avoids compiling a `Pattern` on every call.

## Clarifications

* `replace(CharSequence, CharSequence)` replaces all occurrences (like `replaceAll`), and since neither the search nor the replacement string contains regex/replacement metacharacters, the behaviour is identical.

# Screenshots & Video

N/A — no UI change.

# Executed Tests

```
mvn clean install -B -ntp -Plegacy,snapshot \
  -pl xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api
```

BUILD SUCCESS, 0 Checkstyle violations, all unit tests pass.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  *

---

## Token usage (this agent run)

Tokens consumed per phase (main thread + the `Explore` triage subagent), bucketed by wall-clock phase boundaries from the session transcript. "cache_w" = cache-creation input tokens, "cache_r" = cache-read input tokens.

| Phase | input | cache_w | cache_r | output | **total** |
|---|--:|--:|--:|--:|--:|
| (1) Find an issue | 17,771 | 260,378 | 814,008 | 22,109 | **1,114,266** |
| (2) Fix it | 408 | 11,799 | 541,019 | 6,098 | **559,324** |
| (3) Post-fix work | 1,129 | 27,755 | 1,218,884 | 17,150 | **1,264,918** |
| **Grand total** | | | | | **2,938,508** |

Approximate USD cost (standard Opus rates: $15 / $75 per M input/output, cache write $18.75/M, cache read $1.50/M): **(1)** ≈ $8.03, **(2)** ≈ $1.50, **(3)** ≈ $3.65 — total ≈ **$13.2**. Cache-write tier (5 min vs 1 h) is approximated, so treat USD as indicative.

Notes:
* Phase (1) includes the full cost of the `Explore` subagent that triaged candidate Sonar issues — its rejected-candidate file reads stayed out of the main thread.
* Phase (3) is measured up to just before this PR-body edit; the edit itself and the subsequent SonarCloud "Accept" transition are not counted (an agent can't bill its own final calls).