### PR TITLE
[Misc] Replace replaceAll() with replace() in DefaultTemplateHTMLDisplayer

### DIFF
--- a/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-html/src/main/java/org/xwiki/rendering/display/html/internal/DefaultTemplateHTMLDisplayer.java
+++ b/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-html/src/main/java/org/xwiki/rendering/display/html/internal/DefaultTemplateHTMLDisplayer.java
@@ -155,7 +155,7 @@ public class DefaultTemplateHTMLDisplayer implements HTMLDisplayer<Object>
 
     private String cleanPath(String path)
     {
-        return path.replaceAll("<", "(").replaceAll(">", ")").replaceAll("\\?", "_").replaceAll(" ", "");
+        return path.replace("<", "(").replace(">", ")").replace("?", "_").replace(" ", "");
     }
 
     private List<String> getTemplatePaths(Type type, String mode)


### PR DESCRIPTION
# Jira URL

N/A — trivial `[Misc]` change, no JIRA issue (per XWiki dev practices, trivial changes don't warrant one).

# Changes

## Description

* Fixes the SonarCloud `java:S5361` issues on `DefaultTemplateHTMLDisplayer.cleanPath()` (line 158, all four occurrences):
  * [`replaceAll("<", "(")`](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AW5-S8vk1Yj5qvzeRoOw&open=AW5-S8vk1Yj5qvzeRoOw)
  * [`replaceAll(">", ")")`](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AW5-S8vk1Yj5qvzeRoOv&open=AW5-S8vk1Yj5qvzeRoOv)
  * [`replaceAll("\\?", "_")`](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AW5-S8vk1Yj5qvzeRoOu&open=AW5-S8vk1Yj5qvzeRoOu)
  * [`replaceAll(" ", "")`](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AXnpAhc8DDFOvAKXAQw5&open=AXnpAhc8DDFOvAKXAQw5)
* Replaced the four chained `replaceAll(...)` calls with the non-regex `String.replace(CharSequence, CharSequence)`. Each first argument was a literal with no regex semantics, so `replace()` is exactly equivalent while avoiding a `Pattern` compilation on every call.

## Clarifications

* `String.replace(CharSequence, CharSequence)` replaces *all* occurrences (just like `replaceAll`), and since none of the search or replacement strings contain regex/replacement metacharacters, the behaviour is identical.
* `replaceAll("\\?", "_")` becomes `replace("?", "_")`: in a regex `\?` matches a single literal `?`, which is exactly what the literal `CharSequence` `"?"` matches in `replace()`. SonarCloud flags this call too, confirming the equivalence.

# Screenshots & Video

N/A — no UI change.

# Executed Tests

```
mvn clean install -B -ntp -Plegacy,snapshot \
  -pl xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-html
```

BUILD SUCCESS — 0 Checkstyle violations, Revapi API checks clean, all unit tests pass.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  *

---

## Token usage (this agent run)

Real token counts read from the session transcript (main thread + the `Explore` triage subagent), bucketed by wall-clock phase boundaries. `cache_w` = cache-creation input tokens, `cache_r` = cache-read input tokens. USD is approximate at standard Opus rates ($15 / $75 per M input/output, $18.75/M cache write, $1.50/M cache read).

| Phase | input | cache_w | cache_r | output | **total** | ~USD |
|---|--:|--:|--:|--:|--:|--:|
| (1) Find an issue | 5,559 | 79,043 | 254,304 | 8,784 | **347,690** | $2.61 |
| (2) Fix it | 138 | 11,950 | 271,270 | 3,237 | **286,595** | $0.88 |
| (3) Post-fix work | 592 | 11,361 | 508,771 | 7,562 | **528,286** | $1.55 |
| **Grand total** | 6,289 | 102,354 | 1,034,345 | 19,583 | **1,162,571** | $5.03 |

Notes:
* Phase (1) includes the `Explore` triage subagent (≈140,710 tokens) that listed/read SonarCloud candidates — its rejected-candidate file reads stayed out of the main thread.
* Phase (3) is measured up to just before this PR-body edit; the edit itself and the SonarCloud "Accept" transitions are not counted (an agent can't bill its own final calls).