### PR TITLE
[Misc] Replace replaceAll() with replace() in ImageFilter

### DIFF
--- a/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/internal/filter/ImageFilter.java
+++ b/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/internal/filter/ImageFilter.java
@@ -197,7 +197,7 @@ public class ImageFilter extends AbstractHTMLFilter
                 concerns "&" character.
                 Finally '@' is used in XWiki Syntax so it needs to be escaped to build the link properly.
                  */
-                fileName = fileName.replaceAll("\\+", "%2B");
+                fileName = fileName.replace("+", "%2B");
                 // We have to decode the image file name in case it contains URL special characters.
                 fileName = URLDecoder.decode(fileName, UTF_8);
             } catch (Exception e) {


### PR DESCRIPTION
# Jira URL

N/A — trivial `[Misc]` change, no JIRA issue.

# Changes

## Description

* Fixes SonarCloud issue [java:S5361](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AXnpAgiPDDFOvAKXAQnt&open=AXnpAgiPDDFOvAKXAQnt) in `ImageFilter.parseImageReference()`.
* Replaced `fileName.replaceAll("\\+", "%2B")` with `fileName.replace("+", "%2B")`. The first argument of `replaceAll()` was the regex `\+`, which matches a single literal `+` character (no other metacharacters), so the non-regex `String.replace()` is equivalent and avoids compiling a `Pattern` on every call.

## Clarifications

* `String.replace(CharSequence, CharSequence)` replaces all occurrences (like `replaceAll`), and since neither the search string (`+`) nor the replacement string (`%2B`) contains regex/replacement metacharacters, the behaviour is identical.

# Screenshots & Video

N/A — no UI change.

# Executed Tests

```
mvn clean verify -Pquality -pl xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer -Plegacy,snapshot
```

BUILD SUCCESS (63 goals executed, Spoon + Checkstyle + unit tests pass).

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  *

---

## Token usage (this agent run)

Approximate output-token cost, bucketed by phase:

| Phase | Tokens |
|---|--:|
| (1) Finding an issue to fix | ~10,500 |
| (2) Fixing the issue (edit + `mvn clean verify -Pquality`) | ~1,200 |
| (3) Work after fixing (commit, push, PR, SonarCloud transition) | ~2,800 |

Notes:
* Phase (1) covers querying the SonarCloud API (BLOCKER then CRITICAL issues), rejecting the single BLOCKER (`java:S1845`, a public-API rename that would break backward compatibility) and several other candidates, then settling on this `java:S5361` issue.
* Figures are indicative output-token estimates from the session, not exact billing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WA3TKX7ukr5jS18jDKN3bA)_