### PR TITLE
XWIKI-22125: The UI should be clearer about finished attachment uploads

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/importer/import.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/js/xwiki/importer/import.js
@@ -78,17 +78,19 @@ var XWiki = (function(XWiki){
       hookRichImporterUI();
       /** Attach the HTML5 uploader, if available */
       var form = $('AddAttachment');
-      if (form && typeof(XWiki.FileUploader) != 'undefined') {
-        var input = form.down("input[type='file']");
-        var html5Uploader = new XWiki.FileUploader(input, {
-          'progressAutohide' : true,
-          'responseContainer' : $('packagelistcontainer'),
-          'responseURL' : window.docgeturl + '?xpage=packagelist&forceTestRights=1',
-          'maxFilesize' : parseInt(input.readAttribute('data-max-file-size'))
-        });
-        form.observe("xwiki:html5upload:done", hookRichImporterUI);
-        html5Uploader.hideFormButtons();
-      }
+      require(['xwiki-upload'], function(FileUploader) {
+        if (form && typeof (FileUploader) != 'undefined') {
+          var input = form.down("input[type='file']");
+          var html5Uploader = new FileUploader(input, {
+            'progressAutohide': true,
+            'responseContainer': $('packagelistcontainer'),
+            'responseURL': window.docgeturl + '?xpage=packagelist&forceTestRights=1',
+            'maxFilesize': parseInt(input.readAttribute('data-max-file-size'))
+          });
+          form.observe("xwiki:html5upload:done", hookRichImporterUI);
+          html5Uploader.hideFormButtons();
+        }
+      });
     });
 
     /**

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/widgets/upload.js
@@ -409,6 +409,10 @@ define('xwiki-upload', ['xwiki-l10n!upload-translations'], function(l10n) {
         return;
       }
 
+      if (event?.target?.responseText) {
+        this.statusUI.UPLOAD_RESPONSE.update(event.target.responseText);
+      }
+
       if (this.options.enableProgressInfo) {
         this.statusUI.PROGRESS_PERCENTAGE.update('100%');
         this.statusUI.PROGRESS_REMAINING.update('00:00:00');


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-22125

# Changes

## Description

* Restored the page update with the server response after a successful upload
* Ensure the file uploader is loaded in import.js

## Clarifications

* The original XWIKI-22125 PR accidentally dropped the line that writes the server response back to the page after a successful upload. This caused the package list in the XAR import administration section to no longer update after uploading a file, requiring a manual page refresh.
* The file uploader initialization in import.js is now wrapped in a `require()` callback to guarantee the module is loaded before use. This is the same solution as the one that's already been used once in `history.js`

# Screenshots & Video

Here is how the Import UI looks after importing one XAR:
<img width="955" height="400" alt="image" src="https://github.com/user-attachments/assets/fd22ff94-9cf6-43f0-ae63-9775b6568617" />

There were two bugs on this UI: 
* attach button being present
* The package list wouldn't update on upload

We can see here than both are solved.

# Executed Tests
Manual tests, as seen above.
All 9 XARImportIT Docker integration tests pass:

```
mvn clean verify -pl xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker -Plegacy,snapshot,docker,integration-tests -Dxwiki.checkstyle.skip=true -Dxwiki.revapi.skip=true -B -ntp
```

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches: NA - cause on master only