### PR TITLE
[Misc] Replace replaceAll() with replace() in PDFAction (SonarCloud java:S5361)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/web/PDFAction.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/web/PDFAction.java
@@ -64,7 +64,7 @@ public class PDFAction extends XWikiAction
             // computing a directory hierarchy but a file name
             EntityReferenceSerializer<String> serializer =
                 Utils.getComponent(EntityReferenceSerializer.TYPE_STRING, "path");
-            String filename = serializer.serialize(doc.getDocumentReference()).replaceAll("/", "_");
+            String filename = serializer.serialize(doc.getDocumentReference()).replace("/", "_");
             // Make sure we don't go over 255 chars since several filesystems don't support filename longer than that!
             filename = StringUtils.abbreviateMiddle(filename, "__", 255);
 


### PR DESCRIPTION
## Summary

Fixes SonarCloud issue [java:S5361 — "String.replaceAll()" should be replaced by "String.replace()"](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&issues=AW5-S6eX1Yj5qvzeRnZh&open=AW5-S6eX1Yj5qvzeRnZh) in `PDFAction.java`.

### Problem

`String.replaceAll(String, String)` compiles its first argument as a regular expression. When the
argument is a plain literal (here `"/"`), this is needless overhead and misleading to readers.

### Fix

Replaced `.replaceAll("/", "_")` with `.replace("/", "_")`. Since `"/"` contains no regex
metacharacters, `String.replace(CharSequence, CharSequence)` is semantically identical (it also
replaces all occurrences) and clearer.

## Test plan

- [x] Build `xwiki-platform-legacy-oldcore` with `mvn clean install -Plegacy,snapshot` — BUILD SUCCESS (Checkstyle/Spoon included).
- [ ] Verify the SonarCloud issue is marked resolved after the next scan.

## Token usage

Measured from the session transcript (deduplicated per message). The "find" phase includes the
`Explore` triage subagent. Cache-read tokens are billed at ~10% the rate of fresh input/output, so
they dominate the raw totals without dominating the cost.

| Phase | Input (fresh) | Output | Cache create | Cache read | Raw total |
|---|---:|---:|---:|---:|---:|
| 1. Find an issue (incl. Explore subagent) | 5,788 | 5,399 | 99,119 | 610,331 | ~721K |
| 2. Fix it (edit + module build + verify) | 556 | 5,165 | 49,824 | 1,065,403 | ~1,121K |
| 3. Post-fix (commit, push, PR, label, accept issue)\* | 892 | 8,434 | 13,844 | 691,846 | ~715K |

\* Phase 3 is a near-complete snapshot taken while writing this body; it excludes the final
learnings commit and this edit itself.

Notes for future runs: phase 2's large cache-read figure comes from the wait loop around the ~6.5‑min
Maven build (each turn re-reads the cached context). The expensive-to-bill components (fresh input +
cache creation + output) stayed small in every phase because file reads were kept narrow and triage
was delegated to a subagent.