### PR TITLE
[Misc] Replace replaceAll with replace in RedundancyFilter (SonarCloud java:S5361)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/internal/filter/RedundancyFilter.java
+++ b/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/internal/filter/RedundancyFilter.java
@@ -86,7 +86,7 @@ public class RedundancyFilter extends AbstractHTMLFilter
             if ("".equals(textContent)) {
                 element.getParentNode().removeChild(element);
             } else {
-                element.setTextContent(textContent.replaceAll(" ", "&nbsp;"));
+                element.setTextContent(textContent.replace(" ", "&nbsp;"));
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes SonarCloud issue [java:S5361 - "replaceAll" should be replaced by "replace" when the pattern is a plain literal](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AW5-S8Ef1Yj5qvzeRoEG&open=AW5-S8Ef1Yj5qvzeRoEG) in `RedundancyFilter.java`.

### Problem

`textContent.replaceAll(" ", "&nbsp;")` uses `String.replaceAll`, whose first argument is compiled as a regular expression. Here the argument is the plain literal `" "` (a single space) with no regex metacharacters, so the regex machinery is pure overhead.

### Fix

Switched to `String.replace(" ", "&nbsp;")`. `String.replace(CharSequence, CharSequence)` also replaces every occurrence and treats both arguments as literals, so the behaviour is identical while avoiding needless regex compilation.

## Test plan

- Built the `xwiki-platform-office-importer` module with checkstyle + Spoon — BUILD SUCCESS.
- One-line change, semantically equivalent; no behavioural change expected.

## Token usage

Total tokens (input + cache-creation + cache-read + output), broken down by phase:

| Phase | Tokens | Notes |
|-------|-------:|-------|
| 1. Finding an issue | ~263K | Querying SonarCloud, reading candidate snippets locally |
| 2. Fixing it | ~1,059K | One-line edit + Maven build/checkstyle verification |
| 3. Post-fix work | ~472K | Commit, push, PR creation, label, marking the issue Accepted, recording learnings |
| **Total** | **~1,794K** | |

The bulk of the "fix" phase is cumulative **cache-read** (cheap, ~10% rate) incurred while waiting on the ~4-minute Maven build: each progress check re-reads the full cached context. The expensive components (fresh input + cache-creation + output) stayed small — ~118K across the whole run — thanks to narrow local file reads.
