### PR TITLE
[Misc] Replace replaceAll() with replace() in DefaultNotificationRSSRenderer

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/rss/DefaultNotificationRSSRenderer.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/rss/DefaultNotificationRSSRenderer.java
@@ -116,7 +116,7 @@ public class DefaultNotificationRSSRenderer implements NotificationRSSRenderer
 
             // Try to get a template associated with the composite event
             Template template = this.templateManager.getTemplate(String.format("notification/rss/%s.vm",
-                    eventNotification.getType().replaceAll("\\/", ".")));
+                    eventNotification.getType().replace("/", ".")));
 
             // If no template is found, fallback on the default one
             if (template == null) {


### PR DESCRIPTION
## Summary

Fixes SonarCloud issue [java:S5361](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AXnpAeDnDDFOvAKXAQJ3&open=AXnpAeDnDDFOvAKXAQJ3) in `DefaultNotificationRSSRenderer.java`: *"Replace this call to `replaceAll()` by a call to the `replace()` method."*

### Problem

`eventNotification.getType().replaceAll("\\/", ".")` uses the regex-based `replaceAll()` even though the pattern (`\/`) is just the literal character `/`. Compiling a regex here is unnecessary overhead.

### Fix

Replaced with `replace("/", ".")`. `String.replace(CharSequence, CharSequence)` also replaces **all** occurrences, so the behaviour is identical — the `/` (previously written as the regex `\/`) becomes a plain literal and the `.` replacement was already a literal string. No functional change.

## Test plan

- [x] `mvn clean install -pl xwiki-platform-core/.../xwiki-platform-notifications-notifiers-api -Plegacy,snapshot` — BUILD SUCCESS (checkstyle + Spoon pass).

---

### Token usage (this automated run)

| Phase | Total tokens | Fresh input | Output | Cache create | Cache read |
|-------|-------------:|------------:|-------:|-------------:|-----------:|
| 1. Find an issue | 328,754 | 5,393 | 5,618 | 48,541 | 269,202 |
| 2. Fix it | 521,945 | 277 | 2,974 | 37,590 | 481,104 |
| 3. Post-fix work | 226,065 | 456 | 2,947 | 3,647 | 219,015 |
| **Total** | **1,076,764** | 6,126 | 11,539 | 89,778 | 969,321 |

The figures are dominated by cumulative **cache-read** (cheap, ~10% rate). The *fix* phase is the largest only because it spans the ~3-min module build: each wait/notification turn re-reads the full cached context. *Post-fix* = PR creation, labelling, and marking the SonarCloud issue Accepted.
