### PR TITLE
[Misc] Replace String.replaceAll() with String.replace() for literal patterns (SonarCloud java:S5361)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/FeedPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/FeedPlugin.java
@@ -528,7 +528,7 @@ public class FeedPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfa
             SyndEntry entry = entries.get(i);
             if (oneDocPerEntry) {
                 String hashCode = "" + entry.getLink().hashCode();
-                String pagename = feedname + "_" + hashCode.replaceAll("-", "") + "_" + entry.getTitle();
+                String pagename = feedname + "_" + hashCode.replace("-", "") + "_" + entry.getTitle();
                 doc =
                     context.getWiki().getDocument(
                         prefix + "_" + context.getWiki().clearName(pagename, true, true, context), context);

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/web/TempResourceAction.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/web/TempResourceAction.java
@@ -124,7 +124,7 @@ public class TempResourceAction extends XWikiAction
         response.setContentType(contentType);
         if ("1".equals(request.getParameter("force-download"))) {
             String fileName = StringUtils.defaultIfBlank(request.getParameter("force-filename"), tempFile.getName());
-            fileName = Util.encodeURI(fileName, context).replaceAll("\\+", "%20");
+            fileName = Util.encodeURI(fileName, context).replace("+", "%20");
             response.addHeader("Content-disposition", "attachment; filename*=utf-8''" + fileName);
         }
         try (FileInputStream tempFileInputStream = FileUtils.openInputStream(tempFile)) {

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/AbstractNotificationEmailRenderer.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/AbstractNotificationEmailRenderer.java
@@ -60,7 +60,7 @@ public abstract class AbstractNotificationEmailRenderer implements NotificationE
             throws NotificationException
     {
         // Generate the full template name
-        String templateName = String.format(templatePath, event.getType().replaceAll("\\/", "."));
+        String templateName = String.format(templatePath, event.getType().replace("/", "."));
         // Get the template
         Template template = templateManager.getTemplate(templateName);
         if (template == null) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
@@ -5779,7 +5779,7 @@ public class XWiki implements EventListener
         }
         if (!path.startsWith(segment)) {
             // Some clients also encode -, although it's allowed in the path
-            segment = segment.replaceAll("-", "%2D");
+            segment = segment.replace("-", "%2D");
         }
         if (!path.startsWith(segment)) {
             // Can't find the context path in the URL (shouldn't happen), just skip to the next path segment

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Document.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Document.java
@@ -3200,7 +3200,7 @@ public class Document extends Api
                 i = fname.lastIndexOf("/");
             }
             filename = fname.substring(i + 1);
-            filename = filename.replaceAll("\\+", " ");
+            filename = filename.replace("+", " ");
 
             if ((data != null) && (data.length > 0)) {
                 XWikiAttachment attachment = this.getDoc().addAttachment(filename, data, getXWikiContext());

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -4216,7 +4216,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
                     }
                     String data = display(propertyName, object, context);
                     data = data.trim();
-                    data = data.replaceAll("\n", " ");
+                    data = data.replace("\n", " ");
                     if (data.length() == 0) {
                         result.append("&nbsp;");
                     } else {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/HibernateStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/HibernateStore.java
@@ -561,7 +561,7 @@ public class HibernateStore implements Disposable, Initializable
      */
     public String toDynamicMappingTableName(String className)
     {
-        return "xwikicustom_" + className.replaceAll("\\.", "_");
+        return "xwikicustom_" + className.replace(".", "_");
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/Package.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/Package.java
@@ -526,7 +526,7 @@ public class Package
                             "Failed to parse document [{}] from XML during import, thus it will not be installed. "
                                 + "The error was: " + ExceptionUtils.getRootCauseMessage(e));
                         // It will be listed in the "failed documents" section after the import.
-                        addToErrors(entry.getName().replaceAll("/", "."), context);
+                        addToErrors(entry.getName().replace("/", "."), context);
 
                         continue;
                     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyPersistentLoginManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyPersistentLoginManager.java
@@ -370,7 +370,7 @@ public class MyPersistentLoginManager extends DefaultPersistentLoginManager
                 // with something else. Bas64 does not use _, and it is allowed in cookies, so
                 // we're using that instead of =. In decryptText the reverse operation is perfomed.
                 // See XWIKI-2211
-                return encryptedEncodedText.replaceAll("=", "_");
+                return encryptedEncodedText.replace("=", "_");
             }
             if (LOGGER.isErrorEnabled()) {
                 LOGGER.error("ERROR! >> SecretKey not generated...");
@@ -576,7 +576,7 @@ public class MyPersistentLoginManager extends DefaultPersistentLoginManager
             // so here we must re-introduce the = sign needed by Base64.
             // See XWIKI-2211
             byte[] decodedEncryptedText =
-                Base64.decodeBase64(encryptedText.replaceAll("_", "=").getBytes("ISO-8859-1"));
+                Base64.decodeBase64(encryptedText.replace("_", "=").getBytes("ISO-8859-1"));
             Cipher c1 = Cipher.getInstance(this.cipherParameters);
             c1.init(Cipher.DECRYPT_MODE, this.secretKey);
             byte[] decryptedText = c1.doFinal(decodedEncryptedText);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiAuthServiceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiAuthServiceImpl.java
@@ -337,7 +337,7 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
         }
 
         // Trim the username to allow users to enter their names with spaces before or after
-        String cannonicalUsername = username.replaceAll(" ", "");
+        String cannonicalUsername = username.replace(" ", "");
 
         // Check for superadmin
         if (isSuperAdmin(cannonicalUsername)) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/ExportAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/ExportAction.java
@@ -216,7 +216,7 @@ public class ExportAction extends XWikiAction
         // a directory hierarchy but a file name
         EntityReferenceSerializer<String> serializer =
             Utils.getComponent(EntityReferenceSerializer.TYPE_STRING, "path");
-        String filename = serializer.serialize(doc.getDocumentReference()).replaceAll("/", "_");
+        String filename = serializer.serialize(doc.getDocumentReference()).replace("/", "_");
         // Make sure we don't go over 255 chars since several filesystems don't support filename longer than that!
         filename = StringUtils.abbreviateMiddle(filename, "__", 255);
         context.getResponse().addHeader("Content-disposition",

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/PropAddForm.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/PropAddForm.java
@@ -33,7 +33,7 @@ public class PropAddForm extends XWikiForm
 
     public void setPropName(String propName)
     {
-        this.propName = propName.replaceAll(" ", "");
+        this.propName = propName.replace(" ", "");
     }
 
     public String getPropType()

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/PropUpdateAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/PropUpdateAction.java
@@ -80,7 +80,7 @@ public class PropUpdateAction extends XWikiAction
             }
 
             if (newName.indexOf(" ") != -1) {
-                newName = newName.replaceAll(" ", "");
+                newName = newName.replace(" ", "");
                 newProperty.setName(newName);
             }
             bclass2.addField(newName, newProperty);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/UploadAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/UploadAction.java
@@ -286,7 +286,7 @@ public class UploadAction extends XWikiAction
             filename = fname;
         }
         // Sometimes spaces are replaced with '+' by the browser.
-        filename = filename.replaceAll("\\+", " ");
+        filename = filename.replace("+", " ");
 
         if (StringUtils.isBlank(filename)) {
             // The file field was left empty, ignore this

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/Utils.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/Utils.java
@@ -577,7 +577,7 @@ public class Utils
     public static String SQLFilter(String text)
     {
         try {
-            return text.replaceAll("'", "''");
+            return text.replace("'", "''");
         } catch (Exception e) {
             return text;
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiServletURLFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiServletURLFactory.java
@@ -457,7 +457,7 @@ public class XWikiServletURLFactory extends XWikiDefaultURLFactory
         }
 
         // The previous call will convert " " into "+" (and "+" into "%2B") so we need to convert "+" into "%20"
-        encodedName = encodedName.replaceAll("\\+", "%20");
+        encodedName = encodedName.replace("+", "%20");
 
         return encodedName;
     }

--- a/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/AbstractQueryFilter.java
+++ b/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/AbstractQueryFilter.java
@@ -106,8 +106,8 @@ public abstract class AbstractQueryFilter implements QueryFilter
             if (gidx > -1) {
                 fragment = fragment.substring(0, gidx);
             }
-            fragment = fragment.replaceAll(" desc", "");
-            fragment = fragment.replaceAll(" asc", "");
+            fragment = fragment.replace(" desc", "");
+            fragment = fragment.replace(" asc", "");
 
             for (String column : fragment.split(COLUMN_SEPARATOR)) {
                 columns.add(column.trim());


### PR DESCRIPTION
## Summary

Fixes **all 19** open occurrences of SonarCloud rule
[java:S5361 — "`String#replaceAll()` should not be used with a `String` argument that does not contain special regex characters"](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&issueStatuses=OPEN&rules=java%3AS5361).

Each flagged call passes a plain **literal** as the first argument, so the regex
compilation done by `replaceAll()` is unnecessary. `String.replace(CharSequence,
CharSequence)` replaces **all** occurrences too, so the change is semantically
identical while avoiding the regex overhead.

Escaped single-metacharacter patterns were rewritten to their literal
equivalents:
- `"\\+"` → `"+"`
- `"\\/"` → `"/"`
- `"\\."` → `"."`

All other patterns were already plain literals (`"="`, `"_"`, `" desc"`,
`" asc"`, `"\n"`, `"/"`, `" "`, `"-"`, `"'"`), so only the method name changed.
Genuine regex calls in the same files (character classes, `\\s+`, the
`;jsessionid=...` patterns, the `noaccents`/`clearName` table in `XWiki.java`)
were **not** flagged and are left untouched.

### Files (19 fixes across 5 modules)

- `xwiki-platform-oldcore` (13): `XWiki`, `Document`, `XWikiDocument`,
  `HibernateStore`, `Package`, `MyPersistentLoginManager` (×2),
  `XWikiAuthServiceImpl`, `ExportAction`, `UploadAction`, `XWikiServletURLFactory`,
  `PropUpdateAction`, `PropAddForm`, `Utils`
- `xwiki-platform-query-manager` (2): `AbstractQueryFilter`
- `xwiki-platform-legacy-oldcore` (1): `TempResourceAction`
- `xwiki-platform-feed-api` (1): `FeedPlugin`
- `xwiki-platform-notifications-notifiers-default` (1): `AbstractNotificationEmailRenderer`

## Test plan

- [x] `mvn clean install` of the 5 affected modules with `-Plegacy,snapshot`
      passes (Checkstyle + Spoon included). BUILD SUCCESS.

## Token usage

Token cost of this routine, broken down by phase (sum of input + output +
cache-read + cache-write across deduplicated assistant turns):

| Phase | Total tokens | input | output | cache read | cache write |
|-------|-------------:|------:|-------:|-----------:|------------:|
| 1. Find an issue | 304,194 | 5,619 | 11,207 | 190,570 | 96,798 |
| 2. Fix it (edit + 5-module build + commit + push) | 889,764 | 281 | 6,987 | 802,284 | 80,212 |
| 3. Post-fix (PR, label, accept 19 issues, report) | 426,498 | 458 | 5,246 | 413,551 | 7,243 |
| **Total** | **1,620,456** | 6,358 | 23,440 | 1,406,405 | 184,253 |

The fix phase dominates because it spans the ~8-minute build wait: each
wait/wakeup turn re-reads the full cached context. Phase 3 is a snapshot taken
mid-phase (the report itself is still being written).

---
_Generated by [Claude Code](https://claude.ai/code/session_017tgtqY41sdxT5ZM23yxZ23)_