### PR TITLE
[Misc] Use try-with-resources in AbstractContentResourceReferenceHandler (SonarCloud java:S2093)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/AbstractContentResourceReferenceHandler.java
+++ b/xwiki-platform-core/xwiki-platform-vfs/xwiki-platform-vfs-api/src/main/java/org/xwiki/vfs/internal/AbstractContentResourceReferenceHandler.java
@@ -63,9 +63,7 @@ public abstract class AbstractContentResourceReferenceHandler extends AbstractRe
         //
         // Note that even though the stream returned by TrueVFS returns true for markSupported() in practice it
         // doesn't! Thus we need to wrap the stream to make it support mark and reset.
-        InputStream markResetSupportingStream = new BufferedInputStream(resourceStream);
-
-        try {
+        try (InputStream markResetSupportingStream = new BufferedInputStream(resourceStream)) {
             Response response = this.container.getResponse();
 
             String actualContentType = (contentType != null) ? contentType
@@ -80,8 +78,6 @@ public abstract class AbstractContentResourceReferenceHandler extends AbstractRe
             IOUtils.copy(markResetSupportingStream, response.getOutputStream());
         } catch (Exception e) {
             throw new ResourceReferenceHandlerException(String.format("Failed to read resource [%s]", resourceName), e);
-        } finally {
-            IOUtils.closeQuietly(markResetSupportingStream);
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes SonarCloud blocker issue [java:S2093 — Change this "try" to a try-with-resources](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AW-AiN0Ypjn0nASQAOha&open=AW-AiN0Ypjn0nASQAOha) in `AbstractContentResourceReferenceHandler.java`.

### Problem

The `BufferedInputStream` (`markResetSupportingStream`) was closed manually in a `finally` block via `IOUtils.closeQuietly()`, which SonarCloud flags as a candidate for try-with-resources.

### Fix

- Moved the `BufferedInputStream` creation into a try-with-resources header, removing the explicit `finally { IOUtils.closeQuietly(...) }`.
- Behavior is unchanged: the stream is still closed when the block exits; the surrounding `catch` that wraps failures in a `ResourceReferenceHandlerException` is preserved.

## Test plan

- [x] Build `xwiki-platform-vfs-api` with `mvn clean install -Plegacy,snapshot` (Checkstyle + Spoon) — BUILD SUCCESS.
- [ ] Verify the SonarCloud issue is marked resolved after the next scan.

---

### Token usage

Total tokens per phase (fresh input + output + cache read + cache write):

| Phase | Total | Fresh in | Output | Cache read | Cache write |
|-------|-------:|------:|-----:|---------:|----------:|
| 1. Find an issue | ~436K | 5.6K | 5.3K | 335K | 90K |
| 2. Fix it | ~598K | 0.3K | 3.4K | 554K | 41K |
| 3. Post-fix work* | ~355K | 0.5K | 3.1K | 347K | 5K |

\* Post-fix (PR creation, label, Sonar accept, this report) is a mid-phase snapshot, since the report itself is part of it. Cache-read dominates every phase; the fix phase is most expensive because it spans the Maven build wait.