### PR TITLE
[Misc] Use try-with-resources in XarPackage.read(InputStream)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-xar/xwiki-platform-xar-model/src/main/java/org/xwiki/xar/XarPackage.java
+++ b/xwiki-platform-core/xwiki-platform-xar/xwiki-platform-xar-model/src/main/java/org/xwiki/xar/XarPackage.java
@@ -195,16 +195,12 @@ public class XarPackage
      */
     public void read(InputStream xarStream) throws IOException
     {
-        ZipArchiveInputStream zis = new ZipArchiveInputStream(xarStream, "UTF-8", false);
-
-        try {
+        try (ZipArchiveInputStream zis = new ZipArchiveInputStream(xarStream, "UTF-8", false)) {
             for (ZipArchiveEntry entry = zis.getNextZipEntry(); entry != null; entry = zis.getNextZipEntry()) {
                 if (!entry.isDirectory() && zis.canReadEntryData(entry)) {
                     readEntry(zis, entry.getName());
                 }
             }
-        } finally {
-            zis.close();
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes SonarCloud blocker issue [java:S2093 - Change this "try" to a try-with-resources](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AW-AiO5rpjn0nASQAOhf&open=AW-AiO5rpjn0nASQAOhf) in `XarPackage.java`.

### Problem

`XarPackage.read(InputStream)` created a `ZipArchiveInputStream` and closed it manually in a `finally` block.

### Fix

Converted the manual `try { ... } finally { zis.close(); }` into a `try`-with-resources statement. Behavior is preserved; the resource is still always closed, and a close-time exception now propagates instead of being silently swallowed.

## Test plan

- [x] Build the `xwiki-platform-xar-model` module with `mvn clean install` (Checkstyle + Spoon) — passes.

## Token usage

Totals (input + output + cache read + cache write) per phase:

| Phase | Input | Output | Cache read | Cache write | Total |
|-------|------:|-------:|-----------:|------------:|------:|
| 1. Find the issue | 5,625 | 3,647 | 309,483 | 92,375 | 411,130 |
| 2. Fix it (edit + build + commit + push) | 277 | 2,466 | 474,745 | 35,223 | 512,711 |
| 3. Post-fix (PR + label + accept + report) | 327 | 2,078 | 213,454 | 2,036 | 217,895 |

The post-fix figure is a mid-phase snapshot taken while generating this report. Cache-read dominates; the fix phase is the most expensive because it spans the Maven build wait.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)