### PR TITLE
[Misc] Use try-with-resources instead of manual finally close (SonarCloud java:S2093)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/handler/packager/Packager.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/handler/packager/Packager.java
@@ -152,11 +152,8 @@ public class Packager
     private void importXARToWiki(String comment, File xarFile, WikiReference wikiReference,
         PackageConfiguration configuration) throws IOException, XarException, XWikiException
     {
-        FileInputStream fis = new FileInputStream(xarFile);
-        try {
+        try (FileInputStream fis = new FileInputStream(xarFile)) {
             importXARToWiki(comment, fis, wikiReference, configuration);
-        } finally {
-            fis.close();
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWikiConfig.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWikiConfig.java
@@ -52,7 +52,7 @@ public class XWikiConfig extends Properties
         } catch (IOException e) {
             Object[] args = { path };
             throw new XWikiException(XWikiException.MODULE_XWIKI_CONFIG,
-                XWikiException.ERROR_XWIKI_CONFIG_FORMATERROR, "Error reading configuration file", e, args);
+                XWikiException.ERROR_XWIKI_CONFIG_FORMATERROR, "Error reading configuration file {0}", e, args);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWikiConfig.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWikiConfig.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import com.xpn.xwiki.internal.XWikiCfgConfigurationSource;
@@ -44,17 +43,16 @@ public class XWikiConfig extends Properties
 
     public XWikiConfig(String path) throws XWikiException
     {
-        try {
-            FileInputStream fis = new FileInputStream(path);
-            try {
-                loadConfig(fis, path);
-            } finally {
-                IOUtils.closeQuietly(fis);
-            }
+        try (FileInputStream fis = new FileInputStream(path)) {
+            loadConfig(fis, path);
         } catch (FileNotFoundException e) {
             Object[] args = { path };
             throw new XWikiException(XWikiException.MODULE_XWIKI_CONFIG,
                 XWikiException.ERROR_XWIKI_CONFIG_FILENOTFOUND, "Configuration file {0} not found", e, args);
+        } catch (IOException e) {
+            Object[] args = { path };
+            throw new XWikiException(XWikiException.MODULE_XWIKI_CONFIG,
+                XWikiException.ERROR_XWIKI_CONFIG_FORMATERROR, "Error reading configuration file", e, args);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-integration/src/main/java/org/xwiki/test/integration/XWikiExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-integration/src/main/java/org/xwiki/test/integration/XWikiExecutor.java
@@ -676,11 +676,8 @@ public class XWikiExecutor
 
     private void saveProperties(String path, Properties properties) throws Exception
     {
-        FileOutputStream fos = new FileOutputStream(path);
-        try {
+        try (FileOutputStream fos = new FileOutputStream(path)) {
             properties.store(fos, null);
-        } finally {
-            fos.close();
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-zipexplorer/src/main/java/com/xpn/xwiki/plugin/zipexplorer/ZipExplorerPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-zipexplorer/src/main/java/com/xpn/xwiki/plugin/zipexplorer/ZipExplorerPlugin.java
@@ -128,10 +128,7 @@ public class ZipExplorerPlugin extends XWikiDefaultPlugin
         newAttachment.setAuthorReference(attachment.getAuthorReference());
         newAttachment.setDate(attachment.getDate());
 
-        InputStream stream = null;
-        try {
-            stream = new BufferedInputStream(attachment.getContentInputStream(context));
-
+        try (InputStream stream = new BufferedInputStream(attachment.getContentInputStream(context))) {
             if (!isZipFile(stream)) {
                 return attachment;
             }
@@ -162,8 +159,6 @@ public class ZipExplorerPlugin extends XWikiDefaultPlugin
             e.printStackTrace();
         } catch (IOException e) {
             e.printStackTrace();
-        } finally {
-            IOUtils.closeQuietly(stream);
         }
         return newAttachment;
     }

--- a/xwiki-platform-tools/xwiki-platform-tool-packager-plugin/src/main/java/com/xpn/xwiki/tool/backup/Importer.java
+++ b/xwiki-platform-tools/xwiki-platform-tool-packager-plugin/src/main/java/com/xpn/xwiki/tool/backup/Importer.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 
-import org.apache.commons.io.IOUtils;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.tool.utils.OldCoreHelper;
 
@@ -116,11 +115,8 @@ public class Importer
         pack.setWithVersions(false);
 
         // Parse XAR
-        FileInputStream fis = new FileInputStream(file);
-        try {
+        try (FileInputStream fis = new FileInputStream(file)) {
             pack.Import(fis, context);
-        } finally {
-            IOUtils.closeQuietly(fis);
         }
 
         // Import into the database


### PR DESCRIPTION
## Summary

Fixes 5 SonarCloud CRITICAL issues for rule [java:S2093 — "Change this `try` to a try-with-resources"](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS2093&rule_key=java%3AS2093). Each fix converts a manual `try { ... } finally { resource.close()/IOUtils.closeQuietly(resource) }` block into a `try`-with-resources statement, so the resource is closed automatically and a close-time exception is no longer silently swallowed.

## Fixed issues

| File | Resource | SonarCloud issue |
|------|----------|------------------|
| `Packager.java` | `FileInputStream` | [AW-AiMVZpjn0nASQAOhV](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AW-AiMVZpjn0nASQAOhV&open=AW-AiMVZpjn0nASQAOhV) |
| `XWikiExecutor.java` | `FileOutputStream` | [AW-AiPBlpjn0nASQAOhh](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AW-AiPBlpjn0nASQAOhh&open=AW-AiPBlpjn0nASQAOhh) |
| `Importer.java` | `FileInputStream` | [AW-AiPS-pjn0nASQAOhk](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AW-AiPS-pjn0nASQAOhk&open=AW-AiPS-pjn0nASQAOhk) |
| `XWikiConfig.java` | `FileInputStream` | [AW-AiMExpjn0nASQAOhS](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AW-AiMExpjn0nASQAOhS&open=AW-AiMExpjn0nASQAOhS) |
| `ZipExplorerPlugin.java` | `BufferedInputStream` | [AW5-S-oQ1Yj5qvzeRo49](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AW5-S-oQ1Yj5qvzeRo49&open=AW5-S-oQ1Yj5qvzeRo49) |

## Notes

- In `XWikiConfig`, the original code only caught `FileNotFoundException`; since the implicit
  `close()` of the try-with-resources can throw `IOException`, an extra `catch (IOException)` was
  added that wraps it as a configuration format error (consistent with `loadConfig`'s existing
  handling). The unused `IOUtils` import was removed (likewise in `Importer`).
- No behavior change other than that a previously-swallowed close exception now surfaces — which is
  exactly the intent of the rule.

## Test plan

- [x] `mvn clean install` of the 5 affected modules passes (Checkstyle + Spoon included).

---

## Token-usage report

Costs are computed from this session's transcript (assistant turns deduped by message id), priced at Opus rates (input $15, output $75, cache-write $18.75, cache-read $1.50 per Mtok). Cache-read dominates, as expected.

| Phase | Fresh in | Cache write | Cache read | Output | Cost |
|-------|---------:|------------:|-----------:|-------:|-----:|
| **1. Find an issue** (start → first fix edit) | 5,913 | 154,742 | 1,224,411 | 20,550 | **~$6.37** |
| **2. Fix it** (edits + build + commit + push) | 424 | 18,670 | 1,649,697 | 9,959 | **~$3.58** |
| **3. Post-fix work** (PR + label + accept + report) | 457 | 4,972 | 492,945 | 3,633 | **~$1.11** |
| **Total** | | | | | **~$11.06** |

Notes:
- The find phase additionally spawned two `Explore` triage subagents (~79K subagent tokens combined) to evaluate/reject S2093 candidates without polluting the main context; that incremental cost is not included in the main-transcript figures above.
- The post-fix figure is a snapshot taken at report time (this section is itself being written), so it slightly understates the true total.
