### PR TITLE
[Misc] Reuse a single SecureRandom instance in PasswordClass

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PasswordClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PasswordClass.java
@@ -72,6 +72,8 @@ public class PasswordClass extends StringClass
     private static final String PASSWORD_FIELD_TYPE = "password";
     private static final String XCLASSNAME = PASSWORD_FIELD_TYPE;
 
+    private static final SecureRandom RANDOM = new SecureRandom();
+
     /**
      * Default constructor with a metaclass.
      * @param wclass the metaclass value.
@@ -333,9 +335,8 @@ public class PasswordClass extends StringClass
     public static String randomSalt()
     {
         StringBuilder salt = new StringBuilder();
-        SecureRandom random = new SecureRandom();
         byte[] bytes = new byte[32];
-        random.nextBytes(bytes);
+        RANDOM.nextBytes(bytes);
         for (byte temp : bytes) {
             String s = Integer.toHexString(Byte.valueOf(temp));
             while (s.length() < 2) {


### PR DESCRIPTION
# Jira URL

N/A — `[Misc]` change, no JIRA issue (SonarCloud cleanup).

# Changes

## Description

Fixes SonarCloud issue [java:S2119](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AZwHNLcaj2W8yC0lSxt3&open=AZwHNLcaj2W8yC0lSxt3) ("Save and re-use this `Random`") in `PasswordClass`.

* `PasswordClass.randomSalt()` created a new `SecureRandom` instance on every invocation. Seeding a fresh `SecureRandom` on each call is unnecessary work.
* Extracted it to a reused `private static final SecureRandom RANDOM` field and use it in `randomSalt()`.

## Clarifications

* `SecureRandom` is thread-safe (its `nextBytes` is synchronized), so a single shared static instance is safe and is exactly the reuse pattern the rule recommends. This does not weaken the salt generation.

# Screenshots & Video

N/A — no UI change.

# Executed Tests

Built the affected module:

```
mvn clean install -pl xwiki-platform-core/xwiki-platform-oldcore -Plegacy,snapshot -Dxwiki.revapi.skip=true -DskipTests
```

→ `BUILD SUCCESS` (checkstyle/Spoon pass).

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches: none

---

## Token usage

Token usage for this automated run, broken down by phase (assistant turns deduped by message id). Cache-read dominates; fresh input/output stay small thanks to narrow reads and delegating candidate triage to a sub-agent.

| Phase | Input | Output | Cache read | Cache write |
|-------|------:|-------:|-----------:|------------:|
| 1. Find an issue | 5,894 | 14,828 | 687,176 | 149,652 |
| 2. Fix it (edit + build + commit + push) | 148 | 2,322 | 740,750 | 3,807 |
| 3. Post-fix work (PR + label + accept + report)\* | 459 | 3,335 | 469,093 | 4,596 |
| **Total** | **6,501** | **20,485** | **1,897,019** | **158,055** |

Approximate cost at standard Opus rates (input $15, output $75, cache-read $1.50, cache-write $18.75 per Mtok): find ≈ $5.0, fix ≈ $1.4, post ≈ $1.1 — **total ≈ $7.5**.

\* The post-fix figure is a mid-phase snapshot captured while generating this report; it excludes the tokens spent writing/uploading this report and recording learnings afterwards.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)