### PR TITLE
XWIKI-24536: Screenshots of tests are saved in configuration-specific subdirectory

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/DockerTestUtils.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/DockerTestUtils.java
@@ -238,7 +238,12 @@ public final class DockerTestUtils
      */
     public static File getScreenshotsDirectory(TestConfiguration testConfiguration)
     {
-        File directory = new File(String.format("%s/screenshots", testConfiguration.getOutputDirectory()));
+        // Save screenshots and videos directly under the Maven build directory (and not under the
+        // configuration-specific output directory returned by getOutputDirectory()) so that they always end up in
+        // "<maven.build.dir>/screenshots". This keeps a stable, predictable location for the CI pipeline that attaches
+        // them to failing tests. The configuration name is still part of the file name (see getResultFileLocation()) so
+        // that artifacts stay unique when Jenkins flattens them during archiving.
+        File directory = new File(String.format("%s/screenshots", testConfiguration.getMavenBuildDirectory()));
         directory.mkdirs();
         return directory;
     }
@@ -279,8 +284,8 @@ public final class DockerTestUtils
         // Note: There's currently a limitation in Jenkins when archiving artifacts: they are copied without caring
         // about their locations. And since we run the same test several times but with different configurations,
         // the test name is not enough to uniquely point to a given test in a given configuration. Thus we also
-        // need to save the configuration name, even though the directory in which we're saving the screenshot
-        // is already named after the executing configuration name.
+        // need to prefix the file name with the configuration name so that artifacts stay unique across
+        // configurations once Jenkins has flattened them.
         File newDir = DockerTestUtils.getScreenshotsDirectory(testConfiguration);
         // Tests could be repeated and if they are we need to compute a file name that takes into account the repetition
         // There seems to be no easy way to get them right now, see https://github.com/junit-team/junit5/issues/1884

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/test/java/org/xwiki/test/docker/internal/junit5/DockerTestUtilsTest.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/test/java/org/xwiki/test/docker/internal/junit5/DockerTestUtilsTest.java
@@ -55,8 +55,7 @@ public class DockerTestUtilsTest
             DockerTestUtilsTest.class.getDeclaredMethod("getResultFileLocation"));
         when(extensionContext.getUniqueId()).thenReturn("...[test-template-invocation:#25]");
 
-        assertEquals("./target/mysql-default-default-tomcat-default-chrome/screenshots/"
-                + "mysql-default-default-tomcat-default-chrome-"
+        assertEquals("./target/screenshots/mysql-default-default-tomcat-default-chrome-"
             + "org.xwiki.test.docker.internal.junit5.DockerTestUtilsTest-getResultFileLocation25.test",
             DockerTestUtils.getResultFileLocation("test", configuration, extensionContext).toString());
     }


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/XWIKI-24536

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Save screenshots in the screenshot directory inside the Maven build directory.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* This also needs an adapted Jenkins pipeline that doesn't test anymore if the subdirectory for the default configuration exists.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

No UI changes.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

Built the changed module with the quality profile.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * stable-18.4.x
  * stable-17.10.x
  * stable-16.10.x