### PR TITLE
[Misc] Don't throw exceptions from a finally block in XarPackage#write

### DIFF
--- a/xwiki-platform-core/xwiki-platform-xar/xwiki-platform-xar-model/src/main/java/org/xwiki/xar/XarPackage.java
+++ b/xwiki-platform-core/xwiki-platform-xar/xwiki-platform-xar-model/src/main/java/org/xwiki/xar/XarPackage.java
@@ -731,7 +731,7 @@ public class XarPackage
             try {
                 writer.close();
             } catch (XMLStreamException e) {
-                LOGGER.warn("Failed to close XML writer: {}", ExceptionUtils.getRootCauseMessage(e));
+                LOGGER.warn("Failed to close XML writer: [{}]", ExceptionUtils.getRootCauseMessage(e));
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-xar/xwiki-platform-xar-model/src/main/java/org/xwiki/xar/XarPackage.java
+++ b/xwiki-platform-core/xwiki-platform-xar/xwiki-platform-xar-model/src/main/java/org/xwiki/xar/XarPackage.java
@@ -44,6 +44,7 @@ import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.apache.commons.io.input.CloseShieldInputStream;
 import org.apache.commons.lang3.LocaleUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Attr;
@@ -730,7 +731,7 @@ public class XarPackage
             try {
                 writer.close();
             } catch (XMLStreamException e) {
-                throw new XarException("Failed to close XML writer", e);
+                LOGGER.warn("Failed to close XML writer: {}", ExceptionUtils.getRootCauseMessage(e));
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes SonarCloud issues:
- [java:S1143 - Remove this throw statement from this finally block](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AW5-S-O11Yj5qvzeRozP&open=AW5-S-O11Yj5qvzeRozP)
- [java:S1163 - Refactor this code to not throw exceptions in finally blocks](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AW5-S-O11Yj5qvzeRozQ&open=AW5-S-O11Yj5qvzeRozQ)

in `XarPackage#write(OutputStream, String)`.

### Problem

The `finally` block closing the `XMLStreamWriter` threw a new `XarException` if `close()` failed.
When the `try` block had already thrown (e.g. "Failed to write XML"), this second throw from
`finally` silently replaced/masked the original exception, hiding the real cause of the failure.

### Fix

Log the close failure with `LOGGER.warn` instead of throwing, following the same pattern already
used elsewhere in the codebase (e.g. `XWikiAttachment#getContentInputStream`) for exactly this
situation.

## Test plan

- [x] `mvn clean install -B -ntp -pl xwiki-platform-core/xwiki-platform-xar/xwiki-platform-xar-model -Plegacy,snapshot` — `BUILD SUCCESS`, 0 Checkstyle violations.

## Token usage report

Approximate LLM token cost for this run, broken down by phase (includes cache reads/writes, which
dominate the total):

| Phase | Input | Output | Cache read | Cache write | Total |
|---|---:|---:|---:|---:|---:|
| 1. Find the issue | 6,937 | 7,190 | 756,175 | 113,066 | ~883K |
| 2. Fix it (edit + build + commit + push) | 291 | 4,203 | 1,137,654 | 11,385 | ~1.15M |
| 3. Post-fix work (PR + label + accept issues + this report)* | 464 | 5,824 | 635,271 | 11,424 | ~653K |

\* Snapshot taken mid-phase (before the final learnings write), so this bucket is a lower bound.
