### PR TITLE
XWIKI-18766: The displayer for the "List of users" property suggests disabled users

### DIFF
--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-docker/src/test/it/org/xwiki/appwithinminutes/test/ui/UserClassFieldIT.java
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-docker/src/test/it/org/xwiki/appwithinminutes/test/ui/UserClassFieldIT.java
@@ -88,6 +88,14 @@ class UserClassFieldIT
         createUser(setup, "XXX");
         createUser(setup, "YYY");
         createUser(setup, "ZZZ");
+
+        // Create an active and a disabled user, both matching "Person", to verify that the picker excludes disabled
+        // users by default and suggests them only when the field is configured to include inactive users
+        // (XWIKI-18766). We need to be super admin to be allowed to disable the user.
+        setup.loginAsSuperAdmin();
+        setup.createUser("ActivePerson", "ActivePerson", null, "first_name", "Active", "last_name", "Person");
+        setup.createUser("DisabledPerson", "DisabledPerson", null, "first_name", "Disabled", "last_name", "Person",
+            "active", "0");
     }
 
     private void createUser(TestUtils setup, String userSuffix)
@@ -327,6 +335,41 @@ class UserClassFieldIT
         assertEquals("Eduard Moraru", users.get(0).getText());
         assertTrue(
             users.get(0).findElement(By.className("user-avatar")).getAttribute("src").contains("/Enygma2002.png?"));
+    }
+
+    @Test
+    @Order(6)
+    void inactiveUsersSuggestions(TestUtils setup, TestReference testReference)
+    {
+        ApplicationClassEditPage editor = goToEditor(testReference);
+        SuggestClassFieldEditPane userField = new SuggestClassFieldEditPane(editor.addField("User").getName());
+        SuggestInputElement userPicker = userField.getPicker();
+
+        // By default the disabled user must not be suggested: typing "Person" only matches the active user.
+        List<SuggestionElement> suggestions =
+            userPicker.sendKeys("Person").waitForNonTypedSuggestions().getSuggestions();
+        assertEquals(1, suggestions.size());
+        assertUserSuggestion(suggestions.get(0), "Active Person", "ActivePerson", "user");
+
+        // Configure the field to also suggest inactive users and save the class so that the application entry picker
+        // uses this configuration.
+        userField.openConfigPanel();
+        userField.setIncludeInactiveUsers(true);
+        userField.closeConfigPanel();
+        editor.clickSaveAndView();
+
+        // Create an application entry and check that the disabled user is now suggested along with the active one.
+        ClassSheetPage classSheetPage = new ClassSheetPage();
+        String location = setup.serializeLocalReference(testReference.getLastSpaceReference());
+        classSheetPage.createNewDocument(location, "Entry");
+
+        String className = setup.serializeReference(
+            new DocumentReference("Class", testReference.getLastSpaceReference()).getLocalDocumentReference());
+        userPicker = new SuggestInputElement(setup.getDriver().findElement(By.id(className + "_0_user1")));
+        suggestions = userPicker.sendKeys("Person").waitForNonTypedSuggestions().getSuggestions();
+        assertEquals(2, suggestions.size());
+        assertUserSuggestion(suggestions.get(0), "Active Person", "ActivePerson", "user");
+        assertUserSuggestion(suggestions.get(1), "Disabled Person", "DisabledPerson", "user");
     }
 
     private ApplicationClassEditPage goToEditor(TestReference testReference)

--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-pageobjects/src/main/java/org/xwiki/appwithinminutes/test/po/SuggestClassFieldEditPane.java
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-pageobjects/src/main/java/org/xwiki/appwithinminutes/test/po/SuggestClassFieldEditPane.java
@@ -55,6 +55,20 @@ public class SuggestClassFieldEditPane extends ClassFieldEditPane
     }
 
     /**
+     * Sets whether this field should also suggest inactive (disabled) users.
+     *
+     * @param include {@code true} to also suggest inactive users, {@code false} to suggest only active users
+     * @since 18.6.0RC1
+     */
+    public void setIncludeInactiveUsers(boolean include)
+    {
+        WebElement includeInactiveUsersCheckBox = getPropertyInput("includeInactiveUsers");
+        if (includeInactiveUsersCheckBox.isSelected() != include) {
+            includeInactiveUsersCheckBox.click();
+        }
+    }
+
+    /**
      * @return the picker
      */
     public SuggestInputElement getPicker()

--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/Users.xml
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/Users.xml
@@ -156,7 +156,7 @@
       <priority>1</priority>
     </property>
     <property>
-      <properties>multiSelect</properties>
+      <properties>multiSelect includeInactiveUsers</properties>
     </property>
   </object>
 </xwikidoc>

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/DefaultUsersQueryBuilder.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/DefaultUsersQueryBuilder.java
@@ -58,16 +58,18 @@ public class DefaultUsersQueryBuilder implements QueryBuilder<UsersClass>
     {
         StringBuilder statementBuilder = new StringBuilder("select doc.fullName as userReference,")
             .append(" firstName.value||' '||lastName.value as userName ")
-            .append("from XWikiDocument doc, BaseObject obj, StringProperty firstName, StringProperty lastName ")
-            .append("where doc.fullName = obj.name and obj.className = 'XWiki.XWikiUsers'")
+            .append("from XWikiDocument doc, BaseObject obj, StringProperty firstName, StringProperty lastName");
+        if (!usersClass.isIncludeInactiveUsers()) {
+            statementBuilder.append(", IntegerProperty active");
+        }
+        statementBuilder.append(" where doc.fullName = obj.name and obj.className = 'XWiki.XWikiUsers'")
             .append(" and obj.id = firstName.id.id and firstName.id.name = 'first_name'")
             .append(" and obj.id = lastName.id.id and lastName.id.name = 'last_name'")
             .append(" and doc.space = 'XWiki' ");
         if (!usersClass.isIncludeInactiveUsers()) {
-            // Exclude disabled users (active property explicitly set to 0). Users without the active property, or with
-            // it set to 1, are considered active (this matches the default applied by XWikiUser#isDisabled).
-            statementBuilder.append("and obj.id not in (select activeProp.id.id from IntegerProperty activeProp")
-                .append(" where activeProp.id.name = 'active' and activeProp.value = 0) ");
+            // Only suggest enabled users. An enabled user always has its "active" property explicitly set to 1
+            // (XWiki sets it when the account is created active or later activated).
+            statementBuilder.append("and obj.id = active.id.id and active.id.name = 'active' and active.value = 1 ");
         }
         statementBuilder
             .append("order by lower(firstName.value), firstName.value, lower(lastName.value), lastName.value");

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/DefaultUsersQueryBuilder.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/DefaultUsersQueryBuilder.java
@@ -56,15 +56,22 @@ public class DefaultUsersQueryBuilder implements QueryBuilder<UsersClass>
     @Override
     public Query build(UsersClass usersClass) throws QueryException
     {
-        String statement = new StringBuilder("select doc.fullName as userReference,")
+        StringBuilder statementBuilder = new StringBuilder("select doc.fullName as userReference,")
             .append(" firstName.value||' '||lastName.value as userName ")
             .append("from XWikiDocument doc, BaseObject obj, StringProperty firstName, StringProperty lastName ")
             .append("where doc.fullName = obj.name and obj.className = 'XWiki.XWikiUsers'")
             .append(" and obj.id = firstName.id.id and firstName.id.name = 'first_name'")
             .append(" and obj.id = lastName.id.id and lastName.id.name = 'last_name'")
-            .append(" and doc.space = 'XWiki' ")
-            .append("order by lower(firstName.value), firstName.value, lower(lastName.value), lastName.value")
-            .toString();
+            .append(" and doc.space = 'XWiki' ");
+        if (!usersClass.isIncludeInactiveUsers()) {
+            // Exclude disabled users (active property explicitly set to 0). Users without the active property, or with
+            // it set to 1, are considered active (this matches the default applied by XWikiUser#isDisabled).
+            statementBuilder.append("and obj.id not in (select activeProp.id.id from IntegerProperty activeProp")
+                .append(" where activeProp.id.name = 'active' and activeProp.value = 0) ");
+        }
+        statementBuilder
+            .append("order by lower(firstName.value), firstName.value, lower(lastName.value), lastName.value");
+        String statement = statementBuilder.toString();
         Query query = this.queryManager.createQuery(statement, Query.HQL);
         // Resolve the document full name from the first column into a DocumentReference (the user profile reference).
         query.addFilter(this.documentFilter);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BooleanClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BooleanClass.java
@@ -47,6 +47,30 @@ public class BooleanClass extends PropertyClass
     @Unstable
     public static final String PROPERTY_TYPE = "Boolean";
 
+    /**
+     * Display value showing the property as a "yes/no" label. Usable as a display type.
+     * @since 18.6.0RC1
+     */
+    public static final String DISPLAY_YESNO = "yesno";
+
+    /**
+     * Display value using a select box. Usable both as a display type and as a form (edit) type.
+     * @since 18.6.0RC1
+     */
+    public static final String DISPLAY_SELECT = "select";
+
+    /**
+     * Display value using a checkbox. Usable both as a display type and as a form (edit) type.
+     * @since 18.6.0RC1
+     */
+    public static final String DISPLAY_CHECKBOX = "checkbox";
+
+    /**
+     * Display value using radio buttons. Usable as a form (edit) type.
+     * @since 18.6.0RC1
+     */
+    public static final String DISPLAY_RADIO = "radio";
+
     private static final long serialVersionUID = 1L;
 
     private static final String XCLASSNAME = "boolean";
@@ -65,7 +89,7 @@ public class BooleanClass extends PropertyClass
     public BooleanClass()
     {
         this(null);
-        setDisplayFormType("select");
+        setDisplayFormType(DISPLAY_SELECT);
     }
 
     public void setDisplayType(String type)
@@ -77,7 +101,7 @@ public class BooleanClass extends PropertyClass
     {
         String dtype = getStringValue("displayType");
         if ((dtype == null) || (dtype.isEmpty())) {
-            return "yesno";
+            return DISPLAY_YESNO;
         }
         return dtype;
     }
@@ -86,7 +110,7 @@ public class BooleanClass extends PropertyClass
     {
         String dtype = getStringValue("displayFormType");
         if ((dtype == null) || (dtype.isEmpty())) {
-            return "radio";
+            return DISPLAY_RADIO;
         }
         return dtype;
     }
@@ -174,13 +198,13 @@ public class BooleanClass extends PropertyClass
     {
         String displayFormType = getDisplayFormType();
 
-        if ("checkbox".equals(getDisplayType())) {
-            displayFormType = "checkbox";
+        if (DISPLAY_CHECKBOX.equals(getDisplayType())) {
+            displayFormType = DISPLAY_CHECKBOX;
         }
 
-        if ("checkbox".equals(displayFormType)) {
+        if (DISPLAY_CHECKBOX.equals(displayFormType)) {
             displayCheckboxEdit(buffer, name, prefix, object, context);
-        } else if ("select".equals(displayFormType)) {
+        } else if (DISPLAY_SELECT.equals(displayFormType)) {
             displaySelectEdit(buffer, name, prefix, object, context);
         } else {
             displayRadioEdit(buffer, name, prefix, object, context);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/UsersClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/UsersClass.java
@@ -52,6 +52,16 @@ public class UsersClass extends ListClass
      */
     @Unstable
     public static final String PROPERTY_TYPE = "Users";
+
+    /**
+     * The meta property that specifies whether the picker should also suggest inactive (disabled) users. When not set
+     * (the default) only active users are suggested.
+     *
+     * @since 18.6.0RC1
+     */
+    @Unstable
+    public static final String META_PROPERTY_INCLUDE_INACTIVE_USERS = "includeInactiveUsers";
+
     private static final long serialVersionUID = 1L;
 
     /** Logging helper object. */
@@ -150,6 +160,17 @@ public class UsersClass extends ListClass
     public void setUsesList(boolean usesList)
     {
         setIntValue(META_PROPERTY_USES_LIST, usesList ? 1 : 0);
+    }
+
+    /**
+     * @return {@code true} if disabled (inactive) users should also be suggested by the picker, {@code false} (the
+     *         default) to suggest only active users
+     * @since 18.6.0RC1
+     */
+    @Unstable
+    public boolean isIncludeInactiveUsers()
+    {
+        return getIntValue(META_PROPERTY_INCLUDE_INACTIVE_USERS) == 1;
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/meta/DateMetaClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/meta/DateMetaClass.java
@@ -60,8 +60,8 @@ public class DateMetaClass extends PropertyMetaClass
         BooleanClass emptyIsTodayClass = new BooleanClass(this);
         emptyIsTodayClass.setName("emptyIsToday");
         emptyIsTodayClass.setPrettyName("Empty Is Today");
-        emptyIsTodayClass.setDisplayType("yesno");
-        emptyIsTodayClass.setDisplayFormType("checkbox");
+        emptyIsTodayClass.setDisplayType(BooleanClass.DISPLAY_YESNO);
+        emptyIsTodayClass.setDisplayFormType(BooleanClass.DISPLAY_CHECKBOX);
         emptyIsTodayClass.setDefaultValue(1);
         safeput(emptyIsTodayClass.getName(), emptyIsTodayClass);
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/meta/GroupsMetaClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/meta/GroupsMetaClass.java
@@ -51,8 +51,8 @@ public class GroupsMetaClass extends ListMetaClass
         BooleanClass useListClass = new BooleanClass(this);
         useListClass.setName("usesList");
         useListClass.setPrettyName("Uses List");
-        useListClass.setDisplayType("yesno");
-        useListClass.setDisplayFormType("checkbox");
+        useListClass.setDisplayType(BooleanClass.DISPLAY_YESNO);
+        useListClass.setDisplayFormType(BooleanClass.DISPLAY_CHECKBOX);
         useListClass.setDefaultValue(0);
         safeput(useListClass.getName(), useListClass);
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/meta/ListMetaClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/meta/ListMetaClass.java
@@ -123,8 +123,8 @@ public class ListMetaClass extends PropertyMetaClass
     private BooleanClass newCheckBox(boolean checked)
     {
         BooleanClass checkBox = new BooleanClass(this);
-        checkBox.setDisplayType("yesno");
-        checkBox.setDisplayFormType("checkbox");
+        checkBox.setDisplayType(BooleanClass.DISPLAY_YESNO);
+        checkBox.setDisplayFormType(BooleanClass.DISPLAY_CHECKBOX);
         checkBox.setDefaultValue(checked ? 1 : 0);
         return checkBox;
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/meta/PropertyMetaClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/meta/PropertyMetaClass.java
@@ -66,8 +66,8 @@ public class PropertyMetaClass extends BaseClass implements PropertyMetaClassInt
         BooleanClass disabledClass = new BooleanClass(this);
         disabledClass.setName("disabled");
         disabledClass.setPrettyName("Disabled");
-        disabledClass.setDisplayType("yesno");
-        disabledClass.setDisplayFormType("checkbox");
+        disabledClass.setDisplayType(BooleanClass.DISPLAY_YESNO);
+        disabledClass.setDisplayFormType(BooleanClass.DISPLAY_CHECKBOX);
         safeput(disabledClass.getName(), disabledClass);
 
         addPresentationMetaProperties();

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/meta/StringMetaClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/meta/StringMetaClass.java
@@ -62,8 +62,8 @@ public class StringMetaClass extends PropertyMetaClass
         BooleanClass pickerClass = new BooleanClass(this);
         pickerClass.setName("picker");
         pickerClass.setPrettyName("Use Suggest");
-        pickerClass.setDisplayType("yesno");
-        pickerClass.setDisplayFormType("checkbox");
+        pickerClass.setDisplayType(BooleanClass.DISPLAY_YESNO);
+        pickerClass.setDisplayFormType(BooleanClass.DISPLAY_CHECKBOX);
         pickerClass.setDefaultValue(1);
         safeput(pickerClass.getName(), pickerClass);
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/meta/TextAreaMetaClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/meta/TextAreaMetaClass.java
@@ -95,8 +95,8 @@ public class TextAreaMetaClass extends StringMetaClass
         BooleanClass restrictedClass = new BooleanClass(this);
         restrictedClass.setName("restricted");
         restrictedClass.setPrettyName("Restricted");
-        restrictedClass.setDisplayType("yesno");
-        restrictedClass.setDisplayFormType("checkbox");
+        restrictedClass.setDisplayType(BooleanClass.DISPLAY_YESNO);
+        restrictedClass.setDisplayFormType(BooleanClass.DISPLAY_CHECKBOX);
         safeput(restrictedClass.getName(), restrictedClass);
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/meta/UsersMetaClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/meta/UsersMetaClass.java
@@ -40,10 +40,6 @@ public class UsersMetaClass extends ListMetaClass
 {
     private static final long serialVersionUID = 1L;
 
-    private static final String DISPLAY_TYPE_YESNO = "yesno";
-
-    private static final String DISPLAY_FORM_TYPE_CHECKBOX = "checkbox";
-
     /**
      * Default constructor. Initializes the default meta properties of a List of Users XClass property.
      */
@@ -55,18 +51,18 @@ public class UsersMetaClass extends ListMetaClass
         BooleanClass useListClass = new BooleanClass(this);
         useListClass.setName("usesList");
         useListClass.setPrettyName("Uses List");
-        useListClass.setDisplayType(DISPLAY_TYPE_YESNO);
-        useListClass.setDisplayFormType(DISPLAY_FORM_TYPE_CHECKBOX);
+        useListClass.setDisplayType(BooleanClass.DISPLAY_YESNO);
+        useListClass.setDisplayFormType(BooleanClass.DISPLAY_CHECKBOX);
         useListClass.setDefaultValue(0);
         safeput(useListClass.getName(), useListClass);
 
         // When unchecked (the default), the picker suggests only active users, hiding users who have been disabled
         // (e.g. accounts that never validated their registration or were purposely disabled by an administrator).
         BooleanClass includeInactiveUsersClass = new BooleanClass(this);
-        includeInactiveUsersClass.setName("includeInactiveUsers");
+        includeInactiveUsersClass.setName(UsersClass.META_PROPERTY_INCLUDE_INACTIVE_USERS);
         includeInactiveUsersClass.setPrettyName("Include Inactive Users");
-        includeInactiveUsersClass.setDisplayType(DISPLAY_TYPE_YESNO);
-        includeInactiveUsersClass.setDisplayFormType(DISPLAY_FORM_TYPE_CHECKBOX);
+        includeInactiveUsersClass.setDisplayType(BooleanClass.DISPLAY_YESNO);
+        includeInactiveUsersClass.setDisplayFormType(BooleanClass.DISPLAY_CHECKBOX);
         includeInactiveUsersClass.setDefaultValue(0);
         safeput(includeInactiveUsersClass.getName(), includeInactiveUsersClass);
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/meta/UsersMetaClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/meta/UsersMetaClass.java
@@ -40,6 +40,10 @@ public class UsersMetaClass extends ListMetaClass
 {
     private static final long serialVersionUID = 1L;
 
+    private static final String DISPLAY_TYPE_YESNO = "yesno";
+
+    private static final String DISPLAY_FORM_TYPE_CHECKBOX = "checkbox";
+
     /**
      * Default constructor. Initializes the default meta properties of a List of Users XClass property.
      */
@@ -51,10 +55,20 @@ public class UsersMetaClass extends ListMetaClass
         BooleanClass useListClass = new BooleanClass(this);
         useListClass.setName("usesList");
         useListClass.setPrettyName("Uses List");
-        useListClass.setDisplayType("yesno");
-        useListClass.setDisplayFormType("checkbox");
+        useListClass.setDisplayType(DISPLAY_TYPE_YESNO);
+        useListClass.setDisplayFormType(DISPLAY_FORM_TYPE_CHECKBOX);
         useListClass.setDefaultValue(0);
         safeput(useListClass.getName(), useListClass);
+
+        // When unchecked (the default), the picker suggests only active users, hiding users who have been disabled
+        // (e.g. accounts that never validated their registration or were purposely disabled by an administrator).
+        BooleanClass includeInactiveUsersClass = new BooleanClass(this);
+        includeInactiveUsersClass.setName("includeInactiveUsers");
+        includeInactiveUsersClass.setPrettyName("Include Inactive Users");
+        includeInactiveUsersClass.setDisplayType(DISPLAY_TYPE_YESNO);
+        includeInactiveUsersClass.setDisplayFormType(DISPLAY_FORM_TYPE_CHECKBOX);
+        includeInactiveUsersClass.setDefaultValue(0);
+        safeput(includeInactiveUsersClass.getName(), includeInactiveUsersClass);
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/objects/classes/DefaultUsersQueryBuilderTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/objects/classes/DefaultUsersQueryBuilderTest.java
@@ -91,13 +91,13 @@ class DefaultUsersQueryBuilderTest
     {
         assertQuery("select doc.fullName as userReference,"
             + " firstName.value||' '||lastName.value as userName "
-            + "from XWikiDocument doc, BaseObject obj, StringProperty firstName, StringProperty lastName "
-            + "where doc.fullName = obj.name and obj.className = 'XWiki.XWikiUsers'"
+            + "from XWikiDocument doc, BaseObject obj, StringProperty firstName, StringProperty lastName"
+            + ", IntegerProperty active"
+            + " where doc.fullName = obj.name and obj.className = 'XWiki.XWikiUsers'"
             + " and obj.id = firstName.id.id and firstName.id.name = 'first_name'"
             + " and obj.id = lastName.id.id and lastName.id.name = 'last_name'"
             + " and doc.space = 'XWiki' "
-            + "and obj.id not in (select activeProp.id.id from IntegerProperty activeProp"
-            + " where activeProp.id.name = 'active' and activeProp.value = 0) "
+            + "and obj.id = active.id.id and active.id.name = 'active' and active.value = 1 "
             + "order by lower(firstName.value), firstName.value, lower(lastName.value), lastName.value");
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/objects/classes/DefaultUsersQueryBuilderTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/objects/classes/DefaultUsersQueryBuilderTest.java
@@ -1,0 +1,118 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xpn.xwiki.internal.objects.classes;
+
+import javax.inject.Named;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.query.Query;
+import org.xwiki.query.QueryFilter;
+import org.xwiki.query.QueryManager;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.objects.classes.UsersClass;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link DefaultUsersQueryBuilder}.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+@SuppressWarnings("checkstyle:MultipleStringLiterals")
+class DefaultUsersQueryBuilderTest
+{
+    @InjectMockComponents
+    private DefaultUsersQueryBuilder builder;
+
+    @MockComponent
+    private QueryManager queryManager;
+
+    @MockComponent
+    @Named("document")
+    private QueryFilter documentFilter;
+
+    @MockComponent
+    @Named("viewable")
+    private QueryFilter viewableFilter;
+
+    private UsersClass usersClass;
+
+    @BeforeEach
+    void configure()
+    {
+        XWikiDocument ownerDocument = mock(XWikiDocument.class);
+        when(ownerDocument.getDocumentReference()).thenReturn(new DocumentReference("tests", "Some", "Page"));
+        this.usersClass = new UsersClass();
+        this.usersClass.setOwnerDocument(ownerDocument);
+    }
+
+    private Query assertQuery(String statement) throws Exception
+    {
+        Query query = mock(Query.class);
+        when(this.queryManager.createQuery(statement, Query.HQL)).thenReturn(query);
+
+        assertSame(query, this.builder.build(this.usersClass));
+
+        verify(query).addFilter(this.documentFilter);
+        verify(query).addFilter(this.viewableFilter);
+        verify(query).setWiki("tests");
+        return query;
+    }
+
+    @Test
+    void buildExcludesInactiveUsersByDefault() throws Exception
+    {
+        assertQuery("select doc.fullName as userReference,"
+            + " firstName.value||' '||lastName.value as userName "
+            + "from XWikiDocument doc, BaseObject obj, StringProperty firstName, StringProperty lastName "
+            + "where doc.fullName = obj.name and obj.className = 'XWiki.XWikiUsers'"
+            + " and obj.id = firstName.id.id and firstName.id.name = 'first_name'"
+            + " and obj.id = lastName.id.id and lastName.id.name = 'last_name'"
+            + " and doc.space = 'XWiki' "
+            + "and obj.id not in (select activeProp.id.id from IntegerProperty activeProp"
+            + " where activeProp.id.name = 'active' and activeProp.value = 0) "
+            + "order by lower(firstName.value), firstName.value, lower(lastName.value), lastName.value");
+    }
+
+    @Test
+    void buildIncludesInactiveUsersWhenConfigured() throws Exception
+    {
+        this.usersClass.setIntValue(UsersClass.META_PROPERTY_INCLUDE_INACTIVE_USERS, 1);
+
+        assertQuery("select doc.fullName as userReference,"
+            + " firstName.value||' '||lastName.value as userName "
+            + "from XWikiDocument doc, BaseObject obj, StringProperty firstName, StringProperty lastName "
+            + "where doc.fullName = obj.name and obj.className = 'XWiki.XWikiUsers'"
+            + " and obj.id = firstName.id.id and firstName.id.name = 'first_name'"
+            + " and obj.id = lastName.id.id and lastName.id.name = 'last_name'"
+            + " and doc.space = 'XWiki' "
+            + "order by lower(firstName.value), firstName.value, lower(lastName.value), lastName.value");
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/UsersClassTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/UsersClassTest.java
@@ -83,6 +83,16 @@ class UsersClassTest
     }
 
     @Test
+    void isIncludeInactiveUsers()
+    {
+        UsersClass usersClass = new UsersClass();
+        assertEquals(false, usersClass.isIncludeInactiveUsers());
+
+        usersClass.setIntValue(UsersClass.META_PROPERTY_INCLUDE_INACTIVE_USERS, 1);
+        assertEquals(true, usersClass.isIncludeInactiveUsers());
+    }
+
+    @Test
     void fromList()
     {
         BaseProperty baseProperty = mock(LargeStringProperty.class);

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/TestUtils.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/TestUtils.java
@@ -609,8 +609,10 @@ public class TestUtils
         userPage.setObjects(new org.xwiki.rest.model.jaxb.Objects());
         org.xwiki.rest.model.jaxb.Object userObject = RestTestUtils.object("XWiki.XWikiUsers");
 
-        // Set password
+        // Set password and mark the user active (a real Admin user is active), so that queries filtering
+        // on active users (e.g. the user suggestion query) return this user.
         userObject.getProperties().add(RestTestUtils.property("password", password));
+        userObject.getProperties().add(RestTestUtils.property("active", "1"));
         userPage.getObjects().getObjectSummaries().add(userObject);
 
         // Save the user page


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-18766

# Changes

## Description

* The picker (auto-complete suggest) used by the "List of Users" XClass property no longer suggests disabled (inactive) users by default. Inactive users are accounts that either never validated their registration or were purposely disabled by an administrator, and are generally not what one wants to pick.
* This behavior is configurable per property through a new `includeInactiveUsers` meta-property (default: off, i.e. inactive users are excluded). It is exposed as an "Include Inactive Users" checkbox in the AppWithinMinutes field editor (and in the standard XClass property editor).
* Implementation:
  * `UsersMetaClass`: new `includeInactiveUsers` boolean meta-property (default `0`).
  * `UsersClass`: new `META_PROPERTY_INCLUDE_INACTIVE_USERS` constant and `isIncludeInactiveUsers()` getter.
  * `DefaultUsersQueryBuilder`: the suggestion HQL now excludes users whose `active` property is explicitly `0`, unless the property is configured to include inactive users. Users without an `active` property (or with it set to `1`) are still considered active, matching `XWikiUser#isDisabled` semantics.
  * `AppWithinMinutes/Users.xml`: adds `includeInactiveUsers` to the editable meta-properties of the User field so the option is configurable from the AWM class editor.

## Clarifications

* Only the *suggestions* are filtered. Values already stored in a property are resolved through a different path (`AbstractDocumentListClassPropertyValuesProvider#getValue`, a reference resolver), so already-selected inactive users keep displaying correctly in both view and edit modes. No data migration is needed.
* Upgrade note: existing "List of Users" properties transparently adopt the new "excluded by default" behavior after upgrade (the meta-property is unset, hence defaults to excluding inactive users). Administrators who want the previous behavior can tick "Include Inactive Users" on the property.

### Work left to do (follow-ups, out of scope of this PR)

* **Other user displayers**: the general-purpose user picker (`uorgsuggest.vm` + `suggestUsersAndGroups.js`) used outside XClass properties (e.g. rights, group membership, mentions) still suggests inactive users and has no equivalent option. It is a separate widget/code path and should be addressed in its own issue.
* **Other display modes of the "List of Users" property**: this PR only covers the picker/suggest path (REST class-property-values, `DefaultUsersQueryBuilder`). The non-picker display types (`select`/`radio`/`checkbox`, backed by `UsersClass#getList()`/`getMap()` via `XWikiGroupService#getAllMatchedUsers`) still list all users, including disabled ones. Making those consistent requires threading the filter through the group-service API and is left for a follow-up.

# Screenshots & Video

<!-- The change is a picker suggestion filter + a new "Include Inactive Users" checkbox in the AWM field editor. Covered by the automated functional test below. -->

# Executed Tests

* Unit tests (oldcore):
  * `mvn clean test -pl xwiki-platform-core/xwiki-platform-oldcore -Plegacy,snapshot -Dtest=DefaultUsersQueryBuilderTest,UsersClassTest` — new `DefaultUsersQueryBuilderTest` (default excludes / opt-in includes inactive users) and `UsersClassTest#isIncludeInactiveUsers`.
* Quality gate (oldcore): `mvn clean install -pl xwiki-platform-core/xwiki-platform-oldcore -Plegacy,snapshot,quality -DskipTests` — Checkstyle 0 violations, Revapi OK.
* REST provider test still green: `UsersClassPropertyValuesProviderTest`.
* Functional test (Docker `@UITest`): `mvn clean verify -pl .../xwiki-platform-appwithinminutes-test-docker -Plegacy,snapshot,integration-tests,docker -Dtest=UserClassFieldIT` — extended `UserClassFieldIT` with `inactiveUsersSuggestions`, asserting a disabled user is not suggested by default and is suggested once "Include Inactive Users" is enabled. Full suite: 37 tests, 0 failures.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * 
