### PR TITLE
XWIKI-24476: The create user modal doesn't confirm when pressing the enter key

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminUsersSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminUsersSheet.xml
@@ -149,7 +149,7 @@
           &lt;button type="button" class="btn btn-default" data-dismiss="modal"&gt;
             $escapetool.xml($services.localization.render('cancel'))
           &lt;/button&gt;
-          &lt;button type="button" class="btn btn-primary" disabled="disabled"&gt;
+          &lt;button type="submit" class="btn btn-primary" form="register" disabled="disabled"&gt;
             $escapetool.xml($services.localization.render('create'))
           &lt;/button&gt;
         &lt;/div&gt;
@@ -467,12 +467,13 @@ require(['jquery', 'xwiki-meta', 'xwiki-livedata-modal', 'xwiki-events-bridge'],
       createUserForm.find(':input').filter(':visible').first().focus();
       createUserButton.prop('disabled', !createUserForm.length);
     });
-  }).on('click', '.btn-primary', function(event) {
+  }).on('submit', 'form#register', function(event) {
+    event.preventDefault();
     var createUserForm = createUserModal.find('form#register');
     if (!validateCreateUserForm(createUserForm)) {
       return;
     }
-    var createUserButton = $(this).prop('disabled', true);
+    var createUserButton = createUserModal.find('.btn-primary').prop('disabled', true);
     var notification = new XWiki.widgets.Notification(
       $jsontool.serialize($services.localization.render('xe.admin.users.create.inProgress')),
       'inprogress'


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-24476

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Updated the button and the event listener on the form

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* We need to use the `form` attribute on the button so that it submits the register form even though it's in the page footer.
* We update the event listener so that validation and proper submission follows however we try to submit the form. Before that, the button use was pretty much hardcoded in.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
Here is the change in action in the register form for a guest user:

https://github.com/user-attachments/assets/1d395d5e-5503-4b7e-8ced-56ba62747105


# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Manual check: Enter now submits the create-user form (blocked + validation messages on missing fields, submits and closes modal when valid); clicking "Create" still works as before.
Built and passed the tests successfully with:
* `mvn clean verify -pl xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui`
* `mvn clean verify -pl xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker -Pintegration-tests,docker -Dit.test=RegisterIT` 


# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * NA