### PR TITLE
XWIKI-24464: The edit group modal is hard to close from the keyboard

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminGroupsSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminGroupsSheet.xml
@@ -39,7 +39,7 @@
   <content>{{velocity output="false"}}
 #macro (createGroupModal)
   &lt;div class="modal" id="createGroupModal" tabindex="-1" role="dialog"
-      aria-labelledby="createGroupModal-label" data-backdrop="static" data-keyboard="false"&gt;
+      aria-labelledby="createGroupModal-label" data-backdrop="static"&gt;
     &lt;div class="modal-dialog" role="document"&gt;
       &lt;form class="modal-content xform"&gt;
         &lt;div class="modal-header"&gt;
@@ -86,7 +86,7 @@
 
 #macro (editGroupModal)
   &lt;div class="modal" id="editGroupModal" tabindex="-1" role="dialog" aria-labelledby="editGroupModal-label"
-      data-backdrop="static" data-keyboard="false" data-live-data="#groupstable" data-live-data-action="edit"&gt;
+      data-backdrop="static" data-live-data="#groupstable" data-live-data-action="edit"&gt;
     &lt;div class="modal-dialog" role="document"&gt;
       &lt;div class="modal-content"&gt;
         &lt;div class="modal-header"&gt;

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminUsersSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/main/resources/XWiki/AdminUsersSheet.xml
@@ -133,7 +133,7 @@
 
 #macro (createUserModal)
   &lt;div class="modal" id="createUserModal" tabindex="-1" role="dialog" aria-labelledby="createUserModal-label"
-      data-backdrop="static" data-keyboard="false"&gt;
+      data-backdrop="static"&gt;
     &lt;div class="modal-dialog" role="document"&gt;
       &lt;div class="modal-content"&gt;
         &lt;div class="modal-header"&gt;
@@ -160,7 +160,7 @@
 
 #macro (editUserModal)
   &lt;div class="modal" id="editUserModal" tabindex="-1" role="dialog" aria-labelledby="editUserModal-label"
-      data-backdrop="static" data-keyboard="false" data-live-data="#userstable" data-live-data-action="edit"&gt;
+      data-backdrop="static" data-live-data="#userstable" data-live-data-action="edit"&gt;
     &lt;div class="modal-dialog modal-lg" role="document"&gt;
       &lt;div class="modal-content"&gt;
         &lt;div class="modal-header"&gt;

--- a/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/LiveTableViewSheet.xml
+++ b/xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui/src/main/resources/AppWithinMinutes/LiveTableViewSheet.xml
@@ -150,7 +150,7 @@
 
 #macro (renameAppModal)
   &lt;div class="modal" id="renameAppModal" tabindex="-1" role="dialog" aria-labelledby="renameAppModal-label"
-      data-backdrop="static" data-keyboard="false"&gt;
+      data-backdrop="static"&gt;
     &lt;div class="modal-dialog" role="document"&gt;
       &lt;form class="modal-content xform"&gt;
         ## The fieldset allows us to disable and enable the entire form quickly and easy.

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-ui/src/main/resources/XWiki/EntityNameValidation/Administration.xml
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-ui/src/main/resources/XWiki/EntityNameValidation/Administration.xml
@@ -50,7 +50,7 @@
 
 #macro (createReplacementCharacterModal)
   &lt;div class="modal" id="createReplacementCharacterModal" tabindex="-1" role="dialog" aria-labelledby="createReplacementCharacterModal-label"
-      data-backdrop="static" data-keyboard="false"&gt;
+      data-backdrop="static"&gt;
     &lt;div class="modal-dialog" role="document"&gt;
       &lt;div class="modal-content"&gt;
         &lt;div class="modal-header"&gt;
@@ -96,7 +96,7 @@
 
 #macro (removeReplacementCharacterModal)
   &lt;div class="modal" id="removeReplacementCharacterModal" tabindex="-1" role="dialog" aria-labelledby="removeReplacementCharacterModal-label"
-      data-backdrop="static" data-keyboard="false"&gt;
+      data-backdrop="static"&gt;
     &lt;div class="modal-dialog" role="document"&gt;
       &lt;div class="modal-content"&gt;
         &lt;div class="modal-header"&gt;


### PR DESCRIPTION


# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-24464

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
* Removed the `data-keyboard=false` from the modals

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* Fixed six more modals to make sure the fix for this issue is applied consistently across our codebase.
* The logic behind this behaviour was done in bootstrap. I left it in our fork because it's still used at least once in the codebase (see https://github.com/xwiki/xwiki-platform/blob/e4988dc0d381d3f1fc99637578898cbbabb4af63/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-webjar/src/main/webjar/resource/entityResourcePicker.js#L151-L155) and probably in a few extensions and some more customizations.
* I looked for discussions about this feature and couldn't find anything. This was probably an undiscussed choice and nowadays it hurts more than it helps. That's why I think it's alright to revert this decision without a proposal.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

None.

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Tested the change manually on my local instance.
Built the changes successfully with:
`mvn -pl xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui,xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-ui,xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-ui install`
Ran docker tests successfully with:
`cd xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker && mvn verify -Pdocker -Dit.test=UsersGroupsRightsManagementIT`

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A