### PR TITLE
[stable-17.10.x] XWIKI-18672: Add automated test for "Change Default Editor"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/AllIT.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/AllIT.java
@@ -75,4 +75,9 @@ public class AllIT
     class NestedUserEditIT extends UserEditIT
     {
     }
+
+    @Nested
+    class NestedEditingIT extends EditingIT
+    {
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/EditingIT.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/EditingIT.java
@@ -1,0 +1,89 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.administration.test.ui;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.xwiki.administration.test.po.EditingAdministrationSectionPage;
+import org.xwiki.test.docker.junit5.TestReference;
+import org.xwiki.test.docker.junit5.UITest;
+import org.xwiki.test.ui.TestUtils;
+import org.xwiki.test.ui.po.editor.EditPage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Validate the Editing section of the Administration application, and in particular that changing the wiki-level
+ * default editor controls which editor is used when editing a page.
+ *
+ * @version $Id$
+ * @since 18.5.0RC1
+ */
+@UITest
+class EditingIT
+{
+    private String initialDefaultEditor;
+
+    @BeforeAll
+    void beforeAll(TestUtils setup)
+    {
+        setup.loginAsSuperAdmin();
+        // Remember the configured default editor so that we can restore it after the test.
+        this.initialDefaultEditor = EditingAdministrationSectionPage.gotoPage().getDefaultEditor();
+    }
+
+    @AfterAll
+    void afterAll(TestUtils setup)
+    {
+        // Restore the default editor to its initial value so that other tests are not affected.
+        setup.loginAsSuperAdmin();
+        EditingAdministrationSectionPage.gotoPage().setDefaultEditor(this.initialDefaultEditor);
+    }
+
+    /**
+     * Validate that changing the default editor in the Editing administration section controls the editor used when
+     * editing a page. See XWIKI-18672.
+     */
+    @Test
+    @Order(1)
+    void changeDefaultEditor(TestUtils setup, TestReference testReference)
+    {
+        // Create the page used to verify which editor is loaded by default.
+        setup.createPage(testReference, "");
+
+        // Set the default editor to Text (i.e. the Wiki editor) and verify that the Wiki editor is loaded instead.
+        EditingAdministrationSectionPage editingSection = EditingAdministrationSectionPage.gotoPage();
+        editingSection.setDefaultEditor("Text");
+        assertEquals("Text", editingSection.getDefaultEditor());
+
+        setup.gotoPage(testReference, "edit");
+        assertEquals(EditPage.Editor.WIKI, new EditPage().getEditor());
+
+        // Set the default editor to WYSIWYG and verify that the WYSIWYG editor is loaded when editing the page.
+        editingSection = EditingAdministrationSectionPage.gotoPage();
+        editingSection.setDefaultEditor("Wysiwyg");
+        assertEquals("Wysiwyg", editingSection.getDefaultEditor());
+
+        setup.gotoPage(testReference, "edit");
+        assertEquals(EditPage.Editor.WYSIWYG, new EditPage().getEditor());
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/EditingAdministrationSectionPage.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/EditingAdministrationSectionPage.java
@@ -28,6 +28,8 @@ import org.xwiki.test.ui.po.Select;
  * default edit mode used when editing a page) can be configured.
  *
  * @version $Id$
+ * @since 17.10.10
+ * @since 18.4.3
  * @since 18.5.0RC1
  */
 public class EditingAdministrationSectionPage extends AdministrationSectionPage

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/EditingAdministrationSectionPage.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/EditingAdministrationSectionPage.java
@@ -1,0 +1,88 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.administration.test.po;
+
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.xwiki.test.ui.po.Select;
+
+/**
+ * Represents the actions possible on the Editing administration section, where the wiki-level default editor (the
+ * default edit mode used when editing a page) can be configured.
+ *
+ * @version $Id$
+ * @since 18.5.0RC1
+ */
+public class EditingAdministrationSectionPage extends AdministrationSectionPage
+{
+    private static final String SECTION_ID = "Editing";
+
+    /**
+     * The dropdown used to select the default editor (i.e. the default edit mode). The empty value means "Default",
+     * "Text" means the Wiki editor, and "Wysiwyg" means the WYSIWYG editor.
+     */
+    @FindBy(name = "XWiki.XWikiPreferences_0_editor")
+    private WebElement defaultEditorSelect;
+
+    /**
+     * Open the Editing administration section.
+     *
+     * @return the Editing administration section
+     */
+    public static EditingAdministrationSectionPage gotoPage()
+    {
+        AdministrationSectionPage.gotoPage(SECTION_ID);
+        return new EditingAdministrationSectionPage();
+    }
+
+    public EditingAdministrationSectionPage()
+    {
+        super(SECTION_ID);
+    }
+
+    /**
+     * @return the dropdown element used to select the default editor
+     */
+    public Select getDefaultEditorSelect()
+    {
+        return new Select(this.defaultEditorSelect);
+    }
+
+    /**
+     * Set the default editor and save the changes.
+     *
+     * @param value the value of the editor to select ({@code ""} for "Default", {@code "Text"} for the Wiki editor and
+     *            {@code "Wysiwyg"} for the WYSIWYG editor)
+     */
+    public void setDefaultEditor(String value)
+    {
+        getDefaultEditorSelect().selectByValue(value);
+        clickSave();
+    }
+
+    /**
+     * @return the value of the currently selected default editor ({@code ""} for "Default", {@code "Text"} for the Wiki
+     *         editor and {@code "Wysiwyg"} for the WYSIWYG editor)
+     */
+    public String getDefaultEditor()
+    {
+        return getDefaultEditorSelect().getFirstSelectedOption().getAttribute("value");
+    }
+}


### PR DESCRIPTION
Backport of XWIKI-18672 to stable-17.10.x.

Cherry-picked from master (git cherry-pick -x):
- a83ba1d8a5d XWIKI-18672: Add automated test for "Change Default Editor"

The test was added on master (18.5.0) but was missing from this branch.