### PR TITLE
[stable-17.10.x] XWIKI-23960: Add automated test for "Copy a page by preserving children"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/CopyPageIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/CopyPageIT.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.xwiki.flamingo.skin.test.po.AttachmentsPane;
 import org.xwiki.flamingo.skin.test.po.AttachmentsViewPage;
@@ -238,5 +239,55 @@ class CopyPageIT
         // Verify that the title of the copy has been updated (independent from the name of the copy).
         assertEquals("My copy", viewPage.getDocumentTitle());
         assertEquals(PAGE_CONTENT, viewPage.getContent());
+    }
+
+    @Test
+    void copyPagePreservingChildren(TestUtils setup) throws Exception
+    {
+        String sourceSpaceName = "CopyWithChildren";
+        String childSpaceName = "ChildSpace";
+        String targetSpaceName = "CopyWithChildrenCopy";
+
+        DocumentReference sourceReference = new DocumentReference("xwiki", sourceSpaceName, "WebHome");
+        DocumentReference childReference =
+            new DocumentReference("xwiki", Arrays.asList(sourceSpaceName, childSpaceName), "WebHome");
+        DocumentReference targetReference = new DocumentReference("xwiki", targetSpaceName, "WebHome");
+        DocumentReference targetChildReference =
+            new DocumentReference("xwiki", Arrays.asList(targetSpaceName, childSpaceName), "WebHome");
+
+        // Clean-up: delete pages that may already exist
+        setup.rest().delete(sourceReference);
+        setup.rest().delete(childReference);
+        setup.rest().delete(targetReference);
+        setup.rest().delete(targetChildReference);
+
+        // Create the parent and child source pages
+        setup.rest().savePage(sourceReference, PAGE_CONTENT, "Source");
+        setup.rest().savePage(childReference, PAGE_CONTENT, "Child");
+
+        // Navigate to the source page and start the copy
+        ViewPage viewPage = setup.gotoPage(sourceReference);
+        viewPage.copy();
+        CopyPage copyPage = new CopyPage();
+
+        // Verify that the preserve children checkbox is present and checked by default
+        assertTrue(copyPage.isDeepCopy());
+
+        // Set the target space name
+        copyPage.getDocumentPicker().toggleLocationAdvancedEdit().setName(targetSpaceName);
+
+        // Click copy button and wait for completion
+        CopyOrRenameOrDeleteStatusPage copyStatusPage = copyPage.clickCopyButton().waitUntilFinished();
+
+        // Check successful copy confirmation
+        assertEquals(COPY_SUCCESSFUL, copyStatusPage.getInfoMessage());
+
+        // Verify the parent page was copied
+        assertTrue(setup.pageExists(Arrays.asList(targetSpaceName), "WebHome"),
+            String.format("Target page [%s.WebHome] should have been copied", targetSpaceName));
+
+        // Verify the child page was preserved during the copy
+        assertTrue(setup.pageExists(Arrays.asList(targetSpaceName, childSpaceName), "WebHome"),
+            String.format("Child page [%s.%s.WebHome] should have been copied", targetSpaceName, childSpaceName));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/CopyPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/CopyPage.java
@@ -68,6 +68,9 @@ public class CopyPage extends ViewPage
     @FindBy(xpath = "//input[@type='checkbox' and @name = 'terminal']")
     private WebElement terminalCheckbox;
 
+    @FindBy(xpath = "//input[@type='checkbox' and @name = 'deep']")
+    private WebElement deepCheckbox;
+
     /**
      * @return the breadcrumb that specified the location of the source document
      * @since 7.2M3
@@ -129,6 +132,28 @@ public class CopyPage extends ViewPage
     public boolean isTerminal()
     {
         return this.terminalCheckbox.isSelected();
+    }
+
+    /**
+     * @return {@code true} if the checkbox for preserving children during copy is checked.
+     * @since 17.4.0RC1
+     */
+    public boolean isDeepCopy()
+    {
+        return this.deepCheckbox.isSelected();
+    }
+
+    /**
+     * Sets whether children should be preserved during copy.
+     *
+     * @param deep {@code true} to preserve children, {@code false} otherwise
+     * @since 17.4.0RC1
+     */
+    public void setDeepCopy(boolean deep)
+    {
+        if (deep != isDeepCopy()) {
+            this.deepCheckbox.click();
+        }
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/CopyPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/CopyPage.java
@@ -137,6 +137,7 @@ public class CopyPage extends ViewPage
     /**
      * @return {@code true} if the checkbox for preserving children during copy is checked.
      * @since 17.4.0RC1
+     * @since 17.10.10
      */
     public boolean isDeepCopy()
     {
@@ -148,6 +149,7 @@ public class CopyPage extends ViewPage
      *
      * @param deep {@code true} to preserve children, {@code false} otherwise
      * @since 17.4.0RC1
+     * @since 17.10.10
      */
     public void setDeepCopy(boolean deep)
     {


### PR DESCRIPTION
Backport of XWIKI-23960 to stable-17.10.x.

Cherry-picked from master (git cherry-pick -x):
afca1718baa XWIKI-23960: Add automated test for "Copy a page by preserving children"