### PR TITLE
[stable-17.10.x] XWIKI-18772: Add automated test for "Disable Version Summaries"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/EditIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/EditIT.java
@@ -72,16 +72,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
         "xwikiPropertiesAdditionalProperties=test.prchecker.excludePattern=.*:Test\\.XWikiConfigurationPageForTest"
     }
 )
-public class EditIT
+class EditIT
 {
     @BeforeAll
-    public void setup(TestUtils setup)
+    void setup(TestUtils setup)
     {
         setup.loginAsSuperAdmin();
     }
 
     @AfterEach
-    public void tearDown(TestUtils setup, LogCaptureConfiguration logCaptureConfiguration)
+    void tearDown(TestUtils setup, LogCaptureConfiguration logCaptureConfiguration)
     {
         logCaptureConfiguration.registerExpected("Secret CSRF token verification failed");
 
@@ -102,7 +102,7 @@ public class EditIT
      */
     @Test
     @Order(1)
-    public void showAndHideEditComments(TestUtils setup, TestReference reference) throws Exception
+    void showAndHideEditComments(TestUtils setup, TestReference reference) throws Exception
     {
         ViewPage vp = setup.gotoPage(reference);
 
@@ -121,6 +121,17 @@ public class EditIT
         } finally {
             setup.setPropertyInXWikiCfg("xwiki.editcomment.hidden=0");
         }
+
+        // Verify that disabling the version summary feature from Administration (Editing > Edit Mode,
+        // "Enable Version Summaries" = No, i.e. the "editcomment" wiki preference) removes the field entirely.
+        try {
+            setup.setWikiPreference("editcomment", "0");
+            vp = setup.gotoPage(reference);
+            wep = vp.editWiki();
+            assertFalse(wep.hasEditComment());
+        } finally {
+            setup.setWikiPreference("editcomment", "1");
+        }
     }
 
     /**
@@ -128,7 +139,7 @@ public class EditIT
      */
     @Test
     @Order(2)
-    public void minorEdit(TestUtils setup, TestReference reference) throws Exception
+    void minorEdit(TestUtils setup, TestReference reference) throws Exception
     {
         setup.deletePage(reference);
         ViewPage vp = setup.gotoPage(reference);
@@ -188,7 +199,7 @@ public class EditIT
      */
     @Test
     @Order(3)
-    public void emptyDocumentContentIsAllowed(TestUtils setup, TestReference reference)
+    void emptyDocumentContentIsAllowed(TestUtils setup, TestReference reference)
     {
         setup.deletePage(reference);
         setup.createPage(reference, "this is some content", "EmptyContentAllowed");
@@ -203,7 +214,7 @@ public class EditIT
 
     @Test
     @Order(4)
-    public void emptyLineAndSpaceCharactersBeforeSectionTitleIsNotRemoved(TestUtils setup, TestReference reference)
+    void emptyLineAndSpaceCharactersBeforeSectionTitleIsNotRemoved(TestUtils setup, TestReference reference)
     {
         setup.deletePage(reference);
         String content = "\n== Section ==\n\ntext";
@@ -215,7 +226,7 @@ public class EditIT
 
     @Test
     @Order(5)
-    public void editWikiFormattingToolbarButtons(TestUtils setup, TestReference reference)
+    void editWikiFormattingToolbarButtons(TestUtils setup, TestReference reference)
     {
         testToolBarButton(setup, reference, "Bold", "**%s**", "Text in Bold");
         testToolBarButton(setup, reference, "Italics", "//%s//", "Text in Italics");
@@ -263,7 +274,7 @@ public class EditIT
      */
     @Test
     @Order(6)
-    public void saveAndFormManipulation(TestUtils setup, TestReference reference)
+    void saveAndFormManipulation(TestUtils setup, TestReference reference)
     {
         setup.deletePage(reference);
         ViewPage viewPage = setup.gotoPage(reference);
@@ -307,7 +318,7 @@ public class EditIT
 
     @Test
     @Order(7)
-    public void allowForceSaveWhenCSRFIssue(TestUtils setup, TestReference testReference)
+    void allowForceSaveWhenCSRFIssue(TestUtils setup, TestReference testReference)
     {
         try {
             DocumentReference invalidateCSRF = new DocumentReference("InvalidateCSRF",
@@ -451,7 +462,7 @@ public class EditIT
      */
     @Test
     @Order(8)
-    public void editWithConflict(TestUtils setup, TestReference testReference)
+    void editWithConflict(TestUtils setup, TestReference testReference)
     {
         // Fixture
         String title = testReference.getLastSpaceReference().getName();
@@ -798,7 +809,7 @@ public class EditIT
      */
     @Test
     @Order(9)
-    public void createDocumentLongTitle(TestUtils setup, TestReference reference)
+    void createDocumentLongTitle(TestUtils setup, TestReference reference)
     {
         String spaceName1 = "Company Presentation Events";
         String spaceName2 = "Presentation from 10 december 2015 at the Fourth edition of the International Conference for "
@@ -827,7 +838,7 @@ public class EditIT
      */
     @Test
     @Order(10)
-    public void editLeaveAndBack(TestUtils setup, TestReference testReference) throws InterruptedException
+    void editLeaveAndBack(TestUtils setup, TestReference testReference) throws InterruptedException
     {
         setup.deletePage(testReference);
         WikiEditPage wikiEditPage = setup.gotoPage(testReference).editWiki();
@@ -863,7 +874,7 @@ public class EditIT
 
     @Test
     @Order(11)
-    public void editTitle768Characters(TestUtils setup, TestConfiguration testConfiguration,
+    void editTitle768Characters(TestUtils setup, TestConfiguration testConfiguration,
         TestReference testReference, LogCaptureConfiguration logCaptureConfiguration)
     {
         setup.deletePage(testReference);
@@ -943,7 +954,7 @@ public class EditIT
 
     @Test
     @Order(12)
-    public void switchSyntaxFromWikiEditMode(TestUtils setup, TestReference testReference) throws Exception
+    void switchSyntaxFromWikiEditMode(TestUtils setup, TestReference testReference) throws Exception
     {
         // Fixture: enable the XHTML syntax.
         setup.addObject("Rendering", "RenderingConfig", "Rendering.RenderingConfigClass",
@@ -1045,7 +1056,7 @@ public class EditIT
 
     @Test
     @Order(13)
-    public void saveActionValidatesWhenXValidateIsPresent(TestUtils setup, TestReference testReference)
+    void saveActionValidatesWhenXValidateIsPresent(TestUtils setup, TestReference testReference)
     {
         String content = "{{velocity}}"
             + "value: $doc.display('prop')\n\n"
@@ -1086,7 +1097,7 @@ public class EditIT
 
     @Test
     @Order(14)
-    public void logoutDuringEdit(TestUtils setup, TestReference testReference)
+    void logoutDuringEdit(TestUtils setup, TestReference testReference)
     {
         // fixture: deny right edit to the guest user on the page, since we want to get a 401 as in XWiki Standard
         setup.createPage(testReference, "", "");

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/editor/WikiEditPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/editor/WikiEditPage.java
@@ -187,6 +187,15 @@ public class WikiEditPage extends PreviewableEditPage
         return this.commentInput.isDisplayed();
     }
 
+    /**
+     * @return {@code true} if the edit comment (version summary) field is present in the form
+     * @since 18.3.0RC1
+     */
+    public boolean hasEditComment()
+    {
+        return getDriver().hasElement(By.name("comment"));
+    }
+
     public boolean loginModalDisplayed() {
         if (!this.modal.isDisplayed()) {
             return false;

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/editor/WikiEditPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/editor/WikiEditPage.java
@@ -189,9 +189,6 @@ public class WikiEditPage extends PreviewableEditPage
 
     /**
      * @return {@code true} if the edit comment (version summary) field is present in the form
-     * @since 17.10.10
-     * @since 18.3.0RC1
-     * @since 18.4.3
      */
     public boolean hasEditComment()
     {

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/editor/WikiEditPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/editor/WikiEditPage.java
@@ -189,7 +189,9 @@ public class WikiEditPage extends PreviewableEditPage
 
     /**
      * @return {@code true} if the edit comment (version summary) field is present in the form
+     * @since 17.10.10
      * @since 18.3.0RC1
+     * @since 18.4.3
      */
     public boolean hasEditComment()
     {


### PR DESCRIPTION
Backport of XWIKI-18772 to stable-17.10.x.

Cherry-picked from master (git cherry-pick -x):
1424a7d445e XWIKI-18772: Add automated test for "Disable Version Summaries"