### PR TITLE
[stable-17.10.x] XWIKI-23344: Add automated test for "Attach a restricted Mimetype file disguised as an allowed Mimetype file"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-validation/xwiki-platform-attachment-validation-test/xwiki-platform-attachment-validation-test-docker/src/test/it/org/xwiki/attachment/validation/test/ui/docker/AttachmentValidationIT.java
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-validation/xwiki-platform-attachment-validation-test/xwiki-platform-attachment-validation-test-docker/src/test/it/org/xwiki/attachment/validation/test/ui/docker/AttachmentValidationIT.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import org.apache.commons.httpclient.methods.PutMethod;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
@@ -69,6 +70,51 @@ class AttachmentValidationIT
     }
 
     @Test
+    @Order(1)
+    void validateDisguisedAttachment(TestUtils setup, TestReference testReference, TestConfiguration testConfiguration)
+        throws Exception
+    {
+        setup.createPage(testReference, "");
+        // Only allow images to be uploaded on this space.
+        AttachmentRestrictionAdministrationSectionPage administrationSectionPage =
+            AttachmentRestrictionAdministrationSectionPage.goToPage(testReference.getLastSpaceReference());
+        administrationSectionPage.setAllowedMimetypes("image/*");
+        administrationSectionPage.save();
+
+        // Navigate back to the test page to upload.
+        setup.createPage(testReference, "");
+        AttachmentsPane attachmentsPane = new AttachmentsViewPage().openAttachmentsDocExtraPane();
+
+        // Upload a text file disguised as a GIF image (extension is .gif but content is text/plain).
+        // The client-side validation uses the browser-reported MIME type (image/gif from the .gif extension), which
+        // matches image/*, so the client-side check passes and the file is sent to the server. The server uses Tika
+        // to detect the real MIME type from the file content (text/plain) and rejects it, causing a generic upload
+        // error. The server-side content-based MIME detection is verified through the REST API below.
+        upload(attachmentsPane, testConfiguration, DISGUISED_FILE_NAME);
+        WebElement error = getNotificationError(setup);
+        assertEquals("An error occurred while uploading " + DISGUISED_FILE_NAME, error.getText());
+
+        cleanNotification(setup, error);
+
+        // Check if the same validation is applied when uploading through the REST API.
+        PutMethod putMethod = restUploadImage(setup, testReference, DISGUISED_FILE_NAME);
+        assertEquals(415, putMethod.getStatusCode());
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map<String, Object> mapResult = objectMapper.readValue(putMethod.getResponseBodyAsStream(), Map.class);
+        assertEquals(Map.of(
+            "message", "Invalid mimetype [text/plain]",
+            "translationKey", "attachment.validation.mimetype.rejected",
+            "translationParameters", List.of(List.of("image/*"), List.of())
+        ), mapResult);
+
+        // Check that no attachment was saved.
+        setup.gotoPage(testReference);
+        attachmentsPane = new AttachmentsViewPage().openAttachmentsDocExtraPane();
+        assertEquals(0, attachmentsPane.getNumberOfAttachments());
+    }
+
+    @Test
+    @Order(2)
     void validateAttachment(TestUtils setup, TestReference testReference, TestConfiguration testConfiguration)
         throws Exception
     {
@@ -120,51 +166,8 @@ class AttachmentValidationIT
             "translationParameters", List.of("10 bytes")
         );
         assertEquals(expectedMap, mapResult);
-        // Check that no image are saved to the document after the various upload tries.
+        // Check that no image is saved to the document after the various upload tries.
         page.reloadPage();
-        attachmentsPane = new AttachmentsViewPage().openAttachmentsDocExtraPane();
-        assertEquals(0, attachmentsPane.getNumberOfAttachments());
-    }
-
-    @Test
-    void validateDisguisedAttachment(TestUtils setup, TestReference testReference, TestConfiguration testConfiguration)
-        throws Exception
-    {
-        setup.createPage(testReference, "");
-        // Only allow images to be uploaded on this space.
-        AttachmentRestrictionAdministrationSectionPage administrationSectionPage =
-            AttachmentRestrictionAdministrationSectionPage.goToPage(testReference.getLastSpaceReference());
-        administrationSectionPage.setAllowedMimetypes("image/*");
-        administrationSectionPage.save();
-
-        // Navigate back to the test page to upload.
-        setup.createPage(testReference, "");
-        AttachmentsPane attachmentsPane = new AttachmentsViewPage().openAttachmentsDocExtraPane();
-
-        // Upload a text file disguised as a GIF image (extension is .gif but content is text/plain).
-        // The client-side validation uses the browser-reported MIME type (image/gif from the .gif extension), which
-        // matches image/*, so the client-side check passes and the file is sent to the server. The server uses Tika
-        // to detect the real MIME type from the file content (text/plain) and rejects it, causing a generic upload
-        // error. The server-side content-based MIME detection is verified through the REST API below.
-        upload(attachmentsPane, testConfiguration, DISGUISED_FILE_NAME);
-        WebElement error = getNotificationError(setup);
-        assertEquals("An error occurred while uploading " + DISGUISED_FILE_NAME, error.getText());
-
-        cleanNotification(setup, error);
-
-        // Check if the same validation is applied when uploading through the REST API.
-        PutMethod putMethod = restUploadImage(setup, testReference, DISGUISED_FILE_NAME);
-        assertEquals(415, putMethod.getStatusCode());
-        ObjectMapper objectMapper = new ObjectMapper();
-        Map<String, Object> mapResult = objectMapper.readValue(putMethod.getResponseBodyAsStream(), Map.class);
-        assertEquals(Map.of(
-            "message", "Invalid mimetype [text/plain]",
-            "translationKey", "attachment.validation.mimetype.rejected",
-            "translationParameters", List.of(List.of("image/*"), List.of())
-        ), mapResult);
-
-        // Check that no attachment was saved.
-        ViewPage page = setup.gotoPage(testReference);
         attachmentsPane = new AttachmentsViewPage().openAttachmentsDocExtraPane();
         assertEquals(0, attachmentsPane.getNumberOfAttachments());
     }

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-validation/xwiki-platform-attachment-validation-test/xwiki-platform-attachment-validation-test-docker/src/test/it/org/xwiki/attachment/validation/test/ui/docker/AttachmentValidationIT.java
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-validation/xwiki-platform-attachment-validation-test/xwiki-platform-attachment-validation-test-docker/src/test/it/org/xwiki/attachment/validation/test/ui/docker/AttachmentValidationIT.java
@@ -59,6 +59,8 @@ class AttachmentValidationIT
 
     private static final String IMAGE_FILE_NAME = "image.gif";
 
+    private static final String DISGUISED_FILE_NAME = "fake.gif";
+
     @BeforeEach
     void setUp(TestUtils setup, TestReference testReference)
     {
@@ -120,6 +122,49 @@ class AttachmentValidationIT
         assertEquals(expectedMap, mapResult);
         // Check that no image are saved to the document after the various upload tries.
         page.reloadPage();
+        attachmentsPane = new AttachmentsViewPage().openAttachmentsDocExtraPane();
+        assertEquals(0, attachmentsPane.getNumberOfAttachments());
+    }
+
+    @Test
+    void validateDisguisedAttachment(TestUtils setup, TestReference testReference, TestConfiguration testConfiguration)
+        throws Exception
+    {
+        setup.createPage(testReference, "");
+        // Only allow images to be uploaded on this space.
+        AttachmentRestrictionAdministrationSectionPage administrationSectionPage =
+            AttachmentRestrictionAdministrationSectionPage.goToPage(testReference.getLastSpaceReference());
+        administrationSectionPage.setAllowedMimetypes("image/*");
+        administrationSectionPage.save();
+
+        // Navigate back to the test page to upload.
+        setup.createPage(testReference, "");
+        AttachmentsPane attachmentsPane = new AttachmentsViewPage().openAttachmentsDocExtraPane();
+
+        // Upload a text file disguised as a GIF image (extension is .gif but content is text/plain).
+        // The client-side validation uses the browser-reported MIME type (image/gif from the .gif extension), which
+        // matches image/*, so the client-side check passes and the file is sent to the server. The server uses Tika
+        // to detect the real MIME type from the file content (text/plain) and rejects it, causing a generic upload
+        // error. The server-side content-based MIME detection is verified through the REST API below.
+        upload(attachmentsPane, testConfiguration, DISGUISED_FILE_NAME);
+        WebElement error = getNotificationError(setup);
+        assertEquals("An error occurred while uploading " + DISGUISED_FILE_NAME, error.getText());
+
+        cleanNotification(setup, error);
+
+        // Check if the same validation is applied when uploading through the REST API.
+        PutMethod putMethod = restUploadImage(setup, testReference, DISGUISED_FILE_NAME);
+        assertEquals(415, putMethod.getStatusCode());
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map<String, Object> mapResult = objectMapper.readValue(putMethod.getResponseBodyAsStream(), Map.class);
+        assertEquals(Map.of(
+            "message", "Invalid mimetype [text/plain]",
+            "translationKey", "attachment.validation.mimetype.rejected",
+            "translationParameters", List.of(List.of("image/*"), List.of())
+        ), mapResult);
+
+        // Check that no attachment was saved.
+        ViewPage page = setup.gotoPage(testReference);
         attachmentsPane = new AttachmentsViewPage().openAttachmentsDocExtraPane();
         assertEquals(0, attachmentsPane.getNumberOfAttachments());
     }

--- a/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-validation/xwiki-platform-attachment-validation-test/xwiki-platform-attachment-validation-test-docker/src/test/resources/fake.gif
+++ b/xwiki-platform-core/xwiki-platform-attachment/xwiki-platform-attachment-validation/xwiki-platform-attachment-validation-test/xwiki-platform-attachment-validation-test-docker/src/test/resources/fake.gif
@@ -1,0 +1,2 @@
+This is a plain text file disguised as a GIF image.
+Its extension is .gif but its MIME type should be detected as text/plain by Apache Tika.


### PR DESCRIPTION
Backport of XWIKI-23344 to stable-17.10.x.

Cherry-picked from master (git cherry-pick -x):
b0b884fda74 XWIKI-23344: Add automated test for "Attach a restricted Mimetype file disguised as an allowed Mimetype file"
ff9c9a2c176 XWIKI-23344: Add automated test for "Attach a restricted Mimetype file disguised as an allowed Mimetype file" * Push resource file that was forgotten + control the test order for reproducibility