### PR TITLE
[stable-18.4.x] XWIKI-20349: Add automated test for "Footer Space Copyright"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/PresentationIT.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/PresentationIT.java
@@ -21,6 +21,7 @@ package org.xwiki.administration.test.ui;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.xwiki.administration.test.po.AdministrablePage;
 import org.xwiki.administration.test.po.AdministrationSectionPage;
@@ -63,6 +64,8 @@ class PresentationIT
         presentationSectionPage.setShowAttachments(PresentationAdministrationSectionPage.ShowTabValue.DEFAULT);
         presentationSectionPage.setShowHistory(PresentationAdministrationSectionPage.ShowTabValue.DEFAULT);
         presentationSectionPage.setShowInformation(PresentationAdministrationSectionPage.ShowTabValue.DEFAULT);
+        presentationSectionPage.setCopyright("");
+        presentationSectionPage.setVersion("");
         presentationSectionPage.clickSave();
     }
 
@@ -70,6 +73,7 @@ class PresentationIT
      * Validate that the show information setting of the Presentation section of the administration has an effect.
      */
     @Test
+    @Order(1)
     void showPageInformationTabSettings(TestUtils setup, TestReference testReference)
     {
         ViewPage viewPage = setup.createPage(testReference, "");
@@ -91,6 +95,7 @@ class PresentationIT
     }
 
     @Test
+    @Order(2)
     void showPageAttachmentsTab(TestUtils setup, TestReference testReference)
     {
         setup.createPage(testReference, "");
@@ -115,6 +120,7 @@ class PresentationIT
     }
 
     @Test
+    @Order(3)
     void showPageCommentsTab(TestUtils setup, TestReference testReference)
     {
         ViewPage viewPage = setup.createPage(testReference, "");
@@ -136,6 +142,7 @@ class PresentationIT
     }
 
     @Test
+    @Order(4)
     void showPageHistoryTab(TestUtils setup, TestReference testReference)
     {
         ViewPage viewPage = setup.createPage(testReference, "");
@@ -154,6 +161,34 @@ class PresentationIT
         // Check that the history tab is no longer displayed.
         viewPage = setup.gotoPage(testReference);
         assertFalse(viewPage.hasHistoryDocExtraPane());
+    }
+
+    @Test
+    @Order(5)
+    void customizeCopyright(TestUtils setup, TestReference testReference)
+    {
+        PresentationAdministrationSectionPage presentationSectionPage = gotoPresentationAdministration();
+        // Check that there is no copyright in the footer by default
+        assertTrue(presentationSectionPage.getFooterCopyright().isEmpty());
+        presentationSectionPage.setCopyright("test-copyright");
+        presentationSectionPage.clickSave();
+        // The page is reloaded, we can see directly on this page if the copyright is correctly applied.
+        assertEquals("test-copyright", presentationSectionPage.getFooterCopyright());
+    }
+
+    @Test
+    @Order(6)
+    void customizeVersion(TestUtils setup, TestReference testReference) throws Exception
+    {
+        PresentationAdministrationSectionPage presentationSectionPage = gotoPresentationAdministration();
+        String defaultVersion = presentationSectionPage.getFooterVersion();
+        // The default version should contain the xwiki-platform project version.
+        String version = setup.getVersion();
+        assertTrue(defaultVersion.contains(version));
+        presentationSectionPage.setVersion("test-version");
+        presentationSectionPage.clickSave();
+        // The page is reloaded, we can see directly on this page if the version is correctly applied.
+        assertEquals("test-version", presentationSectionPage.getFooterVersion());
     }
 
     private static PresentationAdministrationSectionPage gotoPresentationAdministration()

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/PresentationAdministrationSectionPage.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/PresentationAdministrationSectionPage.java
@@ -198,6 +198,8 @@ public class PresentationAdministrationSectionPage extends AdministrationSection
 
     /**
      * @param value the value to set for the "Copyright" option
+     * @since 17.10.10
+     * @since 18.4.3
      * @since 18.6.0RC1
      */
     public void setCopyright(String value)
@@ -208,6 +210,8 @@ public class PresentationAdministrationSectionPage extends AdministrationSection
 
     /**
      * @param value the value to set for the "Version" option
+     * @since 17.10.10
+     * @since 18.4.3
      * @since 18.6.0RC1
      */
     public void setVersion(String value)

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/PresentationAdministrationSectionPage.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/PresentationAdministrationSectionPage.java
@@ -198,9 +198,6 @@ public class PresentationAdministrationSectionPage extends AdministrationSection
 
     /**
      * @param value the value to set for the "Copyright" option
-     * @since 17.10.10
-     * @since 18.4.3
-     * @since 18.6.0RC1
      */
     public void setCopyright(String value)
     {
@@ -210,9 +207,6 @@ public class PresentationAdministrationSectionPage extends AdministrationSection
 
     /**
      * @param value the value to set for the "Version" option
-     * @since 17.10.10
-     * @since 18.4.3
-     * @since 18.6.0RC1
      */
     public void setVersion(String value)
     {

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/PresentationAdministrationSectionPage.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/PresentationAdministrationSectionPage.java
@@ -102,6 +102,12 @@ public class PresentationAdministrationSectionPage extends AdministrationSection
     @FindBy(id = "XWiki.XWikiPreferences_0_showinformation")
     private WebElement showInformation;
 
+    @FindBy(id = "XWiki.XWikiPreferences_0_webcopyright")
+    private WebElement copyright;
+
+    @FindBy(id = "XWiki.XWikiPreferences_0_version")
+    private WebElement version;
+
     /**
      * Default constructor.
      */
@@ -188,5 +194,25 @@ public class PresentationAdministrationSectionPage extends AdministrationSection
     public void setShowInformation(ShowTabValue value)
     {
         new Select(this.showInformation).selectByValue(value.getValue());
+    }
+
+    /**
+     * @param value the value to set for the "Copyright" option
+     * @since 18.6.0RC1
+     */
+    public void setCopyright(String value)
+    {
+        this.copyright.clear();
+        this.copyright.sendKeys(value);
+    }
+
+    /**
+     * @param value the value to set for the "Version" option
+     * @since 18.6.0RC1
+     */
+    public void setVersion(String value)
+    {
+        this.version.clear();
+        this.version.sendKeys(value);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/ViewPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/ViewPage.java
@@ -432,6 +432,8 @@ public class ViewPage extends BasePage
 
     /**
      * @return the content of the copyright section in the page footer
+     * @since 17.10.10
+     * @since 18.4.3
      * @since 18.6.0RC1
      */
     public String getFooterCopyright()
@@ -441,6 +443,8 @@ public class ViewPage extends BasePage
 
     /**
      * @return the content of the version section in the page footer
+     * @since 17.10.10
+     * @since 18.4.3
      * @since 18.6.0RC1
      */
     public String getFooterVersion()

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/ViewPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/ViewPage.java
@@ -429,4 +429,22 @@ public class ViewPage extends BasePage
         reviewButton.click();
         return new RequiredRightsModal();
     }
+
+    /**
+     * @return the content of the copyright section in the page footer
+     * @since 18.6.0RC1
+     */
+    public String getFooterCopyright()
+    {
+        return getDriver().findElement(By.id("xwikilicence")).getText();
+    }
+
+    /**
+     * @return the content of the version section in the page footer
+     * @since 18.6.0RC1
+     */
+    public String getFooterVersion()
+    {
+        return getDriver().findElement(By.id("xwikiplatformversion")).getText();
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/ViewPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/ViewPage.java
@@ -432,9 +432,6 @@ public class ViewPage extends BasePage
 
     /**
      * @return the content of the copyright section in the page footer
-     * @since 17.10.10
-     * @since 18.4.3
-     * @since 18.6.0RC1
      */
     public String getFooterCopyright()
     {
@@ -443,9 +440,6 @@ public class ViewPage extends BasePage
 
     /**
      * @return the content of the version section in the page footer
-     * @since 17.10.10
-     * @since 18.4.3
-     * @since 18.6.0RC1
      */
     public String getFooterVersion()
     {


### PR DESCRIPTION
Backport of XWIKI-20349 to stable-18.4.x.

Cherry-picked from master (git cherry-pick -x):
f8b8b7aa425 XWIKI-20349: Add automated test for "Footer Space Copyright" (#5348)