### PR TITLE
[stable-18.4.x] XWIKI-19562: Add automated test for "Display Left Panel Column from Administer Wiki"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker/src/test/it/org/xwiki/panels/test/ui/docker/NavigationPanelIT.java
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker/src/test/it/org/xwiki/panels/test/ui/docker/NavigationPanelIT.java
@@ -83,6 +83,10 @@ class NavigationPanelIT
         setup.gotoPage(page);
         assertFalse(new NavigationPanel().getNavigationTree().hasDocument(appName, "WebHome"),
             "The application home page is not excluded from the Navigation Panel");
+
+        // Clean up the application created by this test because its top level page interferes with the navigation
+        // panel administration test (which asserts the exact list of top level pages).
+        AppWithinMinutesHomePage.gotoPage().deleteApplication(appName);
     }
 
     private ApplicationHomePage createEmptyApp(String appName)

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker/src/test/it/org/xwiki/panels/test/ui/docker/PanelIT.java
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker/src/test/it/org/xwiki/panels/test/ui/docker/PanelIT.java
@@ -287,6 +287,51 @@ class PanelIT
         assertAlmostEqualSize(200, panelPage.getPanelWidth(PageWithPanels.Column.RIGHT));
     }
 
+    @Test
+    @Order(6)
+    void displayLeftPanelColumn(TestUtils testUtils, TestReference testReference)
+    {
+        // Automates the "Display Left Panel Column" manual test: create two panels, configure them on the
+        // left column as a comma-separated list via the Panels administration UI, and verify both are
+        // displayed in the left column. This proves the Panel Admin UI works for the left column and that
+        // a comma-separated list of more than one panel is supported.
+        String baseName = testReference.getLastSpaceReference().getName();
+        String title1 = baseName + "1";
+        String title2 = baseName + "2";
+
+        for (String title : new String[] { title1, title2 }) {
+            testUtils.deletePage("Panels", title);
+            PanelEditPage panelEditPage = PanelsHomePage.gotoPage().createPanel(title);
+            panelEditPage.setContent(String.format(PanelEditPage.DEFAULT_CONTENT_FORMAT, title, "Panel content."));
+            panelEditPage.clickSaveAndContinue();
+        }
+
+        setLeftPanelsInAdministration(
+            StringUtils.join(new Object[] { "Panels." + title1, "Panels." + title2 }, ','));
+
+        testUtils.gotoPage(testReference);
+        PageWithPanels page = new PageWithPanels();
+        assertTrue(page.hasLeftPanels());
+        assertTrue(page.hasLeftPanel(title1));
+        assertTrue(page.hasLeftPanel(title2));
+
+        // Clean up the pages created by this test because they interfere with the navigation panel
+        // administration test (which asserts the exact list of top level pages).
+        testUtils.deletePage("Panels", title1);
+        testUtils.deletePage("Panels", title2);
+        testUtils.deletePage(testReference);
+    }
+
+    private void setLeftPanelsInAdministration(String panels)
+    {
+        AdministrationPage.gotoPage().clickSection("Look & Feel", "Panels");
+        PanelsAdministrationPage panelsAdminPage = new PanelsAdministrationPage();
+        PageLayoutTabContent pageLayout = panelsAdminPage.selectPageLayout();
+        pageLayout.selectLeftColumnLayout();
+        pageLayout.setLeftPanels(panels);
+        panelsAdminPage.clickSave();
+    }
+
     private void setRightPanelInAdministration(String panelName)
     {
         AdministrationPage.gotoPage().clickSection("Look & Feel", "Panels");

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker/src/test/it/org/xwiki/panels/test/ui/docker/PanelsAdministrationIT.java
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-docker/src/test/it/org/xwiki/panels/test/ui/docker/PanelsAdministrationIT.java
@@ -226,5 +226,9 @@ class PanelsAdministrationIT
         assertTrue(pageWithPanels.hasPanelInRightColumn("Welcome"));
         assertTrue(pageWithPanels.hasPanelInLeftColumn("Applications"));
         assertFalse(pageWithPanels.hasPanelInRightColumn("QuickLinks"));
+
+        // Clean up the page created by this test because its top level page interferes with the navigation panel
+        // administration test (which asserts the exact list of top level pages).
+        setup.deletePage(testReference);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-pageobjects/src/main/java/org/xwiki/panels/test/po/PageLayoutTabContent.java
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-pageobjects/src/main/java/org/xwiki/panels/test/po/PageLayoutTabContent.java
@@ -127,9 +127,6 @@ public class PageLayoutTabContent extends BaseElement
 
     /**
      * @return the comma-separated list of panels configured for the left column
-     * @since 17.10.10
-     * @since 18.4.3
-     * @since 18.6.0RC1
      */
     public String getLeftPanels()
     {
@@ -139,9 +136,6 @@ public class PageLayoutTabContent extends BaseElement
     /**
      * @param leftPanels the comma-separated list of panels to set for the left column
      * @return this object
-     * @since 17.10.10
-     * @since 18.4.3
-     * @since 18.6.0RC1
      */
     public PageLayoutTabContent setLeftPanels(String leftPanels)
     {

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-pageobjects/src/main/java/org/xwiki/panels/test/po/PageLayoutTabContent.java
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-pageobjects/src/main/java/org/xwiki/panels/test/po/PageLayoutTabContent.java
@@ -56,6 +56,9 @@ public class PageLayoutTabContent extends BaseElement
     @FindBy(css = "#XWiki\\.XWikiPreferences_0_rightPanels")
     private WebElement rightPanelsInput;
 
+    @FindBy(css = "#XWiki\\.XWikiPreferences_0_leftPanels")
+    private WebElement leftPanelsInput;
+
     @FindBy(id = "rightPanels")
     private WebElement rightPanels;
 
@@ -119,6 +122,27 @@ public class PageLayoutTabContent extends BaseElement
     {
         this.rightPanelsInput.clear();
         this.rightPanelsInput.sendKeys(rightPanels);
+        return this;
+    }
+
+    /**
+     * @return the comma-separated list of panels configured for the left column
+     * @since 18.6.0RC1
+     */
+    public String getLeftPanels()
+    {
+        return this.leftPanelsInput.getText();
+    }
+
+    /**
+     * @param leftPanels the comma-separated list of panels to set for the left column
+     * @return this object
+     * @since 18.6.0RC1
+     */
+    public PageLayoutTabContent setLeftPanels(String leftPanels)
+    {
+        this.leftPanelsInput.clear();
+        this.leftPanelsInput.sendKeys(leftPanels);
         return this;
     }
 

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-pageobjects/src/main/java/org/xwiki/panels/test/po/PageLayoutTabContent.java
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-pageobjects/src/main/java/org/xwiki/panels/test/po/PageLayoutTabContent.java
@@ -127,6 +127,8 @@ public class PageLayoutTabContent extends BaseElement
 
     /**
      * @return the comma-separated list of panels configured for the left column
+     * @since 17.10.10
+     * @since 18.4.3
      * @since 18.6.0RC1
      */
     public String getLeftPanels()
@@ -137,6 +139,8 @@ public class PageLayoutTabContent extends BaseElement
     /**
      * @param leftPanels the comma-separated list of panels to set for the left column
      * @return this object
+     * @since 17.10.10
+     * @since 18.4.3
      * @since 18.6.0RC1
      */
     public PageLayoutTabContent setLeftPanels(String leftPanels)


### PR DESCRIPTION
Backport of XWIKI-19562 to stable-18.4.x.

Cherry-picked from master (git cherry-pick -x):
0053fa152ff XWIKI-19562: Add automated test for "Display Left Panel Column from Administer Wiki"