### PR TITLE
[stable-17.10.x] XWIKI-22081: Add automated test for "See The Logging Page"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-test/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-test/pom.xml
@@ -20,31 +20,31 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.xwiki.platform</groupId>
-    <artifactId>xwiki-platform-core</artifactId>
+    <artifactId>xwiki-platform-logging</artifactId>
     <version>17.10.10-SNAPSHOT</version>
   </parent>
-  <artifactId>xwiki-platform-logging</artifactId>
-  <name>XWiki Platform - Loggging</name>
+  <artifactId>xwiki-platform-logging-test</artifactId>
+  <name>XWiki Platform - Logging - Tests - Parent POM</name>
+  <description>XWiki Platform - Logging - Tests - Parent POM</description>
   <packaging>pom</packaging>
-  <description>XWiki Platform - Loggging</description>
+  <properties>
+    <!-- Don't run backward-compatibility checks in test modules since we don't consider them as public APIs -->
+    <xwiki.revapi.skip>true</xwiki.revapi.skip>
+    <!-- Don't run Checkstyle in test modules -->
+    <xwiki.checkstyle.skip>true</xwiki.checkstyle.skip>
+  </properties>
   <modules>
-    <module>xwiki-platform-logging-script</module>
-    <module>xwiki-platform-logging-ui</module>
+    <module>xwiki-platform-logging-test-pageobjects</module>
   </modules>
-
-  <scm>
-    <tag>stable-17.10.x</tag>
-  </scm>
-
   <profiles>
     <profile>
-      <id>integration-tests</id>
+      <id>docker</id>
       <modules>
-        <module>xwiki-platform-logging-test</module>
+        <module>xwiki-platform-logging-test-docker</module>
       </modules>
     </profile>
   </profiles>

--- a/xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-test/xwiki-platform-logging-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-test/xwiki-platform-logging-test-docker/pom.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.xwiki.platform</groupId>
+    <artifactId>xwiki-platform-logging-test</artifactId>
+    <version>17.10.10-SNAPSHOT</version>
+  </parent>
+  <artifactId>xwiki-platform-logging-test-docker</artifactId>
+  <name>XWiki Platform - Logging - Tests - Functional Tests in Docker</name>
+  <description>XWiki Platform - Logging - Tests - Functional Tests in Docker</description>
+  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
+       see https://jira.xwiki.org/browse/XWIKI-7683 -->
+  <packaging>jar</packaging>
+  <properties>
+    <!-- Functional tests are allowed to output content to the console -->
+    <xwiki.surefire.captureconsole.skip>true</xwiki.surefire.captureconsole.skip>
+  </properties>
+  <dependencies>
+    <!-- Runtime dependencies. -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-logging-ui</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+      <type>xar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-administration-ui</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+      <type>xar</type>
+    </dependency>
+    <!-- Test only dependencies. -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-test-docker</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-logging-test-pageobjects</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-flamingo-skin-test-pageobjects</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <testSourceDirectory>src/test/it</testSourceDirectory>
+    <plugins>
+      <!-- We need to explicitly include the failsafe plugin since it's not part of the default maven lifecycle -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+  <profiles>
+    <profile>
+      <id>clover</id>
+      <!-- Add the Clover JAR to the WAR so that it's available at runtime when XWiki executes.
+           It's needed because instrumented jars in the WAR will call Clover APIs at runtime when they execute. -->
+      <dependencies>
+        <dependency>
+          <groupId>org.openclover</groupId>
+          <artifactId>clover</artifactId>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <systemPropertyVariables>
+                <!-- Tell the Docker-based test to activate the Clover profile so that the Clover JAR is added to
+                     WEB-INF/lib -->
+                <xwiki.test.ui.profiles>clover</xwiki.test.ui.profiles>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-test/xwiki-platform-logging-test-docker/src/test/it/org/xwiki/logging/test/ui/docker/AllIT.java
+++ b/xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-test/xwiki-platform-logging-test-docker/src/test/it/org/xwiki/logging/test/ui/docker/AllIT.java
@@ -1,0 +1,38 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.logging.test.ui.docker;
+
+import org.junit.jupiter.api.Nested;
+import org.xwiki.test.docker.junit5.UITest;
+
+/**
+ * All UI tests for the Logging administration section.
+ *
+ * @version $Id$
+ * @since 18.5.0RC1
+ */
+@UITest
+public class AllIT
+{
+    @Nested
+    class NestedLoggingAdminIT extends LoggingAdminIT
+    {
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-test/xwiki-platform-logging-test-docker/src/test/it/org/xwiki/logging/test/ui/docker/LoggingAdminIT.java
+++ b/xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-test/xwiki-platform-logging-test-docker/src/test/it/org/xwiki/logging/test/ui/docker/LoggingAdminIT.java
@@ -1,0 +1,114 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.logging.test.ui.docker;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.xwiki.logging.test.po.LoggingAdministrationSectionPage;
+import org.xwiki.test.docker.junit5.UITest;
+import org.xwiki.test.ui.TestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verify that the Logging administration section works: it lists the registered loggers and allows changing a logger's
+ * level and resetting it to its default.
+ *
+ * @version $Id$
+ * @since 18.5.0RC1
+ */
+@UITest
+class LoggingAdminIT
+{
+    /**
+     * The Logging section is reachable from the Administration and renders its intro text and the Live Data table of
+     * loggers (with the logger, level and actions columns).
+     */
+    @Test
+    @Order(1)
+    void sectionIsReachableAndRenders(TestUtils setup)
+    {
+        // Programming right is required for the "Actions" column (the level-setting form) to be displayed.
+        setup.loginAsSuperAdmin();
+
+        LoggingAdministrationSectionPage section = LoggingAdministrationSectionPage.gotoPage();
+
+        assertTrue(section.getContent().contains("review and modify the log level"),
+            "The Logging section intro text is missing");
+        assertTrue(section.getLiveDataTable().countRows() > 0, "No logger is listed in the Logging section");
+        assertTrue(section.hasAllColumns(), "The logger, level and actions columns are not all displayed");
+    }
+
+    /**
+     * Change the level of a logger to a value different from its current one, verify the success message and that the
+     * change is reflected in the table, then reset the logger to its default level and verify the unset success message
+     * and that the level is cleared. The logger is read from the table rather than hardcoded so that the test does not
+     * depend on which loggers happen to be registered in the running instance.
+     */
+    @Test
+    @Order(2)
+    void setAndUnsetLevel()
+    {
+        LoggingAdministrationSectionPage section = LoggingAdministrationSectionPage.gotoPage();
+
+        String logger = section.getLogger(1);
+        String targetLevel = differentLevel(section.getLevel(1));
+
+        // Set the level and check the success message. The message box text is prefixed by a "Success" label coming
+        // from the skin, so we assert on the message being contained rather than on strict equality.
+        section.setLevel(1, targetLevel);
+        String setMessage = section.getSuccessMessage();
+        assertTrue(
+            setMessage.contains(String.format("Logger \"%s\" level has been set to \"%s\".", logger, targetLevel)),
+            String.format("Unexpected success message after setting the level: [%s]", setMessage));
+
+        // The new level is reflected in the table.
+        int row = section.findRowForLogger(logger);
+        assertEquals(targetLevel, section.getLevel(row));
+
+        // Reset the logger to its default level (empty value option) and check the unset success message.
+        section.setLevel(row, "");
+        String unsetMessage = section.getSuccessMessage();
+        assertTrue(unsetMessage.contains(String.format("Logger \"%s\" level has been unset.", logger)),
+            String.format("Unexpected success message after unsetting the level: [%s]", unsetMessage));
+
+        // The level is cleared in the table.
+        assertEquals("", section.getLevel(section.findRowForLogger(logger)));
+    }
+
+    /**
+     * @param currentLevel the level currently set on a logger (possibly empty for the default level)
+     * @return a level guaranteed to be different from {@code currentLevel}, hence offered by the level select (which
+     *         omits the option matching the current level)
+     */
+    private static String differentLevel(String currentLevel)
+    {
+        for (String level : List.of("DEBUG", "INFO", "WARN", "ERROR", "TRACE")) {
+            if (!level.equals(currentLevel)) {
+                return level;
+            }
+        }
+        return "DEBUG";
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-test/xwiki-platform-logging-test-pageobjects/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-test/xwiki-platform-logging-test-pageobjects/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.xwiki.platform</groupId>
+    <artifactId>xwiki-platform-logging-test</artifactId>
+    <version>17.10.10-SNAPSHOT</version>
+  </parent>
+  <artifactId>xwiki-platform-logging-test-pageobjects</artifactId>
+  <name>XWiki Platform - Logging - Tests - Page Objects</name>
+  <description>XWiki Platform - Logging - Tests - Page Objects</description>
+  <packaging>jar</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-test-ui</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-administration-test-pageobjects</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-livedata-test-pageobjects</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-test/xwiki-platform-logging-test-pageobjects/src/main/java/org/xwiki/logging/test/po/LoggingAdministrationSectionPage.java
+++ b/xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-test/xwiki-platform-logging-test-pageobjects/src/main/java/org/xwiki/logging/test/po/LoggingAdministrationSectionPage.java
@@ -1,0 +1,164 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.logging.test.po;
+
+import java.util.List;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.Select;
+import org.xwiki.administration.test.po.AdministrationSectionPage;
+import org.xwiki.livedata.test.po.LiveDataElement;
+import org.xwiki.livedata.test.po.TableLayoutElement;
+
+/**
+ * Represents the Logging administration section, where the level of each registered logger can be viewed and changed
+ * (or reset to its default). The loggers are displayed in a Live Data table with one row per logger; each row exposes,
+ * in its "Actions" column, a form to select a new level and submit it.
+ *
+ * @version $Id$
+ * @since 18.5.0RC1
+ */
+public class LoggingAdministrationSectionPage extends AdministrationSectionPage
+{
+    private static final String SECTION_ID = "Logging";
+
+    private static final String LIVE_DATA_ID = "logging";
+
+    /**
+     * Live Data column label (English) for the logger name.
+     */
+    private static final String COLUMN_LOGGER = "Logger";
+
+    /**
+     * Live Data column label (English) for the logger level.
+     */
+    private static final String COLUMN_LEVEL = "Level";
+
+    /**
+     * Live Data column label (English) for the actions form. This column is only displayed when the current user has
+     * programming right.
+     */
+    private static final String COLUMN_ACTIONS = "Actions";
+
+    private static final By LEVEL_SELECT = By.cssSelector("select[name='logger_level']");
+
+    private static final By SET_BUTTON = By.cssSelector("input[name='loggeraction_set']");
+
+    /**
+     * Open the Logging administration section.
+     *
+     * @return the Logging administration section
+     */
+    public static LoggingAdministrationSectionPage gotoPage()
+    {
+        AdministrationSectionPage.gotoPage(SECTION_ID);
+        return new LoggingAdministrationSectionPage();
+    }
+
+    public LoggingAdministrationSectionPage()
+    {
+        super(SECTION_ID);
+    }
+
+    /**
+     * @return the table layout of the Live Data listing the loggers
+     */
+    public TableLayoutElement getLiveDataTable()
+    {
+        return new LiveDataElement(LIVE_DATA_ID).getTableLayout();
+    }
+
+    /**
+     * @param rowNumber the row number, starting at 1
+     * @return the logger name displayed in the given row
+     */
+    public String getLogger(int rowNumber)
+    {
+        return getLiveDataTable().getCell(COLUMN_LOGGER, rowNumber).getText().trim();
+    }
+
+    /**
+     * @param rowNumber the row number, starting at 1
+     * @return the level displayed in the given row (empty when the logger uses its default level)
+     */
+    public String getLevel(int rowNumber)
+    {
+        return getLiveDataTable().getCell(COLUMN_LEVEL, rowNumber).getText().trim();
+    }
+
+    /**
+     * @return {@code true} if the {@code logger}, {@code level} and {@code actions} columns are all displayed
+     */
+    public boolean hasAllColumns()
+    {
+        TableLayoutElement table = getLiveDataTable();
+        return table.hasColumn(COLUMN_LOGGER) && table.hasColumn(COLUMN_LEVEL) && table.hasColumn(COLUMN_ACTIONS);
+    }
+
+    /**
+     * Set the level of the logger displayed in the given row and submit the form. The page is reloaded as a result, so
+     * any previously obtained Live Data page object becomes stale.
+     *
+     * @param rowNumber the row number, starting at 1
+     * @param level the level value to select (e.g. {@code "DEBUG"}, or {@code ""} to reset the logger to its default
+     *            level). The selected value must be one of the options offered by the form: the option matching the
+     *            logger's current level is not present, and the "default" option (empty value) is only present when a
+     *            level is currently set.
+     */
+    public void setLevel(int rowNumber, String level)
+    {
+        WebElement actionsCell = getLiveDataTable().getCell(COLUMN_ACTIONS, rowNumber);
+        new Select(actionsCell.findElement(LEVEL_SELECT)).selectByValue(level);
+        getDriver().addPageNotYetReloadedMarker();
+        actionsCell.findElement(SET_BUTTON).click();
+        getDriver().waitUntilPageIsReloaded();
+    }
+
+    /**
+     * Locate the row of a logger by its exact name, filtering the Live Data on the logger column first so that the
+     * logger is displayed even if it isn't on the first page.
+     *
+     * @param loggerName the exact logger name to look for
+     * @return the row number (starting at 1) of the logger
+     * @throws NoSuchElementException if no row matches the logger name exactly
+     */
+    public int findRowForLogger(String loggerName)
+    {
+        TableLayoutElement table = getLiveDataTable();
+        table.filterColumn(COLUMN_LOGGER, loggerName);
+        List<WebElement> cells = table.getAllCells(COLUMN_LOGGER);
+        for (int i = 0; i < cells.size(); i++) {
+            if (loggerName.equals(cells.get(i).getText().trim())) {
+                return i + 1;
+            }
+        }
+        throw new NoSuchElementException(String.format("No logger row found for [%s]", loggerName));
+    }
+
+    /**
+     * @return the text of the on-page success message displayed after a level has been set or unset
+     */
+    public String getSuccessMessage()
+    {
+        return getDriver().findElement(By.cssSelector(".box.successmessage")).getText().trim();
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-test/xwiki-platform-logging-test-pageobjects/src/main/java/org/xwiki/logging/test/po/LoggingAdministrationSectionPage.java
+++ b/xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-test/xwiki-platform-logging-test-pageobjects/src/main/java/org/xwiki/logging/test/po/LoggingAdministrationSectionPage.java
@@ -35,6 +35,8 @@ import org.xwiki.livedata.test.po.TableLayoutElement;
  * in its "Actions" column, a form to select a new level and submit it.
  *
  * @version $Id$
+ * @since 17.10.10
+ * @since 18.4.3
  * @since 18.5.0RC1
  */
 public class LoggingAdministrationSectionPage extends AdministrationSectionPage


### PR DESCRIPTION
Backport of XWIKI-22081 to stable-17.10.x.

Cherry-picked from master (git cherry-pick -x):
4bb573afb3c XWIKI-22081: Add automated test for "See The Logging Page"

Reconciled xwiki-platform-logging/pom.xml: kept both the branch <scm> tag and the incoming integration-tests <profiles> block; adjusted the new logging-test module parent versions from 18.5.0-SNAPSHOT to the branch version 17.10.10-SNAPSHOT.