### PR TITLE
[stable-17.10.x] XWIKI-21853: Add automated test for "Name strategies test selected strategy"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-test/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-test/pom.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
 <!--
  * See the NOTICE file distributed with this work for additional
  * information regarding copyright ownership.
@@ -18,32 +19,32 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.xwiki.platform</groupId>
-    <artifactId>xwiki-platform-model</artifactId>
+    <artifactId>xwiki-platform-model-validation</artifactId>
     <version>17.10.10-SNAPSHOT</version>
   </parent>
-  <artifactId>xwiki-platform-model-validation</artifactId>
-  <name>XWiki Platform - Model - Validation - Parent POM</name>
-  <description>Validations for the XWiki Model</description>
+  <artifactId>xwiki-platform-model-validation-test</artifactId>
+  <name>XWiki Platform - Model - Validation - Tests - Parent POM</name>
+  <description>XWiki Platform - Model - Validation - Tests - Parent POM</description>
   <packaging>pom</packaging>
+  <properties>
+    <!-- Don't run backward-compatibility checks in test modules since we don't consider them as public APIs -->
+    <xwiki.revapi.skip>true</xwiki.revapi.skip>
+    <!-- Don't run Checkstyle in test modules -->
+    <xwiki.checkstyle.skip>true</xwiki.checkstyle.skip>
+  </properties>
   <modules>
-    <module>xwiki-platform-model-validation-api</module>
-    <module>xwiki-platform-model-validation-default</module>
-    <module>xwiki-platform-model-validation-ui</module>
+    <module>xwiki-platform-model-validation-test-pageobjects</module>
   </modules>
-
-  <scm>
-    <tag>stable-17.10.x</tag>
-  </scm>
-
   <profiles>
     <profile>
-      <id>integration-tests</id>
+      <id>docker</id>
       <modules>
-        <module>xwiki-platform-model-validation-test</module>
+        <module>xwiki-platform-model-validation-test-docker</module>
       </modules>
     </profile>
   </profiles>

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-test/xwiki-platform-model-validation-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-test/xwiki-platform-model-validation-test-docker/pom.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.xwiki.platform</groupId>
+    <artifactId>xwiki-platform-model-validation-test</artifactId>
+    <version>17.10.10-SNAPSHOT</version>
+  </parent>
+  <artifactId>xwiki-platform-model-validation-test-docker</artifactId>
+  <name>XWiki Platform - Model - Validation - Tests - Functional Tests in Docker</name>
+  <description>XWiki Platform - Model - Validation - Tests - Functional Tests in Docker</description>
+  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
+       see https://jira.xwiki.org/browse/XWIKI-7683 -->
+  <packaging>jar</packaging>
+  <properties>
+    <!-- Functional tests are allowed to output content to the console -->
+    <xwiki.surefire.captureconsole.skip>true</xwiki.surefire.captureconsole.skip>
+  </properties>
+  <dependencies>
+    <!-- Runtime dependencies. -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-model-validation-ui</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+      <type>xar</type>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-administration-ui</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+      <type>xar</type>
+    </dependency>
+    <!--Test only dependencies. -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-test-docker</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-model-validation-test-pageobjects</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-flamingo-skin-test-pageobjects</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <testSourceDirectory>src/test/it</testSourceDirectory>
+    <plugins>
+      <!-- We need to explicitly include the failsafe plugin since it's not part of the default maven lifecycle -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+  <profiles>
+    <profile>
+      <id>clover</id>
+      <!-- Add the Clover JAR to the WAR so that it's available at runtime when XWiki executes.
+           It's needed because instrumented jars in the WAR will call Clover APIs at runtime when they execute. -->
+      <dependencies>
+        <dependency>
+          <groupId>org.openclover</groupId>
+          <artifactId>clover</artifactId>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <systemPropertyVariables>
+                <!-- Tell the Docker-based test to activate the Clover profile so that the Clover JAR is added to
+                     WEB-INF/lib -->
+                <xwiki.test.ui.profiles>clover</xwiki.test.ui.profiles>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-test/xwiki-platform-model-validation-test-docker/src/test/it/org/xwiki/model/validation/test/ui/docker/AllIT.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-test/xwiki-platform-model-validation-test-docker/src/test/it/org/xwiki/model/validation/test/ui/docker/AllIT.java
@@ -1,0 +1,38 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.model.validation.test.ui.docker;
+
+import org.junit.jupiter.api.Nested;
+import org.xwiki.test.docker.junit5.UITest;
+
+/**
+ * All UI tests for the Model Validation (entity name validation) feature.
+ *
+ * @version $Id$
+ * @since 18.5.0RC1
+ */
+@UITest
+public class AllIT
+{
+    @Nested
+    class NestedNameStrategiesIT extends NameStrategiesIT
+    {
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-test/xwiki-platform-model-validation-test-docker/src/test/it/org/xwiki/model/validation/test/ui/docker/NameStrategiesIT.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-test/xwiki-platform-model-validation-test-docker/src/test/it/org/xwiki/model/validation/test/ui/docker/NameStrategiesIT.java
@@ -1,0 +1,70 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.model.validation.test.ui.docker;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.xwiki.model.validation.test.po.NameStrategiesAdministrationSectionPage;
+import org.xwiki.test.docker.junit5.UITest;
+import org.xwiki.test.ui.TestUtils;
+
+/**
+ * Validate the "test selected strategy" field of the Name Strategies administration section: entering a name there must
+ * report whether the name is valid for the currently selected entity name validation strategy and display the
+ * transformed version of that name.
+ *
+ * @version $Id$
+ * @since 18.5.0RC1
+ */
+@UITest
+class NameStrategiesIT
+{
+    @BeforeAll
+    void beforeAll(TestUtils setup)
+    {
+        setup.loginAsSuperAdmin();
+    }
+
+    /**
+     * Select and save the Slug strategy, then verify through the "test selected strategy" field that names are
+     * validated and transformed according to that strategy. The Slug strategy is used because, once saved with its
+     * default configuration, its behaviour is deterministic. The expected results below mirror the unit tests in
+     * {@code SlugEntityNameValidationTest}.
+     */
+    @Test
+    void testSelectedStrategy()
+    {
+        NameStrategiesAdministrationSectionPage section = NameStrategiesAdministrationSectionPage.gotoPage();
+        // Select and save the Slug strategy so that its configuration properties are initialized before testing it.
+        section.selectStrategy("SlugEntityNameValidation");
+        section.save();
+
+        section = NameStrategiesAdministrationSectionPage.gotoPage();
+
+        // A name that is already a valid slug: it is reported as valid and left unchanged by the transformation.
+        section.assertTestResult("TeSt", true, "TeSt");
+
+        // A name containing an accent: it is reported as invalid, and the accent is removed by the transformation.
+        section.assertTestResult("tést", false, "test");
+
+        // A name with accents and special characters: it is reported as invalid and transformed into a valid slug.
+        section.assertTestResult("test âccents/and.special%characters", false, "test-accents-and-special-characters");
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-test/xwiki-platform-model-validation-test-pageobjects/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-test/xwiki-platform-model-validation-test-pageobjects/pom.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
 <!--
  * See the NOTICE file distributed with this work for additional
  * information regarding copyright ownership.
@@ -18,33 +19,28 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.xwiki.platform</groupId>
-    <artifactId>xwiki-platform-model</artifactId>
+    <artifactId>xwiki-platform-model-validation-test</artifactId>
     <version>17.10.10-SNAPSHOT</version>
   </parent>
-  <artifactId>xwiki-platform-model-validation</artifactId>
-  <name>XWiki Platform - Model - Validation - Parent POM</name>
-  <description>Validations for the XWiki Model</description>
-  <packaging>pom</packaging>
-  <modules>
-    <module>xwiki-platform-model-validation-api</module>
-    <module>xwiki-platform-model-validation-default</module>
-    <module>xwiki-platform-model-validation-ui</module>
-  </modules>
-
-  <scm>
-    <tag>stable-17.10.x</tag>
-  </scm>
-
-  <profiles>
-    <profile>
-      <id>integration-tests</id>
-      <modules>
-        <module>xwiki-platform-model-validation-test</module>
-      </modules>
-    </profile>
-  </profiles>
+  <artifactId>xwiki-platform-model-validation-test-pageobjects</artifactId>
+  <name>XWiki Platform - Model - Validation - Tests - Page Objects</name>
+  <description>XWiki Platform - Model - Validation - Tests - Page Objects</description>
+  <packaging>jar</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-test-ui</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-administration-test-pageobjects</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
 </project>

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-test/xwiki-platform-model-validation-test-pageobjects/src/main/java/org/xwiki/model/validation/test/po/NameStrategiesAdministrationSectionPage.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-test/xwiki-platform-model-validation-test-pageobjects/src/main/java/org/xwiki/model/validation/test/po/NameStrategiesAdministrationSectionPage.java
@@ -29,6 +29,8 @@ import org.xwiki.test.ui.po.Select;
  * saved, and where a name can be entered to test the currently selected strategy.
  *
  * @version $Id$
+ * @since 17.10.10
+ * @since 18.4.3
  * @since 18.5.0RC1
  */
 public class NameStrategiesAdministrationSectionPage extends AdministrationSectionPage

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-test/xwiki-platform-model-validation-test-pageobjects/src/main/java/org/xwiki/model/validation/test/po/NameStrategiesAdministrationSectionPage.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-test/xwiki-platform-model-validation-test-pageobjects/src/main/java/org/xwiki/model/validation/test/po/NameStrategiesAdministrationSectionPage.java
@@ -1,0 +1,134 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.model.validation.test.po;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.xwiki.administration.test.po.AdministrationSectionPage;
+import org.xwiki.test.ui.po.Select;
+
+/**
+ * Represents the Name Strategies administration section, where the entity name validation strategy can be selected and
+ * saved, and where a name can be entered to test the currently selected strategy.
+ *
+ * @version $Id$
+ * @since 18.5.0RC1
+ */
+public class NameStrategiesAdministrationSectionPage extends AdministrationSectionPage
+{
+    private static final String SECTION_ID = "nameStrategies";
+
+    private static final By CONFIG_FORM = By.id("entityNameValidationConfigForm");
+
+    private static final By STRATEGY_SELECT =
+        By.id("XWiki.EntityNameValidation.ConfigurationClass_0_currentStrategy");
+
+    private static final By TEST_NAME_INPUT = By.id("testNameStrategy");
+
+    private static final By TEST_VALID_TRUE = By.id("testNameStrategyIsValid_true");
+
+    private static final By TEST_TRANSFORMED_NAME = By.id("testNameStrategyTransformedName");
+
+    /**
+     * Open the Name Strategies administration section.
+     *
+     * @return the Name Strategies administration section
+     */
+    public static NameStrategiesAdministrationSectionPage gotoPage()
+    {
+        AdministrationSectionPage.gotoPage(SECTION_ID);
+        return new NameStrategiesAdministrationSectionPage();
+    }
+
+    public NameStrategiesAdministrationSectionPage()
+    {
+        super(SECTION_ID);
+    }
+
+    /**
+     * Select the entity name validation strategy to use. This only changes the selected value in the form; call
+     * {@link #save()} to persist it.
+     *
+     * @param value the strategy hint to select (e.g. {@code "ReplaceCharacterEntityNameValidation"} or
+     *            {@code "SlugEntityNameValidation"})
+     */
+    public void selectStrategy(String value)
+    {
+        new Select(getDriver().findElement(STRATEGY_SELECT)).selectByValue(value);
+    }
+
+    /**
+     * Save the configuration. This persists the selected strategy and its configuration (which is necessary, for the
+     * Slug strategy, so that its configuration properties are initialized before the strategy is tested).
+     */
+    public void save()
+    {
+        // The save button of this section's form has no name attribute, so the generic AdministrationSectionPage save
+        // logic cannot be used. Submit the form's submit button directly instead.
+        getDriver().addPageNotYetReloadedMarker();
+        getDriver().findElement(CONFIG_FORM).findElement(By.cssSelector("input[type='submit']")).click();
+        getDriver().waitUntilPageIsReloaded();
+    }
+
+    /**
+     * Enter a name in the "test selected strategy" field, then wait until the asynchronously computed result matches the
+     * expected transformed name and verify the validity.
+     * <p>
+     * The name is set and an {@code input} event is dispatched on every polling iteration, which makes the method robust
+     * against (a) the asynchronous loading of the section's JavaScript (the {@code input} handler that triggers the test
+     * might not be bound yet on the first attempt) and (b) out-of-order responses (all the requests carry the same name,
+     * so the displayed result converges to the expected one).
+     *
+     * @param name the name to test against the selected strategy
+     * @param expectedValid the expected validity of the tested name
+     * @param expectedTransformedName the expected transformed name
+     */
+    public void assertTestResult(String name, boolean expectedValid, String expectedTransformedName)
+    {
+        WebElement input = getDriver().findElement(TEST_NAME_INPUT);
+        getDriver().waitUntilCondition(driver -> {
+            getDriver().executeJavascript(
+                "arguments[0].value = arguments[1]; arguments[0].dispatchEvent(new Event('input'));", input, name);
+            return expectedTransformedName.equals(getTransformedName());
+        });
+        if (isTestedNameValid() != expectedValid) {
+            throw new AssertionError(String.format(
+                "The name [%s] was expected to be [%s] but was [%s] (transformed name [%s])", name,
+                expectedValid ? "valid" : "invalid", isTestedNameValid() ? "valid" : "invalid",
+                expectedTransformedName));
+        }
+    }
+
+    /**
+     * @return {@code true} if the last tested name was reported as valid for the selected strategy
+     */
+    private boolean isTestedNameValid()
+    {
+        return getDriver().findElementWithoutWaiting(TEST_VALID_TRUE).isDisplayed();
+    }
+
+    /**
+     * @return the transformed version of the last tested name, as computed by the selected strategy
+     */
+    private String getTransformedName()
+    {
+        return getDriver().findElement(TEST_TRANSFORMED_NAME).getText();
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-ui/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-ui/pom.xml
@@ -39,4 +39,14 @@
   <scm>
     <tag>stable-17.10.x</tag>
   </scm>
+
+  <dependencies>
+    <dependency>
+      <!-- The Administration page renders its content with the {{display}} macro. -->
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-display-macro</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+  </dependencies>
 </project>


### PR DESCRIPTION
Backport of XWIKI-21853 to stable-17.10.x.

Cherry-picked from master (git cherry-pick -x):
5e67cd7cd2a XWIKI-21853: Add automated test for "Name strategies test selected strategy"

Reconciled conflicts in xwiki-platform-model-validation/pom.xml and xwiki-platform-model-validation-ui/pom.xml by keeping both the target branch's <scm> block and the incoming <profiles>/<dependencies> additions; set the new test module poms' <version> to the target branch value (17.10.10-SNAPSHOT).