### PR TITLE
[stable-17.10.x] XWIKI-24474: Add automated tests for "Solr Reindex" and "Solr Delete from Index"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-test/xwiki-platform-search-test-docker/src/test/it/org/xwiki/search/test/ui/SolrIndexerIT.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-test/xwiki-platform-search-test-docker/src/test/it/org/xwiki/search/test/ui/SolrIndexerIT.java
@@ -22,6 +22,7 @@ package org.xwiki.search.test.ui;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.SpaceReference;
@@ -121,6 +122,7 @@ class SolrIndexerIT
     private static final String WEB_HOME = "WebHome";
 
     @Test
+    @Order(1)
     void sortOrder(TestReference testReference, TestUtils testUtils, TestConfiguration testConfiguration)
         throws Exception
     {

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-test/xwiki-platform-search-test-docker/src/test/it/org/xwiki/search/test/ui/SolrSearchIT.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-test/xwiki-platform-search-test-docker/src/test/it/org/xwiki/search/test/ui/SolrSearchIT.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -45,6 +46,7 @@ import org.xwiki.test.ui.po.SuggestInputElement.SuggestionElement;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.matchesRegex;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -73,6 +75,7 @@ class SolrSearchIT
     private static final String GET_ACTION = "get";
 
     @Test
+    @Order(1)
     void verifySpaceFaucetEscaping(TestUtils setup, TestConfiguration testConfiguration) throws Exception
     {
         setup.loginAsSuperAdmin();
@@ -90,6 +93,7 @@ class SolrSearchIT
 
     @ParameterizedTest
     @ValueSource(strings = { "de_DE", "fr_FR", "fr_BE" })
+    @Order(2)
     void verifySearchInLocale(String locale, TestUtils setup, TestConfiguration testConfiguration,
         TestReference testReference) throws Exception
     {
@@ -131,6 +135,7 @@ class SolrSearchIT
     }
 
     @Test
+    @Order(3)
     void searchLimit(TestUtils setup, TestConfiguration testConfiguration, TestReference testReference) throws Exception
     {
         setup.loginAsSuperAdmin();
@@ -162,6 +167,7 @@ class SolrSearchIT
     }
 
     @Test
+    @Order(4)
     void suggestService(TestUtils setup, TestConfiguration testConfiguration, TestReference testReference)
         throws Exception
     {
@@ -193,7 +199,64 @@ class SolrSearchIT
         assertThat(pageSource, containsString(formattedExpectedError));
     }
 
+    /**
+     * Verifies the "Delete from index" and "Reindex" administration actions, covering the corresponding manual tests.
+     * The two actions are tested together (delete, then reindex) so that the test restores the index state for the
+     * other tests running on the same instance.
+     */
     @Test
+    @Order(5)
+    void deleteFromIndexAndReindex(TestUtils setup, TestReference testReference) throws Exception
+    {
+        setup.loginAsSuperAdmin();
+
+        String matchedWord = "antidisestablishmentarianism";
+        String pageTitle = "Delete Reindex Test";
+        DocumentReference pageReference = new DocumentReference("WebHome",
+            new SpaceReference("DeleteReindex", testReference.getLastSpaceReference()));
+        setup.rest().savePage(pageReference, matchedWord, pageTitle);
+
+        SolrTestUtils solrUtils = new SolrTestUtils(setup);
+        solrUtils.waitEmptyQueue();
+
+        // The page is initially indexed and thus found by the search.
+        SolrSearchPage searchPage = SolrSearchPage.gotoPage().search(matchedWord);
+        assertThat("The page should be found before deleting it from the index.",
+            searchPage.getSearchResults().stream().map(SolrSearchResult::getTitle).toList(), hasItem(pageTitle));
+
+        // Delete the entire farm from the index (Administer Wiki > Search > Search > Delete from index > Entire farm).
+        SearchAdministrationPage adminPage = SearchAdministrationPage.gotoPage();
+        adminPage.getIndexingActionField().selectByValue("delete");
+        adminPage.getIndexingWikiField().selectByValue("");
+        adminPage.submitIndexingAction();
+        assertThat(adminPage.getActionResultMessage(), containsString("Delete successfully triggered"));
+
+        solrUtils.waitEmptyQueue();
+        // Once the deletion is done the queue size displayed in the administration section is 0.
+        assertEquals(0, SearchAdministrationPage.gotoPage().getQueueSize());
+
+        // The page is no longer found by the search.
+        searchPage = SolrSearchPage.gotoPage().search(matchedWord);
+        assertTrue(searchPage.getSearchResults().isEmpty(),
+            "The page should not be found after deleting it from the index.");
+
+        // Reindex the entire farm (Administer Wiki > Search > Search > Reindex > Entire farm).
+        adminPage = SearchAdministrationPage.gotoPage();
+        adminPage.getIndexingActionField().selectByValue("reindex");
+        adminPage.getIndexingWikiField().selectByValue("");
+        adminPage.submitIndexingAction();
+        assertThat(adminPage.getActionResultMessage(), containsString("Reindex successfully triggered"));
+
+        solrUtils.waitEmptyQueue();
+
+        // The page is found again after reindexing.
+        searchPage = SolrSearchPage.gotoPage().search(matchedWord);
+        assertThat("The page should be found again after reindexing.",
+            searchPage.getSearchResults().stream().map(SolrSearchResult::getTitle).toList(), hasItem(pageTitle));
+    }
+
+    @Test
+    @Order(6)
     void searchExclusions(TestUtils setup, TestConfiguration testConfiguration, TestReference testReference)
         throws Exception
     {

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-test/xwiki-platform-search-test-pageobjects/src/main/java/org/xwiki/search/test/po/SearchAdministrationPage.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-test/xwiki-platform-search-test-pageobjects/src/main/java/org/xwiki/search/test/po/SearchAdministrationPage.java
@@ -89,9 +89,6 @@ public class SearchAdministrationPage extends AdministrationSectionPage
     /**
      * @return the dropdown list used to select the indexing action to perform (add to the index, delete from the
      *         index or reindex)
-     * @since 17.10.10
-     * @since 18.4.3
-     * @since 18.5.0RC1
      */
     public Select getIndexingActionField()
     {
@@ -101,9 +98,6 @@ public class SearchAdministrationPage extends AdministrationSectionPage
     /**
      * @return the dropdown list used to select the wiki on which to perform the indexing action (or the entire farm
      *         when the empty value is selected)
-     * @since 17.10.10
-     * @since 18.4.3
-     * @since 18.5.0RC1
      */
     public Select getIndexingWikiField()
     {
@@ -112,10 +106,6 @@ public class SearchAdministrationPage extends AdministrationSectionPage
 
     /**
      * Submit the indexing action form, i.e. click the "Apply" button. This triggers a full-page reload.
-     *
-     * @since 17.10.10
-     * @since 18.4.3
-     * @since 18.5.0RC1
      */
     public void submitIndexingAction()
     {
@@ -125,9 +115,6 @@ public class SearchAdministrationPage extends AdministrationSectionPage
 
     /**
      * @return the current size of the Solr indexing queue, as displayed in the administration section
-     * @since 17.10.10
-     * @since 18.4.3
-     * @since 18.5.0RC1
      */
     public int getQueueSize()
     {
@@ -136,9 +123,6 @@ public class SearchAdministrationPage extends AdministrationSectionPage
 
     /**
      * @return the text of the success message displayed after submitting an indexing action
-     * @since 17.10.10
-     * @since 18.4.3
-     * @since 18.5.0RC1
      */
     public String getActionResultMessage()
     {

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-test/xwiki-platform-search-test-pageobjects/src/main/java/org/xwiki/search/test/po/SearchAdministrationPage.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-test/xwiki-platform-search-test-pageobjects/src/main/java/org/xwiki/search/test/po/SearchAdministrationPage.java
@@ -19,6 +19,7 @@
  */
 package org.xwiki.search.test.po;
 
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.xwiki.administration.test.po.AdministrationSectionPage;
@@ -40,6 +41,15 @@ public class SearchAdministrationPage extends AdministrationSectionPage
 
     @FindBy(id = "XWiki.SearchConfigClass_0_exclusions")
     private WebElement searchExclusionsField;
+
+    @FindBy(id = "solrAdminAction")
+    private WebElement indexingActionField;
+
+    @FindBy(id = "solrAdminWiki")
+    private WebElement indexingWikiField;
+
+    @FindBy(className = "solrQueueSize")
+    private WebElement queueSizeField;
 
     /**
      * Open the search administration section.
@@ -74,5 +84,54 @@ public class SearchAdministrationPage extends AdministrationSectionPage
     public SuggestInputElement getSearchExclusionsField()
     {
         return new SuggestInputElement(this.searchExclusionsField);
+    }
+
+    /**
+     * @return the dropdown list used to select the indexing action to perform (add to the index, delete from the
+     *         index or reindex)
+     * @since 18.5.0RC1
+     */
+    public Select getIndexingActionField()
+    {
+        return new Select(this.indexingActionField);
+    }
+
+    /**
+     * @return the dropdown list used to select the wiki on which to perform the indexing action (or the entire farm
+     *         when the empty value is selected)
+     * @since 18.5.0RC1
+     */
+    public Select getIndexingWikiField()
+    {
+        return new Select(this.indexingWikiField);
+    }
+
+    /**
+     * Submit the indexing action form, i.e. click the "Apply" button. This triggers a full-page reload.
+     *
+     * @since 18.5.0RC1
+     */
+    public void submitIndexingAction()
+    {
+        getDriver().findElement(
+            By.xpath("//select[@id = 'solrAdminAction']/ancestor::form//input[@type = 'submit']")).click();
+    }
+
+    /**
+     * @return the current size of the Solr indexing queue, as displayed in the administration section
+     * @since 18.5.0RC1
+     */
+    public int getQueueSize()
+    {
+        return Integer.parseInt(this.queueSizeField.getText().trim());
+    }
+
+    /**
+     * @return the text of the success message displayed after submitting an indexing action
+     * @since 18.5.0RC1
+     */
+    public String getActionResultMessage()
+    {
+        return getDriver().findElement(By.cssSelector("div.box.successmessage")).getText();
     }
 }

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-test/xwiki-platform-search-test-pageobjects/src/main/java/org/xwiki/search/test/po/SearchAdministrationPage.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-test/xwiki-platform-search-test-pageobjects/src/main/java/org/xwiki/search/test/po/SearchAdministrationPage.java
@@ -89,6 +89,8 @@ public class SearchAdministrationPage extends AdministrationSectionPage
     /**
      * @return the dropdown list used to select the indexing action to perform (add to the index, delete from the
      *         index or reindex)
+     * @since 17.10.10
+     * @since 18.4.3
      * @since 18.5.0RC1
      */
     public Select getIndexingActionField()
@@ -99,6 +101,8 @@ public class SearchAdministrationPage extends AdministrationSectionPage
     /**
      * @return the dropdown list used to select the wiki on which to perform the indexing action (or the entire farm
      *         when the empty value is selected)
+     * @since 17.10.10
+     * @since 18.4.3
      * @since 18.5.0RC1
      */
     public Select getIndexingWikiField()
@@ -109,6 +113,8 @@ public class SearchAdministrationPage extends AdministrationSectionPage
     /**
      * Submit the indexing action form, i.e. click the "Apply" button. This triggers a full-page reload.
      *
+     * @since 17.10.10
+     * @since 18.4.3
      * @since 18.5.0RC1
      */
     public void submitIndexingAction()
@@ -119,6 +125,8 @@ public class SearchAdministrationPage extends AdministrationSectionPage
 
     /**
      * @return the current size of the Solr indexing queue, as displayed in the administration section
+     * @since 17.10.10
+     * @since 18.4.3
      * @since 18.5.0RC1
      */
     public int getQueueSize()
@@ -128,6 +136,8 @@ public class SearchAdministrationPage extends AdministrationSectionPage
 
     /**
      * @return the text of the success message displayed after submitting an indexing action
+     * @since 17.10.10
+     * @since 18.4.3
      * @since 18.5.0RC1
      */
     public String getActionResultMessage()


### PR DESCRIPTION
Backport of XWIKI-24474 to stable-17.10.x.

Cherry-picked from master (git cherry-pick -x):
dffd8822943 XWIKI-24474: Add automated tests for "Solr Reindex" and "Solr Delete from Index"

Resolved conflicts in SolrSearchIT.java and SolrIndexerIT.java: kept the branch's existing test-method signatures (which carry the extra TestConfiguration parameter) while adding the incoming @Order annotations and the new deleteFromIndexAndReindex test method.