### PR TITLE
[Misc] Do not throw an exception from a finally block in XARInputFilterStream

### DIFF
--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/XARInputFilterStream.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/XARInputFilterStream.java
@@ -104,7 +104,7 @@ public class XARInputFilterStream extends AbstractBeanInputFilterStream<XARInput
                 try {
                     inputSource.close();
                 } catch (IOException e) {
-                    this.logger.warn("Failed to close the source: {}", ExceptionUtils.getRootCauseMessage(e));
+                    this.logger.warn("Failed to close the source: [{}]", ExceptionUtils.getRootCauseMessage(e));
                 }
             }
         } else {

--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/XARInputFilterStream.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/input/XARInputFilterStream.java
@@ -26,6 +26,8 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.annotation.InstantiationStrategy;
 import org.xwiki.component.descriptor.ComponentInstantiationStrategy;
@@ -61,6 +63,9 @@ public class XARInputFilterStream extends AbstractBeanInputFilterStream<XARInput
 
     @Inject
     private Provider<DocumentLocaleReader> documentLocaleReaderProvider;
+
+    @Inject
+    private Logger logger;
 
     @Override
     public void close() throws IOException
@@ -99,7 +104,7 @@ public class XARInputFilterStream extends AbstractBeanInputFilterStream<XARInput
                 try {
                     inputSource.close();
                 } catch (IOException e) {
-                    throw new FilterException("Failed to close the source", e);
+                    this.logger.warn("Failed to close the source: {}", ExceptionUtils.getRootCauseMessage(e));
                 }
             }
         } else {


### PR DESCRIPTION
## Summary

Fixes two SonarCloud issues that both fire on line 102 of `XARInputFilterStream.java` (same defect, two rules):

- [java:S1143 — Remove this throw statement from this finally block](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AW5-S8e31Yj5qvzeRoMB&open=AW5-S8e31Yj5qvzeRoMB)
- [java:S1163 — Refactor this code to not throw exceptions in finally blocks](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AW5-S8e31Yj5qvzeRoMC&open=AW5-S8e31Yj5qvzeRoMC)

### Problem

When reading a XAR input stream, the `finally` block closing the source rethrew a `FilterException` if `close()` failed. Throwing from a `finally` block silently discards any exception raised in the `try` body (e.g. a genuine read failure), hiding the real cause of a failure.

### Fix

Log a warning when closing the source fails instead of rethrowing, so the original exception from the `try` body propagates. This matches the existing idiom in the sibling `WikiReader` class (`logger.warn(..., ExceptionUtils.getRootCauseMessage(e))`), using an injected `Logger`.

## Test plan

- [x] `mvn clean install` of `xwiki-platform-filter-stream-xar` passes (checkstyle + Spoon included).

## Token usage

Measured from the session transcript. Cache-read is the dominant cost (long-lived cached context re-read on every turn, including the build wait). Fresh input + output stay tiny thanks to narrow reads. The container restarted mid-build, so the "fix" bucket spans two build attempts.

| Phase | Fresh in | Output | Cache read | Cache create | Total |
|-------|---------:|-------:|-----------:|-------------:|------:|
| 1. Find the issue | 6,796 | 4,044 | 431,857 | 50,592 | **493,289** |
| 2. Fix it (edit + 2 builds + commit + push) | 985 | 4,251 | 730,621 | 122,551 | **858,408** |
| 3. Post-fix (PR + label + accept + report) | 329 | 2,899 | 311,273 | 3,302 | **317,803** |

Total: **~1.67M tokens** (find 30% / fix 51% / post 19%). The post bucket is a mid-phase snapshot taken at PR creation; the label/accept/report turns after it are not included.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X9j9ZNw8FXitou7XsvmU2Y)_