### PR TITLE
[stable-18.4.x] XWIKI-19511: Add automated test for "Change the Icon Theme from Administer Page"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/pom.xml
@@ -95,6 +95,20 @@
       <artifactId>xwiki-platform-jodatime</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- Provides the Silk icon theme so that the icon theme can be switched from the Themes administration. -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-icon-ui</artifactId>
+      <version>${project.version}</version>
+      <type>xar</type>
+    </dependency>
+    <!-- Provides the Font Awesome icon theme (the default), used as the starting point of the icon theme test. -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-icon-fontawesome</artifactId>
+      <version>${project.version}</version>
+      <type>xar</type>
+    </dependency>
     <!-- ================================
          Test only dependencies
          ================================ -->

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/AllIT.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/AllIT.java
@@ -80,4 +80,9 @@ public class AllIT
     class NestedEditingIT extends EditingIT
     {
     }
+
+    @Nested
+    class NestedIconThemeIT extends IconThemeIT
+    {
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/IconThemeIT.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/IconThemeIT.java
@@ -1,0 +1,99 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.administration.test.ui;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.xwiki.administration.test.po.AdministrationPage;
+import org.xwiki.administration.test.po.ThemesAdministrationSectionPage;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.SpaceReference;
+import org.xwiki.test.docker.junit5.TestReference;
+import org.xwiki.test.docker.junit5.UITest;
+import org.xwiki.test.ui.TestUtils;
+import org.xwiki.test.ui.po.ViewPage;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Validate that the icon theme can be changed from the Themes administration section (at space level) and that the
+ * change is inherited by child pages.
+ *
+ * @version $Id$
+ * @since 18.6.0RC1
+ */
+@UITest
+class IconThemeIT
+{
+    /**
+     * Content that renders the {@code add} icon using the currently configured icon theme. With the Font Awesome
+     * theme this produces a {@code <span class="fa fa-plus">} element while with the Silk theme this produces an
+     * {@code <img src=".../icons/silk/add.png">} element.
+     */
+    private static final String ICON_CONTENT = "{{displayIcon name=\"add\"/}}";
+
+    @BeforeAll
+    void beforeAll(TestUtils setup)
+    {
+        setup.loginAsSuperAdmin();
+    }
+
+    @Test
+    void changeIconThemeFromSpaceAdministration(TestUtils setup, TestReference testReference)
+    {
+        // Create a parent page 'a' and a child page 'a.b', both rendering an icon, so that we can observe the icon
+        // theme used and the inheritance from the parent space to the child page.
+        SpaceReference parentSpace = new SpaceReference("a", testReference.getLastSpaceReference());
+        DocumentReference parentPage = new DocumentReference("WebHome", parentSpace);
+        DocumentReference parentPreferences = new DocumentReference("WebPreferences", parentSpace);
+        DocumentReference childPage =
+            new DocumentReference("WebHome", new SpaceReference("b", parentSpace));
+        setup.createPage(parentPage, ICON_CONTENT, "a");
+        setup.createPage(childPage, ICON_CONTENT, "b");
+
+        // Establish a deterministic baseline by setting the Font Awesome icon theme on the parent space (the icon
+        // theme is not configured by default in the test instance).
+        setup.updateObject(parentPreferences, "XWiki.XWikiPreferences", 0, "iconTheme", "IconThemes.FontAwesome");
+
+        // The parent page uses Font Awesome (font-based icons).
+        ViewPage viewPage = setup.gotoPage(parentPage);
+        assertTrue(viewPage.isFontAwesomeIconDisplayedInContent(),
+            "The parent page should use the Font Awesome icon theme before the change");
+
+        // Change the icon theme to Silk from the parent space administration.
+        ThemesAdministrationSectionPage themesPage =
+            AdministrationPage.gotoSpaceAdministrationPage(parentSpace).clickThemesSection();
+        themesPage.setIconTheme("Silk");
+        themesPage.clickSave();
+
+        // The parent page now uses Silk (image-based icons).
+        viewPage = setup.gotoPage(parentPage);
+        assertTrue(viewPage.isSilkIconDisplayedInContent(),
+            "The parent page should use the Silk icon theme after the change");
+        assertFalse(viewPage.isFontAwesomeIconDisplayedInContent(),
+            "The parent page should no longer use the Font Awesome icon theme after the change");
+
+        // The child page inherits the Silk icon theme from its parent space.
+        viewPage = setup.gotoPage(childPage);
+        assertTrue(viewPage.isSilkIconDisplayedInContent(),
+            "The child page should inherit the Silk icon theme from its parent space");
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/ThemesAdministrationSectionPage.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/ThemesAdministrationSectionPage.java
@@ -51,6 +51,12 @@ public class ThemesAdministrationSectionPage extends AdministrationSectionPage
     @FindBy(xpath = "//a[contains(text(), 'Manage color themes')]")
     private WebElement manageColorThemesButton;
 
+    /**
+     * The select input to set the icon theme.
+     */
+    @FindBy(id = "XWiki.XWikiPreferences_0_iconTheme")
+    private WebElement iconThemeSelect;
+
     @FindBy(xpath = "//select[@id='XWiki.XWikiPreferences_0_skin']")
     private WebElement skinInput;
 
@@ -200,5 +206,67 @@ public class ThemesAdministrationSectionPage extends AdministrationSectionPage
     public void clickOnCustomizeSkin()
     {
         this.customizeSkinButton.click();
+    }
+
+    private List<WebElement> getIconThemeOptions()
+    {
+        return this.iconThemeSelect.findElements(By.tagName("option"));
+    }
+
+    private WebElement getIconThemeOptionElement(String iconThemeName)
+    {
+        for (WebElement option : getIconThemeOptions()) {
+            if (iconThemeName.equals(option.getText())) {
+                return option;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @return the list of available icon themes
+     */
+    public List<String> getIconThemes()
+    {
+        List<String> results = new ArrayList<>();
+        for (WebElement option : getIconThemeOptions()) {
+            results.add(option.getText());
+        }
+        return results;
+    }
+
+    /**
+     * Select the specified icon theme.
+     *
+     * @param iconThemeName the name of the icon theme to select (e.g. {@code Silk} or {@code Font Awesome})
+     */
+    public void setIconTheme(String iconThemeName)
+    {
+        // Make sure the icon theme that we want to set is available from the list first.
+        try {
+            getDriver().waitUntilCondition(driver -> getIconThemeOptionElement(iconThemeName) != null);
+        } catch (TimeoutException e) {
+            throw new TimeoutException(String.format("Icon theme [%s] wasn't found among [%s]", iconThemeName,
+                StringUtils.join(getIconThemes(), ',')), e);
+        }
+
+        // Click on it to set the theme.
+        getIconThemeOptionElement(iconThemeName).click();
+
+        // Wait to be sure the change is effective.
+        getDriver().waitUntilCondition(driver -> Strings.CS.equals(getCurrentIconTheme(), iconThemeName));
+    }
+
+    /**
+     * @return the currently selected icon theme
+     */
+    public String getCurrentIconTheme()
+    {
+        for (WebElement option : getIconThemeOptions()) {
+            if (option.isSelected()) {
+                return option.getText();
+            }
+        }
+        return null;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BasePage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BasePage.java
@@ -855,4 +855,22 @@ public class BasePage extends BaseElement
     {
         return getDriver().hasElementWithoutWaiting(By.className("xwikirenderingerror"));
     }
+
+    /**
+     * @return {@code true} if an icon rendered by the Font Awesome (font-based) icon theme is displayed in the page
+     *         content; Font Awesome renders icons as {@code <span class="fa ...">} elements
+     */
+    public boolean isFontAwesomeIconDisplayedInContent()
+    {
+        return getDriver().hasElementWithoutWaiting(By.cssSelector("#xwikicontent span.fa"));
+    }
+
+    /**
+     * @return {@code true} if an icon rendered by the Silk (image-based) icon theme is displayed in the page content;
+     *         Silk renders icons as {@code <img src=".../icons/silk/...">} elements
+     */
+    public boolean isSilkIconDisplayedInContent()
+    {
+        return getDriver().hasElementWithoutWaiting(By.cssSelector("#xwikicontent img[src*='/icons/silk/']"));
+    }
 }


### PR DESCRIPTION
Backport of XWIKI-19511 to stable-18.4.x.

Cherry-picked from master (git cherry-pick -x):
068d22a8f00 XWIKI-19511: Add automated test for "Change the Icon Theme from Administer Page"

Resolved conflict in AllIT.java: added the new @Nested NestedIconThemeIT entry alongside the existing entries (kept the branch's existing entries; did not pull in NestedEditingIT/EditingIT which does not exist on this branch).