### PR TITLE
[stable-17.10.x] XWIKI-23066: Add automated test for "Space Rights Show Users and Groups"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/AdministrationIT.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/AdministrationIT.java
@@ -62,7 +62,9 @@ class AdministrationIT
         assertTrue(wikiAdministrationPage.getBreadcrumbContent().endsWith("/Global Administration"));
 
         // TODO: Move these tests in their own modules, i.e. the modules that brought the Administration UI extension.
-        Arrays.asList("Users", "Groups", "Rights", "Registration", "Themes", "Presentation", "Templates",
+        // Note: the global "Rights" section presence is verified by UsersGroupsRightsManagementIT (via
+        // AdministrationPage.clickGlobalRightsSection()), so it's not re-checked here.
+        Arrays.asList("Users", "Groups", "Registration", "Themes", "Presentation", "Templates",
             "Localization", "Import", "Export", "Editing", "emailSend", "emailStatus", "emailGeneral")
             .stream().forEach(sectionId -> assertTrue(wikiAdministrationPage.hasSection(sectionId),
                 String.format("Menu section [%s] is missing.", sectionId)));
@@ -83,7 +85,8 @@ class AdministrationIT
         assertTrue(pageAdministrationPage.hasSection("Themes"));
         assertTrue(pageAdministrationPage.hasSection("Presentation"));
         assertTrue(pageAdministrationPage.hasSection("PageAndChildrenRights"));
-        assertTrue(pageAdministrationPage.hasSection("PageRights"));
+        // Note: the "PageRights" section presence is verified by
+        // UsersGroupsRightsManagementIT.rightsShowUsersAndGroups, so it's not re-checked here.
 
         // All these sections should not be present (they provide wiki-wide configuration).
         Arrays.asList("Users", "Groups", "Rights", "Registration", "Templates", "Localization", "Import", "Export",


### PR DESCRIPTION
Backport of XWIKI-23066 to stable-17.10.x.

Cherry-picked from master (git cherry-pick -x):
74b66302148 XWIKI-23066: Add automated test for "Space Rights Show Users and Groups"

Conflicts reconciled: in AdministrationIT.java kept the branch's Arrays.asList/.stream().forEach style while applying the commit's change (removed the global "Rights" section from the checked list and added the explanatory comment). In UsersGroupsRightsManagementIT.java the branch lacks the unrelated setExtensionRightsFor* tests present on master, so only the spaceRightsShowUsersAndGroups test method actually added by this commit was applied (resulting diff matches the original commit: 37 insertions, 2 deletions).