### PR TITLE
[stable-18.4.x] XWIKI-22446: Add automated test for "Solr Add to Index"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-test/xwiki-platform-search-test-docker/src/test/it/org/xwiki/search/test/ui/SolrSearchIT.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-test/xwiki-platform-search-test-docker/src/test/it/org/xwiki/search/test/ui/SolrSearchIT.java
@@ -199,9 +199,9 @@ class SolrSearchIT
     }
 
     /**
-     * Verifies the "Delete from index", "Add to index" and "Reindex" administration actions, covering the
-     * corresponding manual tests. The three actions are tested together in a single flow (delete, then add to index,
-     * then reindex) so that the test restores the index state for the other tests running on the same instance.
+     * Verifies the "Delete from index", "Add to index" and "Reindex" administration actions. The three actions are
+     * tested together in a single flow (delete, then add to index, then reindex) so that the test restores the index
+     * state for the other tests running on the same instance.
      */
     @Test
     @Order(5)

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-test/xwiki-platform-search-test-docker/src/test/it/org/xwiki/search/test/ui/SolrSearchIT.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-test/xwiki-platform-search-test-docker/src/test/it/org/xwiki/search/test/ui/SolrSearchIT.java
@@ -199,13 +199,13 @@ class SolrSearchIT
     }
 
     /**
-     * Verifies the "Delete from index" and "Reindex" administration actions, covering the corresponding manual tests.
-     * The two actions are tested together (delete, then reindex) so that the test restores the index state for the
-     * other tests running on the same instance.
+     * Verifies the "Delete from index", "Add to index" and "Reindex" administration actions, covering the
+     * corresponding manual tests. The three actions are tested together in a single flow (delete, then add to index,
+     * then reindex) so that the test restores the index state for the other tests running on the same instance.
      */
     @Test
     @Order(5)
-    void deleteFromIndexAndReindex(TestUtils setup, TestReference testReference) throws Exception
+    void verifyIndexingActionsFromAdministration(TestUtils setup, TestReference testReference) throws Exception
     {
         setup.loginAsSuperAdmin();
 
@@ -238,6 +238,20 @@ class SolrSearchIT
         searchPage = SolrSearchPage.gotoPage().search(matchedWord);
         assertTrue(searchPage.getSearchResults().isEmpty(),
             "The page should not be found after deleting it from the index.");
+
+        // Add the entire farm to the index (Administer Wiki > Search > Search > Add to index > Entire farm).
+        adminPage = SearchAdministrationPage.gotoPage();
+        adminPage.getIndexingActionField().selectByValue("index");
+        adminPage.getIndexingWikiField().selectByValue("");
+        adminPage.submitIndexingAction();
+        assertThat(adminPage.getActionResultMessage(), containsString("Index successfully triggered"));
+
+        solrUtils.waitEmptyQueue();
+
+        // The page is found again after adding it back to the index.
+        searchPage = SolrSearchPage.gotoPage().search(matchedWord);
+        assertThat("The page should be found again after adding it to the index.",
+            searchPage.getSearchResults().stream().map(SolrSearchResult::getTitle).toList(), hasItem(pageTitle));
 
         // Reindex the entire farm (Administer Wiki > Search > Search > Reindex > Entire farm).
         adminPage = SearchAdministrationPage.gotoPage();


### PR DESCRIPTION
Backport of XWIKI-22446 to stable-18.4.x.

Cherry-picked from master (git cherry-pick -x):
a2854ead209 XWIKI-22446: Add automated test for "Solr Add to Index"
bc64d746c43 XWIKI-22446: Add automated test for "Solr Add to Index" * Remove reference to manual tests

Resolved a conflict in SolrSearchIT.java: added the new verifyIndexingActionsFromAdministration test, dropped the master-only @Order annotations (this branch doesn't order its Solr tests), and added the missing hasItem static import.