### PR TITLE
[stable-18.4.x] XWIKI-22286: Add automated test for "Show User and Group Rights"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/UsersGroupsRightsManagementIT.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/UsersGroupsRightsManagementIT.java
@@ -725,4 +725,43 @@ class UsersGroupsRightsManagementIT
         assertTrue(vp.getContent().contains("ALLOWED"),
             "Custom right should be allowed on child page when set as page-only on parent");
     }
+
+    /**
+     * Verify that the Rights administration section displays the listing of Users and Groups, both at the global
+     * (wiki) level ("Rights" section, see XWIKI-22286) and at the page/space level ("Rights: Page" section, see
+     * XWIKI-23066).
+     */
+    @Test
+    @Order(13)
+    void rightsShowUsersAndGroups(TestUtils setup, TestReference testReference)
+    {
+        // Ensure the space exists so it has a Page Administration with a Rights: Page section.
+        setup.createPage(testReference, "", testReference.getName());
+
+        // Create the admin user so that we can verify it's listed in the Rights table.
+        setup.createAdminUser();
+
+        // Global level -> Administer Wiki -> Users & Rights -> Rights.
+        AdministrationPage administrationPage = AdministrationPage.gotoPage();
+        assertRightsTableShowsUsersAndGroups(administrationPage.clickGlobalRightsSection().getEditRightsPane());
+
+        // Page/space level -> Administer Page -> Users & Rights -> Rights: Page.
+        AdministrationPage adminPage =
+            AdministrationPage.gotoSpaceAdministrationPage(testReference.getLastSpaceReference());
+        adminPage.clickSection("Users & Rights", "Rights: Page");
+        assertRightsTableShowsUsersAndGroups(new EditRightsPane());
+    }
+
+    private void assertRightsTableShowsUsersAndGroups(EditRightsPane editRightsPane)
+    {
+        // Select Users: the user listing is displayed (default Admin user present).
+        editRightsPane.switchToUsers();
+        editRightsPane.getRightsTable().filterColumn("name", "Admin");
+        assertTrue(editRightsPane.hasEntity("Admin"));
+
+        // Select Groups: the groups listing is displayed (default groups present).
+        editRightsPane.switchToGroups();
+        editRightsPane.getRightsTable().filterColumn("name", "XWikiAdminGroup");
+        assertTrue(editRightsPane.hasEntity("XWikiAdminGroup"));
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/UsersGroupsRightsManagementIT.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/UsersGroupsRightsManagementIT.java
@@ -740,6 +740,11 @@ class UsersGroupsRightsManagementIT
 
         // Create the admin user so that we can verify it's listed in the Rights table.
         setup.createAdminUser();
+        // createAdminUser() logs in as the non-superadmin "Admin" user; log back in as superadmin so that
+        // navigating to the (global and page) administration is race-free, matching the rest of this class. The
+        // "Admin" user document is created via REST regardless of who is logged in, so it's still listed in the
+        // Rights table below.
+        setup.loginAsSuperAdmin();
 
         // Global level -> Administer Wiki -> Users & Rights -> Rights.
         AdministrationPage administrationPage = AdministrationPage.gotoPage();


### PR DESCRIPTION
Backport of XWIKI-22286 to stable-18.4.x.

Cherry-picked from master (git cherry-pick -x):
- 5818386a56a XWIKI-22286: Add automated test for "Show User and Group Rights"
- ed0a7fc8c3e XWIKI-22286: Add automated test for "Show User and Group Rights" * Fix test

Conflict resolution: added the new rightsShowUsersAndGroups test (+ assertRightsTableShowsUsersAndGroups helper) alongside the existing tests in UsersGroupsRightsManagementIT (the branch already has the Order 11/12 extension-rights tests). In AdministrationIT the existing assertTrue(hasSection("PageRights")) assertion was kept instead of the master change that replaced it with a comment, so that file is unchanged on the branch.