### PR TITLE
[Misc] Adjust @since after backporting testneeded tests to stable-17.10.x and stable-18.4.x

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/EditingAdministrationSectionPage.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/EditingAdministrationSectionPage.java
@@ -28,6 +28,8 @@ import org.xwiki.test.ui.po.Select;
  * default edit mode used when editing a page) can be configured.
  *
  * @version $Id$
+ * @since 17.10.10
+ * @since 18.4.3
  * @since 18.5.0RC1
  */
 public class EditingAdministrationSectionPage extends AdministrationSectionPage

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/PresentationAdministrationSectionPage.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/PresentationAdministrationSectionPage.java
@@ -198,7 +198,6 @@ public class PresentationAdministrationSectionPage extends AdministrationSection
 
     /**
      * @param value the value to set for the "Copyright" option
-     * @since 18.6.0RC1
      */
     public void setCopyright(String value)
     {
@@ -208,7 +207,6 @@ public class PresentationAdministrationSectionPage extends AdministrationSection
 
     /**
      * @param value the value to set for the "Version" option
-     * @since 18.6.0RC1
      */
     public void setVersion(String value)
     {

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/TemplateProviderViewPage.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/TemplateProviderViewPage.java
@@ -28,6 +28,7 @@ import org.xwiki.test.ui.po.ViewPage;
 /**
  * Represents a template provider page in view mode.
  *
+ * @since 17.10.10
  * @since 18.3.0RC1
  */
 public class TemplateProviderViewPage extends ViewPage

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/ThemesAdministrationSectionPage.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/ThemesAdministrationSectionPage.java
@@ -225,7 +225,6 @@ public class ThemesAdministrationSectionPage extends AdministrationSectionPage
 
     /**
      * @return the list of available icon themes
-     * @since 18.6.0RC1
      */
     public List<String> getIconThemes()
     {
@@ -240,7 +239,6 @@ public class ThemesAdministrationSectionPage extends AdministrationSectionPage
      * Select the specified icon theme.
      *
      * @param iconThemeName the name of the icon theme to select (e.g. {@code Silk} or {@code Font Awesome})
-     * @since 18.6.0RC1
      */
     public void setIconTheme(String iconThemeName)
     {
@@ -261,7 +259,6 @@ public class ThemesAdministrationSectionPage extends AdministrationSectionPage
 
     /**
      * @return the currently selected icon theme
-     * @since 18.6.0RC1
      */
     public String getCurrentIconTheme()
     {

--- a/xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-test/xwiki-platform-logging-test-pageobjects/src/main/java/org/xwiki/logging/test/po/LoggingAdministrationSectionPage.java
+++ b/xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-test/xwiki-platform-logging-test-pageobjects/src/main/java/org/xwiki/logging/test/po/LoggingAdministrationSectionPage.java
@@ -35,6 +35,8 @@ import org.xwiki.livedata.test.po.TableLayoutElement;
  * in its "Actions" column, a form to select a new level and submit it.
  *
  * @version $Id$
+ * @since 17.10.10
+ * @since 18.4.3
  * @since 18.5.0RC1
  */
 public class LoggingAdministrationSectionPage extends AdministrationSectionPage

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-test/xwiki-platform-model-validation-test-pageobjects/src/main/java/org/xwiki/model/validation/test/po/NameStrategiesAdministrationSectionPage.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-test/xwiki-platform-model-validation-test-pageobjects/src/main/java/org/xwiki/model/validation/test/po/NameStrategiesAdministrationSectionPage.java
@@ -29,6 +29,8 @@ import org.xwiki.test.ui.po.Select;
  * saved, and where a name can be entered to test the currently selected strategy.
  *
  * @version $Id$
+ * @since 17.10.10
+ * @since 18.4.3
  * @since 18.5.0RC1
  */
 public class NameStrategiesAdministrationSectionPage extends AdministrationSectionPage

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-pageobjects/src/main/java/org/xwiki/panels/test/po/PageLayoutTabContent.java
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-test/xwiki-platform-panels-test-pageobjects/src/main/java/org/xwiki/panels/test/po/PageLayoutTabContent.java
@@ -127,7 +127,6 @@ public class PageLayoutTabContent extends BaseElement
 
     /**
      * @return the comma-separated list of panels configured for the left column
-     * @since 18.6.0RC1
      */
     public String getLeftPanels()
     {
@@ -137,7 +136,6 @@ public class PageLayoutTabContent extends BaseElement
     /**
      * @param leftPanels the comma-separated list of panels to set for the left column
      * @return this object
-     * @since 18.6.0RC1
      */
     public PageLayoutTabContent setLeftPanels(String leftPanels)
     {

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-test/xwiki-platform-search-test-pageobjects/src/main/java/org/xwiki/search/test/po/SearchAdministrationPage.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-test/xwiki-platform-search-test-pageobjects/src/main/java/org/xwiki/search/test/po/SearchAdministrationPage.java
@@ -89,7 +89,6 @@ public class SearchAdministrationPage extends AdministrationSectionPage
     /**
      * @return the dropdown list used to select the indexing action to perform (add to the index, delete from the
      *         index or reindex)
-     * @since 18.5.0RC1
      */
     public Select getIndexingActionField()
     {
@@ -99,7 +98,6 @@ public class SearchAdministrationPage extends AdministrationSectionPage
     /**
      * @return the dropdown list used to select the wiki on which to perform the indexing action (or the entire farm
      *         when the empty value is selected)
-     * @since 18.5.0RC1
      */
     public Select getIndexingWikiField()
     {
@@ -108,8 +106,6 @@ public class SearchAdministrationPage extends AdministrationSectionPage
 
     /**
      * Submit the indexing action form, i.e. click the "Apply" button. This triggers a full-page reload.
-     *
-     * @since 18.5.0RC1
      */
     public void submitIndexingAction()
     {
@@ -119,7 +115,6 @@ public class SearchAdministrationPage extends AdministrationSectionPage
 
     /**
      * @return the current size of the Solr indexing queue, as displayed in the administration section
-     * @since 18.5.0RC1
      */
     public int getQueueSize()
     {
@@ -128,7 +123,6 @@ public class SearchAdministrationPage extends AdministrationSectionPage
 
     /**
      * @return the text of the success message displayed after submitting an indexing action
-     * @since 18.5.0RC1
      */
     public String getActionResultMessage()
     {

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BasePage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/BasePage.java
@@ -887,7 +887,6 @@ public class BasePage extends BaseElement
     /**
      * @return {@code true} if an icon rendered by the Font Awesome (font-based) icon theme is displayed in the page
      *         content; Font Awesome renders icons as {@code <span class="fa ...">} elements
-     * @since 18.6.0RC1
      */
     public boolean isFontAwesomeIconDisplayedInContent()
     {
@@ -897,7 +896,6 @@ public class BasePage extends BaseElement
     /**
      * @return {@code true} if an icon rendered by the Silk (image-based) icon theme is displayed in the page content;
      *         Silk renders icons as {@code <img src=".../icons/silk/...">} elements
-     * @since 18.6.0RC1
      */
     public boolean isSilkIconDisplayedInContent()
     {

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/CopyPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/CopyPage.java
@@ -136,7 +136,6 @@ public class CopyPage extends ViewPage
 
     /**
      * @return {@code true} if the checkbox for preserving children during copy is checked.
-     * @since 17.4.0RC1
      */
     public boolean isDeepCopy()
     {
@@ -147,7 +146,6 @@ public class CopyPage extends ViewPage
      * Sets whether children should be preserved during copy.
      *
      * @param deep {@code true} to preserve children, {@code false} otherwise
-     * @since 17.4.0RC1
      */
     public void setDeepCopy(boolean deep)
     {

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/CreatePagePage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/CreatePagePage.java
@@ -96,7 +96,6 @@ public class CreatePagePage extends BaseElement
      * @param template the value of the template option
      * @return the icon name displayed for the specified template option, extracted from the {@code <img>} element's
      *         {@code src} attribute
-     * @since 18.3.0RC1
      */
     public String getTemplateIcon(String template)
     {
@@ -106,7 +105,6 @@ public class CreatePagePage extends BaseElement
     /**
      * @param template the value of the template option
      * @return the description text displayed for the specified template option
-     * @since 18.3.0RC1
      */
     public String getTemplateDescription(String template)
     {

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/PageTypePicker.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/PageTypePicker.java
@@ -87,7 +87,6 @@ public class PageTypePicker extends XWikiSelectWidget
      * @param template the value of the template option
      * @return the icon name displayed for the specified template option, extracted from the {@code <img>} element's
      *         {@code src} attribute, or an empty string if no icon is displayed
-     * @since 18.3.0RC1
      */
     public String getTemplateIcon(String template)
     {
@@ -105,7 +104,6 @@ public class PageTypePicker extends XWikiSelectWidget
     /**
      * @param template the value of the template option
      * @return the description text displayed for the specified template option, or an empty string if none
-     * @since 18.3.0RC1
      */
     public String getTemplateDescription(String template)
     {

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/ViewPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/ViewPage.java
@@ -432,7 +432,6 @@ public class ViewPage extends BasePage
 
     /**
      * @return the content of the copyright section in the page footer
-     * @since 18.6.0RC1
      */
     public String getFooterCopyright()
     {
@@ -441,7 +440,6 @@ public class ViewPage extends BasePage
 
     /**
      * @return the content of the version section in the page footer
-     * @since 18.6.0RC1
      */
     public String getFooterVersion()
     {

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/editor/WikiEditPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/editor/WikiEditPage.java
@@ -189,7 +189,6 @@ public class WikiEditPage extends PreviewableEditPage
 
     /**
      * @return {@code true} if the edit comment (version summary) field is present in the form
-     * @since 18.3.0RC1
      */
     public boolean hasEditComment()
     {

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-test/xwiki-platform-user-profile-test-pageobjects/src/main/java/org/xwiki/user/test/po/ProfileEditPage.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-test/xwiki-platform-user-profile-test-pageobjects/src/main/java/org/xwiki/user/test/po/ProfileEditPage.java
@@ -158,7 +158,6 @@ public class ProfileEditPage extends EditPage
      *
      * @param propertyName the name of the property on the {@code XWiki.XWikiUsers} class
      * @param value the value to set
-     * @since 18.5.0RC1
      */
     public void setUserCustomProperty(String propertyName, String value)
     {

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-test/xwiki-platform-user-profile-test-pageobjects/src/main/java/org/xwiki/user/test/po/ProfileUserProfilePage.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-test/xwiki-platform-user-profile-test-pageobjects/src/main/java/org/xwiki/user/test/po/ProfileUserProfilePage.java
@@ -155,7 +155,6 @@ public class ProfileUserProfilePage extends AbstractUserProfilePage
      *
      * @param prettyName the pretty name (label) of the custom field as displayed in the profile
      * @return the displayed value of the custom field
-     * @since 18.5.0RC1
      */
     public String getUserCustomProperty(String prettyName)
     {

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-test/xwiki-platform-user-profile-test-pageobjects/src/main/java/org/xwiki/user/test/po/UserProfileAdministrationSectionPage.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-profile/xwiki-platform-user-profile-test/xwiki-platform-user-profile-test-pageobjects/src/main/java/org/xwiki/user/test/po/UserProfileAdministrationSectionPage.java
@@ -31,6 +31,8 @@ import org.xwiki.test.ui.po.ViewPage;
  * own {@code save} submit button) on plain view.
  *
  * @version $Id$
+ * @since 17.10.10
+ * @since 18.4.3
  * @since 18.5.0RC1
  */
 public class UserProfileAdministrationSectionPage extends ViewPage

--- a/xwiki-platform-core/xwiki-platform-xclass/xwiki-platform-xclass-test/xwiki-platform-xclass-test-pageobjects/src/main/java/org/xwiki/xclass/test/po/ClassSheetPage.java
+++ b/xwiki-platform-core/xwiki-platform-xclass/xwiki-platform-xclass-test/xwiki-platform-xclass-test-pageobjects/src/main/java/org/xwiki/xclass/test/po/ClassSheetPage.java
@@ -222,7 +222,6 @@ public class ClassSheetPage extends ViewPage
      * contains an instance of the class.
      *
      * @return the current page, after it is reloaded
-     * @since 18.6.0RC1
      */
     public ClassSheetPage clickCreateTemplateProviderButton()
     {
@@ -236,7 +235,6 @@ public class ClassSheetPage extends ViewPage
      * created.
      *
      * @return the page that represents the class template provider
-     * @since 18.6.0RC1
      */
     public ViewPage clickTemplateProviderLink()
     {


### PR DESCRIPTION
The `testneeded`-labelled automated tests resolved since 2026-01-01 were backported to the supported
stable branches **stable-17.10.x** and **stable-18.4.x**. This PR adjusts `@since` on master so all
branches carry the **same** `@since` content (no functional change). One commit per issue, each
keeping the **original commit title**.

Two kinds of change:
- **New page-object classes** get the backport versions added to their class-level `@since`
  (`@since 17.10.10` / `@since 18.4.3`) alongside the original, ascending and in 3-digit format.
- **Page-object / test-support methods** have their `@since` **removed** — by convention, test-support
  methods do not carry `@since` (the class-level tag covers availability).

Issues (one commit each): XWIKI-18672, XWIKI-21853, XWIKI-22081, XWIKI-23960, XWIKI-18260,
XWIKI-18629, XWIKI-18772, XWIKI-24474, XWIKI-19511, XWIKI-18390, XWIKI-19562, XWIKI-20349.

The matching `@since` edits are on each issue's backport PR branch(es) so the three branches stay
consistent.
