### PR TITLE
[Misc] Define a constant for the duplicated "keywords" literal

### DIFF
--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/DatabaseKeywordSearchSource.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/DatabaseKeywordSearchSource.java
@@ -88,6 +88,11 @@ public class DatabaseKeywordSearchSource implements KeywordSearchSource
      */
     private static final String SPACE = "space";
 
+    /**
+     * The {@code keywords} literal, used as the query parameter name for the search keywords.
+     */
+    private static final String KEYWORDS = "keywords";
+
     @Inject
     protected ContextualAuthorizationManager authorizationManager;
 
@@ -267,7 +272,7 @@ public class DatabaseKeywordSearchSource implements KeywordSearchSource
             String queryString = f.toString();
 
             Query query = finalQueryManager.createQuery(queryString, Query.HQL)
-                .bindValue("keywords", String.format("%%%s%%", keywords.toUpperCase()))
+                .bindValue(KEYWORDS, String.format("%%%s%%", keywords.toUpperCase()))
                 .addFilter(this.hiddenDocumentFilterProvider.get()).setOffset(options.start())
                 // Worst case scenario when making the locale aware query:
                 // e.g.: Search matches a document translated in fr_CA and fr
@@ -409,7 +414,7 @@ public class DatabaseKeywordSearchSource implements KeywordSearchSource
             + " order by lower(space.reference), space.reference";
 
         List<Object> queryResult = this.queryManager.createQuery(query, Query.HQL)
-            .bindValue("keywords", String.format("%%%s%%", escapedKeywords))
+            .bindValue(KEYWORDS, String.format("%%%s%%", escapedKeywords))
             .bindValue("prefix", String.format("%s%%", escapedKeywords))
             .setWiki(wikiName).setLimit(number).setOffset(start)
             .addFilter(this.hiddenSpaceFilterProvider.get()).execute();
@@ -533,12 +538,12 @@ public class DatabaseKeywordSearchSource implements KeywordSearchSource
             if (options.space() != null) {
                 queryResult =
                     finalQueryManager.createQuery(query, Query.XWQL)
-                        .bindValue("keywords", String.format("%%%s%%", keywords.toUpperCase()))
+                        .bindValue(KEYWORDS, String.format("%%%s%%", keywords.toUpperCase()))
                         .bindValue(SPACE, options.space()).setLimit(options.number()).execute();
             } else {
                 queryResult =
                     finalQueryManager.createQuery(query, Query.XWQL)
-                        .bindValue("keywords", String.format("%%%s%%", keywords.toUpperCase()))
+                        .bindValue(KEYWORDS, String.format("%%%s%%", keywords.toUpperCase()))
                         .setLimit(options.number())
                         .execute();
             }


### PR DESCRIPTION
## Summary

Fixes SonarCloud issue [java:S1192 — "keywords" is duplicated 4 times](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AZeKdlNsdMqt9rTWYu_r&open=AZeKdlNsdMqt9rTWYu_r) in `DatabaseKeywordSearchSource.java`.

### Fix

The string literal `"keywords"` — used as the Hibernate query bind-parameter name — appeared 4 times in the class. Extracted it into a `private static final String KEYWORDS = "keywords";` constant (following the existing `SPACE` constant pattern in the same class) and replaced all occurrences.

## Test plan

- [x] `mvn clean install` on `xwiki-platform-rest-server` passes (checkstyle + build green).
- [ ] Verify the SonarCloud issue is resolved after the next scan.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ML2HcqPDzeUaR5ggACvYDF)_