### PR TITLE
[Misc] Define constants for duplicated literals reported by SonarQube

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
@@ -128,6 +128,12 @@ import com.xpn.xwiki.util.Util;
 @Singleton
 public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWikiStoreInterface, Initializable
 {
+    private static final String CREATE_SCHEMA = "CREATE SCHEMA ";
+    private static final String CASCADE_SUFFIX = " CASCADE";
+    private static final String DROP_SCHEMA = "DROP SCHEMA ";
+    private static final String DOC_ID = "docId";
+    private static final String SELECT_DISTINCT_DOC_FULLNAME = "select distinct doc.fullName";
+
     @Inject
     private Logger logger;
 
@@ -333,9 +339,9 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
                         escapedSchema, escapedSchema));
                 } else if (DatabaseProduct.DERBY == databaseProduct || DatabaseProduct.DB2 == databaseProduct
                     || DatabaseProduct.H2 == databaseProduct) {
-                    statement.execute("CREATE SCHEMA " + escapedSchema);
+                    statement.execute(CREATE_SCHEMA + escapedSchema);
                 } else if (DatabaseProduct.HSQLDB == databaseProduct) {
-                    statement.execute("CREATE SCHEMA " + escapedSchema + " AUTHORIZATION DBA");
+                    statement.execute(CREATE_SCHEMA + escapedSchema + " AUTHORIZATION DBA");
                 } else if (DatabaseProduct.MYSQL == databaseProduct) {
                     StringBuilder statementBuilder = new StringBuilder("create database " + escapedSchema);
                     String[] charsetAndCollation = getCharsetAndCollation(wikiName, session, context);
@@ -346,7 +352,7 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
                     statement.execute(statementBuilder.toString());
                 } else if (DatabaseProduct.POSTGRESQL == databaseProduct) {
                     if (isInSchemaMode()) {
-                        statement.execute("CREATE SCHEMA " + escapedSchema);
+                        statement.execute(CREATE_SCHEMA + escapedSchema);
                     } else {
                         this.logger.error("Creation of a new database is currently only supported in the schema mode, "
                             + "see https://jira.xwiki.org/browse/XWIKI-8753");
@@ -469,17 +475,17 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
         String escapedSchemaName) throws SQLException
     {
         if (DatabaseProduct.ORACLE == databaseProduct) {
-            statement.execute("DROP USER " + escapedSchemaName + " CASCADE");
+            statement.execute("DROP USER " + escapedSchemaName + CASCADE_SUFFIX);
         } else if (DatabaseProduct.DERBY == databaseProduct || DatabaseProduct.MYSQL == databaseProduct
             || DatabaseProduct.H2 == databaseProduct) {
-            statement.execute("DROP SCHEMA " + escapedSchemaName);
+            statement.execute(DROP_SCHEMA + escapedSchemaName);
         } else if (DatabaseProduct.HSQLDB == databaseProduct) {
-            statement.execute("DROP SCHEMA " + escapedSchemaName + " CASCADE");
+            statement.execute(DROP_SCHEMA + escapedSchemaName + CASCADE_SUFFIX);
         } else if (DatabaseProduct.DB2 == databaseProduct) {
-            statement.execute("DROP SCHEMA " + escapedSchemaName + " RESTRICT");
+            statement.execute(DROP_SCHEMA + escapedSchemaName + " RESTRICT");
         } else if (DatabaseProduct.POSTGRESQL == databaseProduct) {
             if (isInSchemaMode()) {
-                statement.execute("DROP SCHEMA " + escapedSchemaName + " CASCADE");
+                statement.execute(DROP_SCHEMA + escapedSchemaName + CASCADE_SUFFIX);
             } else {
                 this.logger.warn("Subwiki deletion not yet supported in Database mode for PostgreSQL");
             }
@@ -2049,7 +2055,7 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
 
                 Query<Long> query = session
                     .createQuery("select lock.docId from XWikiLock as lock where lock.docId = :docId", Long.class);
-                query.setParameter("docId", docId);
+                query.setParameter(DOC_ID, docId);
                 if (query.uniqueResult() != null) {
                     lock = new XWikiLock();
                     session.load(lock, Long.valueOf(docId));
@@ -2070,7 +2076,7 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
             try {
                 Query<Long> query = session
                     .createQuery("select lock.docId from XWikiLock as lock where lock.docId = :docId", Long.class);
-                query.setParameter("docId", lock.getDocId());
+                query.setParameter(DOC_ID, lock.getDocId());
                 if (query.uniqueResult() == null) {
                     session.save(lock);
                 } else {
@@ -2185,7 +2191,7 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
             try {
                 Query<XWikiLink> query =
                     session.createQuery(" from XWikiLink as link where link.id.docId = :docId", XWikiLink.class);
-                query.setParameter("docId", docId);
+                query.setParameter(DOC_ID, docId);
 
                 return query.list();
             } catch (Exception e) {
@@ -2406,7 +2412,7 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
         executeWrite(inputxcontext, session -> {
             try {
                 Query<?> query = session.createQuery("delete from XWikiLink as link where link.id.docId = :docId");
-                query.setParameter("docId", docId);
+                query.setParameter(DOC_ID, docId);
                 query.executeUpdate();
             } catch (Exception e) {
                 throw new XWikiException(XWikiException.MODULE_XWIKI_STORE,
@@ -2501,7 +2507,7 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
     public List<DocumentReference> searchDocumentReferences(String parametrizedSqlClause, int nb, int start,
         List<?> parameterValues, XWikiContext context) throws XWikiException
     {
-        String sql = createSQLQuery("select distinct doc.fullName", parametrizedSqlClause);
+        String sql = createSQLQuery(SELECT_DISTINCT_DOC_FULLNAME, parametrizedSqlClause);
         return searchDocumentReferencesInternal(sql, nb, start, parameterValues, context);
     }
 
@@ -2509,7 +2515,7 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
     public List<String> searchDocumentsNames(String parametrizedSqlClause, int nb, int start, List<?> parameterValues,
         XWikiContext context) throws XWikiException
     {
-        String sql = createSQLQuery("select distinct doc.fullName", parametrizedSqlClause);
+        String sql = createSQLQuery(SELECT_DISTINCT_DOC_FULLNAME, parametrizedSqlClause);
         return searchDocumentsNamesInternal(sql, nb, start, parameterValues, context);
     }
 
@@ -2543,7 +2549,7 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
     public List<DocumentReference> searchDocumentReferences(String wheresql, int nb, int start, String selectColumns,
         XWikiContext context) throws XWikiException
     {
-        String sql = createSQLQuery("select distinct doc.fullName", wheresql);
+        String sql = createSQLQuery(SELECT_DISTINCT_DOC_FULLNAME, wheresql);
         return searchDocumentReferencesInternal(sql, nb, start, Collections.EMPTY_LIST, context);
     }
 
@@ -2551,7 +2557,7 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
     public List<String> searchDocumentsNames(String wheresql, int nb, int start, String selectColumns,
         XWikiContext context) throws XWikiException
     {
-        String sql = createSQLQuery("select distinct doc.fullName", wheresql);
+        String sql = createSQLQuery(SELECT_DISTINCT_DOC_FULLNAME, wheresql);
         return searchDocumentsNamesInternal(sql, nb, start, Collections.EMPTY_LIST, context);
     }
 
@@ -2814,7 +2820,7 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
             if (distinctbylanguage) {
                 sql = createSQLQuery("select distinct doc.fullName, doc.language", wheresql);
             } else {
-                sql = createSQLQuery("select distinct doc.fullName", wheresql);
+                sql = createSQLQuery(SELECT_DISTINCT_DOC_FULLNAME, wheresql);
             }
 
             // Start monitoring timer
@@ -3338,7 +3344,7 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
             try {
                 Query<Long> query =
                     session.createQuery("select count(*) from XWikiLink as link where link.id.docId = :docId")
-                        .setParameter("docId", docId);
+                        .setParameter(DOC_ID, docId);
                 return query.getSingleResult();
             } catch (Exception e) {
                 throw new XWikiException(XWikiException.MODULE_XWIKI_STORE,

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiAuthServiceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiAuthServiceImpl.java
@@ -65,8 +65,13 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(XWikiAuthServiceImpl.class);
 
+    private static final String XWIKI_SPACE = "XWiki";
+    private static final String AUTHENTICATION_REALM_NAME = "xwiki.authentication.realmname";
+    private static final String USER_LOG_PREFIX = "User ";
+    private static final String MESSAGE_CONTEXT_KEY = "message";
+
     private static final EntityReference USERCLASS_REFERENCE = new EntityReference("XWikiUsers", EntityType.DOCUMENT,
-        new EntityReference("XWiki", EntityType.SPACE));
+        new EntityReference(XWIKI_SPACE, EntityType.SPACE));
 
     /**
      * Used to convert a string into a proper Document Name.
@@ -113,10 +118,10 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
                 authenticator = new MyBasicAuthenticator();
                 SecurityConfig sconfig = new SecurityConfig(false);
                 sconfig.setAuthMethod("BASIC");
-                if (xwiki.Param("xwiki.authentication.realmname") != null) {
-                    sconfig.setRealmName(xwiki.Param("xwiki.authentication.realmname"));
+                if (xwiki.Param(AUTHENTICATION_REALM_NAME) != null) {
+                    sconfig.setRealmName(xwiki.Param(AUTHENTICATION_REALM_NAME));
                 } else {
-                    sconfig.setRealmName("XWiki");
+                    sconfig.setRealmName(XWIKI_SPACE);
                 }
                 authenticator.init(null, sconfig);
             } else {
@@ -125,10 +130,10 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
 
                 sconfig.setAuthMethod("FORM");
 
-                if (xwiki.Param("xwiki.authentication.realmname") != null) {
-                    sconfig.setRealmName(xwiki.Param("xwiki.authentication.realmname"));
+                if (xwiki.Param(AUTHENTICATION_REALM_NAME) != null) {
+                    sconfig.setRealmName(xwiki.Param(AUTHENTICATION_REALM_NAME));
                 } else {
-                    sconfig.setRealmName("XWiki");
+                    sconfig.setRealmName(XWIKI_SPACE);
                 }
 
                 if (xwiki.Param("xwiki.authentication.defaultpage") != null) {
@@ -143,21 +148,21 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
                     sconfig.setLoginPage(xwiki.Param("xwiki.authentication.loginpage"));
                 } else {
                     sconfig.setLoginPage(stripContextPathFromURL(
-                        context.getURLFactory().createURL("XWiki", "XWikiLogin", "login", context), context));
+                        context.getURLFactory().createURL(XWIKI_SPACE, "XWikiLogin", "login", context), context));
                 }
 
                 if (xwiki.Param("xwiki.authentication.logoutpage") != null) {
                     sconfig.setLogoutPage(xwiki.Param("xwiki.authentication.logoutpage"));
                 } else {
                     sconfig.setLogoutPage(stripContextPathFromURL(
-                        context.getURLFactory().createURL("XWiki", "XWikiLogout", "logout", context), context));
+                        context.getURLFactory().createURL(XWIKI_SPACE, "XWikiLogout", "logout", context), context));
                 }
 
                 if (xwiki.Param("xwiki.authentication.errorpage") != null) {
                     sconfig.setErrorPage(xwiki.Param("xwiki.authentication.errorpage"));
                 } else {
                     sconfig.setErrorPage(stripContextPathFromURL(
-                        context.getURLFactory().createURL("XWiki", "XWikiLogin", "loginerror", context), context));
+                        context.getURLFactory().createURL(XWIKI_SPACE, "XWikiLogin", "loginerror", context), context));
                 }
 
                 sconfig.setPersistentLoginManager(this.persistentLoginManagerProvider.get());
@@ -206,7 +211,7 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
             // Process logout (this only works with Forms)
             if (auth.processLogout(wrappedRequest, response, new URLPatternMatcher())) {
                 if (LOGGER.isInfoEnabled()) {
-                    LOGGER.info("User " + context.getUser() + " has been logged-out");
+                    LOGGER.info(USER_LOG_PREFIX + context.getUser() + " has been logged-out");
                 }
                 wrappedRequest.setUserPrincipal(null);
                 return null;
@@ -215,7 +220,7 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
             final String userName = getContextUserName(wrappedRequest.getUserPrincipal(), context);
             if (LOGGER.isInfoEnabled()) {
                 if (userName != null) {
-                    LOGGER.info("User " + userName + " is authentified");
+                    LOGGER.info(USER_LOG_PREFIX + userName + " is authentified");
                 }
             }
 
@@ -264,7 +269,7 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
             Principal principal = wrappedRequest.getUserPrincipal();
             if (LOGGER.isInfoEnabled()) {
                 if (principal != null) {
-                    LOGGER.info("User " + principal.getName() + " is authentified");
+                    LOGGER.info(USER_LOG_PREFIX + principal.getName() + " is authentified");
                 }
             }
 
@@ -326,13 +331,13 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
 
         // Check for empty usernames
         if (StringUtils.isBlank(username)) {
-            context.put("message", "nousername");
+            context.put(MESSAGE_CONTEXT_KEY, "nousername");
             return null;
         }
 
         // Check for empty passwords
         if (password == null || password.isEmpty()) {
-            context.put("message", "nopassword");
+            context.put(MESSAGE_CONTEXT_KEY, "nopassword");
             return null;
         }
 
@@ -391,13 +396,13 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
                             return new SimplePrincipal(context.getWikiId() + ":" + user);
                         }
                     } catch (Exception e) {
-                        context.put("message", "loginfailed");
+                        context.put(MESSAGE_CONTEXT_KEY, "loginfailed");
                         return null;
                     }
                 }
 
                 // No user found
-                context.put("message", "invalidcredentials");
+                context.put(MESSAGE_CONTEXT_KEY, "invalidcredentials");
                 return null;
 
             } finally {
@@ -416,7 +421,7 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
         String user;
 
         // First let's look in the cache
-        if (context.getWiki().exists(new DocumentReference(context.getWikiId(), "XWiki", username), context)) {
+        if (context.getWiki().exists(new DocumentReference(context.getWikiId(), XWIKI_SPACE, username), context)) {
             user = "XWiki." + username;
         } else {
             // Note: The result of this search depends on the Database. If the database is
@@ -424,7 +429,7 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
             // username in any case. For case-sensitive databases (like HSQLDB) they'll need to
             // enter it exactly as they've created it.
             String sql = "select distinct doc.fullName from XWikiDocument as doc";
-            Object[][] whereParameters = new Object[][] { { "doc.space", "XWiki" }, { "doc.name", username } };
+            Object[][] whereParameters = new Object[][] { { "doc.space", XWIKI_SPACE }, { "doc.name", username } };
 
             List<String> list = context.getWiki().search(sql, whereParameters, context);
             if (list.size() == 0) {
@@ -501,7 +506,7 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
         if (createuser != null) {
             String wikiname = context.getWiki().clearName(user, true, true, context);
             XWikiDocument userdoc =
-                context.getWiki().getDocument(new DocumentReference(context.getWikiId(), "XWiki", wikiname), context);
+                context.getWiki().getDocument(new DocumentReference(context.getWikiId(), XWIKI_SPACE, wikiname), context);
             if (userdoc.isNew()) {
                 if (LOGGER.isDebugEnabled()) {
                     LOGGER.debug("User page does not exist for user " + user);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiRightServiceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiRightServiceImpl.java
@@ -66,13 +66,27 @@ public class XWikiRightServiceImpl implements XWikiRightService
     public static final EntityReference GLOBALRIGHTCLASS_REFERENCE = new EntityReference("XWikiGlobalRights",
         EntityType.DOCUMENT, new EntityReference("XWiki", EntityType.SPACE));
 
+    private static final String ADMIN = "admin";
+    private static final String COMMENT = "comment";
+    private static final String DELETE = "delete";
+    private static final String PROGRAMMING = "programming";
+    private static final String REGISTER = "register";
+    private static final String UNDELETE = "undelete";
+    private static final String LOGIN = "login";
+    private static final String AUTHENTICATE_PREFIX = "authenticate_";
+    private static final String GROUP_LIST_CONTEXT_KEY = "grouplist";
+    private static final String WEB_PREFERENCES = "WebPreferences";
+    private static final String XWIKI_PREFERENCES = "XWiki.XWikiPreferences";
+    private static final String CHECKING_MATCH_LOG = "Checking match: [{}] in [{}]";
+    private static final String FOUND_MATCHING_RIGHT_LOG = "Found matching right in [{}] for [{}]";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(XWikiRightServiceImpl.class);
 
     private static final EntityReference XWIKIPREFERENCES_REFERENCE = new EntityReference("XWikiPreferences",
         EntityType.DOCUMENT, new EntityReference("XWiki", EntityType.SPACE));
 
-    private static final List<String> ALLLEVELS = Arrays.asList("admin", "view", "edit", "comment", "delete",
-        "undelete", "register", "programming");
+    private static final List<String> ALLLEVELS = Arrays.asList(ADMIN, "view", "edit", COMMENT, DELETE,
+        UNDELETE, REGISTER, PROGRAMMING);
 
     private static final EntityReference DEFAULTUSERSPACE = new EntityReference("XWiki", EntityType.SPACE);
 
@@ -115,10 +129,10 @@ public class XWikiRightServiceImpl implements XWikiRightService
     {
         if (actionMap == null) {
             actionMap = new HashMap<>();
-            actionMap.put("login", "login");
-            actionMap.put("logout", "login");
-            actionMap.put("loginerror", "login");
-            actionMap.put("loginsubmit", "login");
+            actionMap.put(LOGIN, LOGIN);
+            actionMap.put("logout", LOGIN);
+            actionMap.put("loginerror", LOGIN);
+            actionMap.put("loginsubmit", LOGIN);
             actionMap.put("view", "view");
             actionMap.put("viewrev", "view");
             actionMap.put("get", "view");
@@ -129,18 +143,18 @@ public class XWikiRightServiceImpl implements XWikiRightService
             actionMap.put("skin", "view");
             actionMap.put("download", "view");
             actionMap.put("pdf", "view");
-            actionMap.put("delete", "delete");
-            actionMap.put("deletespace", "admin");
-            actionMap.put("deleteversions", "admin");
-            actionMap.put("undelete", "undelete");
-            actionMap.put("reset", "delete");
-            actionMap.put("commentadd", "comment");
-            actionMap.put("commentsave", "comment");
-            actionMap.put("register", "register");
+            actionMap.put(DELETE, DELETE);
+            actionMap.put("deletespace", ADMIN);
+            actionMap.put("deleteversions", ADMIN);
+            actionMap.put(UNDELETE, UNDELETE);
+            actionMap.put("reset", DELETE);
+            actionMap.put("commentadd", COMMENT);
+            actionMap.put("commentsave", COMMENT);
+            actionMap.put(REGISTER, REGISTER);
             actionMap.put("redirect", "view");
-            actionMap.put("admin", "admin");
+            actionMap.put(ADMIN, ADMIN);
             actionMap.put("export", "view");
-            actionMap.put("import", "admin");
+            actionMap.put("import", ADMIN);
             actionMap.put("jsx", "view");
             actionMap.put("ssx", "view");
             actionMap.put("tex", "view");
@@ -167,7 +181,7 @@ public class XWikiRightServiceImpl implements XWikiRightService
         boolean needsAuth = false;
         String right = getRight(action);
 
-        if ("login".equals(right)) {
+        if (LOGIN.equals(right)) {
             user = context.getWiki().checkAuth(context);
             if (user == null) {
                 username = XWikiRightService.GUEST_USER_FULLNAME;
@@ -182,7 +196,7 @@ public class XWikiRightServiceImpl implements XWikiRightService
             return true;
         }
 
-        if ("delete".equals(right)) {
+        if (DELETE.equals(right)) {
             user = context.getWiki().checkAuth(context);
             String creator = doc.getCreator();
             if ((user != null) && (user.getUser() != null) && (creator != null)) {
@@ -282,23 +296,23 @@ public class XWikiRightServiceImpl implements XWikiRightService
 
         try {
             needsAuth =
-                "yes".equalsIgnoreCase(context.getWiki().getXWikiPreference("authenticate_" + right, "", context));
+                "yes".equalsIgnoreCase(context.getWiki().getXWikiPreference(AUTHENTICATE_PREFIX + right, "", context));
         } catch (Exception e) {
         }
 
         try {
-            needsAuth |= (context.getWiki().getXWikiPreferenceAsInt("authenticate_" + right, 0, context) == 1);
+            needsAuth |= (context.getWiki().getXWikiPreferenceAsInt(AUTHENTICATE_PREFIX + right, 0, context) == 1);
         } catch (Exception e) {
         }
 
         try {
             needsAuth |=
-                "yes".equalsIgnoreCase(context.getWiki().getSpacePreference("authenticate_" + right, "", context));
+                "yes".equalsIgnoreCase(context.getWiki().getSpacePreference(AUTHENTICATE_PREFIX + right, "", context));
         } catch (Exception e) {
         }
 
         try {
-            needsAuth |= (context.getWiki().getSpacePreferenceAsInt("authenticate_" + right, 0, context) == 1);
+            needsAuth |= (context.getWiki().getSpacePreferenceAsInt(AUTHENTICATE_PREFIX + right, 0, context) == 1);
         } catch (Exception e) {
         }
 
@@ -319,7 +333,7 @@ public class XWikiRightServiceImpl implements XWikiRightService
     public boolean checkRight(String userOrGroupName, XWikiDocument doc, String accessLevel, boolean user,
         boolean allow, boolean global, XWikiContext context) throws XWikiRightNotFoundException, XWikiException
     {
-        if (!global && ("admin".equals(accessLevel))) {
+        if (!global && (ADMIN.equals(accessLevel))) {
             // Admin rights do not exist at document level.
             throw new XWikiRightNotFoundException();
         }
@@ -364,14 +378,14 @@ public class XWikiRightServiceImpl implements XWikiRightService
                 boolean allowdeny = (bobj.getIntValue("allow") == 1);
 
                 if (allowdeny == allow) {
-                    LOGGER.debug("Checking match: [{}] in [{}]", accessLevel, levels);
+                    LOGGER.debug(CHECKING_MATCH_LOG, accessLevel, levels);
 
                     String[] levelsarray = StringUtils.split(levels, " ,|");
                     if (ArrayUtils.contains(levelsarray, accessLevel)) {
                         LOGGER.debug("Found a right for [{}]", allow);
                         found = true;
 
-                        LOGGER.debug("Checking match: [{}] in [{}]", userOrGroupName, users);
+                        LOGGER.debug(CHECKING_MATCH_LOG, userOrGroupName, users);
 
                         String[] userarray = GroupsClass.getListFromString(users).toArray(new String[0]);
 
@@ -380,7 +394,7 @@ public class XWikiRightServiceImpl implements XWikiRightService
                         }
 
                         if (LOGGER.isDebugEnabled()) {
-                            LOGGER.debug("Checking match: [{}] in [{}]", userOrGroupName,
+                            LOGGER.debug(CHECKING_MATCH_LOG, userOrGroupName,
                                 StringUtils.join(userarray, ","));
                         }
 
@@ -389,7 +403,7 @@ public class XWikiRightServiceImpl implements XWikiRightService
                         // name is requested
                         if (doc.getWikiName().equals(userOrGroupDocumentReference.getWikiReference().getName())) {
                             if (ArrayUtils.contains(userarray, shortname)) {
-                                LOGGER.debug("Found matching right in [{}] for [{}]", users, shortname);
+                                LOGGER.debug(FOUND_MATCHING_RIGHT_LOG, users, shortname);
                                 return true;
                             }
 
@@ -397,13 +411,13 @@ public class XWikiRightServiceImpl implements XWikiRightService
                             // lists
                             String veryshortname = shortname.substring(shortname.indexOf(".") + 1);
                             if (ArrayUtils.contains(userarray, veryshortname)) {
-                                LOGGER.debug("Found matching right in [{}] for [{}]", users, shortname);
+                                LOGGER.debug(FOUND_MATCHING_RIGHT_LOG, users, shortname);
                                 return true;
                             }
                         }
 
                         if ((context.getWikiId() != null) && (ArrayUtils.contains(userarray, userOrGroupName))) {
-                            LOGGER.debug("Found matching right in [{}] for [{}]", users, userOrGroupName);
+                            LOGGER.debug(FOUND_MATCHING_RIGHT_LOG, users, userOrGroupName);
                             return true;
                         }
 
@@ -418,10 +432,10 @@ public class XWikiRightServiceImpl implements XWikiRightService
         LOGGER.debug("Searching for matching rights at group level");
 
         // Didn't found right at this level.. Let's go to group level
-        Map<String, Collection<String>> grouplistcache = (Map<String, Collection<String>>) context.get("grouplist");
+        Map<String, Collection<String>> grouplistcache = (Map<String, Collection<String>>) context.get(GROUP_LIST_CONTEXT_KEY);
         if (grouplistcache == null) {
             grouplistcache = new HashMap<>();
-            context.put("grouplist", grouplistcache);
+            context.put(GROUP_LIST_CONTEXT_KEY, grouplistcache);
         }
 
         Collection<String> grouplist = new HashSet<>();
@@ -468,10 +482,10 @@ public class XWikiRightServiceImpl implements XWikiRightService
     {
         XWikiGroupService groupService = context.getWiki().getGroupService(context);
 
-        Map<String, Collection<String>> grouplistcache = (Map<String, Collection<String>>) context.get("grouplist");
+        Map<String, Collection<String>> grouplistcache = (Map<String, Collection<String>>) context.get(GROUP_LIST_CONTEXT_KEY);
         if (grouplistcache == null) {
             grouplistcache = new HashMap<>();
-            context.put("grouplist", grouplistcache);
+            context.put(GROUP_LIST_CONTEXT_KEY, grouplistcache);
         }
 
         // the key is for the entity <code>prefixedFullName</code> in current wiki
@@ -532,8 +546,8 @@ public class XWikiRightServiceImpl implements XWikiRightService
         XWikiDocument currentdoc = null;
 
         if (isReadOnly) {
-            if ("edit".equals(accessLevel) || "delete".equals(accessLevel) || "undelete".equals(accessLevel)
-                || "comment".equals(accessLevel) || "register".equals(accessLevel)) {
+            if ("edit".equals(accessLevel) || DELETE.equals(accessLevel) || UNDELETE.equals(accessLevel)
+                || COMMENT.equals(accessLevel) || REGISTER.equals(accessLevel)) {
                 logDeny(userOrGroupName, entityReference, accessLevel, "server in read-only mode");
 
                 return false;
@@ -547,7 +561,7 @@ public class XWikiRightServiceImpl implements XWikiRightService
         }
 
         // Fast return for delete right: allow the creator to delete the document
-        if ("delete".equals(accessLevel) && user) {
+        if (DELETE.equals(accessLevel) && user) {
             currentdoc = context.getWiki().getDocument(entityReference, context);
             DocumentReference creator = currentdoc.getCreatorReference();
             if (ObjectUtils.equals(userOrGroupNameReference, creator)) {
@@ -557,7 +571,7 @@ public class XWikiRightServiceImpl implements XWikiRightService
         }
 
         allow = isSuperAdminOrProgramming(userOrGroupName, entityReference, accessLevel, user, context);
-        if ((allow == true) || ("programming".equals(accessLevel))) {
+        if ((allow == true) || (PROGRAMMING.equals(accessLevel))) {
             return allow;
         }
 
@@ -567,12 +581,12 @@ public class XWikiRightServiceImpl implements XWikiRightService
             DocumentReference docReference = currentdoc.getDocumentReference();
 
             if ("edit".equals(accessLevel)
-                && ("WebPreferences".equals(docReference.getName()) || ("XWiki".equals(docReference.getLastSpaceReference().getName())
+                && (WEB_PREFERENCES.equals(docReference.getName()) || ("XWiki".equals(docReference.getLastSpaceReference().getName())
                     && "XWikiPreferences".equals(docReference.getName())))) {
                 // Since edit rights on these documents would be sufficient for a user to elevate himself to
                 // admin or even programmer, we will instead check for admin access on these documents.
                 // See https://jira.xwiki.org/browse/XWIKI-6987 and https://jira.xwiki.org/browse/XWIKI-2184.
-                accessLevel = "admin";
+                accessLevel = ADMIN;
             }
 
             // We need to make sure we are in the context of the document which rights is being checked
@@ -591,9 +605,9 @@ public class XWikiRightServiceImpl implements XWikiRightService
             XWikiDocument entityWikiPreferences = context.getWiki().getDocument(XWIKIPREFERENCES_REFERENCE, context);
 
             // Verify XWiki register right
-            if ("register".equals(accessLevel)) {
+            if (REGISTER.equals(accessLevel)) {
                 try {
-                    allow = checkRight(userOrGroupName, entityWikiPreferences, "register", user, true, true, context);
+                    allow = checkRight(userOrGroupName, entityWikiPreferences, REGISTER, user, true, true, context);
                     if (allow) {
                         logAllow(userOrGroupName, entityReference, accessLevel, "register level");
 
@@ -606,7 +620,7 @@ public class XWikiRightServiceImpl implements XWikiRightService
                 } catch (XWikiRightNotFoundException e) {
                     try {
                         deny =
-                            checkRight(userOrGroupName, entityWikiPreferences, "register", user, false, true, context);
+                            checkRight(userOrGroupName, entityWikiPreferences, REGISTER, user, false, true, context);
                         if (deny) {
                             return false;
                         }
@@ -669,7 +683,7 @@ public class XWikiRightServiceImpl implements XWikiRightService
                 recursiveSpaceChecks++;
                 // add to list of spaces already checked
                 spacesChecked.add(space);
-                XWikiDocument webdoc = context.getWiki().getDocument(space, "WebPreferences", context);
+                XWikiDocument webdoc = context.getWiki().getDocument(space, WEB_PREFERENCES, context);
                 if (!webdoc.isNew()) {
                     if (hasDenyRights()) {
                         try {
@@ -700,7 +714,7 @@ public class XWikiRightServiceImpl implements XWikiRightService
                     }
 
                     // find the parent web to check rights on it
-                    space = webdoc.getStringValue("XWiki.XWikiPreferences", "parent");
+                    space = webdoc.getStringValue(XWIKI_PREFERENCES, "parent");
                     if ((space == null) || (space.trim().isEmpty()) || spacesChecked.contains(space)) {
                         // no parent space or space already checked (recursive loop). let's finish
                         // the loop
@@ -747,8 +761,8 @@ public class XWikiRightServiceImpl implements XWikiRightService
             // should be allowed.
             if (!allow_found) {
                 // Delete must be denied by default.
-                if ("delete".equals(accessLevel)) {
-                    if (hasAccessLevel("admin", userOrGroupName, entityReference, user, context)) {
+                if (DELETE.equals(accessLevel)) {
+                    if (hasAccessLevel(ADMIN, userOrGroupName, entityReference, user, context)) {
                         logAllow(userOrGroupName, entityReference, accessLevel,
                             "admin rights imply delete on empty wiki");
                         return true;
@@ -821,7 +835,7 @@ public class XWikiRightServiceImpl implements XWikiRightService
             XWikiDocument xwikimasterdoc = context.getWiki().getDocument(XWIKIPREFERENCES_REFERENCE, context);
             // Verify XWiki Master super user
             try {
-                allow = checkRight(name, xwikimasterdoc, "admin", true, true, true, context);
+                allow = checkRight(name, xwikimasterdoc, ADMIN, true, true, true, context);
                 if (allow) {
                     logAllow(name, resourceKey, accessLevel, "master admin level");
                     return true;
@@ -830,14 +844,14 @@ public class XWikiRightServiceImpl implements XWikiRightService
             }
 
             // Verify XWiki programming right
-            if ("programming".equals(accessLevel)) {
+            if (PROGRAMMING.equals(accessLevel)) {
                 // Programming right can only been given if user is from main wiki
                 if (!name.startsWith(context.getMainXWiki() + ":")) {
                     return false;
                 }
 
                 try {
-                    allow = checkRight(name, xwikimasterdoc, "programming", user, true, true, context);
+                    allow = checkRight(name, xwikimasterdoc, PROGRAMMING, user, true, true, context);
                     if (allow) {
                         logAllow(name, resourceKey, accessLevel, "programming level");
 
@@ -869,7 +883,7 @@ public class XWikiRightServiceImpl implements XWikiRightService
 
         // Verify XWiki super user
         try {
-            allow = checkRight(name, xwikidoc, "admin", user, true, true, context);
+            allow = checkRight(name, xwikidoc, ADMIN, user, true, true, context);
             if (allow) {
                 logAllow(name, resourceKey, accessLevel, "admin level");
 
@@ -890,10 +904,10 @@ public class XWikiRightServiceImpl implements XWikiRightService
             recursiveSpaceChecks++;
             // add to list of spaces already checked
             spacesChecked.add(space);
-            XWikiDocument webdoc = context.getWiki().getDocument(space, "WebPreferences", context);
+            XWikiDocument webdoc = context.getWiki().getDocument(space, WEB_PREFERENCES, context);
             if (!webdoc.isNew()) {
                 try {
-                    allow = checkRight(name, webdoc, "admin", user, true, true, context);
+                    allow = checkRight(name, webdoc, ADMIN, user, true, true, context);
                     if (allow) {
                         logAllow(name, resourceKey, accessLevel, "web admin level");
                         return true;
@@ -902,7 +916,7 @@ public class XWikiRightServiceImpl implements XWikiRightService
                 }
 
                 // find the parent web to check rights on it
-                space = webdoc.getStringValue("XWiki.XWikiPreferences", "parent");
+                space = webdoc.getStringValue(XWIKI_PREFERENCES, "parent");
                 if ((space == null) || (space.trim().isEmpty()) || spacesChecked.contains(space)) {
                     // no parent space or space already checked (recursive loop). let's finish the
                     // loop
@@ -939,7 +953,7 @@ public class XWikiRightServiceImpl implements XWikiRightService
             if (doc == null) {
                 // If no context document is set, then check the rights of the current user
                 return isSuperAdminOrProgramming(this.entityReferenceSerializer.serialize(context.getUserReference()),
-                    null, "programming", true, context);
+                    null, PROGRAMMING, true, context);
             }
 
             String username = doc.getContentAuthor();
@@ -958,7 +972,7 @@ public class XWikiRightServiceImpl implements XWikiRightService
                 docname = doc.getFullName();
             }
 
-            return hasAccessLevel("programming", username, docname, context);
+            return hasAccessLevel(PROGRAMMING, username, docname, context);
         } catch (Exception e) {
             LOGGER.error("Failed to check programming right for document [{}]", doc.getPrefixedFullName(), e);
 
@@ -974,7 +988,7 @@ public class XWikiRightServiceImpl implements XWikiRightService
         if (!hasAdmin) {
             try {
                 hasAdmin =
-                    hasAccessLevel("admin", context.getUser(), context.getDoc().getSpace() + ".WebPreferences", context);
+                    hasAccessLevel(ADMIN, context.getUser(), context.getDoc().getSpace() + ".WebPreferences", context);
             } catch (Exception e) {
                 LOGGER.error("Failed to check space admin right for user [{}]", context.getUser(), e);
             }
@@ -987,7 +1001,7 @@ public class XWikiRightServiceImpl implements XWikiRightService
     public boolean hasWikiAdminRights(XWikiContext context)
     {
         try {
-            return hasAccessLevel("admin", context.getUser(), "XWiki.XWikiPreferences", context);
+            return hasAccessLevel(ADMIN, context.getUser(), XWIKI_PREFERENCES, context);
         } catch (Exception e) {
             LOGGER.error("Failed to check wiki admin right for user [{}]", context.getUser(), e);
             return false;


### PR DESCRIPTION
## Summary

Fixes 22 SonarCloud [`java:S1192`](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS1192&rule_key=java%3AS1192) issues (*Define a constant instead of duplicating this literal N times*) in three `xwiki-platform-oldcore` classes. Each duplicated string literal is extracted into a `private static final String` constant and all its occurrences replaced.

### Files & literals

- **`XWikiRightServiceImpl`** (13): `"admin"`, `"comment"`, `"delete"`, `"programming"`, `"register"`, `"undelete"`, `"login"`, `"authenticate_"`, `"grouplist"`, `"WebPreferences"`, `"XWiki.XWikiPreferences"`, `"Checking match: [{}] in [{}]"`, `"Found matching right in [{}] for [{}]"`
- **`XWikiHibernateStore`** (5): `"CREATE SCHEMA "`, `" CASCADE"`, `"DROP SCHEMA "`, `"docId"`, `"select distinct doc.fullName"`
- **`XWikiAuthServiceImpl`** (4): `"XWiki"`, `"xwiki.authentication.realmname"`, `"User "`, `"message"`

No behavior change — pure literal-to-constant extraction. The `xwiki-platform-oldcore` module builds successfully (`mvn clean install`, which runs Checkstyle and Spoon).

[View these issues on SonarCloud](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&rules=java%3AS1192&issueStatuses=OPEN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1JLsSnG4oGtvVMxthFUss)_