### PR TITLE
[stable-17.10.x] XWIKI-23960: Remove @since from test-support methods

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/CopyPage.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/CopyPage.java
@@ -136,8 +136,6 @@ public class CopyPage extends ViewPage
 
     /**
      * @return {@code true} if the checkbox for preserving children during copy is checked.
-     * @since 17.4.0RC1
-     * @since 17.10.10
      */
     public boolean isDeepCopy()
     {
@@ -148,8 +146,6 @@ public class CopyPage extends ViewPage
      * Sets whether children should be preserved during copy.
      *
      * @param deep {@code true} to preserve children, {@code false} otherwise
-     * @since 17.4.0RC1
-     * @since 17.10.10
      */
     public void setDeepCopy(boolean deep)
     {


### PR DESCRIPTION
Follow-up to the already-merged backport: page-object/test-support methods should not carry @since (see convention). Removes them.