### PR TITLE
[stable-17.10.x] XWIKI-18740: Add automated test for "Make Document Title Field Mandatory"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/EditingIT.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-docker/src/test/it/org/xwiki/administration/test/ui/EditingIT.java
@@ -30,10 +30,13 @@ import org.xwiki.test.ui.TestUtils;
 import org.xwiki.test.ui.po.editor.EditPage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Validate the Editing section of the Administration application, and in particular that changing the wiki-level
- * default editor controls which editor is used when editing a page.
+ * Validate the Editing section of the Administration application: that changing the wiki-level default editor controls
+ * which editor is used when editing a page, and that the "Make page title field mandatory" setting can be toggled and
+ * is properly reflected.
  *
  * @version $Id$
  * @since 18.5.0RC1
@@ -85,5 +88,35 @@ class EditingIT
 
         setup.gotoPage(testReference, "edit");
         assertEquals(EditPage.Editor.WYSIWYG, new EditPage().getEditor());
+    }
+
+    /**
+     * Validate that the "Make page title field mandatory" setting in the Editing administration section can be toggled
+     * and that the {@code xwiki.title.mandatory} wiki preference and the Administration UI stay in sync. The enforcement
+     * of the mandatory title in the editor is tested separately (see {@code WikiEditIT}).
+     */
+    @Test
+    @Order(2)
+    void mandatoryTitleSetting(TestUtils setup) throws Exception
+    {
+        EditingAdministrationSectionPage editingSection = EditingAdministrationSectionPage.gotoPage();
+        assertFalse(editingSection.isMandatoryTitle());
+
+        try {
+            // Setting the preference (e.g. programmatically) is reflected in the Administration UI.
+            setup.setWikiPreference("xwiki.title.mandatory", "1");
+            assertTrue(EditingAdministrationSectionPage.gotoPage().isMandatoryTitle());
+
+            // Toggling the control off in the Administration UI persists the change.
+            EditingAdministrationSectionPage.gotoPage().setMandatoryTitle(false);
+            assertFalse(EditingAdministrationSectionPage.gotoPage().isMandatoryTitle());
+
+            // Toggling it back on in the Administration UI persists the change.
+            EditingAdministrationSectionPage.gotoPage().setMandatoryTitle(true);
+            assertTrue(EditingAdministrationSectionPage.gotoPage().isMandatoryTitle());
+        } finally {
+            // Restore the default (non-mandatory) so that other tests are not affected.
+            setup.setWikiPreference("xwiki.title.mandatory", "0");
+        }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/EditingAdministrationSectionPage.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-test/xwiki-platform-administration-test-pageobjects/src/main/java/org/xwiki/administration/test/po/EditingAdministrationSectionPage.java
@@ -44,6 +44,13 @@ public class EditingAdministrationSectionPage extends AdministrationSectionPage
     private WebElement defaultEditorSelect;
 
     /**
+     * The dropdown used to control whether the document title field is mandatory when editing a page (the
+     * {@code xwiki.title.mandatory} preference). The value "1" means Yes (mandatory) and "0" means No.
+     */
+    @FindBy(name = "XWiki.XWikiPreferences_0_xwiki.title.mandatory")
+    private WebElement mandatoryTitleSelect;
+
+    /**
      * Open the Editing administration section.
      *
      * @return the Editing administration section
@@ -86,5 +93,24 @@ public class EditingAdministrationSectionPage extends AdministrationSectionPage
     public String getDefaultEditor()
     {
         return getDefaultEditorSelect().getFirstSelectedOption().getAttribute("value");
+    }
+
+    /**
+     * Set whether the document title field is mandatory when editing a page and save the changes.
+     *
+     * @param mandatory {@code true} to make the document title mandatory, {@code false} otherwise
+     */
+    public void setMandatoryTitle(boolean mandatory)
+    {
+        new Select(this.mandatoryTitleSelect).selectByValue(mandatory ? "1" : "0");
+        clickSave();
+    }
+
+    /**
+     * @return {@code true} if the document title field is configured as mandatory when editing a page
+     */
+    public boolean isMandatoryTitle()
+    {
+        return "1".equals(new Select(this.mandatoryTitleSelect).getFirstSelectedOption().getAttribute("value"));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/AllIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/AllIT.java
@@ -33,7 +33,7 @@ import org.xwiki.test.docker.junit5.UITest;
 public class AllIT
 {
     @Nested
-    class NestedEditIT extends EditIT
+    class NestedEditIT extends WikiEditIT
     {
     }
 

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/WikiEditIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/WikiEditIT.java
@@ -72,7 +72,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
         "xwikiPropertiesAdditionalProperties=test.prchecker.excludePattern=.*:Test\\.XWikiConfigurationPageForTest"
     }
 )
-class EditIT
+class WikiEditIT
 {
     @BeforeAll
     void setup(TestUtils setup)
@@ -1136,5 +1136,41 @@ class EditIT
 
         assertEquals(test, viewPage.getDocumentTitle());
         assertEquals(test, viewPage.getContent());
+    }
+
+    /**
+     * Verify that, when the document title is made mandatory (Administration &gt; Editing &gt; Edit Mode,
+     * "Make page title field mandatory" = Yes, i.e. the {@code xwiki.title.mandatory} wiki preference), the Wiki editor
+     * does not let the user save the page with an empty title.
+     */
+    @Test
+    @Order(15)
+    void mandatoryTitle(TestUtils setup, TestReference testReference) throws Exception
+    {
+        setup.deletePage(testReference);
+        try {
+            setup.setWikiPreference("xwiki.title.mandatory", "1");
+
+            WikiEditPage editPage = WikiEditPage.gotoPage(testReference);
+
+            // The form pre-fills the title with the page name when mandatory, so clear it to trigger validation.
+            editPage.setTitle("");
+            assertFalse(editPage.isDocumentTitleValid());
+
+            // Saving with an empty title is blocked client-side (HTML5 form validation): the page is not saved and we
+            // remain in edit mode.
+            editPage.clickSaveAndView(false);
+            assertTrue(setup.getDriver().getCurrentUrl().contains("/edit/"));
+            assertFalse(editPage.isDocumentTitleValid());
+            assertEquals("This field is required.",
+                editPage.getDocumentTitleField().getDomProperty("validationMessage"));
+
+            // Providing a title makes the field valid and allows saving.
+            editPage.setTitle("My Title");
+            assertTrue(editPage.isDocumentTitleValid());
+            assertEquals("My Title", editPage.clickSaveAndView().getDocumentTitle());
+        } finally {
+            setup.setWikiPreference("xwiki.title.mandatory", "0");
+        }
     }
 }


### PR DESCRIPTION
Backport of XWIKI-18740 to stable-17.10.x.

Cherry-picked from master commit `85e60f2d24e` (clean). Adds:
- `EditingIT.mandatoryTitleSetting` — verifies the "Make page title field mandatory" setting in the Editing administration section toggles and stays in sync with the `xwiki.title.mandatory` wiki preference.
- `EditingAdministrationSectionPage.setMandatoryTitle()` / `isMandatoryTitle()` page-object helpers.
- Flamingo `EditIT` → `WikiEditIT` rename + `mandatoryTitle` test verifying the Wiki editor blocks saving an empty title when the setting is on.

This was previously blocked because `EditingIT` / `EditingAdministrationSectionPage` did not exist on the stable branches; they were introduced by the XWIKI-18672 backport, so this now applies cleanly.

Per the backport `@since` policy, the method-level `@since 18.6.0RC1` tags added by the original commit on the two page-object helpers are dropped (test-support methods carry no `@since`; the class already has a class-level `@since` block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)