### PR TITLE
[stable-17.10.x] XWIKI-20411: Add automated test for "Name strategies automatic character replacement validation"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-test/xwiki-platform-model-validation-test-pageobjects/src/main/java/org/xwiki/model/validation/test/po/NameStrategiesAdministrationSectionPage.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-test/xwiki-platform-model-validation-test-pageobjects/src/main/java/org/xwiki/model/validation/test/po/NameStrategiesAdministrationSectionPage.java
@@ -77,6 +77,15 @@ public class NameStrategiesAdministrationSectionPage extends AdministrationSecti
     }
 
     /**
+     * @return the hint of the currently selected entity name validation strategy (e.g.
+     *         {@code "ReplaceCharacterEntityNameValidation"} or {@code "SlugEntityNameValidation"})
+     */
+    public String getSelectedStrategy()
+    {
+        return new Select(getDriver().findElement(STRATEGY_SELECT)).getFirstSelectedOption().getAttribute("value");
+    }
+
+    /**
      * Save the configuration. This persists the selected strategy and its configuration (which is necessary, for the
      * Slug strategy, so that its configuration properties are initialized before the strategy is tested).
      */

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/ExtensionInstaller.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/ExtensionInstaller.java
@@ -29,6 +29,7 @@ import org.apache.commons.httpclient.UsernamePasswordCredentials;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Model;
 import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.resolution.ArtifactResult;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.xwiki.extension.ExtensionId;
@@ -55,6 +56,8 @@ public class ExtensionInstaller
     private static final String XAR = "xar";
 
     private static final String JAR = "jar";
+
+    private static final String PLATFORM_GROUPID = "org.xwiki.platform";
 
     private static final String DEPENDENCIES_SYSTEM_PROPERTY = System.getProperty("xwiki.test.ui.dependencies");
 
@@ -129,14 +132,26 @@ public class ExtensionInstaller
         List<Artifact> extraArtifacts = this.mavenResolver.convertToArtifacts(this.testConfiguration.getExtraJARs(),
             this.testConfiguration.isResolveExtraJARs());
         this.mavenResolver.addCloverJAR(extraArtifacts);
+        // Use the same dependencies root as the one used to build the WAR (see WARBuilder). This is required so that
+        // the set of extensions considered as already part of the distribution (i.e. bundled in WEB-INF/lib and thus
+        // not to be re-provisioned) matches what the WAR actually contains. In standardFlavor mode this avoids
+        // re-installing as extensions the core extensions that are already bundled in the WAR.
         Collection<ArtifactResult> distributionArtifactResults =
-            this.artifactResolver.getDistributionDependencies(commonsVersion, platformVersion, extraArtifacts);
+            this.artifactResolver.getDistributionDependencies(commonsVersion, platformVersion, extraArtifacts,
+                this.testConfiguration.getWARDependenciesRootArtifactId());
         List<ExtensionId> distributionExtensionIds = new ArrayList<>();
         for (ArtifactResult artifactResult : distributionArtifactResults) {
             Artifact artifact = artifactResult.getArtifact();
             ExtensionId extensionId = convertToExtensionId(artifact);
             distributionExtensionIds.add(extensionId);
-            if (artifact.getExtension().equalsIgnoreCase(XAR)) {
+            // Auto-provision the distribution's mandatory XAR extensions (they're not bundled in WEB-INF/lib), but
+            // ONLY in minimal mode. In standardFlavor mode the distribution dependencies pull in
+            // xwiki-platform-distribution-ui-base only to bundle its JARs in WEB-INF/lib, and that drags in its whole
+            // transitive XAR closure (the entire standard UI). We must not auto-provision those here: they are
+            // installed through the flavor (see Step 3), exactly as a real XWiki instance installs the flavor via its
+            // Distribution Wizard. XWiki's Extension Manager then resolves the flavor tree server-side and skips the
+            // JAR core extensions already bundled in WEB-INF/lib.
+            if (!this.testConfiguration.isStandardFlavor() && artifact.getExtension().equalsIgnoreCase(XAR)) {
                 extensions.add(extensionId);
             }
         }
@@ -148,6 +163,17 @@ public class ExtensionInstaller
         // dependencies in your POM (can be useful when you want to test your extension on a vesion of XWiki for which
         // it wasn't developed for).
         extensions.addAll(getProjectExtensionIds(distributionExtensionIds));
+
+        // Step 3: In standardFlavor mode, install the standard flavor automatically (as on a fresh standard
+        // distribution), so the test module doesn't need to declare it as a dependency. The flavor is restricted to
+        // the main wiki (wiki:xwiki) by the flavor extension itself. Installing it makes XWiki's Extension Manager
+        // resolve and install the whole standard UI server-side while skipping the JAR core extensions already
+        // bundled in WEB-INF/lib (see Step 1).
+        if (this.testConfiguration.isStandardFlavor()) {
+            Artifact flavorArtifact = new DefaultArtifact(PLATFORM_GROUPID,
+                "xwiki-platform-distribution-flavor-mainwiki", XAR, platformVersion);
+            extensions.add(convertToExtensionId(flavorArtifact));
+        }
 
         installExtensions(extensions, credentials, installUserReference, namespaces, true);
     }

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/UITestTestConfigurationResolver.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/UITestTestConfigurationResolver.java
@@ -85,6 +85,8 @@ public class UITestTestConfigurationResolver
 
     private static final String OFFICE_PROPERTY = "xwiki.test.ui.office";
 
+    private static final String STANDARDFLAVOR_PROPERTY = "xwiki.test.ui.standardFlavor";
+
     private static final String SAVEDBDATA_PROPERTY = "xwiki.test.ui.saveDatabaseData";
 
     private static final String SAVEPERMANENTDIRECTORY_PROPERTY = "xwiki.test.ui.savePermanentDirectoryData";
@@ -118,6 +120,7 @@ public class UITestTestConfigurationResolver
         configuration.setSSHPorts(resolveSSHPorts(uiTestAnnotation.sshPorts()));
         configuration.setProfiles(resolveCommaSeparatedValues(uiTestAnnotation.profiles(), PROFILES_PROPERTY));
         configuration.setOffice(resolveOffice(uiTestAnnotation.office()));
+        configuration.setStandardFlavor(resolveStandardFlavor(uiTestAnnotation.standardFlavor()));
         configuration.setForbiddenServletEngines(resolveForbiddenServletEngines(uiTestAnnotation.forbiddenEngines()));
         configuration.setDatabaseCommands(resolveDatabaseCommands(uiTestAnnotation.databaseCommands()));
         configuration.setSaveDatabaseData(resolveSaveDatabaseData(uiTestAnnotation.saveDatabaseData()));
@@ -256,6 +259,11 @@ public class UITestTestConfigurationResolver
     private boolean resolveWCAGStopOnError(boolean wcagStopOnError)
     {
         return resolve(wcagStopOnError, WCAG_STOP_ON_ERROR_PROPERTY);
+    }
+
+    private boolean resolveStandardFlavor(boolean standardFlavor)
+    {
+        return resolve(standardFlavor, STANDARDFLAVOR_PROPERTY);
     }
 
     private boolean resolveOffice(boolean office)

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/WARBuilder.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/WARBuilder.java
@@ -141,8 +141,13 @@ public class WARBuilder
                 this.testConfiguration.isResolveExtraJARs());
             this.mavenResolver.addCloverJAR(extraArtifacts);
             maybeAddS3BlobStore(extraArtifacts);
+            // Resolve WEB-INF/lib from the minimal dependencies by default, or from the standard distribution WAR
+            // dependencies when the test requested the standardFlavor mode (so that the bundled core extensions match
+            // a real XWiki instance). Note: ExtensionInstaller must use the same root so that it agrees on what is
+            // bundled (and thus must not be re-provisioned).
             Collection<ArtifactResult> artifactResults =
-                this.artifactResolver.getDistributionDependencies(commonsVersion, platformVersion, extraArtifacts);
+                this.artifactResolver.getDistributionDependencies(commonsVersion, platformVersion, extraArtifacts,
+                    this.testConfiguration.getWARDependenciesRootArtifactId());
             List<File> warDependencies = new ArrayList<>();
             List<Artifact> jarDependencies = new ArrayList<>();
             List<File> skinDependencies = new ArrayList<>();

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/configuration/ConfigurationFilesGenerator.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/internal/junit5/configuration/ConfigurationFilesGenerator.java
@@ -330,6 +330,18 @@ public class ConfigurationFilesGenerator
                     this.testConfiguration.getDatabase()));
         }
 
+        // In standardFlavor mode the WAR bundles the full standard distribution JARs and installs the standard
+        // flavor, so register the same extra Hibernate mappings the standard distribution registers (see
+        // xwiki.db.common.extraMappings / xwiki.db.default.extraMappings in xwiki-platform-distribution/pom.xml).
+        // Without this the standard UI (e.g. the notifications watch menu) queries entities such as
+        // DefaultNotificationFilterPreference that would otherwise be unmapped. In minimal mode these JARs are
+        // absent from WEB-INF/lib, so the mappings must NOT be registered.
+        if (this.testConfiguration.isStandardFlavor()) {
+            props.setProperty("xwikiDbHbmCommonExtraMappings",
+                "instance.hbm.xml,notification-filter-preferences.hbm.xml");
+            props.setProperty("xwikiDbHbmDefaultExtraMappings", "mailsender.hbm.xml");
+        }
+
         return props;
     }
 

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/TestConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/TestConfiguration.java
@@ -819,6 +819,8 @@ public class TestConfiguration
      *         dependencies (instead of the minimal set) and the standard flavor
      *         ({@code xwiki-platform-distribution-flavor-mainwiki}) is installed automatically. See
      *         {@link org.xwiki.test.docker.junit5.UITest#standardFlavor()}.
+     * @since 17.10.10
+     * @since 18.4.3
      * @since 18.6.0RC1
      */
     public boolean isStandardFlavor()
@@ -828,6 +830,8 @@ public class TestConfiguration
 
     /**
      * @param standardFlavor see {@link #isStandardFlavor()}
+     * @since 17.10.10
+     * @since 18.4.3
      * @since 18.6.0RC1
      */
     public void setStandardFlavor(boolean standardFlavor)
@@ -841,6 +845,8 @@ public class TestConfiguration
      *         dependencies when {@link #isStandardFlavor()} is true (the {@code legacy} variant when the
      *         {@code legacy} profile is active), or the minimal set otherwise. Used by both the WAR builder and the
      *         extension installer so that they agree on what is bundled versus provisioned.
+     * @since 17.10.10
+     * @since 18.4.3
      * @since 18.6.0RC1
      */
     public String getWARDependenciesRootArtifactId()

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/TestConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/TestConfiguration.java
@@ -83,6 +83,8 @@ public class TestConfiguration
 
     private boolean office;
 
+    private boolean standardFlavor;
+
     private List<ServletEngine> forbiddenServletEngines;
 
     private Properties databaseCommands;
@@ -103,6 +105,8 @@ public class TestConfiguration
      * @param testConfiguration the configuration to merge with the current one
      * @throws DockerTestException when a merge error occurs
      */
+    // This is a flat sequence of one merge call per configuration option; splitting it would only hurt readability.
+    @SuppressWarnings("ExecutableStatementCount")
     public void merge(TestConfiguration testConfiguration) throws DockerTestException
     {
         mergeBrowser(testConfiguration.getBrowser());
@@ -125,6 +129,7 @@ public class TestConfiguration
         mergeSSHPorts(testConfiguration.getSSHPorts());
         mergeProfiles(testConfiguration.getProfiles());
         mergeOffice(testConfiguration.isOffice());
+        mergeStandardFlavor(testConfiguration.isStandardFlavor());
         mergeForbiddenServletEngines(testConfiguration.getForbiddenServletEngines());
         mergeDatabaseCommands(testConfiguration.getDatabaseCommands());
         mergeSaveDatabaseData(testConfiguration.isDatabaseDataSaved());
@@ -276,6 +281,13 @@ public class TestConfiguration
     {
         if (!isOffice() && office) {
             this.office = true;
+        }
+    }
+
+    private void mergeStandardFlavor(boolean standardFlavor)
+    {
+        if (!isStandardFlavor() && standardFlavor) {
+            this.standardFlavor = true;
         }
     }
 
@@ -744,13 +756,17 @@ public class TestConfiguration
      */
     public String getName()
     {
-        return String.format("%s-%s-%s-%s-%s-%s",
+        // Note: the standardFlavor mode is part of the name so that the minimal-WAR and standard-flavor variants get
+        // distinct output directories (and thus distinct build.marker files). Otherwise switching modes for the same
+        // db/servlet/browser combination would reuse a stale WAR.
+        return String.format("%s-%s-%s-%s-%s-%s%s",
             getDatabase().name().toLowerCase(),
             StringUtils.isEmpty(getDatabaseTag()) ? DEFAULT : getDatabaseTag(),
             StringUtils.isEmpty(getJDBCDriverVersion()) ? DEFAULT : getDatabaseTag(),
             getServletEngine().name().toLowerCase(),
             StringUtils.isEmpty(getServletEngineTag()) ? DEFAULT : getServletEngineTag(),
-            getBrowser().name().toLowerCase());
+            getBrowser().name().toLowerCase(),
+            isStandardFlavor() ? "-standardflavor" : "");
     }
 
     /**
@@ -795,6 +811,46 @@ public class TestConfiguration
     public void setOffice(boolean office)
     {
         this.office = office;
+    }
+
+    /**
+     * @return true to make the test instance equivalent to an XWiki installed from the standard flavor
+     *         distribution: the WAR's {@code WEB-INF/lib} is built from the standard distribution WAR
+     *         dependencies (instead of the minimal set) and the standard flavor
+     *         ({@code xwiki-platform-distribution-flavor-mainwiki}) is installed automatically. See
+     *         {@link org.xwiki.test.docker.junit5.UITest#standardFlavor()}.
+     * @since 18.6.0RC1
+     */
+    public boolean isStandardFlavor()
+    {
+        return this.standardFlavor;
+    }
+
+    /**
+     * @param standardFlavor see {@link #isStandardFlavor()}
+     * @since 18.6.0RC1
+     */
+    public void setStandardFlavor(boolean standardFlavor)
+    {
+        this.standardFlavor = standardFlavor;
+    }
+
+    /**
+     * @return the artifactId (in the {@code org.xwiki.platform} groupId) of the {@code pom} artifact whose
+     *         dependencies define the JARs to put in the WAR's {@code WEB-INF/lib}: the full standard distribution
+     *         dependencies when {@link #isStandardFlavor()} is true (the {@code legacy} variant when the
+     *         {@code legacy} profile is active), or the minimal set otherwise. Used by both the WAR builder and the
+     *         extension installer so that they agree on what is bundled versus provisioned.
+     * @since 18.6.0RC1
+     */
+    public String getWARDependenciesRootArtifactId()
+    {
+        if (!isStandardFlavor()) {
+            return "xwiki-platform-minimaldependencies";
+        }
+        return getProfiles().contains("legacy")
+            ? "xwiki-platform-distribution-war-legacydependencies"
+            : "xwiki-platform-distribution-war-dependencies";
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/UITest.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/UITest.java
@@ -197,6 +197,18 @@ public @interface UITest
     boolean office() default false;
 
     /**
+     * @return true to make the test instance equivalent to an XWiki installed from the standard flavor
+     *         distribution. When true, two things happen: (1) the generated WAR contains the full set of core
+     *         extensions of the standard XWiki distribution WAR (i.e. the {@code WEB-INF/lib} JARs resolved from
+     *         {@code xwiki-platform-distribution-war-dependencies}) instead of the minimal set (resolved from
+     *         {@code xwiki-platform-minimaldependencies}); and (2) the standard flavor
+     *         ({@code xwiki-platform-distribution-flavor-mainwiki}) is installed automatically, so the test does
+     *         not need to declare it as a dependency. False by default.
+     * @since 18.6.0RC1
+     */
+    boolean standardFlavor() default false;
+
+    /**
      * @return the list of Servlet Engines on which this test must not be executed. If the Servlet Engine is selected
      *         then the test will be skipped
      * @since 10.11RC1

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/UITest.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-docker/src/main/java/org/xwiki/test/docker/junit5/UITest.java
@@ -204,6 +204,8 @@ public @interface UITest
      *         {@code xwiki-platform-minimaldependencies}); and (2) the standard flavor
      *         ({@code xwiki-platform-distribution-flavor-mainwiki}) is installed automatically, so the test does
      *         not need to declare it as a dependency. False by default.
+     * @since 17.10.10
+     * @since 18.4.3
      * @since 18.6.0RC1
      */
     boolean standardFlavor() default false;

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-integration/src/main/java/org/xwiki/test/integration/maven/ArtifactResolver.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-integration/src/main/java/org/xwiki/test/integration/maven/ArtifactResolver.java
@@ -209,6 +209,8 @@ public class ArtifactResolver
      * @return the collection of resolved artifact results for the XWiki distribution/flavor to be used for
      *         functional tests
      * @throws Exception if an error occurred during resolving
+     * @since 17.10.10
+     * @since 18.4.3
      * @since 18.6.0RC1
      */
     public Collection<ArtifactResult> getDistributionDependencies(String commonsVersion, String platformVersion,

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-integration/src/main/java/org/xwiki/test/integration/maven/ArtifactResolver.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-integration/src/main/java/org/xwiki/test/integration/maven/ArtifactResolver.java
@@ -193,8 +193,29 @@ public class ArtifactResolver
     public Collection<ArtifactResult> getDistributionDependencies(String commonsVersion, String platformVersion,
         List<Artifact> extraArtifacts) throws Exception
     {
+        return getDistributionDependencies(commonsVersion, platformVersion, extraArtifacts,
+            "xwiki-platform-minimaldependencies");
+    }
+
+    /**
+     * @param commonsVersion the version to use for xwiki-commons artifacts
+     * @param platformVersion the version to use for xwiki-platform artifacts
+     * @param extraArtifacts the list of extra artifacts that should be added to {@code WEB-INF/lib}. Can be empty
+     * @param rootDistributionArtifactId the artifactId (in the {@code org.xwiki.platform} groupId) of the {@code pom}
+     *        artifact whose dependencies define the set of JARs to put in {@code WEB-INF/lib}. Use
+     *        {@code xwiki-platform-minimaldependencies} for the minimal WAR or
+     *        {@code xwiki-platform-distribution-war-dependencies} (or the {@code -legacydependencies} variant) to
+     *        generate a WAR with the same core extensions as the standard XWiki distribution WAR
+     * @return the collection of resolved artifact results for the XWiki distribution/flavor to be used for
+     *         functional tests
+     * @throws Exception if an error occurred during resolving
+     * @since 18.6.0RC1
+     */
+    public Collection<ArtifactResult> getDistributionDependencies(String commonsVersion, String platformVersion,
+        List<Artifact> extraArtifacts, String rootDistributionArtifactId) throws Exception
+    {
         Artifact rootDistributionArtifact = new DefaultArtifact(PLATFORM_GROUPID,
-            "xwiki-platform-minimaldependencies", "pom", platformVersion);
+            rootDistributionArtifactId, "pom", platformVersion);
 
         List<Artifact> dependentArtifacts = new ArrayList<>();
 

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-integration/src/main/java/org/xwiki/test/integration/maven/RepositoryResolver.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-integration/src/main/java/org/xwiki/test/integration/maven/RepositoryResolver.java
@@ -130,6 +130,11 @@ public class RepositoryResolver
         String localRepoLocation = System.getProperty("maven.repo.local",
             String.format("%s/.m2/repository", System.getProperty("user.home")));
         DefaultRepositorySystemSession session = MavenRepositorySystemUtils.newSession();
+        // Initialize the session with the current JVM system properties. Without this, the session has no system
+        // properties at all, and any POM in the resolved lineage that declares a profile activated by <jdk> (for
+        // example software.amazon.awssdk:aws-sdk-java-pom, imported transitively through xwiki-commons) cannot be
+        // evaluated since "java.version" is missing, which makes the Maven model building fail.
+        session.setSystemProperties(System.getProperties());
         LocalRepository localRepo = new LocalRepository(localRepoLocation);
         session.setLocalRepositoryManager(system.newLocalRepositoryManager(session, localRepo));
 

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/pom.xml
@@ -30,7 +30,6 @@
   <artifactId>xwiki-platform-distribution-flavor</artifactId>
   <name>XWiki Platform - Distribution - Flavor</name>
   <packaging>pom</packaging>
-
   <properties>
     <!-- The default UI -->
     <xwiki.extension.distribution.ui.name>XWiki Standard Flavor</xwiki.extension.distribution.ui.name>
@@ -48,7 +47,6 @@
     <xwiki.extension.distribution.wikiui.version>${xwiki.extension.distribution.ui.version}</xwiki.extension.distribution.wikiui.version>
     <xwiki.extension.distribution.wikiui.id>${xwiki.extension.distribution.wikiui.groupId}:${xwiki.extension.distribution.wikiui.artifactId}/${xwiki.extension.distribution.wikiui.version}</xwiki.extension.distribution.wikiui.id>
   </properties>
-
   <modules>
     <module>xwiki-platform-distribution-flavor-common</module>
     <module>xwiki-platform-distribution-flavor-tour</module>
@@ -58,7 +56,6 @@
     <module>xwiki-platform-distribution-flavor-jetty-hsqldb</module>
     <module>xwiki-platform-distribution-flavor-xip</module>
   </modules>
-
   <profiles>
     <profile>
       <id>flavor-integration-tests</id>

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/pom.xml
@@ -495,6 +495,12 @@
         <browser>*custom ${browserPath}</browser>
       </properties>
     </profile>
+    <profile>
+      <id>docker</id>
+      <modules>
+        <module>xwiki-platform-distribution-flavor-test-docker</module>
+      </modules>
+    </profile>
   </profiles>
   <modules>
     <module>xwiki-platform-distribution-flavor-test-misc</module>

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-docker/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-docker/pom.xml
@@ -37,16 +37,26 @@
     <!-- Functional tests are allowed to output content to the console -->
     <xwiki.surefire.captureconsole.skip>true</xwiki.surefire.captureconsole.skip>
   </properties>
+  <!--
+    This module hosts Docker-based functional tests that need the assembled standard distribution (shipped defaults,
+    cross-feature/distribution behaviour) rather than a single feature's UI. The tests use
+    "@UITest(standardFlavor = true)", which makes the test instance equivalent to an XWiki installed from the standard
+    flavor distribution:
+    - The generated WAR's WEB-INF/lib core extensions are resolved from xwiki-platform-distribution-war-dependencies
+      (the same set used by the standard distribution WAR, xwiki-platform-distribution-war) instead of from the
+      minimal set (xwiki-platform-minimaldependencies).
+    - The standard flavor (xwiki-platform-distribution-flavor-mainwiki) is installed automatically by the Docker test
+      framework, so it does NOT need to be declared as a dependency here.
+
+    Remaining (intentional) differences from the standard production WAR, which are inherent to the test setup and
+    not yet addressed:
+    - The XWiki configuration files (xwiki.cfg, xwiki.properties, hibernate.cfg.xml) are generated for the test
+      database/environment instead of shipping the production defaults.
+    - A few test-only JARs are added to WEB-INF/lib by the Docker test framework (e.g. xwiki-platform-test-checker,
+      xwiki-platform-component-script, and the Clover JAR when the clover profile is active).
+  -->
   <dependencies>
-    <!-- Runtime dependencies. -->
-    <dependency>
-      <groupId>org.xwiki.platform</groupId>
-      <artifactId>xwiki-platform-distribution-flavor-mainwiki</artifactId>
-      <version>${project.version}</version>
-      <scope>runtime</scope>
-      <type>xar</type>
-    </dependency>
-    <!--Test only dependencies. -->
+    <!-- Test only dependencies. -->
     <dependency>
       <groupId>org.xwiki.platform</groupId>
       <artifactId>xwiki-platform-test-docker</artifactId>

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-docker/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-docker/pom.xml
@@ -38,13 +38,10 @@
     <xwiki.surefire.captureconsole.skip>true</xwiki.surefire.captureconsole.skip>
   </properties>
   <dependencies>
-    <!-- Runtime dependencies.
-         We depend on the flavor base UI so that the shipped default configuration documents (such as
-         XWiki.EntityNameValidation.Configuration, which selects the Character Replacement strategy and forbids
-         "/" and "\" by default) are present in the tested instance. -->
+    <!-- Runtime dependencies. -->
     <dependency>
       <groupId>org.xwiki.platform</groupId>
-      <artifactId>xwiki-platform-distribution-ui-base</artifactId>
+      <artifactId>xwiki-platform-distribution-flavor-mainwiki</artifactId>
       <version>${project.version}</version>
       <scope>runtime</scope>
       <type>xar</type>

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-docker/pom.xml
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-docker/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.xwiki.platform</groupId>
+    <artifactId>xwiki-platform-distribution-flavor-test</artifactId>
+    <version>18.5.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>xwiki-platform-distribution-flavor-test-docker</artifactId>
+  <name>XWiki Platform - Distribution - Flavor - Functional Tests - Docker</name>
+  <description>XWiki Platform - Distribution - Flavor - Functional Tests - Docker</description>
+  <!-- TODO: Move to use "functional-test" in the future when http://jira.codehaus.org/browse/MNG-1911 is fixed,
+       see https://jira.xwiki.org/browse/XWIKI-7683 -->
+  <packaging>jar</packaging>
+  <properties>
+    <!-- Functional tests are allowed to output content to the console -->
+    <xwiki.surefire.captureconsole.skip>true</xwiki.surefire.captureconsole.skip>
+  </properties>
+  <dependencies>
+    <!-- Runtime dependencies.
+         We depend on the flavor base UI so that the shipped default configuration documents (such as
+         XWiki.EntityNameValidation.Configuration, which selects the Character Replacement strategy and forbids
+         "/" and "\" by default) are present in the tested instance. -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-distribution-ui-base</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+      <type>xar</type>
+    </dependency>
+    <!--Test only dependencies. -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-test-docker</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-model-validation-test-pageobjects</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <testSourceDirectory>src/test/it</testSourceDirectory>
+    <plugins>
+      <!-- We need to explicitly include the failsafe plugin since it's not part of the default maven lifecycle -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+  <profiles>
+    <profile>
+      <id>clover</id>
+      <!-- Add the Clover JAR to the WAR so that it's available at runtime when XWiki executes.
+           It's needed because instrumented jars in the WAR will call Clover APIs at runtime when they execute. -->
+      <dependencies>
+        <dependency>
+          <groupId>org.openclover</groupId>
+          <artifactId>clover</artifactId>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <systemPropertyVariables>
+                <!-- Tell the Docker-based test to activate the Clover profile so that the Clover JAR is added to
+                     WEB-INF/lib -->
+                <xwiki.test.ui.profiles>clover</xwiki.test.ui.profiles>
+              </systemPropertyVariables>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-docker/src/test/it/org/xwiki/test/ui/docker/AllIT.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-docker/src/test/it/org/xwiki/test/ui/docker/AllIT.java
@@ -1,0 +1,38 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.test.ui.docker;
+
+import org.junit.jupiter.api.Nested;
+import org.xwiki.test.docker.junit5.UITest;
+
+/**
+ * All UI tests for the standard flavor that need to run against the shipped default configuration.
+ *
+ * @version $Id$
+ * @since 18.5.0RC1
+ */
+@UITest
+public class AllIT
+{
+    @Nested
+    class NestedNameStrategiesDefaultConfigurationIT extends NameStrategiesDefaultConfigurationIT
+    {
+    }
+}

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-docker/src/test/it/org/xwiki/test/ui/docker/NameStrategiesDefaultConfigurationIT.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-docker/src/test/it/org/xwiki/test/ui/docker/NameStrategiesDefaultConfigurationIT.java
@@ -1,0 +1,71 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.test.ui.docker;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.xwiki.model.validation.test.po.NameStrategiesAdministrationSectionPage;
+import org.xwiki.test.docker.junit5.UITest;
+import org.xwiki.test.ui.TestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Validate the default entity name validation configuration shipped with the standard flavor: the Character
+ * Replacement strategy must be selected by default, with {@code "/"} and {@code "\"} forbidden (and removed by the
+ * transformation). This complements {@code NameStrategiesIT} (in the model-validation module), which validates the
+ * "test selected strategy" administration field but cannot verify the shipped default because that default is provided
+ * by the flavor (in {@code xwiki-platform-distribution-ui-base}), not by the model-validation module itself.
+ *
+ * @version $Id$
+ * @since 18.5.0RC1
+ */
+@UITest
+class NameStrategiesDefaultConfigurationIT
+{
+    @BeforeAll
+    void beforeAll(TestUtils setup)
+    {
+        setup.loginAsSuperAdmin();
+    }
+
+    /**
+     * Open the Name Strategies administration section and verify, without changing anything, that the shipped default
+     * uses the Character Replacement strategy and forbids the {@code "/"} and {@code "\"} characters (both removed by
+     * the transformation).
+     */
+    @Test
+    void defaultStrategyForbidsSlashAndBackslash()
+    {
+        NameStrategiesAdministrationSectionPage section = NameStrategiesAdministrationSectionPage.gotoPage();
+
+        // The Character Replacement strategy is selected by default (no selection/save is performed here: the default
+        // Configuration document is shipped by the flavor).
+        assertEquals("ReplaceCharacterEntityNameValidation", section.getSelectedStrategy());
+
+        // "/" and "\" are forbidden by default: a name containing either is reported as invalid and the character is
+        // removed by the transformation.
+        section.assertTestResult("a/b", false, "ab");
+        section.assertTestResult("a\\b", false, "ab");
+
+        // A name with neither forbidden character is valid and left unchanged.
+        section.assertTestResult("abc", true, "abc");
+    }
+}

--- a/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-docker/src/test/it/org/xwiki/test/ui/docker/NameStrategiesDefaultConfigurationIT.java
+++ b/xwiki-platform-distribution/xwiki-platform-distribution-flavor/xwiki-platform-distribution-flavor-test/xwiki-platform-distribution-flavor-test-docker/src/test/it/org/xwiki/test/ui/docker/NameStrategiesDefaultConfigurationIT.java
@@ -37,7 +37,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @version $Id$
  * @since 18.5.0RC1
  */
-@UITest
+// standardFlavor = true so that the shipped default is validated on an instance equivalent to a standard flavor
+// install: a WAR whose WEB-INF/lib core extensions match the standard XWiki distribution WAR, with the standard flavor
+// installed automatically on top.
+@UITest(standardFlavor = true)
 class NameStrategiesDefaultConfigurationIT
 {
     @BeforeAll


### PR DESCRIPTION
Backports the `testneeded` automated test of [XWIKI-20411](https://jira.xwiki.org/browse/XWIKI-20411) — "Name strategies automatic character replacement validation" — which introduces the new `xwiki-platform-distribution-flavor-test-docker` module for Docker-based functional tests running on a full XS (standard flavor) distribution.

### Why this also backports XWIKI-24524

20411's test (`NameStrategiesDefaultConfigurationIT`) uses `@UITest(standardFlavor = true)`. On `master` that capability was **not** part of 20411's original commits — it was added later by [XWIKI-24524](https://jira.xwiki.org/browse/XWIKI-24524) ("Provide the ability for docker-based tests to execute on a full XS flavor"), which then switched 20411's test to `standardFlavor = true`. XWIKI-24524 chronologically follows 20411 and edits the files it created, so it cannot be a separate prerequisite PR — and 20411's test is only complete/working with it. It is therefore bundled here.

### Commits (cherry-picked `-x`, oldest-first)

- `XWIKI-20411` ×2 — new `flavor-test-docker` module + `RepositoryResolver` fix (system properties on the Aether session) + `NameStrategiesAdministrationSectionPage.getSelectedStrategy()`.
- `XWIKI-24524` ×2 — the `standardFlavor` framework capability (`UITest`, `TestConfiguration`, `ExtensionInstaller`, `WARBuilder`, `ConfigurationFilesGenerator`, `ArtifactResolver`) and the switch of 20411's test to it.
- `[Misc]` — `@since` layering (see below).

### `@since`

The new framework API members on existing classes (`UITest.standardFlavor()`, `TestConfiguration` getters/setters, `ArtifactResolver.getDistributionDependencies(...)` 4-arg overload) get ascending `@since 17.10.10 / 18.4.3 / 18.6.0RC1` blocks. The two new-module IT classes keep their single `@since 18.5.0RC1` (ITs are not API). The `getSelectedStrategy()` page-object helper carries no `@since` (test-support member; the class-level block is inherited). A matching `@since` sync on `master` (adding the stable lines to these framework members) is still needed.

### Verification

Cherry-picks applied cleanly. Locally compiled (offline) `xwiki-platform-test-integration`, `xwiki-platform-test-docker` and `xwiki-platform-model-validation-test-pageobjects` against this stable base — all green, confirming the framework change is API-compatible with the branch. The Docker functional tests run on CI (authoritative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
