### PR TITLE
[stable-17.10.x] XWIKI-20410: Add automated test for "Name strategies automatic character replacement"

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/pom.xml
@@ -140,6 +140,13 @@
       <artifactId>xwiki-platform-diff-xml</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- Needed for NameStrategiesReplaceCharacterIT -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-model-validation-ui</artifactId>
+      <version>${project.version}</version>
+      <type>xar</type>
+    </dependency>
     <!-- ================================
          Test only dependencies
          ================================ -->
@@ -166,6 +173,13 @@
     <dependency>
       <groupId>org.xwiki.platform</groupId>
       <artifactId>xwiki-platform-rendering-macro-include</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- Needed for NameStrategiesReplaceCharacterIT: the Name Strategies administration section page object. -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-model-validation-test-pageobjects</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/AllIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/AllIT.java
@@ -211,4 +211,9 @@ public class AllIT
     class NestedSkinActionIT extends SkinActionIT
     {
     }
+
+    @Nested
+    class NestedNameStrategiesReplaceCharacterIT extends NameStrategiesReplaceCharacterIT
+    {
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/NameStrategiesReplaceCharacterIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/NameStrategiesReplaceCharacterIT.java
@@ -1,0 +1,177 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.flamingo.test.docker;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.SpaceReference;
+import org.xwiki.model.validation.test.po.NameStrategiesAdministrationSectionPage;
+import org.xwiki.rest.model.jaxb.Objects;
+import org.xwiki.rest.model.jaxb.Page;
+import org.xwiki.test.docker.junit5.TestReference;
+import org.xwiki.test.docker.junit5.UITest;
+import org.xwiki.test.ui.TestUtils;
+import org.xwiki.test.ui.TestUtils.RestTestUtils;
+import org.xwiki.test.ui.po.CreatePagePage;
+import org.xwiki.test.ui.po.DocumentPicker;
+import org.xwiki.test.ui.po.ViewPage;
+import org.xwiki.test.ui.po.editor.EditPage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verify the "Character Replacement" entity name validation strategy end to end: a custom {@code "@"} to {@code "-"}
+ * mapping is configured, the automatic transformation and validation options are set through the Name Strategies
+ * administration section, and the effect is checked by creating a page whose name contains the forbidden character.
+ * <p>
+ * The strategy is configured with its own forbidden character (nothing is inherited from the standard flavor, which is
+ * not installed here). The mapping is seeded directly through the REST API rather than through the administration's
+ * "Add new character" UI, because that UI relies on the configuration document (with its list properties) shipped by
+ * the flavor, which is absent from this WAR. Seeding through REST also avoids triggering the name-strategy validation
+ * (only invoked on the UI create/save actions): the strategy caches its replacement map in a singleton initialized on
+ * first use, and it reads the seeded mapping when it is first initialized (on the first administration visit below).
+ *
+ * @version $Id$
+ * @since 18.6.0RC1
+ */
+@UITest
+class NameStrategiesReplaceCharacterIT
+{
+    private static final String STRATEGY = "ReplaceCharacterEntityNameValidation";
+
+    private static final String FORBIDDEN_NAME = "Te@st";
+
+    private static final String TRANSFORMED_NAME = "Te-st";
+
+    @BeforeAll
+    void beforeAll(TestUtils setup) throws Exception
+    {
+        setup.loginAsSuperAdmin();
+
+        // Configure the Character Replacement strategy with a custom "@" -> "-" mapping directly through the REST API.
+        // The administration's "Add new character" UI is not used because it requires the configuration document (with
+        // its list properties) shipped by the standard flavor, which is not installed in this test's WAR. Seeding
+        // through REST also avoids the name-strategy validation (only invoked on the UI create/save actions): the
+        // strategy caches its replacement map in a singleton initialized on first use, and it reads this seeded mapping
+        // when it is first initialized (on the first administration visit in the tests below).
+        DocumentReference configReference =
+            new DocumentReference("xwiki", List.of("XWiki", "EntityNameValidation"), "Configuration");
+        Page configPage = setup.rest().page(configReference);
+        Objects objects = new Objects();
+        configPage.setObjects(objects);
+        org.xwiki.rest.model.jaxb.Object configObject =
+            RestTestUtils.object("XWiki.EntityNameValidation.ConfigurationClass");
+        configObject.setNumber(0);
+        // The forbidden and replacement characters are single-value StaticListClass properties here; they are zipped by
+        // index into the "@" -> "-" replacement map.
+        configObject.withProperties(RestTestUtils.property("currentStrategy", STRATEGY));
+        configObject.withProperties(RestTestUtils.property("replaceCharacters.forbiddenCharacters", "@"));
+        configObject.withProperties(RestTestUtils.property("replaceCharacters.replacementCharacters", "-"));
+        objects.withObjectSummaries(configObject);
+        setup.rest().save(configPage);
+    }
+
+    /**
+     * With the automatic transformation enabled, creating a page whose name contains the forbidden character must
+     * automatically replace it in the page name, while the page title is kept as typed.
+     */
+    @Test
+    @Order(1)
+    void transformNameAutomatically(TestUtils setup, TestReference reference)
+    {
+        SpaceReference spaceReference = reference.getLastSpaceReference();
+        setup.deleteSpace(spaceReference);
+
+        // Enable the automatic transformation and disable the validation through the administration UI.
+        NameStrategiesAdministrationSectionPage section = NameStrategiesAdministrationSectionPage.gotoPage();
+        assertEquals(STRATEGY, section.getSelectedStrategy());
+        section.setTransformNameAutomatically(true);
+        section.setValidateNames(false);
+        section.save();
+
+        // Typing a title that contains the forbidden character makes the create form automatically derive a page name
+        // where the strategy has replaced it ("Te@st" -> "Te-st"), while the title is kept as typed.
+        CreatePagePage createPage = openCreateFormInTestSpace(setup, spaceReference);
+        DocumentPicker picker = createPage.getDocumentPicker();
+        picker.setTitle(FORBIDDEN_NAME);
+        picker.waitForName(TRANSFORMED_NAME);
+        createPage.setTerminalPage(true);
+        createPage.clickCreate();
+
+        // The name has been transformed while the title has been kept as typed.
+        ViewPage savedPage = new EditPage().clickSaveAndView();
+        assertEquals(TRANSFORMED_NAME, savedPage.getMetaDataValue("page"));
+        assertEquals(FORBIDDEN_NAME, savedPage.getDocumentTitle());
+    }
+
+    /**
+     * With the validation enabled (and the automatic transformation disabled), creating a page whose name contains the
+     * forbidden character must be rejected with an error message and the page must not be created.
+     */
+    @Test
+    void validateNamesBeforeSaving(TestUtils setup, TestReference reference) throws Exception
+    {
+        SpaceReference spaceReference = reference.getLastSpaceReference();
+        setup.deleteSpace(spaceReference);
+
+        // Disable the automatic transformation and enable the validation through the administration UI.
+        NameStrategiesAdministrationSectionPage section = NameStrategiesAdministrationSectionPage.gotoPage();
+        assertEquals(STRATEGY, section.getSelectedStrategy());
+        section.setTransformNameAutomatically(false);
+        section.setValidateNames(true);
+        section.save();
+
+        // With the automatic transformation disabled, the create form keeps the forbidden character in the derived
+        // page name, so it reaches the server where the validation rejects it.
+        CreatePagePage createPage = openCreateFormInTestSpace(setup, spaceReference);
+        DocumentPicker picker = createPage.getDocumentPicker();
+        picker.setTitle(FORBIDDEN_NAME);
+        picker.waitForName(FORBIDDEN_NAME);
+        createPage.setTerminalPage(true);
+        createPage.clickCreate();
+
+        createPage = new CreatePagePage();
+        createPage.waitForErrorMessage();
+        assertTrue(createPage.getErrorMessage().contains(FORBIDDEN_NAME),
+            String.format("Unexpected error message: [%s]", createPage.getErrorMessage()));
+
+        // The page has not been created.
+        assertFalse(setup.rest().exists(new DocumentReference(FORBIDDEN_NAME, spaceReference)));
+    }
+
+    private CreatePagePage openCreateFormInTestSpace(TestUtils setup, SpaceReference spaceReference)
+    {
+        // Open the create form from an existing page located in the test's own space so that the location fields are
+        // editable and default to that space. Reaching the create form from the wiki home instead yields a read-only
+        // location that cannot be overridden.
+        setup.createPage(new DocumentReference("WebHome", spaceReference), "", "Parent");
+        setup.gotoPage(new DocumentReference("WebHome", spaceReference));
+        CreatePagePage createPage = new ViewPage().createPage();
+        // Reveal the advanced location fields so that the page name is editable and kept in sync with the title.
+        createPage.getDocumentPicker().toggleLocationAdvancedEdit();
+        return createPage;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/NameStrategiesReplaceCharacterIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/NameStrategiesReplaceCharacterIT.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.SpaceReference;
 import org.xwiki.model.validation.test.po.NameStrategiesAdministrationSectionPage;
+import org.xwiki.rendering.syntax.Syntax;
 import org.xwiki.rest.model.jaxb.Objects;
 import org.xwiki.rest.model.jaxb.Page;
 import org.xwiki.test.docker.junit5.TestReference;
@@ -50,9 +51,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * The strategy is configured with its own forbidden character (nothing is inherited from the standard flavor, which is
  * not installed here). The mapping is seeded directly through the REST API rather than through the administration's
  * "Add new character" UI, because that UI relies on the configuration document (with its list properties) shipped by
- * the flavor, which is absent from this WAR. Seeding through REST also avoids triggering the name-strategy validation
- * (only invoked on the UI create/save actions): the strategy caches its replacement map in a singleton initialized on
- * first use, and it reads the seeded mapping when it is first initialized (on the first administration visit below).
+ * the flavor, which is absent from this WAR. The {@code ReplaceCharacterEntityNameValidation} strategy caches its
+ * replacement map in a singleton and only reloads it from {@code EntityNameValidationManager.resetStrategies()} (the
+ * "Add new character" UI is the only production caller); the REST seed alone does not refresh it, so {@code beforeAll}
+ * calls {@code resetStrategies()} explicitly once the mapping has been seeded.
  *
  * @version $Id$
  * @since 18.6.0RC1
@@ -73,10 +75,7 @@ class NameStrategiesReplaceCharacterIT
 
         // Configure the Character Replacement strategy with a custom "@" -> "-" mapping directly through the REST API.
         // The administration's "Add new character" UI is not used because it requires the configuration document (with
-        // its list properties) shipped by the standard flavor, which is not installed in this test's WAR. Seeding
-        // through REST also avoids the name-strategy validation (only invoked on the UI create/save actions): the
-        // strategy caches its replacement map in a singleton initialized on first use, and it reads this seeded mapping
-        // when it is first initialized (on the first administration visit in the tests below).
+        // its list properties) shipped by the standard flavor, which is not installed in this test's WAR.
         DocumentReference configReference =
             new DocumentReference("xwiki", List.of("XWiki", "EntityNameValidation"), "Configuration");
         Page configPage = setup.rest().page(configReference);
@@ -92,6 +91,14 @@ class NameStrategiesReplaceCharacterIT
         configObject.withProperties(RestTestUtils.property("replaceCharacters.replacementCharacters", "-"));
         objects.withObjectSummaries(configObject);
         setup.rest().save(configPage);
+
+        // The ReplaceCharacterEntityNameValidation strategy caches its replacement map at component initialisation and
+        // is only refreshed by EntityNameValidationManager.resetStrategies(). In this shared-instance test run the
+        // singleton has already been initialised (with an empty map) by an earlier test, and neither the REST save
+        // above nor the administration form save in the tests below refreshes it. Force the reload so the seeded
+        // "@" -> "-" mapping is actually used.
+        setup.executeWikiPlain("{{velocity}}$services.modelvalidation.manager.resetStrategies(){{/velocity}}",
+            Syntax.XWIKI_2_1);
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-test/xwiki-platform-model-validation-test-pageobjects/src/main/java/org/xwiki/model/validation/test/po/NameStrategiesAdministrationSectionPage.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-test/xwiki-platform-model-validation-test-pageobjects/src/main/java/org/xwiki/model/validation/test/po/NameStrategiesAdministrationSectionPage.java
@@ -48,6 +48,12 @@ public class NameStrategiesAdministrationSectionPage extends AdministrationSecti
 
     private static final By TEST_TRANSFORMED_NAME = By.id("testNameStrategyTransformedName");
 
+    private static final By USE_TRANSFORMATION_SELECT =
+        By.id("XWiki.EntityNameValidation.ConfigurationClass_0_useTransformation");
+
+    private static final By USE_VALIDATION_SELECT =
+        By.id("XWiki.EntityNameValidation.ConfigurationClass_0_useValidation");
+
     /**
      * Open the Name Strategies administration section.
      *
@@ -83,6 +89,28 @@ public class NameStrategiesAdministrationSectionPage extends AdministrationSecti
     public String getSelectedStrategy()
     {
         return new Select(getDriver().findElement(STRATEGY_SELECT)).getFirstSelectedOption().getAttribute("value");
+    }
+
+    /**
+     * Enable or disable the automatic transformation of names that don't respect the selected strategy. This only
+     * changes the selected value in the form; call {@link #save()} to persist it.
+     *
+     * @param enabled {@code true} to enable the automatic transformation, {@code false} to disable it
+     */
+    public void setTransformNameAutomatically(boolean enabled)
+    {
+        new Select(getDriver().findElement(USE_TRANSFORMATION_SELECT)).selectByValue(enabled ? "1" : "0");
+    }
+
+    /**
+     * Enable or disable the validation of names before saving. This only changes the selected value in the form; call
+     * {@link #save()} to persist it.
+     *
+     * @param enabled {@code true} to enable the validation, {@code false} to disable it
+     */
+    public void setValidateNames(boolean enabled)
+    {
+        new Select(getDriver().findElement(USE_VALIDATION_SELECT)).selectByValue(enabled ? "1" : "0");
     }
 
     /**


### PR DESCRIPTION
Backports the `testneeded` automated test of [XWIKI-20410](https://jira.xwiki.org/browse/XWIKI-20410) — "Name strategies automatic character replacement" (`NameStrategiesReplaceCharacterIT` in the flamingo-skin docker tests, plain `@UITest`).

### Stacked on XWIKI-20411

This PR is **based on `backport/stable-17.10.x/XWIKI-20411`**, not directly on the stable branch, because 20410's test calls `NameStrategiesAdministrationSectionPage.getSelectedStrategy()`, which is introduced by the XWIKI-20411 backport. Merge that PR first.

### Commits (cherry-picked `-x`, oldest-first)

- `XWIKI-20410` ×2 — the flamingo-skin `NameStrategiesReplaceCharacterIT`, its `AllIT` `@Nested` entry, the pom test dependencies, and the `setTransformNameAutomatically` / `setValidateNames` page-object helpers.
- `[Misc]` (18.4.x only) — strips the method-level `@since` from those two page-object helpers per policy (the class already carries a class-level `@since` block that members inherit). On 17.10.x this strip is folded into the first commit during conflict resolution.

### Conflict note (17.10.x)

The `AllIT` cherry-pick brought a hunk that also referenced `HTMLExportIT` / `BreadcrumbsIT` / `CreatePageNestedDocumentsIT` `@Nested` classes that don't exist on `stable-17.10.x`; only `NestedNameStrategiesReplaceCharacterIT` (this issue's actual addition) was kept.

### Verification

Cherry-picks applied; conflict resolved to keep only this issue's change. The page-objects module compiles against this stable base. The Docker functional test runs on CI (authoritative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
