### PR TITLE
[Misc] Define constants for duplicated string literals reported by SonarQube

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWikiContext.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWikiContext.java
@@ -168,6 +168,10 @@ public class XWikiContext extends Hashtable<Object, Object>
 
     private static final String LANGUAGE_KEY = "language";
 
+    private static final String LINKS_ACTION_KEY = "links_action";
+
+    private static final String LINKS_QS_KEY = "links_qs";
+
     private Locale interfaceLocale;
 
     private int mode;
@@ -893,32 +897,32 @@ public class XWikiContext extends Hashtable<Object, Object>
 
     public void setLinksAction(String action)
     {
-        put("links_action", action);
+        put(LINKS_ACTION_KEY, action);
     }
 
     public void unsetLinksAction()
     {
-        remove("links_action");
+        remove(LINKS_ACTION_KEY);
     }
 
     public String getLinksAction()
     {
-        return (String) get("links_action");
+        return (String) get(LINKS_ACTION_KEY);
     }
 
     public void setLinksQueryString(String value)
     {
-        put("links_qs", value);
+        put(LINKS_QS_KEY, value);
     }
 
     public void unsetLinksQueryString()
     {
-        remove("links_qs");
+        remove(LINKS_QS_KEY);
     }
 
     public String getLinksQueryString()
     {
-        return (String) get("links_qs");
+        return (String) get(LINKS_QS_KEY);
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -230,6 +230,19 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
 
     private static final String[] HTML_MACRO_REPLACE_STRINGS = new String[] { "&#123;&#123;html", "&#123;&#123;/html" };
 
+    private static final String CURRENT = "current";
+
+    private static final String PRE_START = "{pre}";
+
+    private static final String PRE_END = "{/pre}";
+
+    private static final String HIDDEN = "hidden";
+
+    private static final String XWIKIGUEST_REFERENCE_WARNING =
+        "A reference to XWikiGuest user has been set instead of null. This is probably a mistake.";
+
+    private static final String SEE_STACK_TRACE = "See stack trace";
+
     /**
      * An attachment waiting to be deleted at next document save.
      *
@@ -351,7 +364,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
      */
     private static DocumentReferenceResolver<String> getCurrentDocumentReferenceResolver()
     {
-        return Utils.getComponent(DocumentReferenceResolver.TYPE_STRING, "current");
+        return Utils.getComponent(DocumentReferenceResolver.TYPE_STRING, CURRENT);
     }
 
     /**
@@ -383,7 +396,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
      */
     private static DocumentReferenceResolver<EntityReference> getCurrentReferenceDocumentReferenceResolver()
     {
-        return Utils.getComponent(DocumentReferenceResolver.TYPE_REFERENCE, "current");
+        return Utils.getComponent(DocumentReferenceResolver.TYPE_REFERENCE, CURRENT);
     }
 
     /**
@@ -417,7 +430,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
      */
     private static ObjectReferenceResolver<EntityReference> getCurrentReferenceObjectReferenceResolver()
     {
-        return Utils.getComponent(ObjectReferenceResolver.TYPE_REFERENCE, "current");
+        return Utils.getComponent(ObjectReferenceResolver.TYPE_REFERENCE, CURRENT);
     }
 
     /**
@@ -2169,8 +2182,8 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
             this.authors.setEffectiveMetadataAuthor(GuestUserReference.INSTANCE);
         } else {
             if (authorReference.getName().equals(XWikiRightService.GUEST_USER)) {
-                LOGGER.warn("A reference to XWikiGuest user has been set instead of null. This is probably a mistake.",
-                    new Exception("See stack trace"));
+                LOGGER.warn(XWIKIGUEST_REFERENCE_WARNING,
+                    new Exception(SEE_STACK_TRACE));
             }
             UserReference user = this.getUserReferenceDocumentReferenceResolver().resolve(authorReference);
             this.authors.setEffectiveMetadataAuthor(user);
@@ -2228,8 +2241,8 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
             this.authors.setContentAuthor(GuestUserReference.INSTANCE);
         } else {
             if (contentAuthorReference.getName().equals(XWikiRightService.GUEST_USER)) {
-                LOGGER.warn("A reference to XWikiGuest user has been set instead of null. This is probably a mistake.",
-                    new Exception("See stack trace"));
+                LOGGER.warn(XWIKIGUEST_REFERENCE_WARNING,
+                    new Exception(SEE_STACK_TRACE));
             }
             UserReference user = this.getUserReferenceDocumentReferenceResolver().resolve(contentAuthorReference);
             this.authors.setContentAuthor(user);
@@ -2284,8 +2297,8 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
             this.authors.setCreator(GuestUserReference.INSTANCE);
         } else {
             if (creatorReference.getName().equals(XWikiRightService.GUEST_USER)) {
-                LOGGER.warn("A reference to XWikiGuest user has been set instead of null. This is probably a mistake.",
-                    new Exception("See stack trace"));
+                LOGGER.warn(XWIKIGUEST_REFERENCE_WARNING,
+                    new Exception(SEE_STACK_TRACE));
             }
             UserReference user = this.getUserReferenceDocumentReferenceResolver().resolve(creatorReference);
             this.authors.setCreator(user);
@@ -3976,25 +3989,25 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
                 if (is10Syntax(wrappingSyntaxId)) {
                     // Don't use pre when not in the rendernig engine since for template we don't evaluate wiki syntax.
                     if (isInRenderingEngine) {
-                        result.append("{pre}");
+                        result.append(PRE_START);
                     }
                 }
                 pclass.displayEdit(result, fieldname, prefix, obj, context);
                 if (is10Syntax(wrappingSyntaxId)) {
                     if (isInRenderingEngine) {
-                        result.append("{/pre}");
+                        result.append(PRE_END);
                     }
                 }
-            } else if ("hidden".equals(type)) {
+            } else if (HIDDEN.equals(type)) {
                 // If the Syntax id is "xwiki/1.0" then use the old rendering subsystem and prevent wiki syntax
                 // rendering using the pre macro. In the new rendering system it's the XWiki Class itself that does the
                 // escaping. For example for a textarea check the TextAreaClass class.
                 if (is10Syntax(wrappingSyntaxId) && isInRenderingEngine) {
-                    result.append("{pre}");
+                    result.append(PRE_START);
                 }
                 pclass.displayHidden(result, fieldname, prefix, obj, context);
                 if (is10Syntax(wrappingSyntaxId) && isInRenderingEngine) {
-                    result.append("{/pre}");
+                    result.append(PRE_END);
                 }
             } else if ("search".equals(type)) {
                 // Backward compatibility
@@ -4014,12 +4027,12 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
                     // the
                     // escaping. For example for a textarea check the TextAreaClass class.
                     if (is10Syntax(wrappingSyntaxId) && isInRenderingEngine) {
-                        result.append("{pre}");
+                        result.append(PRE_START);
                     }
                     prefix = LOCAL_REFERENCE_SERIALIZER.serialize(obj.getXClass(context).getDocumentReference()) + "_";
                     searchMethod.invoke(pclass, result, fieldname, prefix, context.get("query"), context);
                     if (is10Syntax(wrappingSyntaxId) && isInRenderingEngine) {
-                        result.append("{/pre}");
+                        result.append(PRE_END);
                     }
                 } else {
                     pclass.displayView(result, fieldname, prefix, obj, context);
@@ -6111,7 +6124,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
                 .createQuery("select distinct doc.fullName from XWikiDocument doc where "
                     + "doc.parent=:prefixedFullName or doc.parent=:fullName or (doc.parent=:name and doc.space=:space)",
                     Query.XWQL);
-            query.addFilter(Utils.getComponent(QueryFilter.class, "hidden"));
+            query.addFilter(Utils.getComponent(QueryFilter.class, HIDDEN));
             query.bindValue("prefixedFullName",
                 getDefaultEntityReferenceSerializer().serialize(getDocumentReference()));
             query.bindValue("fullName", LOCAL_REFERENCE_SERIALIZER.serialize(getDocumentReference()));
@@ -7235,7 +7248,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
         }
 
         if (fromDoc.isHidden() != toDoc.isHidden()) {
-            list.add(new MetaDataDiff("hidden", fromDoc.isHidden(), toDoc.isHidden()));
+            list.add(new MetaDataDiff(HIDDEN, fromDoc.isHidden(), toDoc.isHidden()));
         }
 
         if (fromDoc.isEnforceRequiredRights() != toDoc.isEnforceRequiredRights()) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiPreferencesDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiPreferencesDocumentInitializer.java
@@ -82,6 +82,14 @@ public class XWikiPreferencesDocumentInitializer extends AbstractMandatoryClassI
      */
     private static final String TIMEZONE_FIELD = "timezone";
 
+    private static final String YESNO = "yesno";
+
+    private static final String IMAGE_TEXT = "Image|Text";
+
+    private static final String ANONYMOUS = "Anonymous";
+
+    private static final String REGISTERED = "Registered";
+
     private static final LocalDocumentReference SHEET_REFERENCE =
         new LocalDocumentReference(XWiki.SYSTEM_SPACE, "AdminSheet");
 
@@ -106,10 +114,10 @@ public class XWikiPreferencesDocumentInitializer extends AbstractMandatoryClassI
         xclass.setCustomMapping("internal");
 
         xclass.addTextField("parent", "Parent Space", 30);
-        xclass.addBooleanField("multilingual", "Multi-Lingual", "yesno");
+        xclass.addBooleanField("multilingual", "Multi-Lingual", YESNO);
         xclass.addTextField("default_language", "Default Language", 5);
-        xclass.addBooleanField("authenticate_edit", "Authenticated Edit", "yesno");
-        xclass.addBooleanField("authenticate_view", "Authenticated View", "yesno");
+        xclass.addBooleanField("authenticate_edit", "Authenticated Edit", YESNO);
+        xclass.addBooleanField("authenticate_view", "Authenticated View", YESNO);
 
         xclass.addPageField("skin", "Skin", 30, false, false, ", BaseObject obj"
                         + " where doc.fullName = obj.name and obj.className = 'XWiki.XWikiSkins'",
@@ -128,7 +136,7 @@ public class XWikiPreferencesDocumentInitializer extends AbstractMandatoryClassI
                 + "and theme.id = propName.id and propName.name = 'name'");
         xclass.addTextField("stylesheet", "Default Stylesheet", 30);
         xclass.addTextField("stylesheets", "Alternative Stylesheet", 60);
-        xclass.addBooleanField("accessibility", "Enable extra accessibility features", "yesno");
+        xclass.addBooleanField("accessibility", "Enable extra accessibility features", YESNO);
 
         xclass.addStaticListField("editor", "Default Editor", "Text|Wysiwyg");
 
@@ -139,7 +147,7 @@ public class XWikiPreferencesDocumentInitializer extends AbstractMandatoryClassI
         xclass.addTextField("dateformat", "Date Format", 30);
 
         // mail
-        xclass.addBooleanField("use_email_verification", "Use eMail Verification", "yesno");
+        xclass.addBooleanField("use_email_verification", "Use eMail Verification", YESNO);
         xclass.addTextField("admin_email", "Admin eMail", 30);
         xclass.addTextField("smtp_server", "SMTP Server", 30);
         xclass.addTextField("smtp_port", "SMTP Port", 5);
@@ -150,14 +158,14 @@ public class XWikiPreferencesDocumentInitializer extends AbstractMandatoryClassI
         xclass.addTextAreaField("confirmation_email_content", "Confirmation eMail Content", 72, 10,
             ContentType.PURE_TEXT);
         xclass.addTextAreaField("invitation_email_content", "Invitation eMail Content", 72, 10, ContentType.PURE_TEXT);
-        xclass.addBooleanField("obfuscateEmailAddresses", "Obfuscate Email Addresses", "yesno");
+        xclass.addBooleanField("obfuscateEmailAddresses", "Obfuscate Email Addresses", YESNO);
 
-        xclass.addStaticListField("registration_anonymous", "Anonymous", "Image|Text");
-        xclass.addStaticListField("registration_registered", "Registered", "Image|Text");
-        xclass.addStaticListField("edit_anonymous", "Anonymous", "Image|Text");
-        xclass.addStaticListField("edit_registered", "Registered", "Image|Text");
-        xclass.addStaticListField("comment_anonymous", "Anonymous", "Image|Text");
-        xclass.addStaticListField("comment_registered", "Registered", "Image|Text");
+        xclass.addStaticListField("registration_anonymous", ANONYMOUS, IMAGE_TEXT);
+        xclass.addStaticListField("registration_registered", REGISTERED, IMAGE_TEXT);
+        xclass.addStaticListField("edit_anonymous", ANONYMOUS, IMAGE_TEXT);
+        xclass.addStaticListField("edit_registered", REGISTERED, IMAGE_TEXT);
+        xclass.addStaticListField("comment_anonymous", ANONYMOUS, IMAGE_TEXT);
+        xclass.addStaticListField("comment_registered", REGISTERED, IMAGE_TEXT);
 
         xclass.addNumberField("upload_maxsize", "Maximum Upload Size", 5, "long");
 
@@ -167,19 +175,19 @@ public class XWikiPreferencesDocumentInitializer extends AbstractMandatoryClassI
 
         // Document editing
         xclass.addTextField("core.defaultDocumentSyntax", "Default document syntax", 60);
-        xclass.addBooleanField("xwiki.title.mandatory", "Make document title field mandatory", "yesno");
+        xclass.addBooleanField("xwiki.title.mandatory", "Make document title field mandatory", YESNO);
 
         // for tags
-        xclass.addBooleanField("tags", "Activate the tagging", "yesno");
+        xclass.addBooleanField("tags", "Activate the tagging", YESNO);
 
         // for backlinks
-        xclass.addBooleanField("backlinks", "Activate the backlinks", "yesno");
+        xclass.addBooleanField("backlinks", "Activate the backlinks", YESNO);
 
         // New fields for the XWiki 1.0 skin
         xclass.addTextField("leftPanels", "Panels displayed on the left", 60);
         xclass.addTextField("rightPanels", "Panels displayed on the right", 60);
-        xclass.addBooleanField("showLeftPanels", "Display the left panel column", "yesno");
-        xclass.addBooleanField("showRightPanels", "Display the right panel column", "yesno");
+        xclass.addBooleanField("showLeftPanels", "Display the left panel column", YESNO);
+        xclass.addBooleanField("showRightPanels", "Display the right panel column", YESNO);
         xclass.addStaticListField("leftPanelsWidth", "Width of the left panel column", "Small|Medium|Large");
         xclass.addStaticListField("rightPanelsWidth", "Width of the right panel column", "Small|Medium|Large");
         xclass.addTextField("languages", "Supported languages", 30);
@@ -188,34 +196,34 @@ public class XWikiPreferencesDocumentInitializer extends AbstractMandatoryClassI
 
         // Only used by LDAP authentication service
 
-        xclass.addBooleanField("ldap", "Ldap", "yesno");
+        xclass.addBooleanField("ldap", "Ldap", YESNO);
         xclass.addTextField("ldap_server", "Ldap server adress", 60);
         xclass.addTextField("ldap_port", "Ldap server port", 60);
         xclass.addTextField("ldap_bind_DN", "Ldap login matching", 60);
         xclass.addPasswordField("ldap_bind_pass", "Ldap password matching", 60, PasswordMetaClass.CLEAR);
-        xclass.addBooleanField("ldap_validate_password", "Validate Ldap user/password", "yesno");
+        xclass.addBooleanField("ldap_validate_password", "Validate Ldap user/password", YESNO);
         xclass.addTextField("ldap_user_group", "Ldap group filter", 60);
         xclass.addTextField("ldap_exclude_group", "Ldap group to exclude", 60);
         xclass.addTextField("ldap_base_DN", "Ldap base DN", 60);
         xclass.addTextField("ldap_UID_attr", "Ldap UID attribute name", 60);
         xclass.addTextAreaField("ldap_fields_mapping", "Ldap user fields mapping", 60, 1, ContentType.PURE_TEXT);
-        xclass.addBooleanField("ldap_update_user", "Update user from LDAP", "yesno");
-        xclass.addBooleanField("ldap_update_photo", "Update user photo from LDAP", "yesno");
+        xclass.addBooleanField("ldap_update_user", "Update user from LDAP", YESNO);
+        xclass.addBooleanField("ldap_update_photo", "Update user photo from LDAP", YESNO);
         xclass.addTextField("ldap_photo_attachment_name", "Attachment name to save LDAP photo", 30);
         xclass.addTextField("ldap_photo_attribute", "Ldap photo attribute name", 60);
         xclass.addTextAreaField("ldap_group_mapping", "Ldap groups mapping", 60, 5, ContentType.PURE_TEXT);
         xclass.addTextField("ldap_groupcache_expiration", "LDAP groups members cache", 60);
         xclass.addStaticListField("ldap_mode_group_sync", "LDAP groups sync mode", "always|create");
-        xclass.addBooleanField("ldap_trylocal", "Try local login", "yesno");
+        xclass.addBooleanField("ldap_trylocal", "Try local login", YESNO);
 
-        xclass.addBooleanField("showannotations", "Show document annotations", "yesno");
-        xclass.addBooleanField("showcomments", "Show document comments", "yesno");
-        xclass.addBooleanField("showattachments", "Show document attachments", "yesno");
-        xclass.addBooleanField("showhistory", "Show document history", "yesno");
-        xclass.addBooleanField("showinformation", "Show document information", "yesno");
-        xclass.addBooleanField("editcomment", "Enable version summary", "yesno");
-        xclass.addBooleanField("editcomment_mandatory", "Make version summary mandatory", "yesno");
-        xclass.addBooleanField("minoredit", "Enable minor edits", "yesno");
+        xclass.addBooleanField("showannotations", "Show document annotations", YESNO);
+        xclass.addBooleanField("showcomments", "Show document comments", YESNO);
+        xclass.addBooleanField("showattachments", "Show document attachments", YESNO);
+        xclass.addBooleanField("showhistory", "Show document history", YESNO);
+        xclass.addBooleanField("showinformation", "Show document information", YESNO);
+        xclass.addBooleanField("editcomment", "Enable version summary", YESNO);
+        xclass.addBooleanField("editcomment_mandatory", "Make version summary mandatory", YESNO);
+        xclass.addBooleanField("minoredit", "Enable minor edits", YESNO);
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/Package.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/Package.java
@@ -99,6 +99,22 @@ public class Package
 
     private static final Logger LOGGER = LoggerFactory.getLogger(Package.class);
 
+    private static final String INFOS = "infos";
+
+    private static final String DESCRIPTION = "description";
+
+    private static final String LICENCE = "licence";
+
+    private static final String AUTHOR = "author";
+
+    private static final String VERSION = "version";
+
+    private static final String FILES = "files";
+
+    private static final String LANGUAGE = "language";
+
+    private static final String DEFAULT_ACTION = "defaultAction";
+
     private String name = "My package";
 
     private String description = "";
@@ -572,7 +588,7 @@ public class Package
     private boolean documentExistInPackageFile(String docName, String language, Document xml)
     {
         Element docFiles = xml.getRootElement();
-        Element infosFiles = docFiles.element("files");
+        Element infosFiles = docFiles.element(FILES);
 
         @SuppressWarnings("unchecked")
         List<Element> fileList = infosFiles.elements("file");
@@ -582,7 +598,7 @@ public class Package
             if (tmpDocName.compareTo(docName) != 0) {
                 continue;
             }
-            String tmpLanguage = el.attributeValue("language");
+            String tmpLanguage = el.attributeValue(LANGUAGE);
             if (tmpLanguage == null) {
                 tmpLanguage = "";
             }
@@ -597,13 +613,13 @@ public class Package
     private void updateFileInfos(Document xml)
     {
         Element docFiles = xml.getRootElement();
-        Element infosFiles = docFiles.element("files");
+        Element infosFiles = docFiles.element(FILES);
 
         @SuppressWarnings("unchecked")
         List<Element> fileList = infosFiles.elements("file");
         for (Element el : fileList) {
-            String defaultAction = el.attributeValue("defaultAction");
-            String language = el.attributeValue("language");
+            String defaultAction = el.attributeValue(DEFAULT_ACTION);
+            String language = el.attributeValue(LANGUAGE);
             if (language == null) {
                 language = "";
             }
@@ -1082,26 +1098,26 @@ public class Package
         Element docel = new DOMElement("package");
         wr.writeOpen(docel);
 
-        Element elInfos = new DOMElement("infos");
+        Element elInfos = new DOMElement(INFOS);
         wr.write(elInfos);
 
         Element el = new DOMElement("name");
         el.addText(this.name);
         wr.write(el);
 
-        el = new DOMElement("description");
+        el = new DOMElement(DESCRIPTION);
         el.addText(this.description);
         wr.write(el);
 
-        el = new DOMElement("licence");
+        el = new DOMElement(LICENCE);
         el.addText(this.licence);
         wr.write(el);
 
-        el = new DOMElement("author");
+        el = new DOMElement(AUTHOR);
         el.addText(this.authorName);
         wr.write(el);
 
-        el = new DOMElement("version");
+        el = new DOMElement(VERSION);
         el.addText(this.version);
         wr.write(el);
 
@@ -1113,13 +1129,13 @@ public class Package
         el.addText(new Boolean(this.preserveVersion).toString());
         wr.write(el);
 
-        Element elfiles = new DOMElement("files");
+        Element elfiles = new DOMElement(FILES);
         wr.writeOpen(elfiles);
 
         for (DocumentInfo docInfo : this.files) {
             Element elfile = new DOMElement("file");
-            elfile.addAttribute("defaultAction", String.valueOf(docInfo.getAction()));
-            elfile.addAttribute("language", String.valueOf(docInfo.getLanguage()));
+            elfile.addAttribute(DEFAULT_ACTION, String.valueOf(docInfo.getAction()));
+            elfile.addAttribute(LANGUAGE, String.valueOf(docInfo.getLanguage()));
             elfile.addText(docInfo.getFullName());
             wr.write(elfile);
         }
@@ -1321,14 +1337,14 @@ public class Package
 
         Element docEl = domdoc.getRootElement();
 
-        Element infosEl = docEl.element("infos");
+        Element infosEl = docEl.element(INFOS);
 
         this.name = getElementText(infosEl, "name");
-        this.description = getElementText(infosEl, "description");
-        this.licence = getElementText(infosEl, "licence");
-        this.authorName = getElementText(infosEl, "author");
+        this.description = getElementText(infosEl, DESCRIPTION);
+        this.licence = getElementText(infosEl, LICENCE);
+        this.authorName = getElementText(infosEl, AUTHOR);
         this.extensionId = getElementText(infosEl, "extensionId", null);
-        this.version = getElementText(infosEl, "version");
+        this.version = getElementText(infosEl, VERSION);
         this.backupPack = new Boolean(getElementText(infosEl, "backupPack")).booleanValue();
         this.preserveVersion = new Boolean(getElementText(infosEl, "preserveVersion")).booleanValue();
 
@@ -1465,18 +1481,18 @@ public class Package
 
         Map<String, Object> infos = new HashMap<>();
         infos.put("name", this.name);
-        infos.put("description", this.description);
-        infos.put("licence", this.licence);
-        infos.put("author", this.authorName);
-        infos.put("version", this.version);
+        infos.put(DESCRIPTION, this.description);
+        infos.put(LICENCE, this.licence);
+        infos.put(AUTHOR, this.authorName);
+        infos.put(VERSION, this.version);
         infos.put("backup", this.isBackupPack());
 
         Map<String, Map<String, List<Map<String, String>>>> files = new HashMap<>();
 
         for (DocumentInfo docInfo : this.files) {
             Map<String, String> fileInfos = new HashMap<>();
-            fileInfos.put("defaultAction", String.valueOf(docInfo.getAction()));
-            fileInfos.put("language", String.valueOf(docInfo.getLanguage()));
+            fileInfos.put(DEFAULT_ACTION, String.valueOf(docInfo.getAction()));
+            fileInfos.put(LANGUAGE, String.valueOf(docInfo.getLanguage()));
             fileInfos.put("fullName", docInfo.getFullName());
 
             // If the space does not exist in the map of spaces, we create it.
@@ -1495,8 +1511,8 @@ public class Package
             files.get(docInfo.getDoc().getSpace()).get(docInfo.getDoc().getName()).add(fileInfos);
         }
 
-        json.put("infos", infos);
-        json.put("files", files);
+        json.put(INFOS, infos);
+        json.put(FILES, files);
 
         return json;
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/ExportURLFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/ExportURLFactory.java
@@ -73,6 +73,10 @@ public class ExportURLFactory extends XWikiServletURLFactory
      */
     protected static final Logger LOGGER = LoggerFactory.getLogger(ExportURLFactory.class);
 
+    private static final String FILE_PROTOCOL = "file://";
+
+    private static final String FAILED_TO_CREATE_SKIN_URL = "Failed to create skin URL";
+
     // TODO: use real css parser
     private static Pattern CSSIMPORT = Pattern.compile("^\\s*@import\\s*\"(.*)\"\\s*;$", Pattern.MULTILINE);
 
@@ -225,7 +229,7 @@ public class ExportURLFactory extends XWikiServletURLFactory
         try {
             getFilesystemExportContext().addNeededSkin(skin);
 
-            StringBuilder newPath = new StringBuilder("file://");
+            StringBuilder newPath = new StringBuilder(FILE_PROTOCOL);
 
             // Adjust path for links inside CSS files (since they need to be relative to the CSS file they're in).
             adjustCSSPath(newPath);
@@ -237,7 +241,7 @@ public class ExportURLFactory extends XWikiServletURLFactory
 
             return new URL(newPath.toString());
         } catch (Exception e) {
-            LOGGER.error("Failed to create skin URL", e);
+            LOGGER.error(FAILED_TO_CREATE_SKIN_URL, e);
         }
 
         return super.createSkinURL(filename, skin, context);
@@ -313,7 +317,7 @@ public class ExportURLFactory extends XWikiServletURLFactory
                 followCssImports(file, spaces, name, wikiId, context);
             }
 
-            StringBuilder newPath = new StringBuilder("file://");
+            StringBuilder newPath = new StringBuilder(FILE_PROTOCOL);
 
             // Adjust path for links inside CSS files (since they need to be relative to the CSS file they're in).
             adjustCSSPath(newPath);
@@ -322,7 +326,7 @@ public class ExportURLFactory extends XWikiServletURLFactory
 
             skinURL = new URL(newPath.toString());
         } catch (Exception e) {
-            LOGGER.error("Failed to create skin URL", e);
+            LOGGER.error(FAILED_TO_CREATE_SKIN_URL, e);
         }
 
         return skinURL;
@@ -450,7 +454,7 @@ public class ExportURLFactory extends XWikiServletURLFactory
                 }
             }
 
-            StringBuilder newPath = new StringBuilder("file://");
+            StringBuilder newPath = new StringBuilder(FILE_PROTOCOL);
 
             // Adjust path for links inside CSS files (since they need to be relative to the CSS file they're in).
             adjustCSSPath(newPath);
@@ -461,7 +465,7 @@ public class ExportURLFactory extends XWikiServletURLFactory
 
             return new URL(newPath.toString());
         } catch (Exception e) {
-            LOGGER.error("Failed to create skin URL", e);
+            LOGGER.error(FAILED_TO_CREATE_SKIN_URL, e);
         }
 
         return super.createResourceURL(filename, forceSkinAction, context);
@@ -491,7 +495,7 @@ public class ExportURLFactory extends XWikiServletURLFactory
             {
                 StringBuffer newpath = new StringBuffer();
 
-                newpath.append("file://");
+                newpath.append(FILE_PROTOCOL);
 
                 // Adjust depending on the exported location of the current doc.
                 newpath.append(StringUtils.repeat("../", getFilesystemExportContext().getDocParentLevel()));
@@ -585,7 +589,7 @@ public class ExportURLFactory extends XWikiServletURLFactory
                 context.getUserReference(), attachmentReference);
         }
 
-        StringBuilder newPath = new StringBuilder("file://");
+        StringBuilder newPath = new StringBuilder(FILE_PROTOCOL);
 
         // Adjust path for links inside CSS files (since they need to be relative to the CSS file they're in).
         adjustCSSPath(newPath);
@@ -632,7 +636,7 @@ public class ExportURLFactory extends XWikiServletURLFactory
         String path = url.toString();
 
         if ("file".equals(url.getProtocol())) {
-            path = path.substring("file://".length());
+            path = path.substring(FILE_PROTOCOL.length());
         }
 
         return path;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/Utils.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/Utils.java
@@ -66,6 +66,10 @@ public class Utils
     private static final String PLACEHOLDERS_ENABLED_CONTEXT_KEY = Utils.class.getCanonicalName()
         + "_placeholders_enabled";
 
+    private static final String CACHE_CONTROL_HEADER = "Cache-Control";
+
+    private static final String NO_CACHE = "no-cache";
+
     /**
      * The component manager used by {@link #getComponent(Class)} and {@link #getComponent(Class, String)}. It is useful
      * for any non component code that need to initialize/access components.
@@ -137,15 +141,15 @@ public class Utils
                 }
                 // Set a nocache to make sure the page is reloaded after an edit
                 if (cacheSetting == 1) {
-                    response.setHeader("Pragma", "no-cache");
-                    response.setHeader("Cache-Control", "no-cache");
+                    response.setHeader("Pragma", NO_CACHE);
+                    response.setHeader(CACHE_CONTROL_HEADER, NO_CACHE);
                 } else if (cacheSetting == 2) {
-                    response.setHeader("Pragma", "no-cache");
-                    response.setHeader("Cache-Control", "max-age=0, no-cache, no-store");
+                    response.setHeader("Pragma", NO_CACHE);
+                    response.setHeader(CACHE_CONTROL_HEADER, "max-age=0, no-cache, no-store");
                 } else if (cacheSetting == 3) {
-                    response.setHeader("Cache-Control", "private");
+                    response.setHeader(CACHE_CONTROL_HEADER, "private");
                 } else if (cacheSetting == 4) {
-                    response.setHeader("Cache-Control", "public");
+                    response.setHeader(CACHE_CONTROL_HEADER, "public");
                 }
 
                 // Set an expires in one month
@@ -161,7 +165,7 @@ public class Utils
         if (("download".equals(action)) || ("skin".equals(action))) {
             // Set a nocache to make sure these files are not cached by proxies
             if (cacheSetting == 1 || cacheSetting == 2) {
-                response.setHeader("Cache-Control", "no-cache");
+                response.setHeader(CACHE_CONTROL_HEADER, NO_CACHE);
             }
         }
 


### PR DESCRIPTION
## Summary

Fixes 24 SonarCloud [`java:S1192`](https://rules.sonarsource.com/java/RSPEC-1192) issues ("Define a constant instead of duplicating this literal") across 6 classes in `xwiki-platform-oldcore`. Each duplicated string literal is replaced by a `private static final String` constant and all its occurrences updated.

### Files changed

| File | Constants introduced |
|------|----------------------|
| `XWikiPreferencesDocumentInitializer` | `YESNO`, `IMAGE_TEXT`, `ANONYMOUS`, `REGISTERED` (4 issues) |
| `Package` | `INFOS`, `DESCRIPTION`, `LICENCE`, `AUTHOR`, `VERSION`, `FILES`, `LANGUAGE`, `DEFAULT_ACTION` (8 issues) |
| `XWikiDocument` | `CURRENT`, `PRE_START`, `PRE_END`, `HIDDEN`, `XWIKIGUEST_REFERENCE_WARNING`, `SEE_STACK_TRACE` (6 issues) |
| `ExportURLFactory` | `FILE_PROTOCOL`, `FAILED_TO_CREATE_SKIN_URL` (2 issues) |
| `XWikiContext` | `LINKS_ACTION_KEY`, `LINKS_QS_KEY` (2 issues) |
| `Utils` | `CACHE_CONTROL_HEADER`, `NO_CACHE` (2 issues) |

Pure refactoring — no behavior change.

SonarCloud issues: [full list for this project (rule java:S1192)](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&rules=java%3AS1192).

## Test plan

- [x] `mvn clean install` on `xwiki-platform-oldcore` (checkstyle + Spoon run in `install`) — BUILD SUCCESS.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XC8tJH7j51ZZBvB1MtU6En)_