### PR TITLE
[Misc] Suppress false-positive java:S2077 SQL injection warnings in XWikiHibernateStore

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
@@ -303,6 +303,10 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
     }
 
     @Override
+    // The schema/user name is escaped as a quoted SQL identifier (dialect quoting with internal-quote doubling)
+    // by HibernateAdapter#escapeDatabaseName. DDL statements such as CREATE SCHEMA/USER cannot use bind parameters
+    // for identifiers, so identifier quoting is the correct protection against SQL injection here.
+    @SuppressWarnings("java:S2077")
     public void createWiki(String wikiName, XWikiContext inputxcontext) throws XWikiException
     {
         XWikiContext context = getExecutionXContext(inputxcontext, false);
@@ -471,6 +475,11 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
      * @param escapedSchemaName the subwiki schema name being deleted
      * @throws SQLException in case of an error while deleting the sub wiki
      */
+    // The schema/user name is already escaped as a quoted SQL identifier (dialect quoting with internal-quote
+    // doubling) by HibernateAdapter#escapeDatabaseName before being passed here. DDL statements such as DROP
+    // SCHEMA/USER cannot use bind parameters for identifiers, so identifier quoting is the correct protection
+    // against SQL injection here.
+    @SuppressWarnings("java:S2077")
     protected void executeDeleteWikiStatement(Statement statement, DatabaseProduct databaseProduct,
         String escapedSchemaName) throws SQLException
     {


### PR DESCRIPTION
# Jira URL

N/A — `[Misc]` change (no JIRA issue needed).

# Changes

## Description

* Suppress 8 false-positive `java:S2077` ("Make sure using a dynamically formatted SQL query is safe here") SonarCloud vulnerability findings in `XWikiHibernateStore`.
* The schema/user names concatenated into the `CREATE`/`DROP SCHEMA`/`USER` DDL statements in `createWiki` and `executeDeleteWikiStatement` are escaped as **quoted SQL identifiers** (dialect quoting with internal-quote doubling) by `HibernateAdapter#escapeDatabaseName`. DDL statements cannot use bind parameters for identifiers, so identifier quoting is the correct and only applicable protection against SQL injection here.
* Added `@SuppressWarnings("java:S2077")` on the two enclosing methods (the findings are on statements inside method bodies where the annotation cannot be placed individually), each with an explanatory comment as required by the [XWiki SonarQube convention](https://dev.xwiki.org/xwiki/bin/view/Community/CodeStyle/JavaCodeStyle/#HSonarQube).

## Clarifications

* These are not real vulnerabilities: the escaping already exists and predates this change. `java:S2077` is a review-type rule that fires on any dynamically-built SQL and cannot see that the identifier is safely quoted upstream.
* Covered findings: lines 342/344/355 (`createWiki`) and 478/481/483/485/488 (`executeDeleteWikiStatement`).

# Screenshots & Video

N/A — no UI change.

# Executed Tests

* No behavioral change (comment + `@SuppressWarnings` annotation only). Verified the edited lines stay within the 120-character limit.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  *
