### PR TITLE
XWIKI-19708: Upgrade to Hibernate 6+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <jetty.client.version>10.0.26</jetty.client.version>
     <jetty.version>${jetty.client.version}</jetty.version>
     <netty.version>4.2.15.Final</netty.version>
-    <hibernate.version>5.6.15.Final</hibernate.version>
+    <hibernate.version>6.6.54.Final</hibernate.version>
     <!-- Used for CVSS score calculation -->
     <metaeffekt.version>0.156.2</metaeffekt.version>
     <solr.major.version>9</solr.major.version>
@@ -146,7 +146,7 @@
     <dependencies>
       <!-- Hibernate -->
       <dependency>
-        <groupId>org.hibernate</groupId>
+        <groupId>org.hibernate.orm</groupId>
         <artifactId>hibernate-core</artifactId>
         <version>${hibernate.version}</version>
         <exclusions>

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-default/src/main/java/org/xwiki/index/migration/R140300001XWIKI19571DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-default/src/main/java/org/xwiki/index/migration/R140300001XWIKI19571DataMigration.java
@@ -170,7 +170,7 @@ public class R140300001XWIKI19571DataMigration extends AbstractHibernateDataMigr
         // updated later in the migration.
         String sql = String.format("select %s, %s, %s, %s, %s from %s", docIdColumnName, versionColumnName,
             typeColumnName, instanceIdColumnName, timestampColumnName, tableName);
-        List<Object[]> resultList = session.createSQLQuery(sql).getResultList();
+        List<Object[]> resultList = session.createNativeQuery(sql).getResultList();
         for (Object[] resultSet : resultList) {
             XWikiDocumentIndexingTask task = new XWikiDocumentIndexingTask();
             task.setDocId(((Number) resultSet[0]).longValue());

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-default/src/test/java/org/xwiki/index/migration/R140300001XWIKI19571DataMigrationTest.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-default/src/test/java/org/xwiki/index/migration/R140300001XWIKI19571DataMigrationTest.java
@@ -37,7 +37,7 @@ import org.hibernate.boot.Metadata;
 import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.mapping.PersistentClass;
-import org.hibernate.query.spi.NativeQueryImplementor;
+import org.hibernate.query.sql.spi.NativeQueryImplementor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -154,7 +154,7 @@ class R140300001XWIKI19571DataMigrationTest
         ResultSet resultSet = mock(ResultSet.class);
         when(resultSet.next()).thenReturn(true);
         when(this.databaseMetaData.getTables("dbname", null, "XWIKIDOCUMENTINDEXINGQUEUE", null)).thenReturn(resultSet);
-        when(this.session.createSQLQuery(
+        when(this.session.createNativeQuery(
             "select DOC_ID, VERSION, TYPE, INSTANCE_ID, TIMESTAMP from XWIKIDOCUMENTINDEXINGQUEUE"))
             .thenReturn(this.nativeQueryImplementor);
 
@@ -192,7 +192,7 @@ class R140300001XWIKI19571DataMigrationTest
         ResultSet resultSet = mock(ResultSet.class);
         when(resultSet.next()).thenReturn(true);
         when(this.databaseMetaData.getTables(null, "dbname", "XWIKIDOCUMENTINDEXINGQUEUE", null)).thenReturn(resultSet);
-        when(this.session.createSQLQuery(
+        when(this.session.createNativeQuery(
             "select DOC_ID, VERSION, TYPE, INSTANCE_ID, TIMESTAMP from XWIKIDOCUMENTINDEXINGQUEUE"))
             .thenReturn(this.nativeQueryImplementor);
         Timestamp now = new Timestamp(new Date().getTime());

--- a/xwiki-platform-core/xwiki-platform-oldcore/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-oldcore/pom.xml
@@ -145,7 +145,7 @@
 
     <!-- Storage -->
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>org.hibernate.orm</groupId>
       <artifactId>hibernate-core</artifactId>
     </dependency>
     <!-- Hibernate 5 seems to require (but don't declare) javax validation-->
@@ -157,6 +157,17 @@
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
+    </dependency>
+    <!-- Hibernate 6 parses the hbm.xml mapping files through a Jakarta JAXB runtime. Only the jakarta.xml.bind-api is
+         available transitively (via Hibernate), with no runtime provider, so the JAXBContext cannot be built. Provide
+         the Glassfish Jakarta implementation for the tests that boot Hibernate's mapping binder. -->
+    <dependency>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+      <!-- Force the Jakarta (4.x) implementation: the version managed for the javax.xml.bind consumers is 2.x, which
+           cannot build the jakarta.xml.bind JAXBContext that Hibernate 6 needs to parse hbm.xml. -->
+      <version>4.0.5</version>
+      <scope>test</scope>
     </dependency>
     <!-- Replace the one from DBCP -->
     <dependency>

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/HibernateStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/HibernateStore.java
@@ -1123,7 +1123,7 @@ public class HibernateStore implements Disposable, Initializable
      */
     public String getConfiguredColumnName(Property property)
     {
-        Column column = (Column) property.getColumnIterator().next();
+        Column column = property.getColumns().get(0);
 
         return getConfiguredColumnName(column);
     }
@@ -1231,8 +1231,8 @@ public class HibernateStore implements Disposable, Initializable
 
         if (result == -1) {
             PersistentClass persistentClass = getConfigurationMetadata().getEntityBinding(entityType.getName());
-            Column column2 = (Column) persistentClass.getProperty(propertyName).getColumnIterator().next();
-            result = column2.getLength();
+            Column column2 = persistentClass.getProperty(propertyName).getColumns().get(0);
+            result = column2.getLength().intValue();
             this.logger.warn(
                 "Error while getting the size limit for entity [{}] and propertyName [{}]. "
                     + "The length value set by hibernate [{}] will be used.",

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/QueryImplementorDelegate.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/QueryImplementorDelegate.java
@@ -19,46 +19,11 @@
  */
 package com.xpn.xwiki.internal.store.hibernate;
 
-import java.io.Serializable;
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
-import java.time.ZonedDateTime;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Date;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Stream;
-
-import javax.persistence.FlushModeType;
-import javax.persistence.LockModeType;
-import javax.persistence.Parameter;
-import javax.persistence.TemporalType;
-
-import org.hibernate.CacheMode;
-import org.hibernate.FlushMode;
-import org.hibernate.LockMode;
-import org.hibernate.LockOptions;
-import org.hibernate.ScrollMode;
-import org.hibernate.ScrollableResults;
-import org.hibernate.engine.spi.RowSelection;
-import org.hibernate.graph.GraphSemantic;
-import org.hibernate.graph.RootGraph;
-import org.hibernate.query.ParameterMetadata;
-import org.hibernate.query.Query;
-import org.hibernate.query.QueryParameter;
 import org.hibernate.query.spi.QueryImplementor;
-import org.hibernate.query.spi.QueryProducerImplementor;
-import org.hibernate.transform.ResultTransformer;
-import org.hibernate.type.Type;
 
 /**
- * Wrap a QueryImplementor.
- * 
+ * Wrap a {@link QueryImplementor}.
+ *
  * @param <R> query result type
  * @version $Id$
  * @since 11.5RC1
@@ -76,115 +41,309 @@ public class QueryImplementorDelegate<R> implements QueryImplementor<R>
     }
 
     @Override
-    public Optional<R> uniqueResultOptional()
+    public org.hibernate.query.spi.QueryImplementor<R> setProperties(java.lang.Object arg0)
     {
-        return this.delegate.uniqueResultOptional();
+        return this.delegate.setProperties(arg0);
     }
 
     @Override
-    public Stream<R> stream()
+    public org.hibernate.query.spi.QueryImplementor<R> setProperties(java.util.Map arg0)
     {
-        return this.delegate.stream();
+        return this.delegate.setProperties(arg0);
     }
 
     @Override
-    public Query<R> applyGraph(RootGraph graph, GraphSemantic semantic)
+    public org.hibernate.engine.spi.SharedSessionContractImplementor getSession()
     {
-        return this.delegate.applyGraph(graph, semantic);
+        return this.delegate.getSession();
     }
 
     @Override
-    public Query<R> setParameter(Parameter<Instant> param, Instant value, TemporalType temporalType)
+    public void setOptionalId(java.io.Serializable arg0)
     {
-        return this.delegate.setParameter(param, value, temporalType);
+        this.delegate.setOptionalId(arg0);
     }
 
     @Override
-    public Query<R> setParameter(Parameter<LocalDateTime> param, LocalDateTime value, TemporalType temporalType)
+    public void setOptionalEntityName(java.lang.String arg0)
     {
-        return this.delegate.setParameter(param, value, temporalType);
+        this.delegate.setOptionalEntityName(arg0);
     }
 
     @Override
-    public Query<R> setParameter(Parameter<ZonedDateTime> param, ZonedDateTime value, TemporalType temporalType)
+    public void setOptionalObject(java.lang.Object arg0)
     {
-        return this.delegate.setParameter(param, value, temporalType);
+        this.delegate.setOptionalObject(arg0);
     }
 
     @Override
-    public Query<R> setParameter(Parameter<OffsetDateTime> param, OffsetDateTime value, TemporalType temporalType)
+    public org.hibernate.query.spi.QueryParameterBindings getParameterBindings()
     {
-        return this.delegate.setParameter(param, value, temporalType);
+        return this.delegate.getParameterBindings();
     }
 
     @Override
-    public Query<R> setParameter(String name, Instant value, TemporalType temporalType)
-    {
-        return this.delegate.setParameter(name, value, temporalType);
-    }
-
-    @Override
-    public Query<R> setParameter(String name, LocalDateTime value, TemporalType temporalType)
-    {
-        return this.delegate.setParameter(name, value, temporalType);
-    }
-
-    @Override
-    public Query<R> setParameter(String name, ZonedDateTime value, TemporalType temporalType)
-    {
-        return this.delegate.setParameter(name, value, temporalType);
-    }
-
-    @Override
-    public Query<R> setParameter(String name, OffsetDateTime value, TemporalType temporalType)
-    {
-        return this.delegate.setParameter(name, value, temporalType);
-    }
-
-    @Override
-    public Query<R> setParameter(int position, Instant value, TemporalType temporalType)
-    {
-        // Convert from legacy Hibernate positional parameter to JPA positional parameter
-        return this.delegate.setParameter(position, value, temporalType);
-    }
-
-    @Override
-    public Query<R> setParameter(int position, LocalDateTime value, TemporalType temporalType)
-    {
-        // Convert from legacy Hibernate positional parameter to JPA positional parameter
-        return this.delegate.setParameter(position, value, temporalType);
-    }
-
-    @Override
-    public Query<R> setParameter(int position, ZonedDateTime value, TemporalType temporalType)
-    {
-        // Convert from legacy Hibernate positional parameter to JPA positional parameter
-        return this.delegate.setParameter(position, value, temporalType);
-    }
-
-    @Override
-    public Query<R> setParameter(int position, OffsetDateTime value, TemporalType temporalType)
-    {
-        // Convert from legacy Hibernate positional parameter to JPA positional parameter
-        return this.delegate.setParameter(position, value, temporalType);
-    }
-
-    @Override
-    public ScrollableResults scroll()
+    public org.hibernate.query.spi.ScrollableResultsImplementor<R> scroll()
     {
         return this.delegate.scroll();
     }
 
     @Override
-    public ScrollableResults scroll(ScrollMode scrollMode)
+    public org.hibernate.query.spi.ScrollableResultsImplementor<R> scroll(org.hibernate.ScrollMode arg0)
     {
-        return this.delegate.scroll(scrollMode);
+        return this.delegate.scroll(arg0);
     }
 
     @Override
-    public List<R> list()
+    public <T> org.hibernate.query.spi.QueryImplementor<T> setTupleTransformer(org.hibernate.query.TupleTransformer<T> arg0)
+    {
+        return this.delegate.setTupleTransformer(arg0);
+    }
+
+    @Override
+    public org.hibernate.query.spi.QueryImplementor<R> setResultListTransformer(org.hibernate.query.ResultListTransformer<R> arg0)
+    {
+        return this.delegate.setResultListTransformer(arg0);
+    }
+
+    @Override
+    public <P> org.hibernate.query.spi.QueryImplementor<R> setParameter(org.hibernate.query.QueryParameter<P> arg0, P arg1, java.lang.Class<P> arg2)
+    {
+        return this.delegate.setParameter(arg0, arg1, arg2);
+    }
+
+    @Override
+    public <P> org.hibernate.query.spi.QueryImplementor<R> setParameter(org.hibernate.query.QueryParameter<P> arg0, P arg1, org.hibernate.query.BindableType<P> arg2)
+    {
+        return this.delegate.setParameter(arg0, arg1, arg2);
+    }
+
+    @Override
+    public <T> org.hibernate.query.spi.QueryImplementor<R> setParameter(org.hibernate.query.QueryParameter<T> arg0, T arg1)
+    {
+        return this.delegate.setParameter(arg0, arg1);
+    }
+
+    @Override
+    public org.hibernate.query.spi.QueryImplementor<R> setParameter(jakarta.persistence.Parameter<java.util.Calendar> arg0, java.util.Calendar arg1, jakarta.persistence.TemporalType arg2)
+    {
+        return this.delegate.setParameter(arg0, arg1, arg2);
+    }
+
+    @Override
+    public <T> org.hibernate.query.spi.QueryImplementor<R> setParameter(jakarta.persistence.Parameter<T> arg0, T arg1)
+    {
+        return this.delegate.setParameter(arg0, arg1);
+    }
+
+    @Override
+    public org.hibernate.query.spi.QueryImplementor<R> setParameter(jakarta.persistence.Parameter<java.util.Date> arg0, java.util.Date arg1, jakarta.persistence.TemporalType arg2)
+    {
+        return this.delegate.setParameter(arg0, arg1, arg2);
+    }
+
+    @Override
+    public <P> org.hibernate.query.spi.QueryImplementor<R> setParameter(int arg0, P arg1, org.hibernate.query.BindableType<P> arg2)
+    {
+        return this.delegate.setParameter(arg0, arg1, arg2);
+    }
+
+    @Override
+    public <P> org.hibernate.query.spi.QueryImplementor<R> setParameter(int arg0, P arg1, java.lang.Class<P> arg2)
+    {
+        return this.delegate.setParameter(arg0, arg1, arg2);
+    }
+
+    @Override
+    public org.hibernate.query.spi.QueryImplementor<R> setParameter(int arg0, java.lang.Object arg1)
+    {
+        return this.delegate.setParameter(arg0, arg1);
+    }
+
+    @Override
+    public org.hibernate.query.spi.QueryImplementor<R> setParameter(java.lang.String arg0, java.util.Date arg1, jakarta.persistence.TemporalType arg2)
+    {
+        return this.delegate.setParameter(arg0, arg1, arg2);
+    }
+
+    @Override
+    public org.hibernate.query.spi.QueryImplementor<R> setParameter(int arg0, java.util.Calendar arg1, jakarta.persistence.TemporalType arg2)
+    {
+        return this.delegate.setParameter(arg0, arg1, arg2);
+    }
+
+    @Override
+    public org.hibernate.query.spi.QueryImplementor<R> setParameter(int arg0, java.util.Date arg1, jakarta.persistence.TemporalType arg2)
+    {
+        return this.delegate.setParameter(arg0, arg1, arg2);
+    }
+
+    @Override
+    public org.hibernate.query.spi.QueryImplementor<R> setParameter(int arg0, java.time.Instant arg1, jakarta.persistence.TemporalType arg2)
+    {
+        return this.delegate.setParameter(arg0, arg1, arg2);
+    }
+
+    @Override
+    public org.hibernate.query.spi.QueryImplementor<R> setParameter(java.lang.String arg0, java.util.Calendar arg1, jakarta.persistence.TemporalType arg2)
+    {
+        return this.delegate.setParameter(arg0, arg1, arg2);
+    }
+
+    @Override
+    public org.hibernate.query.spi.QueryImplementor<R> setParameter(java.lang.String arg0, java.time.Instant arg1, jakarta.persistence.TemporalType arg2)
+    {
+        return this.delegate.setParameter(arg0, arg1, arg2);
+    }
+
+    @Override
+    public <P> org.hibernate.query.spi.QueryImplementor<R> setParameter(java.lang.String arg0, P arg1, org.hibernate.query.BindableType<P> arg2)
+    {
+        return this.delegate.setParameter(arg0, arg1, arg2);
+    }
+
+    @Override
+    public <P> org.hibernate.query.spi.QueryImplementor<R> setParameter(java.lang.String arg0, P arg1, java.lang.Class<P> arg2)
+    {
+        return this.delegate.setParameter(arg0, arg1, arg2);
+    }
+
+    @Override
+    public org.hibernate.query.spi.QueryImplementor<R> setParameter(java.lang.String arg0, java.lang.Object arg1)
+    {
+        return this.delegate.setParameter(arg0, arg1);
+    }
+
+    @Override
+    public <P> org.hibernate.query.spi.QueryImplementor<R> setParameterList(java.lang.String arg0, P[] arg1, java.lang.Class<P> arg2)
+    {
+        return this.delegate.setParameterList(arg0, arg1, arg2);
+    }
+
+    @Override
+    public org.hibernate.query.spi.QueryImplementor<R> setParameterList(java.lang.String arg0, java.lang.Object[] arg1)
+    {
+        return this.delegate.setParameterList(arg0, arg1);
+    }
+
+    @Override
+    public <P> org.hibernate.query.spi.QueryImplementor<R> setParameterList(java.lang.String arg0, java.util.Collection<? extends P> arg1, org.hibernate.query.BindableType<P> arg2)
+    {
+        return this.delegate.setParameterList(arg0, arg1, arg2);
+    }
+
+    @Override
+    public <P> org.hibernate.query.spi.QueryImplementor<R> setParameterList(java.lang.String arg0, P[] arg1, org.hibernate.query.BindableType<P> arg2)
+    {
+        return this.delegate.setParameterList(arg0, arg1, arg2);
+    }
+
+    @Override
+    public org.hibernate.query.spi.QueryImplementor<R> setParameterList(int arg0, java.util.Collection arg1)
+    {
+        return this.delegate.setParameterList(arg0, arg1);
+    }
+
+    @Override
+    public <P> org.hibernate.query.spi.QueryImplementor<R> setParameterList(org.hibernate.query.QueryParameter<P> arg0, P[] arg1, org.hibernate.query.BindableType<P> arg2)
+    {
+        return this.delegate.setParameterList(arg0, arg1, arg2);
+    }
+
+    @Override
+    public org.hibernate.query.spi.QueryImplementor<R> setParameterList(java.lang.String arg0, java.util.Collection arg1)
+    {
+        return this.delegate.setParameterList(arg0, arg1);
+    }
+
+    @Override
+    public <P> org.hibernate.query.spi.QueryImplementor<R> setParameterList(java.lang.String arg0, java.util.Collection<? extends P> arg1, java.lang.Class<P> arg2)
+    {
+        return this.delegate.setParameterList(arg0, arg1, arg2);
+    }
+
+    @Override
+    public <P> org.hibernate.query.spi.QueryImplementor<R> setParameterList(org.hibernate.query.QueryParameter<P> arg0, java.util.Collection<? extends P> arg1)
+    {
+        return this.delegate.setParameterList(arg0, arg1);
+    }
+
+    @Override
+    public <P> org.hibernate.query.spi.QueryImplementor<R> setParameterList(org.hibernate.query.QueryParameter<P> arg0, java.util.Collection<? extends P> arg1, java.lang.Class<P> arg2)
+    {
+        return this.delegate.setParameterList(arg0, arg1, arg2);
+    }
+
+    @Override
+    public <P> org.hibernate.query.spi.QueryImplementor<R> setParameterList(org.hibernate.query.QueryParameter<P> arg0, java.util.Collection<? extends P> arg1, org.hibernate.query.BindableType<P> arg2)
+    {
+        return this.delegate.setParameterList(arg0, arg1, arg2);
+    }
+
+    @Override
+    public <P> org.hibernate.query.spi.QueryImplementor<R> setParameterList(org.hibernate.query.QueryParameter<P> arg0, P[] arg1)
+    {
+        return this.delegate.setParameterList(arg0, arg1);
+    }
+
+    @Override
+    public <P> org.hibernate.query.spi.QueryImplementor<R> setParameterList(org.hibernate.query.QueryParameter<P> arg0, P[] arg1, java.lang.Class<P> arg2)
+    {
+        return this.delegate.setParameterList(arg0, arg1, arg2);
+    }
+
+    @Override
+    public <P> org.hibernate.query.spi.QueryImplementor<R> setParameterList(int arg0, java.util.Collection<? extends P> arg1, java.lang.Class<P> arg2)
+    {
+        return this.delegate.setParameterList(arg0, arg1, arg2);
+    }
+
+    @Override
+    public <P> org.hibernate.query.spi.QueryImplementor<R> setParameterList(int arg0, java.util.Collection<? extends P> arg1, org.hibernate.query.BindableType<P> arg2)
+    {
+        return this.delegate.setParameterList(arg0, arg1, arg2);
+    }
+
+    @Override
+    public org.hibernate.query.spi.QueryImplementor<R> setParameterList(int arg0, java.lang.Object[] arg1)
+    {
+        return this.delegate.setParameterList(arg0, arg1);
+    }
+
+    @Override
+    public <P> org.hibernate.query.spi.QueryImplementor<R> setParameterList(int arg0, P[] arg1, java.lang.Class<P> arg2)
+    {
+        return this.delegate.setParameterList(arg0, arg1, arg2);
+    }
+
+    @Override
+    public <P> org.hibernate.query.spi.QueryImplementor<R> setParameterList(int arg0, P[] arg1, org.hibernate.query.BindableType<P> arg2)
+    {
+        return this.delegate.setParameterList(arg0, arg1, arg2);
+    }
+
+    @Override
+    public java.util.List<R> list()
     {
         return this.delegate.list();
+    }
+
+    @Override
+    public org.hibernate.query.Query<R> setReadOnly(boolean arg0)
+    {
+        return this.delegate.setReadOnly(arg0);
+    }
+
+    @Override
+    public org.hibernate.query.Query<R> setComment(java.lang.String arg0)
+    {
+        return this.delegate.setComment(arg0);
+    }
+
+    @Override
+    public java.lang.String getComment()
+    {
+        return this.delegate.getComment();
     }
 
     @Override
@@ -194,312 +353,183 @@ public class QueryImplementorDelegate<R> implements QueryImplementor<R>
     }
 
     @Override
-    public FlushMode getHibernateFlushMode()
+    public R getSingleResult()
     {
-        return this.delegate.getHibernateFlushMode();
+        return this.delegate.getSingleResult();
     }
 
     @Override
-    public CacheMode getCacheMode()
+    public java.util.Optional<R> uniqueResultOptional()
     {
-        return this.delegate.getCacheMode();
-    }
-
-    @Override
-    public String getCacheRegion()
-    {
-        return this.delegate.getCacheRegion();
-    }
-
-    @Override
-    public Integer getFetchSize()
-    {
-        return this.delegate.getFetchSize();
-    }
-
-    @Override
-    public LockOptions getLockOptions()
-    {
-        return this.delegate.getLockOptions();
-    }
-
-    @Override
-    public String getComment()
-    {
-        return this.delegate.getComment();
-    }
-
-    @Override
-    public String getQueryString()
-    {
-        return this.delegate.getQueryString();
-    }
-
-    @Override
-    public ParameterMetadata getParameterMetadata()
-    {
-        return this.delegate.getParameterMetadata();
-    }
-
-    @Override
-    public Query<R> setMaxResults(int maxResult)
-    {
-        return this.delegate.setMaxResults(maxResult);
-    }
-
-    @Override
-    public Query<R> setFirstResult(int startPosition)
-    {
-        return this.delegate.setFirstResult(startPosition);
-    }
-
-    @Override
-    public Query<R> setHint(String hintName, Object value)
-    {
-        return this.delegate.setHint(hintName, value);
-    }
-
-    @Override
-    public <T> Query<R> setParameter(Parameter<T> param, T value)
-    {
-        return this.delegate.setParameter(param, value);
-    }
-
-    @Override
-    public Query<R> setParameter(Parameter<Calendar> param, Calendar value, TemporalType temporalType)
-    {
-        return this.delegate.setParameter(param, value, temporalType);
-    }
-
-    @Override
-    public Query<R> setParameter(Parameter<Date> param, Date value, TemporalType temporalType)
-    {
-        return this.delegate.setParameter(param, value, temporalType);
-    }
-
-    @Override
-    public Query<R> setParameter(String name, Object value)
-    {
-        return this.delegate.setParameter(name, value);
-    }
-
-    @Override
-    public Query<R> setParameter(String name, Object value, Type type)
-    {
-        return this.delegate.setParameter(name, value, type);
-    }
-
-    @Override
-    public Query<R> setParameter(String name, Calendar value, TemporalType temporalType)
-    {
-        return this.delegate.setParameter(name, value, temporalType);
-    }
-
-    @Override
-    public Query<R> setParameter(String name, Date value, TemporalType temporalType)
-    {
-        return this.delegate.setParameter(name, value, temporalType);
-    }
-
-    @Override
-    public Query<R> setParameter(int position, Object value)
-    {
-        return this.delegate.setParameter(position, value);
-    }
-
-    @Override
-    public Query<R> setParameter(int position, Calendar value, TemporalType temporalType)
-    {
-        return this.delegate.setParameter(position, value, temporalType);
-    }
-
-    @Override
-    public Query<R> setParameter(int position, Date value, TemporalType temporalType)
-    {
-        return this.delegate.setParameter(position, value, temporalType);
-    }
-
-    @Override
-    public <T> Query<R> setParameter(QueryParameter<T> parameter, T val)
-    {
-        return this.delegate.setParameter(parameter, val);
-    }
-
-    @Override
-    public Query<R> setParameter(int position, Object val, TemporalType temporalType)
-    {
-        return this.delegate.setParameter(position, val, temporalType);
-    }
-
-    @Override
-    public <T> Query<R> setParameter(QueryParameter<T> parameter, T val, Type type)
-    {
-        return this.delegate.setParameter(parameter, val, type);
-    }
-
-    @Override
-    public Query<R> setParameter(int position, Object val, Type type)
-    {
-        return this.delegate.setParameter(position, val, type);
-    }
-
-    @Override
-    public <T> Query<R> setParameter(QueryParameter<T> parameter, T val, TemporalType temporalType)
-    {
-        return this.delegate.setParameter(parameter, val, temporalType);
-    }
-
-    @Override
-    public Query<R> setParameter(String name, Object val, TemporalType temporalType)
-    {
-        return this.delegate.setParameter(name, val, temporalType);
-    }
-
-    @Override
-    public Query<R> setFlushMode(FlushModeType flushMode)
-    {
-        return this.delegate.setFlushMode(flushMode);
-    }
-
-    @Override
-    public Query<R> setLockMode(LockModeType lockMode)
-    {
-        return this.delegate.setLockMode(lockMode);
-    }
-
-    @Override
-    public Query<R> setReadOnly(boolean readOnly)
-    {
-        return this.delegate.setReadOnly(readOnly);
-    }
-
-    @Override
-    public Query<R> setHibernateFlushMode(FlushMode flushMode)
-    {
-        return this.delegate.setHibernateFlushMode(flushMode);
-    }
-
-    @Override
-    public Query<R> setCacheMode(CacheMode cacheMode)
-    {
-        return this.delegate.setCacheMode(cacheMode);
-    }
-
-    @Override
-    public Query<R> setCacheable(boolean cacheable)
-    {
-        return this.delegate.setCacheable(cacheable);
-    }
-
-    @Override
-    public Query<R> setCacheRegion(String cacheRegion)
-    {
-        return this.delegate.setCacheRegion(cacheRegion);
-    }
-
-    @Override
-    public Query<R> setTimeout(int timeout)
-    {
-        return this.delegate.setTimeout(timeout);
-    }
-
-    @Override
-    public Query<R> setFetchSize(int fetchSize)
-    {
-        return this.delegate.setFetchSize(fetchSize);
-    }
-
-    @Override
-    public Query<R> setLockOptions(LockOptions lockOptions)
-    {
-        return this.delegate.setLockOptions(lockOptions);
-    }
-
-    @Override
-    public Query<R> setLockMode(String alias, LockMode lockMode)
-    {
-        return this.delegate.setLockMode(alias, lockMode);
-    }
-
-    @Override
-    public Query<R> setComment(String comment)
-    {
-        return this.delegate.setComment(comment);
-    }
-
-    @Override
-    public Query<R> addQueryHint(String hint)
-    {
-        return this.delegate.addQueryHint(hint);
-    }
-
-    @Override
-    public <T> Query<R> setParameterList(QueryParameter<T> parameter, Collection<T> values)
-    {
-        return this.delegate.setParameterList(parameter, values);
-    }
-
-    @Override
-    public Query<R> setParameterList(String name, Collection values)
-    {
-        return this.delegate.setParameterList(name, values);
-    }
-
-    @Override
-    public Query<R> setParameterList(String name, Collection values, Type type)
-    {
-        return this.delegate.setParameterList(name, values, type);
-    }
-
-    @Override
-    public Query<R> setParameterList(String name, Object[] values, Type type)
-    {
-        return this.delegate.setParameterList(name, values, type);
-    }
-
-    @Override
-    public Query<R> setParameterList(String name, Object[] values)
-    {
-        return this.delegate.setParameterList(name, values);
-    }
-
-    @Override
-    public Query<R> setProperties(Object bean)
-    {
-        return this.delegate.setProperties(bean);
-    }
-
-    @Override
-    public Query<R> setProperties(Map bean)
-    {
-        return this.delegate.setProperties(bean);
-    }
-
-    @Override
-    @Deprecated
-    public Query<R> setEntity(int position, Object val)
-    {
-        return this.delegate.setEntity(position, val);
-    }
-
-    @Override
-    @Deprecated
-    public Query<R> setEntity(String name, Object val)
-    {
-        return this.delegate.setEntity(name, val);
-    }
-
-    @Override
-    @Deprecated
-    public Query<R> setResultTransformer(ResultTransformer transformer)
-    {
-        return this.delegate.setResultTransformer(transformer);
+        return this.delegate.uniqueResultOptional();
     }
 
     @Override
     public int executeUpdate()
     {
         return this.delegate.executeUpdate();
+    }
+
+    @Override
+    public java.lang.String getQueryString()
+    {
+        return this.delegate.getQueryString();
+    }
+
+    @Override
+    public org.hibernate.query.Query<R> applyGraph(org.hibernate.graph.RootGraph arg0, org.hibernate.graph.GraphSemantic arg1)
+    {
+        return this.delegate.applyGraph(arg0, arg1);
+    }
+
+    @Override
+    public org.hibernate.query.Query<R> addQueryHint(java.lang.String arg0)
+    {
+        return this.delegate.addQueryHint(arg0);
+    }
+
+    @Override
+    public org.hibernate.LockOptions getLockOptions()
+    {
+        return this.delegate.getLockOptions();
+    }
+
+    @Override
+    public org.hibernate.query.Query<R> setLockOptions(org.hibernate.LockOptions arg0)
+    {
+        return this.delegate.setLockOptions(arg0);
+    }
+
+    @Override
+    public org.hibernate.query.Query<R> setLockMode(jakarta.persistence.LockModeType arg0)
+    {
+        return this.delegate.setLockMode(arg0);
+    }
+
+    @Override
+    public org.hibernate.query.Query<R> setLockMode(java.lang.String arg0, org.hibernate.LockMode arg1)
+    {
+        return this.delegate.setLockMode(arg0, arg1);
+    }
+
+    @Override
+    public org.hibernate.query.spi.QueryOptions getQueryOptions()
+    {
+        return this.delegate.getQueryOptions();
+    }
+
+    @Override
+    public org.hibernate.query.ParameterMetadata getParameterMetadata()
+    {
+        return this.delegate.getParameterMetadata();
+    }
+
+    @Override
+    public org.hibernate.query.Query<R> setHibernateFlushMode(org.hibernate.FlushMode arg0)
+    {
+        return this.delegate.setHibernateFlushMode(arg0);
+    }
+
+    @Override
+    public org.hibernate.query.Query<R> setCacheable(boolean arg0)
+    {
+        return this.delegate.setCacheable(arg0);
+    }
+
+    @Override
+    public org.hibernate.query.Query<R> setCacheRegion(java.lang.String arg0)
+    {
+        return this.delegate.setCacheRegion(arg0);
+    }
+
+    @Override
+    public org.hibernate.query.Query<R> setCacheMode(org.hibernate.CacheMode arg0)
+    {
+        return this.delegate.setCacheMode(arg0);
+    }
+
+    @Override
+    public org.hibernate.query.Query<R> setCacheStoreMode(jakarta.persistence.CacheStoreMode arg0)
+    {
+        return this.delegate.setCacheStoreMode(arg0);
+    }
+
+    @Override
+    public org.hibernate.query.Query<R> setCacheRetrieveMode(jakarta.persistence.CacheRetrieveMode arg0)
+    {
+        return this.delegate.setCacheRetrieveMode(arg0);
+    }
+
+    @Override
+    public org.hibernate.query.Query<R> setTimeout(int arg0)
+    {
+        return this.delegate.setTimeout(arg0);
+    }
+
+    @Override
+    public org.hibernate.query.Query<R> setFetchSize(int arg0)
+    {
+        return this.delegate.setFetchSize(arg0);
+    }
+
+    @Override
+    public org.hibernate.query.Query<R> setMaxResults(int arg0)
+    {
+        return this.delegate.setMaxResults(arg0);
+    }
+
+    @Override
+    public org.hibernate.query.Query<R> setFirstResult(int arg0)
+    {
+        return this.delegate.setFirstResult(arg0);
+    }
+
+    @Override
+    public org.hibernate.query.Query<R> setHint(java.lang.String arg0, java.lang.Object arg1)
+    {
+        return this.delegate.setHint(arg0, arg1);
+    }
+
+    @Override
+    public org.hibernate.query.Query<R> setEntityGraph(jakarta.persistence.EntityGraph<R> arg0, org.hibernate.graph.GraphSemantic arg1)
+    {
+        return this.delegate.setEntityGraph(arg0, arg1);
+    }
+
+    @Override
+    public org.hibernate.query.Query<R> enableFetchProfile(java.lang.String arg0)
+    {
+        return this.delegate.enableFetchProfile(arg0);
+    }
+
+    @Override
+    public org.hibernate.query.Query<R> disableFetchProfile(java.lang.String arg0)
+    {
+        return this.delegate.disableFetchProfile(arg0);
+    }
+
+    @Override
+    public org.hibernate.query.Query<R> setFlushMode(jakarta.persistence.FlushModeType arg0)
+    {
+        return this.delegate.setFlushMode(arg0);
+    }
+
+    @Override
+    public org.hibernate.query.Query<R> setOrder(org.hibernate.query.Order<? super R> arg0)
+    {
+        return this.delegate.setOrder(arg0);
+    }
+
+    @Override
+    public org.hibernate.query.Query<R> setOrder(java.util.List<org.hibernate.query.Order<? super R>> arg0)
+    {
+        return this.delegate.setOrder(arg0);
+    }
+
+    @Override
+    public boolean isReadOnly()
+    {
+        return this.delegate.isReadOnly();
     }
 
     @Override
@@ -515,203 +545,183 @@ public class QueryImplementorDelegate<R> implements QueryImplementor<R>
     }
 
     @Override
-    public Map<String, Object> getHints()
+    public R getSingleResultOrNull()
     {
-        return this.delegate.getHints();
+        return this.delegate.getSingleResultOrNull();
     }
 
     @Override
-    public Set<Parameter<?>> getParameters()
+    public long getResultCount()
     {
-        return this.delegate.getParameters();
+        return this.delegate.getResultCount();
     }
 
     @Override
-    public Parameter<?> getParameter(String name)
+    public org.hibernate.query.KeyedResultList<R> getKeyedResultList(org.hibernate.query.KeyedPage<R> arg0)
     {
-        return this.delegate.getParameter(name);
+        return this.delegate.getKeyedResultList(arg0);
     }
 
     @Override
-    public <T> Parameter<T> getParameter(String name, Class<T> type)
+    public java.lang.Integer getFetchSize()
     {
-        return this.delegate.getParameter(name, type);
+        return this.delegate.getFetchSize();
     }
 
     @Override
-    public Parameter<?> getParameter(int position)
+    public org.hibernate.CacheMode getCacheMode()
     {
-        return this.delegate.getParameter(position);
+        return this.delegate.getCacheMode();
     }
 
     @Override
-    public <T> Parameter<T> getParameter(int position, Class<T> type)
+    public jakarta.persistence.CacheStoreMode getCacheStoreMode()
     {
-        return this.delegate.getParameter(position, type);
+        return this.delegate.getCacheStoreMode();
     }
 
     @Override
-    public boolean isBound(Parameter<?> param)
+    public jakarta.persistence.CacheRetrieveMode getCacheRetrieveMode()
     {
-        return this.delegate.isBound(param);
+        return this.delegate.getCacheRetrieveMode();
     }
 
     @Override
-    public <T> T getParameterValue(Parameter<T> param)
-    {
-        return this.delegate.getParameterValue(param);
-    }
-
-    @Override
-    public Object getParameterValue(String name)
-    {
-        return this.delegate.getParameterValue(name);
-    }
-
-    @Override
-    public Object getParameterValue(int position)
-    {
-        return this.delegate.getParameterValue(position);
-    }
-
-    @Override
-    @Deprecated
-    public FlushModeType getFlushMode()
-    {
-        return this.delegate.getFlushMode();
-    }
-
-    @Override
-    public LockModeType getLockMode()
-    {
-        return this.delegate.getLockMode();
-    }
-
-    @Override
-    public <T> T unwrap(Class<T> cls)
-    {
-        return this.delegate.unwrap(cls);
-    }
-
-    @Override
-    @Deprecated
-    public RowSelection getQueryOptions()
-    {
-        return this.delegate.getQueryOptions();
-    }
-
-    @Override
-    @Deprecated
     public boolean isCacheable()
     {
         return this.delegate.isCacheable();
     }
 
     @Override
-    @Deprecated
-    public Integer getTimeout()
+    public boolean isQueryPlanCacheable()
+    {
+        return this.delegate.isQueryPlanCacheable();
+    }
+
+    @Override
+    public org.hibernate.query.SelectionQuery<R> setQueryPlanCacheable(boolean arg0)
+    {
+        return this.delegate.setQueryPlanCacheable(arg0);
+    }
+
+    @Override
+    public java.lang.String getCacheRegion()
+    {
+        return this.delegate.getCacheRegion();
+    }
+
+    @Override
+    public jakarta.persistence.LockModeType getLockMode()
+    {
+        return this.delegate.getLockMode();
+    }
+
+    @Override
+    public org.hibernate.LockMode getHibernateLockMode()
+    {
+        return this.delegate.getHibernateLockMode();
+    }
+
+    @Override
+    public org.hibernate.query.SelectionQuery<R> setHibernateLockMode(org.hibernate.LockMode arg0)
+    {
+        return this.delegate.setHibernateLockMode(arg0);
+    }
+
+    @Override
+    public org.hibernate.query.SelectionQuery<R> setAliasSpecificLockMode(java.lang.String arg0, org.hibernate.LockMode arg1)
+    {
+        return this.delegate.setAliasSpecificLockMode(arg0, arg1);
+    }
+
+    @Override
+    public org.hibernate.query.SelectionQuery<R> setFollowOnLocking(boolean arg0)
+    {
+        return this.delegate.setFollowOnLocking(arg0);
+    }
+
+    @Override
+    public jakarta.persistence.FlushModeType getFlushMode()
+    {
+        return this.delegate.getFlushMode();
+    }
+
+    @Override
+    public org.hibernate.FlushMode getHibernateFlushMode()
+    {
+        return this.delegate.getHibernateFlushMode();
+    }
+
+    @Override
+    public java.lang.Integer getTimeout()
     {
         return this.delegate.getTimeout();
     }
 
     @Override
-    @Deprecated
-    public boolean isReadOnly()
+    public java.util.Set<jakarta.persistence.Parameter<?>> getParameters()
     {
-        return this.delegate.isReadOnly();
+        return this.delegate.getParameters();
     }
 
     @Override
-    @Deprecated
-    public Type[] getReturnTypes()
+    public <T> T unwrap(java.lang.Class<T> arg0)
     {
-        return this.delegate.getReturnTypes();
+        return this.delegate.unwrap(arg0);
     }
 
     @Override
-    @Deprecated
-    public Iterator<R> iterate()
+    public java.util.Map<java.lang.String, java.lang.Object> getHints()
     {
-        return this.delegate.iterate();
+        return this.delegate.getHints();
     }
 
     @Override
-    @Deprecated
-    public String[] getNamedParameters()
+    public jakarta.persistence.Parameter<?> getParameter(int arg0)
     {
-        return this.delegate.getNamedParameters();
+        return this.delegate.getParameter(arg0);
     }
 
     @Override
-    @Deprecated
-    public org.hibernate.Query<R> setParameterList(int position, Collection values)
+    public jakarta.persistence.Parameter<?> getParameter(java.lang.String arg0)
     {
-        return this.delegate.setParameterList(position, values);
+        return this.delegate.getParameter(arg0);
     }
 
     @Override
-    @Deprecated
-    public org.hibernate.Query<R> setParameterList(int position, Collection values, Type type)
+    public <T> jakarta.persistence.Parameter<T> getParameter(java.lang.String arg0, java.lang.Class<T> arg1)
     {
-        return this.delegate.setParameterList(position, values, type);
+        return this.delegate.getParameter(arg0, arg1);
     }
 
     @Override
-    @Deprecated
-    public org.hibernate.Query<R> setParameterList(int position, Object[] values, Type type)
+    public <T> jakarta.persistence.Parameter<T> getParameter(int arg0, java.lang.Class<T> arg1)
     {
-        return this.delegate.setParameterList(position, values, type);
+        return this.delegate.getParameter(arg0, arg1);
     }
 
     @Override
-    @Deprecated
-    public org.hibernate.Query<R> setParameterList(int position, Object[] values)
+    public boolean isBound(jakarta.persistence.Parameter<?> arg0)
     {
-        return this.delegate.setParameterList(position, values);
+        return this.delegate.isBound(arg0);
     }
 
     @Override
-    @Deprecated
-    public Type determineProperBooleanType(int position, Object value, Type defaultType)
+    public java.lang.Object getParameterValue(java.lang.String arg0)
     {
-        return this.delegate.determineProperBooleanType(position, value, defaultType);
+        return this.delegate.getParameterValue(arg0);
     }
 
     @Override
-    @Deprecated
-    public Type determineProperBooleanType(String name, Object value, Type defaultType)
+    public java.lang.Object getParameterValue(int arg0)
     {
-        return this.delegate.determineProperBooleanType(name, value, defaultType);
+        return this.delegate.getParameterValue(arg0);
     }
 
     @Override
-    @Deprecated
-    public String[] getReturnAliases()
+    public <T> T getParameterValue(jakarta.persistence.Parameter<T> arg0)
     {
-        return this.delegate.getReturnAliases();
+        return this.delegate.getParameterValue(arg0);
     }
 
-    @Override
-    public QueryProducerImplementor getProducer()
-    {
-        return this.delegate.getProducer();
-    }
-
-    @Override
-    public void setOptionalId(Serializable id)
-    {
-        this.delegate.setOptionalId(id);
-    }
-
-    @Override
-    public void setOptionalEntityName(String entityName)
-    {
-        this.delegate.setOptionalEntityName(entityName);
-    }
-
-    @Override
-    public void setOptionalObject(Object optionalObject)
-    {
-        this.delegate.setOptionalObject(optionalObject);
-    }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/legacy/LegacyQueryImplementor.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/legacy/LegacyQueryImplementor.java
@@ -19,31 +19,23 @@
  */
 package com.xpn.xwiki.internal.store.hibernate.legacy;
 
-import java.io.Serializable;
-import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
-import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
-import java.util.Locale;
 
-import javax.persistence.Parameter;
-import javax.persistence.TemporalType;
+import jakarta.persistence.Parameter;
+import jakarta.persistence.TemporalType;
 
-import org.hibernate.query.Query;
+import org.hibernate.query.BindableType;
 import org.hibernate.query.spi.QueryImplementor;
-import org.hibernate.type.Type;
 
 import com.xpn.xwiki.internal.store.hibernate.QueryImplementorDelegate;
 
 /**
  * Wrap a QueryImplementor to convert the positional parameters from legacy 0-based Hibernate parameters to 1-based JPA
  * parameters.
- * 
+ *
  * @param <R> query result type
  * @version $Id$
  * @since 11.5RC1
@@ -61,232 +53,75 @@ public class LegacyQueryImplementor<R> extends QueryImplementorDelegate<R>
     }
 
     @Override
-    public Query<R> setParameter(int position, Calendar value, TemporalType temporalType)
-    {
-        return super.setParameter(position + 1, value, temporalType);
-    }
-
-    @Override
-    public Query<R> setParameter(int position, Date value, TemporalType temporalType)
-    {
-        return super.setParameter(position + 1, value, temporalType);
-    }
-
-    @Override
-    public Query<R> setParameter(int position, Instant value, TemporalType temporalType)
-    {
-        return super.setParameter(position + 1, value, temporalType);
-    }
-
-    @Override
-    public Query<R> setParameter(int position, LocalDateTime value, TemporalType temporalType)
-    {
-        return super.setParameter(position + 1, value, temporalType);
-    }
-
-    @Override
-    public Query<R> setParameter(int position, Object val, TemporalType temporalType)
-    {
-        return super.setParameter(position + 1, val, temporalType);
-    }
-
-    @Override
-    public Query<R> setParameter(int position, Object val, Type type)
-    {
-        return super.setParameter(position + 1, val, type);
-    }
-
-    @Override
-    public Query<R> setParameter(int position, Object value)
+    public QueryImplementor<R> setParameter(int position, Object value)
     {
         return super.setParameter(position + 1, value);
     }
 
     @Override
-    public Query<R> setParameter(int position, OffsetDateTime value, TemporalType temporalType)
+    public <P> QueryImplementor<R> setParameter(int position, P value, Class<P> type)
+    {
+        return super.setParameter(position + 1, value, type);
+    }
+
+    @Override
+    public <P> QueryImplementor<R> setParameter(int position, P value, BindableType<P> type)
+    {
+        return super.setParameter(position + 1, value, type);
+    }
+
+    @Override
+    public QueryImplementor<R> setParameter(int position, Instant value, TemporalType temporalType)
     {
         return super.setParameter(position + 1, value, temporalType);
     }
 
     @Override
-    public Query<R> setParameter(int position, ZonedDateTime value, TemporalType temporalType)
+    public QueryImplementor<R> setParameter(int position, Calendar value, TemporalType temporalType)
     {
         return super.setParameter(position + 1, value, temporalType);
     }
 
     @Override
-    @Deprecated
-    public Query<R> setBigDecimal(int position, BigDecimal val)
+    public QueryImplementor<R> setParameter(int position, Date value, TemporalType temporalType)
     {
-        return super.setBigDecimal(position + 1, val);
+        return super.setParameter(position + 1, value, temporalType);
     }
 
     @Override
-    @Deprecated
-    public Query<R> setBigInteger(int position, BigInteger val)
-    {
-        return super.setBigInteger(position + 1, val);
-    }
-
-    @Override
-    @Deprecated
-    public Query<R> setBinary(int position, byte[] val)
-    {
-        return super.setBinary(position + 1, val);
-    }
-
-    @Override
-    @Deprecated
-    public Query<R> setBoolean(int position, boolean val)
-    {
-        return super.setBoolean(position + 1, val);
-    }
-
-    @Override
-    @Deprecated
-    public Query<R> setByte(int position, byte val)
-    {
-        return super.setByte(position + 1, val);
-    }
-
-    @Override
-    @Deprecated
-    public Query<R> setCalendar(int position, Calendar val)
-    {
-        return super.setCalendar(position + 1, val);
-    }
-
-    @Override
-    @Deprecated
-    public Query<R> setCalendarDate(int position, Calendar val)
-    {
-        return super.setCalendarDate(position + 1, val);
-    }
-
-    @Override
-    @Deprecated
-    public Query<R> setCharacter(int position, char val)
-    {
-        return super.setCharacter(position + 1, val);
-    }
-
-    @Override
-    @Deprecated
-    public Query<R> setDate(int position, Date val)
-    {
-        return super.setDate(position + 1, val);
-    }
-
-    @Override
-    @Deprecated
-    public Query<R> setDouble(int position, double val)
-    {
-        return super.setDouble(position + 1, val);
-    }
-
-    @Override
-    @Deprecated
-    public Query<R> setEntity(int position, Object val)
-    {
-        return super.setEntity(position + 1, val);
-    }
-
-    @Override
-    @Deprecated
-    public Query<R> setFloat(int position, float val)
-    {
-        return super.setFloat(position + 1, val);
-    }
-
-    @Override
-    @Deprecated
-    public Query<R> setInteger(int position, int val)
-    {
-        return super.setInteger(position + 1, val);
-    }
-
-    @Override
-    @Deprecated
-    public Query<R> setLocale(int position, Locale val)
-    {
-        return super.setLocale(position + 1, val);
-    }
-
-    @Override
-    @Deprecated
-    public Query<R> setLong(int position, long val)
-    {
-        return super.setLong(position + 1, val);
-    }
-
-    @Override
-    @Deprecated
-    public org.hibernate.Query<R> setParameterList(int position, Collection values)
+    public QueryImplementor<R> setParameterList(int position, @SuppressWarnings("rawtypes") Collection values)
     {
         return super.setParameterList(position + 1, values);
     }
 
     @Override
-    @Deprecated
-    public org.hibernate.Query<R> setParameterList(int position, Collection values, Type type)
+    public <P> QueryImplementor<R> setParameterList(int position, Collection<? extends P> values, Class<P> javaType)
+    {
+        return super.setParameterList(position + 1, values, javaType);
+    }
+
+    @Override
+    public <P> QueryImplementor<R> setParameterList(int position, Collection<? extends P> values, BindableType<P> type)
     {
         return super.setParameterList(position + 1, values, type);
     }
 
     @Override
-    @Deprecated
-    public org.hibernate.Query<R> setParameterList(int position, Object[] values)
+    public QueryImplementor<R> setParameterList(int position, Object[] values)
     {
         return super.setParameterList(position + 1, values);
     }
 
     @Override
-    @Deprecated
-    public org.hibernate.Query<R> setParameterList(int position, Object[] values, Type type)
+    public <P> QueryImplementor<R> setParameterList(int position, P[] values, Class<P> javaType)
+    {
+        return super.setParameterList(position + 1, values, javaType);
+    }
+
+    @Override
+    public <P> QueryImplementor<R> setParameterList(int position, P[] values, BindableType<P> type)
     {
         return super.setParameterList(position + 1, values, type);
-    }
-
-    @Override
-    @Deprecated
-    public Query<R> setSerializable(int position, Serializable val)
-    {
-        return super.setSerializable(position + 1, val);
-    }
-
-    @Override
-    @Deprecated
-    public Query<R> setShort(int position, short val)
-    {
-        return super.setShort(position + 1, val);
-    }
-
-    @Override
-    @Deprecated
-    public Query<R> setString(int position, String val)
-    {
-        return super.setString(position + 1, val);
-    }
-
-    @Override
-    @Deprecated
-    public Query<R> setText(int position, String val)
-    {
-        return super.setText(position + 1, val);
-    }
-
-    @Override
-    @Deprecated
-    public Query<R> setTime(int position, Date val)
-    {
-        return super.setTime(position + 1, val);
-    }
-
-    @Override
-    @Deprecated
-    public Query<R> setTimestamp(int position, Date val)
-    {
-        return super.setTimestamp(position + 1, val);
     }
 
     @Override
@@ -305,12 +140,5 @@ public class LegacyQueryImplementor<R> extends QueryImplementorDelegate<R>
     public Object getParameterValue(int position)
     {
         return super.getParameterValue(position + 1);
-    }
-
-    @Override
-    @Deprecated
-    public Type determineProperBooleanType(int position, Object value, Type defaultType)
-    {
-        return super.determineProperBooleanType(position + 1, value, defaultType);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/legacy/LegacySessionImplementor.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/legacy/LegacySessionImplementor.java
@@ -19,13 +19,10 @@
  */
 package com.xpn.xwiki.internal.store.hibernate.legacy;
 
-import java.util.Collections;
 import java.util.regex.Pattern;
 
-import org.hibernate.QueryException;
 import org.hibernate.engine.spi.SessionDelegatorBaseImpl;
 import org.hibernate.engine.spi.SessionImplementor;
-import org.hibernate.hql.spi.QueryTranslator;
 import org.hibernate.query.spi.QueryImplementor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,9 +46,6 @@ import com.xpn.xwiki.internal.store.hibernate.query.HqlQueryUtils;
 public class LegacySessionImplementor extends SessionDelegatorBaseImpl
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(XWiki.class);
-
-    private static final String LEGACY_ORDINAL_PARAMS_PREFIX =
-        QueryTranslator.ERROR_LEGACY_ORDINAL_PARAMS_NO_LONGER_SUPPORTED.substring(0, 115);
 
     private static final Pattern LEGACY_MATCHER = Pattern.compile("\\?($|[^\\d])");
 
@@ -93,23 +87,15 @@ public class LegacySessionImplementor extends SessionDelegatorBaseImpl
 
     private String checkStatement(String statement)
     {
-        // Check if the statement might (it's not using the real hql parser to limit the number of fully parser
-        // statements) contain legacy HQL ordinal parameters
+        // Check if the statement might (it's not using the real hql parser to limit the number of fully parsed
+        // statements) contain legacy HQL ordinal parameters.
+        // Note: Hibernate 6 removed org.hibernate.hql.spi.QueryTranslator (and its
+        // ERROR_LEGACY_ORDINAL_PARAMS_NO_LONGER_SUPPORTED marker) as well as the SessionFactory query plan cache API
+        // that were previously used to confirm that the statement actually failed because of legacy ordinal
+        // parameters before converting it. As a faithful equivalent we now rely solely on the heuristic matcher to
+        // decide whether to convert the legacy ordinal parameters.
         if (containsLegacyOrdinalStatement(statement)) {
-            // Check if the statement is valid and if not translate it
-            // FIXME: find a more efficient way (we currently parse and validate the statement twice, plus the if which
-            // is parsing the statement String...). The problem is that when createQuery fail it's too late and the
-            // session is dead (marked as rollback only) and it's not possible to avoid it without reimplementing a lot
-            // of stuff.
-            try {
-                getFactory().getQueryPlanCache().getHQLQueryPlan(statement, false, Collections.emptyMap());
-            } catch (QueryException e) {
-                if (e.getMessage() != null && e.getMessage().contains(LEGACY_ORDINAL_PARAMS_PREFIX)) {
-                    return replaceLegacyQueryParameters(statement);
-                }
-
-                throw e;
-            }
+            return replaceLegacyQueryParameters(statement);
         }
 
         return null;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateBaseStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateBaseStore.java
@@ -395,7 +395,7 @@ public class XWikiHibernateBaseStore extends AbstractXWikiStore
                         // Ignore errors in the log during the creation of the sequence since we know it can fail and we
                         // don't want to show false positives to the user.
                         this.loggerManager.pushLogListener(null);
-                        session.createSQLQuery(sequenceSQL).executeUpdate();
+                        session.createNativeQuery(sequenceSQL).executeUpdate();
                     } catch (HibernateException e) {
                         // Sequence failed to be created, we assume it already exists and that's why an exception was
                         // raised!
@@ -435,7 +435,7 @@ public class XWikiHibernateBaseStore extends AbstractXWikiStore
             for (String element : createSQL) {
                 sql = element;
                 LOGGER.debug("Update Schema sql: [{}]", sql);
-                session.createSQLQuery(sql).executeUpdate();
+                session.createNativeQuery(sql).executeUpdate();
             }
             session.getTransaction().commit();
         } catch (Exception e) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateRecycleBinStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateRecycleBinStore.java
@@ -27,11 +27,11 @@ import java.util.Objects;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Path;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
 
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.hibernate.HibernateException;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
@@ -3128,7 +3128,7 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
             return true;
         }
 
-        Iterator<Property> it = mapping.getPropertyIterator();
+        Iterator<Property> it = mapping.getProperties().iterator();
         while (it.hasNext()) {
             Property hibprop = it.next();
             String propname = hibprop.getName();
@@ -3164,7 +3164,7 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
             return null;
         }
 
-        Iterator<Property> it = mapping.getPropertyIterator();
+        Iterator<Property> it = mapping.getProperties().iterator();
         while (it.hasNext()) {
             Property hibprop = it.next();
             String propname = hibprop.getName();

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/HibernateAttachmentRecycleBinStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/HibernateAttachmentRecycleBinStore.java
@@ -26,10 +26,10 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/query/HqlQueryExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/query/HqlQueryExecutor.java
@@ -35,8 +35,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.hibernate.Session;
 import org.hibernate.cfg.Configuration;
-import org.hibernate.engine.spi.NamedQueryDefinition;
-import org.hibernate.engine.spi.NamedSQLQueryDefinition;
+import org.hibernate.boot.query.NamedNativeQueryDefinition;
 import org.hibernate.query.NativeQuery;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
@@ -126,19 +125,21 @@ public class HqlQueryExecutor extends AbstractQueryExecutor implements Initializ
                 if (this.safeNamedQueries == null) {
                     Set<String> safeQueries = new HashSet<>();
 
-                    // Gather the list of allowed named queries
-                    Collection<NamedQueryDefinition> namedQueries =
-                        this.hibernate.getConfigurationMetadata().getNamedQueryDefinitions();
-                    for (NamedQueryDefinition definition : namedQueries) {
+                    // Gather the list of allowed named queries.
+                    // Note: Hibernate 6 replaced Metadata#getNamedQueryDefinitions() (which returned a Collection of
+                    // org.hibernate.engine.spi.NamedQueryDefinition) with a visitor over
+                    // org.hibernate.boot.query.NamedHqlQueryDefinition.
+                    this.hibernate.getConfigurationMetadata().visitNamedHqlQueryDefinitions(definition -> {
                         try {
-                            if (this.queryValidator.isSafe(definition.getQuery())) {
-                                safeQueries.add(definition.getName());
+                            if (this.queryValidator.isSafe(definition.getHqlString())) {
+                                safeQueries.add(definition.getRegistrationName());
                             }
                         } catch (QueryException e) {
                             this.logger.warn("Failed to validate named query [{}] with statement [{}]: {}",
-                                definition.getName(), definition.getQuery(), ExceptionUtils.getRootCauseMessage(e));
+                                definition.getRegistrationName(), definition.getHqlString(),
+                                ExceptionUtils.getRootCauseMessage(e));
                         }
-                    }
+                    });
 
                     this.safeNamedQueries = safeQueries;
                 }
@@ -359,7 +360,13 @@ public class HqlQueryExecutor extends AbstractQueryExecutor implements Initializ
             // the execution.
             boolean isNative = hQuery instanceof NativeQuery;
             String language = isNative ? "sql" : Query.HQL;
-            final String statement = hQuery.getQueryString();
+            // On Hibernate 6, a named native query's NativeQuery#getQueryString() has its named parameters rewritten to
+            // positional ones, which later clashes with filters that add named parameters ("Cannot mix parameter
+            // styles"). Source the base statement from the original mapped SQL, which keeps its named parameters.
+            NamedNativeQueryDefinition nativeDefinition = isNative
+                ? this.hibernate.getConfigurationMetadata().getNamedNativeQueryMapping(query.getStatement()) : null;
+            final String statement =
+                nativeDefinition != null ? nativeDefinition.getSqlQueryString() : hQuery.getQueryString();
 
             // Run filters
             filteredQuery = filterQuery(new WrappingQuery(filteredQuery)
@@ -372,12 +379,15 @@ public class HqlQueryExecutor extends AbstractQueryExecutor implements Initializ
             }, language);
 
             if (isNative) {
-                hQuery = session.createSQLQuery(filteredQuery.getStatement());
                 // Copy the information about the return column types, if possible.
-                NamedSQLQueryDefinition definition =
-                    this.hibernate.getConfigurationMetadata().getNamedNativeQueryDefinition(query.getStatement());
-                if (!StringUtils.isEmpty(definition.getResultSetRef())) {
-                    ((NativeQuery<T>) hQuery).setResultSetMapping(definition.getResultSetRef());
+                // Note: Hibernate 6 removed NativeQuery#setResultSetMapping(String); the result set mapping can only
+                // be provided when the native query is created, so we pass it to createNativeQuery directly.
+                String resultSetMappingName =
+                    nativeDefinition == null ? null : nativeDefinition.getResultSetMappingName();
+                if (!StringUtils.isEmpty(resultSetMappingName)) {
+                    hQuery = session.createNativeQuery(filteredQuery.getStatement(), resultSetMappingName);
+                } else {
+                    hQuery = session.createNativeQuery(filteredQuery.getStatement());
                 }
             } else {
                 hQuery = session.createQuery(filteredQuery.getStatement());

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/query/VersioningStoreQueryFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/query/VersioningStoreQueryFactory.java
@@ -23,11 +23,11 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
-import javax.persistence.criteria.Subquery;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
 
 import org.hibernate.Session;
 import org.hibernate.query.Query;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/AbstractDropNotNullDataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/AbstractDropNotNullDataMigration.java
@@ -21,7 +21,6 @@
 package com.xpn.xwiki.store.migration.hibernate;
 
 import org.hibernate.boot.Metadata;
-import org.hibernate.dialect.Dialect;
 import org.hibernate.mapping.Column;
 import org.hibernate.mapping.PersistentClass;
 
@@ -55,11 +54,10 @@ public abstract class AbstractDropNotNullDataMigration extends AbstractHibernate
     public String getLiquibaseChangeLog() throws DataMigrationException
     {
         XWikiHibernateBaseStore store = getStore();
-        Dialect dialect = store.getDialect();
         Metadata metadata = store.getMetadata();
         PersistentClass pClass = metadata.getEntityBinding(this.table.getName());
-        Column column = ((Column) pClass.getProperty(this.property).getColumnIterator().next());
-        String columnType = column.getSqlType(dialect, metadata);
+        Column column = ((Column) pClass.getProperty(this.property).getColumns().get(0));
+        String columnType = column.getSqlType(metadata);
 
         StringBuilder builder = new StringBuilder();
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/AbstractResizeMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/AbstractResizeMigration.java
@@ -166,7 +166,7 @@ public abstract class AbstractResizeMigration extends AbstractHibernateDataMigra
         Map<String, String> rowFormats, StringBuilder builder, Session session)
         throws SQLException, HibernateStoreException
     {
-        int expectedLenght = column.getLength();
+        int expectedLenght = column.getLength().intValue();
 
         if (expectedLenght >= MAXSIZE_MIN && expectedLenght <= MAXSIZE_MAX) {
             Integer databaseSize = getDatabaseSize(column, databaseMetaData);
@@ -214,11 +214,11 @@ public abstract class AbstractResizeMigration extends AbstractHibernateDataMigra
         if (value instanceof Collection collection) {
             Table collectionTable = collection.getCollectionTable();
 
-            for (Iterator<Column> it = collectionTable.getColumnIterator(); it.hasNext();) {
+            for (Iterator<Column> it = collectionTable.getColumns().iterator(); it.hasNext();) {
                 updateColumn(it.next(), databaseMetaData, dynamicTables, rowFormats, builder, session);
             }
         } else if (value != null) {
-            for (Iterator<Selectable> it = value.getColumnIterator(); it.hasNext();) {
+            for (Iterator<Selectable> it = value.getSelectables().iterator(); it.hasNext();) {
                 Selectable selectable = it.next();
                 if (selectable instanceof Column column) {
                     updateColumn(column, databaseMetaData, dynamicTables, rowFormats, builder, session);
@@ -334,7 +334,7 @@ public abstract class AbstractResizeMigration extends AbstractHibernateDataMigra
     {
         for (PersistentClass entity : existingTables) {
             // Find properties to update
-            for (Iterator<Property> it = entity.getPropertyIterator(); it.hasNext();) {
+            for (Iterator<Property> it = entity.getProperties().iterator(); it.hasNext();) {
                 updateProperty(it.next(), databaseMetaData, dynamicTables, rowFormats, builder, session);
             }
 
@@ -426,7 +426,7 @@ public abstract class AbstractResizeMigration extends AbstractHibernateDataMigra
                 builder);
             appendXmlAttribute("columnName", this.hibernateStore.getConfiguredColumnName(column), builder);
             appendXmlAttribute("newDataType",
-                column.getSqlType(this.hibernateStore.getDialect(), this.hibernateStore.getConfigurationMetadata()),
+                column.getSqlType(this.hibernateStore.getConfigurationMetadata()),
                 builder);
             builder.append("/>");
         }
@@ -436,7 +436,7 @@ public abstract class AbstractResizeMigration extends AbstractHibernateDataMigra
     {
         Dialect dialect = this.hibernateStore.getDialect();
 
-        StringBuilder builder = new StringBuilder(column.getSqlType(dialect, configurationMetadata));
+        StringBuilder builder = new StringBuilder(column.getSqlType(configurationMetadata));
 
         if (column.isNullable()) {
             builder.append(dialect.getNullColumnString());

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/HibernateDataMigrationManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/HibernateDataMigrationManager.java
@@ -27,9 +27,9 @@ import java.util.Map;
 
 import javax.inject.Named;
 import javax.inject.Singleton;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Root;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
 
 import org.hibernate.HibernateException;
 import org.hibernate.Session;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R130200000XWIKI17200DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R130200000XWIKI17200DataMigration.java
@@ -33,6 +33,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.hibernate.boot.Metadata;
+import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
 import org.hibernate.engine.spi.SessionImplementor;
@@ -216,12 +217,15 @@ public class R130200000XWIKI17200DataMigration extends AbstractHibernateDataMigr
             if (resultSet.next()) {
                 String currentColumnType = resultSet.getString("TYPE_NAME");
 
-                Column column = (Column) property.getColumnIterator().next();
+                Column column = (Column) property.getColumns().get(0);
+                // Note: Hibernate 6 removed Dialect#getTypeName(int); the DDL type name for a SQL type code is now
+                // resolved through the DdlTypeRegistry.
                 String expectedColumnType =
-                    this.hibernateStore.getDialect().getTypeName(column.getSqlTypeCode(configurationMetadata));
+                    ((MetadataImplementor) configurationMetadata).getTypeConfiguration().getDdlTypeRegistry()
+                        .getTypeName(column.getSqlTypeCode(configurationMetadata), this.hibernateStore.getDialect());
 
                 if (!currentColumnType.equalsIgnoreCase(expectedColumnType)) {
-                    int expectedLenght = column.getLength();
+                    int expectedLenght = column.getLength().intValue();
 
                     int currentColumnSize = resultSet.getInt("COLUMN_SIZE");
 
@@ -250,7 +254,7 @@ public class R130200000XWIKI17200DataMigration extends AbstractHibernateDataMigr
     {
         Dialect dialect = this.hibernateStore.getDialect();
 
-        StringBuilder builder = new StringBuilder(column.getSqlType(dialect, configurationMetadata));
+        StringBuilder builder = new StringBuilder(column.getSqlType(configurationMetadata));
 
         if (column.isNullable()) {
             builder.append(dialect.getNullColumnString());

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R40000XWIKI6990DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R40000XWIKI6990DataMigration.java
@@ -294,7 +294,7 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
             sb.append("UPDATE ").append(name).append(" SET ").append(field).append('=').append(':').append(NEWID)
                 .append(" WHERE ").append(field).append('=').append(':').append(OLDID);
             long now = System.nanoTime();
-            this.session.createSQLQuery(sb.toString()).setParameter(NEWID, this.currentNewId).setParameter(OLDID, this.currentOldId)
+            this.session.createNativeQuery(sb.toString()).setParameter(NEWID, this.currentNewId).setParameter(OLDID, this.currentOldId)
                 .executeUpdate();
             return System.nanoTime() - now;
         }
@@ -509,7 +509,7 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
 
         if (pClass != null) {
             @SuppressWarnings("unchecked")
-            Iterator<Property> it = pClass.getPropertyIterator();
+            Iterator<Property> it = pClass.getProperties().iterator();
             while (it.hasNext()) {
                 Property property = it.next();
                 if (property.getType().isCollectionType()) {
@@ -554,7 +554,7 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
      */
     private String getKeyColumnName(org.hibernate.mapping.Collection coll)
     {
-        return ((Column) coll.getKey().getColumnIterator().next()).getName();
+        return ((Column) coll.getKey().getColumns().get(0)).getName();
     }
 
     /**
@@ -578,9 +578,9 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
     private String getColumnName(PersistentClass pClass, String propertyName)
     {
         if (propertyName != null) {
-            return ((Column) pClass.getProperty(propertyName).getColumnIterator().next()).getName();
+            return ((Column) pClass.getProperty(propertyName).getColumns().get(0)).getName();
         }
-        return ((Column) pClass.getKey().getColumnIterator().next()).getName();
+        return ((Column) pClass.getKey().getColumns().get(0)).getName();
     }
 
     @Override
@@ -919,7 +919,7 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
                 pkName = getStore().failSafeExecuteRead(getXWikiContext(), session -> {
                     // Retrieve the constraint name from the database
                     return (String) session
-                        .createSQLQuery("SELECT CONSTRAINT_NAME FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS"
+                        .createNativeQuery("SELECT CONSTRAINT_NAME FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS"
                             + " WHERE TABLE_NAME = :tableName AND CONSTRAINT_TYPE = 'PRIMARY KEY'")
                         .setParameter("tableName", tableName).uniqueResult();
                 });
@@ -951,7 +951,7 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
 
         sb.append("    <addPrimaryKey tableName=\"").append(table.getName()).append("\"  columnNames=\"");
 
-        Iterator<Column> columns = pk.getColumnIterator();
+        Iterator<Column> columns = pk.getColumns().iterator();
         while (columns.hasNext()) {
             Column column = columns.next();
             sb.append(column.getName());
@@ -990,7 +990,7 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
         sb.append("    <createIndex tableName=\"").append(index.getTable().getName()).append("\"  indexName=\"")
             .append(index.getName()).append("\">\n");
 
-        Iterator<Column> columns = index.getColumnIterator();
+        Iterator<Column> columns = index.getColumns().iterator();
         while (columns.hasNext()) {
             Column column = columns.next();
             sb.append("      <column name=\"").append(column.getName()).append("\"/>\n");
@@ -1043,7 +1043,7 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
             }
 
             // We drop all index related to the table, this is overkill, but does not hurt
-            for (Iterator<Index> it = table.getIndexIterator(); it.hasNext();) {
+            for (Iterator<Index> it = table.getIndexes().values().iterator(); it.hasNext();) {
                 Index index = it.next();
                 appendDropIndex(sb, index);
             }
@@ -1057,7 +1057,7 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
                 appendAddPrimaryKey(sb, table);
             }
 
-            for (Iterator<Index> it = table.getIndexIterator(); it.hasNext();) {
+            for (Iterator<Index> it = table.getIndexes().values().iterator(); it.hasNext();) {
                 Index index = it.next();
                 appendAddIndex(sb, index);
             }
@@ -1124,7 +1124,7 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
             }
 
             @SuppressWarnings("unchecked")
-            Iterator<Property> it = pClass.getPropertyIterator();
+            Iterator<Property> it = pClass.getProperties().iterator();
             while (it.hasNext()) {
                 Property property = it.next();
                 if (property.getType().isCollectionType()) {
@@ -1204,7 +1204,7 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
 
                 // Reuse the data from the old foreign key
                 // Columns in the current table
-                Iterator<Column> columns = fk.getColumnIterator();
+                Iterator<Column> columns = fk.getColumns().iterator();
                 while (columns.hasNext()) {
                     Column column = columns.next();
                     sb.append(column.getName());
@@ -1216,7 +1216,7 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
                     .append("\" referencedColumnNames=\"");
 
                 // Columns in the referenced table
-                columns = fk.getReferencedTable().getPrimaryKey().getColumnIterator();
+                columns = fk.getReferencedTable().getPrimaryKey().getColumns().iterator();
                 while (columns.hasNext()) {
                     Column column = columns.next();
                     sb.append(column.getName());
@@ -1259,7 +1259,7 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
         this.isMySQL = true;
 
         String createTable = store.failSafeExecuteRead(getXWikiContext(), session -> {
-            NativeQuery<Object[]> query = session.createSQLQuery("SHOW TABLE STATUS like 'xwikidoc'");
+            NativeQuery<Object[]> query = session.createNativeQuery("SHOW TABLE STATUS like 'xwikidoc'");
             return (String) query.uniqueResult()[1];
         });
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R4359XWIKI1459DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R4359XWIKI1459DataMigration.java
@@ -27,9 +27,9 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.hibernate.HibernateException;
-import org.hibernate.SQLQuery;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
+import org.hibernate.query.NativeQuery;
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.manager.ComponentLookupException;
@@ -106,7 +106,7 @@ public class R4359XWIKI1459DataMigration extends AbstractHibernateDataMigration
                         // XWD_ARCHIVE column had a not null constraint and since this column has disappeared in 1.2
                         // and after, the hibernate update script will not have modified the nullability of it...
                         // (see https://jira.xwiki.org/browse/XWIKI-2074).
-                        rs = session.createSQLQuery("select XWD_ID, XWD_ARCHIVE, XWD_FULLNAME from xwikidoc"
+                        rs = session.createNativeQuery("select XWD_ID, XWD_ARCHIVE, XWD_FULLNAME from xwikidoc"
                             + " where (XWD_ARCHIVE is not null and XWD_ARCHIVE <> ' ') order by XWD_VERSION").list();
                     } catch (HibernateException e) {
                         // most likely there is no XWD_ARCHIVE column, so migration is not needed
@@ -119,8 +119,8 @@ public class R4359XWIKI1459DataMigration extends AbstractHibernateDataMigration
                     Transaction originalTransaction = versioningStore.getTransaction(context);
                     versioningStore.setSession(null, context);
                     versioningStore.setTransaction(null, context);
-                    SQLQuery deleteStatement =
-                            session.createSQLQuery("update xwikidoc set XWD_ARCHIVE=' ' where XWD_ID=?");
+                    NativeQuery<?> deleteStatement =
+                            session.createNativeQuery("update xwikidoc set XWD_ARCHIVE=' ' where XWD_ID=?");
 
                     for (Object[] result : rs) {
                         if (R4359XWIKI1459DataMigration.this.logger.isInfoEnabled()) {
@@ -150,7 +150,7 @@ public class R4359XWIKI1459DataMigration extends AbstractHibernateDataMigration
                                     "Empty revision found for document [{}]. Ignoring non-fatal error.",
                                     result[2].toString());
                         }
-                        deleteStatement.setLong(1, docId);
+                        deleteStatement.setParameter(1, docId);
                         deleteStatement.executeUpdate();
                     }
                     versioningStore.setSession(session, context);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R7350XWIKI2079DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R7350XWIKI2079DataMigration.java
@@ -68,14 +68,14 @@ public class R7350XWIKI2079DataMigration extends AbstractHibernateDataMigration
             public Object doInHibernate(Session session) throws HibernateException, XWikiException
             {
                 try {
-                    session.createSQLQuery("ALTER TABLE xwikidoc DROP COLUMN XWD_ARCHIVE").executeUpdate();
+                    session.createNativeQuery("ALTER TABLE xwikidoc DROP COLUMN XWD_ARCHIVE").executeUpdate();
                 } catch (HibernateException ex) {
                     // Maybe the column doesn't exist. Anyway, in case we're using a DBMS which
                     // doesn't support DROP COLUMN (such as Derby < 10.3.1.4), we can try to alter
                     // the column to allow NULL values.
                     // TODO Can we check the exception and see what is happening?
                     try {
-                        session.createSQLQuery("ALTER TABLE xwikidoc ALTER COLUMN XWD_ARCHIVE " + "SET DEFAULT ' '")
+                        session.createNativeQuery("ALTER TABLE xwikidoc ALTER COLUMN XWD_ARCHIVE " + "SET DEFAULT ' '")
                                 .executeUpdate();
                     } catch (HibernateException ex2) {
                         // Maybe the column doesn't exist, after all.

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/AbstractHibernateAdapter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/AbstractHibernateAdapter.java
@@ -21,6 +21,7 @@ package org.xwiki.store.hibernate;
 
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import javax.inject.Inject;
@@ -31,11 +32,22 @@ import org.hibernate.HibernateException;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.boot.Metadata;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.dialect.Dialect;
+import org.hibernate.engine.config.spi.ConfigurationService;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Table;
-import org.hibernate.tool.hbm2ddl.SchemaUpdate;
 import org.hibernate.tool.schema.TargetType;
+import org.hibernate.tool.schema.internal.ExceptionHandlerCollectingImpl;
+import org.hibernate.tool.schema.spi.CommandAcceptanceException;
+import org.hibernate.tool.schema.spi.ContributableMatcher;
+import org.hibernate.tool.schema.spi.ExecutionOptions;
+import org.hibernate.tool.schema.spi.SchemaManagementTool;
+import org.hibernate.tool.schema.spi.SchemaManagementToolCoordinator;
+import org.hibernate.tool.schema.spi.SchemaMigrator;
+import org.hibernate.tool.schema.spi.ScriptTargetOutput;
+import org.hibernate.tool.schema.spi.TargetDescriptor;
 import org.slf4j.Logger;
 import org.xwiki.stability.Unstable;
 import org.xwiki.wiki.descriptor.WikiDescriptorManager;
@@ -218,9 +230,39 @@ public abstract class AbstractHibernateAdapter implements HibernateAdapter
 
     private void updateDatabaseStandard(Metadata metadata) throws HibernateStoreException
     {
-        SchemaUpdate updater = new SchemaUpdate();
-        updater.execute(EnumSet.of(TargetType.DATABASE), metadata);
-        List<Exception> exceptions = updater.getExceptions();
+        // Note: Hibernate 6 removed org.hibernate.tool.hbm2ddl.SchemaUpdate. The faithful equivalent is to run the
+        // SchemaMigrator obtained from the SchemaManagementTool service, which is exactly what SchemaUpdate did
+        // internally. Errors are collected through an ExceptionHandlerCollectingImpl to preserve the previous
+        // "log all errors then fail" behavior.
+        StandardServiceRegistry serviceRegistry =
+            ((MetadataImplementor) metadata).getMetadataBuildingOptions().getServiceRegistry();
+        SchemaManagementTool schemaManagementTool = serviceRegistry.getService(SchemaManagementTool.class);
+        Map<String, Object> configuration = serviceRegistry.getService(ConfigurationService.class).getSettings();
+
+        ExceptionHandlerCollectingImpl exceptionHandler = new ExceptionHandlerCollectingImpl();
+        ExecutionOptions executionOptions =
+            SchemaManagementToolCoordinator.buildExecutionOptions(configuration, exceptionHandler);
+
+        TargetDescriptor targetDescriptor = new TargetDescriptor()
+        {
+            @Override
+            public EnumSet<TargetType> getTargetTypes()
+            {
+                return EnumSet.of(TargetType.DATABASE);
+            }
+
+            @Override
+            public ScriptTargetOutput getScriptTargetOutput()
+            {
+                // Not used when the target is the database only.
+                return null;
+            }
+        };
+
+        SchemaMigrator schemaMigrator = schemaManagementTool.getSchemaMigrator(configuration);
+        schemaMigrator.doMigration(metadata, executionOptions, ContributableMatcher.ALL, targetDescriptor);
+
+        List<CommandAcceptanceException> exceptions = exceptionHandler.getExceptions();
 
         if (!exceptions.isEmpty()) {
             // Print the errors

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/XWikiHibernateStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/XWikiHibernateStoreTest.java
@@ -284,12 +284,12 @@ class XWikiHibernateStoreTest
         when(this.hibernateStore.getDialect()).thenReturn(dialect);
         when(dialect.getNativeIdentifierGeneratorStrategy()).thenReturn("sequence");
         NativeQuery sqlQuery = mock(NativeQuery.class);
-        when(session.createSQLQuery("create sequence schema.hibernate_sequence")).thenReturn(sqlQuery);
+        when(session.createNativeQuery("create sequence schema.hibernate_sequence")).thenReturn(sqlQuery);
         when(sqlQuery.executeUpdate()).thenReturn(0);
 
         this.store.createHibernateSequenceIfRequired(new String[] {}, "schema", session);
 
-        verify(session).createSQLQuery("create sequence schema.hibernate_sequence");
+        verify(session).createNativeQuery("create sequence schema.hibernate_sequence");
         verify(sqlQuery).executeUpdate();
     }
 
@@ -304,13 +304,13 @@ class XWikiHibernateStoreTest
         when(this.hibernateStore.getDialect()).thenReturn(dialect);
         when(dialect.getNativeIdentifierGeneratorStrategy()).thenReturn("sequence");
         NativeQuery sqlQuery = mock(NativeQuery.class);
-        when(session.createSQLQuery("create sequence schema.hibernate_sequence")).thenReturn(sqlQuery);
+        when(session.createNativeQuery("create sequence schema.hibernate_sequence")).thenReturn(sqlQuery);
         when(sqlQuery.executeUpdate()).thenReturn(0);
 
         this.store.createHibernateSequenceIfRequired(
             new String[] {"whatever", "create sequence schema.hibernate_sequence"}, "schema", session);
 
-        verify(session, never()).createSQLQuery("create sequence schema.hibernate_sequence");
+        verify(session, never()).createNativeQuery("create sequence schema.hibernate_sequence");
         verify(sqlQuery, never()).executeUpdate();
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/hibernate/query/HqlQueryExecutorTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/hibernate/query/HqlQueryExecutorTest.java
@@ -30,8 +30,8 @@ import javax.inject.Named;
 
 import org.hibernate.Session;
 import org.hibernate.boot.Metadata;
+import org.hibernate.boot.query.NamedNativeQueryDefinition;
 import org.hibernate.cfg.Configuration;
-import org.hibernate.engine.spi.NamedSQLQueryDefinition;
 import org.hibernate.query.NativeQuery;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -314,7 +314,6 @@ class HqlQueryExecutorTest
         Session session = mock(Session.class);
         NativeQuery sqlQuery = mock(NativeQuery.class);
         when(session.getNamedQuery(query.getStatement())).thenReturn(sqlQuery);
-        when(sqlQuery.getQueryString()).thenReturn("foo");
 
         // Add a Query Filter to verify it's called and can change the statement
         QueryFilter filter = mock(QueryFilter.class);
@@ -323,18 +322,18 @@ class HqlQueryExecutorTest
         when(filter.filterQuery(any(Query.class))).then(returnsFirstArg());
 
         NativeQuery finalQuery = mock(NativeQuery.class);
-        when(session.createSQLQuery("bar")).thenReturn(finalQuery);
+        when(session.createNativeQuery("bar", "someResultSet")).thenReturn(finalQuery);
 
-        NamedSQLQueryDefinition definition = mock(NamedSQLQueryDefinition.class);
-        when(definition.getResultSetRef()).thenReturn("someResultSet");
-        when(definition.getName()).thenReturn(query.getStatement());
+        // On Hibernate 6 the base statement comes from the original mapped SQL (which keeps its named parameters)
+        // rather than from NativeQuery#getQueryString() (which would have the named parameters rewritten to ?).
+        NamedNativeQueryDefinition definition = mock(NamedNativeQueryDefinition.class);
+        when(definition.getSqlQueryString()).thenReturn("foo");
+        when(definition.getResultSetMappingName()).thenReturn("someResultSet");
 
-        when(this.hibernateStore.getConfigurationMetadata().getNamedNativeQueryDefinition(query.getStatement()))
+        when(this.hibernateStore.getConfigurationMetadata().getNamedNativeQueryMapping(query.getStatement()))
             .thenReturn(definition);
 
         assertSame(finalQuery, this.executor.createHibernateQuery(session, query));
-
-        verify(finalQuery).setResultSetMapping(definition.getResultSetRef());
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/hibernate/query/VersioningStoreQueryFactoryTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/hibernate/query/VersioningStoreQueryFactoryTest.java
@@ -24,20 +24,23 @@ import java.util.Date;
 import java.util.List;
 import java.util.stream.Stream;
 
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Order;
-import javax.persistence.criteria.Path;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Order;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
 
 import org.hibernate.Session;
 import org.hibernate.query.Query;
-import org.hibernate.query.criteria.internal.CriteriaBuilderImpl;
-import org.hibernate.query.criteria.internal.OrderImpl;
-import org.hibernate.query.criteria.internal.expression.LiteralExpression;
-import org.hibernate.query.criteria.internal.predicate.BetweenPredicate;
-import org.hibernate.query.criteria.internal.predicate.ComparisonPredicate;
-import org.hibernate.query.criteria.internal.predicate.NullnessPredicate;
+import org.hibernate.query.criteria.HibernateCriteriaBuilder;
+import org.hibernate.query.criteria.JpaCriteriaQuery;
+import org.hibernate.query.criteria.JpaOrder;
+import org.hibernate.query.criteria.JpaRoot;
+import org.hibernate.query.sqm.ComparisonOperator;
+import org.hibernate.query.sqm.tree.domain.SqmPath;
+import org.hibernate.query.sqm.tree.expression.SqmLiteral;
+import org.hibernate.query.sqm.tree.predicate.SqmBetweenPredicate;
+import org.hibernate.query.sqm.tree.predicate.SqmComparisonPredicate;
+import org.hibernate.query.sqm.tree.predicate.SqmNullnessPredicate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -60,6 +63,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -77,16 +81,16 @@ public class VersioningStoreQueryFactoryTest
     private Session session;
 
     @Mock
-    private CriteriaBuilderImpl builder;
+    private HibernateCriteriaBuilder builder;
 
     @Mock
-    private Root<XWikiRCSNodeInfo> root;
+    private JpaRoot<XWikiRCSNodeInfo> root;
 
     @Mock
-    private CriteriaQuery<XWikiRCSNodeInfo> criteriaQueryNodeInfo;
+    private JpaCriteriaQuery<XWikiRCSNodeInfo> criteriaQueryNodeInfo;
 
     @Mock
-    private CriteriaQuery<Long> criteriaQueryLong;
+    private JpaCriteriaQuery<Long> criteriaQueryLong;
 
     @Mock
     private Query<XWikiRCSNodeInfo> queryNodeInfo;
@@ -108,42 +112,46 @@ public class VersioningStoreQueryFactoryTest
     {
         when(this.session.getCriteriaBuilder()).thenReturn(this.builder);
 
+        // The Hibernate builder overrides createQuery() with a covariant JpaCriteriaQuery return type, so the mocks
+        // are typed as JpaCriteriaQuery to match what Mockito sees on the concrete builder.
         when(this.builder.createQuery(XWikiRCSNodeInfo.class)).thenReturn(this.criteriaQueryNodeInfo);
         when(this.builder.createQuery(Long.class)).thenReturn(this.criteriaQueryLong);
 
         when(this.builder.equal(any(), any(Object.class))).thenAnswer(i -> {
-            ComparisonPredicate predicate = mock(ComparisonPredicate.class);
-            when(predicate.getComparisonOperator()).thenReturn(ComparisonPredicate.ComparisonOperator.EQUAL);
-            when(predicate.getLeftHandOperand()).thenReturn(i.getArgument(0));
-            when(predicate.getRightHandOperand()).thenReturn(new LiteralExpression(null, i.getArgument(1)));
+            SqmComparisonPredicate predicate = mock(SqmComparisonPredicate.class);
+            when(predicate.getSqmOperator()).thenReturn(ComparisonOperator.EQUAL);
+            // Use doReturn() so the mockLiteral() helper (which stubs its own mock) fully completes before this
+            // stubbing starts, avoiding a nested/unfinished-stubbing state.
+            doReturn(i.getArgument(0)).when(predicate).getLeftHandExpression();
+            doReturn(mockLiteral(i.getArgument(1))).when(predicate).getRightHandExpression();
             return predicate;
         });
 
         when(this.builder.isNotNull(any())).thenAnswer(i -> {
-            NullnessPredicate predicate = mock(NullnessPredicate.class);
-            when(predicate.getOperand()).thenReturn(i.getArgument(0));
+            SqmNullnessPredicate predicate = mock(SqmNullnessPredicate.class);
+            when(predicate.getExpression()).thenReturn(i.getArgument(0));
             when(predicate.isNegated()).thenReturn(true);
             return predicate;
         });
 
         when(this.builder.between(Mockito.<Path<Date>>any(), Mockito.<Date>any(), any())).thenAnswer(i -> {
-            BetweenPredicate<?> predicate = mock(BetweenPredicate.class);
-            when(predicate.getExpression()).thenReturn(i.getArgument(0));
-            when(predicate.getLowerBound()).thenReturn(new LiteralExpression(null, i.getArgument(1)));
-            when(predicate.getUpperBound()).thenReturn(new LiteralExpression(null, i.getArgument(2)));
+            SqmBetweenPredicate predicate = mock(SqmBetweenPredicate.class);
+            doReturn(i.getArgument(0)).when(predicate).getExpression();
+            doReturn(mockLiteral(i.getArgument(1))).when(predicate).getLowerBound();
+            doReturn(mockLiteral(i.getArgument(2))).when(predicate).getUpperBound();
             return predicate;
         });
 
-        when(this.builder.asc(any())).thenAnswer(i -> new OrderImpl(i.getArgument(0), true));
-        when(this.builder.desc(any())).thenAnswer(i -> new OrderImpl(i.getArgument(0), false));
+        when(this.builder.asc(any(Expression.class))).thenAnswer(i -> mockOrder(i.getArgument(0), true));
+        when(this.builder.desc(any(Expression.class))).thenAnswer(i -> mockOrder(i.getArgument(0), false));
 
         // With this mock we rely on toString() to check that the relative path is correct.
         when(this.root.get(anyString())).thenAnswer(i -> {
-            Path<?> path = mock(Path.class);
+            SqmPath<?> path = mock(SqmPath.class);
             String pString = "mocked " + i.getArgument(0, String.class);
             when(path.toString()).thenReturn(pString);
             when(path.get(anyString())).thenAnswer(i3 -> {
-                Path<?> path2 = mock(Path.class);
+                SqmPath<?> path2 = mock(SqmPath.class);
                 when(path2.toString()).thenReturn(pString + "." + i3.getArgument(0, String.class));
                 return path2;
             });
@@ -156,6 +164,26 @@ public class VersioningStoreQueryFactoryTest
         when(this.session.createQuery(this.criteriaQueryLong)).thenReturn(this.queryLong);
         when(this.session.createQuery(anyString())).thenReturn(this.queryAny);
         when(this.queryAny.setParameter(anyString(), any())).thenReturn(this.queryAny);
+    }
+
+    // Mocks an SQM literal expression exposing the given value through getLiteralValue(). The type parameter is left
+    // free so that it can be unified with the captured wildcard of the expression accessor being stubbed.
+    private static <T> SqmLiteral<T> mockLiteral(Object value)
+    {
+        @SuppressWarnings("unchecked")
+        SqmLiteral<T> literal = mock(SqmLiteral.class);
+        doReturn(value).when(literal).getLiteralValue();
+        return literal;
+    }
+
+    // Mocks an order exposing the given expression and direction.
+    private static JpaOrder mockOrder(Expression<?> expression, boolean ascending)
+    {
+        // HibernateCriteriaBuilder.asc()/desc() covariantly return JpaOrder, so the mock must be a JpaOrder.
+        JpaOrder order = mock(JpaOrder.class);
+        doReturn(expression).when(order).getExpression();
+        when(order.isAscending()).thenReturn(ascending);
+        return order;
     }
 
     @Test
@@ -176,15 +204,15 @@ public class VersioningStoreQueryFactoryTest
         List<Predicate> predicates = Arrays.asList(this.predicatesCaptor.getValue());
         assertEquals(2, predicates.size());
 
-        ComparisonPredicate idPredicate = (ComparisonPredicate) predicates.get(0);
-        LiteralExpression<Long> idExpression = (LiteralExpression<Long>) idPredicate.getRightHandOperand();
-        assertEquals(ComparisonPredicate.ComparisonOperator.EQUAL, idPredicate.getComparisonOperator());
-        assertEquals("mocked id.docId", idPredicate.getLeftHandOperand().toString());
-        assertEquals(42L, idExpression.getLiteral());
+        SqmComparisonPredicate idPredicate = (SqmComparisonPredicate) predicates.get(0);
+        SqmLiteral<Long> idExpression = (SqmLiteral<Long>) idPredicate.getRightHandExpression();
+        assertEquals(ComparisonOperator.EQUAL, idPredicate.getSqmOperator());
+        assertEquals("mocked id.docId", idPredicate.getLeftHandExpression().toString());
+        assertEquals(Long.valueOf(42L), idExpression.getLiteralValue());
 
-        NullnessPredicate nonNullDiffPredicate = (NullnessPredicate) predicates.get(1);
+        SqmNullnessPredicate nonNullDiffPredicate = (SqmNullnessPredicate) predicates.get(1);
         assertTrue(nonNullDiffPredicate.isNegated());
-        assertEquals("mocked diff", nonNullDiffPredicate.getOperand().toString());
+        assertEquals("mocked diff", nonNullDiffPredicate.getExpression().toString());
     }
 
     @Test
@@ -197,18 +225,18 @@ public class VersioningStoreQueryFactoryTest
         List<Predicate> predicates = Arrays.asList(this.predicatesCaptor.getValue());
         assertEquals(4, predicates.size());
 
-        ComparisonPredicate authorPredicate = (ComparisonPredicate) predicates.get(2);
-        LiteralExpression<String> authorExpression = (LiteralExpression<String>) authorPredicate.getRightHandOperand();
-        assertEquals(ComparisonPredicate.ComparisonOperator.EQUAL, authorPredicate.getComparisonOperator());
-        assertEquals("mocked author", authorPredicate.getLeftHandOperand().toString());
-        assertEquals("TestAuthor", authorExpression.getLiteral());
+        SqmComparisonPredicate authorPredicate = (SqmComparisonPredicate) predicates.get(2);
+        SqmLiteral<String> authorExpression = (SqmLiteral<String>) authorPredicate.getRightHandExpression();
+        assertEquals(ComparisonOperator.EQUAL, authorPredicate.getSqmOperator());
+        assertEquals("mocked author", authorPredicate.getLeftHandExpression().toString());
+        assertEquals("TestAuthor", authorExpression.getLiteralValue());
 
-        BetweenPredicate<Date> datePredicate = (BetweenPredicate<Date>) predicates.get(3);
-        LiteralExpression<Date> dateLowerExpression = (LiteralExpression<Date>) datePredicate.getLowerBound();
-        LiteralExpression<Date> dateUpperExpression = (LiteralExpression<Date>) datePredicate.getUpperBound();
+        SqmBetweenPredicate datePredicate = (SqmBetweenPredicate) predicates.get(3);
+        SqmLiteral<Date> dateLowerExpression = (SqmLiteral<Date>) datePredicate.getLowerBound();
+        SqmLiteral<Date> dateUpperExpression = (SqmLiteral<Date>) datePredicate.getUpperBound();
         assertEquals("mocked date", datePredicate.getExpression().toString());
-        assertEquals(new Date(0L), dateLowerExpression.getLiteral());
-        assertEquals(new Date(Integer.MAX_VALUE * 1000L), dateUpperExpression.getLiteral());
+        assertEquals(new Date(0L), dateLowerExpression.getLiteralValue());
+        assertEquals(new Date(Integer.MAX_VALUE * 1000L), dateUpperExpression.getLiteralValue());
     }
 
     @Test
@@ -221,12 +249,12 @@ public class VersioningStoreQueryFactoryTest
         List<Predicate> predicates = Arrays.asList(this.predicatesCaptor.getValue());
         assertEquals(3, predicates.size());
 
-        BetweenPredicate<Date> datePredicate = (BetweenPredicate<Date>) predicates.get(2);
-        LiteralExpression<Date> dateLowerExpression = (LiteralExpression<Date>) datePredicate.getLowerBound();
-        LiteralExpression<Date> dateUpperExpression = (LiteralExpression<Date>) datePredicate.getUpperBound();
+        SqmBetweenPredicate datePredicate = (SqmBetweenPredicate) predicates.get(2);
+        SqmLiteral<Date> dateLowerExpression = (SqmLiteral<Date>) datePredicate.getLowerBound();
+        SqmLiteral<Date> dateUpperExpression = (SqmLiteral<Date>) datePredicate.getUpperBound();
         assertEquals("mocked date", datePredicate.getExpression().toString());
-        assertEquals(new Date(1000L), dateLowerExpression.getLiteral());
-        assertEquals(new Date(2000L), dateUpperExpression.getLiteral());
+        assertEquals(new Date(1000L), dateLowerExpression.getLiteralValue());
+        assertEquals(new Date(2000L), dateUpperExpression.getLiteralValue());
     }
 
     @Test
@@ -238,15 +266,15 @@ public class VersioningStoreQueryFactoryTest
         List<Predicate> predicates = Arrays.asList(this.predicatesCaptor.getValue());
         assertEquals(2, predicates.size());
 
-        ComparisonPredicate idPredicate = (ComparisonPredicate) predicates.get(0);
-        LiteralExpression<Long> idExpression = (LiteralExpression<Long>) idPredicate.getRightHandOperand();
-        assertEquals(ComparisonPredicate.ComparisonOperator.EQUAL, idPredicate.getComparisonOperator());
-        assertEquals("mocked id.docId", idPredicate.getLeftHandOperand().toString());
-        assertEquals(42L, idExpression.getLiteral());
+        SqmComparisonPredicate idPredicate = (SqmComparisonPredicate) predicates.get(0);
+        SqmLiteral<Long> idExpression = (SqmLiteral<Long>) idPredicate.getRightHandExpression();
+        assertEquals(ComparisonOperator.EQUAL, idPredicate.getSqmOperator());
+        assertEquals("mocked id.docId", idPredicate.getLeftHandExpression().toString());
+        assertEquals(Long.valueOf(42L), idExpression.getLiteralValue());
 
-        NullnessPredicate nonNullDiffPredicate = (NullnessPredicate) predicates.get(1);
+        SqmNullnessPredicate nonNullDiffPredicate = (SqmNullnessPredicate) predicates.get(1);
         assertTrue(nonNullDiffPredicate.isNegated());
-        assertEquals("mocked diff", nonNullDiffPredicate.getOperand().toString());
+        assertEquals("mocked diff", nonNullDiffPredicate.getExpression().toString());
     }
 
     @Test
@@ -259,18 +287,18 @@ public class VersioningStoreQueryFactoryTest
         List<Predicate> predicates = Arrays.asList(this.predicatesCaptor.getValue());
         assertEquals(4, predicates.size());
 
-        ComparisonPredicate authorPredicate = (ComparisonPredicate) predicates.get(2);
-        LiteralExpression<String> authorExpression = (LiteralExpression<String>) authorPredicate.getRightHandOperand();
-        assertEquals(ComparisonPredicate.ComparisonOperator.EQUAL, authorPredicate.getComparisonOperator());
-        assertEquals("mocked author", authorPredicate.getLeftHandOperand().toString());
-        assertEquals("TestAuthor", authorExpression.getLiteral());
+        SqmComparisonPredicate authorPredicate = (SqmComparisonPredicate) predicates.get(2);
+        SqmLiteral<String> authorExpression = (SqmLiteral<String>) authorPredicate.getRightHandExpression();
+        assertEquals(ComparisonOperator.EQUAL, authorPredicate.getSqmOperator());
+        assertEquals("mocked author", authorPredicate.getLeftHandExpression().toString());
+        assertEquals("TestAuthor", authorExpression.getLiteralValue());
 
-        BetweenPredicate<Date> datePredicate = (BetweenPredicate<Date>) predicates.get(3);
-        LiteralExpression<Date> dateLowerExpression = (LiteralExpression<Date>) datePredicate.getLowerBound();
-        LiteralExpression<Date> dateUpperExpression = (LiteralExpression<Date>) datePredicate.getUpperBound();
+        SqmBetweenPredicate datePredicate = (SqmBetweenPredicate) predicates.get(3);
+        SqmLiteral<Date> dateLowerExpression = (SqmLiteral<Date>) datePredicate.getLowerBound();
+        SqmLiteral<Date> dateUpperExpression = (SqmLiteral<Date>) datePredicate.getUpperBound();
         assertEquals("mocked date", datePredicate.getExpression().toString());
-        assertEquals(new Date(0L), dateLowerExpression.getLiteral());
-        assertEquals(new Date(Integer.MAX_VALUE * 1000L), dateUpperExpression.getLiteral());
+        assertEquals(new Date(0L), dateLowerExpression.getLiteralValue());
+        assertEquals(new Date(Integer.MAX_VALUE * 1000L), dateUpperExpression.getLiteralValue());
     }
 
     @Test
@@ -283,12 +311,12 @@ public class VersioningStoreQueryFactoryTest
         List<Predicate> predicates = Arrays.asList(this.predicatesCaptor.getValue());
         assertEquals(3, predicates.size());
 
-        BetweenPredicate<Date> datePredicate = (BetweenPredicate<Date>) predicates.get(2);
-        LiteralExpression<Date> dateLowerExpression = (LiteralExpression<Date>) datePredicate.getLowerBound();
-        LiteralExpression<Date> dateUpperExpression = (LiteralExpression<Date>) datePredicate.getUpperBound();
+        SqmBetweenPredicate datePredicate = (SqmBetweenPredicate) predicates.get(2);
+        SqmLiteral<Date> dateLowerExpression = (SqmLiteral<Date>) datePredicate.getLowerBound();
+        SqmLiteral<Date> dateUpperExpression = (SqmLiteral<Date>) datePredicate.getUpperBound();
         assertEquals("mocked date", datePredicate.getExpression().toString());
-        assertEquals(new Date(1000L), dateLowerExpression.getLiteral());
-        assertEquals(new Date(2000L), dateUpperExpression.getLiteral());
+        assertEquals(new Date(1000L), dateLowerExpression.getLiteralValue());
+        assertEquals(new Date(2000L), dateUpperExpression.getLiteralValue());
     }
 
     static Stream<Arguments> rangesProvider()

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/main/java/org/xwiki/platform/security/requiredrights/internal/analyzer/DBListClassRequiredRightAnalyzer.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/main/java/org/xwiki/platform/security/requiredrights/internal/analyzer/DBListClassRequiredRightAnalyzer.java
@@ -29,7 +29,7 @@ import javax.inject.Singleton;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.hibernate.engine.spi.NamedQueryDefinition;
+import org.hibernate.boot.query.NamedHqlQueryDefinition;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.platform.security.requiredrights.RequiredRight;
 import org.xwiki.platform.security.requiredrights.RequiredRightAnalysisResult;
@@ -146,6 +146,6 @@ public class DBListClassRequiredRightAnalyzer implements RequiredRightAnalyzer<D
     private Optional<String> getNamedQuery(Query query)
     {
         return Optional.ofNullable(this.hibernate.getConfiguration().getNamedQueries().get(query.getStatement()))
-            .map(NamedQueryDefinition::getQuery);
+            .map(NamedHqlQueryDefinition::getHqlString);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/test/java/org/xwiki/platform/security/requiredrights/internal/analyzer/DefaultBaseClassRequiredRightAnalyzerTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/test/java/org/xwiki/platform/security/requiredrights/internal/analyzer/DefaultBaseClassRequiredRightAnalyzerTest.java
@@ -262,7 +262,7 @@ class DefaultBaseClassRequiredRightAnalyzerTest
         when(this.hibernate.getConfiguration()).thenReturn(mock());
         when(this.hibernate.getConfiguration().getNamedQueries()).thenReturn(Map.of(queryName, mock()));
         when(this.hibernate.getConfiguration().getNamedQueries()
-            .get(queryName).getQuery()).thenReturn(hqlQuery);
+            .get(queryName).getHqlString()).thenReturn(hqlQuery);
 
         when(this.hqlStatementValidator.isSafe(hqlQuery)).thenReturn(safe);
 


### PR DESCRIPTION
Jira: https://jira.xwiki.org/browse/XWIKI-19708

## What this is

A **spike / jump-start** for the Hibernate 6 upgrade, to move XWIKI-19708 from "open, unscheduled" to "here is a concrete starting point." It takes `xwiki-platform-oldcore` from Hibernate 5.6.15 to **Hibernate 6.6.54.Final** and makes the module **compile**.

## Scope of this PR

`xwiki-platform-oldcore` only. It **compiles** against Hibernate 6.6.54 on `master` (JDK 21). It does **not** yet cover: the module's tests, downstream modules that use oldcore's persistence, the per-database dialect behaviour, `hbm.xml` runtime behaviour, or any cross-database validation. Because the `javax.persistence` → `jakarta.persistence` switch is atomic, this cannot merge until the wider platform moves with it — this is a foundation, not a finished migration.

## Changes

- **Coordinates + version**: `org.hibernate:hibernate-core` → `org.hibernate.orm:hibernate-core` 6.6.54.Final (Hibernate 6 changed the Maven groupId).
- **Namespace** (mechanical): `javax.persistence.*` → `jakarta.persistence.*`.
- **`QueryImplementorDelegate`**: regenerated as a faithful thin delegate against Hibernate 6's `QueryImplementor<R>` — removed methods deleted (the `org.hibernate.type.Type`-based `setParameter`/`setParameterList` overloads, `iterate()`, `getReturnTypes/Aliases`, `setEntity`, …), new methods forwarded (`getResultCount`, `getKeyedResultList`, `setOrder`, cache-mode getters/setters, `getSingleResultOrNull`, `scroll()` → `ScrollableResultsImplementor`, …).
- **`LegacyQueryImplementor`**: reduced to the int-positional methods still present in H6, preserving the 0-based→1-based conversion.
- **Package moves**: `org.hibernate.tool.hbm2ddl.SchemaUpdate` (removed in H6) reimplemented via `SchemaManagementTool.getSchemaMigrator(...).doMigration(...)`; `org.hibernate.hql.spi.QueryTranslator` (removed) dropped from `LegacySessionImplementor`.
- **API renames**: `createSQLQuery`→`createNativeQuery`; `getColumnIterator()`/`getPropertyIterator()`→ `getColumns()`/`getProperties()`; `Column.getLength()` now `Long`; `getSqlType(dialect, metadata)`→`getSqlType(metadata)`; `Dialect.getTypeName(int)`→`TypeConfiguration.getDdlTypeRegistry()...`; named-query metadata API renames in `HqlQueryExecutor`.

## Status / caveats

- **Compiles, not runtime-tested.** No behaviour has been exercised. Cross-DB validation (Postgres/MySQL/…) is the obvious next step.
