### PR TITLE
[Misc] Fix flickering PageTemplatesIT#createTemplateProviderWithIconAndRestrictions

### DIFF
--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/SuggestInputElement.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-ui/src/main/java/org/xwiki/test/ui/po/SuggestInputElement.java
@@ -182,7 +182,14 @@ public class SuggestInputElement extends BaseElement
      */
     public SuggestInputElement clearSelectedSuggestions()
     {
-        getSelectedSuggestions().forEach(SuggestionElement::delete);
+        // Deleting a suggestion re-renders the widget and invalidates the element references of the remaining
+        // selected suggestions, so iterating over a pre-fetched list triggers a StaleElementReferenceException.
+        // Instead, always delete the first selected suggestion and re-fetch the list after each deletion.
+        List<SuggestionElement> selectedSuggestions = getSelectedSuggestions();
+        while (!selectedSuggestions.isEmpty()) {
+            selectedSuggestions.get(0).delete();
+            selectedSuggestions = getSelectedSuggestions();
+        }
         return this;
     }
 


### PR DESCRIPTION
## Problem

`PageTemplatesIT#createTemplateProviderWithIconAndRestrictions` (run as `NestedPageTemplatesIT`) flickers on `stable-17.10.x` with a `StaleElementReferenceException`:

```
org.openqa.selenium.StaleElementReferenceException
  at ...SuggestInputElement$SuggestionElement.delete(SuggestInputElement.java:109)
  at java.base/java.lang.Iterable.forEach(Iterable.java:75)
  at ...SuggestInputElement.clearSelectedSuggestions(SuggestInputElement.java:185)
  at ...TemplateProviderInlinePage.setTemplate(...)
  at ...PageTemplatesIT.createTemplateProviderWithIconAndRestrictions(PageTemplatesIT.java:604)
```

Seen on [stable-17.10.x build 345](https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/stable-17.10.x/345/).

## Cause

`clearSelectedSuggestions()` iterated over a pre-fetched list of suggestion elements and deleted them one by one. `delete()` clicks the suggestion then sends `BACK_SPACE`, which re-renders the Selectize widget and invalidates the element references of the remaining selected suggestions — so the second deletion throws. It only bites when 2+ suggestions are selected (this test sets restrictions on multiple page types), hence the flicker.

## Fix

Re-fetch the list after each deletion, always deleting the first selected suggestion, so no stale reference is reused.

## Scope

`stable-17.10.x` only. `master` and `stable-18.4.x` already avoid this through the Tom Select migration (XWIKI-24088), which is not backported — so no up/forward-port is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)