### PR TITLE
XWIKI-24176: Fix the backported test to work on stable-17.10.x

### DIFF
--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/RenamePageIT.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-skin/xwiki-platform-flamingo-skin-test/xwiki-platform-flamingo-skin-test-docker/src/test/it/org/xwiki/flamingo/test/docker/RenamePageIT.java
@@ -826,7 +826,7 @@ class RenamePageIT
 
     @Order(12)
     @Test
-    void convertTerminalPageToNestedPage(TestUtils setup) throws Exception
+    void convertTerminalPageToNestedPage(TestUtils setup, TestConfiguration testConfiguration) throws Exception
     {
         DocumentReference sourceParent = new DocumentReference("xwiki", Arrays.asList("a", "b", "c"), "WebHome");
         DocumentReference sourceTerminal = new DocumentReference("xwiki", Arrays.asList("a", "b", "c"), "4");
@@ -845,7 +845,7 @@ class RenamePageIT
         setup.createPage(sourceParent, "", "");
         setup.createPage(sourceTerminal, "Content of terminal page", "4");
 
-        new SolrTestUtils(setup).waitEmptyQueue();
+        new SolrTestUtils(setup, testConfiguration.getServletEngine()).waitEmptyQueue();
 
         ViewPage vp = setup.gotoPage(sourceTerminal);
         RenamePage renamePage = vp.rename();


### PR DESCRIPTION
## Problem

`RenamePageIT#convertTerminalPageToNestedPage` fails on `stable-17.10.x` (e.g. [build #345](https://ci.xwiki.org/job/XWiki/job/xwiki-platform/job/stable-17.10.x/345/)) with:

```
java.net.UnknownHostException: host.testcontainers.internal
    at org.xwiki.repository.test.SolrTestUtils.getSolrQueueSize(SolrTestUtils.java:92)
    at org.xwiki.repository.test.SolrTestUtils.waitEmptyQueue(SolrTestUtils.java:79)
    at org.xwiki.flamingo.test.docker.RenamePageIT.convertTerminalPageToNestedPage(RenamePageIT.java:848)
```

## Root cause

The test was backported from `master`, where the single-argument `SolrTestUtils(TestUtils)` constructor resolves the Solr service URL from the current executor (a host-reachable URL). That self-sufficient constructor comes from the clustering-tests refactoring (XWIKI-17828), which is `master`-only.

On `stable-17.10.x` the single-argument constructor instead leaves the URL `null`, so the queue query is sent to the default base URL `host.testcontainers.internal` — the address the browser container uses to reach XWiki, which is not resolvable from the test JVM. Hence the `UnknownHostException`.

Every other test in this class on this branch already passes the servlet engine explicitly for exactly this reason.

## Fix

Adapt the backported method to the branch's convention: inject `TestConfiguration` and use `new SolrTestUtils(setup, testConfiguration.getServletEngine())`.

`master` and `stable-18.4.x` are not affected (both have the self-sufficient one-argument constructor), so this fix is specific to `stable-17.10.x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
