### PR TITLE
[Misc] Move remaining XWiki.XWikiUsers property names to constants

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
@@ -320,8 +320,6 @@ public class XWiki implements EventListener
 
     private static final String DEFAULT_LANGUAGE = "default_language";
 
-    private static final String XWIKIUSERS_CLASS = "XWiki.XWikiUsers";
-
     private static final String INTERFACE_LANGUAGE = "interfacelanguage";
 
     private static final String XWIKINAME = "xwikiname";
@@ -3388,7 +3386,8 @@ public class XWiki implements EventListener
             String user = context.getUser();
             XWikiDocument userdoc = getDocument(user, context);
             if (userdoc != null) {
-                userPreferenceLanguage = userdoc.getStringValue(XWIKIUSERS_CLASS, DEFAULT_LANGUAGE);
+                userPreferenceLanguage =
+                    userdoc.getStringValue(XWikiUsersDocumentInitializer.CLASS_REFERENCE_STRING, DEFAULT_LANGUAGE);
             }
         } catch (XWikiException e) {
         }
@@ -3490,7 +3489,8 @@ public class XWiki implements EventListener
             XWikiDocument userdoc = null;
             userdoc = getDocument(user, context);
             if (userdoc != null) {
-                userPreferenceLanguage = userdoc.getStringValue(XWIKIUSERS_CLASS, "default_interface_language");
+                userPreferenceLanguage = userdoc.getStringValue(XWikiUsersDocumentInitializer.CLASS_REFERENCE_STRING,
+                    "default_interface_language");
             }
         } catch (XWikiException e) {
         }
@@ -3898,13 +3898,14 @@ public class XWiki implements EventListener
             userDocument = userDocument.clone();
 
             // Get the stored validation key
-            BaseObject userObject = userDocument.getObject(XWIKIUSERS_CLASS, 0);
+            BaseObject userObject = userDocument.getObject(XWikiUsersDocumentInitializer.CLASS_REFERENCE_STRING, 0);
             String storedKey = userObject.getStringValue(XWikiUsersDocumentInitializer.VALIDKEY_FIELD);
 
             // Get the validation key from the URL
             String validationKey = request.getParameter(XWikiUsersDocumentInitializer.VALIDKEY_FIELD);
             PropertyInterface validationKeyClass =
-                getClass(XWIKIUSERS_CLASS, context).get(XWikiUsersDocumentInitializer.VALIDKEY_FIELD);
+                getClass(XWikiUsersDocumentInitializer.CLASS_REFERENCE_STRING, context)
+                    .get(XWikiUsersDocumentInitializer.VALIDKEY_FIELD);
             if (validationKeyClass instanceof PasswordClass) {
                 validationKey = ((PasswordClass) validationKeyClass).getEquivalentPassword(storedKey, validationKey);
             }
@@ -3980,7 +3981,7 @@ public class XWiki implements EventListener
             }
 
             if ((parent == null) || (parent.isEmpty())) {
-                parent = XWIKIUSERS_CLASS;
+                parent = XWikiUsersDocumentInitializer.CLASS_REFERENCE_STRING;
             }
 
             // Mark the user as active or waiting email validation.
@@ -6371,7 +6372,7 @@ public class XWiki implements EventListener
                 return escapeXML ? XMLUtils.escape(userReference.getName()) : userReference.getName();
             }
 
-            BaseObject userobj = userdoc.getObject(XWIKIUSERS_CLASS);
+            BaseObject userobj = userdoc.getObject(XWikiUsersDocumentInitializer.CLASS_REFERENCE_STRING);
             if (userobj == null) {
                 return escapeXML ? XMLUtils.escape(userdoc.getDocumentReference().getName())
                     : userdoc.getDocumentReference().getName();

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
@@ -4040,8 +4040,8 @@ public class XWiki implements EventListener
     public boolean createEmptyUser(String xwikiname, String userRights, XWikiContext context) throws XWikiException
     {
         Map<String, String> map = new HashMap<>();
-        map.put("active", "1");
-        map.put("first_name", xwikiname);
+        map.put(XWikiUser.ACTIVE_PROPERTY, "1");
+        map.put(XWikiUsersDocumentInitializer.FIRST_NAME_FIELD, xwikiname);
 
         if (createUser(xwikiname, map, userRights, context) == 1) {
             return true;
@@ -6380,12 +6380,12 @@ public class XWiki implements EventListener
             String text;
 
             if (format == null) {
-                text = userobj.getStringValue("first_name");
-                String lastName = userobj.getStringValue("last_name");
+                text = userobj.getStringValue(XWikiUsersDocumentInitializer.FIRST_NAME_FIELD);
+                String lastName = userobj.getStringValue(XWikiUsersDocumentInitializer.LAST_NAME_FIELD);
                 if (!text.isEmpty() && !lastName.isEmpty()) {
                     text += ' ';
                 }
-                text += userobj.getStringValue("last_name");
+                text += userobj.getStringValue(XWikiUsersDocumentInitializer.LAST_NAME_FIELD);
                 if (StringUtils.isBlank(text)) {
                     text = userdoc.getDocumentReference().getName();
                 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiUsersDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiUsersDocumentInitializer.java
@@ -60,6 +60,16 @@ public class XWikiUsersDocumentInitializer extends AbstractMandatoryClassInitial
         XWiki.SYSTEM_SPACE + '.' + XWIKI_USERS_DOCUMENT_REFERENCE.getName();
 
     /**
+     * The name of the field containing the user first name.
+     */
+    public static final String FIRST_NAME_FIELD = "first_name";
+
+    /**
+     * The name of the field containing the user last name.
+     */
+    public static final String LAST_NAME_FIELD = "last_name";
+
+    /**
      * The name of the field containing the user email.
      */
     public static final String EMAIL_FIELD = "email";
@@ -97,8 +107,8 @@ public class XWikiUsersDocumentInitializer extends AbstractMandatoryClassInitial
     @Override
     protected void createClass(BaseClass xclass)
     {
-        xclass.addTextField("first_name", "First Name", 30);
-        xclass.addTextField("last_name", "Last Name", 30);
+        xclass.addTextField(FIRST_NAME_FIELD, "First Name", 30);
+        xclass.addTextField(LAST_NAME_FIELD, "Last Name", 30);
         xclass.addEmailField(EMAIL_FIELD, "e-Mail", 30);
         xclass.addPasswordField(PASSWORD_FIELD, "Password", 10);
         xclass.addPasswordField(VALIDKEY_FIELD, "Validation Key", 10);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiUsersDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/mandatory/XWikiUsersDocumentInitializer.java
@@ -61,26 +61,36 @@ public class XWikiUsersDocumentInitializer extends AbstractMandatoryClassInitial
 
     /**
      * The name of the field containing the user first name.
+     *
+     * @since 18.6.0RC1
      */
     public static final String FIRST_NAME_FIELD = "first_name";
 
     /**
      * The name of the field containing the user last name.
+     *
+     * @since 18.6.0RC1
      */
     public static final String LAST_NAME_FIELD = "last_name";
 
     /**
      * The name of the field containing the user email.
+     *
+     * @since 18.6.0RC1
      */
     public static final String EMAIL_FIELD = "email";
 
     /**
      * The name of the field containing the user password.
+     *
+     * @since 18.6.0RC1
      */
     public static final String PASSWORD_FIELD = "password";
 
     /**
      * The name of the field containing the account validation key.
+     *
+     * @since 18.6.0RC1
      */
     public static final String VALIDKEY_FIELD = "validkey";
 


### PR DESCRIPTION
## Summary

Follow-up to #5779 (merged), addressing tmortagne's [review comment](https://github.com/xwiki/xwiki-platform/pull/5779#discussion_r3527064299): *"there was a lot of other stuff that should have moved to XWikiUsersDocumentInitializer."*

That PR routed only `email` / `password` / `validkey` through constants. This PR handles the remaining `XWiki.XWikiUsers` property-name literals that were still hardcoded in `XWiki`:

- **`first_name`, `last_name`** — added as public `FIRST_NAME_FIELD` / `LAST_NAME_FIELD` constants in `XWikiUsersDocumentInitializer` (used both in the class initializer and in `XWiki`), matching the existing `EMAIL_FIELD` / `PASSWORD_FIELD` / `VALIDKEY_FIELD` pattern.
- **`active`** — reuses the pre-existing `XWikiUser.ACTIVE_PROPERTY` constant (already used elsewhere in `XWiki`) rather than introducing a duplicate in the initializer.

## Scope

The sweep is scoped to `XWiki.java` (where the review comments were anchored); those three were the only genuine user-property literals still hardcoded there (the remaining `"skin"` occurrences are the *skin action*, not the user property). Happy to widen to other classes if wanted.

## Test plan

- [x] `mvn clean install` on `xwiki-platform-oldcore` (checkstyle + Spoon) — **BUILD SUCCESS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SGk77r8wNpVFvw43mw1aQu)_