### PR TITLE
[Misc] Address review comments on the SonarQube constant extraction

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiAuthServiceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiAuthServiceImpl.java
@@ -65,13 +65,11 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(XWikiAuthServiceImpl.class);
 
-    private static final String XWIKI_SPACE = "XWiki";
     private static final String AUTHENTICATION_REALM_NAME = "xwiki.authentication.realmname";
-    private static final String USER_LOG_PREFIX = "User ";
     private static final String MESSAGE_CONTEXT_KEY = "message";
 
     private static final EntityReference USERCLASS_REFERENCE = new EntityReference("XWikiUsers", EntityType.DOCUMENT,
-        new EntityReference(XWIKI_SPACE, EntityType.SPACE));
+        new EntityReference(XWiki.SYSTEM_SPACE, EntityType.SPACE));
 
     /**
      * Used to convert a string into a proper Document Name.
@@ -121,7 +119,7 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
                 if (xwiki.Param(AUTHENTICATION_REALM_NAME) != null) {
                     sconfig.setRealmName(xwiki.Param(AUTHENTICATION_REALM_NAME));
                 } else {
-                    sconfig.setRealmName(XWIKI_SPACE);
+                    sconfig.setRealmName(XWiki.SYSTEM_SPACE);
                 }
                 authenticator.init(null, sconfig);
             } else {
@@ -133,7 +131,7 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
                 if (xwiki.Param(AUTHENTICATION_REALM_NAME) != null) {
                     sconfig.setRealmName(xwiki.Param(AUTHENTICATION_REALM_NAME));
                 } else {
-                    sconfig.setRealmName(XWIKI_SPACE);
+                    sconfig.setRealmName(XWiki.SYSTEM_SPACE);
                 }
 
                 if (xwiki.Param("xwiki.authentication.defaultpage") != null) {
@@ -148,21 +146,21 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
                     sconfig.setLoginPage(xwiki.Param("xwiki.authentication.loginpage"));
                 } else {
                     sconfig.setLoginPage(stripContextPathFromURL(
-                        context.getURLFactory().createURL(XWIKI_SPACE, "XWikiLogin", "login", context), context));
+                        context.getURLFactory().createURL(XWiki.SYSTEM_SPACE, "XWikiLogin", "login", context), context));
                 }
 
                 if (xwiki.Param("xwiki.authentication.logoutpage") != null) {
                     sconfig.setLogoutPage(xwiki.Param("xwiki.authentication.logoutpage"));
                 } else {
                     sconfig.setLogoutPage(stripContextPathFromURL(
-                        context.getURLFactory().createURL(XWIKI_SPACE, "XWikiLogout", "logout", context), context));
+                        context.getURLFactory().createURL(XWiki.SYSTEM_SPACE, "XWikiLogout", "logout", context), context));
                 }
 
                 if (xwiki.Param("xwiki.authentication.errorpage") != null) {
                     sconfig.setErrorPage(xwiki.Param("xwiki.authentication.errorpage"));
                 } else {
                     sconfig.setErrorPage(stripContextPathFromURL(
-                        context.getURLFactory().createURL(XWIKI_SPACE, "XWikiLogin", "loginerror", context), context));
+                        context.getURLFactory().createURL(XWiki.SYSTEM_SPACE, "XWikiLogin", "loginerror", context), context));
                 }
 
                 sconfig.setPersistentLoginManager(this.persistentLoginManagerProvider.get());
@@ -211,7 +209,7 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
             // Process logout (this only works with Forms)
             if (auth.processLogout(wrappedRequest, response, new URLPatternMatcher())) {
                 if (LOGGER.isInfoEnabled()) {
-                    LOGGER.info(USER_LOG_PREFIX + context.getUser() + " has been logged-out");
+                    LOGGER.info("User [{}] has been logged-out", context.getUser());
                 }
                 wrappedRequest.setUserPrincipal(null);
                 return null;
@@ -220,7 +218,7 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
             final String userName = getContextUserName(wrappedRequest.getUserPrincipal(), context);
             if (LOGGER.isInfoEnabled()) {
                 if (userName != null) {
-                    LOGGER.info(USER_LOG_PREFIX + userName + " is authentified");
+                    LOGGER.info("User [{}] is authentified", userName);
                 }
             }
 
@@ -269,7 +267,7 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
             Principal principal = wrappedRequest.getUserPrincipal();
             if (LOGGER.isInfoEnabled()) {
                 if (principal != null) {
-                    LOGGER.info(USER_LOG_PREFIX + principal.getName() + " is authentified");
+                    LOGGER.info("User [{}] is authentified", principal.getName());
                 }
             }
 
@@ -421,7 +419,7 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
         String user;
 
         // First let's look in the cache
-        if (context.getWiki().exists(new DocumentReference(context.getWikiId(), XWIKI_SPACE, username), context)) {
+        if (context.getWiki().exists(new DocumentReference(context.getWikiId(), XWiki.SYSTEM_SPACE, username), context)) {
             user = "XWiki." + username;
         } else {
             // Note: The result of this search depends on the Database. If the database is
@@ -429,7 +427,7 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
             // username in any case. For case-sensitive databases (like HSQLDB) they'll need to
             // enter it exactly as they've created it.
             String sql = "select distinct doc.fullName from XWikiDocument as doc";
-            Object[][] whereParameters = new Object[][] { { "doc.space", XWIKI_SPACE }, { "doc.name", username } };
+            Object[][] whereParameters = new Object[][] { { "doc.space", XWiki.SYSTEM_SPACE }, { "doc.name", username } };
 
             List<String> list = context.getWiki().search(sql, whereParameters, context);
             if (list.size() == 0) {
@@ -506,7 +504,7 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
         if (createuser != null) {
             String wikiname = context.getWiki().clearName(user, true, true, context);
             XWikiDocument userdoc =
-                context.getWiki().getDocument(new DocumentReference(context.getWikiId(), XWIKI_SPACE, wikiname), context);
+                context.getWiki().getDocument(new DocumentReference(context.getWikiId(), XWiki.SYSTEM_SPACE, wikiname), context);
             if (userdoc.isNew()) {
                 if (LOGGER.isDebugEnabled()) {
                     LOGGER.debug("User page does not exist for user " + user);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiAuthServiceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiAuthServiceImpl.java
@@ -67,6 +67,7 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
 
     private static final String AUTHENTICATION_REALM_NAME = "xwiki.authentication.realmname";
     private static final String MESSAGE_CONTEXT_KEY = "message";
+    private static final String USER_AUTHENTIFIED_MESSAGE = "User [{}] is authentified";
 
     private static final EntityReference USERCLASS_REFERENCE = new EntityReference("XWikiUsers", EntityType.DOCUMENT,
         new EntityReference(XWiki.SYSTEM_SPACE, EntityType.SPACE));
@@ -218,7 +219,7 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
             final String userName = getContextUserName(wrappedRequest.getUserPrincipal(), context);
             if (LOGGER.isInfoEnabled()) {
                 if (userName != null) {
-                    LOGGER.info("User [{}] is authentified", userName);
+                    LOGGER.info(USER_AUTHENTIFIED_MESSAGE, userName);
                 }
             }
 
@@ -267,7 +268,7 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
             Principal principal = wrappedRequest.getUserPrincipal();
             if (LOGGER.isInfoEnabled()) {
                 if (principal != null) {
-                    LOGGER.info("User [{}] is authentified", principal.getName());
+                    LOGGER.info(USER_AUTHENTIFIED_MESSAGE, principal.getName());
                 }
             }
 


### PR DESCRIPTION
## Summary

Follow-up to the merged PR #5763 (`java:S1192` constant extraction), addressing @tmortagne's two review comments on `XWikiAuthServiceImpl`:

1. [*"Already exist as `XWiki#SYSTEM_SPACE`"*](https://github.com/xwiki/xwiki-platform/pull/5763#discussion_r3527174635) — dropped the newly introduced `XWIKI_SPACE` constant and reuse the existing `com.xpn.xwiki.XWiki.SYSTEM_SPACE` (`= "XWiki"`) for all 9 references.
2. [*"No need for this field if the right slf4j syntax is used"*](https://github.com/xwiki/xwiki-platform/pull/5763#discussion_r3527179516) — removed the `USER_LOG_PREFIX` constant and converted the three concatenated log statements to parameterized slf4j calls following the XWiki `[{}]` convention (`LOGGER.info("User [{}] is authentified", userName)` etc.). The duplicated `"User "` literal disappears, so no constant is needed.

The two remaining `S1192` constants in the class (`AUTHENTICATION_REALM_NAME`, `MESSAGE_CONTEXT_KEY`) are unchanged. No behavior change. The `xwiki-platform-oldcore` module builds successfully (`mvn clean install`, running Checkstyle and Spoon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V1JLsSnG4oGtvVMxthFUss)_