### PR TITLE
XWIKI-24546: Images inserted by uploading in Annotations become broken after save

### DIFF
--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/main/java/org/xwiki/annotation/Annotation.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/main/java/org/xwiki/annotation/Annotation.java
@@ -99,6 +99,16 @@ public class Annotation
     public static final String PLAIN_TEXT_END_OFFSET_FIELD = "plainTextEndOffset";
 
     /**
+     * The name of the field holding the comma-separated list of temporary uploaded file names that must be attached
+     * to the annotated document when the annotation is persisted (e.g. images inserted in the annotation comment).
+     *
+     * @since 17.10.10
+     * @since 18.4.3
+     * @since 18.6.0RC1
+     */
+    public static final String UPLOADED_FILES_FIELD = "uploadedFiles";
+
+    /**
      * The unique identifier of this annotation, which should be unique among all the annotations on the same target.
      */
     protected final String id;

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/main/java/org/xwiki/annotation/Annotation.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/main/java/org/xwiki/annotation/Annotation.java
@@ -99,16 +99,6 @@ public class Annotation
     public static final String PLAIN_TEXT_END_OFFSET_FIELD = "plainTextEndOffset";
 
     /**
-     * The name of the field holding the comma-separated list of temporary uploaded file names that must be attached
-     * to the annotated document when the annotation is persisted (e.g. images inserted in the annotation comment).
-     *
-     * @since 17.10.10
-     * @since 18.4.3
-     * @since 18.6.0RC1
-     */
-    public static final String UPLOADED_FILES_FIELD = "uploadedFiles";
-
-    /**
      * The unique identifier of this annotation, which should be unique among all the annotations on the same target.
      */
     protected final String id;

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-io/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-io/pom.xml
@@ -31,7 +31,7 @@
   <name>XWiki Platform - Annotations - XWiki Storage Implementation</name>
   <packaging>jar</packaging>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.04</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.21</xwiki.jacoco.instructionRatio>
     </properties>
   <dependencies>
     <dependency>

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-io/src/main/java/org/xwiki/annotation/io/internal/DefaultIOService.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-io/src/main/java/org/xwiki/annotation/io/internal/DefaultIOService.java
@@ -65,6 +65,13 @@ import com.xpn.xwiki.objects.BaseProperty;
 public class DefaultIOService implements IOService
 {
     /**
+     * The name of the transient annotation metadata field holding the comma-separated list of temporary uploaded file
+     * names to attach to the annotated document on save (e.g. images inserted in the annotation comment). It is never
+     * stored as an annotation object property.
+     */
+    private static final String UPLOADED_FILES_FIELD = "uploadedFiles";
+
+    /**
      * The execution used to get the deprecated XWikiContext.
      */
     @Inject
@@ -440,7 +447,7 @@ public class DefaultIOService implements IOService
         // the target. Don't set the author either, will be set by caller, if needed
         Collection<String> skippedFields =
             Arrays.asList(Annotation.STATE_FIELD, Annotation.DATE_FIELD, Annotation.AUTHOR_FIELD,
-                Annotation.TARGET_FIELD, Annotation.UPLOADED_FILES_FIELD);
+                Annotation.TARGET_FIELD, UPLOADED_FILES_FIELD);
         // all fields in the annotation, try to put them in object (I wonder what happens if I can't...)
         for (String propName : annotation.getFieldNames()) {
             if (!skippedFields.contains(propName)) {
@@ -476,12 +483,12 @@ public class DefaultIOService implements IOService
      * persisted when the document is saved.
      *
      * @param document the document instance that is about to be saved
-     * @param annotation the annotation possibly carrying uploaded file names in {@link Annotation#UPLOADED_FILES_FIELD}
+     * @param annotation the annotation possibly carrying uploaded file names in the uploaded-files metadata field
      * @return {@code true} if at least one temporary attachment was added to the document, {@code false} otherwise
      */
     private boolean attachTemporaryUploadedFiles(XWikiDocument document, Annotation annotation)
     {
-        Object uploadedFiles = annotation.get(Annotation.UPLOADED_FILES_FIELD);
+        Object uploadedFiles = annotation.get(UPLOADED_FILES_FIELD);
         if (uploadedFiles != null) {
             String[] fileNames = StringUtils.split(String.valueOf(uploadedFiles), ",");
             if (fileNames != null && fileNames.length > 0) {

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-io/src/main/java/org/xwiki/annotation/io/internal/DefaultIOService.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-io/src/main/java/org/xwiki/annotation/io/internal/DefaultIOService.java
@@ -43,6 +43,7 @@ import org.xwiki.context.Execution;
 import org.xwiki.model.EntityType;
 import org.xwiki.model.reference.EntityReference;
 import org.xwiki.model.reference.EntityReferenceSerializer;
+import org.xwiki.store.TemporaryAttachmentSessionsManager;
 
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
@@ -101,6 +102,13 @@ public class DefaultIOService implements IOService
     private AnnotationConfiguration configuration;
 
     /**
+     * Used to persist the temporary uploaded files (e.g. images inserted in the annotation comment) on the document
+     * that holds the annotation.
+     */
+    @Inject
+    private TemporaryAttachmentSessionsManager temporaryAttachmentSessionsManager;
+
+    /**
      * {@inheritDoc}
      * <p>
      * This implementation saves the added annotation in the document where the target of the annotation is.
@@ -126,6 +134,9 @@ public class DefaultIOService implements IOService
             XWikiDocument document = deprecatedContext.getWiki().getDocument(documentFullName, deprecatedContext);
             // Avoid modifying the cached document
             document = document.clone();
+            // Attach the temporary uploaded files (e.g. images inserted in the annotation comment) to the same
+            // document instance that is going to be saved, so they are persisted together with the annotation.
+            attachTemporaryUploadedFiles(document, annotation);
             // create a new object in this document to hold the annotation
             // Make sure to use a relative reference when creating the XObject, since we can`t use absolute references
             // for an object's class. This avoids ugly log warning messages.
@@ -355,6 +366,9 @@ public class DefaultIOService implements IOService
                     continue;
                 }
                 updated = updateObject(object, annotation, deprecatedContext) || updated;
+                // Attach the temporary uploaded files to the same document instance that is going to be saved, so
+                // they are persisted even when the uploaded image is the only change made to the annotation.
+                updated = attachTemporaryUploadedFiles(document, annotation) || updated;
                 updateNotifs.add(annotation.getId());
             }
             if (updated) {
@@ -426,7 +440,7 @@ public class DefaultIOService implements IOService
         // the target. Don't set the author either, will be set by caller, if needed
         Collection<String> skippedFields =
             Arrays.asList(Annotation.STATE_FIELD, Annotation.DATE_FIELD, Annotation.AUTHOR_FIELD,
-                Annotation.TARGET_FIELD);
+                Annotation.TARGET_FIELD, Annotation.UPLOADED_FILES_FIELD);
         // all fields in the annotation, try to put them in object (I wonder what happens if I can't...)
         for (String propName : annotation.getFieldNames()) {
             if (!skippedFields.contains(propName)) {
@@ -453,6 +467,28 @@ public class DefaultIOService implements IOService
         if (newValue != null) {
             object.set(fieldName, newValue, deprecatedContext);
             return true;
+        }
+        return false;
+    }
+
+    /**
+     * Attaches the temporary uploaded files referenced by the annotation to the given document instance, so they get
+     * persisted when the document is saved.
+     *
+     * @param document the document instance that is about to be saved
+     * @param annotation the annotation possibly carrying uploaded file names in {@link Annotation#UPLOADED_FILES_FIELD}
+     * @return {@code true} if at least one temporary attachment was added to the document, {@code false} otherwise
+     */
+    private boolean attachTemporaryUploadedFiles(XWikiDocument document, Annotation annotation)
+    {
+        Object uploadedFiles = annotation.get(Annotation.UPLOADED_FILES_FIELD);
+        if (uploadedFiles != null) {
+            String[] fileNames = StringUtils.split(String.valueOf(uploadedFiles), ",");
+            if (fileNames != null && fileNames.length > 0) {
+                this.temporaryAttachmentSessionsManager
+                    .attachTemporaryAttachmentsInDocument(document, Arrays.asList(fileNames));
+                return true;
+            }
         }
         return false;
     }

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-io/src/test/java/org/xwiki/annotation/io/internal/DefaultIOServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-io/src/test/java/org/xwiki/annotation/io/internal/DefaultIOServiceTest.java
@@ -114,7 +114,7 @@ class DefaultIOServiceTest
     {
         Annotation annotation = new Annotation("selection", "left", "right");
         annotation.setAuthor("xwiki:XWiki.Admin");
-        annotation.set(Annotation.UPLOADED_FILES_FIELD, "image1.png,image2.png");
+        annotation.set("uploadedFiles", "image1.png,image2.png");
 
         this.ioService.addAnnotation(TARGET, annotation);
 
@@ -123,7 +123,7 @@ class DefaultIOServiceTest
             .attachTemporaryAttachmentsInDocument(this.clonedDocument, Arrays.asList("image1.png", "image2.png"));
         verify(this.xwiki).saveDocument(eq(this.clonedDocument), anyString(), eq(true), eq(this.xcontext));
         // The uploaded files list must not be written as a (bogus) annotation object property.
-        verify(this.annotationObject, never()).set(eq(Annotation.UPLOADED_FILES_FIELD), any(), any());
+        verify(this.annotationObject, never()).set(eq("uploadedFiles"), any(), any());
     }
 
     @Test
@@ -145,7 +145,7 @@ class DefaultIOServiceTest
         // An update whose only change is an uploaded image: updateObject would report no change, but the attachment
         // must still be persisted, forcing a save.
         Annotation annotation = new Annotation("0");
-        annotation.set(Annotation.UPLOADED_FILES_FIELD, "image.png");
+        annotation.set("uploadedFiles", "image.png");
 
         this.ioService.updateAnnotations(TARGET, List.of(annotation));
 

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-io/src/test/java/org/xwiki/annotation/io/internal/DefaultIOServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-io/src/test/java/org/xwiki/annotation/io/internal/DefaultIOServiceTest.java
@@ -1,0 +1,156 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.annotation.io.internal;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.xwiki.annotation.Annotation;
+import org.xwiki.annotation.AnnotationConfiguration;
+import org.xwiki.annotation.reference.internal.DefaultTypedStringEntityReferenceResolver;
+import org.xwiki.context.Execution;
+import org.xwiki.context.ExecutionContext;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.model.reference.EntityReference;
+import org.xwiki.store.TemporaryAttachmentSessionsManager;
+import org.xwiki.test.annotation.ComponentList;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+
+import com.xpn.xwiki.XWiki;
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.objects.BaseObject;
+import com.xpn.xwiki.test.reference.ReferenceComponentList;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests that {@link DefaultIOService} persists the temporary uploaded files (e.g. images inserted in an annotation
+ * comment) on the very document instance that is saved with the annotation. See XWIKI-24546.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+@ComponentList({ DefaultTypedStringEntityReferenceResolver.class })
+@ReferenceComponentList
+class DefaultIOServiceTest
+{
+    private static final String TARGET = "xwiki:Space.Page";
+
+    @InjectMockComponents
+    private DefaultIOService ioService;
+
+    @MockComponent
+    private Execution execution;
+
+    @MockComponent
+    private AnnotationConfiguration configuration;
+
+    @MockComponent
+    private TemporaryAttachmentSessionsManager temporaryAttachmentSessionsManager;
+
+    private XWiki xwiki;
+
+    private XWikiContext xcontext;
+
+    private XWikiDocument clonedDocument;
+
+    private BaseObject annotationObject;
+
+    @BeforeEach
+    void setUp() throws Exception
+    {
+        ExecutionContext executionContext = mock(ExecutionContext.class);
+        when(this.execution.getContext()).thenReturn(executionContext);
+        this.xcontext = mock(XWikiContext.class);
+        when(executionContext.getProperty("xwikicontext")).thenReturn(this.xcontext);
+
+        this.xwiki = mock(XWiki.class);
+        when(this.xcontext.getWiki()).thenReturn(this.xwiki);
+
+        // getDocument returns the (shared) cached instance; the service clones it before modifying it.
+        XWikiDocument cachedDocument = mock(XWikiDocument.class);
+        this.clonedDocument = mock(XWikiDocument.class);
+        when(cachedDocument.clone()).thenReturn(this.clonedDocument);
+        when(this.xwiki.getDocument(anyString(), eq(this.xcontext))).thenReturn(cachedDocument);
+
+        DocumentReference annotationClassReference = new DocumentReference("xwiki", "XWiki", "AnnotationClass");
+        when(this.configuration.getAnnotationClassReference()).thenReturn(annotationClassReference);
+
+        this.annotationObject = mock(BaseObject.class);
+        when(this.clonedDocument.createXObject(any(EntityReference.class), eq(this.xcontext))).thenReturn(0);
+        when(this.clonedDocument.getXObject(annotationClassReference, 0)).thenReturn(this.annotationObject);
+    }
+
+    @Test
+    void addAnnotationAttachesTemporaryUploadedFilesToTheSavedDocument() throws Exception
+    {
+        Annotation annotation = new Annotation("selection", "left", "right");
+        annotation.setAuthor("xwiki:XWiki.Admin");
+        annotation.set(Annotation.UPLOADED_FILES_FIELD, "image1.png,image2.png");
+
+        this.ioService.addAnnotation(TARGET, annotation);
+
+        // The attachments are added to the exact instance that is saved.
+        verify(this.temporaryAttachmentSessionsManager)
+            .attachTemporaryAttachmentsInDocument(this.clonedDocument, Arrays.asList("image1.png", "image2.png"));
+        verify(this.xwiki).saveDocument(eq(this.clonedDocument), anyString(), eq(true), eq(this.xcontext));
+        // The uploaded files list must not be written as a (bogus) annotation object property.
+        verify(this.annotationObject, never()).set(eq(Annotation.UPLOADED_FILES_FIELD), any(), any());
+    }
+
+    @Test
+    void addAnnotationWithoutUploadedFilesDoesNotAttachAnything() throws Exception
+    {
+        Annotation annotation = new Annotation("selection", "left", "right");
+        annotation.setAuthor("xwiki:XWiki.Admin");
+
+        this.ioService.addAnnotation(TARGET, annotation);
+
+        verify(this.temporaryAttachmentSessionsManager, never())
+            .attachTemporaryAttachmentsInDocument(any(), any());
+        verify(this.xwiki).saveDocument(eq(this.clonedDocument), anyString(), eq(true), eq(this.xcontext));
+    }
+
+    @Test
+    void updateAnnotationsAttachesAndSavesEvenWhenNoOtherFieldChanged() throws Exception
+    {
+        // An update whose only change is an uploaded image: updateObject would report no change, but the attachment
+        // must still be persisted, forcing a save.
+        Annotation annotation = new Annotation("0");
+        annotation.set(Annotation.UPLOADED_FILES_FIELD, "image.png");
+
+        this.ioService.updateAnnotations(TARGET, List.of(annotation));
+
+        verify(this.temporaryAttachmentSessionsManager)
+            .attachTemporaryAttachmentsInDocument(this.clonedDocument, Arrays.asList("image.png"));
+        verify(this.xwiki).saveDocument(eq(this.clonedDocument), anyString(), eq(true), eq(this.xcontext));
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/AbstractAnnotationRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/AbstractAnnotationRESTResource.java
@@ -23,7 +23,6 @@ package org.xwiki.annotation.rest.internal;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -33,7 +32,6 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
-import org.apache.commons.lang3.StringUtils;
 import org.xwiki.annotation.Annotation;
 import org.xwiki.annotation.AnnotationService;
 import org.xwiki.annotation.AnnotationServiceException;
@@ -414,18 +412,18 @@ public abstract class AbstractAnnotationRESTResource extends XWikiResource
         return metadataMap;
     }
 
-    protected void handleTemporaryUploadedFiles(DocumentReference documentReference, Map<String, Object> metadataMap)
+    protected boolean handleTemporaryUploadedFiles(DocumentReference documentReference, Map<String, Object> metadataMap)
         throws XWikiException
     {
         String documentName = this.referenceSerializer.serialize(documentReference);
         boolean canUploadAttachment = this.annotationRightService.canUploadAttachment(documentName, getXWikiUser());
-        if (canUploadAttachment && metadataMap.containsKey("uploadedFiles")) {
-            XWikiContext context = this.xcontextProvider.get();
-            XWikiDocument document = context.getWiki().getDocument(documentReference, context);
-            String[] uploadedFiles = StringUtils.split(String.valueOf(metadataMap.get("uploadedFiles")), ",");
-            this.temporaryAttachmentSessionsManager
-                .attachTemporaryAttachmentsInDocument(document, Arrays.asList(uploadedFiles));
+        // When the user is not allowed to upload attachments, drop the temporary uploaded file names so that they are
+        // never persisted. When allowed, the names stay in the metadata, reach the Annotation object, and the IO
+        // service persists the attachments on the same document instance that holds the annotation, in a single save.
+        if (!canUploadAttachment) {
+            metadataMap.remove(Annotation.UPLOADED_FILES_FIELD);
         }
+        return canUploadAttachment;
     }
 
     protected void cleanTemporaryUploadedFiles(DocumentReference documentReference)

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/AbstractAnnotationRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/AbstractAnnotationRESTResource.java
@@ -77,6 +77,14 @@ public abstract class AbstractAnnotationRESTResource extends XWikiResource
     private static final String COMMENT_SYNTAX_KEY = "comment_syntax";
 
     /**
+     * The name of the transient metadata field holding the comma-separated list of temporary uploaded file names that
+     * must be attached to the annotated document when the annotation is persisted (e.g. images inserted in the
+     * annotation comment). It matches the {@code uploadedFiles} request parameter and is never stored as an annotation
+     * object property.
+     */
+    protected static final String UPLOADED_FILES_FIELD = "uploadedFiles";
+
+    /**
      * The name of the request parameter value represents the parameter that requires
      * conversion from HTML to wiki syntax.
      * This parameter and its implementation is directly inspired from
@@ -421,7 +429,7 @@ public abstract class AbstractAnnotationRESTResource extends XWikiResource
         // never persisted. When allowed, the names stay in the metadata, reach the Annotation object, and the IO
         // service persists the attachments on the same document instance that holds the annotation, in a single save.
         if (!canUploadAttachment) {
-            metadataMap.remove(Annotation.UPLOADED_FILES_FIELD);
+            metadataMap.remove(UPLOADED_FILES_FIELD);
         }
         return canUploadAttachment;
     }

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/SingleAnnotationRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/SingleAnnotationRESTResource.java
@@ -136,7 +136,11 @@ public class SingleAnnotationRESTResource extends AbstractAnnotationRESTResource
             }
             Map<String, Object> annotationMetaData = getMap(updateRequest.getAnnotation());
 
-            this.handleTemporaryUploadedFiles(documentReference, annotationMetaData);
+            // The annotation fields were already copied above from the request; if the user is not allowed to upload
+            // attachments, make sure the uploaded file names don't survive on the annotation either.
+            if (!this.handleTemporaryUploadedFiles(documentReference, annotationMetaData)) {
+                newAnnotation.set(Annotation.UPLOADED_FILES_FIELD, null);
+            }
             // skip these fields as we don't want to overwrite them with whatever is in this map. Setters should be used
             // for these values or constructor
             Collection<String> skippedFields =

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/SingleAnnotationRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/SingleAnnotationRESTResource.java
@@ -139,7 +139,7 @@ public class SingleAnnotationRESTResource extends AbstractAnnotationRESTResource
             // The annotation fields were already copied above from the request; if the user is not allowed to upload
             // attachments, make sure the uploaded file names don't survive on the annotation either.
             if (!this.handleTemporaryUploadedFiles(documentReference, annotationMetaData)) {
-                newAnnotation.set(Annotation.UPLOADED_FILES_FIELD, null);
+                newAnnotation.set(UPLOADED_FILES_FIELD, null);
             }
             // skip these fields as we don't want to overwrite them with whatever is in this map. Setters should be used
             // for these values or constructor


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24546

# Changes

## Description

* Images inserted into an annotation comment by *uploading* them (via CKEditor in the annotation
  popup) were broken after save — only the file name showed. The uploaded attachment was never
  persisted on the annotated document.
* The temporary uploaded files are now attached (from the temporary attachment session store) to the
  same cloned `XWikiDocument` instance that receives the annotation xobject, right before it is
  saved, so a single save persists both the annotation and its uploaded attachments. This is done in
  `DefaultIOService` for both the add and the update (edit) annotation paths.
* The bogus writing of `uploadedFiles` as an `AnnotationClass` xobject property is removed (it is now
  in the object-update skip list).

## Clarifications

* Temporary uploaded attachments are not bound to a specific `XWikiDocument` instance; they live in
  the user session keyed by the document reference and must be attached to the actual document
  instance only *before save* — as documented on
  `TemporaryAttachmentSessionsManager#attachTemporaryAttachmentsInDocument`. The previous annotation
  code instead attached them to a throwaway document that was never saved, relying on a shared
  cached-instance side effect. That side effect stopped working once the cache store started
  reloading a clean copy of a document flagged dirty, so the attachment was dropped on save.
* The REST layer keeps the `AnnotationRightService#canUploadAttachment` security gate but no longer
  mutates any document instance on upload handling: when the user lacks the upload right it strips
  the uploaded file names from the metadata (and from the annotation on the update path) so they
  never reach the IO layer.

# Screenshots & Video

<img width="529" height="879" alt="after" src="https://github.com/user-attachments/assets/7b191696-a4f9-488d-b72f-8cc80b21314f" />

# Executed Tests

* New unit test `DefaultIOServiceTest` (add attaches to the saved instance and does not write the
  bogus property; add without uploaded files attaches nothing; update attaches and saves even when
  the uploaded image is the only change).
* `mvn -B -ntp -Pquality -f xwiki-platform-core/xwiki-platform-annotation/pom.xml install -pl xwiki-platform-annotation-core,xwiki-platform-annotation-io,xwiki-platform-annotation-rest`
  → BUILD SUCCESS (unit tests, Checkstyle, license, Revapi, Spoon and JaCoCo checks all green).
* Manual verification too + docker tests passing

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * stable-18.4.x
  * stable-17.10.x
