### PR TITLE
[stable-17.10.x] XWIKI-21059: RSS feed is displaying wrong notification titles

### DIFF
--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -166,8 +166,25 @@
                 </item>
               </differences>
             </revapi.differences>
-            
-            
+            <revapi.differences>
+              <justification>
+                Adding @Produces("application/rss+xml") only forces the media type of the RSS response so that browsers
+                and feed readers recognize it as a feed instead of rendering it as HTML. It doesn't change the Java
+                signature nor the REST contract (the endpoint already only ever returned RSS).
+              </justification>
+              <criticality>allowed</criticality>
+              <differences>
+                <item>
+                  <ignore>true</ignore>
+                  <code>java.annotation.added</code>
+                  <old>method java.lang.String org.xwiki.notifications.rest.NotificationsResource::getNotificationsRSS(java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String) throws java.lang.Exception</old>
+                  <new>method java.lang.String org.xwiki.notifications.rest.NotificationsResource::getNotificationsRSS(java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String) throws java.lang.Exception</new>
+                  <annotation>@javax.ws.rs.Produces({"application/rss+xml"})</annotation>
+                </item>
+              </differences>
+            </revapi.differences>
+
+
           </analysisConfiguration>
         </configuration>
       </plugin>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/pom.xml
@@ -34,7 +34,7 @@
     <!-- Skipping revapi since xwiki-platform-legacy-notifications-notifiers-api wraps this module and runs checks on it
      -->
     <xwiki.revapi.skip>true</xwiki.revapi.skip>
-    <xwiki.jacoco.instructionRatio>0.75</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.79</xwiki.jacoco.instructionRatio>
   </properties>
   <dependencies>
     <dependency>

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/rss/DefaultNotificationRSSRenderer.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/rss/DefaultNotificationRSSRenderer.java
@@ -149,8 +149,9 @@ public class DefaultNotificationRSSRenderer implements NotificationRSSRenderer
     private String getTitle(CompositeEvent eventNotification)
     {
         String entryTitle;
-        String eventTitle = eventNotification.getEvents().get(0).getTitle();
-        String documentTitle = eventNotification.getEvents().get(0).getDocumentTitle();
+        int mainEventIndex = getMainEventIndex(eventNotification);
+        String eventTitle = eventNotification.getEvents().get(mainEventIndex).getTitle();
+        String documentTitle = eventNotification.getEvents().get(mainEventIndex).getDocumentTitle();
         boolean concernsDocument = !StringUtils.isEmpty(documentTitle);
         boolean translationExist = !StringUtils.isEmpty(eventTitle)
             && this.contextualLocalizationManager.getTranslation(eventTitle) != null;
@@ -167,5 +168,23 @@ public class DefaultNotificationRSSRenderer implements NotificationRSSRenderer
                 .getTranslationPlain("notifications.rss.defaultTitle");
         }
         return entryTitle;
+    }
+
+    /**
+     * @return the index of the event representing the composite event, i.e. the first event whose type matches the
+     *     composite event type. This mirrors {@link CompositeEvent#getType()} so that the entry title is taken from the
+     *     actual event (e.g. a comment addition) rather than from a technical event (e.g. the document update triggered
+     *     by that comment) which can share the same date and end up first in the composite
+     */
+    private int getMainEventIndex(CompositeEvent eventNotification)
+    {
+        String type = eventNotification.getType();
+        for (int i = 0; i < eventNotification.getEvents().size(); i++) {
+            if (type != null && type.equals(eventNotification.getEvents().get(i).getType())) {
+                return i;
+            }
+        }
+        // Fallback: no event matches the composite type, keep the most recent one.
+        return 0;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/rss/DefaultNotificationRSSRendererTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/rss/DefaultNotificationRSSRendererTest.java
@@ -207,4 +207,39 @@ public class DefaultNotificationRSSRendererTest
         assertEquals("Guest", resultEntry.getAuthors().get(0).getName());
         assertEquals("id1", resultEntry.getUri());
     }
+
+    @Test
+    void renderNotificationUsesEventMatchingCompositeType() throws Exception
+    {
+        when(this.scriptContextManager.getCurrentScriptContext()).thenReturn(Mockito.mock(ScriptContext.class));
+        when(this.templateManager.getTemplate(ArgumentMatchers.any())).thenReturn(Mockito.mock(Template.class));
+
+        // Technical update event triggered by the comment save: it shares the comment date and can end up first in
+        // the composite.
+        Event updateEvent = mock(Event.class);
+        when(updateEvent.getType()).thenReturn("update");
+        when(updateEvent.getTitle()).thenReturn("UpdateEventTitle");
+        when(updateEvent.getDocumentTitle()).thenReturn("EventDocumentTitle");
+
+        // The actual comment event, whose type matches the composite type.
+        Event commentEvent = mock(Event.class);
+        when(commentEvent.getType()).thenReturn("addComment");
+        when(commentEvent.getTitle()).thenReturn("EventTitle");
+        when(commentEvent.getDocumentTitle()).thenReturn("EventDocumentTitle");
+        when(this.contextualLocalizationManager.getTranslation("EventTitle")).thenReturn(mock(Translation.class));
+
+        CompositeEvent compositeEvent = mock(CompositeEvent.class);
+        // The update event is first (as it would be after a date tie), the comment event second.
+        when(compositeEvent.getEvents()).thenReturn(Arrays.asList(updateEvent, commentEvent));
+        when(compositeEvent.getType()).thenReturn("addComment");
+        when(compositeEvent.getUsers()).thenReturn(Set.of(testEventAuthor1));
+        when(compositeEvent.getEventIds()).thenReturn(Arrays.asList("id1"));
+        when(compositeEvent.getDates()).thenReturn(Arrays.asList(mock(Date.class)));
+
+        SyndEntry resultEntry = this.defaultNotificationRSSRenderer.renderNotification(compositeEvent);
+
+        // The title must come from the comment event (matching the composite type), not from the technical update
+        // event which happens to be first in the composite.
+        assertEquals("TranslatedEventTitle", resultEntry.getTitle());
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/main/java/org/xwiki/notifications/rest/NotificationsResource.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/main/java/org/xwiki/notifications/rest/NotificationsResource.java
@@ -24,6 +24,7 @@ import javax.ws.rs.FormParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 
@@ -104,6 +105,10 @@ public interface NotificationsResource
      */
     @GET
     @Path("/rss")
+    // Force the RSS media type on the response: the method returns a raw String, so without this the JAX-RS runtime
+    // negotiates the content type from the browser's Accept header (typically text/html), which makes browsers and
+    // feed readers render the feed as HTML instead of recognizing it as an RSS feed.
+    @Produces("application/rss+xml")
     String getNotificationsRSS(
             @QueryParam("useUserPreferences") String useUserPreferences,
             @QueryParam("userId") String userId,

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/src/test/it/org/xwiki/platform/notifications/test/ui/NotificationsIT.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-docker/src/test/it/org/xwiki/platform/notifications/test/ui/NotificationsIT.java
@@ -19,6 +19,8 @@
  */
 package org.xwiki.platform.notifications.test.ui;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -52,6 +54,8 @@ import org.xwiki.test.ui.po.ViewPage;
 import org.xwiki.test.ui.po.editor.ObjectEditPage;
 import org.xwiki.test.ui.po.editor.ObjectEditPane;
 import org.xwiki.test.ui.po.editor.WikiEditPage;
+
+import com.rometools.rome.feed.synd.SyndEntry;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -325,14 +329,33 @@ class NotificationsIT
             String.format("%s:%s", servletEngine.getIP(), servletEngine.getPort()));
         assertEquals(2, notificationsRSS.getEntries().size());
 
-        assertEquals("A comment has been added to the page \"Linux as a title\"",
-                notificationsRSS.getEntries().get(0).getTitle());
-        String descriptionValue = notificationsRSS.getEntries().get(0).getDescription().getValue();
+        // Both RSS feeds must be served with a feed media type so that browsers and feed readers recognize them as
+        // feeds instead of rendering the XML as HTML (see XWIKI-24543). The menu feed is served by the
+        // NotificationRSSService wiki page (application/xml) while the macro feed is served by the /notifications/rss
+        // REST endpoint (application/rss+xml).
+        assertTrue(notificationsRSS.getContentType().startsWith("application/xml"),
+            "Menu RSS feed Content-Type was: " + notificationsRSS.getContentType());
+
+        String macroRSSURL = String.format(
+            "%srest/notifications/rss?userId=%s&useUserPreferences=false&count=10&displayOwnEvents=true",
+            setup.getBaseURL(), URLEncoder.encode("xwiki:XWiki." + SECOND_USER_NAME, StandardCharsets.UTF_8));
+        NotificationsRSS macroRSS = new NotificationsRSS(macroRSSURL, SECOND_USER_NAME, SECOND_USER_PASSWORD);
+        macroRSS.loadEntries(
+            String.format("%s:%s", servletEngine.getInternalIP(), servletEngine.getInternalPort()),
+            String.format("%s:%s", servletEngine.getIP(), servletEngine.getPort()));
+        assertTrue(macroRSS.getContentType().startsWith("application/rss+xml"),
+            "Macro (REST) RSS feed Content-Type was: " + macroRSS.getContentType());
+
+        // The comment event and the page-update composite event can share the same timestamp (posting a
+        // comment also updates the page), so the RSS feed may return them in either order (see XWIKI-21059).
+        // Match the entries by title rather than by position.
+        SyndEntry commentEntry = getEntryByTitle(notificationsRSS,
+            "A comment has been added to the page \"Linux as a title\"");
+        getEntryByTitle(notificationsRSS, "The page \"Linux as a title\" has been modified");
+        String descriptionValue = commentEntry.getDescription().getValue();
         assertTrue(descriptionValue.contains("<strong>Pages</strong>"), "Value was: " + descriptionValue);
         assertTrue(descriptionValue.contains("Linux as a title"), "Value was: " + descriptionValue);
         assertTrue(descriptionValue.contains("edited by " + FIRST_USER_NAME), "Value was: " + descriptionValue);
-        assertEquals("The page \"Linux as a title\" has been modified",
-                notificationsRSS.getEntries().get(1).getTitle());
 
         tray.clearAllNotifications();
     }
@@ -542,5 +565,14 @@ class NotificationsIT
 
         assertTrue(notificationsContainerElement.getNotificationPage(4).startsWith("Profile of "));
         assertTrue(notificationsContainerElement.getNotificationPage(5).startsWith("Profile of "));
+    }
+
+    private SyndEntry getEntryByTitle(NotificationsRSS rss, String title)
+    {
+        return rss.getEntries().stream()
+            .filter(entry -> title.equals(entry.getTitle()))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError(String.format("No RSS entry with title [%s]. Titles: %s",
+                title, rss.getEntries().stream().map(SyndEntry::getTitle).toList())));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-pageobjects/src/main/java/org/xwiki/platform/notifications/test/po/NotificationsRSS.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-test/xwiki-platform-notifications-test-pageobjects/src/main/java/org/xwiki/platform/notifications/test/po/NotificationsRSS.java
@@ -21,6 +21,7 @@ package org.xwiki.platform.notifications.test.po;
 
 import java.util.List;
 
+import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
@@ -43,6 +44,8 @@ import com.rometools.rome.io.impl.Base64;
 public class NotificationsRSS
 {
     private SyndFeed feed;
+
+    private String contentType;
 
     private String url;
     private String user;
@@ -85,6 +88,11 @@ public class NotificationsRSS
                     response.getStatusLine().getStatusCode()));
             }
 
+            // Capture the Content-Type before consuming the entity so that tests can verify the feed is served with a
+            // feed media type (and not, e.g., text/html which browsers would render as HTML).
+            Header responseContentType = response.getEntity().getContentType();
+            this.contentType = (responseContentType == null) ? null : responseContentType.getValue();
+
             SyndFeedInput input = new SyndFeedInput();
             feed = input.build(new XmlReader(response.getEntity().getContent()));
         } catch (Exception e) {
@@ -102,5 +110,14 @@ public class NotificationsRSS
     public List<SyndEntry> getEntries()
     {
         return feed.getEntries();
+    }
+
+    /**
+     * @return the value of the {@code Content-Type} HTTP response header returned when the feed was loaded
+     * @since 17.10.10
+     */
+    public String getContentType()
+    {
+        return this.contentType;
     }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `stable-17.10.x`:
 - [XWIKI-21059: RSS feed is displaying wrong notification titles](https://github.com/xwiki/xwiki-platform/pull/5782)

Created manually because the automated backport tool failed on `stable-17.10.x` with merge conflicts (the `master` test infrastructure has since diverged — notably XWIKI-17828 "Add support for clustering tests", which is on `stable-18.4.x` but deliberately not backported to `stable-17.10.x`).

## Conflict resolution
 - `NotificationsResource.java` — inserted `@Produces("application/rss+xml")` directly after `@Path("/rss")` (17.10.x has no `@SuppressWarnings` checkstyle annotations to anchor on).
 - `NotificationsRSS.java` — re-applied the `getContentType()` additions on top of 17.10.x's two-argument `loadEntries(containerDomain, realDomain)`; `@since` set to `17.10.10`.
 - `NotificationsIT.java` — ported the content-type + match-by-title assertions, adapting the new macro RSS load to 17.10.x's two-argument `loadEntries` (using the `ServletEngine` internal/real domains).

## Executed Tests
 - `mvn clean install -Plegacy,snapshot,quality` on `xwiki-platform-notifications-notifiers-api` (unit tests pass, JaCoCo 0.79 met, Checkstyle clean).
 - `mvn clean install -Plegacy,snapshot,quality` on `xwiki-platform-notifications-rest` (unit tests pass, Checkstyle clean, Revapi `@Produces` ignore validated).
 - Compilation of `xwiki-platform-notifications-test-pageobjects` and `xwiki-platform-notifications-test-docker` (the `NotificationsIT` functional test compiles; execution left to CI).
 - I've fully rebuilt the xwiki-platform-notification module on 17.10.x and it passed :) 