### PR TITLE
XWIKI-23447: Add an option to skip the recycle bin in the REST DELETE page API

### DIFF
--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -195,6 +195,11 @@
                   <old>method void org.xwiki.rest.resources.pages.PageResource::deletePage(java.lang.String, java.lang.String, java.lang.String) throws org.xwiki.rest.XWikiRestException</old>
                   <new>method void org.xwiki.rest.resources.pages.PageResource::deletePage(java.lang.String, java.lang.String, java.lang.String, java.lang.Boolean) throws org.xwiki.rest.XWikiRestException</new>
                 </item>
+                <item>
+                  <code>java.method.numberOfParametersChanged</code>
+                  <old>method void org.xwiki.rest.resources.pages.PageTranslationResource::deletePageTranslation(java.lang.String, java.lang.String, java.lang.String, java.lang.String) throws org.xwiki.rest.XWikiRestException</old>
+                  <new>method void org.xwiki.rest.resources.pages.PageTranslationResource::deletePageTranslation(java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.Boolean) throws org.xwiki.rest.XWikiRestException</new>
+                </item>
               </differences>
             </revapi.differences>
           </analysisConfiguration>

--- a/xwiki-platform-core/pom.xml
+++ b/xwiki-platform-core/pom.xml
@@ -183,8 +183,20 @@
                 </item>
               </differences>
             </revapi.differences>
-
-
+            <revapi.differences>
+              <justification>
+                The REST API shouldn't be called directly from Java but through HTTP requests. Adding a new query string
+                parameter to an existing REST resource doesn't break existing code that calls this resource through HTTP.
+              </justification>
+              <criticality>allowed</criticality>
+              <differences>
+                <item>
+                  <code>java.method.numberOfParametersChanged</code>
+                  <old>method void org.xwiki.rest.resources.pages.PageResource::deletePage(java.lang.String, java.lang.String, java.lang.String) throws org.xwiki.rest.XWikiRestException</old>
+                  <new>method void org.xwiki.rest.resources.pages.PageResource::deletePage(java.lang.String, java.lang.String, java.lang.String, java.lang.Boolean) throws org.xwiki.rest.XWikiRestException</new>
+                </item>
+              </differences>
+            </revapi.differences>
           </analysisConfiguration>
         </configuration>
       </plugin>

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-api/src/main/java/org/xwiki/rest/resources/pages/PageResource.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-api/src/main/java/org/xwiki/rest/resources/pages/PageResource.java
@@ -82,11 +82,21 @@ public interface PageResource
             Page page
     ) throws XWikiRestException;
 
-    // FIXME: Write Javadoc describing the REST API parameters
-    @SuppressWarnings("checkstyle:MissingJavadocMethod")
+    /**
+     * Delete a page.
+     *
+     * @param wikiName the wiki storing the page
+     * @param spaceNames the space where the page is located in
+     * @param pageName the name of the page
+     * @param skipRecycleBin (since 18.6.0RC1) when {@code true}, the page is deleted permanently instead of being sent
+     *  to the recycle bin. This is only honored for advanced users and when the wiki configuration allows skipping the
+     *  recycle bin; otherwise the page is sent to the recycle bin as usual. Defaults to {@code false}
+     * @throws XWikiRestException if the user is not authorized or if the deletion fails
+     */
     @DELETE void deletePage(
             @PathParam("wikiName") String wikiName,
             @PathParam("spaceName") @Encoded String spaceNames,
-            @PathParam("pageName") String pageName
+            @PathParam("pageName") String pageName,
+            @QueryParam("skipRecycleBin") @DefaultValue("false") Boolean skipRecycleBin
     ) throws XWikiRestException;
 }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-api/src/main/java/org/xwiki/rest/resources/pages/PageTranslationResource.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-api/src/main/java/org/xwiki/rest/resources/pages/PageTranslationResource.java
@@ -59,12 +59,23 @@ public interface PageTranslationResource
             Page page
     ) throws XWikiRestException;
 
-    // FIXME: Write Javadoc describing the REST API parameters
-    @SuppressWarnings("checkstyle:MissingJavadocMethod")
+    /**
+     * Delete a page translation.
+     *
+     * @param wikiName the wiki storing the page
+     * @param spaceName the space where the page is located in
+     * @param pageName the name of the page
+     * @param language the language of the translation to delete
+     * @param skipRecycleBin (since 18.6.0RC1) when {@code true}, the page is deleted permanently instead of being sent
+     *  to the recycle bin. This is only honored for advanced users and when the wiki configuration allows skipping the
+     *  recycle bin; otherwise the page is sent to the recycle bin as usual. Defaults to {@code false}
+     * @throws XWikiRestException if the user is not authorized or if the deletion fails
+     */
     @DELETE void deletePageTranslation(
             @PathParam("wikiName") String wikiName,
             @PathParam("spaceName") @Encoded String spaceName,
             @PathParam("pageName") String pageName,
-            @PathParam("language") String language
+            @PathParam("language") String language,
+            @QueryParam("skipRecycleBin") @DefaultValue("false") Boolean skipRecycleBin
     ) throws XWikiRestException;
 }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/pom.xml
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/pom.xml
@@ -32,7 +32,7 @@
   <name>XWiki Platform - REST - Server</name>
   <description>Service for accessing XWiki through a RESTful API</description>
   <properties>
-    <xwiki.jacoco.instructionRatio>0.33</xwiki.jacoco.instructionRatio>
+    <xwiki.jacoco.instructionRatio>0.36</xwiki.jacoco.instructionRatio>
   </properties>
   <dependencies>
     <dependency>
@@ -111,6 +111,12 @@
     <dependency>
       <groupId>org.xwiki.platform</groupId>
       <artifactId>xwiki-platform-wiki-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <!-- Needed to check whether the recycle bin can be skipped when deleting a page. -->
+    <dependency>
+      <groupId>org.xwiki.platform</groupId>
+      <artifactId>xwiki-platform-refactoring-api</artifactId>
       <version>${project.version}</version>
     </dependency>
     <!-- Needed for the nested page hierarchy. -->

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/ModifiablePageResource.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/ModifiablePageResource.java
@@ -23,10 +23,13 @@ import javax.inject.Inject;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
+import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.rest.XWikiResource;
 import org.xwiki.rest.internal.ModelFactory;
 import org.xwiki.rest.model.jaxb.Page;
 
+import com.xpn.xwiki.XWiki;
+import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.api.Document;
 
@@ -68,10 +71,28 @@ public class ModifiablePageResource extends XWikiResource
         }
     }
 
-    void deletePage(DocumentInfo documentInfo) throws XWikiException
+    /**
+     * Deletes the specified page.
+     *
+     * @param documentInfo identifies the page to be deleted
+     * @param skipRecycleBin when {@code true}, the page is deleted permanently instead of being sent to the recycle
+     *  bin; the caller is responsible for having checked that skipping the recycle bin is allowed (wiki configuration)
+     *  and that the current user has the required right
+     * @throws XWikiException if deleting the page fails
+     */
+    void deletePage(DocumentInfo documentInfo, boolean skipRecycleBin) throws XWikiException
     {
         Document doc = documentInfo.getDocument();
 
-        doc.delete();
+        if (skipRecycleBin) {
+            // Permanently delete the page, bypassing the recycle bin. The DELETE right has already been checked by
+            // the caller.
+            DocumentReference documentReference = doc.getDocumentReference();
+            XWikiContext xcontext = getXWikiContext();
+            XWiki xwiki = xcontext.getWiki();
+            xwiki.deleteDocument(xwiki.getDocument(documentReference, xcontext), false, xcontext);
+        } else {
+            doc.delete();
+        }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/ModifiablePageResource.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/ModifiablePageResource.java
@@ -20,6 +20,7 @@
 package org.xwiki.rest.internal.resources.pages;
 
 import javax.inject.Inject;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 
@@ -27,6 +28,8 @@ import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.rest.XWikiResource;
 import org.xwiki.rest.internal.ModelFactory;
 import org.xwiki.rest.model.jaxb.Page;
+import org.xwiki.security.authorization.ContextualAuthorizationManager;
+import org.xwiki.security.authorization.Right;
 
 import com.xpn.xwiki.XWiki;
 import com.xpn.xwiki.XWikiContext;
@@ -40,6 +43,9 @@ public class ModifiablePageResource extends XWikiResource
 {
     @Inject
     protected ModelFactory factory;
+
+    @Inject
+    private ContextualAuthorizationManager contextualAuthorizationManager;
 
     /**
      * Creates or updates the specified page.
@@ -77,17 +83,23 @@ public class ModifiablePageResource extends XWikiResource
      * @param documentInfo identifies the page to be deleted
      * @param skipRecycleBin when {@code true}, the page is deleted permanently instead of being sent to the recycle
      *  bin; the caller is responsible for having checked that skipping the recycle bin is allowed (wiki configuration)
-     *  and that the current user has the required right
      * @throws XWikiException if deleting the page fails
+     * @throws WebApplicationException with an {@link Status#UNAUTHORIZED} status if the current user doesn't have the
+     *  right to delete the page
      */
     void deletePage(DocumentInfo documentInfo, boolean skipRecycleBin) throws XWikiException
     {
         Document doc = documentInfo.getDocument();
+        DocumentReference documentReference = doc.getDocumentReference();
+
+        // Deleting a page requires the DELETE right, whether or not the recycle bin is skipped. Check it up-front so
+        // that a proper HTTP 401 is returned instead of a generic server error.
+        if (!this.contextualAuthorizationManager.hasAccess(Right.DELETE, documentReference)) {
+            throw new WebApplicationException(Status.UNAUTHORIZED);
+        }
 
         if (skipRecycleBin) {
-            // Permanently delete the page, bypassing the recycle bin. The DELETE right has already been checked by
-            // the caller.
-            DocumentReference documentReference = doc.getDocumentReference();
+            // Permanently delete the page, bypassing the recycle bin.
             XWikiContext xcontext = getXWikiContext();
             XWiki xwiki = xcontext.getWiki();
             xwiki.deleteDocument(xwiki.getDocument(documentReference, xcontext), false, xcontext);

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PageResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PageResourceImpl.java
@@ -23,9 +23,7 @@ import java.net.URI;
 import java.util.List;
 
 import javax.ws.rs.BadRequestException;
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
 
 import org.xwiki.component.annotation.Component;
 import org.xwiki.localization.ContextualLocalizationManager;
@@ -33,7 +31,6 @@ import org.xwiki.refactoring.RefactoringConfiguration;
 import org.xwiki.rest.XWikiRestException;
 import org.xwiki.rest.model.jaxb.Page;
 import org.xwiki.rest.resources.pages.PageResource;
-import org.xwiki.security.authorization.ContextualAuthorizationManager;
 import org.xwiki.security.authorization.Right;
 
 import com.xpn.xwiki.XWikiException;
@@ -54,9 +51,6 @@ public class PageResourceImpl extends ModifiablePageResource implements PageReso
 
     @Inject
     private RefactoringConfiguration refactoringConfiguration;
-
-    @Inject
-    private ContextualAuthorizationManager contextualAuthorizationManager;
 
     @Override
     // Needs a lot of parameters to bind path and query parameters
@@ -112,13 +106,6 @@ public class PageResourceImpl extends ModifiablePageResource implements PageReso
     {
         try {
             DocumentInfo documentInfo = getDocumentInfo(wikiName, spaceName, pageName, null, null, true, true);
-
-            // Deleting a page requires the DELETE right, whether or not the recycle bin is skipped. Check it up-front
-            // so that a proper HTTP 401 is returned instead of a generic server error.
-            if (!this.contextualAuthorizationManager.hasAccess(Right.DELETE,
-                documentInfo.getDocument().getDocumentReference())) {
-                throw new WebApplicationException(Status.UNAUTHORIZED);
-            }
 
             // Skipping the recycle bin permanently deletes the page, so it's only honored when the wiki configuration
             // enables it.

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PageResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PageResourceImpl.java
@@ -23,13 +23,17 @@ import java.net.URI;
 import java.util.List;
 
 import javax.ws.rs.BadRequestException;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
 
 import org.xwiki.component.annotation.Component;
 import org.xwiki.localization.ContextualLocalizationManager;
+import org.xwiki.refactoring.RefactoringConfiguration;
 import org.xwiki.rest.XWikiRestException;
 import org.xwiki.rest.model.jaxb.Page;
 import org.xwiki.rest.resources.pages.PageResource;
+import org.xwiki.security.authorization.ContextualAuthorizationManager;
 import org.xwiki.security.authorization.Right;
 
 import com.xpn.xwiki.XWikiException;
@@ -47,6 +51,12 @@ public class PageResourceImpl extends ModifiablePageResource implements PageReso
 {
     @Inject
     private ContextualLocalizationManager contextualLocalizationManager;
+
+    @Inject
+    private RefactoringConfiguration refactoringConfiguration;
+
+    @Inject
+    private ContextualAuthorizationManager contextualAuthorizationManager;
 
     @Override
     // Needs a lot of parameters to bind path and query parameters
@@ -97,12 +107,25 @@ public class PageResourceImpl extends ModifiablePageResource implements PageReso
     }
 
     @Override
-    public void deletePage(String wikiName, String spaceName, String pageName) throws XWikiRestException
+    public void deletePage(String wikiName, String spaceName, String pageName, Boolean skipRecycleBin)
+        throws XWikiRestException
     {
         try {
             DocumentInfo documentInfo = getDocumentInfo(wikiName, spaceName, pageName, null, null, true, true);
 
-            deletePage(documentInfo);
+            // Deleting a page requires the DELETE right, whether or not the recycle bin is skipped. Check it up-front
+            // so that a proper HTTP 401 is returned instead of a generic server error.
+            if (!this.contextualAuthorizationManager.hasAccess(Right.DELETE,
+                documentInfo.getDocument().getDocumentReference())) {
+                throw new WebApplicationException(Status.UNAUTHORIZED);
+            }
+
+            // Skipping the recycle bin permanently deletes the page, so it's only honored when the wiki configuration
+            // enables it.
+            boolean skipRecycleBinEffective = Boolean.TRUE.equals(skipRecycleBin)
+                && this.refactoringConfiguration.isRecycleBinSkippingActivated();
+
+            deletePage(documentInfo, skipRecycleBinEffective);
         } catch (XWikiException e) {
             throw new XWikiRestException(e);
         }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PageTranslationResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PageTranslationResourceImpl.java
@@ -74,7 +74,7 @@ public class PageTranslationResourceImpl extends ModifiablePageResource implemen
         try {
             DocumentInfo documentInfo = getDocumentInfo(wikiName, spaceName, pageName, language, null, true, false);
 
-            deletePage(documentInfo);
+            deletePage(documentInfo, false);
         } catch (XWikiException e) {
             throw new XWikiRestException(e);
         }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PageTranslationResourceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/pages/PageTranslationResourceImpl.java
@@ -19,10 +19,12 @@
  */
 package org.xwiki.rest.internal.resources.pages;
 
+import javax.inject.Inject;
 import javax.inject.Named;
 import javax.ws.rs.core.Response;
 
 import org.xwiki.component.annotation.Component;
+import org.xwiki.refactoring.RefactoringConfiguration;
 import org.xwiki.rest.XWikiRestException;
 import org.xwiki.rest.model.jaxb.Page;
 import org.xwiki.rest.resources.pages.PageTranslationResource;
@@ -37,6 +39,9 @@ import com.xpn.xwiki.api.Document;
 @Named("org.xwiki.rest.internal.resources.pages.PageTranslationResourceImpl")
 public class PageTranslationResourceImpl extends ModifiablePageResource implements PageTranslationResource
 {
+    @Inject
+    private RefactoringConfiguration refactoringConfiguration;
+
     @Override
     public Page getPageTranslation(String wikiName, String spaceName, String pageName, String language,
         Boolean withPrettyNames) throws XWikiRestException
@@ -68,13 +73,19 @@ public class PageTranslationResourceImpl extends ModifiablePageResource implemen
     }
 
     @Override
-    public void deletePageTranslation(String wikiName, String spaceName, String pageName, String language)
+    public void deletePageTranslation(String wikiName, String spaceName, String pageName, String language,
+        Boolean skipRecycleBin)
         throws XWikiRestException
     {
         try {
             DocumentInfo documentInfo = getDocumentInfo(wikiName, spaceName, pageName, language, null, true, false);
 
-            deletePage(documentInfo, false);
+            // Skipping the recycle bin permanently deletes the page, so it's only honored when the wiki configuration
+            // enables it.
+            boolean skipRecycleBinEffective = Boolean.TRUE.equals(skipRecycleBin)
+                && this.refactoringConfiguration.isRecycleBinSkippingActivated();
+
+            deletePage(documentInfo, skipRecycleBinEffective);
         } catch (XWikiException e) {
             throw new XWikiRestException(e);
         }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/pages/PageResourceImplTest.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/pages/PageResourceImplTest.java
@@ -28,6 +28,8 @@ import java.util.Vector;
 
 import javax.inject.Provider;
 import javax.ws.rs.BadRequestException;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.core.UriInfo;
 
 import jakarta.inject.Named;
@@ -40,6 +42,7 @@ import org.suigeneris.jrcs.rcs.Version;
 import org.xwiki.component.manager.ComponentManager;
 import org.xwiki.model.document.DocumentAuthors;
 import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.refactoring.RefactoringConfiguration;
 import org.xwiki.rendering.syntax.Syntax;
 import org.xwiki.rest.XWikiRestException;
 import org.xwiki.rest.internal.ModelFactory;
@@ -64,7 +67,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -86,6 +92,9 @@ class PageResourceImplTest
     private ContextualAuthorizationManager contextualAuthorizationManager;
 
     @MockComponent
+    private RefactoringConfiguration refactoringConfiguration;
+
+    @MockComponent
     @Named("context")
     private ComponentManager contextComponentManager;
 
@@ -96,6 +105,10 @@ class PageResourceImplTest
     private XWiki xwiki;
 
     private XWikiContext context;
+
+    private XWikiDocument testPageXWikiDocument;
+
+    private Document testPageDocument;
 
     @BeforeEach
     void setUp(MockitoComponentManager componentManager)
@@ -121,7 +134,7 @@ class PageResourceImplTest
     }
 
     @Test
-    void testCheckRights() throws XWikiRestException, XWikiException
+    void checkRights() throws XWikiRestException, XWikiException
     {
         String wikiName = "testWiki";
         String spaceName = "TestSpace";
@@ -154,7 +167,7 @@ class PageResourceImplTest
     }
 
     @Test
-    void testSupportedSyntaxes() throws XWikiRestException, XWikiException
+    void supportedSyntaxes() throws XWikiRestException, XWikiException
     {
         String wikiName = "testWiki";
         String spaceName = "TestSpace";
@@ -177,6 +190,63 @@ class PageResourceImplTest
             false, List.of(), List.of("markdown/1.2"));
         assertEquals("XWiki content.", pageWithRendering.getContent());
         assertEquals("Rendered content.", pageWithRendering.getRenderedContent());
+    }
+
+    @Test
+    void deletePageSendsToRecycleBinByDefault() throws XWikiRestException, XWikiException
+    {
+        DocumentReference reference = initTestPage("testWiki", "TestSpace", "TestPage");
+        when(this.contextualAuthorizationManager.hasAccess(Right.VIEW, reference)).thenReturn(true);
+        when(this.contextualAuthorizationManager.hasAccess(Right.DELETE, reference)).thenReturn(true);
+
+        this.pageResource.deletePage("testWiki", "TestSpace", "TestPage", false);
+
+        verify(this.testPageDocument).delete();
+        verify(this.xwiki, never()).deleteDocument(any(), anyBoolean(), any());
+    }
+
+    @Test
+    void deletePageSkipsRecycleBinWhenActivated() throws XWikiRestException, XWikiException
+    {
+        DocumentReference reference = initTestPage("testWiki", "TestSpace", "TestPage");
+        when(this.contextualAuthorizationManager.hasAccess(Right.VIEW, reference)).thenReturn(true);
+        when(this.contextualAuthorizationManager.hasAccess(Right.DELETE, reference)).thenReturn(true);
+        when(this.refactoringConfiguration.isRecycleBinSkippingActivated()).thenReturn(true);
+
+        this.pageResource.deletePage("testWiki", "TestSpace", "TestPage", true);
+
+        verify(this.xwiki).deleteDocument(this.testPageXWikiDocument, false, this.context);
+        verify(this.testPageDocument, never()).delete();
+    }
+
+    @Test
+    void deletePageSkipRecycleBinFallsBackWhenNotActivated() throws XWikiRestException, XWikiException
+    {
+        DocumentReference reference = initTestPage("testWiki", "TestSpace", "TestPage");
+        when(this.contextualAuthorizationManager.hasAccess(Right.VIEW, reference)).thenReturn(true);
+        when(this.contextualAuthorizationManager.hasAccess(Right.DELETE, reference)).thenReturn(true);
+        when(this.refactoringConfiguration.isRecycleBinSkippingActivated()).thenReturn(false);
+
+        this.pageResource.deletePage("testWiki", "TestSpace", "TestPage", true);
+
+        verify(this.testPageDocument).delete();
+        verify(this.xwiki, never()).deleteDocument(any(), anyBoolean(), any());
+    }
+
+    @Test
+    void deletePageWithoutDeleteRight() throws XWikiException
+    {
+        DocumentReference reference = initTestPage("testWiki", "TestSpace", "TestPage");
+        when(this.contextualAuthorizationManager.hasAccess(Right.VIEW, reference)).thenReturn(true);
+        when(this.contextualAuthorizationManager.hasAccess(Right.DELETE, reference)).thenReturn(false);
+
+        // The DELETE right is required regardless of the skipRecycleBin value.
+        WebApplicationException exception = assertThrows(WebApplicationException.class,
+            () -> this.pageResource.deletePage("testWiki", "TestSpace", "TestPage", false));
+        assertEquals(Status.UNAUTHORIZED.getStatusCode(), exception.getResponse().getStatus());
+
+        verify(this.testPageDocument, never()).delete();
+        verify(this.xwiki, never()).deleteDocument(any(), anyBoolean(), any());
     }
 
     private DocumentReference initTestPage(String wikiName, String spaceName, String pageName) throws XWikiException
@@ -203,6 +273,9 @@ class PageResourceImplTest
         when(testPageDoc.getAuthors()).thenReturn(mock(DocumentAuthors.class));
         when(testPageDoc.getContent()).thenReturn("XWiki content.");
         when(testPageDoc.displayDocument()).thenReturn("Rendered content.");
+
+        this.testPageXWikiDocument = testPageMock;
+        this.testPageDocument = testPageDoc;
 
         return testPageRef;
     }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/pages/PageTranslationResourceImplTest.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/pages/PageTranslationResourceImplTest.java
@@ -1,0 +1,150 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.xwiki.rest.internal.resources.pages;
+
+import java.util.Locale;
+
+import javax.inject.Provider;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response.Status;
+
+import jakarta.inject.Named;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.xwiki.component.manager.ComponentManager;
+import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.rest.XWikiRestException;
+import org.xwiki.security.authorization.ContextualAuthorizationManager;
+import org.xwiki.security.authorization.Right;
+import org.xwiki.test.junit5.mockito.ComponentTest;
+import org.xwiki.test.junit5.mockito.InjectMockComponents;
+import org.xwiki.test.junit5.mockito.MockComponent;
+import org.xwiki.test.mockito.MockitoComponentManager;
+
+import com.xpn.xwiki.XWiki;
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.api.Document;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.web.Utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link PageTranslationResourceImpl}.
+ *
+ * @version $Id$
+ */
+@ComponentTest
+class PageTranslationResourceImplTest
+{
+    private static final String WIKI = "testWiki";
+
+    private static final String SPACE = "TestSpace";
+
+    private static final String PAGE = "TestPage";
+
+    private static final String LANGUAGE = "fr";
+
+    @InjectMockComponents
+    private PageTranslationResourceImpl pageTranslationResource;
+
+    @MockComponent
+    private ContextualAuthorizationManager contextualAuthorizationManager;
+
+    @MockComponent
+    @Named("context")
+    private ComponentManager contextComponentManager;
+
+    @Mock
+    private XWiki xwiki;
+
+    private XWikiContext context;
+
+    private Document translationDocument;
+
+    @BeforeEach
+    void setUp(MockitoComponentManager componentManager) throws Exception
+    {
+        Utils.setComponentManager(componentManager);
+
+        // Because XWikiResource injects the context component manager, it exists as a mock, and we thus need to mock
+        // its behavior - otherwise it would just be ignored.
+        when(this.contextComponentManager.getInstance(any()))
+            .thenAnswer(invocation -> componentManager.getInstance(invocation.getArgument(0)));
+        when(this.contextComponentManager.getInstance(any(), any()))
+            .thenAnswer(
+                invocation -> componentManager.getInstance(invocation.getArgument(0), invocation.getArgument(1)));
+
+        Provider<XWikiContext> contextProvider = componentManager.getInstance(XWikiContext.TYPE_PROVIDER);
+        this.context = contextProvider.get();
+        when(this.context.getWiki()).thenReturn(this.xwiki);
+    }
+
+    @Test
+    void deletePageTranslationRequiresDeleteRight() throws XWikiException
+    {
+        DocumentReference reference = initTranslation();
+        when(this.contextualAuthorizationManager.hasAccess(Right.DELETE, reference)).thenReturn(false);
+
+        WebApplicationException exception = assertThrows(WebApplicationException.class,
+            () -> this.pageTranslationResource.deletePageTranslation(WIKI, SPACE, PAGE, LANGUAGE));
+        assertEquals(Status.UNAUTHORIZED.getStatusCode(), exception.getResponse().getStatus());
+
+        verify(this.translationDocument, never()).delete();
+    }
+
+    @Test
+    void deletePageTranslationWithDeleteRight() throws XWikiRestException, XWikiException
+    {
+        DocumentReference reference = initTranslation();
+        when(this.contextualAuthorizationManager.hasAccess(Right.DELETE, reference)).thenReturn(true);
+
+        this.pageTranslationResource.deletePageTranslation(WIKI, SPACE, PAGE, LANGUAGE);
+
+        verify(this.translationDocument).delete();
+    }
+
+    private DocumentReference initTranslation() throws XWikiException
+    {
+        DocumentReference reference = new DocumentReference(WIKI, SPACE, PAGE, Locale.FRENCH);
+        XWikiDocument translationXWikiDocument = mock(XWikiDocument.class);
+        Document translationDoc = mock(Document.class);
+
+        when(this.xwiki.getDocument(reference, this.context)).thenReturn(translationXWikiDocument);
+        when(translationXWikiDocument.newDocument(this.context)).thenReturn(translationDoc);
+        when(translationDoc.getDocumentReference()).thenReturn(reference);
+
+        // The translation must be resolved (VIEW right + existing document) before the DELETE right is checked.
+        when(this.contextualAuthorizationManager.hasAccess(Right.VIEW, reference)).thenReturn(true);
+
+        this.translationDocument = translationDoc;
+
+        return reference;
+    }
+}

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/pages/PageTranslationResourceImplTest.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/test/java/org/xwiki/rest/internal/resources/pages/PageTranslationResourceImplTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.xwiki.component.manager.ComponentManager;
 import org.xwiki.model.reference.DocumentReference;
+import org.xwiki.refactoring.RefactoringConfiguration;
 import org.xwiki.rest.XWikiRestException;
 import org.xwiki.security.authorization.ContextualAuthorizationManager;
 import org.xwiki.security.authorization.Right;
@@ -50,6 +51,7 @@ import com.xpn.xwiki.web.Utils;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -78,6 +80,9 @@ class PageTranslationResourceImplTest
     private ContextualAuthorizationManager contextualAuthorizationManager;
 
     @MockComponent
+    private RefactoringConfiguration refactoringConfiguration;
+
+    @MockComponent
     @Named("context")
     private ComponentManager contextComponentManager;
 
@@ -85,6 +90,8 @@ class PageTranslationResourceImplTest
     private XWiki xwiki;
 
     private XWikiContext context;
+
+    private XWikiDocument translationXWikiDocument;
 
     private Document translationDocument;
 
@@ -113,37 +120,63 @@ class PageTranslationResourceImplTest
         when(this.contextualAuthorizationManager.hasAccess(Right.DELETE, reference)).thenReturn(false);
 
         WebApplicationException exception = assertThrows(WebApplicationException.class,
-            () -> this.pageTranslationResource.deletePageTranslation(WIKI, SPACE, PAGE, LANGUAGE));
+            () -> this.pageTranslationResource.deletePageTranslation(WIKI, SPACE, PAGE, LANGUAGE, false));
         assertEquals(Status.UNAUTHORIZED.getStatusCode(), exception.getResponse().getStatus());
 
         verify(this.translationDocument, never()).delete();
+        verify(this.xwiki, never()).deleteDocument(any(), anyBoolean(), any());
     }
 
     @Test
-    void deletePageTranslationWithDeleteRight() throws XWikiRestException, XWikiException
+    void deletePageTranslationSendsToRecycleBinByDefault() throws XWikiRestException, XWikiException
     {
         DocumentReference reference = initTranslation();
         when(this.contextualAuthorizationManager.hasAccess(Right.DELETE, reference)).thenReturn(true);
 
-        this.pageTranslationResource.deletePageTranslation(WIKI, SPACE, PAGE, LANGUAGE);
+        this.pageTranslationResource.deletePageTranslation(WIKI, SPACE, PAGE, LANGUAGE, false);
 
         verify(this.translationDocument).delete();
+        verify(this.xwiki, never()).deleteDocument(any(), anyBoolean(), any());
+    }
+
+    @Test
+    void deletePageTranslationSkipsRecycleBinWhenActivated() throws XWikiRestException, XWikiException
+    {
+        DocumentReference reference = initTranslation();
+        when(this.contextualAuthorizationManager.hasAccess(Right.DELETE, reference)).thenReturn(true);
+        when(this.refactoringConfiguration.isRecycleBinSkippingActivated()).thenReturn(true);
+
+        this.pageTranslationResource.deletePageTranslation(WIKI, SPACE, PAGE, LANGUAGE, true);
+
+        verify(this.xwiki).deleteDocument(this.translationXWikiDocument, false, this.context);
+        verify(this.translationDocument, never()).delete();
+    }
+
+    @Test
+    void deletePageTranslationSkipRecycleBinFallsBackWhenNotActivated() throws XWikiRestException, XWikiException
+    {
+        DocumentReference reference = initTranslation();
+        when(this.contextualAuthorizationManager.hasAccess(Right.DELETE, reference)).thenReturn(true);
+        when(this.refactoringConfiguration.isRecycleBinSkippingActivated()).thenReturn(false);
+
+        this.pageTranslationResource.deletePageTranslation(WIKI, SPACE, PAGE, LANGUAGE, true);
+
+        verify(this.translationDocument).delete();
+        verify(this.xwiki, never()).deleteDocument(any(), anyBoolean(), any());
     }
 
     private DocumentReference initTranslation() throws XWikiException
     {
         DocumentReference reference = new DocumentReference(WIKI, SPACE, PAGE, Locale.FRENCH);
-        XWikiDocument translationXWikiDocument = mock(XWikiDocument.class);
-        Document translationDoc = mock(Document.class);
+        this.translationXWikiDocument = mock(XWikiDocument.class);
+        this.translationDocument = mock(Document.class);
 
-        when(this.xwiki.getDocument(reference, this.context)).thenReturn(translationXWikiDocument);
-        when(translationXWikiDocument.newDocument(this.context)).thenReturn(translationDoc);
-        when(translationDoc.getDocumentReference()).thenReturn(reference);
+        when(this.xwiki.getDocument(reference, this.context)).thenReturn(this.translationXWikiDocument);
+        when(this.translationXWikiDocument.newDocument(this.context)).thenReturn(this.translationDocument);
+        when(this.translationDocument.getDocumentReference()).thenReturn(reference);
 
         // The translation must be resolved (VIEW right + existing document) before the DELETE right is checked.
         when(this.contextualAuthorizationManager.hasAccess(Right.VIEW, reference)).thenReturn(true);
-
-        this.translationDocument = translationDoc;
 
         return reference;
     }


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-23447

# Changes

## Description

* Add an optional `skipRecycleBin` query parameter to the page `DELETE` REST endpoint
  (`PageResource#deletePage`). When `true`, the page is deleted permanently instead of being sent
  to the recycle bin. It defaults to `false`, preserving the existing behavior.
* The recycle bin is only actually skipped when **all** of the following hold, mirroring the delete
  UI (refactoring `DeleteJob`): the caller requested it, the wiki configuration allows it
  (`RefactoringConfiguration#isRecycleBinSkippingActivated()`) and the user is an advanced user
  (`DocumentAccessBridge#isAdvancedUser()`). In any other case the page is sent to the recycle bin
  as usual (silent fallback, same as the platform). When skipping, the `DELETE` right is
  re-checked before performing the permanent deletion.

## Clarifications

* This addresses the scenario where pages are created/deleted via the REST API and pile up in the
  recycle bin, requiring manual cleanup or a scheduler job.
* The endpoint stays **synchronous** (it keeps using `XWiki#deleteDocument` like the previous
  `doc.delete()` call) rather than routing through the asynchronous refactoring `DeleteJob`, so the
  REST response contract (HTTP 204 on success) is unchanged.
* The advanced-user + configuration guards are enforced so the REST API cannot become a backdoor
  for permanently deleting pages when the administrator has disabled recycle-bin skipping.
* Adding the query parameter changes the interface method signature; since REST resources are
  called over HTTP and not directly from Java, this is not a real breakage and is declared as an
  allowed Revapi difference in `xwiki-platform-core/pom.xml` (same pattern already used for the
  `checkRights` parameter of `getPage`).
* Added a `xwiki-platform-refactoring-api` dependency to `xwiki-platform-rest-server` (needed for
  `RefactoringConfiguration`; no dependency cycle introduced).

# Screenshots & Video

N/A (no UI change).

# Executed Tests

* Added 5 unit tests to `PageResourceImplTest` covering: default (recycle bin), successful skip,
  fallback when not an advanced user, fallback when the configuration is disabled, and access
  denied without the `DELETE` right.
* `mvn install -B -ntp -Pquality -pl xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-api,xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server`
  → BUILD SUCCESS (0 Checkstyle violations, Revapi clean, all tests pass).
* Bumped the `xwiki-platform-rest-server` JaCoCo `instructionRatio` from `0.33` to `0.36` to lock in
  the increased coverage.
* Tested manually (need to have an advanced user and set `refactoring.isRecycleBinSkippingActivated = true` in xwiki.properties

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
