### PR TITLE
[Misc] Define constants for duplicated String literals (SonarCloud java:S1192)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/FeedPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/FeedPlugin.java
@@ -88,6 +88,18 @@ public class FeedPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfa
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(FeedPlugin.class);
 
+    private static final String FEED_ENTRY_CLASS = "XWiki.FeedEntryClass";
+
+    private static final String FEEDIMGURL = "feedimgurl";
+
+    private static final String UPDATE_FEED_ERROR = "updateFeedError";
+
+    private static final String TITLE = "title";
+
+    private static final String AUTHOR = "author";
+
+    private static final String FULL_CONTENT = "fullContent";
+
     public static class SyndEntryComparator implements Comparator<SyndEntry>
     {
         @Override
@@ -367,9 +379,9 @@ public class FeedPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfa
                     updateThread.setNbLoadedFeeds(nbfeeds + updateThread.getNbLoadedFeeds());
                     updateThread.setNbLoadedFeedsErrors(nbfeedsErrors + updateThread.getNbLoadedFeedsErrors());
                 }
-                if (context.get("feedimgurl") != null) {
-                    obj.set("imgurl", context.get("feedimgurl"), context);
-                    context.remove("feedimgurl");
+                if (context.get(FEEDIMGURL) != null) {
+                    obj.set("imgurl", context.get(FEEDIMGURL), context);
+                    context.remove(FEEDIMGURL);
                 }
                 obj.set("nb", nb, context);
                 obj.set("date", new Date(), context);
@@ -398,10 +410,10 @@ public class FeedPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfa
                     // an exception occurred while updating feedDocName, don't fail completely, put the exception in the
                     // context and then pass to the next feed
                     @SuppressWarnings("unchecked")
-                    Map<String, Exception> map = (Map<String, Exception>) context.get("updateFeedError");
+                    Map<String, Exception> map = (Map<String, Exception>) context.get(UPDATE_FEED_ERROR);
                     if (map == null) {
                         map = new HashMap<>();
-                        context.put("updateFeedError", map);
+                        context.put(UPDATE_FEED_ERROR, map);
                     }
                     map.put(feedDocName, e);
                     // and log it
@@ -484,7 +496,7 @@ public class FeedPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfa
             SyndFeed feed = getFeedForce(feedurl, true, context);
             if (feed != null) {
                 if (feed.getImage() != null) {
-                    context.put("feedimgurl", feed.getImage().getUrl());
+                    context.put(FEEDIMGURL, feed.getImage().getUrl());
                 }
                 return saveFeed(feedDocumentName, feedname, feedurl, feed, fullContent, oneDocPerEntry, force, space,
                     context);
@@ -493,10 +505,10 @@ public class FeedPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfa
             }
         } catch (Exception e) {
             @SuppressWarnings("unchecked")
-            Map<String, Exception> map = (Map<String, Exception>) context.get("updateFeedError");
+            Map<String, Exception> map = (Map<String, Exception>) context.get(UPDATE_FEED_ERROR);
             if (map == null) {
                 map = new HashMap<>();
-                context.put("updateFeedError", map);
+                context.put(UPDATE_FEED_ERROR, map);
             }
             map.put(feedurl, e);
         }
@@ -515,7 +527,7 @@ public class FeedPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfa
             doc =
                 context.getWiki().getDocument(
                     prefix + "_" + context.getWiki().clearName(feedname, true, true, context), context);
-            objs = doc.getObjects("XWiki.FeedEntryClass");
+            objs = doc.getObjects(FEED_ENTRY_CLASS);
             if (!StringUtils.isBlank(doc.getContent())) {
                 this.prepareFeedEntryDocument(doc, context);
             }
@@ -548,7 +560,7 @@ public class FeedPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfa
                         this.prepareFeedEntryDocument(doc, context);
                     }
                     if (force) {
-                        BaseObject obj = doc.getObject("XWiki.FeedEntryClass");
+                        BaseObject obj = doc.getObject(FEED_ENTRY_CLASS);
                         if (obj == null) {
                             saveEntry(feedname, feedurl, entry, doc, fullContent, context);
                         } else {
@@ -652,8 +664,8 @@ public class FeedPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfa
     private void saveEntry(String feedname, String feedurl, SyndEntry entry, XWikiDocument doc, boolean fullContent,
         XWikiContext context) throws XWikiException
     {
-        int id = doc.createNewObject("XWiki.FeedEntryClass", context);
-        BaseObject obj = doc.getObject("XWiki.FeedEntryClass", id);
+        int id = doc.createNewObject(FEED_ENTRY_CLASS, context);
+        BaseObject obj = doc.getObject(FEED_ENTRY_CLASS, id);
         saveEntry(feedname, feedurl, entry, doc, obj, fullContent, context);
     }
 
@@ -661,7 +673,7 @@ public class FeedPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfa
         boolean fullContent, XWikiContext context)
     {
         obj.setStringValue("feedname", feedname);
-        obj.setStringValue("title", entry.getTitle());
+        obj.setStringValue(TITLE, entry.getTitle());
         // set document title to the feed title
         String title;
         try {
@@ -717,7 +729,7 @@ public class FeedPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfa
 
         obj.setDateValue("date", edate);
         obj.setStringValue("url", entry.getLink());
-        obj.setStringValue("author", entry.getAuthor());
+        obj.setStringValue(AUTHOR, entry.getAuthor());
         obj.setStringValue("feedurl", feedurl);
 
         // TODO: need to get entry xml or serialization
@@ -729,13 +741,13 @@ public class FeedPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfa
             if ((url != null) && (!url.trim().isEmpty())) {
                 try {
                     String sfullContent = context.getWiki().getURLContent(url, context);
-                    obj.setLargeStringValue("fullContent",
+                    obj.setLargeStringValue(FULL_CONTENT,
                         (sfullContent.length() > 65000) ? sfullContent.substring(0, 65000) : sfullContent);
                 } catch (Exception e) {
-                    obj.setLargeStringValue("fullContent", "Exception while reading fullContent: " + e.getMessage());
+                    obj.setLargeStringValue(FULL_CONTENT, "Exception while reading fullContent: " + e.getMessage());
                 }
             } else {
-                obj.setLargeStringValue("fullContent", "No url");
+                obj.setLargeStringValue(FULL_CONTENT, "No url");
             }
         }
     }
@@ -748,7 +760,7 @@ public class FeedPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfa
         String title = context.getWiki().clearName(entry.getTitle(), true, true, context);
         for (BaseObject obj : objs) {
             if (obj != null) {
-                String title2 = obj.getStringValue("title");
+                String title2 = obj.getStringValue(TITLE);
                 if (title2 == null) {
                     title2 = "";
                 } else {
@@ -786,7 +798,7 @@ public class FeedPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfa
                 try {
                     XWikiDocument doc = context.getWiki().getDocument((String) obj[1], context);
                     if (context.getWiki().getRightService().checkAccess("view", doc, context)) {
-                        BaseObject bObj = doc.getObject("XWiki.FeedEntryClass", ((Integer) obj[0]).intValue());
+                        BaseObject bObj = doc.getObject(FEED_ENTRY_CLASS, ((Integer) obj[0]).intValue());
                         com.xpn.xwiki.api.Object apiObj = new com.xpn.xwiki.api.Object(bObj, context);
                         apiObjs.add(apiObj);
                     }
@@ -932,8 +944,8 @@ public class FeedPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfa
         XWiki xwiki = context.getWiki();
         XWikiDocument doc = context.getDoc();
 
-        if (metadata.containsKey("author")) {
-            feed.setAuthor(String.valueOf(metadata.get("author")));
+        if (metadata.containsKey(AUTHOR)) {
+            feed.setAuthor(String.valueOf(metadata.get(AUTHOR)));
         } else if (doc != null) {
             feed.setAuthor(xwiki.getUserName(doc.getAuthor(), null, false, context));
         }
@@ -961,8 +973,8 @@ public class FeedPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfa
             feed.setLink("http://" + context.getRequest().getServerName());
         }
 
-        if (metadata.containsKey("title")) {
-            feed.setTitle(String.valueOf(metadata.get("title")));
+        if (metadata.containsKey(TITLE)) {
+            feed.setTitle(String.valueOf(metadata.get(TITLE)));
         }
 
         if (metadata.containsKey("language")) {

--- a/xwiki-platform-core/xwiki-platform-mailsender/src/main/java/com/xpn/xwiki/plugin/mailsender/MimeTypesUtil.java
+++ b/xwiki-platform-core/xwiki-platform-mailsender/src/main/java/com/xpn/xwiki/plugin/mailsender/MimeTypesUtil.java
@@ -21,41 +21,59 @@ package com.xpn.xwiki.plugin.mailsender;
 
 public class MimeTypesUtil
 {
+    private static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
+
+    private static final String APPLICATION_POSTSCRIPT = "application/postscript";
+
+    private static final String APPLICATION_X_DIRECTOR = "application/x-director";
+
+    private static final String APPLICATION_X_KOAN = "application/x-koan";
+
+    private static final String APPLICATION_X_TROFF = "application/x-troff";
+
+    private static final String AUDIO_MPEG = "audio/mpeg";
+
+    private static final String AUDIO_X_AIFF = "audio/x-aiff";
+
+    private static final String IMAGE_JPEG = "image/jpeg";
+
+    private static final String VIDEO_MPEG = "video/mpeg";
+
     protected static final String[][] MIME_TYPES =
         { {"application/mac-binhex40", "hqx"}, {"application/mac-compactpro", "cpt"},
-        {"application/msword", "doc"}, {"application/octet-stream", "bin"},
-        {"application/octet-stream", "dms"}, {"application/octet-stream", "lha"},
-        {"application/octet-stream", "lzh"}, {"application/octet-stream", "exe"},
-        {"application/octet-stream", "class"}, {"application/oda", "oda"},
-        {"application/pdf", "pdf"}, {"application/postscript", "ai"},
-        {"application/postscript", "eps"}, {"application/postscript", "ps"},
+        {"application/msword", "doc"}, {APPLICATION_OCTET_STREAM, "bin"},
+        {APPLICATION_OCTET_STREAM, "dms"}, {APPLICATION_OCTET_STREAM, "lha"},
+        {APPLICATION_OCTET_STREAM, "lzh"}, {APPLICATION_OCTET_STREAM, "exe"},
+        {APPLICATION_OCTET_STREAM, "class"}, {"application/oda", "oda"},
+        {"application/pdf", "pdf"}, {APPLICATION_POSTSCRIPT, "ai"},
+        {APPLICATION_POSTSCRIPT, "eps"}, {APPLICATION_POSTSCRIPT, "ps"},
         {"application/powerpoint", "ppt"}, {"application/rtf", "rtf"},
         {"application/x-bcpio", "bcpio"}, {"application/x-cdlink", "vcd"},
         {"application/x-compress", "Z"}, {"application/x-cpio", "cpio"},
-        {"application/x-csh", "csh"}, {"application/x-director", "dcr"},
-        {"application/x-director", "dir"}, {"application/x-director", "dxr"},
+        {"application/x-csh", "csh"}, {APPLICATION_X_DIRECTOR, "dcr"},
+        {APPLICATION_X_DIRECTOR, "dir"}, {APPLICATION_X_DIRECTOR, "dxr"},
         {"application/x-dvi", "dvi"}, {"application/x-gtar", "gtar"},
         {"application/x-gzip", "gz"}, {"application/x-hdf", "hdf"},
-        {"application/x-httpd-cgi", "cgi"}, {"application/x-koan", "skp"},
-        {"application/x-koan", "skd"}, {"application/x-koan", "skt"},
-        {"application/x-koan", "skm"}, {"application/x-latex", "latex"},
+        {"application/x-httpd-cgi", "cgi"}, {APPLICATION_X_KOAN, "skp"},
+        {APPLICATION_X_KOAN, "skd"}, {APPLICATION_X_KOAN, "skt"},
+        {APPLICATION_X_KOAN, "skm"}, {"application/x-latex", "latex"},
         {"application/x-mif", "mif"}, {"application/x-netcdf", "nc"},
         {"application/x-netcdf", "cdf"}, {"application/x-sh", "sh"},
         {"application/x-shar", "shar"}, {"application/x-stuffit", "sit"},
         {"application/x-sv4cpio", "sv4cpio"}, {"application/x-sv4crc", "sv4crc"},
         {"application/x-tar", "tar"}, {"application/x-tcl", "tcl"}, {"application/x-tex", "tex"},
         {"application/x-texinfo", "texinfo"}, {"application/x-texinfo", "texi"},
-        {"application/x-troff", "t"}, {"application/x-troff", "tr"},
-        {"application/x-troff", "roff"}, {"application/x-troff-man", "man"},
+        {APPLICATION_X_TROFF, "t"}, {APPLICATION_X_TROFF, "tr"},
+        {APPLICATION_X_TROFF, "roff"}, {"application/x-troff-man", "man"},
         {"application/x-troff-me", "me"}, {"application/x-troff-ms", "ms"},
         {"application/x-ustar", "ustar"}, {"application/x-wais-source", "src"},
         {"application/zip", "zip"}, {"audio/basic", "au"}, {"audio/basic", "snd"},
-        {"audio/mpeg", "mpga"}, {"audio/mpeg", "mp2"}, {"audio/mpeg", "mp3"},
-        {"audio/x-aiff", "aif"}, {"audio/x-aiff", "aiff"}, {"audio/x-aiff", "aifc"},
+        {AUDIO_MPEG, "mpga"}, {AUDIO_MPEG, "mp2"}, {AUDIO_MPEG, "mp3"},
+        {AUDIO_X_AIFF, "aif"}, {AUDIO_X_AIFF, "aiff"}, {AUDIO_X_AIFF, "aifc"},
         {"audio/x-pn-realaudio", "ram"}, {"audio/x-pn-realaudio-plugin", "rpm"},
         {"audio/x-realaudio", "ra"}, {"audio/x-wav", "wav"}, {"chemical/x-pdb", "pdb"},
         {"chemical/x-pdb", "xyz"}, {"image/gif", "gif"}, {"image/ief", "ief"},
-        {"image/jpeg", "jpeg"}, {"image/jpeg", "jpg"}, {"image/jpeg", "jpe"},
+        {IMAGE_JPEG, "jpeg"}, {IMAGE_JPEG, "jpg"}, {IMAGE_JPEG, "jpe"},
         {"image/png", "png"}, {"image/tiff", "tiff"}, {"image/tiff", "tif"},
         {"image/x-cmu-raster", "ras"}, {"image/x-portable-anymap", "pnm"},
         {"image/x-portable-bitmap", "pbm"}, {"image/x-portable-graymap", "pgm"},
@@ -63,8 +81,8 @@ public class MimeTypesUtil
         {"image/x-xpixmap", "xpm"}, {"image/x-xwindowdump", "xwd"}, {"text/html", "html"},
         {"text/html", "htm"}, {"text/plain", "txt"}, {"text/richtext", "rtx"},
         {"text/tab-separated-values", "tsv"}, {"text/x-setext", "etx"}, {"text/x-sgml", "sgml"},
-        {"text/x-sgml", "sgm"}, {"video/mpeg", "mpeg"}, {"video/mpeg", "mpg"},
-        {"video/mpeg", "mpe"}, {"video/quicktime", "qt"}, {"video/quicktime", "mov"},
+        {"text/x-sgml", "sgm"}, {VIDEO_MPEG, "mpeg"}, {VIDEO_MPEG, "mpg"},
+        {VIDEO_MPEG, "mpe"}, {"video/quicktime", "qt"}, {"video/quicktime", "mov"},
         {"video/x-msvideo", "avi"}, {"video/x-sgi-movie", "movie"},
         {"x-conference/x-cooltalk", "ice"}, {"x-world/x-vrml", "wrl"}, {"x-world/x-vrml", "vrml"}};
 
@@ -75,7 +93,7 @@ public class MimeTypesUtil
         String extension = filename;
         if (index != -1) {
             if (index == filename.length())
-                return ("application/octet-stream");
+                return (APPLICATION_OCTET_STREAM);
             else
                 extension = filename.substring(index + 1);
         }
@@ -87,7 +105,7 @@ public class MimeTypesUtil
             }
         }
         if (type == null)
-            return ("application/octet-stream");
+            return (APPLICATION_OCTET_STREAM);
         else
             return (type);
     }

--- a/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-api/src/main/java/com/xpn/xwiki/plugin/scheduler/SchedulerPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-api/src/main/java/com/xpn/xwiki/plugin/scheduler/SchedulerPlugin.java
@@ -99,6 +99,14 @@ public class SchedulerPlugin extends XWikiDefaultPlugin implements EventListener
     @Deprecated
     public static final String XWIKI_JOB_CLASS = "XWiki.SchedulerJobClass";
 
+    private static final String JOB_NAME = "jobName";
+
+    private static final String STATUS = "status";
+
+    private static final String PAUSED = "Paused";
+
+    private static final String NORMAL = "Normal";
+
     /**
      * Local reference of the XWiki Scheduler Job Class representing a job that can be scheduled by this plugin.
      */
@@ -272,7 +280,7 @@ public class SchedulerPlugin extends XWikiDefaultPlugin implements EventListener
             } catch (XWikiException e) {
                 throw new SchedulerPluginException(
                     SchedulerPluginException.ERROR_SCHEDULERPLUGIN_UNABLE_TO_PREPARE_JOB_CONTEXT,
-                    "Failed to prepare context for job with job name " + job.getStringValue("jobName"), e);
+                    "Failed to prepare context for job with job name " + job.getStringValue(JOB_NAME), e);
             } finally {
                 context.setWikiId(iDb);
             }
@@ -318,7 +326,7 @@ public class SchedulerPlugin extends XWikiDefaultPlugin implements EventListener
         } catch (Exception e) {
             throw new SchedulerPluginException(
                 SchedulerPluginException.ERROR_SCHEDULERPLUGIN_UNABLE_TO_PREPARE_JOB_CONTEXT,
-                "Failed to prepare context for job with job name " + job.getStringValue("jobName"), e);
+                "Failed to prepare context for job with job name " + job.getStringValue(JOB_NAME), e);
         }
 
         return scontext;
@@ -365,7 +373,7 @@ public class SchedulerPlugin extends XWikiDefaultPlugin implements EventListener
 
     private void register(BaseObject jobObj, XWikiContext context) throws SchedulerPluginException
     {
-        String status = jobObj.getStringValue("status");
+        String status = jobObj.getStringValue(STATUS);
         if (status.equals(JobState.STATE_NORMAL) || status.equals(JobState.STATE_PAUSED)) {
             scheduleJob(jobObj, context);
         }
@@ -496,33 +504,33 @@ public class SchedulerPlugin extends XWikiDefaultPlugin implements EventListener
                     break;
                 case NORMAL:
                     if (getTrigger(object).compareTo(trigger) != 0) {
-                        LOGGER.debug("Reschedule Job: [{}]", object.getStringValue("jobName"));
+                        LOGGER.debug("Reschedule Job: [{}]", object.getStringValue(JOB_NAME));
                     }
                     getScheduler().rescheduleJob(trigger.getKey(), trigger);
                     break;
                 case NONE:
-                    LOGGER.debug("Schedule Job: [{}]", object.getStringValue("jobName"));
+                    LOGGER.debug("Schedule Job: [{}]", object.getStringValue(JOB_NAME));
                     getScheduler().scheduleJob(trigger);
-                    LOGGER.info("XWiki Job Status: [{}]", object.getStringValue("status"));
-                    if ("Paused".equals(object.getStringValue("status"))) {
+                    LOGGER.info("XWiki Job Status: [{}]", object.getStringValue(STATUS));
+                    if (PAUSED.equals(object.getStringValue(STATUS))) {
                         getScheduler().pauseJob(new JobKey(jobID));
-                        saveStatus("Paused", object, context);
+                        saveStatus(PAUSED, object, context);
                     } else {
-                        saveStatus("Normal", object, context);
+                        saveStatus(NORMAL, object, context);
                     }
                     break;
                 default:
-                    LOGGER.debug("Schedule Job: [{}]", object.getStringValue("jobName"));
+                    LOGGER.debug("Schedule Job: [{}]", object.getStringValue(JOB_NAME));
                     getScheduler().scheduleJob(trigger);
-                    saveStatus("Normal", object, context);
+                    saveStatus(NORMAL, object, context);
                     break;
             }
         } catch (SchedulerException e) {
             throw new SchedulerPluginException(SchedulerPluginException.ERROR_SCHEDULERPLUGIN_SCHEDULE_JOB,
-                "Error while scheduling job " + object.getStringValue("jobName"), e);
+                "Error while scheduling job " + object.getStringValue(JOB_NAME), e);
         } catch (XWikiException e) {
             throw new SchedulerPluginException(SchedulerPluginException.ERROR_SCHEDULERPLUGIN_JOB_XCLASS_NOT_FOUND,
-                "Error while saving job status for job : " + object.getStringValue("jobName"), e);
+                "Error while saving job status for job : " + object.getStringValue(JOB_NAME), e);
         }
 
         return scheduled;
@@ -541,13 +549,13 @@ public class SchedulerPlugin extends XWikiDefaultPlugin implements EventListener
         try {
             getScheduler().pauseJob(new JobKey(job));
 
-            saveStatus("Paused", object, context);
+            saveStatus(PAUSED, object, context);
         } catch (SchedulerException e) {
             throw new SchedulerPluginException(SchedulerPluginException.ERROR_SCHEDULERPLUGIN_PAUSE_JOB,
-                "Error occured while trying to pause job " + object.getStringValue("jobName"), e);
+                "Error occured while trying to pause job " + object.getStringValue(JOB_NAME), e);
         } catch (XWikiException e) {
             throw new SchedulerPluginException(SchedulerPluginException.ERROR_SCHEDULERPLUGIN_PAUSE_JOB,
-                "Error occured while trying to save status of job " + object.getStringValue("jobName"), e);
+                "Error occured while trying to save status of job " + object.getStringValue(JOB_NAME), e);
         }
     }
 
@@ -564,13 +572,13 @@ public class SchedulerPlugin extends XWikiDefaultPlugin implements EventListener
         try {
             getScheduler().resumeJob(new JobKey(job));
 
-            saveStatus("Normal", object, context);
+            saveStatus(NORMAL, object, context);
         } catch (SchedulerException e) {
             throw new SchedulerPluginException(SchedulerPluginException.ERROR_SCHEDULERPLUGIN_RESUME_JOB,
-                "Error occured while trying to resume job " + object.getStringValue("jobName"), e);
+                "Error occured while trying to resume job " + object.getStringValue(JOB_NAME), e);
         } catch (XWikiException e) {
             throw new SchedulerPluginException(SchedulerPluginException.ERROR_SCHEDULERPLUGIN_RESUME_JOB,
-                "Error occured while trying to save status of job " + object.getStringValue("jobName"), e);
+                "Error occured while trying to save status of job " + object.getStringValue(JOB_NAME), e);
         }
     }
 
@@ -589,7 +597,7 @@ public class SchedulerPlugin extends XWikiDefaultPlugin implements EventListener
             getScheduler().triggerJob(new JobKey(job));
         } catch (SchedulerException e) {
             throw new SchedulerPluginException(SchedulerPluginException.ERROR_SCHEDULERPLUGIN_TRIGGER_JOB,
-                "Error occured while trying to trigger job " + object.getStringValue("jobName"), e);
+                "Error occured while trying to trigger job " + object.getStringValue(JOB_NAME), e);
         }
     }
 
@@ -608,7 +616,7 @@ public class SchedulerPlugin extends XWikiDefaultPlugin implements EventListener
             saveStatus("None", object, context);
         } catch (XWikiException e) {
             throw new SchedulerPluginException(SchedulerPluginException.ERROR_SCHEDULERPLUGIN_JOB_XCLASS_NOT_FOUND,
-                "Error while saving status of job " + object.getStringValue("jobName"), e);
+                "Error while saving status of job " + object.getStringValue(JOB_NAME), e);
         }
     }
 
@@ -619,7 +627,7 @@ public class SchedulerPlugin extends XWikiDefaultPlugin implements EventListener
             getScheduler().deleteJob(new JobKey(job));
         } catch (SchedulerException e) {
             throw new SchedulerPluginException(SchedulerPluginException.ERROR_SCHEDULERPLUGIN_PAUSE_JOB,
-                "Error occured while trying to pause job " + object.getStringValue("jobName"), e);
+                "Error occured while trying to pause job " + object.getStringValue(JOB_NAME), e);
         }
         this.schedulersClassLoaderManager.removeScheduler(object.getReference());
     }
@@ -815,7 +823,7 @@ public class SchedulerPlugin extends XWikiDefaultPlugin implements EventListener
         jobHolder = jobHolder.clone();
 
         BaseObject job = jobHolder.getXObject(XWIKI_JOB_CLASSREFERENCE);
-        job.setStringValue("status", status);
+        job.setStringValue(STATUS, status);
         jobHolder.setMinorEdit(true);
         context.getWiki().saveDocument(jobHolder, context);
     }

--- a/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-api/src/main/java/com/xpn/xwiki/plugin/scheduler/SchedulerPluginApi.java
+++ b/xwiki-platform-core/xwiki-platform-scheduler/xwiki-platform-scheduler-api/src/main/java/com/xpn/xwiki/plugin/scheduler/SchedulerPluginApi.java
@@ -52,6 +52,10 @@ public class SchedulerPluginApi extends PluginApi<SchedulerPlugin>
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(SchedulerPluginApi.class);
 
+    private static final String ERROR = "error";
+
+    private static final String JOB_NAME = "jobName";
+
     public SchedulerPluginApi(SchedulerPlugin plugin, XWikiContext context)
     {
         super(plugin, context);
@@ -80,7 +84,7 @@ public class SchedulerPluginApi extends PluginApi<SchedulerPlugin>
         try {
             return getJobStatus(object.getXWikiObject()).getValue();
         } catch (Exception e) {
-            this.context.put("error", e.getMessage());
+            this.context.put(ERROR, e.getMessage());
             return null;
         }
     }
@@ -150,7 +154,7 @@ public class SchedulerPluginApi extends PluginApi<SchedulerPlugin>
             getProtectedPlugin().scheduleJob(object, this.context);
             return true;
         } catch (Exception e) {
-            this.context.put("error", e.getMessage());
+            this.context.put(ERROR, e.getMessage());
             return false;
         }
     }
@@ -176,7 +180,7 @@ public class SchedulerPluginApi extends PluginApi<SchedulerPlugin>
                 result &= scheduleJob(object);
             }
         } catch (Exception e) {
-            this.context.put("error", e.getMessage());
+            this.context.put(ERROR, e.getMessage());
             return false;
         }
         return result;
@@ -204,10 +208,10 @@ public class SchedulerPluginApi extends PluginApi<SchedulerPlugin>
     {
         try {
             getProtectedPlugin().pauseJob(object, this.context);
-            LOGGER.debug("Pause Job: [{}]", object.getStringValue("jobName"));
+            LOGGER.debug("Pause Job: [{}]", object.getStringValue(JOB_NAME));
             return true;
         } catch (XWikiException e) {
-            this.context.put("error", e.getMessage());
+            this.context.put(ERROR, e.getMessage());
             return false;
         }
     }
@@ -234,10 +238,10 @@ public class SchedulerPluginApi extends PluginApi<SchedulerPlugin>
     {
         try {
             getProtectedPlugin().resumeJob(object, this.context);
-            LOGGER.debug("Resume Job: [{}]", object.getStringValue("jobName"));
+            LOGGER.debug("Resume Job: [{}]", object.getStringValue(JOB_NAME));
             return true;
         } catch (XWikiException e) {
-            this.context.put("error", e.getMessage());
+            this.context.put(ERROR, e.getMessage());
             return false;
         }
     }
@@ -264,10 +268,10 @@ public class SchedulerPluginApi extends PluginApi<SchedulerPlugin>
     {
         try {
             getProtectedPlugin().unscheduleJob(object, this.context);
-            LOGGER.debug("Delete Job: [{}]", object.getStringValue("jobName"));
+            LOGGER.debug("Delete Job: [{}]", object.getStringValue(JOB_NAME));
             return true;
         } catch (XWikiException e) {
-            this.context.put("error", e.getMessage());
+            this.context.put(ERROR, e.getMessage());
             return false;
         }
     }
@@ -299,10 +303,10 @@ public class SchedulerPluginApi extends PluginApi<SchedulerPlugin>
     {
         try {
             getProtectedPlugin().triggerJob(object, this.context);
-            LOGGER.debug("Trigger Job: [{}]", object.getStringValue("jobName"));
+            LOGGER.debug("Trigger Job: [{}]", object.getStringValue(JOB_NAME));
             return true;
         } catch (XWikiException e) {
-            this.context.put("error", e.getMessage());
+            this.context.put(ERROR, e.getMessage());
             return false;
         }
     }
@@ -338,7 +342,7 @@ public class SchedulerPluginApi extends PluginApi<SchedulerPlugin>
         try {
             return getProtectedPlugin().getPreviousFireTime(object, this.context);
         } catch (SchedulerPluginException e) {
-            this.context.put("error", e.getMessage());
+            this.context.put(ERROR, e.getMessage());
             return null;
         }
     }
@@ -370,7 +374,7 @@ public class SchedulerPluginApi extends PluginApi<SchedulerPlugin>
         try {
             return getProtectedPlugin().getNextFireTime(object, this.context);
         } catch (SchedulerPluginException e) {
-            this.context.put("error", e.getMessage());
+            this.context.put(ERROR, e.getMessage());
             return null;
         }
     }


### PR DESCRIPTION
## Description

Fixes 21 SonarCloud [`java:S1192`](https://rules.sonarsource.com/java/RSPEC-1192) issues ("Define a constant instead of duplicating this literal N times") by extracting `private static final String` constants for String literals that were duplicated 3+ times within a single class.

Files changed (issues resolved):
- `MimeTypesUtil` — 9 (MIME-type literals repeated across the `MIME_TYPES` lookup table; constants declared before the static array so they can be referenced from its initializer)
- `FeedPlugin` — 6 (`XWiki.FeedEntryClass`, `feedimgurl`, `updateFeedError`, `title`, `author`, `fullContent`)
- `SchedulerPlugin` — 4 (`jobName`, `status`, `Paused`, `Normal`)
- `SchedulerPluginApi` — 2 (`error`, `jobName`)

No behavior change — only literal-to-constant extraction. Javadoc occurrences of the same words were intentionally left untouched. The three affected Maven modules build cleanly (checkstyle + Spoon pass).

SonarCloud issues (rule `java:S1192`, project `org.xwiki.platform:xwiki-platform`):
https://sonarcloud.io/project/issues?resolved=false&rules=java%3AS1192&id=org.xwiki.platform%3Axwiki-platform

---
_Generated by [Claude Code](https://claude.ai/code/session_018jZS66YKjafXkjSJTgG4g4)_