### PR TITLE
[Misc] Define constants for duplicated string literals (SonarCloud java:S1192)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
@@ -287,7 +287,7 @@ public class XWiki implements EventListener
      * 
      * @since 13.2RC1
      */
-    public static final EntityReference SYSTEM_SPACE_REFERENCE = new EntityReference("XWiki", EntityType.SPACE);
+    public static final EntityReference SYSTEM_SPACE_REFERENCE = new EntityReference(SYSTEM_SPACE, EntityType.SPACE);
 
     /** Name of the default space homepage. */
     public static final String DEFAULT_SPACE_HOMEPAGE = "WebHome";
@@ -315,6 +315,10 @@ public class XWiki implements EventListener
 
     /** Represents no value (ie the default value will be used) in xproperties */
     private static final String NO_VALUE = "---";
+
+    private static final String DEFAULT = "default";
+
+    private static final String BACKLINKS = "backlinks";
 
     private static final String LANGUAGE = "language";
 
@@ -3172,7 +3176,7 @@ public class XWiki implements EventListener
         try {
             String language = Util.normalizeLanguage(context.getRequest().getParameter(LANGUAGE));
             if (language != null) {
-                if ("default".equals(language)) {
+                if (DEFAULT.equals(language)) {
                     // forgetting language cookie
                     addLanguageCookie(LANGUAGE, "", 0, context);
                     context.setLocale(defaultLocale);
@@ -3421,7 +3425,7 @@ public class XWiki implements EventListener
         // Determine which language to use
         // First we get the language from the request
         if (StringUtils.isNotEmpty(requestLanguage)) {
-            if ("default".equals(requestLanguage)) {
+            if (DEFAULT.equals(requestLanguage)) {
                 setCookie = true;
             } else {
                 language = requestLanguage;
@@ -3518,7 +3522,7 @@ public class XWiki implements EventListener
         // Determine which language to use
         // First we get the language from the request
         if ((requestLanguage != null) && (!requestLanguage.isEmpty())) {
-            if ("default".equals(requestLanguage)) {
+            if (DEFAULT.equals(requestLanguage)) {
                 setCookie = true;
             } else {
                 language = requestLanguage;
@@ -5323,7 +5327,7 @@ public class XWiki implements EventListener
 
     public String getEncoding()
     {
-        return getConfiguration().getProperty("xwiki.encoding", "UTF-8");
+        return getConfiguration().getProperty("xwiki.encoding", DEFAULT_ENCODING);
     }
 
     public URL getServerURL(String wikiId, XWikiContext xcontext) throws MalformedURLException
@@ -6900,7 +6904,7 @@ public class XWiki implements EventListener
     public boolean hasBacklinks(XWikiContext context)
     {
         if (this.hasBacklinks == null) {
-            this.hasBacklinks = "1".equals(getXWikiPreference("backlinks", "xwiki.backlinks", "0", context));
+            this.hasBacklinks = "1".equals(getXWikiPreference(BACKLINKS, "xwiki.backlinks", "0", context));
         }
         return this.hasBacklinks;
     }
@@ -7852,8 +7856,8 @@ public class XWiki implements EventListener
             if (event instanceof XObjectPropertyEvent xObjectPropertyEvent) {
                 EntityReference reference = xObjectPropertyEvent.getReference();
                 String modifiedProperty = reference.getName();
-                if ("backlinks".equals(modifiedProperty)) {
-                    this.hasBacklinks = doc.getXObject((ObjectReference) reference.getParent()).getIntValue("backlinks",
+                if (BACKLINKS.equals(modifiedProperty)) {
+                    this.hasBacklinks = doc.getXObject((ObjectReference) reference.getParent()).getIntValue(BACKLINKS,
                         getConfiguration().getProperty("xwiki.backlinks", 0)) == 1;
                 }
             }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Document.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Document.java
@@ -114,6 +114,8 @@ public class Document extends Api
     /** Logging helper object. */
     private static final Logger LOGGER = LoggerFactory.getLogger(Document.class);
 
+    private static final String DELETE = "delete";
+
     /**
      * The XWikiDocument object wrapped by this API.
      */
@@ -3106,7 +3108,7 @@ public class Document extends Api
 
     public void delete() throws XWikiException
     {
-        if (hasAccessLevel("delete")) {
+        if (hasAccessLevel(DELETE)) {
             deleteDocument();
         } else {
             java.lang.Object[] args = { this.getFullName() };
@@ -3302,7 +3304,7 @@ public class Document extends Api
     public void rename(DocumentReference newReference) throws XWikiException
     {
         XWiki xWiki = this.context.getWiki();
-        if (hasAccessLevel("delete") && xWiki.checkAccess("edit",
+        if (hasAccessLevel(DELETE) && xWiki.checkAccess("edit",
             xWiki.getDocument(newReference, this.context), this.context)) {
             List<DocumentReference> backLinkedReferences = getDocument().getBackLinkedReferences(this.context);
             List<DocumentReference> childrenReferences = getDocument().getChildrenReferences(this.context);
@@ -3396,7 +3398,7 @@ public class Document extends Api
         List<DocumentReference> childDocumentNames) throws XWikiException
     {
         XWiki xWiki = this.context.getWiki();
-        if (hasAccessLevel("delete") && xWiki.checkAccess("edit",
+        if (hasAccessLevel(DELETE) && xWiki.checkAccess("edit",
             xWiki.getDocument(newReference, this.context), this.context)) {
 
             // Every page given in childDocumentNames has it's parent changed whether it needs it or not.

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -224,6 +224,12 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(XWikiDocument.class);
 
+    private static final String DOCUMENT = "document";
+
+    private static final String REFERENCE = "reference";
+
+    private static final String INLINE = "inline";
+
     private static final String TM_FAILEDDOCUMENTPARSE = "core.document.error.failedParse";
 
     private static final String[] HTML_MACRO_SEARCH_STRINGS = new String[] { "{{html", "{{/html" };
@@ -1007,12 +1013,12 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
 
     private UserReferenceSerializer<DocumentReference> getUserReferenceDocumentReferenceSerializer()
     {
-        return Utils.getComponent(UserReferenceSerializer.TYPE_DOCUMENT_REFERENCE, "document");
+        return Utils.getComponent(UserReferenceSerializer.TYPE_DOCUMENT_REFERENCE, DOCUMENT);
     }
 
     private UserReferenceResolver<DocumentReference> getUserReferenceDocumentReferenceResolver()
     {
-        return Utils.getComponent(UserReferenceResolver.TYPE_DOCUMENT_REFERENCE, "document");
+        return Utils.getComponent(UserReferenceResolver.TYPE_DOCUMENT_REFERENCE, DOCUMENT);
     }
 
     private UserReferenceSerializer<String> getUserReferenceStringSerializer()
@@ -2128,7 +2134,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
         // The user API is missing the concept of relative user references ATM so we're forced to check where the users
         // are stored in order to make sure user references stored in the database are relative.
         // See also XWIKI-19442: APIs to generate various String references from a UserReference
-        if ("document".equals(getUserConfiguration().getStoreHint())) {
+        if (DOCUMENT.equals(getUserConfiguration().getStoreHint())) {
             // Users are stored as documents. We want the user references that are stored in the database to be relative
             // as much as possible (because it makes the content portable). For this we omit the wiki reference when the
             // user (profile document) reference is from the same wiki as this document.
@@ -2147,7 +2153,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
         // The user API is missing the concept of relative user references ATM so if we want to resolve (partial) user
         // references that were stored in the database relative to this document then we need to check where the users
         // are stored. See also XWIKI-19442: APIs to generate various String references from a UserReference
-        if ("document".equals(getUserConfiguration().getStoreHint())) {
+        if (DOCUMENT.equals(getUserConfiguration().getStoreHint())) {
             return getUserReferenceStringResolver().resolve(userString, getDocumentReference().getWikiReference());
         } else {
             return getUserReferenceStringResolver().resolve(userString);
@@ -6305,9 +6311,9 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
                 // play nice with people migrating from 1.0 to 2.0 syntax
 
                 if ("include".equalsIgnoreCase(macroBlock.getId()) || "display".equalsIgnoreCase(macroBlock.getId())) {
-                    String documentName = macroBlock.getParameters().get("reference");
+                    String documentName = macroBlock.getParameters().get(REFERENCE);
                     if (StringUtils.isEmpty(documentName)) {
-                        documentName = macroBlock.getParameters().get("document");
+                        documentName = macroBlock.getParameters().get(DOCUMENT);
                         if (StringUtils.isEmpty(documentName)) {
                             continue;
                         }
@@ -7224,7 +7230,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
         }
 
         if (ObjectUtils.notEqual(fromDoc.getDocumentReference(), toDoc.getDocumentReference())) {
-            list.add(new MetaDataDiff("reference", fromDoc.getDocumentReference(), toDoc.getDocumentReference()));
+            list.add(new MetaDataDiff(REFERENCE, fromDoc.getDocumentReference(), toDoc.getDocumentReference()));
         }
 
         if (!fromDoc.getSpace().equals(toDoc.getSpace())) {
@@ -7679,7 +7685,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
         com.xpn.xwiki.XWiki xwiki = context.getWiki();
         if (is10Syntax()) {
             if (getContent().indexOf("includeForm(") != -1) {
-                return "inline";
+                return INLINE;
             }
         } else {
             // Algorithm: look in all include macros and for all document included check if one of them
@@ -7694,9 +7700,9 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
                 // For backward-compatibility we also check for a "document" parameter since this is the parameter name
                 // that was used prior to XWiki 3.4M1 when the "reference" one was introduced and thus when the
                 // "document" one was deprecated.
-                String includedDocumentReference = macroBlock.getParameter("reference");
+                String includedDocumentReference = macroBlock.getParameter(REFERENCE);
                 if (includedDocumentReference == null) {
-                    includedDocumentReference = macroBlock.getParameter("document");
+                    includedDocumentReference = macroBlock.getParameter(DOCUMENT);
                 }
                 if (includedDocumentReference != null) {
                     // Resolve the document name into a valid Reference
@@ -7716,7 +7722,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
                             if (StringUtils.isBlank(defaultEditMode)) {
                                 // TODO: maybe here the real value should be returned if the object is edit mode class,
                                 // and inline only if the object is sheetclass
-                                return "inline";
+                                return INLINE;
                             } else {
                                 return defaultEditMode;
                             }
@@ -7733,8 +7739,8 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
     {
         String editMode = getDefaultEditMode(context);
 
-        if ("inline".equals(editMode)) {
-            return getEditURL("inline", "", context);
+        if (INLINE.equals(editMode)) {
+            return getEditURL(INLINE, "", context);
         } else {
             com.xpn.xwiki.XWiki xwiki = context.getWiki();
             String editor = xwiki.getEditorPreference(context);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R40000XWIKI6990DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R40000XWIKI6990DataMigration.java
@@ -120,6 +120,12 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
 
     private static final String TIME_ELAPSED_CLASS_MESSAGE = "Time elapsed for {} class: {} ms";
 
+    private static final String CHANGESET_START = "  <changeSet id=\"R";
+
+    private static final String CHANGESET_END = "  </changeSet>\n";
+
+    private static final String ELEMENT_CLOSE = "\"/>\n";
+
     /** Stub statistic class used to compute new ids from existing objects. */
     private static final class StatsIdComputer extends XWikiStats
     {
@@ -939,7 +945,7 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
             sb.append("\"  constraintName=\"").append(pkName);
         }
 
-        sb.append("\"/>\n");
+        sb.append(ELEMENT_CLOSE);
     }
 
     /**
@@ -968,7 +974,7 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
             sb.append("\"  constraintName=\"").append(pkName);
         }
 
-        sb.append("\"/>\n");
+        sb.append(ELEMENT_CLOSE);
     }
 
     /**
@@ -980,7 +986,7 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
     private void appendDropIndex(StringBuilder sb, Index index)
     {
         sb.append("    <dropIndex indexName=\"").append(index.getName()).append("\"  tableName=\"")
-            .append(index.getTable().getName()).append("\"/>\n");
+            .append(index.getTable().getName()).append(ELEMENT_CLOSE);
     }
 
     /**
@@ -997,7 +1003,7 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
         Iterator<Column> columns = index.getColumnIterator();
         while (columns.hasNext()) {
             Column column = columns.next();
-            sb.append("      <column name=\"").append(column.getName()).append("\"/>\n");
+            sb.append("      <column name=\"").append(column.getName()).append(ELEMENT_CLOSE);
         }
 
         sb.append("</createIndex>\n");
@@ -1034,7 +1040,7 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
     {
         String tableName = table.getName();
 
-        sb.append("  <changeSet id=\"R").append(this.getVersion().getVersion()).append('-')
+        sb.append(CHANGESET_START).append(this.getVersion().getVersion()).append('-')
             .append(Util.getHash(String.format("modifyDataType-%s-%s", table, column))).append("\" author=\"xwiki\">\n")
             .append("    <comment>Upgrade identifier [").append(column).append("] from table [").append(tableName)
             .append("] to BIGINT type</comment >\n");
@@ -1067,7 +1073,7 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
             }
         }
 
-        sb.append("  </changeSet>\n");
+        sb.append(CHANGESET_END);
         this.logCount++;
     }
 
@@ -1157,7 +1163,7 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
 
         // Preamble
         String tableName = table.getName();
-        sb.append("  <changeSet id=\"R").append(this.getVersion().getVersion()).append('-')
+        sb.append(CHANGESET_START).append(this.getVersion().getVersion()).append('-')
             .append(Util.getHash(String.format("dropForeignKeyConstraint-%s", tableName)))
             .append("\" author=\"xwiki\" runOnChange=\"true\" runAlways=\"true\" failOnError=\"false\">\n")
             .append("    <comment>Drop foreign keys on table [").append(tableName).append("]</comment>\n");
@@ -1173,7 +1179,7 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
             }
         }
         // All done!
-        sb.append("  </changeSet>\n");
+        sb.append(CHANGESET_END);
         this.logCount++;
     }
 
@@ -1190,7 +1196,7 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
 
         // Preamble
         String tableName = table.getName();
-        sb.append("  <changeSet id=\"R").append(this.getVersion().getVersion()).append('-')
+        sb.append(CHANGESET_START).append(this.getVersion().getVersion()).append('-')
             .append(Util.getHash(String.format("addForeignKeyConstraint-%s", tableName)))
             .append("\" author=\"xwiki\" runOnChange=\"true\" runAlways=\"true\">\n")
             .append("    <comment>Add foreign keys on table [").append(tableName)
@@ -1240,7 +1246,7 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
             }
         }
         // All done!
-        sb.append("  </changeSet>\n");
+        sb.append(CHANGESET_END);
         this.logCount++;
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/api/XWikiRightService.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/api/XWikiRightService.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.xwiki.model.reference.EntityReference;
 
+import com.xpn.xwiki.XWiki;
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiDocument;
@@ -36,16 +37,9 @@ public interface XWikiRightService
     String SUPERADMIN_USER = "superadmin";
 
     /**
-     * The prefix (space part) used to build the full names of the built-in users and groups.
-     *
-     * @since 18.6.0RC1
-     */
-    String XWIKI_SPACE_PREFIX = "XWiki.";
-
-    /**
      * The Superadmin full name.
      */
-    String SUPERADMIN_USER_FULLNAME = XWIKI_SPACE_PREFIX + SUPERADMIN_USER;
+    String SUPERADMIN_USER_FULLNAME = XWiki.SYSTEM_SPACE + "." + SUPERADMIN_USER;
 
     /**
      * The Guest username.
@@ -55,7 +49,7 @@ public interface XWikiRightService
     /**
      * The Guest full name.
      */
-    String GUEST_USER_FULLNAME = XWIKI_SPACE_PREFIX + GUEST_USER;
+    String GUEST_USER_FULLNAME = XWiki.SYSTEM_SPACE + "." + GUEST_USER;
 
     /**
      * The AllGroup username.
@@ -65,7 +59,7 @@ public interface XWikiRightService
     /**
      * The AllGroup full name.
      */
-    String ALLGROUP_GROUP_FULLNAME = XWIKI_SPACE_PREFIX + ALLGROUP_GROUP;
+    String ALLGROUP_GROUP_FULLNAME = XWiki.SYSTEM_SPACE + "." + ALLGROUP_GROUP;
 
     /**
      * @param userReference the user reference

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/api/XWikiRightService.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/api/XWikiRightService.java
@@ -36,9 +36,16 @@ public interface XWikiRightService
     String SUPERADMIN_USER = "superadmin";
 
     /**
+     * The prefix (space part) used to build the full names of the built-in users and groups.
+     *
+     * @since 18.6.0RC1
+     */
+    String XWIKI_SPACE_PREFIX = "XWiki.";
+
+    /**
      * The Superadmin full name.
      */
-    String SUPERADMIN_USER_FULLNAME = "XWiki." + SUPERADMIN_USER;
+    String SUPERADMIN_USER_FULLNAME = XWIKI_SPACE_PREFIX + SUPERADMIN_USER;
 
     /**
      * The Guest username.
@@ -48,7 +55,7 @@ public interface XWikiRightService
     /**
      * The Guest full name.
      */
-    String GUEST_USER_FULLNAME = "XWiki." + GUEST_USER;
+    String GUEST_USER_FULLNAME = XWIKI_SPACE_PREFIX + GUEST_USER;
 
     /**
      * The AllGroup username.
@@ -58,7 +65,7 @@ public interface XWikiRightService
     /**
      * The AllGroup full name.
      */
-    String ALLGROUP_GROUP_FULLNAME = "XWiki." + ALLGROUP_GROUP;
+    String ALLGROUP_GROUP_FULLNAME = XWIKI_SPACE_PREFIX + ALLGROUP_GROUP;
 
     /**
      * @param userReference the user reference

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/api/XWikiUser.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/api/XWikiUser.java
@@ -307,7 +307,7 @@ public class XWikiUser
                 userdoc.setIntValue(getUserClassReference(userdoc.getDocumentReference().getWikiReference()),
                     EMAIL_CHECKED_PROPERTY, checkedFlag);
                 context.getWiki().saveDocument(userdoc, localizePlainOrKey(
-                    "core.users." + (checked ? "email_checked" : "email_unchecked") + ".saveComment"), context);
+                    "core.users." + (checked ? EMAIL_CHECKED_PROPERTY : "email_unchecked") + ".saveComment"), context);
             } catch (XWikiException e) {
                 this.logger.error("Error while setting email_checked status of user [{}]", getUser(), e);
             }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyPersistentLoginManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyPersistentLoginManager.java
@@ -554,7 +554,7 @@ public class MyPersistentLoginManager extends DefaultPersistentLoginManager
     @Override
     public boolean rememberingLogin(HttpServletRequest request)
     {
-        if ("true".equals(getCookieValue(request.getCookies(), getCookiePrefix() + COOKIE_REMEMBERME, "false"))) {
+        if ("true".equals(getCookieValue(request.getCookies(), getCookiePrefix() + COOKIE_REMEMBERME, DEFAULT_VALUE))) {
             return true;
         } else {
             return false;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiRightServiceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiRightServiceImpl.java
@@ -39,6 +39,7 @@ import org.xwiki.model.reference.DocumentReferenceResolver;
 import org.xwiki.model.reference.EntityReference;
 import org.xwiki.model.reference.EntityReferenceSerializer;
 
+import com.xpn.xwiki.XWiki;
 import com.xpn.xwiki.XWikiContext;
 import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.XWikiDocument;
@@ -61,10 +62,10 @@ import com.xpn.xwiki.web.Utils;
 public class XWikiRightServiceImpl implements XWikiRightService
 {
     public static final EntityReference RIGHTCLASS_REFERENCE = new EntityReference("XWikiRights", EntityType.DOCUMENT,
-        new EntityReference("XWiki", EntityType.SPACE));
+        new EntityReference(XWiki.SYSTEM_SPACE, EntityType.SPACE));
 
     public static final EntityReference GLOBALRIGHTCLASS_REFERENCE = new EntityReference("XWikiGlobalRights",
-        EntityType.DOCUMENT, new EntityReference("XWiki", EntityType.SPACE));
+        EntityType.DOCUMENT, new EntityReference(XWiki.SYSTEM_SPACE, EntityType.SPACE));
 
     private static final String ADMIN = "admin";
     private static final String COMMENT = "comment";
@@ -83,12 +84,12 @@ public class XWikiRightServiceImpl implements XWikiRightService
     private static final Logger LOGGER = LoggerFactory.getLogger(XWikiRightServiceImpl.class);
 
     private static final EntityReference XWIKIPREFERENCES_REFERENCE = new EntityReference("XWikiPreferences",
-        EntityType.DOCUMENT, new EntityReference("XWiki", EntityType.SPACE));
+        EntityType.DOCUMENT, new EntityReference(XWiki.SYSTEM_SPACE, EntityType.SPACE));
 
     private static final List<String> ALLLEVELS = Arrays.asList(ADMIN, "view", "edit", COMMENT, DELETE,
         UNDELETE, REGISTER, PROGRAMMING);
 
-    private static final EntityReference DEFAULTUSERSPACE = new EntityReference("XWiki", EntityType.SPACE);
+    private static final EntityReference DEFAULTUSERSPACE = new EntityReference(XWiki.SYSTEM_SPACE, EntityType.SPACE);
 
     private static Map<String, String> actionMap;
 
@@ -581,8 +582,9 @@ public class XWikiRightServiceImpl implements XWikiRightService
             DocumentReference docReference = currentdoc.getDocumentReference();
 
             if ("edit".equals(accessLevel)
-                && (WEB_PREFERENCES.equals(docReference.getName()) || ("XWiki".equals(docReference.getLastSpaceReference().getName())
-                    && "XWikiPreferences".equals(docReference.getName())))) {
+                && (WEB_PREFERENCES.equals(docReference.getName())
+                    || (XWiki.SYSTEM_SPACE.equals(docReference.getLastSpaceReference().getName())
+                        && "XWikiPreferences".equals(docReference.getName())))) {
                 // Since edit rights on these documents would be sufficient for a user to elevate himself to
                 // admin or even programmer, we will instead check for admin access on these documents.
                 // See https://jira.xwiki.org/browse/XWIKI-6987 and https://jira.xwiki.org/browse/XWIKI-2184.

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/ExportAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/ExportAction.java
@@ -70,6 +70,8 @@ import com.xpn.xwiki.util.Util;
 @Singleton
 public class ExportAction extends XWikiAction
 {
+    private static final String EXCEPTION = "exception";
+
     /**
      * Define the different format supported by the export.
      */
@@ -202,7 +204,7 @@ public class ExportAction extends XWikiAction
             exportType = ExportType.PDF;
         } else if (exportType == null) {
             context.put("message", "core.export.formatUnknown");
-            return "exception";
+            return EXCEPTION;
         }
 
         urlFactory.init(context);
@@ -248,7 +250,7 @@ public class ExportAction extends XWikiAction
     {
         if (!context.getWiki().getRightService().hasWikiAdminRights(context)) {
             context.put("message", "needadminrights");
-            return "exception";
+            return EXCEPTION;
         }
 
         XWikiRequest request = context.getRequest();
@@ -358,7 +360,7 @@ public class ExportAction extends XWikiAction
             PackageAPI export = ((PackageAPI) context.getWiki().getPluginApi("package", context));
             if (export == null) {
                 // No Packaging plugin configured
-                return "exception";
+                return EXCEPTION;
             }
 
             export.setWithVersions(history);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/ObjectRemoveAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/ObjectRemoveAction.java
@@ -41,6 +41,8 @@ import com.xpn.xwiki.objects.BaseObject;
 @Singleton
 public class ObjectRemoveAction extends XWikiAction
 {
+    private static final String MESSAGE = "message";
+
     @Override
     protected Class<? extends XWikiForm> getFormClass()
     {
@@ -55,16 +57,16 @@ public class ObjectRemoveAction extends XWikiAction
         String className = form.getClassName();
         int classId = form.getClassId();
         if (StringUtils.isBlank(className)) {
-            getCurrentScriptContext().setAttribute("message",
+            getCurrentScriptContext().setAttribute(MESSAGE,
                 localizePlainOrKey("platform.core.action.objectRemove.noClassnameSpecified"),
                 ScriptContext.ENGINE_SCOPE);
         } else if (classId < 0) {
-            getCurrentScriptContext().setAttribute("message",
+            getCurrentScriptContext().setAttribute(MESSAGE,
                 localizePlainOrKey("platform.core.action.objectRemove.noObjectSpecified"), ScriptContext.ENGINE_SCOPE);
         } else {
             obj = doc.getObject(className, classId);
             if (obj == null) {
-                getCurrentScriptContext().setAttribute("message",
+                getCurrentScriptContext().setAttribute(MESSAGE,
                     localizePlainOrKey("platform.core.action.objectRemove.invalidObject"), ScriptContext.ENGINE_SCOPE);
             }
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SaveAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SaveAction.java
@@ -108,6 +108,10 @@ public class SaveAction extends EditAction
      */
     private static final String FORCE_SAVE_OVERRIDE = "override";
 
+    private static final String EXCEPTION = "exception";
+
+    private static final String PREVIOUS_VERSION = "previousVersion";
+
     @Inject
     private DocumentRevisionProvider documentRevisionProvider;
 
@@ -204,7 +208,7 @@ public class SaveAction extends EditAction
             readFromTemplate(tdoc, form.getTemplate(), context);
         } catch (XWikiException e) {
             if (e.getCode() == XWikiException.ERROR_XWIKI_APP_DOCUMENT_NOT_EMPTY) {
-                context.put("exception", e);
+                context.put(EXCEPTION, e);
                 return true;
             }
         }
@@ -280,7 +284,7 @@ public class SaveAction extends EditAction
         // Detect merge conflicts. We do this only if the previous version is known, otherwise a 3-way merge is not
         // possible, and the save request is asynchronous, i.e. the user is waiting in edit mode for the save result. If
         // a merge conflict is detected the editor will display the merge conflict modal.
-        if (isConflictCheckEnabled() && Utils.isAjaxRequest(context) && request.getParameter("previousVersion") != null
+        if (isConflictCheckEnabled() && Utils.isAjaxRequest(context) && request.getParameter(PREVIOUS_VERSION) != null
             && isConflictingWithVersion(context, originalDoc, tdoc)) {
             return true;
         }
@@ -441,7 +445,7 @@ public class SaveAction extends EditAction
 
         // TODO The check of the previousVersion should be done at a lower level or with a semaphore since
         // another job might have saved a different version of the document
-        Version previousVersion = new Version(request.getParameter("previousVersion"));
+        Version previousVersion = new Version(request.getParameter(PREVIOUS_VERSION));
         Version latestVersion = originalDoc.getRCSVersion();
 
         Date editingVersionDate = new Date(Long.parseLong(request.getParameter("editingVersionDate")));
@@ -528,7 +532,7 @@ public class SaveAction extends EditAction
                 // we have a conflict.
                 // TODO: Improve it to return the diff between the current version and the latest recorder
                 Map<String, String> jsonObject = new LinkedHashMap<>();
-                jsonObject.put("previousVersion", previousVersion.toString());
+                jsonObject.put(PREVIOUS_VERSION, previousVersion.toString());
                 jsonObject.put("previousVersionDate", editingVersionDate.toString());
                 jsonObject.put("latestVersion", latestVersion.toString());
                 jsonObject.put("latestVersionDate", latestVersionDate.toString());
@@ -577,7 +581,7 @@ public class SaveAction extends EditAction
     @Override
     public String render(XWikiContext context) throws XWikiException
     {
-        XWikiException e = (XWikiException) context.get("exception");
+        XWikiException e = (XWikiException) context.get(EXCEPTION);
         if ((e != null) && (e.getCode() == XWikiException.ERROR_XWIKI_APP_DOCUMENT_NOT_EMPTY)) {
             return "docalreadyexists";
         }
@@ -589,7 +593,7 @@ public class SaveAction extends EditAction
             return context.getAction();
         }
 
-        return "exception";
+        return EXCEPTION;
     }
 
     private boolean isAsync(XWikiRequest request)

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiServletURLFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiServletURLFactory.java
@@ -63,6 +63,10 @@ public class XWikiServletURLFactory extends XWikiDefaultURLFactory
 {
     private static final Logger LOGGER = LoggerFactory.getLogger(XWikiServletURLFactory.class);
 
+    private static final String HTML_AMPERSAND = "&amp;";
+
+    private static final String UTF8 = "UTF-8";
+
     private EntityReferenceResolver<String> relativeEntityReferenceResolver;
 
     private EntityReferenceResolver<String> currentEntityReferenceResolver;
@@ -326,7 +330,7 @@ public class XWikiServletURLFactory extends XWikiDefaultURLFactory
 
         if (!StringUtils.isEmpty(querystring)) {
             path.append("?");
-            path.append(Strings.CS.removeEnd(StringUtils.removeEnd(querystring, "&"), "&amp;"));
+            path.append(Strings.CS.removeEnd(StringUtils.removeEnd(querystring, "&"), HTML_AMPERSAND));
         }
 
         if (!StringUtils.isEmpty(anchor)) {
@@ -450,7 +454,7 @@ public class XWikiServletURLFactory extends XWikiDefaultURLFactory
 
         String encodedName;
         try {
-            encodedName = URLEncoder.encode(name, "UTF-8");
+            encodedName = URLEncoder.encode(name, UTF8);
         } catch (Exception e) {
             // Should not happen (UTF-8 is always available)
             throw new RuntimeException("Missing charset [UTF-8]", e);
@@ -524,9 +528,9 @@ public class XWikiServletURLFactory extends XWikiDefaultURLFactory
         throws UnsupportedEncodingException
     {
         if (paramValue instanceof String) {
-            stringBuilder.append(URLEncoder.encode(key, "UTF-8"));
+            stringBuilder.append(URLEncoder.encode(key, UTF8));
             stringBuilder.append('=');
-            stringBuilder.append(URLEncoder.encode((String) paramValue, "UTF-8"));
+            stringBuilder.append(URLEncoder.encode((String) paramValue, UTF8));
         } else if (paramValue.getClass().isArray()) {
             Class ofArray = paramValue.getClass().getComponentType();
             if (ofArray.isPrimitive()) {
@@ -761,7 +765,7 @@ public class XWikiServletURLFactory extends XWikiDefaultURLFactory
 
         if (!StringUtils.isEmpty(querystring)) {
             path.append("?");
-            path.append(Strings.CS.removeEnd(StringUtils.removeEnd(querystring, "&"), "&amp;"));
+            path.append(Strings.CS.removeEnd(StringUtils.removeEnd(querystring, "&"), HTML_AMPERSAND));
         }
 
         try {
@@ -864,7 +868,7 @@ public class XWikiServletURLFactory extends XWikiDefaultURLFactory
                     String querystring = url.getQuery();
                     if (!StringUtils.isEmpty(querystring)) {
                         relativeURLBuilder.append("?")
-                            .append(Strings.CS.removeEnd(StringUtils.removeEnd(querystring, "&"), "&amp;"));
+                            .append(Strings.CS.removeEnd(StringUtils.removeEnd(querystring, "&"), HTML_AMPERSAND));
                     }
 
                     String anchor = url.getRef();


### PR DESCRIPTION
## Summary

Batch fix of **21 SonarCloud `java:S1192`** issues ("Define a constant instead of duplicating this literal" / "Use already-defined constant") in `xwiki-platform-oldcore`.

Each fix either extracts a `private static final String` constant for a literal duplicated ≥3 times, or reuses an already-defined constant that holds the same value. No behavior change.

### Changes per file

- `XWiki.java` — new `DEFAULT`, `BACKLINKS` constants; reuse `SYSTEM_SPACE` and `DEFAULT_ENCODING`.
- `api/Document.java` — new `DELETE` constant.
- `doc/XWikiDocument.java` — new `DOCUMENT`, `REFERENCE`, `INLINE` constants.
- `web/ExportAction.java` — new `EXCEPTION` constant.
- `web/ObjectRemoveAction.java` — new `MESSAGE` constant.
- `web/SaveAction.java` — new `EXCEPTION`, `PREVIOUS_VERSION` constants.
- `web/XWikiServletURLFactory.java` — new `HTML_AMPERSAND`, `UTF8` constants.
- `store/migration/hibernate/R40000XWIKI6990DataMigration.java` — new `CHANGESET_START`, `CHANGESET_END`, `ELEMENT_CLOSE` constants.
- `user/impl/xwiki/XWikiRightServiceImpl.java` — reuse `com.xpn.xwiki.XWiki.SYSTEM_SPACE` for the `"XWiki"` system-space literal.
- `user/impl/xwiki/MyPersistentLoginManager.java` — reuse the existing `DEFAULT_VALUE` constant.
- `user/api/XWikiUser.java` — reuse the existing `EMAIL_CHECKED_PROPERTY` constant.
- `user/api/XWikiRightService.java` — new `XWIKI_SPACE_PREFIX` interface constant (`@since 18.6.0RC1`).

### SonarCloud issues addressed

``[Filtered view of all 21 issues](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&issues=AW5-S50E1Yj5qvzeRm3q%2CAW5-S6aE1Yj5qvzeRnWV%2CAW5-S6ey1Yj5qvzeRnZ9%2CAW5-S6jq1Yj5qvzeRnel%2CAW5-S6jq1Yj5qvzeRnek%2CAW5-S62l1Yj5qvzeRnvz%2CAW5-S62m1Yj5qvzeRnv8%2CAXnpAfSYDDFOvAKXAQXz%2CAW5-S62m1Yj5qvzeRnv-%2CAX-N4fWt2gSgI3Rl_5uG%2CAW5-S6YN1Yj5qvzeRnO1%2CAW5-S6YN1Yj5qvzeRnOu%2CAW5-S6d91Yj5qvzeRnZH%2CAW5-S6d91Yj5qvzeRnZI%2CAW5-S6Lk1Yj5qvzeRnBX%2CAW5-S6MQ1Yj5qvzeRnEP%2CAW5-S6Nz1Yj5qvzeRnFx%2CAW5-S6Nn1Yj5qvzeRnFq%2CAW5-S6j61Yj5qvzeRnfJ%2CAW5-S6j61Yj5qvzeRnfH%2CAW5-S6j61Yj5qvzeRnfG)``

## Test plan

- `mvn clean install -f xwiki-platform-core/xwiki-platform-oldcore/pom.xml -Plegacy,snapshot` (Checkstyle + Spoon) — **BUILD SUCCESS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XyavsVzodS1LBaJSyXeoSq)_