### PR TITLE
[Misc] Use Collection.isEmpty() instead of size() > 0 (SonarCloud)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-api/src/main/java/org/xwiki/url/internal/AbstractExtendedURLResourceTypeResolver.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-api/src/main/java/org/xwiki/url/internal/AbstractExtendedURLResourceTypeResolver.java
@@ -85,7 +85,7 @@ public abstract class AbstractExtendedURLResourceTypeResolver implements Resourc
         // Resource.
         List<String> segments = extendedURL.getSegments();
 
-        String nextSegment = segments.size() > 0 ? segments.get(0) : null;
+        String nextSegment = !segments.isEmpty() ? segments.get(0) : null;
         resourceType = this.defaultStringResourceTypeResolver.resolve(nextSegment, Collections.emptyMap());
 
         // First, find out if an ExtendedURL Resource Resolver exists, only for this URL scheme.


### PR DESCRIPTION
Fixes SonarCloud issue [java:S1155](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&issues=AY_LKmIDx1Hu7W16CGk1&open=AY_LKmIDx1Hu7W16CGk1) in `AbstractExtendedURLResourceTypeResolver`.

`Collection.isEmpty()` should be used to test for emptiness rather than comparing `size()` to `0`. Replaced `segments.size() > 0` with `!segments.isEmpty()`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RY2dLx8NtvBtZ3qqxqdTKa)_