### PR TITLE
[Misc] Fix various SonarQube issues in oldcore

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
@@ -1647,8 +1647,7 @@ public class XWiki implements EventListener
         try {
             Class<?>[] classes = new Class<?>[] { XWikiContext.class };
             Object[] args = new Object[] { context };
-            Object result = Class.forName(storeclass).getConstructor(classes).newInstance(args);
-            return result;
+            return Class.forName(storeclass).getConstructor(classes).newInstance(args);
         } catch (Exception e) {
             Throwable ecause = e;
             if (e instanceof InvocationTargetException) {
@@ -4370,8 +4369,7 @@ public class XWiki implements EventListener
     public User getUser(String username, XWikiContext context)
     {
         XWikiUser xwikiUser = new XWikiUser(username);
-        User user = new User(xwikiUser, context);
-        return user;
+        return new User(xwikiUser, context);
     }
 
     /**
@@ -4385,8 +4383,7 @@ public class XWiki implements EventListener
     public User getUser(DocumentReference userReference, XWikiContext context)
     {
         XWikiUser xwikiUser = new XWikiUser(userReference);
-        User user = new User(xwikiUser, context);
-        return user;
+        return new User(xwikiUser, context);
     }
 
     /**
@@ -4497,7 +4494,7 @@ public class XWiki implements EventListener
                     getCurrentMixedDocumentReferenceResolver().resolve(localTopic);
                 doc = getDocument(targetDocumentReference, context);
 
-                if (checkAccess("view", doc, context) == false) {
+                if (!checkAccess("view", doc, context)) {
                     throw new XWikiException(XWikiException.MODULE_XWIKI_ACCESS,
                         XWikiException.ERROR_XWIKI_ACCESS_DENIED, "Access to this document is denied: " + doc);
                 }
@@ -7181,9 +7178,7 @@ public class XWiki implements EventListener
     {
         Map<String, String[]> map = Util.getObject(context.getRequest(), className);
         BaseClass bclass = context.getWiki().getClass(className, context);
-        BaseObject newobject = (BaseObject) bclass.fromMap(map, context);
-
-        return newobject;
+        return (BaseObject) bclass.fromMap(map, context);
     }
 
     public String getConvertingUserNameType(XWikiContext context)

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Document.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Document.java
@@ -2224,8 +2224,7 @@ public class Document extends Api
         Range range = RangeFactory.ALL;
         Period period = PeriodFactory.getCurrentMonth();
         XWikiStatsService statisticsService = getXWikiContext().getWiki().getStatsService(getXWikiContext());
-        List<RefererStats> stats = statisticsService.getRefererStatistics("", scope, period, range, this.context);
-        return stats;
+        return statisticsService.getRefererStatistics("", scope, period, range, this.context);
     }
 
     public boolean checkAccess(String right)

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/XWiki.java
@@ -410,8 +410,7 @@ public class XWiki extends Api
     public List<DeletedDocument> getDeletedDocuments(String fullname, String locale) throws XWikiException
     {
         XWikiDeletedDocument[] deletedDocuments = this.xwiki.getDeletedDocuments(fullname, locale, this.context);
-        List<DeletedDocument> result = wrapDeletedDocuments(deletedDocuments);
-        return result;
+        return wrapDeletedDocuments(deletedDocuments);
     }
 
     /**
@@ -424,8 +423,7 @@ public class XWiki extends Api
     public List<DeletedDocument> getDeletedDocuments(String batchId) throws XWikiException
     {
         XWikiDeletedDocument[] deletedDocuments = this.xwiki.getDeletedDocuments(batchId, this.context);
-        List<DeletedDocument> result = wrapDeletedDocuments(deletedDocuments);
-        return result;
+        return wrapDeletedDocuments(deletedDocuments);
     }
 
     private List<DeletedDocument> wrapDeletedDocuments(XWikiDeletedDocument[] deletedDocuments)
@@ -625,8 +623,8 @@ public class XWiki extends Api
     public Document getDocument(String space, String fullname) throws XWikiException
     {
         XWikiDocument doc = this.xwiki.getDocument(space, fullname, getXWikiContext());
-        if (this.xwiki.getRightService().hasAccessLevel("view", getXWikiContext().getUser(), doc.getFullName(),
-            getXWikiContext()) == false) {
+        if (!this.xwiki.getRightService().hasAccessLevel("view", getXWikiContext().getUser(), doc.getFullName(),
+            getXWikiContext())) {
             return null;
         }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -4214,7 +4214,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
         result.append("{table}\n");
         boolean first = true;
         for (String propertyName : bclass.getPropertyList()) {
-            if (first == true) {
+            if (first) {
                 first = false;
             } else {
                 result.append("|");
@@ -4228,7 +4228,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
             if (object != null) {
                 first = true;
                 for (String propertyName : bclass.getPropertyList()) {
-                    if (first == true) {
+                    if (first) {
                         first = false;
                     } else {
                         result.append("|");
@@ -4575,9 +4575,9 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
     {
         // We add the new objects that have been submitted in the form, before filling them with their values.
         Map<String, List<Integer>> objectsToAdd = eform.getObjectsToAdd();
-        for (String className : objectsToAdd.keySet()) {
-            DocumentReference classReference = resolveClassReference(className);
-            List<Integer> classIds = objectsToAdd.get(className);
+        for (Map.Entry<String, List<Integer>> entry : objectsToAdd.entrySet()) {
+            DocumentReference classReference = resolveClassReference(entry.getKey());
+            List<Integer> classIds = entry.getValue();
             for (Integer classId : classIds) {
                 // we ensure that the object has not been added yet, for example because of the update or create.
                 getXObject(classReference, classId, true, context);
@@ -4593,9 +4593,9 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
 
         // remove xobjects
         Map<String, List<Integer>> objectsToRemove = eform.getObjectsToRemove();
-        for (String className : objectsToRemove.keySet()) {
-            DocumentReference classReference = resolveClassReference(className);
-            List<Integer> classIds = objectsToRemove.get(className);
+        for (Map.Entry<String, List<Integer>> entry : objectsToRemove.entrySet()) {
+            DocumentReference classReference = resolveClassReference(entry.getKey());
+            List<Integer> classIds = entry.getValue();
             for (Integer classId : classIds) {
                 BaseObject xObject = getXObject(classReference, classId);
                 if (xObject != null) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/HibernateStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/HibernateStore.java
@@ -992,7 +992,7 @@ public class HibernateStore implements Disposable, Initializable
     {
         return this.<List<String>, String>executeNative(String
             .format("select SEQUENCE_NAME from all_sequences where SEQUENCE_OWNER = '%s'", schemaName.toUpperCase()),
-            query -> query.getResultList());
+            NativeQuery::getResultList);
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/monitor/api/MonitorPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/monitor/api/MonitorPlugin.java
@@ -83,7 +83,7 @@ public class MonitorPlugin extends XWikiDefaultPlugin
 
     public void startRequest(String page, String action, URL url)
     {
-        if (isActive() == false) {
+        if (!isActive()) {
             return;
         }
 
@@ -116,7 +116,7 @@ public class MonitorPlugin extends XWikiDefaultPlugin
 
     public void endRequest()
     {
-        if (isActive() == false) {
+        if (!isActive()) {
             return;
         }
 
@@ -156,7 +156,7 @@ public class MonitorPlugin extends XWikiDefaultPlugin
 
     public void setWikiPage(String page)
     {
-        if (isActive() == false) {
+        if (!isActive()) {
             return;
         }
 
@@ -209,7 +209,7 @@ public class MonitorPlugin extends XWikiDefaultPlugin
 
     public void startTimer(String timername, String desc)
     {
-        if (isActive() == false) {
+        if (!isActive()) {
             return;
         }
 
@@ -229,7 +229,7 @@ public class MonitorPlugin extends XWikiDefaultPlugin
 
     public void setTimerDesc(String timername, String desc)
     {
-        if (isActive() == false) {
+        if (!isActive()) {
             return;
         }
 
@@ -249,7 +249,7 @@ public class MonitorPlugin extends XWikiDefaultPlugin
 
     public void endTimer(String timername)
     {
-        if (isActive() == false) {
+        if (!isActive()) {
             return;
         }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BaseClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BaseClass.java
@@ -1366,9 +1366,7 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
     public static BaseObject newCustomClassInstance(String className, XWikiContext context) throws XWikiException
     {
         BaseClass bclass = context.getWiki().getClass(className, context);
-        BaseObject object = (bclass == null) ? new BaseObject() : bclass.newCustomClassInstance(context);
-
-        return object;
+        return (bclass == null) ? new BaseObject() : bclass.newCustomClassInstance(context);
     }
 
     public String getDefaultWeb()

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ComputedFieldClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ComputedFieldClass.java
@@ -96,8 +96,7 @@ public class ComputedFieldClass extends PropertyClass
      */
     public String getScript()
     {
-        String sValue = getLargeStringValue(FIELD_SCRIPT);
-        return sValue;
+        return getLargeStringValue(FIELD_SCRIPT);
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/DBListClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/DBListClass.java
@@ -474,7 +474,7 @@ public class DBListClass extends ListClass
                 firstCol = StringUtils.substringAfterLast(beforeFrom.trim(), " ");
             }
         }
-        if (first == true) {
+        if (first) {
             return firstCol;
         } else {
             return secondCol;
@@ -581,14 +581,14 @@ public class DBListClass extends ListClass
                 }
             }
 
-            if (changeInputName == true) {
+            if (changeInputName) {
                 input.setName(prefix + name + "_suggest");
                 input.setID(prefix + name + "_suggest");
             } else {
                 input.setName(prefix + name);
                 input.setID(prefix + name);
             }
-            if (setInpVal == true) {
+            if (setInpVal) {
                 input.setValue(value);
             }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/XWikiPluginManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/XWikiPluginManager.java
@@ -100,8 +100,8 @@ public class XWikiPluginManager
         Object plugin = this.plugins_classes.get(className);
         this.plugins_classes.remove(className);
 
-        for (String name : this.functionList.keySet()) {
-            Vector<XWikiPluginInterface> pluginList = this.functionList.get(name);
+        for (Map.Entry<String, Vector<XWikiPluginInterface>> entry : this.functionList.entrySet()) {
+            Vector<XWikiPluginInterface> pluginList = entry.getValue();
             pluginList.remove(plugin);
         }
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/XWikiPluginManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/XWikiPluginManager.java
@@ -100,10 +100,7 @@ public class XWikiPluginManager
         Object plugin = this.plugins_classes.get(className);
         this.plugins_classes.remove(className);
 
-        for (Map.Entry<String, Vector<XWikiPluginInterface>> entry : this.functionList.entrySet()) {
-            Vector<XWikiPluginInterface> pluginList = entry.getValue();
-            pluginList.remove(plugin);
-        }
+        this.functionList.values().forEach(pluginList -> pluginList.remove(plugin));
     }
 
     public void addPlugins(String[] classNames, XWikiContext context)

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
@@ -2996,7 +2996,7 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
         throws XWikiException
     {
         boolean result = injectCustomMapping(bclass, context);
-        if (result == false) {
+        if (!result) {
             return getSessionFactory();
         }
 
@@ -3015,7 +3015,7 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
 
         try {
             // If we haven't turned of dynamic custom mappings we should not inject them
-            if (context.getWiki().hasDynamicCustomMappings() == false) {
+            if (!context.getWiki().hasDynamicCustomMappings()) {
                 return getSessionFactory();
             }
 
@@ -3048,7 +3048,7 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
 
         try {
             // If we haven't turned of dynamic custom mappings we should not inject them
-            if (context.getWiki().hasDynamicCustomMappings() == false) {
+            if (!context.getWiki().hasDynamicCustomMappings()) {
                 return false;
             }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyFormAuthenticator.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyFormAuthenticator.java
@@ -292,7 +292,7 @@ public class MyFormAuthenticator extends FormAuthenticator implements XWikiAuthe
         HttpServletResponse httpServletResponse, URLPatternMatcher urlPatternMatcher) throws Exception
     {
         boolean result = super.processLogout(securityRequestWrapper, httpServletResponse, urlPatternMatcher);
-        if (result == true) {
+        if (result) {
             if (this.persistentLoginManager != null) {
                 this.persistentLoginManager.forgetLogin(securityRequestWrapper, httpServletResponse);
             }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyPersistentLoginManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyPersistentLoginManager.java
@@ -320,13 +320,13 @@ public class MyPersistentLoginManager extends DefaultPersistentLoginManager
 
             sbValueBeforeMD5.append(username);
             sbValueBeforeMD5.append(FIELD_SEPARATOR);
-            sbValueBeforeMD5.append(password.toString());
+            sbValueBeforeMD5.append(password);
             sbValueBeforeMD5.append(FIELD_SEPARATOR);
             if (isTrue(this.useIP)) {
-                sbValueBeforeMD5.append(clientIP.toString());
+                sbValueBeforeMD5.append(clientIP);
                 sbValueBeforeMD5.append(FIELD_SEPARATOR);
             }
-            sbValueBeforeMD5.append(this.validationKey.toString());
+            sbValueBeforeMD5.append(this.validationKey);
 
             this.valueBeforeMD5 = sbValueBeforeMD5.toString();
             md5.update(this.valueBeforeMD5.getBytes());
@@ -580,8 +580,7 @@ public class MyPersistentLoginManager extends DefaultPersistentLoginManager
             Cipher c1 = Cipher.getInstance(this.cipherParameters);
             c1.init(Cipher.DECRYPT_MODE, this.secretKey);
             byte[] decryptedText = c1.doFinal(decodedEncryptedText);
-            String decryptedTextString = new String(decryptedText);
-            return decryptedTextString;
+            return new String(decryptedText);
         } catch (Exception e) {
             LOGGER.error("Error decypting text: " + encryptedText, e);
             return null;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiRightServiceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiRightServiceImpl.java
@@ -572,7 +572,7 @@ public class XWikiRightServiceImpl implements XWikiRightService
         }
 
         allow = isSuperAdminOrProgramming(userOrGroupName, entityReference, accessLevel, user, context);
-        if ((allow == true) || (PROGRAMMING.equals(accessLevel))) {
+        if (allow || (PROGRAMMING.equals(accessLevel))) {
             return allow;
         }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/util/Util.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/util/Util.java
@@ -206,12 +206,13 @@ public class Util
     public static <T> Map<String, T> getSubMap(Map<String, T> map, String prefix)
     {
         Map<String, T> result = new HashMap<>();
-        for (String name : map.keySet()) {
+        for (Map.Entry<String, T> entry : map.entrySet()) {
+            String name = entry.getKey();
             if (name.startsWith(prefix + "_")) {
                 String newname = name.substring(prefix.length() + 1);
-                result.put(newname, map.get(name));
+                result.put(newname, entry.getValue());
             } else if (name.equals(prefix)) {
-                result.put("", map.get(name));
+                result.put("", entry.getValue());
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/CreateActionRequestHandler.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/CreateActionRequestHandler.java
@@ -485,8 +485,7 @@ public class CreateActionRequestHandler
                             Utils.getComponent(SpaceReferenceResolver.TYPE_STRING);
                         SpaceReference restrictionSpaceReference = spaceResolver.resolve(restriction);
                         // The specificity score.
-                        int specificity = restrictionSpaceReference.getReversedReferenceChain().size();
-                        return specificity;
+                        return restrictionSpaceReference.getReversedReferenceChain().size();
                     }).max()
                     // Or 0 if no restrictions are set or if none match the current space.
                     .orElse(0);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/EditForm.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/EditForm.java
@@ -217,10 +217,11 @@ public class EditForm extends XWikiForm
         @SuppressWarnings("unchecked")
         Map<String, String[]> allParameters = getRequest().getParameterMap();
         Map<String, String[]> result = new HashMap<>();
-        for (String name : allParameters.keySet()) {
+        for (Map.Entry<String, String[]> entry : allParameters.entrySet()) {
+            String name = entry.getKey();
             if (name.startsWith(prefix + "_")) {
                 String newname = name.substring(prefix.length() + 1);
-                result.put(newname, allParameters.get(name));
+                result.put(newname, entry.getValue());
             }
         }
         return result;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiResourceManagerImpl.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiResourceManagerImpl.java
@@ -31,7 +31,6 @@ public class XWikiResourceManagerImpl extends ResourceManagerImpl
     public Resource getResource(String string, int i, String string1) throws ResourceNotFoundException,
         ParseErrorException
     {
-        Resource result = super.getResource(string, i, string1);
-        return result;
+        return super.getResource(string, i, string1);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/includeservletasstring/IncludeServletAsString.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/includeservletasstring/IncludeServletAsString.java
@@ -66,9 +66,7 @@ public class IncludeServletAsString
             LOGGER.debug("Buffer returned with " + buffer.length + " bytes.");
         }
 
-        String bufferString = new String(buffer, servletResponse.getCharacterEncoding());
-
-        return bufferString;
+        return new String(buffer, servletResponse.getCharacterEncoding());
     }
 
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/AbstractHibernateAdapter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/store/hibernate/AbstractHibernateAdapter.java
@@ -122,9 +122,7 @@ public abstract class AbstractHibernateAdapter implements HibernateAdapter
     {
         // Minus (-) is not supported by many databases
         // TODO: move it to adapters which really needs it ?
-        String cleanName = name.replace('-', '_');
-
-        return cleanName;
+        return name.replace('-', '_');
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/api/DocumentTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/api/DocumentTest.java
@@ -278,7 +278,7 @@ class DocumentTest
 
         this.oldcore.getXWikiContext().dropPermissions();
 
-        Throwable exception = assertThrows(XWikiException.class, () -> doc.saveAsAuthor());
+        Throwable exception = assertThrows(XWikiException.class, doc::saveAsAuthor);
         assertTrue(
             exception.getMessage()
                 .contains("Access denied; user null, acting through script in "
@@ -500,7 +500,7 @@ class DocumentTest
         when(this.oldcore.getMockRightService().hasAccessLevel("edit", this.oldcore.getXWikiContext().getUser(),
             document.getPrefixedFullName(), this.oldcore.getXWikiContext())).thenReturn(false);
 
-        assertThrows(XWikiException.class, () -> document.save());
+        assertThrows(XWikiException.class, document::save);
 
         when(this.oldcore.getMockRightService().hasAccessLevel("edit", this.oldcore.getXWikiContext().getUser(),
             document.getPrefixedFullName(), this.oldcore.getXWikiContext())).thenReturn(true);


### PR DESCRIPTION
## Summary

Mechanical, behaviour-preserving cleanup of 43 open SonarCloud issues in the `xwiki-platform-oldcore` module, across 21 files. Each change is a straightforward code-quality fix with no functional impact.

Rules addressed:

- **[java:S1125](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS1125&rule_key=java%3AS1125)** — remove redundant comparisons to boolean literals (`x == true` / `x == false` → `x` / `!x`).
- **[java:S1488](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS1488&rule_key=java%3AS1488)** — inline local variables that are immediately returned.
- **[java:S2864](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS2864&rule_key=java%3AS2864)** — iterate `entrySet()` instead of `keySet()` followed by `get()`.
- **[java:S1858](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS1858&rule_key=java%3AS1858)** — remove pointless `toString()` calls on values that are already `String`.
- **[java:S1612](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS1612&rule_key=java%3AS1612)** — replace lambdas with method references.

All issues: [SonarCloud filtered view](``https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&resolved=false&rules=java%3AS1125%2Cjava%3AS1488%2Cjava%3AS2864%2Cjava%3AS1858%2Cjava%3AS1612).``

## Test plan

- `mvn clean install` of `xwiki-platform-oldcore` passes (compilation + Checkstyle + Spoon).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MSu2L5L77ueRBuMEErC7xa)_