### PR TITLE
[Misc] Replace lambdas with method references (SonarCloud java:S1612)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-configuration/xwiki-platform-configuration-default/src/main/java/org/xwiki/configuration/internal/AbstractWikisConfigurationSource.java
+++ b/xwiki-platform-core/xwiki-platform-configuration/xwiki-platform-configuration-default/src/main/java/org/xwiki/configuration/internal/AbstractWikisConfigurationSource.java
@@ -67,7 +67,7 @@ public abstract class AbstractWikisConfigurationSource extends AbstractDocumentC
         @Override
         public List<String> getKeys()
         {
-            return getFromWiki(() -> AbstractWikisConfigurationSource.super.getKeysInternal());
+            return getFromWiki(AbstractWikisConfigurationSource.super::getKeysInternal);
         }
 
         @Override
@@ -97,7 +97,7 @@ public abstract class AbstractWikisConfigurationSource extends AbstractDocumentC
         @Override
         public boolean isEmpty()
         {
-            return getFromWiki(() -> AbstractWikisConfigurationSource.super.isEmptyInternal());
+            return getFromWiki(AbstractWikisConfigurationSource.super::isEmptyInternal);
         }
 
         @Override
@@ -182,7 +182,7 @@ public abstract class AbstractWikisConfigurationSource extends AbstractDocumentC
     {
         CompositeConfigurationSource compositeConfigSource = new CompositeConfigurationSource();
         getWikis().stream().map(WikiConfigurationSource::new)
-            .forEachOrdered(wikiConfigSource -> compositeConfigSource.addConfigurationSource(wikiConfigSource));
+            .forEachOrdered(compositeConfigSource::addConfigurationSource);
         return compositeConfigSource;
     }
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/expression/generics/AbstractValueNode.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/expression/generics/AbstractValueNode.java
@@ -171,7 +171,7 @@ public abstract class AbstractValueNode<T> extends AbstractNode
      */
     public InNode inStrings(Collection<String> values)
     {
-        return in(values.stream().map(s -> new StringValueNode(s)).collect(Collectors.toList()));
+        return in(values.stream().map(StringValueNode::new).collect(Collectors.toList()));
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/DefaultNotificationFilterManager.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/DefaultNotificationFilterManager.java
@@ -205,7 +205,7 @@ public class DefaultNotificationFilterManager implements NotificationFilterManag
     @Override
     public Stream<NotificationFilter> getToggleableFilters(Collection<NotificationFilter> filters)
     {
-        return filters.stream().filter(filter -> filter instanceof ToggleableNotificationFilter);
+        return filters.stream().filter(ToggleableNotificationFilter.class::isInstance);
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/DeletedDocumentCleanUpFilterListener.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/DeletedDocumentCleanUpFilterListener.java
@@ -52,7 +52,7 @@ public class DeletedDocumentCleanUpFilterListener extends AbstractLocalEventList
 {
     static final String NAME = "org.xwiki.notifications.notifiers.internal.DeletedDocumentCleanUpFilterListener";
 
-    private static final BeginFoldEvent FOLDED_EVENTS = otherEvent -> otherEvent instanceof BeginFoldEvent;
+    private static final BeginFoldEvent FOLDED_EVENTS = BeginFoldEvent.class::isInstance;
     private static final DocumentRenamingEvent DOCUMENT_RENAMING_EVENT = new DocumentRenamingEvent();
 
     @Inject

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/src/test/java/org/xwiki/store/FileDeleteTransactionRunnableTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/src/test/java/org/xwiki/store/FileDeleteTransactionRunnableTest.java
@@ -167,9 +167,7 @@ public class FileDeleteTransactionRunnableTest
 
     private void validateRollback(final StartableTransactionRunnable str)
     {
-        assertThrows(Exception.class, () -> {
-            str.start();
-        });
+        assertThrows(Exception.class, str::start);
 
         assertTrue(this.location.exists());
         assertFalse(this.temp.exists());

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/src/test/java/org/xwiki/store/FileSaveTransactionRunnableTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/src/test/java/org/xwiki/store/FileSaveTransactionRunnableTest.java
@@ -209,7 +209,7 @@ public class FileSaveTransactionRunnableTest
         final StartableTransactionRunnable str = new StartableTransactionRunnable();
         runnable.runIn(str);
         failRunnable.runIn(str);
-        Exception exception = assertThrows(Exception.class, () -> str.start());
+        Exception exception = assertThrows(Exception.class, str::start);
 
         assertFalse(this.toSave.exists());
         assertFalse(this.temp.exists());
@@ -218,7 +218,7 @@ public class FileSaveTransactionRunnableTest
 
     private void validateRollback(final StartableTransactionRunnable tr) throws Exception
     {
-        assertThrows(Exception.class, () -> tr.start(),
+        assertThrows(Exception.class, tr::start,
             "TransactionRunnable#start() did not throw the exception thrown by run.");
 
         assertTrue(this.toSave.exists());

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-transaction/src/test/java/org/xwiki/store/StartableTransactionRunnableTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-transaction/src/test/java/org/xwiki/store/StartableTransactionRunnableTest.java
@@ -41,7 +41,7 @@ class StartableTransactionRunnableTest
     void alreadyRunTest() throws Exception
     {
         this.testRunnable.start();
-        assertThrows(IllegalStateException.class, () -> this.testRunnable.start()) ;
+        assertThrows(IllegalStateException.class, this.testRunnable::start) ;
     }
 
     @Test
@@ -60,7 +60,7 @@ class StartableTransactionRunnableTest
             }
         } .runIn(this.testRunnable);
 
-        var e = assertThrows(TransactionException.class, () -> this.testRunnable.start()) ;
+        var e = assertThrows(TransactionException.class, this.testRunnable::start) ;
         assertEquals(1, e.exceptionCount(), "Wrong number of exceptions reported");
         assertTrue(hasRun(), "Rollback did not run after exception");
     }
@@ -86,7 +86,7 @@ class StartableTransactionRunnableTest
             }
         } .runIn(this.testRunnable);
 
-        var e = assertThrows(TransactionException.class, () -> this.testRunnable.start()) ;
+        var e = assertThrows(TransactionException.class, this.testRunnable::start) ;
         assertEquals(2, e.exceptionCount(), "Wrong number of exceptions reported");
         assertTrue(e.isNonRecoverable(), "Rollback failed and yet the exception did not warn of possible corruption.");
         assertTrue(hasRun(), "Complete did not run after exception");
@@ -106,7 +106,7 @@ class StartableTransactionRunnableTest
             }
         } .runIn(this.testRunnable);
 
-        assertThrows(TransactionException.class, () -> this.testRunnable.start());
+        assertThrows(TransactionException.class, this.testRunnable::start);
 
     }
 

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-transaction/src/test/java/org/xwiki/store/TransactionRunnableTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-transaction/src/test/java/org/xwiki/store/TransactionRunnableTest.java
@@ -79,7 +79,7 @@ class TransactionRunnableTest
             }
         } .runIn(this.testCase));
 
-        assertThrows(TransactionException.class, () -> this.testCase.preRun());
+        assertThrows(TransactionException.class, this.testCase::preRun);
     }
 
     /**
@@ -104,7 +104,7 @@ class TransactionRunnableTest
             }
         }.runIn(this.testCase);
 
-        assertThrows(TransactionException.class, () -> this.testCase.preRun());
+        assertThrows(TransactionException.class, this.testCase::preRun);
     }
 
     /**
@@ -127,7 +127,7 @@ class TransactionRunnableTest
             }
         }.runIn(this.testCase));
 
-        assertThrows(TransactionException.class, () -> this.testCase.run());
+        assertThrows(TransactionException.class, this.testCase::run);
     }
 
     /**
@@ -152,7 +152,7 @@ class TransactionRunnableTest
             }
         }.runIn(this.testCase);
 
-        assertThrows(TransactionException.class, () -> this.testCase.run());
+        assertThrows(TransactionException.class, this.testCase::run);
     }
 
     /**
@@ -177,7 +177,7 @@ class TransactionRunnableTest
             }
         }.runIn(this.testCase));
 
-        assertThrows(TransactionException.class, () -> this.testCase.commit());
+        assertThrows(TransactionException.class, this.testCase::commit);
     }
 
     /**
@@ -202,7 +202,7 @@ class TransactionRunnableTest
             }
         }.runIn(this.testCase);
 
-        assertThrows(TransactionException.class, () -> this.testCase.commit());
+        assertThrows(TransactionException.class, this.testCase::commit);
     }
 
     /**
@@ -228,7 +228,7 @@ class TransactionRunnableTest
         }.runIn(this.testCase));
 
 
-        var e = assertThrows(TransactionException.class, () -> this.testCase.rollback());
+        var e = assertThrows(TransactionException.class, this.testCase::rollback);
         assertTrue(e.isNonRecoverable(), "onRollback failed and exception did not indicate the possibility of "
             + "storage corruption.");
         assertTrue(hasRun(), "onRollback did not run for a child of a runnable which threw an exception.");
@@ -259,7 +259,7 @@ class TransactionRunnableTest
         }.runIn(this.testCase);
 
 
-        var e = assertThrows(TransactionException.class, () -> this.testCase.rollback());
+        var e = assertThrows(TransactionException.class, this.testCase::rollback);
         assertTrue(e.isNonRecoverable(), "onRollback failed and exception did not indicate the possibility of storage"
             + " corruption.");
         assertTrue(hasRun(), "onRollback did not run for the sibling of a runnable which threw an exception.");
@@ -288,7 +288,7 @@ class TransactionRunnableTest
         }.runIn(this.testCase));
 
 
-        var e = assertThrows(TransactionException.class, () -> this.testCase.complete());
+        var e = assertThrows(TransactionException.class, this.testCase::complete);
         assertFalse(e.isNonRecoverable(), "onComplete failed and exception erroniously indicated the possibility of storage corruption.");
         assertTrue(hasRun(), "onComplete did not run for a child of a runnable which threw an exception.");
     }
@@ -317,7 +317,7 @@ class TransactionRunnableTest
             }
         }.runIn(this.testCase);
 
-        var e = assertThrows(TransactionException.class, () -> this.testCase.complete());
+        var e = assertThrows(TransactionException.class, this.testCase::complete);
         assertFalse(e.isNonRecoverable(), "onComplete failed and exception erroniously indicated the possibility of storage corruption.");
         assertTrue(hasRun(), "onComplete did not run for the sibling of a runnable which threw an exception.");
     }
@@ -349,7 +349,7 @@ class TransactionRunnableTest
             }
         }.runIn(this.testCase);
 
-        assertThrows(TransactionException.class, () -> this.testCase.preRun());
+        assertThrows(TransactionException.class, this.testCase::preRun);
         assertTrue(hasRun(), "onComplete did not run for runnable which was preRun.");
     }
 
@@ -380,7 +380,7 @@ class TransactionRunnableTest
             }
         }.runIn(this.testCase);
 
-        assertThrows(TransactionException.class, () -> this.testCase.run());
+        assertThrows(TransactionException.class, this.testCase::run);
         assertTrue(hasRun(), "onRollback did not run for runnable which was run.");
     }
 


### PR DESCRIPTION
## Summary

Fixes 25 SonarCloud [`java:S1612`](https://rules.sonarsource.com/java/RSPEC-1612/) issues ("Replace this lambda with a method reference") across four modules:

- `xwiki-platform-store-transaction` (16, test code) — `() -> this.testCase.run()` → `this.testCase::run`, etc.
- `xwiki-platform-store-filesystem` (3, test code)
- `xwiki-platform-configuration-default` (3) — including qualified `Outer.super::method` references
- `xwiki-platform-notifications-filters-api` (3) — `x -> x instanceof Foo` → `Foo.class::isInstance` and a `StringValueNode::new` constructor reference

All conversions are behaviour-preserving.

[SonarCloud issues](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&rules=java%3AS1612&issueStatuses=OPEN)

## Test plan

- `mvn clean install` of the four modules passes (Checkstyle + Spoon included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FnGGn7MmmZNfEC2zNBfrPH)_