### PR TITLE
[Misc] Apply mechanical SonarCloud code simplifications

### DIFF
--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/main/java/org/xwiki/annotation/internal/content/ComposedAlteredContent.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/main/java/org/xwiki/annotation/internal/content/ComposedAlteredContent.java
@@ -59,8 +59,7 @@ public class ComposedAlteredContent implements AlteredContent
     public int getInitialOffset(int i)
     {
         int tmp = altered.getInitialOffset(i);
-        int rez = initial.getInitialOffset(tmp);
-        return rez;
+        return initial.getInitialOffset(tmp);
     }
 
     @Override
@@ -79,7 +78,6 @@ public class ComposedAlteredContent implements AlteredContent
     public int getAlteredOffset(int i)
     {
         int tmp = initial.getAlteredOffset(i);
-        int rez = altered.getAlteredOffset(tmp);
-        return rez;
+        return altered.getAlteredOffset(tmp);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/main/java/org/xwiki/annotation/internal/renderer/AnnotationMarkersXHTMLPrinter.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/main/java/org/xwiki/annotation/internal/renderer/AnnotationMarkersXHTMLPrinter.java
@@ -186,7 +186,8 @@ public class AnnotationMarkersXHTMLPrinter extends XHTMLWikiPrinter
         // iterate through the indexes of annotations events, print the chunks in between and then handle the annotation
         // events
         int previous = 0;
-        for (int index : annotations.keySet()) {
+        for (Map.Entry<Integer, List<AnnotationEvent>> entry : annotations.entrySet()) {
+            int index = entry.getKey();
             // create the current chunk
             String currentChunk = text.substring(previous, index);
             // print the current chunk
@@ -194,7 +195,7 @@ public class AnnotationMarkersXHTMLPrinter extends XHTMLWikiPrinter
                 printXML(currentChunk);
             }
             // handle all annotations at this position
-            for (AnnotationEvent evt : annotations.get(index)) {
+            for (AnnotationEvent evt : entry.getValue()) {
                 switch (evt.getType()) {
                     case START:
                         beginAnnotation(evt.getAnnotation());

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/test/java/org/xwiki/annotation/TestDocumentFactory.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/test/java/org/xwiki/annotation/TestDocumentFactory.java
@@ -133,7 +133,7 @@ public class TestDocumentFactory
             doc.set(key, currentValue);
             doc.set(key + "Syntax", syntax);
         } else {
-            doc.set(currentKey, currentValue.toString());
+            doc.set(currentKey, currentValue);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/SingleAnnotationRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/SingleAnnotationRESTResource.java
@@ -87,8 +87,7 @@ public class SingleAnnotationRESTResource extends AbstractAnnotationRESTResource
             // remove the annotation
             annotationService.removeAnnotation(documentName, id);
             // and then return the annotated content, as specified by the annotation request
-            AnnotationResponse response = getSuccessResponseWithAnnotatedContent(documentName, request);
-            return response;
+            return getSuccessResponseWithAnnotatedContent(documentName, request);
         } catch (XWikiException e) {
             getLogger().error(e.getMessage(), e);
             return getErrorResponse(e);
@@ -160,8 +159,7 @@ public class SingleAnnotationRESTResource extends AbstractAnnotationRESTResource
             annotationService.updateAnnotation(documentName, newAnnotation);
             this.cleanTemporaryUploadedFiles(documentReference);
             // and then return the annotated content, as specified by the annotation request
-            AnnotationResponse response = getSuccessResponseWithAnnotatedContent(documentName, updateRequest);
-            return response;
+            return getSuccessResponseWithAnnotatedContent(documentName, updateRequest);
         } catch (XWikiException e) {
             getLogger().error(e.getMessage(), e);
             return getErrorResponse(e);

--- a/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/main/java/org/xwiki/rendering/internal/macro/chart/TemporaryChartImageWriter.java
+++ b/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/main/java/org/xwiki/rendering/internal/macro/chart/TemporaryChartImageWriter.java
@@ -122,8 +122,7 @@ public class TemporaryChartImageWriter implements ChartImageWriter
             // Should not happen since UTF8 encoding should always be present
             throw new MacroExecutionException("Failed to compute chart image location", e);
         }
-        File locationFile = new File(directory, String.format("%s.png", imageId.getId()));
-        return locationFile;
+        return new File(directory, String.format("%s.png", imageId.getId()));
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/main/java/org/xwiki/rendering/internal/macro/chart/source/AbstractDataSource.java
+++ b/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/main/java/org/xwiki/rendering/internal/macro/chart/source/AbstractDataSource.java
@@ -80,28 +80,30 @@ public abstract class AbstractDataSource implements DataSource
      */
     protected void validateParameters(Map<String, String> parameters) throws MacroExecutionException
     {
-        for (String key : parameters.keySet()) {
+        for (Map.Entry<String, String> entry : parameters.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
             if (DATASET_PARAM.equals(key)) {
-                datasetType = DatasetType.forName(parameters.get(key));
+                datasetType = DatasetType.forName(value);
                 if (datasetType == null) {
-                    invalidParameterValue(DATASET_PARAM, parameters.get(key));
+                    invalidParameterValue(DATASET_PARAM, value);
                 }
                 continue;
             }
             if (PLOT_TYPE_PARAM.equals(key)) {
-                plotType = PlotType.forName(parameters.get(key));
+                plotType = PlotType.forName(value);
                 if (plotType == null) {
-                    invalidParameterValue(PLOT_TYPE_PARAM, parameters.get(key));
+                    invalidParameterValue(PLOT_TYPE_PARAM, value);
                 }
                 continue;
             }
-            if (localeConfiguration.setParameter(key, parameters.get(key))) {
+            if (localeConfiguration.setParameter(key, value)) {
                 continue;
             }
-            if (axisConfigurator.setParameter(key, parameters.get(key))) {
+            if (axisConfigurator.setParameter(key, value)) {
                 continue;
             }
-            setParameter(key, parameters.get(key));
+            setParameter(key, value);
         }
 
         localeConfiguration.validateParameters();

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/FileSystemMailContentStore.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/FileSystemMailContentStore.java
@@ -171,8 +171,7 @@ public class FileSystemMailContentStore implements MailContentStore, Initializab
 
     private File getBatchDirectory(String batchId)
     {
-        File batchDirectory = new File(rootDirectory, getURLEncoded(batchId));
-        return batchDirectory;
+        return new File(rootDirectory, getURLEncoded(batchId));
     }
 
     private File getMessageFile(String batchId, String uniqueMessageId)

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/factory/files/SerializedFilesMimeMessageFactory.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/factory/files/SerializedFilesMimeMessageFactory.java
@@ -47,8 +47,7 @@ public class SerializedFilesMimeMessageFactory extends AbstractIteratorMimeMessa
         throws MessagingException
     {
         String batchId = getTypedSource(batchIdObject, String.class);
-        SerializedFilesMimeMessageIterator iterator = new SerializedFilesMimeMessageIterator(batchId, parameters,
+        return new SerializedFilesMimeMessageIterator(batchId, parameters,
             this.componentManagerProvider.get());
-        return iterator;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/factory/group/GroupMimeMessageFactory.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/factory/group/GroupMimeMessageFactory.java
@@ -64,9 +64,8 @@ public class GroupMimeMessageFactory extends AbstractIteratorMimeMessageFactory
 
         MimeMessageFactory factory = getInternalMimeMessageFactory(factoryHint);
 
-        GroupMimeMessageIterator iterator = new GroupMimeMessageIterator(groupReference, factory, parameters,
+        return new GroupMimeMessageIterator(groupReference, factory, parameters,
             this.componentManagerProvider.get());
-        return iterator;
     }
 
 }

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/factory/usersandgroups/UsersAndGroupsMimeMessageFactory.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/main/java/org/xwiki/mail/internal/factory/usersandgroups/UsersAndGroupsMimeMessageFactory.java
@@ -73,8 +73,7 @@ public class UsersAndGroupsMimeMessageFactory extends AbstractIteratorMimeMessag
 
         MimeMessageFactory factory = getInternalMimeMessageFactory(factoryHint);
 
-        UsersAndGroupsMimeMessageIterator iterator = new UsersAndGroupsMimeMessageIterator(source, factory, parameters,
+        return new UsersAndGroupsMimeMessageIterator(source, factory, parameters,
             this.explicitDocumentReferenceResolver, this.execution);
-        return iterator;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-storage/src/main/java/org/xwiki/mail/internal/DatabaseMailResender.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-storage/src/main/java/org/xwiki/mail/internal/DatabaseMailResender.java
@@ -105,7 +105,7 @@ public class DatabaseMailResender implements MailResender
         int count) throws MailStoreException
     {
         return resendGeneric(filterMap, offset, count,
-            (batchId, messageId) -> resendAsynchronously(batchId, messageId));
+            this::resendAsynchronously);
     }
 
     @Override
@@ -113,7 +113,7 @@ public class DatabaseMailResender implements MailResender
         throws MailStoreException
     {
         return resendGeneric(filterMap, offset, count,
-            (batchId, messageId) -> resend(batchId, messageId));
+            this::resend);
     }
 
     private List<Pair<MailStatus, MailStatusResult>> resendGeneric(Map<String, Object> filterMap, int offset,
@@ -149,8 +149,7 @@ public class DatabaseMailResender implements MailResender
 
     private MimeMessage loadMessage(Session session, String batchId, String mailId) throws MailStoreException
     {
-        MimeMessage message = this.mailContentStore.load(session, batchId, mailId);
-        return message;
+        return this.mailContentStore.load(session, batchId, mailId);
     }
 
     private MailStatusResult resend(String batchId, String uniqueMessageId) throws MailStoreException

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-storage/src/main/java/org/xwiki/mail/script/MailStorageScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-storage/src/main/java/org/xwiki/mail/script/MailStorageScriptService.java
@@ -115,8 +115,7 @@ public class MailStorageScriptService extends AbstractMailScriptService
     {
         try {
             MailStatusResult statusResult = this.mailResender.resendAsynchronously(batchId, uniqueMessageId);
-            ScriptMailResult scriptMailResult = new ScriptMailResult(new DefaultMailResult(batchId), statusResult);
-            return scriptMailResult;
+            return new ScriptMailResult(new DefaultMailResult(batchId), statusResult);
         } catch (MailStoreException e) {
             // Save the exception for reporting through the script services's getLastError() API
             setError(e);
@@ -312,8 +311,7 @@ public class MailStorageScriptService extends AbstractMailScriptService
 
     private MimeMessage loadMessage(Session session, String batchId, String mailId) throws MailStoreException
     {
-        MimeMessage message = this.mailContentStore.load(session, batchId, mailId);
-        return message;
+        return this.mailContentStore.load(session, batchId, mailId);
     }
 
     private List<ScriptMailResult> resendGeneric(Map<String, Object> filterMap, int offset, int count,

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/DefaultNotificationParametersFactory.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/DefaultNotificationParametersFactory.java
@@ -470,7 +470,7 @@ public class DefaultNotificationParametersFactory
         // preference.
         boolean noLocationFilter =
             notificationParameters.filterPreferences.stream()
-                .noneMatch(pref -> pref instanceof ScopeNotificationFilterPreference);
+                .noneMatch(ScopeNotificationFilterPreference.class::isInstance);
         notificationParameters.filters = notificationFilterManager.getAllFilters(true)
             .stream()
             .filter(filter -> !excludedFilters.contains(filter.getName())

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/RecordableEventDescriptorHelper.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/RecordableEventDescriptorHelper.java
@@ -58,8 +58,7 @@ public class RecordableEventDescriptorHelper
 
     private boolean isGlobalUser(DocumentReference user)
     {
-        return user != null ? wikiDescriptorManager.getMainWikiId().equals(user.getWikiReference().getName())
-                : false;
+        return user != null && wikiDescriptorManager.getMainWikiId().equals(user.getWikiReference().getName());
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/ScriptQuery.java
+++ b/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/ScriptQuery.java
@@ -282,7 +282,7 @@ public class ScriptQuery implements SecureQuery
     @Override
     public boolean isCurrentAuthorChecked()
     {
-        return this.query instanceof SecureQuery ? ((SecureQuery) this.query).isCurrentAuthorChecked() : true;
+        return !(this.query instanceof SecureQuery) || ((SecureQuery) this.query).isCurrentAuthorChecked();
     }
 
     /**
@@ -329,7 +329,7 @@ public class ScriptQuery implements SecureQuery
     @Override
     public boolean isCurrentUserChecked()
     {
-        return this.query instanceof SecureQuery ? ((SecureQuery) this.query).isCurrentAuthorChecked() : false;
+        return this.query instanceof SecureQuery && ((SecureQuery) this.query).isCurrentAuthorChecked();
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/batch/DefaultBatchOperationExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/internal/batch/DefaultBatchOperationExecutor.java
@@ -84,16 +84,13 @@ public class DefaultBatchOperationExecutor implements BatchOperationExecutor
 
     protected String generateBatchId()
     {
-        String result = UUID.randomUUID().toString();
-        return result;
+        return UUID.randomUUID().toString();
     }
 
     @Override
     public String getCurrentBatchId()
     {
         Object existingBatchIdObject = execution.getContext().getProperty(CONTEXT_PROPERTY);
-        String batchId = Objects.toString(existingBatchIdObject, null);
-
-        return batchId;
+        return Objects.toString(existingBatchIdObject, null);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/job/EntityJobTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/job/EntityJobTest.java
@@ -159,7 +159,7 @@ class EntityJobTest extends AbstractEntityJobTest
         initialize(new EntityRequest());
 
         final List<DocumentReference> documentReferences = new ArrayList<>();
-        this.job.visitDocuments(spaceReference, documentReference -> documentReferences.add(documentReference));
+        this.job.visitDocuments(spaceReference, documentReferences::add);
         // Space preferences documents are handled after their siblings.
         assertEquals(Arrays.asList(carolBio, aliceBio, bobBio, bob, bobPrefs, alice, alicePrefs), documentReferences);
     }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/BaseAttachmentsResource.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/BaseAttachmentsResource.java
@@ -346,14 +346,14 @@ public class BaseAttachmentsResource extends XWikiResource
     {
         String fileName = attachment.getFilename().toUpperCase();
         return acceptedFileNameExtensions.stream()
-            .anyMatch(acceptedFileNamedExtension -> fileName.endsWith(acceptedFileNamedExtension));
+            .anyMatch(fileName::endsWith);
     }
 
     private boolean hasAcceptedMediaType(XWikiAttachment attachment, Set<String> acceptedMediaTypes)
     {
         XWikiContext xcontext = this.xcontextProvider.get();
         String detectedMediaType = attachment.getMimeType(xcontext).toUpperCase();
-        return acceptedMediaTypes.stream().anyMatch(acceptedMediaType -> detectedMediaType.contains(acceptedMediaType));
+        return acceptedMediaTypes.stream().anyMatch(detectedMediaType::contains);
     }
 
     private Attachment toRestAttachment(XWikiAttachment xwikiAttachment, Boolean withPrettyNames)

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/AbstractSolrMetadataExtractor.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/AbstractSolrMetadataExtractor.java
@@ -196,9 +196,7 @@ public abstract class AbstractSolrMetadataExtractor implements SolrMetadataExtra
 
         DocumentReference documentReferenceWithoutLocale = documentReference.getLocale() == null ? documentReference
             : new DocumentReference(documentReference, (Locale) null);
-        XWikiDocument document = xcontext.getWiki().getDocument(documentReferenceWithoutLocale, xcontext);
-
-        return document;
+        return xcontext.getWiki().getDocument(documentReferenceWithoutLocale, xcontext);
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/reference/AbstractSolrReferenceResolver.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/reference/AbstractSolrReferenceResolver.java
@@ -74,19 +74,15 @@ public abstract class AbstractSolrReferenceResolver implements SolrReferenceReso
     protected XWikiDocument getDocument(DocumentReference documentReference) throws Exception
     {
         XWikiContext context = this.xcontextProvider.get();
-        XWikiDocument document = context.getWiki().getDocument(documentReference, context);
-
-        return document;
+        return context.getWiki().getDocument(documentReference, context);
     }
 
     @Override
     public String getId(EntityReference reference) throws SolrIndexerException, IllegalArgumentException
     {
-        String result = this.serializer.serialize(reference);
-
         // TODO: Include locale all the other entities once object/attachment translation is implemented.
 
-        return result;
+        return this.serializer.serialize(reference);
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/main/java/org/xwiki/wiki/internal/descriptor/DefaultWikiDescriptorManager.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/main/java/org/xwiki/wiki/internal/descriptor/DefaultWikiDescriptorManager.java
@@ -239,7 +239,7 @@ public class DefaultWikiDescriptorManager implements WikiDescriptorManager
 
         XWikiContext xcontext = this.xcontextProvider.get();
 
-        return xcontext != null ? xcontext.isMainWiki(wikiId) : true;
+        return xcontext == null || xcontext.isMainWiki(wikiId);
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/main/java/org/xwiki/wiki/internal/descriptor/properties/DefaultWikiPropertyGroupManager.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/main/java/org/xwiki/wiki/internal/descriptor/properties/DefaultWikiPropertyGroupManager.java
@@ -51,8 +51,9 @@ public class DefaultWikiPropertyGroupManager implements WikiPropertyGroupManager
     public void loadForDescriptor(WikiDescriptor descriptor) throws WikiPropertyGroupException
     {
         String wikiId = descriptor.getId();
-        for (String propertyGroupName : propertyGroupProviders.keySet()) {
-            WikiPropertyGroupProvider provider = propertyGroupProviders.get(propertyGroupName);
+        for (Map.Entry<String, WikiPropertyGroupProvider> entry : propertyGroupProviders.entrySet()) {
+            String propertyGroupName = entry.getKey();
+            WikiPropertyGroupProvider provider = entry.getValue();
             try {
                 descriptor.addPropertyGroup(provider.get(wikiId));
             } catch (WikiPropertyGroupException e) {
@@ -65,10 +66,11 @@ public class DefaultWikiPropertyGroupManager implements WikiPropertyGroupManager
     public void saveForDescriptor(WikiDescriptor descriptor) throws WikiPropertyGroupException
     {
         String wikiId = descriptor.getId();
-        for (String propertyGroupName : propertyGroupProviders.keySet()) {
+        for (Map.Entry<String, WikiPropertyGroupProvider> entry : propertyGroupProviders.entrySet()) {
+            String propertyGroupName = entry.getKey();
             WikiPropertyGroup group = descriptor.getPropertyGroup(propertyGroupName);
             if (group != null) {
-                WikiPropertyGroupProvider provider = propertyGroupProviders.get(propertyGroupName);
+                WikiPropertyGroupProvider provider = entry.getValue();
                 provider.save(group, wikiId);
             }
         }

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/main/java/org/xwiki/wiki/internal/provisioning/DefaultWikiProvisioningJobExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/main/java/org/xwiki/wiki/internal/provisioning/DefaultWikiProvisioningJobExecutor.java
@@ -123,7 +123,6 @@ public class DefaultWikiProvisioningJobExecutor implements WikiProvisioningJobEx
     @Override
     public WikiProvisioningJob getJob(List<String> jobId) throws WikiProvisioningJobException
     {
-        WikiProvisioningJob job = jobs.get(jobId);
-        return job;
+        return jobs.get(jobId);
     }
 }


### PR DESCRIPTION
## Summary

Fixes 33 SonarCloud issues across 11 modules. All conversions are mechanical and behaviour-preserving:

- **`java:S1488`** (18) — inline immediately-returned local variables (`X x = expr; return x;` → `return expr;`).
- **`java:S1125`** (4) — remove redundant boolean literals in ternaries (`c ? true : expr`, `c ? expr : false`, …).
- **`java:S1612`** (6) — replace lambdas with method references (`x -> obj.foo(x)` → `obj::foo`, `p -> p instanceof T` → `T.class::isInstance`).
- **`java:S2864`** (4) — iterate `entrySet()` instead of `keySet()` + `get(key)`.
- **`java:S1858`** (1) — drop a `toString()` call on a value that is already a `String`.

Modules touched: mail-send-storage, mail-send-default, annotation-core, annotation-rest, wiki-default, refactoring-api, search-solr-api, chart-macro, query-manager, rest-server, notifications-sources.

[SonarCloud issues (these rules, OPEN)](``https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&rules=java%3AS1488%2Cjava%3AS1125%2Cjava%3AS1612%2Cjava%3AS2864%2Cjava%3AS1858&issueStatuses=OPEN)``

## Test plan

- `mvn clean install` of the 11 modules passes (Checkstyle + Spoon included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01K3KPUdGWvHbm4wv9r5GGkZ)_