### PR TITLE
[Misc] Apply mechanical SonarCloud code cleanups

### DIFF
--- a/xwiki-platform-core/xwiki-platform-captcha/xwiki-platform-captcha-jcaptcha/xwiki-platform-captcha-jcaptcha-api/src/test/java/org/xwiki/captcha/internal/CaptchaServiceManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-captcha/xwiki-platform-captcha-jcaptcha/xwiki-platform-captcha-jcaptcha-api/src/test/java/org/xwiki/captcha/internal/CaptchaServiceManagerTest.java
@@ -21,19 +21,15 @@ package org.xwiki.captcha.internal;
 
 import javax.inject.Named;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.xwiki.captcha.CaptchaException;
-import org.xwiki.component.phase.InitializationException;
 import org.xwiki.configuration.ConfigurationSource;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 /**

--- a/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-renderer/src/test/java/org/xwiki/chart/internal/DefaultChartGeneratorTest.java
+++ b/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-renderer/src/test/java/org/xwiki/chart/internal/DefaultChartGeneratorTest.java
@@ -22,7 +22,6 @@ package org.xwiki.chart.internal;
 import java.util.Map;
 
 import org.jfree.chart.plot.Plot;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.xwiki.chart.ChartGenerator;

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/question/ConflictQuestion.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/question/ConflictQuestion.java
@@ -109,7 +109,7 @@ public class ConflictQuestion
         {
             return this.actions;
         }
-    };
+    }
 
     public enum GlobalAction
     {
@@ -143,7 +143,7 @@ public class ConflictQuestion
          * configure default answers in the request for example.
          */
         ASK
-    };
+    }
 
     // Question datas
 

--- a/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/XARDocumentModel.java
+++ b/xwiki-platform-core/xwiki-platform-filter/xwiki-platform-filter-streams/xwiki-platform-filter-stream-xar/src/main/java/org/xwiki/filter/xar/internal/XARDocumentModel.java
@@ -99,5 +99,5 @@ public class XARDocumentModel extends XarDocumentModel
             new EventParameter(WikiDocumentFilter.PARAMETER_TITLE));
         DOCUMENTREVISION_PARAMETERS.put(ELEMENT_VALIDATIONSCRIPT,
             new EventParameter(WikiDocumentFilter.PARAMETER_VALIDATIONSCRIPT));
-    };
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/test/java/org/xwiki/flamingo/WebHomeSheetPageTest.java
+++ b/xwiki-platform-core/xwiki-platform-flamingo/xwiki-platform-flamingo-theme/xwiki-platform-flamingo-theme-ui/src/test/java/org/xwiki/flamingo/WebHomeSheetPageTest.java
@@ -27,7 +27,6 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.xwiki.localization.macro.internal.TranslationMacro;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.script.ModelScriptService;
 import org.xwiki.query.Query;

--- a/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/test/java/org/xwiki/help/XWikiSyntaxMacrosListPageTest.java
+++ b/xwiki-platform-core/xwiki-platform-help/xwiki-platform-help-ui/src/test/java/org/xwiki/help/XWikiSyntaxMacrosListPageTest.java
@@ -30,7 +30,6 @@ import org.jsoup.select.Elements;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.xwiki.context.internal.concurrent.DefaultContextStoreManager;
-import org.xwiki.localization.macro.internal.TranslationMacro;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.query.Query;
 import org.xwiki.query.script.QueryManagerScriptService;

--- a/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/xwiki-platform-image-style-ui/src/test/java/org/xwiki/image/style/AdministrationPageTest.java
+++ b/xwiki-platform-core/xwiki-platform-image/xwiki-platform-image-style/xwiki-platform-image-style-ui/src/test/java/org/xwiki/image/style/AdministrationPageTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.xwiki.csrf.script.CSRFTokenScriptService;
-import org.xwiki.localization.macro.internal.TranslationMacro;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.script.ModelScriptService;
 import org.xwiki.script.service.ScriptService;

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-notifications/xwiki-platform-legacy-notifications-filters/xwiki-platform-legacy-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/LegacyDefaultNotificationFilterManager.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-notifications/xwiki-platform-legacy-notifications-filters/xwiki-platform-legacy-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/LegacyDefaultNotificationFilterManager.java
@@ -21,33 +21,19 @@ package org.xwiki.notifications.filters.internal;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Stream;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 import javax.inject.Singleton;
 
 import org.xwiki.component.annotation.Component;
-import org.xwiki.component.manager.ComponentLookupException;
-import org.xwiki.component.manager.ComponentManager;
-import org.xwiki.model.ModelContext;
 import org.xwiki.model.reference.DocumentReference;
-import org.xwiki.model.reference.WikiReference;
 import org.xwiki.notifications.NotificationConfiguration;
 import org.xwiki.notifications.NotificationException;
 import org.xwiki.notifications.filters.NotificationFilter;
-import org.xwiki.notifications.filters.NotificationFilterDisplayer;
 import org.xwiki.notifications.filters.NotificationFilterManager;
-import org.xwiki.notifications.filters.NotificationFilterPreference;
-import org.xwiki.notifications.preferences.NotificationPreference;
-import org.xwiki.rendering.block.Block;
-import org.xwiki.wiki.descriptor.WikiDescriptorManager;
 
 /**
  * Default implementation of {@link NotificationFilterManager}.

--- a/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-api/src/main/java/org/xwiki/localization/internal/AbstractTranslationBundle.java
+++ b/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-api/src/main/java/org/xwiki/localization/internal/AbstractTranslationBundle.java
@@ -44,7 +44,7 @@ public abstract class AbstractTranslationBundle implements TranslationBundle
         public Translation getTranslation(String key, Locale locale)
         {
             return null;
-        };
+        }
     };
 
     /**

--- a/xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-ui/src/test/java/org/xwiki/logging/LoggingAdminPageTest.java
+++ b/xwiki-platform-core/xwiki-platform-logging/xwiki-platform-logging-ui/src/test/java/org/xwiki/logging/LoggingAdminPageTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.xwiki.icon.IconManager;
 import org.xwiki.livedata.internal.macro.LiveDataMacroComponentList;
-import org.xwiki.localization.macro.internal.TranslationMacro;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.properties.internal.converter.EnumConverter;
 import org.xwiki.rendering.RenderingScriptServiceComponentList;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersLiveDataConfigurationProvider.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersLiveDataConfigurationProvider.java
@@ -115,7 +115,7 @@ public class NotificationCustomFiltersLiveDataConfigurationProvider implements P
         {
             return this.fieldName;
         }
-    };
+    }
 
     @Inject
     private ContextualLocalizationManager l10n;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/XClassMigratorListener.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/XClassMigratorListener.java
@@ -91,7 +91,7 @@ public class XClassMigratorListener extends AbstractEventListener
     @Inject
     private Logger logger;
 
-    private record PropertyToUpdate(PropertyClass newPropertyClass, BaseProperty<?> newProperty) { };
+    private record PropertyToUpdate(PropertyClass newPropertyClass, BaseProperty<?> newProperty) { }
 
     /**
      * Set up the listener.

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/Package.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/Package.java
@@ -496,7 +496,7 @@ public class Package
      * @throws IOException while reading the ZipFile
      * @throws XWikiException when package content is broken
      */
-    public String Import(byte file[], XWikiContext context) throws IOException, XWikiException
+    public String Import(byte[] file, XWikiContext context) throws IOException, XWikiException
     {
         return Import(new ByteArrayInputStream(file), context);
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/PackageAPI.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/PackageAPI.java
@@ -235,7 +235,7 @@ public class PackageAPI extends Api
      *         message is placed in the velocity context under the <code>import_error</code> key,
      * @since 2.2M1
      */
-    public boolean importPackageFromByteArray(byte data[])
+    public boolean importPackageFromByteArray(byte[] data)
     {
         try {
             this.pack.Import(data, getXWikiContext());
@@ -258,7 +258,7 @@ public class PackageAPI extends Api
      * @throws IOException while reading the ZipFile
      * @throws XWikiException when package content is broken
      */
-    public String Import(byte file[]) throws IOException, XWikiException
+    public String Import(byte[] file) throws IOException, XWikiException
     {
         return this.pack.Import(file, getXWikiContext());
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/util/TOCGenerator.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/util/TOCGenerator.java
@@ -44,7 +44,7 @@ public class TOCGenerator
 
         LinkedHashMap<String, Map<String, Object>> tocData = new LinkedHashMap<>();
 
-        int previousNumbers[] = { 0, 0, 0, 0, 0, 0, 0 };
+        int[] previousNumbers = { 0, 0, 0, 0, 0, 0, 0 };
 
         Pattern pattern = Pattern.compile("(?-s)^[ \\t]*+(1(\\.1){0,5}+)[ \\t]++(.++)$", Pattern.MULTILINE);
         Matcher matcher = pattern.matcher(content);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/includeservletasstring/BufferOutputStream.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/includeservletasstring/BufferOutputStream.java
@@ -42,7 +42,7 @@ public class BufferOutputStream extends ServletOutputStream
     }
 
     @Override
-    public void write(byte b[]) throws IOException
+    public void write(byte[] b) throws IOException
     {
         this.buffer.write(b);
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/BaseObjectTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/BaseObjectTest.java
@@ -246,7 +246,7 @@ class BaseObjectTest
         object.setXClassReference(classReference);
         object.setOwnerDocument(ownerDocument);
 
-        XWikiContext context = this.oldcore.getXWikiContext();;
+        XWikiContext context = this.oldcore.getXWikiContext();
         String fieldName = "myField";
         String value = "myValue";
 
@@ -298,7 +298,7 @@ class BaseObjectTest
         object.setXClassReference(classReference);
         object.setOwnerDocument(ownerDocument);
 
-        XWikiContext context = this.oldcore.getXWikiContext();;
+        XWikiContext context = this.oldcore.getXWikiContext();
         String fieldName = "myField";
         Object value = 4545;
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/plugin/packaging/AbstractPackageTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/plugin/packaging/AbstractPackageTest.java
@@ -60,7 +60,7 @@ public abstract class AbstractPackageTest
      * @param extension the extension id and version or null if none should be added
      * @return the XAR file as a byte array.
      */
-    protected byte[] createZipFile(XWikiDocument docs[], String[] encodings, String packageXmlEncoding,
+    protected byte[] createZipFile(XWikiDocument[] docs, String[] encodings, String packageXmlEncoding,
         ExtensionId extension) throws Exception
     {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -91,7 +91,7 @@ public abstract class AbstractPackageTest
      * @param extension the extension id and version or null if none should be added
      * @return the XAR file as a byte array.
      */
-    protected byte[] createZipFile(XWikiDocument docs[], String[] encodings, ExtensionId extension) throws Exception
+    protected byte[] createZipFile(XWikiDocument[] docs, String[] encodings, ExtensionId extension) throws Exception
     {
         return createZipFile(docs, encodings, "ISO-8859-1", extension);
     }
@@ -104,7 +104,7 @@ public abstract class AbstractPackageTest
      * @param packageXmlEncoding The encoding of package.xml
      * @return the XAR file as a byte array.
      */
-    protected byte[] createZipFileUsingCommonsCompress(XWikiDocument docs[], String[] encodings,
+    protected byte[] createZipFileUsingCommonsCompress(XWikiDocument[] docs, String[] encodings,
         String packageXmlEncoding, ExtensionId extension) throws Exception
     {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -136,7 +136,7 @@ public abstract class AbstractPackageTest
      * @param extension the extension id and version or null if none should be added
      * @return the XAR file as a byte array.
      */
-    protected byte[] createZipFileUsingCommonsCompress(XWikiDocument docs[], String[] encodings, ExtensionId extension)
+    protected byte[] createZipFileUsingCommonsCompress(XWikiDocument[] docs, String[] encodings, ExtensionId extension)
         throws Exception
     {
         return createZipFileUsingCommonsCompress(docs, encodings, "ISO-8859-1", extension);
@@ -164,7 +164,7 @@ public abstract class AbstractPackageTest
         return ostr.toByteArray();
     }
 
-    private String getPackageXML(XWikiDocument docs[], String encoding, ExtensionId extension)
+    private String getPackageXML(XWikiDocument[] docs, String encoding, ExtensionId extension)
     {
         StringBuilder sb = new StringBuilder();
         sb.append("<?xml version=\"1.0\" encoding=\"" + encoding + "\"?>\n");

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/plugin/packaging/PackageTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/plugin/packaging/PackageTest.java
@@ -60,7 +60,7 @@ public class PackageTest extends AbstractPackageTest
         doc2.setTitle(docTitle);
         doc2.setContent(docContent);
 
-        XWikiDocument docs[] = { doc1, doc2 };
+        XWikiDocument[] docs = { doc1, doc2 };
 
         this.pack.Import(this.createZipFile(docs, new String[] { "ISO-8859-1", "UTF-8" }, null),
             this.oldcore.getXWikiContext());
@@ -86,7 +86,7 @@ public class PackageTest extends AbstractPackageTest
         doc2.setTitle(docTitle);
         doc2.setContent(docContent);
 
-        XWikiDocument docs[] = { doc1, doc2 };
+        XWikiDocument[] docs = { doc1, doc2 };
 
         this.pack.Import(this.createZipFileUsingCommonsCompress(docs, new String[] { "ISO-8859-1", "UTF-8" }, null),
             this.oldcore.getXWikiContext());

--- a/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-xwql/src/main/java/org/xwiki/query/xwql/internal/QueryAnalyzer.java
+++ b/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-xwql/src/main/java/org/xwiki/query/xwql/internal/QueryAnalyzer.java
@@ -64,7 +64,7 @@ public class QueryAnalyzer extends DepthFirstAdapter
     @Override
     public void caseAXObjectDecl(AXObjectDecl node)
     {
-        String path[] = splitPath(node.getId().toString());
+        String[] path = splitPath(node.getId().toString());
         if (path.length != 2) {
             throw new InvalidQueryException("docalias.object('classname') expected, but got:" + node.toString());
         }
@@ -88,7 +88,7 @@ public class QueryAnalyzer extends DepthFirstAdapter
     @Override
     public void caseAPath(APath node)
     {
-        String path[] = splitPath(node.toString());
+        String[] path = splitPath(node.toString());
         QueryContext.ObjectInfo obj = context.getObject(path[0]);
         if (path.length >= 2 && obj != null) {
             obj.addProperty(path[1], node);
@@ -99,7 +99,7 @@ public class QueryAnalyzer extends DepthFirstAdapter
     public void outAXPath(AXPath node)
     {
         QueryContext.ObjectInfo obj = context.getObject(node.getXObjectDecl());
-        String path[] = splitPath(node.getProperty().toString());
+        String[] path = splitPath(node.getProperty().toString());
         obj.addProperty(path[0], node);
         super.outAXPath(node);
     }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/job/question/EntitySelection.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/main/java/org/xwiki/refactoring/job/question/EntitySelection.java
@@ -53,7 +53,7 @@ public class EntitySelection implements Comparable<EntitySelection>
          * Default state. By default, UNKNOWN is considered as selected: see {@link #isSelected()}.
          */
         UNKNOWN
-    };
+    }
 
     /**
      * Reference to the entity to select for the refactoring.

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/ExtensionVersionsRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/ExtensionVersionsRESTResource.java
@@ -77,7 +77,7 @@ public class ExtensionVersionsRESTResource extends AbstractExtensionRESTResource
                 IterableResult<Version> versions = repository.resolveVersions(extensionId, 0, -1);
 
                 String extensionName = this.extensionStore.getExtensionName(extensionDocument);
-                String extensionType = this.extensionStore.getExtensionType(extensionDocument);;
+                String extensionType = this.extensionStore.getExtensionType(extensionDocument);
 
                 for (Version version : versions) {
                     extensions.getExtensionVersionSummaries()

--- a/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-api/src/test/java/org/xwiki/resource/ResourceReferenceHandlerTest.java
+++ b/xwiki-platform-core/xwiki-platform-resource/xwiki-platform-resource-api/src/test/java/org/xwiki/resource/ResourceReferenceHandlerTest.java
@@ -52,7 +52,7 @@ class ResourceReferenceHandlerTest
             ResourceReferenceHandlerException
         {
         }
-    };
+    }
 
     @Test
     void priority()

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/AuthorizationManager.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/AuthorizationManager.java
@@ -132,5 +132,5 @@ public interface AuthorizationManager
      */
     default void unregister(Right right) throws AuthorizationException
     {
-    };
+    }
 }

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/testwikis/internal/entities/DefaultTestWiki.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/testwikis/internal/entities/DefaultTestWiki.java
@@ -71,7 +71,6 @@ public class DefaultTestWiki extends AbstractSecureTestEntity implements TestWik
         this.owner = (owner != null) ? new DocumentReference(owner)
                 : new DocumentReference(XWikiConstants.SUPERADMIN, new SpaceReference(XWikiConstants.XWIKI_SPACE,
                     getWikiReference()));
-        ;
         this.description = description;
 
         if (isMainWiki) {

--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-ui/src/test/java/org/xwiki/skin/XWikiSkinsSheetPageTest.java
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-ui/src/test/java/org/xwiki/skin/XWikiSkinsSheetPageTest.java
@@ -35,7 +35,6 @@ import org.xwiki.edit.internal.DefaultEditorDescriptorBuilder;
 import org.xwiki.edit.internal.DefaultEditorManager;
 import org.xwiki.edit.internal.PureTextSyntaxContentEditor;
 import org.xwiki.icon.IconManagerScriptService;
-import org.xwiki.localization.macro.internal.TranslationMacro;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.script.ModelScriptService;
 import org.xwiki.rendering.RenderingScriptServiceComponentList;

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-api/src/main/java/com/xpn/xwiki/doc/merge/MergeConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-api/src/main/java/com/xpn/xwiki/doc/merge/MergeConfiguration.java
@@ -49,7 +49,7 @@ public class MergeConfiguration
          * Next version.
          */
         NEXT
-    };
+    }
 
     /**
      * @see #isProvidedVersionsModifiables()

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-mainwiki/src/test/java/org/xwiki/wiki/DeleteWikiPageTest.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-ui/xwiki-platform-wiki-ui-mainwiki/src/test/java/org/xwiki/wiki/DeleteWikiPageTest.java
@@ -21,7 +21,6 @@ package org.xwiki.wiki;
 
 import org.jsoup.nodes.Document;
 import org.junit.jupiter.api.Test;
-import org.xwiki.localization.macro.internal.TranslationMacro;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.rendering.RenderingScriptServiceComponentList;
 import org.xwiki.rendering.internal.configuration.DefaultExtendedRenderingConfiguration;

--- a/xwiki-platform-core/xwiki-platform-xclass/xwiki-platform-xclass-ui/src/test/java/org/xwiki/xclass/ClassSheetPageTest.java
+++ b/xwiki-platform-core/xwiki-platform-xclass/xwiki-platform-xclass-ui/src/test/java/org/xwiki/xclass/ClassSheetPageTest.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.xwiki.icon.IconManager;
 import org.xwiki.livedata.internal.macro.LiveDataMacroComponentList;
-import org.xwiki.localization.macro.internal.TranslationMacro;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.script.ModelScriptService;
 import org.xwiki.rendering.RenderingScriptServiceComponentList;

--- a/xwiki-platform-core/xwiki-platform-zipexplorer/src/test/java/com/xpn/xwiki/plugin/zipexplorer/ZipExplorerTest.java
+++ b/xwiki-platform-core/xwiki-platform-zipexplorer/src/test/java/com/xpn/xwiki/plugin/zipexplorer/ZipExplorerTest.java
@@ -84,15 +84,15 @@ class ZipExplorerTest
     @Test
     void isZipFile() throws Exception
     {
-        byte txtbuf[] = { 0x00, 0x01, 0x02, 0x03, 0x06, 0x07 };
+        byte[] txtbuf = { 0x00, 0x01, 0x02, 0x03, 0x06, 0x07 };
         ByteArrayInputStream txtBais = new ByteArrayInputStream(txtbuf);
         assertFalse(this.plugin.isZipFile(txtBais));
 
-        byte tinybuf[] = { 0x00 };
+        byte[] tinybuf = { 0x00 };
         ByteArrayInputStream tinyBais = new ByteArrayInputStream(tinybuf);
         assertFalse(this.plugin.isZipFile(tinyBais));
 
-        byte zipbuf[] = createZipFile("test");
+        byte[] zipbuf = createZipFile("test");
         ByteArrayInputStream zipBais = new ByteArrayInputStream(zipbuf);
         assertTrue(this.plugin.isZipFile(zipBais));
     }


### PR DESCRIPTION
## Summary

Fixes **58 SonarCloud issues across 22 modules**. All conversions are mechanical and behaviour-preserving:

- **[`java:S1128`](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&rules=java%3AS1128&issueStatuses=OPEN)** (26) — remove unused imports (mostly leftover test imports and a legacy delegating subclass whose imports were copied from its parent).
- **[`java:S1197`](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&rules=java%3AS1197&issueStatuses=OPEN)** (18) — move array designators `[]` from the variable name to the type (`byte data[]` → `byte[] data`).
- **[`java:S1116`](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&rules=java%3AS1116&issueStatuses=OPEN)** (14) — remove redundant empty statements (stray `;` after a block, a double `;;`, etc.).

Modules touched: oldcore, security-authorization-api, resource-api, localization-api, refactoring-api, query-xwql, filter-stream-xar, store-merge-api, extension-handler-xar, xclass-ui, captcha-jcaptcha-api, chart-renderer, flamingo-theme-ui, notifications-filters-default, help-ui, image-style-ui, logging-ui, repository-server-api, skin-ui, wiki-ui-mainwiki, zipexplorer, legacy-notifications-filters-api.

## Test plan

- `mvn clean install` of the 22 modules passes (Checkstyle + Spoon included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01R7KFr7kRnAtTyFgdoxJMUU)_