### PR TITLE
[Misc] Remove unused code reported by SonarCloud (S1068, S1481, S1854)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Class.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/Class.java
@@ -313,7 +313,6 @@ public class Class extends Collection
         if (!(other instanceof Class)) {
             return false;
         }
-        Class otherClass = (Class) other;
         return getBaseClass().equals(((Class) other).getBaseClass());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/XWiki.java
@@ -48,7 +48,6 @@ import org.xwiki.query.hql.internal.HQLStatementValidator;
 import org.xwiki.rendering.renderer.PrintRendererFactory;
 import org.xwiki.rendering.syntax.Syntax;
 import org.xwiki.security.authorization.AuthorizationException;
-import org.xwiki.security.authorization.ContextualAuthorizationManager;
 import org.xwiki.security.authorization.Right;
 import org.xwiki.user.CurrentUserReference;
 
@@ -104,8 +103,6 @@ public class XWiki extends Api
     private DocumentReferenceResolver<EntityReference> currentgetdocumentResolver;
 
     private DocumentRevisionProvider documentRevisionProvider;
-
-    private ContextualAuthorizationManager contextualAuthorizationManager;
 
     private HQLStatementValidator hqlValidator;
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/output/DocumentInstanceOutputFilterStream.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/output/DocumentInstanceOutputFilterStream.java
@@ -177,7 +177,6 @@ public class DocumentInstanceOutputFilterStream extends AbstractBeanOutputFilter
             return;
         }
 
-
         XWikiContext xcontext = this.xcontextProvider.get();
 
         try {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/output/DocumentInstanceOutputFilterStream.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/output/DocumentInstanceOutputFilterStream.java
@@ -177,7 +177,6 @@ public class DocumentInstanceOutputFilterStream extends AbstractBeanOutputFilter
             return;
         }
 
-        boolean hasJRCSHistory = inputDocument.getDocumentArchive() != null;
 
         XWikiContext xcontext = this.xcontextProvider.get();
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/skin/InternalSkinManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/skin/InternalSkinManager.java
@@ -195,8 +195,6 @@ public class InternalSkinManager implements Initializable
             skin = (String) xcontext.get(CKEY_SKIN);
             if (StringUtils.isNotEmpty(skin)) {
                 return skin;
-            } else {
-                skin = null;
             }
 
             // Try to get it from URL
@@ -204,8 +202,6 @@ public class InternalSkinManager implements Initializable
                 skin = xcontext.getRequest().getParameter("skin");
                 if (StringUtils.isNotEmpty(skin)) {
                     return skin;
-                } else {
-                    skin = null;
                 }
             }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/query/HqlQueryUtils.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/query/HqlQueryUtils.java
@@ -36,11 +36,7 @@ import org.xwiki.query.WrappingQuery;
  */
 public final class HqlQueryUtils
 {
-    private static final String FROM = "from";
-
     private static final String WHERE = "where ";
-
-    private static final String ORDER = "order";
 
     private static final String ORDER_BY = "order by";
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/NumberClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/NumberClass.java
@@ -20,8 +20,6 @@
 package com.xpn.xwiki.objects.classes;
 
 import org.apache.ecs.xhtml.input;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.xwiki.stability.Unstable;
 
 import com.xpn.xwiki.XWikiContext;
@@ -84,9 +82,6 @@ public class NumberClass extends PropertyClass
     private static final String XCLASSNAME = "number";
     private static final String SIZE = "size";
     private static final String NUMBER_TYPE = "numberType";
-
-    /** Logging helper object. */
-    private static final Logger LOG = LoggerFactory.getLogger(NumberClass.class);
 
     /**
      * Constructor with a meta class.

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateVersioningStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateVersioningStore.java
@@ -27,8 +27,6 @@ import java.util.List;
 import javax.inject.Named;
 import javax.inject.Singleton;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.suigeneris.jrcs.rcs.Version;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.component.util.DefaultParameterizedType;
@@ -59,8 +57,6 @@ import com.xpn.xwiki.web.Utils;
 @Singleton
 public class XWikiHibernateVersioningStore extends XWikiHibernateBaseStore implements XWikiVersioningStoreInterface
 {
-    /** Logger. */
-    private static final Logger LOGGER = LoggerFactory.getLogger(XWikiHibernateVersioningStore.class);
 
     /**
      * This allows to initialize our storage engine. The hibernate config file path is taken from xwiki.cfg or directly

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateVersioningStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateVersioningStore.java
@@ -57,7 +57,6 @@ import com.xpn.xwiki.web.Utils;
 @Singleton
 public class XWikiHibernateVersioningStore extends XWikiHibernateBaseStore implements XWikiVersioningStoreInterface
 {
-
     /**
      * This allows to initialize our storage engine. The hibernate config file path is taken from xwiki.cfg or directly
      * in the WEB-INF directory.

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R40000XWIKI6990DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R40000XWIKI6990DataMigration.java
@@ -780,7 +780,7 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
                 this.logger.debug(TIME_ELAPSED_CLASS_MESSAGE, XWikiRCSNodeInfo.class.getName(),
                     times[timer++] / 1000000);
                 this.logger.debug(TIME_ELAPSED_CLASS_MESSAGE, XWikiDocument.class.getName(),
-                    times[timer++] / 1000000);
+                    times[timer] / 1000000);
             }
 
             logProgress("All document IDs has been converted successfully.");
@@ -860,7 +860,7 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
                         times[timer++] / 1000000);
                 }
                 this.logger.debug(TIME_ELAPSED_CLASS_MESSAGE, BaseObject.class.getName(),
-                    times[timer++] / 1000000);
+                    times[timer] / 1000000);
             }
 
             logProgress("All object IDs has been converted successfully.");
@@ -900,7 +900,7 @@ public class R40000XWIKI6990DataMigration extends AbstractHibernateDataMigration
                         this.logger.debug(TIME_ELAPSED_COLLECTION_MESSAGE, coll[0], times[timer++] / 1000000);
                     }
                     this.logger.debug(TIME_ELAPSED_CLASS_MESSAGE, statsClass.getName(),
-                        times[timer++] / 1000000);
+                        times[timer] / 1000000);
                 }
 
                 logProgress("All %s statistics IDs has been converted successfully.", klassName);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyPersistentLoginManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyPersistentLoginManager.java
@@ -64,11 +64,6 @@ public class MyPersistentLoginManager extends DefaultPersistentLoginManager
     private static final String FIELD_SEPARATOR = ":";
 
     /**
-     * The string used to prefix cookie domain to conform to RFC 2109.
-     */
-    private static final String COOKIE_DOT_PFX = ".";
-
-    /**
      * Log4J logger object to log messages in this class.
      */
     private static final Logger LOGGER = LoggerFactory.getLogger(MyPersistentLoginManager.class);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/DeleteAttachmentAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/DeleteAttachmentAction.java
@@ -93,8 +93,6 @@ public class DeleteAttachmentAction extends XWikiAction
         if (context.getMode() == XWikiContext.MODE_PORTLET) {
             filename = request.getParameter("filename");
         } else {
-            // Note: We use getRequestURI() because the spec says the server doesn't decode it, as
-            // we want to use our own decoding.
             filename = getFileName();
         }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/DeleteAttachmentAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/DeleteAttachmentAction.java
@@ -95,7 +95,6 @@ public class DeleteAttachmentAction extends XWikiAction
         } else {
             // Note: We use getRequestURI() because the spec says the server doesn't decode it, as
             // we want to use our own decoding.
-            String requestUri = request.getRequestURI();
             filename = getFileName();
         }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/EditForm.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/EditForm.java
@@ -62,8 +62,6 @@ public class EditForm extends XWikiForm
      */
     private static final Pattern XOBJECTS_REFERENCE_PATTERN = Pattern.compile("^((?:[\\S ]+\\.)+[\\S ]+?)_([0-9]+)$");
 
-    private static final String OBJECTS_CLASS_DELIMITER = "_";
-
     // ---- Form fields -------------------------------------------------
     private String content;
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SaveAndContinueAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SaveAndContinueAction.java
@@ -51,11 +51,6 @@ public class SaveAndContinueAction extends XWikiAction
     /** Key for storing the wrapped action in the context. */
     private static final String WRAPPED_ACTION_CONTEXT_KEY = "SaveAndContinueAction.wrappedAction";
 
-    /**
-     * The default context value to put with {@link #MERGED_DOCUMENTS} key.
-     */
-    private static final String MERGED_DOCUMENTS_VALUE = "true";
-
     /** Logger. */
     private static final Logger LOGGER = LoggerFactory.getLogger(SaveAndContinueAction.class);
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiAction.java
@@ -450,7 +450,7 @@ public abstract class XWikiAction implements LegacyAction
                     // that we
                     // are parsing below.
                     VelocityManager velocityManager = Utils.getComponent(VelocityManager.class);
-                    VelocityContext vcontext = velocityManager.getVelocityContext();
+                    velocityManager.getVelocityContext();
 
                     if (!sendGlobalRedirect(context.getResponse(), context.getURL().toString(), context)) {
                         // Starting XWiki 5.0M2, 'xwiki.virtual.redirect' was removed. Warn users still using it.

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentMockitoTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentMockitoTest.java
@@ -733,8 +733,8 @@ public class XWikiDocumentMockitoTest
         doReturn("iso-8859-1").when(this.oldcore.getSpyXWiki()).getEncoding();
 
         BaseObject object1 = doc.newXObject(tagDocument.getDocumentReference(), this.oldcore.getXWikiContext());
-        BaseObject object2 = doc.newXObject(tagDocument.getDocumentReference(), this.oldcore.getXWikiContext());
-        BaseObject object3 = doc.newXObject(tagDocument.getDocumentReference(), this.oldcore.getXWikiContext());
+        doc.newXObject(tagDocument.getDocumentReference(), this.oldcore.getXWikiContext());
+        doc.newXObject(tagDocument.getDocumentReference(), this.oldcore.getXWikiContext());
 
         // Remove first object
         doc.removeXObject(object1);
@@ -1096,8 +1096,7 @@ public class XWikiDocumentMockitoTest
         this.document.setContentDirty(false);
         this.document.setMetaDataDirty(false);
         // Add attachments (2).
-        XWikiAttachment attachment2 =
-            document.addAttachment("file2", new ByteArrayInputStream(new byte[] {}), this.oldcore.getXWikiContext());
+        document.addAttachment("file2", new ByteArrayInputStream(new byte[] {}), this.oldcore.getXWikiContext());
         assertTrue(this.document.isMetaDataDirty());
         assertFalse(this.document.isContentDirty());
 
@@ -1150,7 +1149,7 @@ public class XWikiDocumentMockitoTest
         XWikiDocument document = new XWikiDocument(new DocumentReference("wiki", "space", "page"));
         XWikiDocument otherDocument = document.clone();
 
-        XWikiAttachment attachment = document.addAttachment("file", new byte[] {1, 2}, this.oldcore.getXWikiContext());
+        document.addAttachment("file", new byte[] {1, 2}, this.oldcore.getXWikiContext());
         XWikiAttachment otherAttachment =
             otherDocument.addAttachment("file", new byte[] {1, 2}, this.oldcore.getXWikiContext());
 
@@ -1168,7 +1167,7 @@ public class XWikiDocumentMockitoTest
     {
         XWikiDocument document = new XWikiDocument();
 
-        XWikiAttachment attachment = document.addAttachment("file", new byte[] {1, 2}, this.oldcore.getXWikiContext());
+        document.addAttachment("file", new byte[] {1, 2}, this.oldcore.getXWikiContext());
 
         // Force the metadata not dirty.
         document.setMetaDataDirty(false);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/ListPropertyTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/ListPropertyTest.java
@@ -65,7 +65,7 @@ class ListPropertyTest
     {
         ListProperty p = new ListProperty();
 
-        List<String> pList = p.getList();
+        p.getList();
 
         p.setValueDirty(false);
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/CreateActionTest.java
@@ -32,8 +32,6 @@ import javax.inject.Provider;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.xwiki.csrf.CSRFToken;
 import org.xwiki.internal.web.PageTemplateRequiredRightsChecker;
 import org.xwiki.model.EntityType;
@@ -84,8 +82,6 @@ import static org.mockito.Mockito.when;
 class CreateActionTest
 {
     private static final String CSRF_TOKEN_VALUE = "token4234343";
-
-    private static final Logger log = LoggerFactory.getLogger(CreateActionTest.class);
 
     @InjectMockitoOldcore
     MockitoOldcore oldcore;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/DownloadActionTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/DownloadActionTest.java
@@ -429,7 +429,7 @@ class DownloadActionTest
     void downloadWhenNameWithSpacesEncodedWithPercent() throws XWikiException, IOException
     {
         Date d = new Date();
-        XWikiAttachment attachment = createAttachment(d, "file name.txt");
+        createAttachment(d, "file name.txt");
         when(this.engineContext.getMimeType("file name.txt")).thenReturn("text/plain");
         setRequestExpectations("/xwiki/bin/download/space/page/file%20name.txt", null, "1", null, -1l, "file name.txt");
         assertNull(this.action.render(this.oldcore.getXWikiContext()));
@@ -443,7 +443,7 @@ class DownloadActionTest
     void downloadWhenNameWithNonAsciiChars() throws XWikiException, IOException
     {
         Date d = new Date();
-        XWikiAttachment attachment = createAttachment(d, "file\u021B.txt");
+        createAttachment(d, "file\u021B.txt");
 
         when(this.engineContext.getMimeType("file\u021B.txt")).thenReturn("text/plain");
         setRequestExpectations("/xwiki/bin/download/space/page/file%C8%9B.txt", null, "1", null, -1l, "file\u021B.txt");
@@ -792,7 +792,7 @@ class DownloadActionTest
         ExecutionContextManager ecm = this.oldcore.getMocker().registerMockComponent(ExecutionContextManager.class);
         ExecutionContext ec = this.oldcore.getExecutionContext();
         when(ecm.clone(ec)).thenReturn(ec);
-        VelocityManager vm = this.oldcore.getMocker().registerMockComponent(VelocityManager.class);
+        this.oldcore.getMocker().registerMockComponent(VelocityManager.class);
 
         // Set the Plugin Manager
         XWikiPluginManager pluginManager = mock(XWikiPluginManager.class);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/XWikiMessageToolTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/XWikiMessageToolTest.java
@@ -59,12 +59,6 @@ class XWikiMessageToolTest
 
     private DocumentReference translationDocumentReference2;
 
-    private DocumentReference translationDocumentReferenceFR2;
-
-    private String translationDocumentName1;
-
-    private String translationDocumentName2;
-
     @BeforeEach
     void beforeEach()
     {
@@ -75,14 +69,9 @@ class XWikiMessageToolTest
 
         this.translationDocumentReferenceFR1 = new DocumentReference(this.translationDocumentReference1, Locale.FRENCH);
 
-        this.translationDocumentName1 = "TranslationSpace1.TranslationPage1";
-
         this.translationDocumentReference2 =
             new DocumentReference(this.oldcore.getXWikiContext().getWikiId(), "TranslationSpace1", "TranslationPage2");
 
-        this.translationDocumentReferenceFR2 = new DocumentReference(this.translationDocumentReference2, Locale.FRENCH);
-
-        this.translationDocumentName2 = "TranslationSpace2.TranslationPage2";
     }
 
     public class TestResources extends ListResourceBundle

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/XWikiMessageToolTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/web/XWikiMessageToolTest.java
@@ -71,7 +71,6 @@ class XWikiMessageToolTest
 
         this.translationDocumentReference2 =
             new DocumentReference(this.oldcore.getXWikiContext().getWikiId(), "TranslationSpace1", "TranslationPage2");
-
     }
 
     public class TestResources extends ListResourceBundle


### PR DESCRIPTION
## Summary

Fixes **42 SonarCloud "unused code" issues in `xwiki-platform-oldcore`** across 3 rules. All changes are behaviour-preserving:

- **[`java:S1068`](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&rules=java%3AS1068&issueStatuses=OPEN)** — remove unused private fields (unused `LOG`/`LOGGER` loggers, unused constants, an unused injected-looking field), plus the now-orphaned imports.
- **[`java:S1481`](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&rules=java%3AS1481&issueStatuses=OPEN)** — remove unused local variables.
- **[`java:S1854`](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&rules=java%3AS1854&issueStatuses=OPEN)** — remove useless assignments / dead stores.

Where the removed variable's initializer has an observable side effect that surrounding code relies on (e.g. `document.addAttachment(...)` mutating the document, `newXObject(...)` adding an xobject, `registerMockComponent(...)` registering a mock, `getVelocityContext()` initializing bindings), the call is **kept as an expression statement** and only the unused `Type name =` assignment is dropped. Purely dead stores (e.g. `skin = null` in an `else` whose sibling `if` returns, a redundant `timer++` post-increment on a last-use) are removed outright.

A handful of flagged issues were intentionally left out because their removal would require broader changes (write-only fields with multiple assignments or a public setter, a dead store whose call must be moved) — those are out of scope for a mechanical cleanup.

## Test plan

- `mvn clean install` of `xwiki-platform-oldcore` passes (Checkstyle + Spoon + test-source compilation included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3qcyfaNBFWESUGAru3hfs)_