### PR TITLE
[Misc] Merge collapsible if statements reported by SonarCloud (java:S1066)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
@@ -4543,20 +4543,14 @@ public class XWiki implements EventListener
                 context.setWikiId(database);
             }
 
-            if (currentAPIdoc != null) {
-                if (scontext != null) {
-                    scontext.setAttribute("doc", currentAPIdoc, ScriptContext.ENGINE_SCOPE);
-                }
+            if (currentAPIdoc != null && scontext != null) {
+                scontext.setAttribute("doc", currentAPIdoc, ScriptContext.ENGINE_SCOPE);
             }
-            if (currentAPIcdoc != null) {
-                if (scontext != null) {
-                    scontext.setAttribute("cdoc", currentAPIcdoc, ScriptContext.ENGINE_SCOPE);
-                }
+            if (currentAPIcdoc != null && scontext != null) {
+                scontext.setAttribute("cdoc", currentAPIcdoc, ScriptContext.ENGINE_SCOPE);
             }
-            if (currentAPItdoc != null) {
-                if (scontext != null) {
-                    scontext.setAttribute("tdoc", currentAPItdoc, ScriptContext.ENGINE_SCOPE);
-                }
+            if (currentAPItdoc != null && scontext != null) {
+                scontext.setAttribute("tdoc", currentAPItdoc, ScriptContext.ENGINE_SCOPE);
             }
         }
     }
@@ -5455,14 +5449,12 @@ public class XWiki implements EventListener
 
         String servletPath = getConfiguration().getProperty("xwiki.servletpath", "");
 
-        if (context.getRequest() != null) {
-            if (StringUtils.isEmpty(servletPath)) {
-                String currentServletpath = context.getRequest().getServletPath();
-                if (currentServletpath != null && currentServletpath.startsWith("/bin")) {
-                    servletPath = "bin/";
-                } else {
-                    servletPath = getConfiguration().getProperty("xwiki.defaultservletpath", "bin/");
-                }
+        if (context.getRequest() != null && StringUtils.isEmpty(servletPath)) {
+            String currentServletpath = context.getRequest().getServletPath();
+            if (currentServletpath != null && currentServletpath.startsWith("/bin")) {
+                servletPath = "bin/";
+            } else {
+                servletPath = getConfiguration().getProperty("xwiki.defaultservletpath", "bin/");
             }
         }
 
@@ -6175,20 +6167,18 @@ public class XWiki implements EventListener
     public XWikiStatsService getStatsService(XWikiContext context)
     {
         synchronized (this.STATS_SERVICE_LOCK) {
-            if (this.statsService == null) {
-                if ("1".equals(getConfiguration().getProperty("xwiki.stats", "1"))) {
-                    String storeClass = getConfiguration().getProperty("xwiki.stats.class",
-                        "com.xpn.xwiki.stats.impl.XWikiStatsServiceImpl");
-                    try {
-                        this.statsService = (XWikiStatsService) Class.forName(storeClass).newInstance();
-                    } catch (Exception e) {
-                        LOGGER.error(e.getMessage(), e);
+            if (this.statsService == null && "1".equals(getConfiguration().getProperty("xwiki.stats", "1"))) {
+                String storeClass = getConfiguration().getProperty("xwiki.stats.class",
+                    "com.xpn.xwiki.stats.impl.XWikiStatsServiceImpl");
+                try {
+                    this.statsService = (XWikiStatsService) Class.forName(storeClass).newInstance();
+                } catch (Exception e) {
+                    LOGGER.error(e.getMessage(), e);
 
-                        this.statsService = new XWikiStatsServiceImpl();
-                    }
-
-                    this.statsService.init(context);
+                    this.statsService = new XWikiStatsServiceImpl();
                 }
+
+                this.statsService.init(context);
             }
 
             return this.statsService;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiAttachment.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiAttachment.java
@@ -507,10 +507,8 @@ public class XWikiAttachment implements Cloneable
             this.doc = doc;
             this.reference = null;
 
-            if (updateDirty) {
-                if (isMetaDataDirty() && doc != null) {
-                    doc.setMetaDataDirty(true);
-                }
+            if (updateDirty && isMetaDataDirty() && doc != null) {
+                doc.setMetaDataDirty(true);
             }
         }
     }
@@ -572,10 +570,8 @@ public class XWikiAttachment implements Cloneable
     {
         setMetaDataDirty(dirty);
 
-        if (deep) {
-            if (this.content != null) {
-                this.content.setContentDirty(dirty);
-            }
+        if (deep && this.content != null) {
+            this.content.setContentDirty(dirty);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiAttachmentArchive.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiAttachmentArchive.java
@@ -182,10 +182,8 @@ public class XWikiAttachmentArchive implements Cloneable
      */
     public String getArchiveAsString(final XWikiContext context) throws XWikiException
     {
-        if (this.archive == null) {
-            if (context != null) {
-                updateArchive(context);
-            }
+        if (this.archive == null && context != null) {
+            updateArchive(context);
         }
 
         return getArchiveAsString();
@@ -216,10 +214,8 @@ public class XWikiAttachmentArchive implements Cloneable
      */
     public byte[] getArchive(final XWikiContext context) throws XWikiException
     {
-        if (this.archive == null) {
-            if (context != null) {
-                updateArchive(context);
-            }
+        if (this.archive == null && context != null) {
+            updateArchive(context);
         }
 
         return getArchive();

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -1997,10 +1997,8 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
     public Object getPreparedTitle()
     {
         // If the content is prepared and it's allowed to use the cache, return it
-        if (this.titlePrepareDate != null) {
-            if (getCacheControl().isCacheReadAllowed(this.titlePrepareDate)) {
-                return this.preparedTitle;
-            }
+        if (this.titlePrepareDate != null && getCacheControl().isCacheReadAllowed(this.titlePrepareDate)) {
+            return this.preparedTitle;
         }
 
         return null;
@@ -3353,10 +3351,8 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
                 return null;
             }
             for (BaseObject obj : objects) {
-                if (obj != null) {
-                    if (value.equals(obj.getStringValue(key))) {
-                        return obj;
-                    }
+                if (obj != null && value.equals(obj.getStringValue(key))) {
+                    return obj;
                 }
             }
 
@@ -3999,10 +3995,8 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
                     }
                 }
                 pclass.displayEdit(result, fieldname, prefix, obj, context);
-                if (is10Syntax(wrappingSyntaxId)) {
-                    if (isInRenderingEngine) {
-                        result.append(PRE_END);
-                    }
+                if (is10Syntax(wrappingSyntaxId) && isInRenderingEngine) {
+                    result.append(PRE_END);
                 }
             } else if (HIDDEN.equals(type)) {
                 // If the Syntax id is "xwiki/1.0" then use the old rendering subsystem and prevent wiki syntax
@@ -7437,10 +7431,8 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
                     result = restoredAttachment;
                 }
 
-                if (result != null) {
-                    if (!Objects.equals(attachment.getVersion(), result.getVersion())) {
-                        result = result.getAttachmentRevision(attachment.getVersion(), context);
-                    }
+                if (result != null && !Objects.equals(attachment.getVersion(), result.getVersion())) {
+                    result = result.getAttachmentRevision(attachment.getVersion(), context);
                 }
             }
         } catch (XWikiException e) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/rcs/XWikiPatch.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/rcs/XWikiPatch.java
@@ -93,11 +93,9 @@ public class XWikiPatch
      */
     public boolean isDiff()
     {
-        if (this.content != null) {
-            if (this.isDiff != isContentDiff()) {
-                LOGGER.warn("isDiff: Patch is inconsistent. Content and diff field are contradicting");
-                return isContentDiff();
-            }
+        if (this.content != null && this.isDiff != isContentDiff()) {
+            LOGGER.warn("isDiff: Patch is inconsistent. Content and diff field are contradicting");
+            return isContentDiff();
         }
         return this.isDiff;
     }
@@ -107,12 +105,10 @@ public class XWikiPatch
      */
     public void setDiff(boolean isDiff)
     {
-        if (this.content != null) {
-            if (isDiff != isContentDiff()) {
-                LOGGER.warn("setDiff: Patch is inconsistent. Content and diff field are contradicting");
-                this.isDiff = isContentDiff();
-                return;
-            }
+        if (this.content != null && isDiff != isContentDiff()) {
+            LOGGER.warn("setDiff: Patch is inconsistent. Content and diff field are contradicting");
+            this.isDiff = isContentDiff();
+            return;
         }
         this.isDiff = isDiff;
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/output/BaseClassOutputFilterStream.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/output/BaseClassOutputFilterStream.java
@@ -82,11 +82,9 @@ public class BaseClassOutputFilterStream extends AbstractElementOutputFilterStre
     @Override
     public void endWikiClassProperty(String name, String type, FilterEventParameters parameters) throws FilterException
     {
-        if (this.enabled) {
-            if (getPropertyClassOutputFilterStream().getEntity() != null) {
-                this.entity.safeput(name, getPropertyClassOutputFilterStream().getEntity());
-                getPropertyClassOutputFilterStream().setEntity(null);
-            }
+        if (this.enabled && getPropertyClassOutputFilterStream().getEntity() != null) {
+            this.entity.safeput(name, getPropertyClassOutputFilterStream().getEntity());
+            getPropertyClassOutputFilterStream().setEntity(null);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/output/BaseObjectOutputFilterStream.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/output/BaseObjectOutputFilterStream.java
@@ -228,12 +228,10 @@ public class BaseObjectOutputFilterStream extends AbstractElementOutputFilterStr
     @Override
     public void onWikiObjectProperty(String name, Object value, FilterEventParameters parameters) throws FilterException
     {
-        if (this.enabled) {
-            if (getBasePropertyOutputFilterStream().getEntity() != null) {
-                this.entity.safeput(name, getBasePropertyOutputFilterStream().getEntity());
+        if (this.enabled && getBasePropertyOutputFilterStream().getEntity() != null) {
+            this.entity.safeput(name, getBasePropertyOutputFilterStream().getEntity());
 
-                getBasePropertyOutputFilterStream().setEntity(null);
-            }
+            getBasePropertyOutputFilterStream().setEntity(null);
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/skin/InternalSkinManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/skin/InternalSkinManager.java
@@ -224,13 +224,11 @@ public class InternalSkinManager implements Initializable
             // TODO: shouldn't we make sure anyone see the skin whatever right he have ?
             if (testRights) {
                 XWikiDocument document = this.wikiSkinUtils.getSkinDocument(skin);
-                if (document != null) {
-                    if (!this.authorization.hasAccess(Right.VIEW, document.getDocumentReference())) {
-                        this.logger.debug(
-                            "Cannot access configured wiki skin [{}] due to access rights, using the default skin.",
-                            skin);
-                        skin = getDefaultSkinId();
-                    }
+                if (document != null && !this.authorization.hasAccess(Right.VIEW, document.getDocumentReference())) {
+                    this.logger.debug(
+                        "Cannot access configured wiki skin [{}] due to access rights, using the default skin.",
+                        skin);
+                    skin = getDefaultSkinId();
                 }
             }
 
@@ -287,13 +285,11 @@ public class InternalSkinManager implements Initializable
             // TODO: shouldn't we make sure anyone see the skin whatever right he have ?
             if (testRights) {
                 XWikiDocument document = this.wikiSkinUtils.getSkinDocument(baseSkin);
-                if (document != null) {
-                    if (!this.authorization.hasAccess(Right.VIEW, document.getDocumentReference())) {
-                        this.logger.debug(
-                            "Cannot access configured wiki skin [{}] due to access rights, using the default skin.",
-                            baseSkin);
-                        baseSkin = getDefaultParentSkinId();
-                    }
+                if (document != null && !this.authorization.hasAccess(Right.VIEW, document.getDocumentReference())) {
+                    this.logger.debug(
+                        "Cannot access configured wiki skin [{}] due to access rights, using the default skin.",
+                        baseSkin);
+                    baseSkin = getDefaultParentSkinId();
                 }
             }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseCollection.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseCollection.java
@@ -705,14 +705,12 @@ public abstract class BaseCollection<R extends EntityReference> extends BaseElem
 
             if (oldProperty == null) {
                 // The property exist in the new object, but not in the old one
-                if ((newProperty != null) && (!"".equals(newProperty.toText()))) {
-                    if (pclass != null) {
-                        String newPropertyValue = (newProperty.getValue() instanceof String) ? newProperty.toText()
-                            : pclass.displayView(propertyName, this, context);
-                        difflist.add(new ObjectDiff(getXClassReference(), getNumber(), "",
-                            ObjectDiff.ACTION_PROPERTYADDED, propertyName, propertyType, "", newPropertyValue,
-                            isSensitive));
-                    }
+                if ((newProperty != null) && (!"".equals(newProperty.toText())) && pclass != null) {
+                    String newPropertyValue = (newProperty.getValue() instanceof String) ? newProperty.toText()
+                        : pclass.displayView(propertyName, this, context);
+                    difflist.add(new ObjectDiff(getXClassReference(), getNumber(), "",
+                        ObjectDiff.ACTION_PROPERTYADDED, propertyName, propertyType, "", newPropertyValue,
+                        isSensitive));
                 }
             } else if (!oldProperty.toText().equals(((newProperty == null) ? "" : newProperty.toText()))) {
                 // The property exists in both objects and is different

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseObjectReference.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseObjectReference.java
@@ -207,12 +207,10 @@ public class BaseObjectReference extends ObjectReference
             name = builder.toString();
         } else {
             Matcher matcher = NUMBERPATTERN.matcher(name);
-            if (matcher.find()) {
-                if (matcher.group(1).length() % 2 == 0) {
-                    StringBuilder builder = new StringBuilder(name);
-                    builder.insert(matcher.start(), '\\');
-                    name = builder.toString();
-                }
+            if (matcher.find() && matcher.group(1).length() % 2 == 0) {
+                StringBuilder builder = new StringBuilder(name);
+                builder.insert(matcher.start(), '\\');
+                name = builder.toString();
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BaseClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/BaseClass.java
@@ -190,10 +190,8 @@ public class BaseClass extends BaseCollection<DocumentReference> implements Clas
     {
         if (element != null) {
             Set<String> properties = getPropertyList();
-            if (!properties.contains(name)) {
-                if (((BaseCollection) element).getNumber() == 0) {
-                    ((BaseCollection) element).setNumber(properties.size() + 1);
-                }
+            if (!properties.contains(name) && ((BaseCollection) element).getNumber() == 0) {
+                ((BaseCollection) element).setNumber(properties.size() + 1);
             }
 
             super.addField(name, element);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
@@ -1098,11 +1098,9 @@ public abstract class ListClass extends PropertyClass
         // Add missing elements
         if (newList != null) {
             for (String element : newList) {
-                if ((previousList == null || !previousList.contains(element))) {
-                    if (!currentList.contains(element)) {
-                        currentList.add(element);
-                        mergeResult.setModified(true);
-                    }
+                if ((previousList == null || !previousList.contains(element)) && !currentList.contains(element)) {
+                    currentList.add(element);
+                    mergeResult.setModified(true);
                 }
             }
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PasswordClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/PasswordClass.java
@@ -225,11 +225,10 @@ public class PasswordClass extends StringClass
     public String getEquivalentPassword(String storedPassword, String plainPassword)
     {
         String result = plainPassword;
-        if (storedPassword != null && plainPassword != null) {
-            if (storedPassword.startsWith(HASH_IDENTIFIER + SEPARATOR)) {
-                result = getPasswordHash(result, getAlgorithmFromPassword(storedPassword),
-                        getSaltFromPassword(storedPassword));
-            }
+        if (storedPassword != null && plainPassword != null
+            && storedPassword.startsWith(HASH_IDENTIFIER + SEPARATOR)) {
+            result = getPasswordHash(result, getAlgorithmFromPassword(storedPassword),
+                    getSaltFromPassword(storedPassword));
         }
         return result;
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/pdf/impl/FileSystemURLFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/pdf/impl/FileSystemURLFactory.java
@@ -137,10 +137,8 @@ public class FileSystemURLFactory extends XWikiServletURLFactory
         try {
             Map<String, File> usedFiles = getFileMapping(context);
             String key = getResourceKey(filename);
-            if (!usedFiles.containsKey(key)) {
-                if (!copyResource("/resources/" + filename, key, usedFiles, context)) {
-                    return super.createResourceURL(filename, forceSkinAction, context);
-                }
+            if (!usedFiles.containsKey(key) && !copyResource("/resources/" + filename, key, usedFiles, context)) {
+                return super.createResourceURL(filename, forceSkinAction, context);
             }
             return usedFiles.get(key).toURI().toURL();
         } catch (Exception ex) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/DocumentInfo.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/DocumentInfo.java
@@ -131,10 +131,8 @@ public class DocumentInfo
                 }
                 XWikiDocument doc1 = context.getWiki().getDocument(this.doc.getFullName(), context);
                 boolean isNew = doc1.isNew();
-                if (!isNew) {
-                    if ((this.doc.getLanguage() != null) && (!"".equals(this.doc.getLanguage()))) {
-                        isNew = !doc1.getTranslationList(context).contains(this.doc.getLanguage());
-                    }
+                if (!isNew && (this.doc.getLanguage() != null) && (!"".equals(this.doc.getLanguage()))) {
+                    isNew = !doc1.getTranslationList(context).contains(this.doc.getLanguage());
                 }
 
                 if (!isNew) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/Package.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/Package.java
@@ -466,13 +466,11 @@ public class Package
 
     public String exportToDir(File dir, XWikiContext context) throws IOException, XWikiException
     {
-        if (!dir.exists()) {
-            if (!dir.mkdirs()) {
-                Object[] args = new Object[1];
-                args[0] = dir.toString();
-                throw new XWikiException(XWikiException.MODULE_XWIKI, XWikiException.ERROR_XWIKI_MKDIR,
-                    "Error creating directory {0}", null, args);
-            }
+        if (!dir.exists() && !dir.mkdirs()) {
+            Object[] args = new Object[1];
+            args[0] = dir.toString();
+            throw new XWikiException(XWikiException.MODULE_XWIKI, XWikiException.ERROR_XWIKI_MKDIR,
+                "Error creating directory {0}", null, args);
         }
 
         for (int i = 0; i < this.files.size(); i++) {
@@ -1275,13 +1273,11 @@ public class Package
         try {
             filter(doc, context);
             File spacedir = new File(dir, getDirectoryForDocument(doc));
-            if (!spacedir.exists()) {
-                if (!spacedir.mkdirs()) {
-                    Object[] args = new Object[1];
-                    args[0] = dir.toString();
-                    throw new XWikiException(XWikiException.MODULE_XWIKI, XWikiException.ERROR_XWIKI_MKDIR,
-                        "Error creating directory {0}", null, args);
-                }
+            if (!spacedir.exists() && !spacedir.mkdirs()) {
+                Object[] args = new Object[1];
+                args[0] = dir.toString();
+                throw new XWikiException(XWikiException.MODULE_XWIKI, XWikiException.ERROR_XWIKI_MKDIR,
+                    "Error creating directory {0}", null, args);
             }
             String filename = getFileNameFromDocument(doc, context);
             File file = new File(spacedir, filename);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/stats/impl/XWikiStats.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/stats/impl/XWikiStats.java
@@ -213,10 +213,8 @@ public class XWikiStats extends BaseCollection
         Element oel = new DOMElement(XMLNODE_OBJECT);
 
         // Add Class
-        if (bclass != null) {
-            if (!bclass.getFieldList().isEmpty()) {
-                oel.add(bclass.toXML());
-            }
+        if (bclass != null && !bclass.getFieldList().isEmpty()) {
+            oel.add(bclass.toXML());
         }
 
         Element el = new DOMElement(XMLNODE_NAME);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiCacheStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiCacheStore.java
@@ -321,10 +321,8 @@ public class XWikiCacheStore extends AbstractXWikiStore
     public void onEvent(Event event, Object source, Object data)
     {
         // only react to remote events since local actions are already taken into account
-        if (this.remoteObservationManagerContext.isRemoteState()) {
-            if (event instanceof WikiDeletedEvent) {
-                flushCache();
-            }
+        if (this.remoteObservationManagerContext.isRemoteState() && event instanceof WikiDeletedEvent) {
+            flushCache();
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
@@ -1662,10 +1662,8 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
                                     loadXWikiProperty(property2, context, false);
                                     property.setValue(property2.getValue());
 
-                                    if (bclass != null) {
-                                        if (bclass.get(name) instanceof TextAreaClass) {
-                                            property = property2;
-                                        }
+                                    if (bclass != null && bclass.get(name) instanceof TextAreaClass) {
+                                        property = property2;
                                     }
 
                                 } else if (property instanceof LargeStringProperty) {
@@ -1675,10 +1673,8 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
                                     loadXWikiProperty(property2, context, false);
                                     property.setValue(property2.getValue());
 
-                                    if (bclass != null) {
-                                        if (bclass.get(name) instanceof StringClass) {
-                                            property = property2;
-                                        }
+                                    if (bclass != null && bclass.get(name) instanceof StringClass) {
+                                        property = property2;
                                     }
                                 } else {
                                     throw e;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyFormAuthenticator.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyFormAuthenticator.java
@@ -292,10 +292,8 @@ public class MyFormAuthenticator extends FormAuthenticator implements XWikiAuthe
         HttpServletResponse httpServletResponse, URLPatternMatcher urlPatternMatcher) throws Exception
     {
         boolean result = super.processLogout(securityRequestWrapper, httpServletResponse, urlPatternMatcher);
-        if (result) {
-            if (this.persistentLoginManager != null) {
-                this.persistentLoginManager.forgetLogin(securityRequestWrapper, httpServletResponse);
-            }
+        if (result && this.persistentLoginManager != null) {
+            this.persistentLoginManager.forgetLogin(securityRequestWrapper, httpServletResponse);
         }
         return result;
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyPersistentLoginManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyPersistentLoginManager.java
@@ -517,13 +517,11 @@ public class MyPersistentLoginManager extends DefaultPersistentLoginManager
     {
         String username = getCookieValue(request.getCookies(), getCookiePrefix() + COOKIE_USERNAME, DEFAULT_VALUE);
 
-        if (!DEFAULT_VALUE.equals(username)) {
-            if (checkValidation(request, response)) {
-                if (PROTECTION_ALL.equals(this.protection) || PROTECTION_ENCRYPTION.equals(this.protection)) {
-                    username = decryptText(username);
-                }
-                return username;
+        if (!DEFAULT_VALUE.equals(username) && checkValidation(request, response)) {
+            if (PROTECTION_ALL.equals(this.protection) || PROTECTION_ENCRYPTION.equals(this.protection)) {
+                username = decryptText(username);
             }
+            return username;
         }
         return null;
     }
@@ -540,13 +538,11 @@ public class MyPersistentLoginManager extends DefaultPersistentLoginManager
     public String getRememberedPassword(HttpServletRequest request, HttpServletResponse response)
     {
         String password = getCookieValue(request.getCookies(), getCookiePrefix() + COOKIE_PASSWORD, DEFAULT_VALUE);
-        if (!DEFAULT_VALUE.equals(password)) {
-            if (checkValidation(request, response)) {
-                if (PROTECTION_ALL.equals(this.protection) || PROTECTION_ENCRYPTION.equals(this.protection)) {
-                    password = decryptText(password);
-                }
-                return password;
+        if (!DEFAULT_VALUE.equals(password) && checkValidation(request, response)) {
+            if (PROTECTION_ALL.equals(this.protection) || PROTECTION_ENCRYPTION.equals(this.protection)) {
+                password = decryptText(password);
             }
+            return password;
         }
         return null;
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiAuthServiceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiAuthServiceImpl.java
@@ -217,10 +217,8 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
             }
 
             final String userName = getContextUserName(wrappedRequest.getUserPrincipal(), context);
-            if (LOGGER.isInfoEnabled()) {
-                if (userName != null) {
-                    LOGGER.info(USER_AUTHENTIFIED_MESSAGE, userName);
-                }
+            if (LOGGER.isInfoEnabled() && userName != null) {
+                LOGGER.info(USER_AUTHENTIFIED_MESSAGE, userName);
             }
 
             if (userName == null) {
@@ -266,10 +264,8 @@ public class XWikiAuthServiceImpl extends AbstractXWikiAuthService
             }
 
             Principal principal = wrappedRequest.getUserPrincipal();
-            if (LOGGER.isInfoEnabled()) {
-                if (principal != null) {
-                    LOGGER.info(USER_AUTHENTIFIED_MESSAGE, principal.getName());
-                }
+            if (LOGGER.isInfoEnabled() && principal != null) {
+                LOGGER.info(USER_AUTHENTIFIED_MESSAGE, principal.getName());
             }
 
             if (principal == null) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiRightServiceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiRightServiceImpl.java
@@ -200,12 +200,10 @@ public class XWikiRightServiceImpl implements XWikiRightService
         if (DELETE.equals(right)) {
             user = context.getWiki().checkAuth(context);
             String creator = doc.getCreator();
-            if ((user != null) && (user.getUser() != null) && (creator != null)) {
-                if (user.getUser().equals(creator)) {
-                    context.setUser(user.getUser());
+            if ((user != null) && (user.getUser() != null) && (creator != null) && user.getUser().equals(creator)) {
+                context.setUser(user.getUser());
 
-                    return true;
-                }
+                return true;
             }
         }
 
@@ -596,12 +594,10 @@ public class XWikiRightServiceImpl implements XWikiRightService
 
             // Verify Wiki Owner
             String wikiOwner = context.getWiki().getWikiOwner(currentdoc.getDatabase(), context);
-            if (wikiOwner != null) {
-                if (wikiOwner.equals(userOrGroupName)) {
-                    logAllow(userOrGroupName, entityReference, accessLevel, "admin level from wiki ownership");
+            if (wikiOwner != null && wikiOwner.equals(userOrGroupName)) {
+                logAllow(userOrGroupName, entityReference, accessLevel, "admin level from wiki ownership");
 
-                    return true;
-                }
+                return true;
             }
 
             XWikiDocument entityWikiPreferences = context.getWiki().getDocument(XWIKIPREFERENCES_REFERENCE, context);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/UploadAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/UploadAction.java
@@ -81,16 +81,14 @@ public class UploadAction extends XWikiAction
         Object exception = context.get("exception");
         boolean ajax = ((Boolean) context.get("ajax")).booleanValue();
         // check Exception File upload is large
-        if (exception != null) {
-            if (exception instanceof AttachmentValidationException) {
-                AttachmentValidationException exp = (AttachmentValidationException) exception;
-                response.setStatus(exp.getHttpStatus());
-                getCurrentScriptContext().setAttribute(MESSAGE, exp.getTranslationKey(), ENGINE_SCOPE);
-                getCurrentScriptContext().setAttribute("parameters", exp.getTranslationParameters(), ENGINE_SCOPE);
-                context.put(MESSAGE, exp.getContextMessage());
+        if (exception != null && exception instanceof AttachmentValidationException) {
+            AttachmentValidationException exp = (AttachmentValidationException) exception;
+            response.setStatus(exp.getHttpStatus());
+            getCurrentScriptContext().setAttribute(MESSAGE, exp.getTranslationKey(), ENGINE_SCOPE);
+            getCurrentScriptContext().setAttribute("parameters", exp.getTranslationParameters(), ENGINE_SCOPE);
+            context.put(MESSAGE, exp.getContextMessage());
 
-                return true;
-            }
+            return true;
         }
 
         // CSRF prevention


### PR DESCRIPTION
## Summary

Fixes **40 SonarCloud [`java:S1066`](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&rules=java%3AS1066&issueStatuses=OPEN) issues** ("Merge this if statement with the enclosing one") in `xwiki-platform-oldcore`.

Each fix collapses a nested `if` whose enclosing `if` contains nothing but that inner `if` (and neither has an `else`) into a single `if` with the two conditions combined via `&&`:

```java
if (a != null) {
    if (b) {
        ...
    }
}
```
becomes
```java
if (a != null && b) {
    ...
}
```

All changes are behaviour-preserving. Operands containing `||` are parenthesised to keep precedence intact, and a couple of longer conditions are wrapped across two lines to respect the 120-character limit.

The remaining ~30 flagged sites in the module were intentionally left out because collapsing them would either push the merged condition past the 120-character checkstyle limit, or the two `if`s are separated by an explanatory comment (so merging would drop it) — those are out of scope for a mechanical cleanup.

## Test plan

- `mvn clean install` of `xwiki-platform-oldcore` passes (Checkstyle + Spoon + test-source compilation included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013iDti2XPsmwP2LExUuq2xG)_