### PR TITLE
[Misc] Add missing @Override annotations reported by SonarCloud (java:S1161)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/cache/internal/DefaultSecurityCacheTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/cache/internal/DefaultSecurityCacheTest.java
@@ -425,11 +425,13 @@ class DefaultSecurityCacheTest extends AbstractSecurityTestCase
         remover.remove(docRef);
         checkEntries(entries, new Keeper()
         {
+            @Override
             public boolean keepRule(SecurityRuleEntry entry)
             {
                 return entry.getReference() != docRef;
             }
 
+            @Override
             public boolean keepAccess(SecurityAccessEntry entry)
             {
                 return entry.getReference() != docRef;
@@ -440,11 +442,13 @@ class DefaultSecurityCacheTest extends AbstractSecurityTestCase
         remover.remove(anotherWikiUserRef);
         checkEntries(entries, new Keeper()
         {
+            @Override
             public boolean keepRule(SecurityRuleEntry entry)
             {
                 return entry.getReference() != anotherWikiUserRef;
             }
 
+            @Override
             public boolean keepAccess(SecurityAccessEntry entry)
             {
                 return entry.getUserReference() != anotherWikiUserRef;
@@ -455,16 +459,19 @@ class DefaultSecurityCacheTest extends AbstractSecurityTestCase
         remover.remove(anotherGroupXUserRef);
         checkEntries(entries, new Keeper()
         {
+            @Override
             public boolean keepRule(SecurityRuleEntry entry)
             {
                 return entry.getReference() != anotherGroupXUserRef;
             }
 
+            @Override
             public boolean keepAccess(SecurityAccessEntry entry)
             {
                 return entry.getUserReference() != anotherGroupXUserRef;
             }
 
+            @Override
             public boolean keepShadow(SecurityShadowEntry entry)
             {
                 return entry.getReference() != anotherGroupXUserRef;
@@ -475,6 +482,7 @@ class DefaultSecurityCacheTest extends AbstractSecurityTestCase
         remover.remove(groupRef);
         checkEntries(entries, new Keeper()
         {
+            @Override
             public boolean keepRule(SecurityRuleEntry entry)
             {
                 return (entry.getReference() != groupRef && (!groupRefs.get(groupRef).contains(entry.getReference())
@@ -482,12 +490,14 @@ class DefaultSecurityCacheTest extends AbstractSecurityTestCase
                         .getOriginalWikiReference()));
             }
 
+            @Override
             public boolean keepAccess(SecurityAccessEntry entry)
             {
                 return (!groupRefs.get(groupRef).contains(entry.getUserReference()) || entry.getReference()
                     .getOriginalReference().extractReference(EntityType.WIKI) != wikiRef.getOriginalWikiReference());
             }
 
+            @Override
             public boolean keepShadow(SecurityShadowEntry entry)
             {
                 return (!groupRefs.get(groupRef).contains(entry.getReference()) || entry.getWikiReference() != wikiRef);
@@ -498,12 +508,14 @@ class DefaultSecurityCacheTest extends AbstractSecurityTestCase
         remover.remove(spaceRef);
         checkEntries(entries, new Keeper()
         {
+            @Override
             public boolean keepRule(SecurityRuleEntry entry)
             {
                 return (entry.getReference().getOriginalReference().extractReference(EntityType.SPACE) != spaceRef
                     .getOriginalSpaceReference());
             }
 
+            @Override
             public boolean keepAccess(SecurityAccessEntry entry)
             {
                 return (entry.getReference().getOriginalReference().extractReference(EntityType.SPACE) != spaceRef
@@ -515,18 +527,21 @@ class DefaultSecurityCacheTest extends AbstractSecurityTestCase
         remover.remove(wikiRef);
         checkEntries(entries, new Keeper()
         {
+            @Override
             public boolean keepRule(SecurityRuleEntry entry)
             {
                 return (entry.getReference().getOriginalReference().extractReference(EntityType.WIKI) != wikiRef
                     .getOriginalWikiReference());
             }
 
+            @Override
             public boolean keepAccess(SecurityAccessEntry entry)
             {
                 return (entry.getReference().getOriginalReference().extractReference(EntityType.WIKI) != wikiRef
                     .getOriginalWikiReference());
             }
 
+            @Override
             public boolean keepShadow(SecurityShadowEntry entry)
             {
                 return (entry.getWikiReference() != wikiRef);
@@ -538,16 +553,19 @@ class DefaultSecurityCacheTest extends AbstractSecurityTestCase
         remover.remove(xwikiRef);
         checkEntries(entries, new Keeper()
         {
+            @Override
             public boolean keepRule(SecurityRuleEntry entry)
             {
                 return false;
             }
 
+            @Override
             public boolean keepAccess(SecurityAccessEntry entry)
             {
                 return false;
             }
 
+            @Override
             public boolean keepShadow(SecurityShadowEntry entry)
             {
                 return false;
@@ -834,6 +852,7 @@ class DefaultSecurityCacheTest extends AbstractSecurityTestCase
 
         checkEntries(entries, new Keeper()
         {
+            @Override
             public boolean keepAccess(SecurityAccessEntry entry)
             {
                 return entry.getReference() != docRef || entry.getUserReference() != userRef;
@@ -853,6 +872,7 @@ class DefaultSecurityCacheTest extends AbstractSecurityTestCase
         securityCache.remove(userRef, docRef);
         checkEntries(entries, new Keeper()
         {
+            @Override
             public boolean keepAccess(SecurityAccessEntry entry)
             {
                 return entry.getReference() != docRef || entry.getUserReference() != userRef;

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/src/test/java/org/xwiki/store/FileDeleteTransactionRunnableTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/src/test/java/org/xwiki/store/FileDeleteTransactionRunnableTest.java
@@ -91,6 +91,7 @@ public class FileDeleteTransactionRunnableTest
         // After preRun(), before run.
         final TransactionRunnable failRunnable = new TransactionRunnable()
         {
+            @Override
             public void onRun() throws Exception
             {
                 assertFalse(temp.exists());
@@ -112,6 +113,7 @@ public class FileDeleteTransactionRunnableTest
         // After run() before onCommit()
         final TransactionRunnable failRunnable = new TransactionRunnable()
         {
+            @Override
             public void onRun() throws Exception
             {
                 assertTrue(temp.exists());
@@ -143,6 +145,7 @@ public class FileDeleteTransactionRunnableTest
 
         final TransactionRunnable failRunnable = new TransactionRunnable()
         {
+            @Override
             public void onRun() throws Exception
             {
                 assertFalse(temp.exists());

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/src/test/java/org/xwiki/store/internal/BlobDeleteTransactionRunnableTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/src/test/java/org/xwiki/store/internal/BlobDeleteTransactionRunnableTest.java
@@ -101,6 +101,7 @@ class BlobDeleteTransactionRunnableTest
         // After preRun(), before run.
         final TransactionRunnable failRunnable = new TransactionRunnable()
         {
+            @Override
             public void onRun() throws Exception
             {
                 assertFalse(temp.exists());
@@ -122,6 +123,7 @@ class BlobDeleteTransactionRunnableTest
         // After run() before onCommit()
         final TransactionRunnable failRunnable = new TransactionRunnable()
         {
+            @Override
             public void onRun() throws Exception
             {
                 assertTrue(temp.exists());

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-transaction/src/test/java/org/xwiki/store/ProvidingTransactionRunnableTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-transaction/src/test/java/org/xwiki/store/ProvidingTransactionRunnableTest.java
@@ -120,6 +120,7 @@ class ProvidingTransactionRunnableTest
 
     private class TR2 extends TransactionRunnable<DBTransaction>
     {
+        @Override
         protected void onRun()
         {
             assertEquals(DB_CONNECTION, this.getContext().getConnection(), "DB Connection was not correct in TR2");
@@ -128,6 +129,7 @@ class ProvidingTransactionRunnableTest
 
     private class TR3 extends TransactionRunnable<MyInterfaceWithDataA1>
     {
+        @Override
         protected void onRun()
         {
             assertEquals(DATA_A1, this.getContext().getDataA1(), "Data A1 was not correct in TR3");

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-transaction/src/test/java/org/xwiki/store/StartableTransactionRunnableTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-transaction/src/test/java/org/xwiki/store/StartableTransactionRunnableTest.java
@@ -49,11 +49,13 @@ class StartableTransactionRunnableTest
     {
         new TransactionRunnable()
         {
+            @Override
             protected void onRun() throws Exception
             {
                 throw new Exception();
             }
 
+            @Override
             protected void onRollback()
             {
                 itRan();
@@ -70,16 +72,19 @@ class StartableTransactionRunnableTest
     {
         new TransactionRunnable()
         {
+            @Override
             protected void onRun() throws Exception
             {
                 throw new Exception();
             }
 
+            @Override
             protected void onRollback() throws Exception
             {
                 throw new Exception();
             }
 
+            @Override
             protected void onComplete()
             {
                 itRan();
@@ -100,6 +105,7 @@ class StartableTransactionRunnableTest
     {
         new TransactionRunnable()
         {
+            @Override
             protected void onComplete() throws Exception
             {
                 throw new Exception();

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-transaction/src/test/java/org/xwiki/store/TransactionRunnableTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-transaction/src/test/java/org/xwiki/store/TransactionRunnableTest.java
@@ -67,12 +67,14 @@ class TransactionRunnableTest
     {
         new TransactionRunnable()
         {
+            @Override
             protected void onPreRun()
             {
                 fail("Run in wrong order.");
             }
         }.runIn(new TransactionRunnable()
         {
+            @Override
             protected void onPreRun() throws Exception
             {
                 throw new CustomException();
@@ -90,6 +92,7 @@ class TransactionRunnableTest
     {
         new TransactionRunnable()
         {
+            @Override
             protected void onPreRun() throws Exception
             {
                 throw new CustomException();
@@ -98,6 +101,7 @@ class TransactionRunnableTest
 
         new TransactionRunnable()
         {
+            @Override
             protected void onPreRun()
             {
                 fail("Run in wrong order.");
@@ -115,12 +119,14 @@ class TransactionRunnableTest
     {
         new TransactionRunnable()
         {
+            @Override
             protected void onRun()
             {
                 fail("Run in wrong order.");
             }
         }.runIn(new TransactionRunnable()
         {
+            @Override
             protected void onRun() throws Exception
             {
                 throw new CustomException();
@@ -138,6 +144,7 @@ class TransactionRunnableTest
     {
         new TransactionRunnable()
         {
+            @Override
             protected void onRun() throws Exception
             {
                 throw new CustomException();
@@ -146,6 +153,7 @@ class TransactionRunnableTest
 
         new TransactionRunnable()
         {
+            @Override
             protected void onRun()
             {
                 fail("Run in wrong order.");
@@ -164,6 +172,7 @@ class TransactionRunnableTest
         new TransactionRunnable()
         {
             // Child first
+            @Override
             protected void onCommit() throws Exception
             {
                 throw new CustomException();
@@ -171,6 +180,7 @@ class TransactionRunnableTest
         }.runIn(new TransactionRunnable()
         {
             // Then parent
+            @Override
             protected void onCommit()
             {
                 fail("Run in wrong order.");
@@ -188,6 +198,7 @@ class TransactionRunnableTest
     {
         new TransactionRunnable()
         {
+            @Override
             protected void onCommit()
             {
                 fail("Run in wrong order.");
@@ -196,6 +207,7 @@ class TransactionRunnableTest
 
         new TransactionRunnable()
         {
+            @Override
             protected void onCommit() throws Exception
             {
                 throw new CustomException();
@@ -214,6 +226,7 @@ class TransactionRunnableTest
     {
         new TransactionRunnable()
         {
+            @Override
             protected void onRollback() throws Exception
             {
                 assertFalse(hasRun(), "Child rolled back after parent.");
@@ -221,6 +234,7 @@ class TransactionRunnableTest
             }
         }.runIn(new TransactionRunnable()
         {
+            @Override
             protected void onRollback() throws Exception
             {
                 itRan();
@@ -243,6 +257,7 @@ class TransactionRunnableTest
     {
         new TransactionRunnable()
         {
+            @Override
             protected void onRollback()
             {
                 itRan();
@@ -251,6 +266,7 @@ class TransactionRunnableTest
 
         new TransactionRunnable()
         {
+            @Override
             protected void onRollback() throws Exception
             {
                 assertFalse(hasRun(), "Siblings rolled back in same order as they were registered.");
@@ -274,6 +290,7 @@ class TransactionRunnableTest
     {
         new TransactionRunnable()
         {
+            @Override
             protected void onComplete() throws Exception
             {
                 itRan();
@@ -281,6 +298,7 @@ class TransactionRunnableTest
             }
         }.runIn(new TransactionRunnable()
         {
+            @Override
             protected void onComplete()
             {
                 assertTrue(hasRun(), "Child run after parent.");
@@ -302,6 +320,7 @@ class TransactionRunnableTest
     {
         new TransactionRunnable()
         {
+            @Override
             protected void onComplete() throws Exception
             {
                 assertTrue(hasRun(), "onComplete for siblings run in same order as registered.");
@@ -311,6 +330,7 @@ class TransactionRunnableTest
 
         new TransactionRunnable()
         {
+            @Override
             protected void onComplete()
             {
                 itRan();
@@ -330,11 +350,13 @@ class TransactionRunnableTest
     {
         new TransactionRunnable()
         {
+            @Override
             protected void onPreRun() throws Exception
             {
                 throw new CustomException();
             }
 
+            @Override
             protected void onComplete()
             {
                 itRan();
@@ -343,6 +365,7 @@ class TransactionRunnableTest
 
         new TransactionRunnable()
         {
+            @Override
             protected void onComplete()
             {
                 fail("onComplete ran for a TransactionRunnable which did not have onPreRun called.");
@@ -361,11 +384,13 @@ class TransactionRunnableTest
     {
         new TransactionRunnable()
         {
+            @Override
             protected void onRun() throws Exception
             {
                 throw new CustomException();
             }
 
+            @Override
             protected void onRollback()
             {
                 itRan();
@@ -374,6 +399,7 @@ class TransactionRunnableTest
 
         new TransactionRunnable()
         {
+            @Override
             protected void onRollback()
             {
                 fail("onRollback ran for a TransactionRunnable which did not have onRun called.");


### PR DESCRIPTION
Adds the missing `@Override` annotations flagged by SonarCloud rule
[java:S1161](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS1161&rule_key=java%3AS1161)
("Add the `@Override` annotation above this method signature").

These are anonymous-class methods (in test code) that override interface / abstract methods but were
missing the annotation. The change is purely mechanical and behaviour-preserving.

59 issues fixed across 3 modules / 6 files:

* `xwiki-platform-store-transaction` — `TransactionRunnableTest` (26), `StartableTransactionRunnableTest` (6), `ProvidingTransactionRunnableTest` (2)
* `xwiki-platform-store-filesystem` — `FileDeleteTransactionRunnableTest` (3), `BlobDeleteTransactionRunnableTest` (2)
* `xwiki-platform-security-authorization-api` — `DefaultSecurityCacheTest` (20)

SonarCloud issues:
https://sonarcloud.io/project/issues?resolved=false&rules=java%3AS1161&id=org.xwiki.platform%3Axwiki-platform

Verified with `mvn clean install` (Checkstyle passes) on the three affected modules.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXwXXLJjqZ2su3yVc4EfmK)_