### PR TITLE
[Misc] Remove unused code and simplify lambdas reported by SonarCloud

### DIFF
--- a/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/main/java/org/xwiki/rendering/internal/macro/chart/source/table/AbstractTableBlockDataSource.java
+++ b/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/main/java/org/xwiki/rendering/internal/macro/chart/source/table/AbstractTableBlockDataSource.java
@@ -97,21 +97,6 @@ public abstract class AbstractTableBlockDataSource extends AbstractDataSource
     private static final String CATEGORY_DATASET = "category";
 
     /**
-     * The name of the time series dataset.
-     */
-    private static final String TIME_SERIES_DATASET = "timeseries";
-
-    /**
-     * The name of the pie dataset.
-     */
-    private static final String PIE_DATASET = "pie";
-
-    /**
-     * The default dataset.
-     */
-    private static final String DEFAULT_DATASET = CATEGORY_DATASET;
-
-    /**
      * The range parameter.
      */
     private String range;

--- a/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-renderer/src/test/java/org/xwiki/chart/internal/DefaultChartGeneratorTest.java
+++ b/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-renderer/src/test/java/org/xwiki/chart/internal/DefaultChartGeneratorTest.java
@@ -71,7 +71,6 @@ class DefaultChartGeneratorTest
         ChartModel model = mock(ChartModel.class);
         String type = "fooType";
         String title = "some title";
-
         when(componentManager.getInstance(PlotGenerator.class, type)).thenReturn(this.plotGenerator);
         Plot plot = mock(Plot.class);
         when(plotGenerator.generate(eq(model), anyMap())).thenReturn(plot);

--- a/xwiki-platform-core/xwiki-platform-csrf/src/test/java/org/xwiki/csrf/DefaultCSRFTokenTest.java
+++ b/xwiki-platform-core/xwiki-platform-csrf/src/test/java/org/xwiki/csrf/DefaultCSRFTokenTest.java
@@ -272,9 +272,6 @@ class DefaultCSRFTokenTest
 
         when(this.httpRequest.getMethod()).thenReturn("GET");
         String url = this.csrf.getResubmissionURL();
-        // srid is random, extract it from the url
-        Matcher matcher = Pattern.compile(".*srid%3D([a-zA-Z0-9]+).*").matcher(url);
-        String srid = matcher.matches() ? matcher.group(1) : "asdf";
         String expected = resubmitUrl + "?xpage=resubmit";
         assertEquals(expected, url, "Invalid resubmission URL");
     }

--- a/xwiki-platform-core/xwiki-platform-dashboard/xwiki-platform-dashboard-macro/src/test/java/org/xwiki/rendering/macro/dashboard/IntegrationTest.java
+++ b/xwiki-platform-core/xwiki-platform-dashboard/xwiki-platform-dashboard-macro/src/test/java/org/xwiki/rendering/macro/dashboard/IntegrationTest.java
@@ -70,8 +70,8 @@ public class IntegrationTest extends RenderingTest
         componentManager.unregisterComponent(org.xwiki.observation.EventListener.class, "ExtensionJobHistoryRecorder");
         componentManager.unregisterComponent(org.xwiki.observation.EventListener.class, "refactoring.legacyParentFieldUpdater");
 
-        SkinExtension mockSsfx = componentManager.registerMockComponent(SkinExtension.class, "ssfx");
-        SkinExtension mockJsfx = componentManager.registerMockComponent(SkinExtension.class, "jsfx");
+        componentManager.registerMockComponent(SkinExtension.class, "ssfx");
+        componentManager.registerMockComponent(SkinExtension.class, "jsfx");
 
         GadgetSource mockGadgetSource = componentManager.registerMockComponent(GadgetSource.class);
         // Mock gadget for macrodashboard_nested_velocity.test

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/test/java/org/xwiki/eventstream/store/solr/internal/EventStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/test/java/org/xwiki/eventstream/store/solr/internal/EventStoreTest.java
@@ -130,8 +130,6 @@ public class EventStoreTest
 
     private static final WikiReference WIKI_REFERENCE = new WikiReference("wiki");
 
-    private static final WikiReference WIKI1_REFERENCE = new WikiReference("wiki1");
-
     private static final WikiReference WIKI2_REFERENCE = new WikiReference("wiki2");
 
     private static final SpaceReference SPACE_REFERENCE = new SpaceReference("space", WIKI_REFERENCE);
@@ -147,16 +145,6 @@ public class EventStoreTest
     private static final DocumentReference RELATED_REFERENCE = new DocumentReference("related", SPACE_REFERENCE);
 
     private static final String SPACE_STRING = "wiki:space";
-
-    private static final String SPACE1_STRING = "wiki1:space1";
-
-    private static final String SPACE2_STRING = "wiki2:space2";
-
-    private static final String DOCUMENT_STRING = "wiki:space.document";
-
-    private static final String USER_STRING = "wiki:space.user";
-
-    private static final String RELATED_STRING = "wiki:space.related";
 
     @XWikiTempDir
     private File permanentDirectory;

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableRequestHandler.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableRequestHandler.java
@@ -39,6 +39,7 @@ import org.xwiki.component.annotation.Component;
 import org.xwiki.livedata.LiveDataQuery;
 import org.xwiki.livedata.LiveDataQuery.Constraint;
 import org.xwiki.livedata.LiveDataQuery.Filter;
+import org.xwiki.livedata.LiveDataQuery.SortEntry;
 import org.xwiki.livedata.LiveDataQuery.Source;
 import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.DocumentReferenceResolver;
@@ -218,7 +219,7 @@ public class LiveTableRequestHandler
     {
         if (query.getSort() != null && !query.getSort().isEmpty()) {
             List<String> sortList =
-                query.getSort().stream().map(sortEntry -> sortEntry.getProperty()).collect(Collectors.toList());
+                query.getSort().stream().map(SortEntry::getProperty).collect(Collectors.toList());
             requestParams.put("sort", sortList.toArray(new String[sortList.size()]));
             List<String> dirList = query.getSort().stream().map(sortEntry -> sortEntry.isDescending() ? "desc" : "asc")
                 .collect(Collectors.toList());

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataEntryStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataEntryStoreTest.java
@@ -287,7 +287,7 @@ class LiveTableLiveDataEntryStoreTest
         when(this.currentDocumentReferenceResolver.resolve("MyTest.MyClass")).thenReturn(classDocumentReference);
 
         this.entryStore.getParameters().put("className", "MyTest.MyClass");
-        Optional<Object> save = this.entryStore.save(entry);
+        this.entryStore.save(entry);
 
         verify(this.modelBridge).updateAll(entry, objectDocumentReference, classDocumentReference, Map.of());
     }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/livedata/system/NotificationSystemFiltersLiveDataEntryStore.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/livedata/system/NotificationSystemFiltersLiveDataEntryStore.java
@@ -139,8 +139,8 @@ public class NotificationSystemFiltersLiveDataEntryStore extends AbstractNotific
         }
 
         List<ToggleableNotificationFilter> allFilters = notificationFilters.stream()
-            .filter(filter -> filter instanceof ToggleableNotificationFilter)
-            .map(item -> (ToggleableNotificationFilter) item)
+            .filter(ToggleableNotificationFilter.class::isInstance)
+            .map(ToggleableNotificationFilter.class::cast)
             .toList();
 
         int totalFilters = allFilters.size();

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/migrators/NotificationFilterPreferencesMigrator.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/migrators/NotificationFilterPreferencesMigrator.java
@@ -84,8 +84,6 @@ public class NotificationFilterPreferencesMigrator extends AbstractEventListener
 
     private static final String FIELD_IS_ENABLED = "isEnabled";
 
-    private static final String FIELD_IS_ACTIVE = "isActive";
-
     private static final String FIELD_APPLICATIONS = "applications";
 
     private static final String FIELD_EVENT_TYPES = "eventTypes";

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersLiveDataEntryStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/livedata/custom/NotificationCustomFiltersLiveDataEntryStoreTest.java
@@ -334,7 +334,6 @@ class NotificationCustomFiltersLiveDataEntryStoreTest
         when(filterPref3.getNotificationFormats()).thenReturn(Set.of(NotificationFormat.EMAIL,
             NotificationFormat.ALERT));
         String pageOnly = "xwiki:XWiki.User1";
-        DocumentReference pageOnlyRef = new DocumentReference("xwiki", "XWiki", "User1");
         when(filterPref3.getPageOnly()).thenReturn(pageOnly);
         when(filterPref3.getFilterType()).thenReturn(NotificationFilterType.EXCLUSIVE);
         when(filterPref3.isEnabled()).thenReturn(true);

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/migration/R160100000XWIKI21738DataMigrationTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/migration/R160100000XWIKI21738DataMigrationTest.java
@@ -90,8 +90,6 @@ class R160100000XWIKI21738DataMigrationTest
     @MockComponent
     private Execution execution;
 
-    private HibernateStore hibernateStore;
-
     @RegisterExtension
     private LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.INFO);
 
@@ -100,7 +98,7 @@ class R160100000XWIKI21738DataMigrationTest
     @BeforeComponent
     void beforeComponent(MockitoComponentManager componentManager) throws Exception
     {
-        this.hibernateStore = componentManager.registerMockComponent(HibernateStore.class);
+        componentManager.registerMockComponent(HibernateStore.class);
         this.hibernateBaseStore = componentManager.registerMockComponent(XWikiStoreInterface.class,
             XWikiHibernateBaseStore.HINT, XWikiHibernateStore.class, false);
     }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/migration/R160500000XWIKI22271DataMigrationTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/migration/R160500000XWIKI22271DataMigrationTest.java
@@ -90,13 +90,12 @@ class R160500000XWIKI22271DataMigrationTest
     @RegisterExtension
     private LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.INFO);
 
-    private HibernateStore hibernateStore;
     private XWikiHibernateStore hibernateBaseStore;
 
     @BeforeComponent
     void beforeComponent(MockitoComponentManager componentManager) throws Exception
     {
-        this.hibernateStore = componentManager.registerMockComponent(HibernateStore.class);
+        componentManager.registerMockComponent(HibernateStore.class);
         this.hibernateBaseStore = componentManager.registerMockComponent(XWikiStoreInterface.class,
             XWikiHibernateBaseStore.HINT, XWikiHibernateStore.class, false);
     }

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/SolrRatingsManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/SolrRatingsManagerTest.java
@@ -154,7 +154,6 @@ public class SolrRatingsManagerTest
         doAnswer(invocationOnMock -> {
             String fieldName = invocationOnMock.getArgument(0);
             Object fieldValue = invocationOnMock.getArgument(1);
-            Type type = invocationOnMock.getArgument(2);
             SolrInputDocument inputDocument = invocationOnMock.getArgument(3);
             inputDocument.setField(fieldName, fieldValue);
             return null;

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/averagerating/AverageRatingProtectionListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/averagerating/AverageRatingProtectionListenerTest.java
@@ -108,7 +108,6 @@ public class AverageRatingProtectionListenerTest
         BaseObject ratingObject3 = mock(BaseObject.class);
         when(ratingObject3.getNumber()).thenReturn(3);
 
-        BaseObject previousObject1 = mock(BaseObject.class);
         BaseObject previousObject2 = mock(BaseObject.class);
 
         when(this.observationContext.isIn(new UpdatingAverageRatingEvent())).thenReturn(false);

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/averagerating/AverageRatingProtectionListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/averagerating/AverageRatingProtectionListenerTest.java
@@ -108,17 +108,17 @@ public class AverageRatingProtectionListenerTest
         BaseObject ratingObject3 = mock(BaseObject.class);
         when(ratingObject3.getNumber()).thenReturn(3);
 
-        BaseObject previousObject2 = mock(BaseObject.class);
+        BaseObject previousObject = mock(BaseObject.class);
 
         when(this.observationContext.isIn(new UpdatingAverageRatingEvent())).thenReturn(false);
         when(sourceDoc.getXObjects(AverageRatingClassDocumentInitializer.AVERAGE_RATINGS_CLASSREFERENCE))
             .thenReturn(Arrays.asList(null, ratingObject2, ratingObject3));
 
         when(previousDoc.getXObject(AverageRatingClassDocumentInitializer.AVERAGE_RATINGS_CLASSREFERENCE, 2))
-            .thenReturn(previousObject2);
+            .thenReturn(previousObject);
 
         this.listener.onEvent(new DocumentUpdatingEvent(), sourceDoc, null);
-        verify(ratingObject2).apply(previousObject2, true);
+        verify(ratingObject2).apply(previousObject, true);
         verify(ratingObject3, never()).apply(any(ElementInterface.class), anyBoolean());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/averagerating/SolrAverageRatingManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/averagerating/SolrAverageRatingManagerTest.java
@@ -117,7 +117,6 @@ class SolrAverageRatingManagerTest
         doAnswer(invocationOnMock -> {
             String fieldName = invocationOnMock.getArgument(0);
             Object fieldValue = invocationOnMock.getArgument(1);
-            Type type = invocationOnMock.getArgument(2);
             SolrInputDocument inputDocument = invocationOnMock.getArgument(3);
             inputDocument.setField(fieldName, fieldValue);
             return null;

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/ModelFactory.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/ModelFactory.java
@@ -285,9 +285,6 @@ public class ModelFactory
         if (propertyNames.length > 0) {
             try {
                 String firstPropertyName = propertyNames[0];
-                BaseClass baseClass = xwikiObject.getXClass(this.xcontextProvider.get());
-                PropertyInterface field = baseClass.getField(firstPropertyName);
-                // The property might not exist in the class. But if it does, it will be a PropertyClass.
                 objectSummary.setHeadline(serializePropertyValue(xwikiObject.get(firstPropertyName)));
             } catch (XWikiException e) {
                 // Should never happen

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/NormalUserConfigurationSourceAuthorizationTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/NormalUserConfigurationSourceAuthorizationTest.java
@@ -57,8 +57,6 @@ import static org.mockito.Mockito.when;
 @ComponentTest
 class NormalUserConfigurationSourceAuthorizationTest
 {
-    private static final String IS_IN_RENDERING_ENGINE = "isInRenderingEngine";
-
     @InjectMockComponents
     private NormalUserConfigurationSourceAuthorization authorization;
 

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/XWikiUserUserReferenceResolverTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/XWikiUserUserReferenceResolverTest.java
@@ -52,7 +52,7 @@ public class XWikiUserUserReferenceResolverTest
     void resolve()
     {
         DocumentReference documentReference = new DocumentReference("wiki", "space", "page");
-        UserReference userReference = this.resolver.resolve(new XWikiUser(documentReference));
+        this.resolver.resolve(new XWikiUser(documentReference));
 
         verify(this.documentReferenceUserReferenceResolver).resolve(documentReference);
     }

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/group/DefaultGroupManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/group/DefaultGroupManagerTest.java
@@ -191,7 +191,7 @@ class DefaultGroupManagerTest
     {
         try {
             when(this.groupService.getAllMembersNamesForGroup(eq(group.toString()), anyInt(), anyInt(), any()))
-                .thenReturn(groups.stream().map(element -> element.toString()).collect(Collectors.toList()));
+                .thenReturn(groups.stream().map(DocumentReference::toString).collect(Collectors.toList()));
         } catch (XWikiException e) {
             // Cannot happen
         }

--- a/xwiki-platform-core/xwiki-platform-whatsnew/xwiki-platform-whatsnew-api/src/main/java/org/xwiki/whatsnew/internal/xwikiblog/XWikiBlogNewsSource.java
+++ b/xwiki-platform-core/xwiki-platform-whatsnew/xwiki-platform-whatsnew-api/src/main/java/org/xwiki/whatsnew/internal/xwikiblog/XWikiBlogNewsSource.java
@@ -103,6 +103,7 @@ public class XWikiBlogNewsSource implements NewsSource
     @Override
     public NewsSource forUser(UserReference userReference)
     {
+        // Not implemented yet.
         return this;
     }
 
@@ -116,18 +117,21 @@ public class XWikiBlogNewsSource implements NewsSource
     @Override
     public NewsSource forXWikiVersion(Version targetXWikiVersion)
     {
+        // Not implemented yet.
         return this;
     }
 
     @Override
     public NewsSource forExtraParameters(Map<String, Object> extraParameters)
     {
+        // Not implemented yet.
         return this;
     }
 
     @Override
     public NewsSource withCount(int count)
     {
+        // Not implemented yet.
         return this;
     }
 

--- a/xwiki-platform-core/xwiki-platform-whatsnew/xwiki-platform-whatsnew-api/src/main/java/org/xwiki/whatsnew/internal/xwikiblog/XWikiBlogNewsSource.java
+++ b/xwiki-platform-core/xwiki-platform-whatsnew/xwiki-platform-whatsnew-api/src/main/java/org/xwiki/whatsnew/internal/xwikiblog/XWikiBlogNewsSource.java
@@ -69,15 +69,7 @@ public class XWikiBlogNewsSource implements NewsSource
 
     private static final String QUESTION_MARK = "?";
 
-    private UserReference userReference;
-
     private Set<NewsCategory> wantedCategories;
-
-    private Version targetXWikiVersion;
-
-    private Map<String, Object> extraParameters;
-
-    private int count;
 
     private String rssURL;
 
@@ -111,7 +103,6 @@ public class XWikiBlogNewsSource implements NewsSource
     @Override
     public NewsSource forUser(UserReference userReference)
     {
-        this.userReference = userReference;
         return this;
     }
 
@@ -125,21 +116,18 @@ public class XWikiBlogNewsSource implements NewsSource
     @Override
     public NewsSource forXWikiVersion(Version targetXWikiVersion)
     {
-        this.targetXWikiVersion = targetXWikiVersion;
         return this;
     }
 
     @Override
     public NewsSource forExtraParameters(Map<String, Object> extraParameters)
     {
-        this.extraParameters = Collections.unmodifiableMap(extraParameters);
         return this;
     }
 
     @Override
     public NewsSource withCount(int count)
     {
-        this.count = count;
         return this;
     }
 


### PR DESCRIPTION
This PR clears a batch of 41 open SonarCloud issues across 20 files in 11 modules. All fixes are mechanical and behaviour-preserving:

* **java:S1068** — remove unused private fields (chart-macro, eventstream-store-solr, notifications-filters, user-default, whatsnew-api). For write-only fields the corresponding setter assignment is also removed.
* **java:S1481 / java:S1854** — remove unused local variables and dead stores (test code across chart-renderer, csrf, dashboard-macro, livedata-livetable, notifications-filters, ratings-api, user-default, and `ModelFactory`). Side-effecting right-hand sides are kept as bare statements; pure ones are deleted. Orphaned comments and now-dead lookups (e.g. an unused `baseClass`/`Matcher` block) are cleaned up too.
* **java:S1612** — replace lambdas with method references (livedata-livetable, notifications-filters, user-default).

The 11 affected modules were built with `mvn clean install` (Checkstyle + Spoon) — BUILD SUCCESS.

SonarCloud issues:
* [java:S1068 (unused private field)](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&issueStatuses=OPEN&rules=java%3AS1068)
* [java:S1481 (unused local variable)](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&issueStatuses=OPEN&rules=java%3AS1481)
* [java:S1854 (dead store)](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&issueStatuses=OPEN&rules=java%3AS1854)
* [java:S1612 (lambda → method reference)](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&issueStatuses=OPEN&rules=java%3AS1612)

---
_Generated by [Claude Code](https://claude.ai/code/session_012a89EnB4M6zYTL9eEnJf3L)_