### PR TITLE
[Misc] Make JUnit5 test classes and methods package-private (SonarCloud java:S5786)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/DefaultModelConfigurationTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/DefaultModelConfigurationTest.java
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
     RelativeStringEntityReferenceResolver.class,
     DefaultStringEntityReferenceSerializer.class
 })
-public class DefaultModelConfigurationTest
+class DefaultModelConfigurationTest
 {
     @InjectMockComponents
     private DefaultModelConfiguration configuration;
@@ -52,13 +52,13 @@ public class DefaultModelConfigurationTest
     private MemoryConfigurationSource configurationSource;
     
     @BeforeEach
-    public void before(MockitoComponentManager componentManager) throws Exception
+    void before(MockitoComponentManager componentManager) throws Exception
     {
         this.configurationSource = componentManager.registerMemoryConfigurationSource();
     }
 
     @Test
-    public void getDefaultReferenceNameWhenDefinedInConfiguration()
+    void getDefaultReferenceNameWhenDefinedInConfiguration()
     {
         this.configurationSource.setProperty("model.reference.default.wiki", "defaultWiki");
         this.configurationSource.setProperty("model.reference.default.document", "defaultDocument");
@@ -76,7 +76,7 @@ public class DefaultModelConfigurationTest
     }
 
     @Test
-    public void testGetDefaultReferenceNameWhenNotDefinedInConfiguration() throws ComponentLookupException
+    void testGetDefaultReferenceNameWhenNotDefinedInConfiguration() throws ComponentLookupException
     {
         assertEquals("xwiki", this.configuration.getDefaultReferenceValue(EntityType.WIKI));
         assertEquals("WebHome", this.configuration.getDefaultReferenceValue(EntityType.DOCUMENT));

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/DefaultDocumentReferenceProviderTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/DefaultDocumentReferenceProviderTest.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class DefaultDocumentReferenceProviderTest implements TestConstants
+class DefaultDocumentReferenceProviderTest implements TestConstants
 {
     @MockComponent
     private EntityReferenceFactory entityReferenceFactory;
@@ -56,7 +56,7 @@ public class DefaultDocumentReferenceProviderTest implements TestConstants
     private DefaultDocumentReferenceProvider provider;
 
     @BeforeEach
-    public void beforeEach()
+    void beforeEach()
     {
         when(this.entityProvider.getDefaultReference(EntityType.DOCUMENT)).thenReturn(DEFAULT_DOCUMENT_REFERENCE);
         when(this.spaceProvider.get())
@@ -65,7 +65,7 @@ public class DefaultDocumentReferenceProviderTest implements TestConstants
     }
 
     @Test
-    public void testGetDefaultValue()
+    void testGetDefaultValue()
     {
         assertEquals(
             DEFAULT_DOCUMENT_REFERENCE.appendParent(DEFAULT_SPACE_REFERENCE.appendParent(DEFAULT_WIKI_REFERENCE)),

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/DefaultEntityReferenceProviderTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/DefaultEntityReferenceProviderTest.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class DefaultEntityReferenceProviderTest implements TestConstants
+class DefaultEntityReferenceProviderTest implements TestConstants
 {
     @MockComponent
     private ModelConfiguration configuration;
@@ -46,7 +46,7 @@ public class DefaultEntityReferenceProviderTest implements TestConstants
     private DefaultEntityReferenceProvider provider;
 
     @BeforeEach
-    public void beforeEach()
+    void beforeEach()
     {
         when(this.configuration.getDefaultReferenceValue(EntityType.SPACE)).thenReturn(DEFAULT_SPACE);
         when(this.configuration.getDefaultReferenceValue(EntityType.WIKI)).thenReturn(DEFAULT_WIKI);
@@ -57,7 +57,7 @@ public class DefaultEntityReferenceProviderTest implements TestConstants
     }
 
     @Test
-    public void testGetDefaultValue()
+    void testGetDefaultValue()
     {
         assertEquals(DEFAULT_DOCUMENT_REFERENCE, this.provider.getDefaultReference(EntityType.DOCUMENT));
         assertEquals(DEFAULT_SPACE_REFERENCE, this.provider.getDefaultReference(EntityType.SPACE));

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/DefaultPageReferenceProviderTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/DefaultPageReferenceProviderTest.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class DefaultPageReferenceProviderTest implements TestConstants
+class DefaultPageReferenceProviderTest implements TestConstants
 {
     @MockComponent
     private EntityReferenceFactory entityReferenceFactory;
@@ -56,7 +56,7 @@ public class DefaultPageReferenceProviderTest implements TestConstants
     private DefaultPageReferenceProvider provider;
 
     @BeforeEach
-    public void beforeEach()
+    void beforeEach()
     {
         when(this.entityProvider.getDefaultReference(EntityType.PAGE)).thenReturn(DEFAULT_PAGE_REFERENCE);
         when(this.wikiReferenceProvider.get()).thenReturn(new WikiReference(DEFAULT_WIKI_REFERENCE));
@@ -64,7 +64,7 @@ public class DefaultPageReferenceProviderTest implements TestConstants
     }
 
     @Test
-    public void testGetDefaultValue()
+    void testGetDefaultValue()
     {
         assertEquals(DEFAULT_PAGE_REFERENCE.appendParent(DEFAULT_WIKI_REFERENCE), this.provider.get());
     }

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/DefaultSpaceReferenceProviderTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/DefaultSpaceReferenceProviderTest.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class DefaultSpaceReferenceProviderTest implements TestConstants
+class DefaultSpaceReferenceProviderTest implements TestConstants
 {
     @MockComponent
     private EntityReferenceFactory entityReferenceFactory;
@@ -56,7 +56,7 @@ public class DefaultSpaceReferenceProviderTest implements TestConstants
     private DefaultSpaceReferenceProvider provider;
 
     @BeforeEach
-    public void beforeEach()
+    void beforeEach()
     {
         when(this.entityProvider.getDefaultReference(EntityType.SPACE)).thenReturn(DEFAULT_SPACE_REFERENCE);
         when(this.wikiReferenceProvider.get()).thenReturn(new WikiReference(DEFAULT_WIKI_REFERENCE));
@@ -64,7 +64,7 @@ public class DefaultSpaceReferenceProviderTest implements TestConstants
     }
 
     @Test
-    public void testGetDefaultValue()
+    void testGetDefaultValue()
     {
         assertEquals(DEFAULT_SPACE_REFERENCE.appendParent(DEFAULT_WIKI_REFERENCE), this.provider.get());
     }

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/DefaultStringEntityReferenceResolverTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/DefaultStringEntityReferenceResolverTest.java
@@ -62,7 +62,7 @@ class DefaultStringEntityReferenceResolverTest implements TestConstants
     private DefaultStringEntityReferenceResolver resolver;
 
     @BeforeEach
-    public void setUp() throws Exception
+    void setUp() throws Exception
     {
         when(this.referenceProvider.getDefaultReference(EntityType.WIKI)).thenReturn(DEFAULT_WIKI_REFERENCE);
         when(this.referenceProvider.getDefaultReference(EntityType.SPACE)).thenReturn(DEFAULT_SPACE_REFERENCE);

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/ExplicitReferenceEntityReferenceResolverTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/ExplicitReferenceEntityReferenceResolverTest.java
@@ -35,18 +35,18 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * @version $Id$
  * @since 2.2.3
  */
-public class ExplicitReferenceEntityReferenceResolverTest
+class ExplicitReferenceEntityReferenceResolverTest
 {
     private EntityReferenceResolver<EntityReference> resolver;
 
     @BeforeEach
-    public void setUp() throws Exception
+    void setUp() throws Exception
     {
         this.resolver = new ExplicitReferenceEntityReferenceResolver();
     }
 
     @Test
-    public void resolveWithExplicitDocumentReference()
+    void resolveWithExplicitDocumentReference()
     {
         EntityReference reference =
             this.resolver.resolve(null, EntityType.DOCUMENT, new DocumentReference("wiki", "space", "page"));
@@ -60,7 +60,7 @@ public class ExplicitReferenceEntityReferenceResolverTest
     }
 
     @Test
-    public void resolveWithExplicitEntityReference()
+    void resolveWithExplicitEntityReference()
     {
         EntityReference reference = this.resolver.resolve(new EntityReference("page", EntityType.DOCUMENT,
             new EntityReference("space", EntityType.SPACE)), EntityType.DOCUMENT,
@@ -75,7 +75,7 @@ public class ExplicitReferenceEntityReferenceResolverTest
     }
 
     @Test
-    public void resolveWithAbsoluteReferenceAndNoExplicitReference()
+    void resolveWithAbsoluteReferenceAndNoExplicitReference()
     {
         EntityReference reference = this.resolver.resolve(new EntityReference("page", EntityType.DOCUMENT,
             new EntityReference("space", EntityType.SPACE, new EntityReference("wiki", EntityType.WIKI))),
@@ -90,7 +90,7 @@ public class ExplicitReferenceEntityReferenceResolverTest
     }
 
     @Test
-    public void resolveWithExplicitReferenceWithHoles()
+    void resolveWithExplicitReferenceWithHoles()
     {
         EntityReference reference = this.resolver.resolve(new EntityReference("page", EntityType.DOCUMENT,
             new EntityReference("space", EntityType.SPACE)), EntityType.DOCUMENT,
@@ -105,7 +105,7 @@ public class ExplicitReferenceEntityReferenceResolverTest
     }
 
     @Test
-    public void resolveWithExplicitReferenceWithHolesAndIncompatibleParameter()
+    void resolveWithExplicitReferenceWithHolesAndIncompatibleParameter()
     {
         EntityReference reference = this.resolver.resolve(
             new EntityReference("page", EntityType.DOCUMENT, new EntityReference("wiki", EntityType.WIKI)),
@@ -120,7 +120,7 @@ public class ExplicitReferenceEntityReferenceResolverTest
     }
 
     @Test
-    public void resolveWithNoExplicitAndPartialReference()
+    void resolveWithNoExplicitAndPartialReference()
     {
         IllegalArgumentException expected = assertThrows(IllegalArgumentException.class,
             () -> this.resolver.resolve(null, EntityType.DOCUMENT));
@@ -129,7 +129,7 @@ public class ExplicitReferenceEntityReferenceResolverTest
     }
 
     @Test
-    public void testResolveWithInvalidParameterType()
+    void testResolveWithInvalidParameterType()
     {
         IllegalArgumentException expected = assertThrows(IllegalArgumentException.class,
             () -> this.resolver.resolve(null, EntityType.DOCUMENT, "wrong type"));
@@ -138,7 +138,7 @@ public class ExplicitReferenceEntityReferenceResolverTest
     }
 
     @Test
-    public void resolveWithIncompleteExplicitReference()
+    void resolveWithIncompleteExplicitReference()
     {
         IllegalArgumentException expected = assertThrows(IllegalArgumentException.class,
             () -> this.resolver.resolve(null, EntityType.DOCUMENT, new EntityReference("wiki", EntityType.WIKI)));

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/ExplicitStringAttachmentReferenceResolverTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/ExplicitStringAttachmentReferenceResolverTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @ComponentList({
     DefaultSymbolScheme.class
 })
-public class ExplicitStringAttachmentReferenceResolverTest
+class ExplicitStringAttachmentReferenceResolverTest
 {
     @InjectMockComponents
     private ExplicitStringEntityReferenceResolver entityReferenceResolver;
@@ -49,14 +49,14 @@ public class ExplicitStringAttachmentReferenceResolverTest
     private AttachmentReferenceResolver<String> resolver;
 
     @BeforeEach
-    public void setUp() throws Exception
+    void setUp() throws Exception
     {
         this.resolver = new ExplicitStringAttachmentReferenceResolver();
         ReflectionUtils.setFieldValue(this.resolver, "entityReferenceResolver", this.entityReferenceResolver);
     }
 
     @Test
-    public void resolveWithExplicitAttachmentReference()
+    void resolveWithExplicitAttachmentReference()
     {
         DocumentReference documentReference = new DocumentReference("wiki", "space", "page");
         AttachmentReference reference = this.resolver.resolve("", new AttachmentReference("file", documentReference));

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/ExplicitStringDocumentReferenceResolverTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/ExplicitStringDocumentReferenceResolverTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @ComponentList({
     DefaultSymbolScheme.class
 })
-public class ExplicitStringDocumentReferenceResolverTest
+class ExplicitStringDocumentReferenceResolverTest
 {
     @InjectMockComponents
     private ExplicitStringEntityReferenceResolver entityReferenceResolver;
@@ -48,7 +48,7 @@ public class ExplicitStringDocumentReferenceResolverTest
     private DocumentReferenceResolver<String> documentReferenceResolver;
 
     @BeforeEach
-    public void setUp() throws Exception
+    void setUp() throws Exception
     {
         this.documentReferenceResolver = new ExplicitStringDocumentReferenceResolver();
         ReflectionUtils.setFieldValue(this.documentReferenceResolver, "entityReferenceResolver", 
@@ -56,7 +56,7 @@ public class ExplicitStringDocumentReferenceResolverTest
     }
 
     @Test
-    public void resolveWithExplicitDocumentReference()
+    void resolveWithExplicitDocumentReference()
     {
         DocumentReference reference = 
             this.documentReferenceResolver.resolve("", new DocumentReference("wiki", "space", "page"));

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/ExplicitStringEntityReferenceResolverTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/ExplicitStringEntityReferenceResolverTest.java
@@ -40,13 +40,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @ComponentList({
     DefaultSymbolScheme.class
 })
-public class ExplicitStringEntityReferenceResolverTest
+class ExplicitStringEntityReferenceResolverTest
 {
     @InjectMockComponents
     private ExplicitStringEntityReferenceResolver resolver;
 
     @Test
-    public void resolveWithExplicitDocumentReference()
+    void resolveWithExplicitDocumentReference()
     {
         EntityReference reference =
             this.resolver.resolve("", EntityType.DOCUMENT, new DocumentReference("wiki", "space", "page"));
@@ -60,7 +60,7 @@ public class ExplicitStringEntityReferenceResolverTest
     }
 
     @Test
-    public void resolveWithExplicitEntityReference()
+    void resolveWithExplicitEntityReference()
     {
         EntityReference reference =
             this.resolver.resolve("space.page", EntityType.DOCUMENT, new EntityReference("wiki", EntityType.WIKI));
@@ -74,7 +74,7 @@ public class ExplicitStringEntityReferenceResolverTest
     }
 
     @Test
-    public void resolveWithAbsoluteReferenceAndNoExplicitReference()
+    void resolveWithAbsoluteReferenceAndNoExplicitReference()
     {
         EntityReference reference = this.resolver.resolve("wiki:space.page", EntityType.DOCUMENT);
 
@@ -87,7 +87,7 @@ public class ExplicitStringEntityReferenceResolverTest
     }
 
     @Test
-    public void resolveWithExplicitReferenceWithHoles()
+    void resolveWithExplicitReferenceWithHoles()
     {
         EntityReference reference = this.resolver.resolve("space.page", EntityType.DOCUMENT,
             new EntityReference("page", EntityType.DOCUMENT, new EntityReference("wiki", EntityType.WIKI)));
@@ -101,7 +101,7 @@ public class ExplicitStringEntityReferenceResolverTest
     }
     
     @Test
-    public void resolveWithNoExplicitAndPartialReference()
+    void resolveWithNoExplicitAndPartialReference()
     {
         IllegalArgumentException expected = assertThrows(IllegalArgumentException.class,
             () -> this.resolver.resolve("", EntityType.DOCUMENT));
@@ -110,7 +110,7 @@ public class ExplicitStringEntityReferenceResolverTest
     }
 
     @Test
-    public void resolveWithInvalidParameterType()
+    void resolveWithInvalidParameterType()
     {
         IllegalArgumentException expected = assertThrows(IllegalArgumentException.class,
             () -> this.resolver.resolve("", EntityType.DOCUMENT, "wrong type"));
@@ -119,7 +119,7 @@ public class ExplicitStringEntityReferenceResolverTest
     }
 
     @Test
-    public void resolveWithIncompleteExplicitReference()
+    void resolveWithIncompleteExplicitReference()
     {
         IllegalArgumentException expected = assertThrows(IllegalArgumentException.class,
             () -> this.resolver.resolve("", EntityType.DOCUMENT, new EntityReference("wiki", EntityType.WIKI)));

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/FSPathStringEntityReferenceSerializerTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/FSPathStringEntityReferenceSerializerTest.java
@@ -35,13 +35,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @sice 9.4RC1
  */
 @ComponentTest
-public class FSPathStringEntityReferenceSerializerTest
+class FSPathStringEntityReferenceSerializerTest
 {
     @InjectMockComponents
     private FSPathStringEntityReferenceSerializer serializer;
 
     @Test
-    public void serialize()
+    void serialize()
     {
         DocumentReference documentReference = new DocumentReference("wik.i", "spac.e", "pag.e");
         AttachmentReference attachmentReference = new AttachmentReference("image.png", documentReference);

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/LocalStringEntityReferenceSerializerTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/LocalStringEntityReferenceSerializerTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @ComponentList({
     DefaultSymbolScheme.class
 })
-public class LocalStringEntityReferenceSerializerTest
+class LocalStringEntityReferenceSerializerTest
 {
     @InjectMockComponents
     private LocalStringEntityReferenceSerializer serializer;
@@ -47,14 +47,14 @@ public class LocalStringEntityReferenceSerializerTest
     private DefaultStringEntityReferenceResolver resolver;
 
     @Test
-    public void serializeDocumentReference()
+    void serializeDocumentReference()
     {
         EntityReference reference = this.resolver.resolve("wiki:space.page", EntityType.DOCUMENT);
         assertEquals("space.page", this.serializer.serialize(reference));
     }
     
     @Test
-    public void serializeSpaceReferenceWithChild()
+    void serializeSpaceReferenceWithChild()
     {
         EntityReference reference = this.resolver.resolve("wiki:space.page", EntityType.DOCUMENT);
         assertEquals("space", this.serializer.serialize(reference.getParent()));

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/LocalUidStringEntityReferenceSerializerTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/LocalUidStringEntityReferenceSerializerTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 @ComponentList({
     DefaultSymbolScheme.class
 })
-public class LocalUidStringEntityReferenceSerializerTest
+class LocalUidStringEntityReferenceSerializerTest
 {
     @InjectMockComponents
     private LocalUidStringEntityReferenceSerializer serializer;
@@ -52,7 +52,7 @@ public class LocalUidStringEntityReferenceSerializerTest
     private DefaultStringEntityReferenceResolver resolver;
 
     @Test
-    public void serializeDocumentReference()
+    void serializeDocumentReference()
     {
         EntityReference reference = resolver.resolve("wiki:space.page", EntityType.DOCUMENT);
         assertEquals("5:space4:page", serializer.serialize(reference));
@@ -65,7 +65,7 @@ public class LocalUidStringEntityReferenceSerializerTest
     }
 
     @Test
-    public void serializeDocumentReferenceWithLocale()
+    void serializeDocumentReferenceWithLocale()
     {
         EntityReference reference = new DocumentReference("wiki", "space", "page", Locale.US);
         assertEquals("5:space4:page5:en_US", serializer.serialize(reference));
@@ -75,21 +75,21 @@ public class LocalUidStringEntityReferenceSerializerTest
     }
 
     @Test
-    public void serializeSpaceReference()
+    void serializeSpaceReference()
     {
         EntityReference reference = resolver.resolve("wiki:space1.space2", EntityType.SPACE);
         assertEquals("6:space16:space2", serializer.serialize(reference));
     }
 
     @Test
-    public void serializeAttachmentReference() throws Exception
+    void serializeAttachmentReference() throws Exception
     {
         EntityReference reference = resolver.resolve("wiki:space.page@filename", EntityType.ATTACHMENT);
         assertEquals("5:space4:page8:filename", serializer.serialize(reference));
     }
 
     @Test
-    public void serializeReferenceWithChild()
+    void serializeReferenceWithChild()
     {
         EntityReference reference = resolver.resolve("wiki:Space.Page", EntityType.DOCUMENT);
         assertEquals("5:Space", serializer.serialize(reference.getParent()));
@@ -101,7 +101,7 @@ public class LocalUidStringEntityReferenceSerializerTest
      * Tests resolving and re-serializing an object reference.
      */
     @Test
-    public void serializeObjectReference()
+    void serializeObjectReference()
     {
         EntityReference reference = resolver.resolve("wiki:space.page^wiki:space.class[0]", EntityType.OBJECT);
         assertEquals("5:space4:page14:space.class[0]", serializer.serialize(reference));
@@ -121,7 +121,7 @@ public class LocalUidStringEntityReferenceSerializerTest
      * Tests resolving and re-serializing an property reference.
      */
     @Test
-    public void serializeObjectPropertyReference()
+    void serializeObjectPropertyReference()
     {
         EntityReference reference =
             resolver.resolve("wiki:space.page^wiki:space.class[0].prop", EntityType.OBJECT_PROPERTY);
@@ -139,7 +139,7 @@ public class LocalUidStringEntityReferenceSerializerTest
      * Tests resolving and re-serializing a class property reference.
      */
     @Test
-    public void serializeClassPropertyReference()
+    void serializeClassPropertyReference()
     {
         EntityReference reference = resolver.resolve("wiki:space.page^ClassProperty", EntityType.CLASS_PROPERTY);
         assertEquals("5:space4:page13:ClassProperty", serializer.serialize(reference));
@@ -150,7 +150,7 @@ public class LocalUidStringEntityReferenceSerializerTest
     }
 
     @Test
-    public void serializeRelativeReference()
+    void serializeRelativeReference()
     {
         EntityReference reference = new EntityReference("page", EntityType.DOCUMENT);
         assertEquals("4:page", serializer.serialize(reference));

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/PathStringDocumentReferenceResolverTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/PathStringDocumentReferenceResolverTest.java
@@ -33,14 +33,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @version $Id$
  * @since 5.3M1
  */
-public class PathStringDocumentReferenceResolverTest
+class PathStringDocumentReferenceResolverTest
 {
     private PathStringEntityReferenceSerializer serializer = new PathStringEntityReferenceSerializer();
 
     private PathStringDocumentReferenceResolver resolver = new PathStringDocumentReferenceResolver();
 
     @Test
-    public void serializeAndResolve()
+    void serializeAndResolve()
     {
         test("wiki", Arrays.asList("space1", "space2"), "page", "wiki/space1/space2/page");
         test("w/i?ki", Arrays.asList("Sp.a#ce"), "P a@g&e", "w%2Fi%3Fki/Sp%2Ea%23ce/P+a%40g%26e");

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/UidStringEntityReferenceSerializerTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/UidStringEntityReferenceSerializerTest.java
@@ -46,7 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 @ComponentList({
     DefaultSymbolScheme.class
 })
-public class UidStringEntityReferenceSerializerTest
+class UidStringEntityReferenceSerializerTest
 {
     @InjectMockComponents
     private DefaultStringEntityReferenceResolver resolver;
@@ -54,13 +54,13 @@ public class UidStringEntityReferenceSerializerTest
     private EntityReferenceSerializer<String> serializer;
 
     @BeforeEach
-    public void setUp() throws Exception
+    void setUp() throws Exception
     {
         this.serializer = new UidStringEntityReferenceSerializer();
     }
 
     @Test
-    public void serializeDocumentReference()
+    void serializeDocumentReference()
     {
         EntityReference reference = resolver.resolve("wiki:space.page", EntityType.DOCUMENT);
         assertEquals("4:wiki5:space4:page", serializer.serialize(reference));
@@ -73,7 +73,7 @@ public class UidStringEntityReferenceSerializerTest
     }
 
     @Test
-    public void serializeDocumentReferenceWithLocale()
+    void serializeDocumentReferenceWithLocale()
     {
         EntityReference reference = new DocumentReference("wiki", "space", "page", Locale.US);
         assertEquals("4:wiki5:space4:page5:en_US", serializer.serialize(reference));
@@ -86,21 +86,21 @@ public class UidStringEntityReferenceSerializerTest
     }
 
     @Test
-    public void serializeSpaceReference()
+    void serializeSpaceReference()
     {
         EntityReference reference = resolver.resolve("wiki:space1.space2", EntityType.SPACE);
         assertEquals("4:wiki6:space16:space2", serializer.serialize(reference));
     }
 
     @Test
-    public void serializeAttachmentReference()
+    void serializeAttachmentReference()
     {
         EntityReference reference = resolver.resolve("wiki:space.page@filename", EntityType.ATTACHMENT);
         assertEquals("4:wiki5:space4:page8:filename", serializer.serialize(reference));
     }
 
     @Test
-    public void serializeReferenceWithChild()
+    void serializeReferenceWithChild()
     {
         EntityReference reference = resolver.resolve("wiki:Space.Page", EntityType.DOCUMENT);
         assertEquals("4:wiki5:Space", serializer.serialize(reference.getParent()));
@@ -112,7 +112,7 @@ public class UidStringEntityReferenceSerializerTest
      * Tests resolving and re-serializing an object reference.
      */
     @Test
-    public void serializeObjectReference()
+    void serializeObjectReference()
     {
         EntityReference reference = resolver.resolve("wiki:space.page^wiki:space.class[0]", EntityType.OBJECT);
         assertEquals("4:wiki5:space4:page19:wiki:space.class[0]", serializer.serialize(reference));
@@ -132,7 +132,7 @@ public class UidStringEntityReferenceSerializerTest
      * Tests resolving and re-serializing an property reference.
      */
     @Test
-    public void serializeObjectPropertyReference()
+    void serializeObjectPropertyReference()
     {
         EntityReference reference =
             resolver.resolve("wiki:space.page^wiki:space.class[0].prop", EntityType.OBJECT_PROPERTY);
@@ -150,7 +150,7 @@ public class UidStringEntityReferenceSerializerTest
      * Tests resolving and re-serializing a class property reference.
      */
     @Test
-    public void serializeClassPropertyReference()
+    void serializeClassPropertyReference()
     {
         EntityReference reference = resolver.resolve("wiki:space.page^ClassProperty", EntityType.CLASS_PROPERTY);
         assertEquals("4:wiki5:space4:page13:ClassProperty", serializer.serialize(reference));
@@ -161,7 +161,7 @@ public class UidStringEntityReferenceSerializerTest
     }
 
     @Test
-    public void serializeRelativeReference()
+    void serializeRelativeReference()
     {
         EntityReference reference = new EntityReference("page", EntityType.DOCUMENT);
         assertEquals("4:page", serializer.serialize(reference));

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/comparator/DocumentReferenceComparatorTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/internal/reference/comparator/DocumentReferenceComparatorTest.java
@@ -36,12 +36,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @since 14.4.2
  * @since 14.5
  */
-public class DocumentReferenceComparatorTest
+class DocumentReferenceComparatorTest
 {
     private DocumentReferenceComparator comparator = new DocumentReferenceComparator();
 
     @Test
-    public void compare()
+    void compare()
     {
         DocumentReference reference = new DocumentReference("wiki", "Space", "Page");
         assertEquals(0, comparator.compare(reference, new DocumentReference(reference)));
@@ -62,7 +62,7 @@ public class DocumentReferenceComparatorTest
     }
 
     @Test
-    public void compareNestedSpaces()
+    void compareNestedSpaces()
     {
         assertTrue(compare(Arrays.asList("math", "Path", "To", "Page"), Arrays.asList("math", "Path", "Page")) > 0);
         assertTrue(compare(Arrays.asList("math", "Path", "Alice"), Arrays.asList("math", "Path", "To", "Bob")) < 0);
@@ -75,7 +75,7 @@ public class DocumentReferenceComparatorTest
     }
 
     @Test
-    public void compareNestedPages()
+    void compareNestedPages()
     {
         this.comparator = new DocumentReferenceComparator(true);
 

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/AttachmentReferenceConverterTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/AttachmentReferenceConverterTest.java
@@ -74,7 +74,7 @@ class AttachmentReferenceConverterTest
     private EntityReferenceSerializer<String> mockSerialier;
 
     @BeforeEach
-    public void setup(MockitoComponentManager componentManager) throws ComponentLookupException
+    void setup(MockitoComponentManager componentManager) throws ComponentLookupException
     {
         this.converterManager = componentManager.getInstance(ConverterManager.class);
     }

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/AttachmentReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/AttachmentReferenceTest.java
@@ -32,10 +32,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * @version $Id$
  * @since 2.2M1
  */
-public class AttachmentReferenceTest
+class AttachmentReferenceTest
 {
     @Test
-    public void testInvalidType()
+    void testInvalidType()
     {
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
             () -> new AttachmentReference(new EntityReference("filename", EntityType.DOCUMENT)));
@@ -44,7 +44,7 @@ public class AttachmentReferenceTest
     }
 
     @Test
-    public void testInvalidNullParent()
+    void testInvalidNullParent()
     {
         IllegalArgumentException e =
             assertThrows(IllegalArgumentException.class, () -> new AttachmentReference("filename", null));
@@ -53,7 +53,7 @@ public class AttachmentReferenceTest
     }
 
     @Test
-    public void testInvalidParentType()
+    void testInvalidParentType()
     {
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new AttachmentReference(
             new EntityReference("filename", EntityType.ATTACHMENT, new WikiReference("wiki"))));
@@ -62,7 +62,7 @@ public class AttachmentReferenceTest
     }
 
     @Test
-    public void testReplaceParent()
+    void testReplaceParent()
     {
         AttachmentReference reference = new AttachmentReference("file", new DocumentReference("wiki", "space", "page"))
             .replaceParent(new DocumentReference("wiki2", "space2", "page2"));

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/BlockReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/BlockReferenceTest.java
@@ -32,13 +32,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * @version $Id$
  * @since 6.0M1
  */
-public class BlockReferenceTest
+class BlockReferenceTest
 {
     /**
      * Ensures the equivalence of constructors.
      */
     @Test
-    public void testConstructors()
+    void testConstructors()
     {
         BlockReference reference = new BlockReference(new EntityReference("Block", EntityType.BLOCK));
         assertEquals(reference, new BlockReference("Block"));
@@ -57,7 +57,7 @@ public class BlockReferenceTest
     }
 
     @Test
-    public void testInvalidType()
+    void testInvalidType()
     {
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
             () -> new BlockReference(new EntityReference("Block", EntityType.DOCUMENT)));
@@ -69,7 +69,7 @@ public class BlockReferenceTest
      * Tests that an object reference throws exception if it doesn't have a document as a parent.
      */
     @Test
-    public void testInvalidParentType()
+    void testInvalidParentType()
     {
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new BlockReference(
             new EntityReference("Block", EntityType.BLOCK, new EntityReference("Object", EntityType.OBJECT))));
@@ -78,7 +78,7 @@ public class BlockReferenceTest
     }
 
     @Test
-    public void testReplaceParent()
+    void testReplaceParent()
     {
         BlockReference reference = new BlockReference("Block", new DocumentReference("wiki", "space", "page"))
             .replaceParent(new DocumentReference("wiki2", "space2", "page2"));

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/ClassPropertyReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/ClassPropertyReferenceTest.java
@@ -31,13 +31,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * 
  * @version $Id$
  */
-public class ClassPropertyReferenceTest
+class ClassPropertyReferenceTest
 {
     /**
      * Ensures the equivalence of constructors.
      */
     @Test
-    public void testConstructors()
+    void testConstructors()
     {
         ClassPropertyReference reference = new ClassPropertyReference(new EntityReference("ClassProperty",
             EntityType.CLASS_PROPERTY, new EntityReference("Document", EntityType.DOCUMENT,
@@ -47,7 +47,7 @@ public class ClassPropertyReferenceTest
     }
 
     @Test
-    public void testInvalidType()
+    void testInvalidType()
     {
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
             () -> new ClassPropertyReference(new EntityReference("propertyName", EntityType.PAGE)));
@@ -56,7 +56,7 @@ public class ClassPropertyReferenceTest
     }
 
     @Test
-    public void testInvalidNullParent()
+    void testInvalidNullParent()
     {
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
             () -> new ClassPropertyReference(new EntityReference("className", EntityType.CLASS_PROPERTY)));
@@ -68,7 +68,7 @@ public class ClassPropertyReferenceTest
      * Tests that an object reference throws exception if it doesn't have a document as a parent.
      */
     @Test
-    public void testInvalidParentType()
+    void testInvalidParentType()
     {
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new ClassPropertyReference(
             new EntityReference("className", EntityType.CLASS_PROPERTY, new EntityReference("wiki", EntityType.WIKI))));
@@ -77,7 +77,7 @@ public class ClassPropertyReferenceTest
     }
 
     @Test
-    public void testReplaceParent()
+    void testReplaceParent()
     {
         ClassPropertyReference reference =
             new ClassPropertyReference("prop", new DocumentReference("wiki", "space", "page"))

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/EntityReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/EntityReferenceTest.java
@@ -49,7 +49,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @version $Id$
  * @since 2.2M1
  */
-public class EntityReferenceTest
+class EntityReferenceTest
 {
     private static final String SPACE_NAME = "space";
 
@@ -77,7 +77,7 @@ public class EntityReferenceTest
     }
 
     @Test
-    public void extractReference()
+    void extractReference()
     {
         EntityReference wiki = new EntityReference(WIKI_NAME, EntityType.WIKI);
         EntityReference space1 = new EntityReference("space1", EntityType.SPACE, wiki);
@@ -91,7 +91,7 @@ public class EntityReferenceTest
     }
 
     @Test
-    public void extractFirstReference()
+    void extractFirstReference()
     {
         EntityReference wiki = new EntityReference(WIKI_NAME, EntityType.WIKI);
         EntityReference space1 = new EntityReference("space1", EntityType.SPACE, wiki);
@@ -105,7 +105,7 @@ public class EntityReferenceTest
     }
 
     @Test
-    public void getRoot()
+    void getRoot()
     {
         EntityReference wiki = new EntityReference(WIKI_NAME, EntityType.WIKI);
         EntityReference reference =
@@ -114,7 +114,7 @@ public class EntityReferenceTest
     }
 
     @Test
-    public void getReversedReferenceChain()
+    void getReversedReferenceChain()
     {
         EntityReference wiki = new EntityReference(WIKI_NAME, EntityType.WIKI);
         EntityReference space = new EntityReference(SPACE_NAME, EntityType.SPACE, wiki);
@@ -129,7 +129,7 @@ public class EntityReferenceTest
     }
 
     @Test
-    public void copyConstructor()
+    void copyConstructor()
     {
         Map<String, Serializable> map1 = getParamMap(3);
         Map<String, Serializable> map2 = getParamMap(1);
@@ -147,7 +147,7 @@ public class EntityReferenceTest
     }
 
     @Test
-    public void validateEquals()
+    void validateEquals()
     {
         EntityReference reference1 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
             new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI)));
@@ -195,7 +195,7 @@ public class EntityReferenceTest
     }
 
     @Test
-    public void equalsTo()
+    void equalsTo()
     {
         EntityReference documentReference = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
             new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI)));
@@ -213,7 +213,7 @@ public class EntityReferenceTest
     }
 
     @Test
-    public void equalsFromTo()
+    void equalsFromTo()
     {
         EntityReference documentReference = new EntityReference("page1", EntityType.DOCUMENT,
             new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI)));
@@ -229,7 +229,7 @@ public class EntityReferenceTest
     }
 
     @Test
-    public void equalsNonRecursive()
+    void equalsNonRecursive()
     {
         EntityReference documentReference1 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
             new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI)));
@@ -242,7 +242,7 @@ public class EntityReferenceTest
     }
 
     @Test
-    public void validateHashCode()
+    void validateHashCode()
     {
         EntityReference reference1 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
             new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI)));
@@ -290,7 +290,7 @@ public class EntityReferenceTest
     }
 
     @Test
-    public void compareTo()
+    void compareTo()
     {
         EntityReference reference = new EntityReference("f", EntityType.DOCUMENT,
             new EntityReference("e", EntityType.SPACE, new EntityReference("d", EntityType.WIKI)));
@@ -360,7 +360,7 @@ public class EntityReferenceTest
     }
 
     @Test
-    public void nullTypeInConstructor()
+    void nullTypeInConstructor()
     {
         try {
             new EntityReference("name", null);
@@ -371,7 +371,7 @@ public class EntityReferenceTest
     }
 
     @Test
-    public void nullNameInConstructor()
+    void nullNameInConstructor()
     {
         try {
             new EntityReference(null, EntityType.WIKI);
@@ -382,7 +382,7 @@ public class EntityReferenceTest
     }
 
     @Test
-    public void emptyNameInConstructor()
+    void emptyNameInConstructor()
     {
         try {
             new EntityReference("", EntityType.WIKI);
@@ -393,7 +393,7 @@ public class EntityReferenceTest
     }
 
     @Test
-    public void testReplaceParent1()
+    void testReplaceParent1()
     {
         Map<String, Serializable> map1 = getParamMap(3);
         Map<String, Serializable> map2 = getParamMap(2);
@@ -416,7 +416,7 @@ public class EntityReferenceTest
     }
 
     @Test
-    public void replaceParent2()
+    void replaceParent2()
     {
         Map<String, Serializable> map1 = getParamMap(3);
         Map<String, Serializable> map2 = getParamMap(2);
@@ -447,7 +447,7 @@ public class EntityReferenceTest
     }
 
     @Test
-    public void replaceUnknownParent2()
+    void replaceUnknownParent2()
     {
         EntityReference wiki = new EntityReference(WIKI_NAME, EntityType.WIKI);
         EntityReference wiki2 = new EntityReference("wiki2", EntityType.WIKI);
@@ -463,7 +463,7 @@ public class EntityReferenceTest
     }
 
     @Test
-    public void constructorCloneNullReference()
+    void constructorCloneNullReference()
     {
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new EntityReference(null,
             new EntityReference(WIKI_NAME, EntityType.WIKI), new EntityReference("wiki2", EntityType.WIKI)));
@@ -472,7 +472,7 @@ public class EntityReferenceTest
     }
 
     @Test
-    public void appendParent()
+    void appendParent()
     {
         Map<String, Serializable> map1 = getParamMap(3);
         Map<String, Serializable> map2 = getParamMap(2);
@@ -496,7 +496,7 @@ public class EntityReferenceTest
     }
 
     @Test
-    public void removeParent()
+    void removeParent()
     {
         Map<String, Serializable> map1 = getParamMap(3);
         Map<String, Serializable> map2 = getParamMap(2);
@@ -519,7 +519,7 @@ public class EntityReferenceTest
     }
 
     @Test
-    public void hasParent()
+    void hasParent()
     {
         EntityReference wiki = new EntityReference(WIKI_NAME, EntityType.WIKI);
         EntityReference alice = new EntityReference("alice", EntityType.SPACE, wiki);
@@ -550,7 +550,7 @@ public class EntityReferenceTest
     }
 
     @Test
-    public void entityReferenceSerialization() throws Exception
+    void entityReferenceSerialization() throws Exception
     {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
@@ -572,7 +572,7 @@ public class EntityReferenceTest
     }
 
     @Test
-    public void validateToString()
+    void validateToString()
     {
         EntityReference reference1 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
             new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI)));

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/EntityReferenceTreeTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/EntityReferenceTreeTest.java
@@ -34,10 +34,10 @@ import static org.junit.jupiter.api.Assertions.assertSame;
  * 
  * @version $Id$
  */
-public class EntityReferenceTreeTest
+class EntityReferenceTreeTest
 {
     @Test
-    public void testOneReference()
+    void testOneReference()
     {
         EntityReferenceTreeNode treeNode = new EntityReferenceTree(new DocumentReference("wiki", "space", "page"));
 
@@ -64,7 +64,7 @@ public class EntityReferenceTreeTest
     }
 
     @Test
-    public void testSeveralReferences()
+    void testSeveralReferences()
     {
         EntityReferenceTreeNode tree = new EntityReferenceTree(new DocumentReference("wiki", "space", "page"),
             new DocumentReference("wiki", "space2", "page2"), new DocumentReference("wiki", "space", "page2"),
@@ -115,7 +115,7 @@ public class EntityReferenceTreeTest
     }
 
     @Test
-    public void getDescendantByReference()
+    void getDescendantByReference()
     {
         DocumentReference documentReference = new DocumentReference("wiki", Arrays.asList("Path", "To"), "Page");
         EntityReferenceTree tree = new EntityReferenceTree(documentReference);
@@ -139,7 +139,7 @@ public class EntityReferenceTreeTest
     }
 
     @Test
-    public void testSiblingWithDifferentType()
+    void testSiblingWithDifferentType()
     {
         DocumentReference document = new DocumentReference("wiki", "space", "entity");
         SpaceReference space = new SpaceReference("wiki", "space", "entity");
@@ -182,7 +182,7 @@ public class EntityReferenceTreeTest
     }
 
     @Test
-    public void testToString()
+    void testToString()
     {
         EntityReferenceTreeNode tree = new EntityReferenceTree(new DocumentReference("wiki", "space", "page"),
             new DocumentReference("wiki", "space2", "page2"), new DocumentReference("wiki", "space", "page2"),

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/LocalDocumentReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/LocalDocumentReferenceTest.java
@@ -33,10 +33,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @version $Id$
  * @since 5.0M1
  */
-public class LocalDocumentReferenceTest
+class LocalDocumentReferenceTest
 {
     @Test
-    public void verifyLocalDocumentReferenceProperties()
+    void verifyLocalDocumentReferenceProperties()
     {
         LocalDocumentReference reference = new LocalDocumentReference("space", "page");
         assertEquals("space", reference.getParent().getName());
@@ -45,7 +45,7 @@ public class LocalDocumentReferenceTest
     }
 
     @Test
-    public void testReplaceParent()
+    void testReplaceParent()
     {
         LocalDocumentReference reference =
             new LocalDocumentReference("space", "page").replaceParent(new EntityReference("space2", EntityType.SPACE));

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/LocalPageReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/LocalPageReferenceTest.java
@@ -30,10 +30,10 @@ import static org.junit.jupiter.api.Assertions.assertSame;
  *
  * @version $Id$
  */
-public class LocalPageReferenceTest
+class LocalPageReferenceTest
 {
     @Test
-    public void testReplaceParent()
+    void testReplaceParent()
     {
         LocalPageReference reference =
             new LocalPageReference("space", "page").replaceParent(new EntityReference("space2", EntityType.PAGE));

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/ObjectPropertyReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/ObjectPropertyReferenceTest.java
@@ -32,13 +32,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * @version $Id$
  * @since 2.3M1
  */
-public class ObjectPropertyReferenceTest
+class ObjectPropertyReferenceTest
 {
     /**
      * Test equivalence of constructors.
      */
     @Test
-    public void testConstructors()
+    void testConstructors()
     {
         ObjectPropertyReference reference =
             new ObjectPropertyReference(new EntityReference("property", EntityType.OBJECT_PROPERTY,
@@ -49,7 +49,7 @@ public class ObjectPropertyReferenceTest
     }
 
     @Test
-    public void testInvalidType()
+    void testInvalidType()
     {
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
             () -> new ObjectPropertyReference(new EntityReference("space.page", EntityType.DOCUMENT)));
@@ -58,7 +58,7 @@ public class ObjectPropertyReferenceTest
     }
 
     @Test
-    public void testInvalidNullParent()
+    void testInvalidNullParent()
     {
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
             () -> new ObjectPropertyReference(new EntityReference("property", EntityType.OBJECT_PROPERTY)));
@@ -70,7 +70,7 @@ public class ObjectPropertyReferenceTest
      * Tests that an object reference throws exception if it doesn't have a document as a parent.
      */
     @Test
-    public void testInvalidParentType()
+    void testInvalidParentType()
     {
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
             () -> new ObjectPropertyReference(new EntityReference("property", EntityType.OBJECT_PROPERTY,
@@ -80,7 +80,7 @@ public class ObjectPropertyReferenceTest
     }
 
     @Test
-    public void testReplaceParent()
+    void testReplaceParent()
     {
         ObjectPropertyReference reference = new ObjectPropertyReference("prop",
             new ObjectReference("object", new DocumentReference("wiki", "space", "page")))

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/ObjectReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/ObjectReferenceTest.java
@@ -32,13 +32,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * @version $Id$
  * @since 2.3M1
  */
-public class ObjectReferenceTest
+class ObjectReferenceTest
 {
     /**
      * Ensures the equivalence of constructors.
      */
     @Test
-    public void testConstructors()
+    void testConstructors()
     {
         ObjectReference reference = new ObjectReference(
             new EntityReference("Object", EntityType.OBJECT, new EntityReference("Page", EntityType.DOCUMENT,
@@ -47,7 +47,7 @@ public class ObjectReferenceTest
     }
 
     @Test
-    public void testInvalidType()
+    void testInvalidType()
     {
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
             () -> new ObjectReference(new EntityReference("className", EntityType.DOCUMENT)));
@@ -56,7 +56,7 @@ public class ObjectReferenceTest
     }
 
     @Test
-    public void testInvalidNullParent()
+    void testInvalidNullParent()
     {
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
             () -> new ObjectReference(new EntityReference("className", EntityType.OBJECT)));
@@ -68,7 +68,7 @@ public class ObjectReferenceTest
      * Tests that an object reference throws exception if it doesn't have a document as a parent.
      */
     @Test
-    public void testInvalidParentType()
+    void testInvalidParentType()
     {
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new ObjectReference(
             new EntityReference("className", EntityType.OBJECT, new EntityReference("Space", EntityType.SPACE))));
@@ -77,7 +77,7 @@ public class ObjectReferenceTest
     }
 
     @Test
-    public void testReplaceParent()
+    void testReplaceParent()
     {
         ObjectReference reference = new ObjectReference("object", new DocumentReference("wiki", "space", "page"))
             .replaceParent(new DocumentReference("wiki2", "space2", "page2"));

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/PageAttachmentReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/PageAttachmentReferenceTest.java
@@ -31,10 +31,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  *
  * @version $Id$
  */
-public class PageAttachmentReferenceTest
+class PageAttachmentReferenceTest
 {
     @Test
-    public void testInvalidType()
+    void testInvalidType()
     {
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
             () -> new PageAttachmentReference(new EntityReference("filename", EntityType.PAGE)));
@@ -43,7 +43,7 @@ public class PageAttachmentReferenceTest
     }
 
     @Test
-    public void testInvalidNullParent()
+    void testInvalidNullParent()
     {
         IllegalArgumentException e =
             assertThrows(IllegalArgumentException.class, () -> new PageAttachmentReference("filename", null));
@@ -52,7 +52,7 @@ public class PageAttachmentReferenceTest
     }
 
     @Test
-    public void testInvalidParentType()
+    void testInvalidParentType()
     {
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new PageAttachmentReference(
             new EntityReference("filename", EntityType.PAGE_ATTACHMENT, new WikiReference("wiki"))));
@@ -61,7 +61,7 @@ public class PageAttachmentReferenceTest
     }
 
     @Test
-    public void testReplaceParent()
+    void testReplaceParent()
     {
         PageAttachmentReference reference =
             new PageAttachmentReference("file", new PageReference("wiki", "space", "page"))

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/PageClassPropertyReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/PageClassPropertyReferenceTest.java
@@ -31,13 +31,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * 
  * @version $Id$
  */
-public class PageClassPropertyReferenceTest
+class PageClassPropertyReferenceTest
 {
     /**
      * Ensures the equivalence of constructors.
      */
     @Test
-    public void testConstructors()
+    void testConstructors()
     {
         PageClassPropertyReference reference =
             new PageClassPropertyReference(new EntityReference("ClassProperty", EntityType.PAGE_CLASS_PROPERTY,
@@ -46,7 +46,7 @@ public class PageClassPropertyReferenceTest
     }
 
     @Test
-    public void testInvalidType()
+    void testInvalidType()
     {
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
             () -> new PageClassPropertyReference(new EntityReference("propertyName", EntityType.PAGE)));
@@ -55,7 +55,7 @@ public class PageClassPropertyReferenceTest
     }
 
     @Test
-    public void testInvalidNullParent()
+    void testInvalidNullParent()
     {
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
             () -> new PageClassPropertyReference(new EntityReference("className", EntityType.PAGE_CLASS_PROPERTY)));
@@ -67,7 +67,7 @@ public class PageClassPropertyReferenceTest
      * Tests that an object reference throws exception if it doesn't have a document as a parent.
      */
     @Test
-    public void testInvalidParentType()
+    void testInvalidParentType()
     {
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
             () -> new PageClassPropertyReference(new EntityReference("className", EntityType.PAGE_CLASS_PROPERTY,
@@ -77,7 +77,7 @@ public class PageClassPropertyReferenceTest
     }
 
     @Test
-    public void testReplaceParent()
+    void testReplaceParent()
     {
         PageClassPropertyReference reference =
             new PageClassPropertyReference("prop", new PageReference("wiki", "space", "page"))

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/PageObjectPropertyReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/PageObjectPropertyReferenceTest.java
@@ -31,13 +31,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * 
  * @version $Id$
  */
-public class PageObjectPropertyReferenceTest
+class PageObjectPropertyReferenceTest
 {
     /**
      * Test equivalence of constructors.
      */
     @Test
-    public void testConstructors()
+    void testConstructors()
     {
         PageObjectPropertyReference reference = new PageObjectPropertyReference(new EntityReference("property",
             EntityType.PAGE_OBJECT_PROPERTY, new EntityReference("Object", EntityType.PAGE_OBJECT,
@@ -47,7 +47,7 @@ public class PageObjectPropertyReferenceTest
     }
 
     @Test
-    public void testInvalidType()
+    void testInvalidType()
     {
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
             () -> new PageObjectPropertyReference(new EntityReference("page", EntityType.PAGE)));
@@ -56,7 +56,7 @@ public class PageObjectPropertyReferenceTest
     }
 
     @Test
-    public void testInvalidNullParent()
+    void testInvalidNullParent()
     {
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
             () -> new PageObjectPropertyReference(new EntityReference("property", EntityType.PAGE_OBJECT_PROPERTY)));
@@ -68,7 +68,7 @@ public class PageObjectPropertyReferenceTest
      * Tests that an object reference throws exception if it doesn't have a page as a parent.
      */
     @Test
-    public void testInvalidParentType()
+    void testInvalidParentType()
     {
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
             () -> new PageObjectPropertyReference(new EntityReference("property", EntityType.PAGE_OBJECT_PROPERTY,
@@ -78,7 +78,7 @@ public class PageObjectPropertyReferenceTest
     }
 
     @Test
-    public void testReplaceParent()
+    void testReplaceParent()
     {
         PageObjectPropertyReference reference = new PageObjectPropertyReference("prop",
             new PageObjectReference("object", new PageReference("wiki", "space", "page")))

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/PageObjectReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/PageObjectReferenceTest.java
@@ -31,13 +31,13 @@ import static org.junit.jupiter.api.Assertions.fail;
  * 
  * @version $Id$
  */
-public class PageObjectReferenceTest
+class PageObjectReferenceTest
 {
     /**
      * Ensures the equivalence of constructors.
      */
     @Test
-    public void testConstructors()
+    void testConstructors()
     {
         PageObjectReference reference = new PageObjectReference(new EntityReference("Object", EntityType.PAGE_OBJECT,
             new EntityReference("Page", EntityType.PAGE, new EntityReference("wiki", EntityType.WIKI))));
@@ -45,7 +45,7 @@ public class PageObjectReferenceTest
     }
 
     @Test
-    public void testInvalidType()
+    void testInvalidType()
     {
         try {
             new PageObjectReference(new EntityReference("className", EntityType.PAGE));
@@ -57,7 +57,7 @@ public class PageObjectReferenceTest
     }
 
     @Test
-    public void testInvalidNullParent()
+    void testInvalidNullParent()
     {
         try {
             new PageObjectReference(new EntityReference("className", EntityType.PAGE_OBJECT));
@@ -72,7 +72,7 @@ public class PageObjectReferenceTest
      * Tests that an object reference throws exception if it doesn't have a document as a parent.
      */
     @Test
-    public void testInvalidParentType()
+    void testInvalidParentType()
     {
         try {
             new PageObjectReference(
@@ -85,7 +85,7 @@ public class PageObjectReferenceTest
     }
 
     @Test
-    public void testReplaceParent()
+    void testReplaceParent()
     {
         PageObjectReference reference =
             new PageObjectReference("object", new PageReference("wiki", "space", "page"))

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/PageReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/PageReferenceTest.java
@@ -34,10 +34,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * 
  * @version $Id$
  */
-public class PageReferenceTest
+class PageReferenceTest
 {
     @Test
-    public void testConstructors()
+    void testConstructors()
     {
         PageReference reference = new PageReference("wiki", "space", "page");
         assertEquals(reference, new PageReference(new EntityReference("page", EntityType.PAGE,
@@ -47,7 +47,7 @@ public class PageReferenceTest
     }
 
     @Test
-    public void testInvalidType()
+    void testInvalidType()
     {
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
             () -> new PageReference(new EntityReference("page", EntityType.DOCUMENT)));
@@ -56,7 +56,7 @@ public class PageReferenceTest
     }
 
     @Test
-    public void testInvalidNullParent()
+    void testInvalidNullParent()
     {
         IllegalArgumentException e =
             assertThrows(IllegalArgumentException.class, () -> new PageReference("page", (WikiReference) null));
@@ -65,7 +65,7 @@ public class PageReferenceTest
     }
 
     @Test
-    public void testInvalidParentType()
+    void testInvalidParentType()
     {
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new PageReference(
             new EntityReference("page", EntityType.PAGE, new EntityReference("document", EntityType.DOCUMENT))));
@@ -74,14 +74,14 @@ public class PageReferenceTest
     }
 
     @Test
-    public void testGetWikiReference()
+    void testGetWikiReference()
     {
         PageReference reference = new PageReference("wiki", "space", "page");
         assertEquals(new WikiReference("wiki"), reference.getWikiReference());
     }
 
     @Test
-    public void testToString()
+    void testToString()
     {
         PageReference reference1 = new PageReference("wiki", "space", "page");
         assertEquals("wiki:space/page", reference1.toString());
@@ -91,14 +91,14 @@ public class PageReferenceTest
     }
 
     @Test
-    public void testCreatePageReferenceFromLocalPageReference()
+    void testCreatePageReferenceFromLocalPageReference()
     {
         assertEquals(new PageReference("wiki", "space", "page"),
             new PageReference(new LocalPageReference("space", "page"), new WikiReference("wiki")));
     }
 
     @Test
-    public void testReplaceParent()
+    void testReplaceParent()
     {
         PageReference reference = new PageReference("wiki", "space", "page").replaceParent(
             new EntityReference("space2", EntityType.PAGE, new EntityReference("wiki2", EntityType.WIKI)));

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/RegexEntityReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/RegexEntityReferenceTest.java
@@ -32,12 +32,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * 
  * @version $Id$
  */
-public class RegexEntityReferenceTest
+class RegexEntityReferenceTest
 {
     private static final DocumentReference REFERENCETOMATCH = new DocumentReference("wiki", "space", "page");
 
     @Test
-    public void equalsWhenExact()
+    void equalsWhenExact()
     {
         EntityReference wikiReference =
             new RegexEntityReference(Pattern.compile(REFERENCETOMATCH.getWikiReference().getName(), Pattern.LITERAL),
@@ -53,7 +53,7 @@ public class RegexEntityReferenceTest
     }
 
     @Test
-    public void equalsWithOnlyPage()
+    void equalsWithOnlyPage()
     {
         EntityReference reference =
             new RegexEntityReference(Pattern.compile(REFERENCETOMATCH.getName(), Pattern.LITERAL), EntityType.DOCUMENT);
@@ -62,7 +62,7 @@ public class RegexEntityReferenceTest
     }
 
     @Test
-    public void equalsWithOnlyWiki()
+    void equalsWithOnlyWiki()
     {
         EntityReference reference =
             new RegexEntityReference(Pattern.compile(REFERENCETOMATCH.getWikiReference().getName(), Pattern.LITERAL),
@@ -72,7 +72,7 @@ public class RegexEntityReferenceTest
     }
 
     @Test
-    public void equalsWithPattern()
+    void equalsWithPattern()
     {
         EntityReference reference = new RegexEntityReference(Pattern.compile("p.*"), EntityType.DOCUMENT);
 
@@ -80,7 +80,7 @@ public class RegexEntityReferenceTest
     }
 
     @Test
-    public void equalsWhenPatternNotMatching()
+    void equalsWhenPatternNotMatching()
     {
         EntityReference reference = new RegexEntityReference(Pattern.compile("space"), EntityType.DOCUMENT);
 
@@ -88,7 +88,7 @@ public class RegexEntityReferenceTest
     }
 
     @Test
-    public void equalsWhenNonRegexParent()
+    void equalsWhenNonRegexParent()
     {
         EntityReference reference =
             new RegexEntityReference(Pattern.compile("space"), EntityType.SPACE, new EntityReference("wiki",

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/SpaceReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/SpaceReferenceTest.java
@@ -32,10 +32,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * @version $Id$
  * @since 2.2M1
  */
-public class SpaceReferenceTest
+class SpaceReferenceTest
 {
     @Test
-    public void testInvalidType()
+    void testInvalidType()
     {
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
             () -> new SpaceReference(new EntityReference("space", EntityType.WIKI)));
@@ -44,7 +44,7 @@ public class SpaceReferenceTest
     }
 
     @Test
-    public void testInvalidNullParent()
+    void testInvalidNullParent()
     {
         IllegalArgumentException e =
             assertThrows(IllegalArgumentException.class, () -> new SpaceReference("page", (WikiReference) null));
@@ -53,7 +53,7 @@ public class SpaceReferenceTest
     }
 
     @Test
-    public void testInvalidParentType()
+    void testInvalidParentType()
     {
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> new SpaceReference(
             new EntityReference("space", EntityType.SPACE, new EntityReference("whatever", EntityType.DOCUMENT))));
@@ -62,7 +62,7 @@ public class SpaceReferenceTest
     }
 
     @Test
-    public void testReplaceParent()
+    void testReplaceParent()
     {
         SpaceReference reference = new SpaceReference("wiki", "space", "page").replaceParent(
             new EntityReference("space2", EntityType.SPACE, new EntityReference("wiki2", EntityType.WIKI)));

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/WikiReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/WikiReferenceTest.java
@@ -31,10 +31,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * @version $Id$
  * @since 2.2M1
  */
-public class WikiReferenceTest
+class WikiReferenceTest
 {
     @Test
-    public void testInvalidType()
+    void testInvalidType()
     {
         IllegalArgumentException expected = assertThrows(IllegalArgumentException.class,
             () -> new WikiReference(new EntityReference("wiki", EntityType.DOCUMENT)));
@@ -42,7 +42,7 @@ public class WikiReferenceTest
     }
 
     @Test
-    public void testInvalidParent()
+    void testInvalidParent()
     {
         EntityReference badParent = new EntityReference("other", EntityType.DOCUMENT);
         IllegalArgumentException expected = assertThrows(IllegalArgumentException.class,

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/script/ModelScriptServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/script/ModelScriptServiceTest.java
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  * @since 2.3M1
  */
-public class ModelScriptServiceTest
+class ModelScriptServiceTest
 {
     private ModelScriptService service;
 
@@ -71,7 +71,7 @@ public class ModelScriptServiceTest
 
     @SuppressWarnings("unchecked")
     @BeforeEach
-    public void beforeEach() throws ComponentLookupException
+    void beforeEach() throws ComponentLookupException
     {
         this.service = new ModelScriptService();
 
@@ -96,7 +96,7 @@ public class ModelScriptServiceTest
     }
 
     @Test
-    public void createDocumentReferenceWithSpecifiedHint() throws Exception
+    void createDocumentReferenceWithSpecifiedHint() throws Exception
     {
         when(this.componentManager.getInstance(DocumentReferenceResolver.TYPE_REFERENCE, "default"))
             .thenReturn(this.documentResolver);
@@ -107,7 +107,7 @@ public class ModelScriptServiceTest
     }
 
     @Test
-    public void createDocumentReferenceWithDefaultHint() throws Exception
+    void createDocumentReferenceWithDefaultHint() throws Exception
     {
         DocumentReference reference = new DocumentReference("wiki", "space", "page");
         when(this.documentResolver.resolve(reference)).thenReturn(reference);
@@ -116,7 +116,7 @@ public class ModelScriptServiceTest
     }
 
     @Test
-    public void createDocumentReferenceWhenEmptyParameters() throws Exception
+    void createDocumentReferenceWhenEmptyParameters() throws Exception
     {
         when(this.componentManager.getInstance(DocumentReferenceResolver.TYPE_REFERENCE, "default"))
             .thenReturn(this.documentResolver);
@@ -127,7 +127,7 @@ public class ModelScriptServiceTest
     }
 
     @Test
-    public void createPageReferenceWhenEmptyParameters() throws Exception
+    void createPageReferenceWhenEmptyParameters() throws Exception
     {
         PageReference reference = new PageReference("defaultwiki", "defaultpage");
         when(this.entityResolver.resolve(null, EntityType.PAGE)).thenReturn(reference);
@@ -136,7 +136,7 @@ public class ModelScriptServiceTest
     }
 
     @Test
-    public void createDocumentReferenceWhenWikiParameterEmpty() throws Exception
+    void createDocumentReferenceWhenWikiParameterEmpty() throws Exception
     {
         when(this.componentManager.getInstance(DocumentReferenceResolver.TYPE_REFERENCE, "default"))
             .thenReturn(this.documentResolver);
@@ -149,7 +149,7 @@ public class ModelScriptServiceTest
     }
 
     @Test
-    public void createDocumentReferenceWhenSpaceParameterEmpty() throws Exception
+    void createDocumentReferenceWhenSpaceParameterEmpty() throws Exception
     {
         when(this.componentManager.getInstance(DocumentReferenceResolver.TYPE_REFERENCE, "default"))
             .thenReturn(this.documentResolver);
@@ -164,7 +164,7 @@ public class ModelScriptServiceTest
     }
 
     @Test
-    public void createDocumentReferenceWhenPageParameterEmpty() throws Exception
+    void createDocumentReferenceWhenPageParameterEmpty() throws Exception
     {
         when(this.componentManager.getInstance(DocumentReferenceResolver.TYPE_REFERENCE, "default"))
             .thenReturn(this.documentResolver);
@@ -177,7 +177,7 @@ public class ModelScriptServiceTest
     }
 
     @Test
-    public void createDocumentReferenceWhenWikiAndSpaceParametersEmpty() throws Exception
+    void createDocumentReferenceWhenWikiAndSpaceParametersEmpty() throws Exception
     {
         when(this.componentManager.getInstance(DocumentReferenceResolver.TYPE_REFERENCE, "default"))
             .thenReturn(this.documentResolver);
@@ -190,7 +190,7 @@ public class ModelScriptServiceTest
     }
 
     @Test
-    public void createDocumentReferenceWhenInvalidHint() throws Exception
+    void createDocumentReferenceWhenInvalidHint() throws Exception
     {
         when(this.componentManager.getInstance(DocumentReferenceResolver.TYPE_REFERENCE, "invalid"))
             .thenThrow(new ComponentLookupException("error"));
@@ -202,7 +202,7 @@ public class ModelScriptServiceTest
     }
 
     @Test
-    public void createDocumentReferenceWithDeprecatedHint() throws Exception
+    void createDocumentReferenceWithDeprecatedHint() throws Exception
     {
         when(this.componentManager.getInstance(DocumentReferenceResolver.TYPE_REFERENCE, "current/reference"))
             .thenThrow(new ComponentLookupException("error"));
@@ -222,7 +222,7 @@ public class ModelScriptServiceTest
     }
 
     @Test
-    public void createDocumentReferenceFromPageNameAndSpaceReference()
+    void createDocumentReferenceFromPageNameAndSpaceReference()
     {
         DocumentReference documentReference = new DocumentReference("wiki", "Space", "Page");
         assertEquals(documentReference, this.service.createDocumentReference(documentReference.getName(),
@@ -230,13 +230,13 @@ public class ModelScriptServiceTest
     }
 
     @Test
-    public void createWikiReference()
+    void createWikiReference()
     {
         assertEquals(new WikiReference("wiki"), this.service.createWikiReference("wiki"));
     }
 
     @Test
-    public void createSpaceReference()
+    void createSpaceReference()
     {
         assertEquals(new SpaceReference("space", new WikiReference("wiki")),
             this.service.createSpaceReference("space", this.service.createWikiReference("wiki")));
@@ -251,14 +251,14 @@ public class ModelScriptServiceTest
     }
 
     @Test
-    public void createEntityReferenceWithoutParent()
+    void createEntityReferenceWithoutParent()
     {
         assertEquals(new EntityReference("page", EntityType.DOCUMENT),
             this.service.createEntityReference("page", EntityType.DOCUMENT));
     }
 
     @Test
-    public void createEntityReferenceWithParent()
+    void createEntityReferenceWithParent()
     {
         assertEquals(new EntityReference("page", EntityType.DOCUMENT, new EntityReference("space", EntityType.SPACE)),
             this.service.createEntityReference("page", EntityType.DOCUMENT,
@@ -266,7 +266,7 @@ public class ModelScriptServiceTest
     }
 
     @Test
-    public void resolveSpace() throws Exception
+    void resolveSpace() throws Exception
     {
         SpaceReference reference = new SpaceReference("Space", new WikiReference("wiki"));
         when(this.stringEntityReferenceResolver.resolve("x", EntityType.SPACE, new Object[] {})).thenReturn(reference);
@@ -275,7 +275,7 @@ public class ModelScriptServiceTest
     }
 
     @Test
-    public void resolveSpaceWithHintAndParameters() throws Exception
+    void resolveSpaceWithHintAndParameters() throws Exception
     {
         when(this.componentManager.getInstance(EntityReferenceResolver.TYPE_STRING, "custom"))
             .thenReturn(this.stringEntityReferenceResolver);
@@ -288,7 +288,7 @@ public class ModelScriptServiceTest
     }
 
     @Test
-    public void resolveClassPropertyWithHintAndParameters() throws Exception
+    void resolveClassPropertyWithHintAndParameters() throws Exception
     {
         when(this.componentManager.getInstance(EntityReferenceResolver.TYPE_STRING, "custom"))
             .thenReturn(this.stringEntityReferenceResolver);


### PR DESCRIPTION
## Summary

Removes redundant `public` visibility modifiers from JUnit5 test classes and their test/lifecycle methods in `xwiki-platform-model-api`, as reported by SonarCloud rule [java:S5786](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS5786&ruleKey=java%3AS5786) ("JUnit5 test classes and methods should have default package visibility").

JUnit5 no longer requires test classes and methods to be `public`; the recommended visibility is package-private. This is a purely mechanical, behaviour-preserving change.

## Details

- 35 test files updated in the `xwiki-platform-model-api` module.
- 204 redundant `public` modifiers removed from test class declarations and their `@Test` / `@BeforeEach` / lifecycle methods.
- No production code changed.

All the fixed issues belong to SonarCloud rule `java:S5786`. See the [open S5786 issues for this project](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&rules=java%3AS5786&issueStatuses=OPEN).

## Test plan

- `mvn clean install` on `xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api` — BUILD SUCCESS (Checkstyle + test compilation pass).


---
_Generated by [Claude Code](https://claude.ai/code/session_012bPqSBeo6Na7VQL5zANSkE)_