### PR TITLE
[Misc] Make JUnit5 test classes and methods package-private (SonarCloud java:S5786)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/AbstractRecordableEventDescriptorTest.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/AbstractRecordableEventDescriptorTest.java
@@ -52,7 +52,7 @@ import static org.mockito.Mockito.when;
  * @since 9.11.6
  */
 @ComponentTest
-public class AbstractRecordableEventDescriptorTest
+class AbstractRecordableEventDescriptorTest
 {
     @InjectMockComponents
     private FakeRecordableEventDescriptor fakeRecordableEventDescriptor;
@@ -112,7 +112,7 @@ public class AbstractRecordableEventDescriptorTest
     }
 
     @Test
-    public void getDescriptionAndApplicationWithExceptionTest() throws Exception
+    void getDescriptionAndApplicationWithExceptionTest() throws Exception
     {
         // Mocks
         Exception e = new Exception("some error");
@@ -185,7 +185,7 @@ public class AbstractRecordableEventDescriptorTest
     }
 
     @Test
-    public void equalsAndHashCodeTest()
+    void equalsAndHashCodeTest()
     {
         OtherFakeRecordableEventDescriptor descriptor1 = new OtherFakeRecordableEventDescriptor(
                 "app1",  "type1");

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/EqualEventQueryTest.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/EqualEventQueryTest.java
@@ -32,7 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * 
  * @version $Id$
  */
-public class EqualEventQueryTest
+class EqualEventQueryTest
 {
     @Test
     void conditions()

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/EventGroupTest.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/EventGroupTest.java
@@ -41,7 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * 
  * @version $Id$
  */
-public class EventGroupTest
+class EventGroupTest
 {
     EventGroup g;
 
@@ -52,7 +52,7 @@ public class EventGroupTest
     DefaultEvent event3 = new DefaultEvent();
 
     @BeforeEach
-    public void beforeEach()
+    void beforeEach()
     {
         this.g = new EventGroup();
 
@@ -62,7 +62,7 @@ public class EventGroupTest
     }
 
     @Test
-    public void testConstructors()
+    void testConstructors()
     {
         assertNotNull(this.g.getEvents());
         assertEquals(0, this.g.getEvents().size());
@@ -94,7 +94,7 @@ public class EventGroupTest
     }
 
     @Test
-    public void testConstructorsWithNull()
+    void testConstructorsWithNull()
     {
         this.g = new EventGroup((List<Event>) null);
         assertNotNull(this.g.getEvents());
@@ -110,7 +110,7 @@ public class EventGroupTest
     }
 
     @Test
-    public void testConstructorsWithNullElements()
+    void testConstructorsWithNullElements()
     {
         List<Event> eventsList = new ArrayList<Event>();
         eventsList.add(this.event1);
@@ -133,7 +133,7 @@ public class EventGroupTest
     }
 
     @Test
-    public void testGetMainEvent()
+    void testGetMainEvent()
     {
         this.event1.setImportance(Importance.BACKGROUND);
         this.event2.setImportance(Importance.MAJOR);
@@ -177,7 +177,7 @@ public class EventGroupTest
     }
 
     @Test
-    public void testAddEvents()
+    void testAddEvents()
     {
         assertTrue(this.g.getEvents().isEmpty());
         assertTrue(this.g.getEvents().isEmpty());
@@ -200,7 +200,7 @@ public class EventGroupTest
     }
 
     @Test
-    public void testAddEventsWithNull()
+    void testAddEventsWithNull()
     {
         this.g.addEvents((Event) null);
         assertTrue(this.g.getEvents().isEmpty());
@@ -212,7 +212,7 @@ public class EventGroupTest
     }
 
     @Test
-    public void testClearEvents()
+    void testClearEvents()
     {
         assertTrue(this.g.getEvents().isEmpty());
         this.g.addEvents(this.event1);
@@ -230,7 +230,7 @@ public class EventGroupTest
     }
 
     @Test
-    public void testGetEventsIsReadonly()
+    void testGetEventsIsReadonly()
     {
         this.g.addEvents(this.event1, this.event2);
 
@@ -238,7 +238,7 @@ public class EventGroupTest
     }
 
     @Test
-    public void testGetEventsIsNotLive()
+    void testGetEventsIsNotLive()
     {
         this.g.addEvents(this.event1, this.event2);
         Set<Event> view = this.g.getEvents();

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/DefaultEventStoreNoLegacyTest.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/DefaultEventStoreNoLegacyTest.java
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class DefaultEventStoreNoLegacyTest
+class DefaultEventStoreNoLegacyTest
 {
     private static final DefaultEvent EVENT = new DefaultEvent();
 

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/DefaultEventStoreNoStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/DefaultEventStoreNoStoreTest.java
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class DefaultEventStoreNoStoreTest
+class DefaultEventStoreNoStoreTest
 {
     private static final DefaultEvent EVENT = new DefaultEvent();
 

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/DefaultEventStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/DefaultEventStoreTest.java
@@ -48,7 +48,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class DefaultEventStoreTest
+class DefaultEventStoreTest
 {
     private static final DefaultEvent EVENT = new DefaultEvent();
 

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/events/EventStatusAddOrUpdatedEventTest.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/events/EventStatusAddOrUpdatedEventTest.java
@@ -30,10 +30,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * 
  * @version $Id$
  */
-public class EventStatusAddOrUpdatedEventTest
+class EventStatusAddOrUpdatedEventTest
 {
     @Test
-    public void matches()
+    void matches()
     {
         EventStatusAddOrUpdatedEvent event = new EventStatusAddOrUpdatedEvent();
 

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/events/EventStatusDeletedEventTest.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/events/EventStatusDeletedEventTest.java
@@ -30,10 +30,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * 
  * @version $Id$
  */
-public class EventStatusDeletedEventTest
+class EventStatusDeletedEventTest
 {
     @Test
-    public void matches()
+    void matches()
     {
         EventStatusDeletedEvent event = new EventStatusDeletedEvent();
 

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/events/MailEntityAddedEventTest.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/events/MailEntityAddedEventTest.java
@@ -31,10 +31,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * 
  * @version $Id$
  */
-public class MailEntityAddedEventTest
+class MailEntityAddedEventTest
 {
     @Test
-    public void matches()
+    void matches()
     {
         MailEntityAddedEvent event = new MailEntityAddedEvent();
 

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/events/MailEntityDeleteEventTest.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/internal/events/MailEntityDeleteEventTest.java
@@ -31,10 +31,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * 
  * @version $Id$
  */
-public class MailEntityDeleteEventTest
+class MailEntityDeleteEventTest
 {
     @Test
-    public void matches()
+    void matches()
     {
         MailEntityDeleteEvent event = new MailEntityDeleteEvent();
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/DefaultAsyncNotificationRendererTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/DefaultAsyncNotificationRendererTest.java
@@ -83,7 +83,7 @@ class DefaultAsyncNotificationRendererTest
     private NotificationParameters notificationParameters;
 
     @BeforeEach
-    public void setup()
+    void setup()
     {
         this.notificationParameters = new NotificationParameters();
         this.notificationParameters.user = USER_DOC_REFERENCE;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/DefaultNotificationCacheManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/DefaultNotificationCacheManagerTest.java
@@ -56,7 +56,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class DefaultNotificationCacheManagerTest
+class DefaultNotificationCacheManagerTest
 {
     @InjectMockComponents
     private DefaultNotificationCacheManager defaultNotificationCacheManager;
@@ -101,7 +101,7 @@ public class DefaultNotificationCacheManagerTest
     }
 
     @Test
-    public void getFromCache()
+    void getFromCache()
     {
         this.defaultNotificationCacheManager.getFromCache("anykey", true, false);
         verify(this.longCountCache).get("anykey");
@@ -116,7 +116,7 @@ public class DefaultNotificationCacheManagerTest
     }
 
     @Test
-    public void setInCache()
+    void setInCache()
     {
         List<Object> events = Arrays.asList(mock(Event.class), mock(Event.class),
             mock(Event.class));
@@ -133,7 +133,7 @@ public class DefaultNotificationCacheManagerTest
     }
 
     @Test
-    public void createCacheKey()
+    void createCacheKey()
     {
         DocumentReference userReference = new DocumentReference("xwiki", "XWiki", "Foobar");
         when(this.entityReferenceSerializer.serialize(userReference)).thenReturn("xwiki:XWiki.Foobar");

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/DefaultNotificationDisplayerTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/DefaultNotificationDisplayerTest.java
@@ -51,7 +51,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class DefaultNotificationDisplayerTest
+class DefaultNotificationDisplayerTest
 {
     @InjectMockComponents
     private DefaultNotificationDisplayer displayer;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/InternalHtmlNotificationRendererTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/InternalHtmlNotificationRendererTest.java
@@ -80,7 +80,7 @@ import static org.mockito.Mockito.when;
     SVGDefinitions.class,
     DefaultExecution.class
 })
-public class InternalHtmlNotificationRendererTest
+class InternalHtmlNotificationRendererTest
 {
     @InjectMockComponents
     private InternalHtmlNotificationRenderer notificationRenderer;
@@ -92,14 +92,14 @@ public class InternalHtmlNotificationRendererTest
     private ContextualLocalizationManager localizationManager;
 
     @Test
-    public void renderCount()
+    void renderCount()
     {
         String renderedCount = this.notificationRenderer.render(42);
         assertEquals("<span class=\"notifications-count badge\">42</span>", renderedCount);
     }
 
     @Test
-    public void renderSingleEvent() throws Exception
+    void renderSingleEvent() throws Exception
     {
         CompositeEvent compositeEvent = mock(CompositeEvent.class);
         CompositeEventStatus eventStatus = mock(CompositeEventStatus.class);
@@ -135,7 +135,7 @@ public class InternalHtmlNotificationRendererTest
     }
 
     @Test
-    public void renderMany() throws NotificationException
+    void renderMany() throws NotificationException
     {
         WordBlock wordBlock = new WordBlock("Nothing");
         Translation translation = mock(Translation.class);

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/NotificationAsyncRendererConfigurationTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/NotificationAsyncRendererConfigurationTest.java
@@ -29,10 +29,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class NotificationAsyncRendererConfigurationTest
+class NotificationAsyncRendererConfigurationTest
 {
     @Test
-    public void constructor()
+    void constructor()
     {
         NotificationParameters parameters = new NotificationParameters();
         NotificationAsyncRendererConfiguration configuration =

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/email/live/MissingLiveNotificationMailsJobTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/email/live/MissingLiveNotificationMailsJobTest.java
@@ -48,7 +48,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class MissingLiveNotificationMailsJobTest
+class MissingLiveNotificationMailsJobTest
 {
     @InjectMockComponents
     private MissingLiveNotificationMailsJob job;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/email/live/PrefilteringLiveNotificationEmailDispatcherTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/email/live/PrefilteringLiveNotificationEmailDispatcherTest.java
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class PrefilteringLiveNotificationEmailDispatcherTest
+class PrefilteringLiveNotificationEmailDispatcherTest
 {
     @InjectMockComponents
     private PrefilteringLiveNotificationEmailDispatcher dispatcher;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/email/live/PrefilteringLiveNotificationEmailManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/email/live/PrefilteringLiveNotificationEmailManagerTest.java
@@ -48,7 +48,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class PrefilteringLiveNotificationEmailManagerTest
+class PrefilteringLiveNotificationEmailManagerTest
 {
     @InjectMockComponents
     private PrefilteringLiveNotificationEmailManager manager;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/email/live/PrefilteringLiveNotificationEmailSenderTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/email/live/PrefilteringLiveNotificationEmailSenderTest.java
@@ -52,7 +52,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class PrefilteringLiveNotificationEmailSenderTest
+class PrefilteringLiveNotificationEmailSenderTest
 {
     @InjectMockComponents
     private PrefilteringLiveNotificationEmailSender sender;
@@ -74,7 +74,7 @@ public class PrefilteringLiveNotificationEmailSenderTest
     private WikiDescriptorManager wikiDescriptorManager;
 
     @Test
-    public void testSendMail() throws Exception
+    void testSendMail() throws Exception
     {
         when(this.wikiDescriptorManager.getCurrentWikiId()).thenReturn("xwiki");
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/rss/DefaultNotificationRSSRendererTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/test/java/org/xwiki/notifications/notifiers/internal/rss/DefaultNotificationRSSRendererTest.java
@@ -58,7 +58,7 @@ import static org.mockito.Mockito.when;
  * @since 9.6RC1
  */
 @ComponentTest
-public class DefaultNotificationRSSRendererTest
+class DefaultNotificationRSSRendererTest
 {
     @InjectMockComponents
     private DefaultNotificationRSSRenderer defaultNotificationRSSRenderer;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/test/java/org/xwiki/notifications/notifiers/internal/UserEventManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/test/java/org/xwiki/notifications/notifiers/internal/UserEventManagerTest.java
@@ -63,7 +63,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class UserEventManagerTest
+class UserEventManagerTest
 {
     @InjectMockComponents
     private UserEventManager userEventManager;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/test/java/org/xwiki/notifications/notifiers/internal/email/live/LiveNotificationEmailEventFilterTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/test/java/org/xwiki/notifications/notifiers/internal/email/live/LiveNotificationEmailEventFilterTest.java
@@ -70,7 +70,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class LiveNotificationEmailEventFilterTest
+class LiveNotificationEmailEventFilterTest
 {
     @InjectMockComponents
     private LiveNotificationEmailEventFilter eventFilter;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/ConfiguredStringUserReferenceSerializerTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/ConfiguredStringUserReferenceSerializerTest.java
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class ConfiguredStringUserReferenceSerializerTest
+class ConfiguredStringUserReferenceSerializerTest
 {
     @InjectMockComponents
     private ConfiguredStringUserReferenceSerializer serializer;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/DefaultConfiguredStringUserReferenceResolverTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/DefaultConfiguredStringUserReferenceResolverTest.java
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.when;
  * @since 12.8RC1
  */
 @ComponentTest
-public class DefaultConfiguredStringUserReferenceResolverTest
+class DefaultConfiguredStringUserReferenceResolverTest
 {
     @InjectMockComponents
     private DefaultConfiguredStringUserReferenceResolver resolver;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/DefaultUserPropertiesResolverTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/DefaultUserPropertiesResolverTest.java
@@ -52,7 +52,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class DefaultUserPropertiesResolverTest
+class DefaultUserPropertiesResolverTest
 {
     @InjectMockComponents
     private DefaultUserPropertiesResolver resolver;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/DefaultUserPropertiesTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/DefaultUserPropertiesTest.java
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class DefaultUserPropertiesTest
+class DefaultUserPropertiesTest
 {
     @MockComponent
     private ConfigurationSource configurationSource;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/CurrentUserReferenceResolverTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/CurrentUserReferenceResolverTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class CurrentUserReferenceResolverTest
+class CurrentUserReferenceResolverTest
 {
     @InjectMockComponents
     private CurrentUserReferenceResolver resolver;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/DocumentDocumentReferenceUserReferenceResolverTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/DocumentDocumentReferenceUserReferenceResolverTest.java
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class DocumentDocumentReferenceUserReferenceResolverTest
+class DocumentDocumentReferenceUserReferenceResolverTest
 {
     @InjectMockComponents
     private DocumentDocumentReferenceUserReferenceResolver resolver;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/DocumentDocumentReferenceUserReferenceSerializerTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/DocumentDocumentReferenceUserReferenceSerializerTest.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ComponentTest
-public class DocumentDocumentReferenceUserReferenceSerializerTest
+class DocumentDocumentReferenceUserReferenceSerializerTest
 {
     @InjectMockComponents
     private DocumentDocumentReferenceUserReferenceSerializer serializer;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/DocumentStringUserReferenceSerializerTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/DocumentStringUserReferenceSerializerTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class DocumentStringUserReferenceSerializerTest
+class DocumentStringUserReferenceSerializerTest
 {
     @InjectMockComponents
     private DocumentStringUserReferenceSerializer serializer;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/NormalUserPreferencesConfigurationSourceTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/NormalUserPreferencesConfigurationSourceTest.java
@@ -51,7 +51,7 @@ import static org.mockito.Mockito.mock;
  * @version $Id$
  */
 @ComponentTest
-public class NormalUserPreferencesConfigurationSourceTest
+class NormalUserPreferencesConfigurationSourceTest
 {
     @InjectMockComponents
     private NormalUserPreferencesConfigurationSource source;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/SecureUserDocumentUserPropertiesResolverTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/SecureUserDocumentUserPropertiesResolverTest.java
@@ -50,7 +50,7 @@ import static org.mockito.Mockito.when;
  * @since 12.4RC1
  */
 @ComponentTest
-public class SecureUserDocumentUserPropertiesResolverTest
+class SecureUserDocumentUserPropertiesResolverTest
 {
     @InjectMockComponents
     private SecureUserDocumentUserPropertiesResolver resolver;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/UserDocumentUserPropertiesResolverTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/UserDocumentUserPropertiesResolverTest.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.mock;
  * @version $Id$
  */
 @ComponentTest
-public class UserDocumentUserPropertiesResolverTest
+class UserDocumentUserPropertiesResolverTest
 {
     @InjectMockComponents
     private UserDocumentUserPropertiesResolver resolver;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/UserPreferencesConfigurationSourceTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/UserPreferencesConfigurationSourceTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.mock;
  * @version $Id$
  */
 @ComponentTest
-public class UserPreferencesConfigurationSourceTest
+class UserPreferencesConfigurationSourceTest
 {
     @InjectMockComponents
     private UserPreferencesConfigurationSource source;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/XWikiUserUserReferenceResolverTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/XWikiUserUserReferenceResolverTest.java
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.verify;
  * @version $Id$
  */
 @ComponentTest
-public class XWikiUserUserReferenceResolverTest
+class XWikiUserUserReferenceResolverTest
 {
     @InjectMockComponents
     private XWikiUserUserReferenceResolver resolver;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/group/GroupsCacheTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/group/GroupsCacheTest.java
@@ -61,7 +61,7 @@ import static org.mockito.Mockito.when;
  */
 @ComponentTest
 @ReferenceComponentList
-public class GroupsCacheTest
+class GroupsCacheTest
 {
     @InjectMockComponents
     private MemberGroupsCache groupsCache;
@@ -106,7 +106,7 @@ public class GroupsCacheTest
     // Tests
 
     @Test
-    public void getCacheEntry()
+    void getCacheEntry()
     {
         GroupCacheEntry entry = getCacheEntry(true);
 
@@ -127,7 +127,7 @@ public class GroupsCacheTest
     }
 
     @Test
-    public void cleanCacheReference()
+    void cleanCacheReference()
     {
         // Clean user
 
@@ -161,7 +161,7 @@ public class GroupsCacheTest
     }
 
     @Test
-    public void cleanCacheWiki()
+    void cleanCacheWiki()
     {
         // Clean user wiki
 

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/group/UsersCacheTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/group/UsersCacheTest.java
@@ -52,7 +52,7 @@ import static org.mockito.Mockito.when;
  */
 @ComponentTest
 @ReferenceComponentList
-public class UsersCacheTest
+class UsersCacheTest
 {
     @MockComponent
     private CacheManager cacheManager;
@@ -112,7 +112,7 @@ public class UsersCacheTest
     // Tests
 
     @Test
-    public void getUsers() throws QueryException
+    void getUsers() throws QueryException
     {
         mockUsers(false, USERS_STRING_ALL);
         mockUsers(true, USERS_STRING_ACTIVE);
@@ -122,7 +122,7 @@ public class UsersCacheTest
     }
 
     @Test
-    public void getUsersNoUser() throws QueryException
+    void getUsersNoUser() throws QueryException
     {
         mockUsers(true, Collections.emptyList());
         mockUsers(false, Collections.emptyList());


### PR DESCRIPTION
## Summary

Removes redundant `public` visibility modifiers from JUnit5 test classes and their test/lifecycle methods, as reported by SonarCloud rule [java:S5786](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS5786&ruleKey=java%3AS5786) ("JUnit5 test classes and methods should have default package visibility").

JUnit5 no longer requires test classes and methods to be `public`; the recommended visibility is package-private. This is a purely mechanical, behaviour-preserving change touching test code only (no production code).

## Details

- **37 test files** updated across 3 areas: `xwiki-platform-eventstream-api`, `xwiki-platform-notifications-notifiers` (api + default), and `xwiki-platform-user-default`.
- **66 redundant `public` modifiers** removed from test class declarations and their `@Test` / `@BeforeEach` / `@AfterEach` / lifecycle methods.
- No production code changed.

All fixed issues belong to SonarCloud rule `java:S5786`. See the [open S5786 issues for this project](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&rules=java%3AS5786&issueStatuses=OPEN).

## Test plan

- `mvn clean install -Plegacy,snapshot -DskipTests` on the 4 affected modules in one reactor — BUILD SUCCESS (Checkstyle + test compilation pass).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CqPNQygqPhCy9akXuspUFS)_