### PR TITLE
[Misc] Make JUnit5 test classes and methods package-private (SonarCloud java:S5786)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-api/src/test/java/org/xwiki/like/internal/DefaultLikeConfigurationTest.java
+++ b/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-api/src/test/java/org/xwiki/like/internal/DefaultLikeConfigurationTest.java
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.when;
  * @since 12.7RC1
  */
 @ComponentTest
-public class DefaultLikeConfigurationTest
+class DefaultLikeConfigurationTest
 {
     @InjectMockComponents
     private DefaultLikeConfiguration defaultLikeConfiguration;

--- a/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-api/src/test/java/org/xwiki/like/internal/LikeExistCacheEntryListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-api/src/test/java/org/xwiki/like/internal/LikeExistCacheEntryListenerTest.java
@@ -42,7 +42,7 @@ import static org.mockito.Mockito.mock;
  *
  * @version $Id$
  */
-public class LikeExistCacheEntryListenerTest
+class LikeExistCacheEntryListenerTest
 {
     private LikeManagerCacheHelper.LikeExistCacheEntryListener cacheEntryListener;
 

--- a/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-api/src/test/java/org/xwiki/like/internal/LikeRightTest.java
+++ b/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-api/src/test/java/org/xwiki/like/internal/LikeRightTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  *
  * @version $Id$
  */
-public class LikeRightTest
+class LikeRightTest
 {
     @Test
     void getters()

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-general/src/test/java/org/xwiki/mail/internal/AddressConverterTest.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-general/src/test/java/org/xwiki/mail/internal/AddressConverterTest.java
@@ -38,13 +38,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * @since 6.2M1
  */
 @ComponentTest
-public class AddressConverterTest
+class AddressConverterTest
 {
     @InjectMockComponents
     private AddressConverter converter;
 
     @Test
-    public void convert() throws Exception
+    void convert() throws Exception
     {
         InternetAddress expected = new InternetAddress("John Doe(comment) <john1@doe.com>");
         assertEquals(expected, this.converter.convert(Address.class, "John Doe(comment) <john1@doe.com>"));

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-general/src/test/java/org/xwiki/mail/internal/AddressesConverterTest.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-general/src/test/java/org/xwiki/mail/internal/AddressesConverterTest.java
@@ -39,13 +39,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * @since 6.1RC1
  */
 @ComponentTest
-public class AddressesConverterTest
+class AddressesConverterTest
 {
     @InjectMockComponents
     private AddressesConverter converter;
 
     @Test
-    public void convert() throws Exception
+    void convert() throws Exception
     {
         InternetAddress[] addresses = new InternetAddress[2];
         addresses[0] = new InternetAddress("John Doe(comment) <john1@doe.com>");
@@ -55,13 +55,13 @@ public class AddressesConverterTest
     }
 
     @Test
-    public void convertWhenNull()
+    void convertWhenNull()
     {
         assertNull(this.converter.convert(Address.class, null));
     }
 
     @Test
-    public void convertWhenTypeIsAlreadyAnAddressArray() throws Exception
+    void convertWhenTypeIsAlreadyAnAddressArray() throws Exception
     {
         InternetAddress[] addresses = new InternetAddress[2];
         addresses[0] = new InternetAddress("John Doe(comment) <john1@doe.com>");
@@ -70,7 +70,7 @@ public class AddressesConverterTest
     }
 
     @Test
-    public void convertWhenInvalid()
+    void convertWhenInvalid()
     {
         Throwable exception = assertThrows(ConversionException.class, () -> {
             this.converter.convert(Address[].class, "invalid(");

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-general/src/test/java/org/xwiki/mail/internal/DefaultEmailAddressObfuscatorTest.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-general/src/test/java/org/xwiki/mail/internal/DefaultEmailAddressObfuscatorTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @since 12.4RC1
  */
 @ComponentTest
-public class DefaultEmailAddressObfuscatorTest
+class DefaultEmailAddressObfuscatorTest
 {
     @InjectMockComponents
     private DefaultEmailAddressObfuscator obfuscator;

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-general/src/test/java/org/xwiki/mail/internal/InternetAddressConverterTest.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-general/src/test/java/org/xwiki/mail/internal/InternetAddressConverterTest.java
@@ -37,13 +37,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * @since 12.4RC1
  */
 @ComponentTest
-public class InternetAddressConverterTest
+class InternetAddressConverterTest
 {
     @InjectMockComponents
     private InternetAddressConverter converter;
 
     @Test
-    public void convert() throws Exception
+    void convert() throws Exception
     {
         InternetAddress address = new InternetAddress("John Doe(comment) <john1@doe.com>");
         assertEquals(address, this.converter.convert(InternetAddress.class, "John Doe(comment) <john1@doe.com>"));

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-general/src/test/java/org/xwiki/mail/internal/configuration/DefaultGeneralMailConfigurationTest.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-general/src/test/java/org/xwiki/mail/internal/configuration/DefaultGeneralMailConfigurationTest.java
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.*;
  * @since 12.4RC1
  */
 @ComponentTest
-public class DefaultGeneralMailConfigurationTest
+class DefaultGeneralMailConfigurationTest
 {
     @InjectMockComponents
     private DefaultGeneralMailConfiguration configuration;
@@ -61,14 +61,14 @@ public class DefaultGeneralMailConfigurationTest
     private WikiDescriptorManager wikiDescriptorManager;
 
     @BeforeEach
-    public void setUp()
+    void setUp()
     {
         when(this.wikiDescriptorManager.getCurrentWikiId()).thenReturn("mainwiki");
         when(this.wikiDescriptorManager.isMainWiki("mainwiki")).thenReturn(true);
     }
 
     @Test
-    public void shouldObfuscateWhenNotConfigured()
+    void shouldObfuscateWhenNotConfigured()
     {
         // Simulate the default value returned by the call to getProperty() and not the value of the
         // "mail.general.obfuscateEmailAddresses" property which is supposed to be null here...
@@ -77,7 +77,7 @@ public class DefaultGeneralMailConfigurationTest
     }
 
     @Test
-    public void shouldObfuscateWhenDefinedInXWikiProperties()
+    void shouldObfuscateWhenDefinedInXWikiProperties()
     {
         when(this.xwikiPropertiesSource.getProperty("mail.general.obfuscate", false)).thenReturn(true);
 
@@ -85,7 +85,7 @@ public class DefaultGeneralMailConfigurationTest
     }
 
     @Test
-    public void shouldObfuscateFromMailConfigDocumentInMainWiki()
+    void shouldObfuscateFromMailConfigDocumentInMainWiki()
     {
         when(this.currentWikiMailConfigDocumentSource.getProperty("obfuscate", Boolean.class))
             .thenReturn(true);
@@ -94,7 +94,7 @@ public class DefaultGeneralMailConfigurationTest
     }
 
     @Test
-    public void shouldObfuscateFromMailConfigDocumentInSubwikiAndConfigInMainWiki()
+    void shouldObfuscateFromMailConfigDocumentInSubwikiAndConfigInMainWiki()
     {
         when(this.wikiDescriptorManager.getCurrentWikiId()).thenReturn("subwiki");
         when(this.wikiDescriptorManager.isMainWiki("subwiki")).thenReturn(false);

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-general/src/test/java/org/xwiki/mail/script/GeneralMailScriptServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-general/src/test/java/org/xwiki/mail/script/GeneralMailScriptServiceTest.java
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.when;
  * @since 12.4RC1
  */
 @ComponentTest
-public class GeneralMailScriptServiceTest
+class GeneralMailScriptServiceTest
 {
     @InjectMockComponents
     private GeneralMailScriptService scriptService;

--- a/xwiki-platform-core/xwiki-platform-observation/xwiki-platform-observation-remote/src/test/java/org/xwiki/observation/remote/RemoteEventDataTest.java
+++ b/xwiki-platform-core/xwiki-platform-observation/xwiki-platform-observation-remote/src/test/java/org/xwiki/observation/remote/RemoteEventDataTest.java
@@ -28,10 +28,10 @@ import static org.junit.jupiter.api.Assertions.assertSame;
  * 
  * @version $Id$
  */
-public class RemoteEventDataTest
+class RemoteEventDataTest
 {
     @Test
-    public void constructor()
+    void constructor()
     {
         RemoteEventData data = new RemoteEventData("event", "source", "data");
 

--- a/xwiki-platform-core/xwiki-platform-observation/xwiki-platform-observation-remote/src/test/java/org/xwiki/observation/remote/internal/converter/LogEventConverterTest.java
+++ b/xwiki-platform-core/xwiki-platform-observation/xwiki-platform-observation-remote/src/test/java/org/xwiki/observation/remote/internal/converter/LogEventConverterTest.java
@@ -34,13 +34,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @version $Id$
  */
 @ComponentTest
-public class LogEventConverterTest
+class LogEventConverterTest
 {
     @InjectMockComponents
     private LogEventConverter converter;
 
     @Test
-    public void toRemote()
+    void toRemote()
     {
         assertFalse(this.converter.toRemote(new LocalEventData(null, null, null), null));
         assertTrue(this.converter.toRemote(new LocalEventData(new LogEvent(), null, null), null));

--- a/xwiki-platform-core/xwiki-platform-observation/xwiki-platform-observation-remote/src/test/java/org/xwiki/observation/remote/internal/converter/SerializableEventConverterTest.java
+++ b/xwiki-platform-core/xwiki-platform-observation/xwiki-platform-observation-remote/src/test/java/org/xwiki/observation/remote/internal/converter/SerializableEventConverterTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @version $Id$
  */
 @ComponentTest
-public class SerializableEventConverterTest
+class SerializableEventConverterTest
 {
     @InjectMockComponents(role = RemoteEventConverter.class)
     private SerializableEventConverter remoteConverter;
@@ -46,7 +46,7 @@ public class SerializableEventConverterTest
     private SerializableEventConverter localConverter;
 
     @Test
-    public void toRemote()
+    void toRemote()
     {
         assertFalse(this.remoteConverter.toRemote(new LocalEventData(null, null, null), null));
         assertFalse(this.remoteConverter.toRemote(new LocalEventData(new LogEvent(), this, this), null));

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/DefaultRatingTest.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/DefaultRatingTest.java
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.mock;
  * @version $Id$
  * @since 12.9RC1
  */
-public class DefaultRatingTest
+class DefaultRatingTest
 {
     @Test
     void simpleConstructor()

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/RatingDeletedEntityListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/RatingDeletedEntityListenerTest.java
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class RatingDeletedEntityListenerTest
+class RatingDeletedEntityListenerTest
 {
     @InjectMockComponents
     private RatingDeletedEntityListener listener;

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/RatingMovedEntityListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/RatingMovedEntityListenerTest.java
@@ -41,7 +41,7 @@ import static org.mockito.Mockito.when;
  * @since 12.10
  */
 @ComponentTest
-public class RatingMovedEntityListenerTest
+class RatingMovedEntityListenerTest
 {
     @InjectMockComponents
     private RatingMovedEntityListener listener;

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/SolrRatingsManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/SolrRatingsManagerTest.java
@@ -90,7 +90,7 @@ import static org.mockito.Mockito.when;
  * @since 12.9RC1
  */
 @ComponentTest
-public class SolrRatingsManagerTest
+class SolrRatingsManagerTest
 {
     @InjectMockComponents
     private SolrRatingsManager manager;

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/averagerating/AbstractAverageRatingManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/averagerating/AbstractAverageRatingManagerTest.java
@@ -43,7 +43,7 @@ import static org.mockito.Mockito.when;
  *
  * @version $Id$
  */
-public class AbstractAverageRatingManagerTest
+class AbstractAverageRatingManagerTest
 {
     private RatingsManager ratingsManager;
     private AverageRating averageRating;
@@ -51,7 +51,7 @@ public class AbstractAverageRatingManagerTest
     private ObservationManager observationManager;
 
     @Component
-    public class DumbAsbtractAverageRatingsManager extends AbstractAverageRatingManager {
+    class DumbAsbtractAverageRatingsManager extends AbstractAverageRatingManager {
         boolean isSaved;
 
         @Override

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/averagerating/AverageRatingProtectionListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/averagerating/AverageRatingProtectionListenerTest.java
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class AverageRatingProtectionListenerTest
+class AverageRatingProtectionListenerTest
 {
     @InjectMockComponents
     private AverageRatingProtectionListener listener;

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/averagerating/DefaultAverageRatingTest.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/internal/averagerating/DefaultAverageRatingTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @version $Id$
  * @since 12.9RC1
  */
-public class DefaultAverageRatingTest
+class DefaultAverageRatingTest
 {
     @Test
     void simpleConstructor()

--- a/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/script/RatingsScriptServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-ratings/xwiki-platform-ratings-api/src/test/java/org/xwiki/ratings/script/RatingsScriptServiceTest.java
@@ -74,7 +74,7 @@ import static org.xwiki.ratings.script.RatingsScriptService.EXECUTION_CONTEXT_PR
  * @version $Id$
  */
 @ComponentTest
-public class RatingsScriptServiceTest
+class RatingsScriptServiceTest
 {
     @InjectMockComponents
     private RatingsScriptService scriptService;

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/src/test/java/org/xwiki/store/FileDeleteTransactionRunnableTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/src/test/java/org/xwiki/store/FileDeleteTransactionRunnableTest.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @since 3.0M2
  */
 @ExtendWith(XWikiTempDirExtension.class)
-public class FileDeleteTransactionRunnableTest
+class FileDeleteTransactionRunnableTest
 {
     private static final String[] FILE_PATH = { "path", "to", "file" };
 
@@ -58,7 +58,7 @@ public class FileDeleteTransactionRunnableTest
     private File tmpDir;
 
     @BeforeEach
-    public void setUp() throws Exception
+    void setUp() throws Exception
     {
         this.location = this.tmpDir;
         for (int i = 0; i < FILE_PATH.length; i++) {
@@ -75,7 +75,7 @@ public class FileDeleteTransactionRunnableTest
     }
 
     @Test
-    public void simpleTest() throws Exception
+    void simpleTest() throws Exception
     {
         assertTrue(this.location.exists());
         this.runnable.start();
@@ -84,7 +84,7 @@ public class FileDeleteTransactionRunnableTest
     }
 
     @Test
-    public void rollbackAfterPreRunTest()
+    void rollbackAfterPreRunTest()
     {
         assertTrue(this.location.exists());
 
@@ -106,7 +106,7 @@ public class FileDeleteTransactionRunnableTest
     }
 
     @Test
-    public void rollbackAfterRunTest()
+    void rollbackAfterRunTest()
     {
         assertTrue(this.location.exists());
 
@@ -128,7 +128,7 @@ public class FileDeleteTransactionRunnableTest
     }
 
     @Test
-    public void deleteNonexistantTest() throws Exception
+    void deleteNonexistantTest() throws Exception
     {
         this.location.delete();
         assertFalse(this.location.exists());
@@ -138,7 +138,7 @@ public class FileDeleteTransactionRunnableTest
     }
 
     @Test
-    public void rollbackDeleteNonexistantTest()
+    void rollbackDeleteNonexistantTest()
     {
         this.location.delete();
         assertFalse(this.location.exists());

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/src/test/java/org/xwiki/store/FileSaveTransactionRunnableTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/src/test/java/org/xwiki/store/FileSaveTransactionRunnableTest.java
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * @since 3.0M2
  */
 @ExtendWith(XWikiTempDirExtension.class)
-public class FileSaveTransactionRunnableTest
+class FileSaveTransactionRunnableTest
 {
     private static final String[] FILE_PATH = { "path", "to", "file" };
 
@@ -68,7 +68,7 @@ public class FileSaveTransactionRunnableTest
     private File testDirectory;
 
     @BeforeEach
-    public void beforeEach() throws Exception
+    void beforeEach() throws Exception
     {
         File storageLocation = new File(this.testDirectory, "test-storage" + System.identityHashCode(this.getClass()));
 
@@ -92,7 +92,7 @@ public class FileSaveTransactionRunnableTest
     }
 
     @Test
-    public void simpleTest() throws Exception
+    void simpleTest() throws Exception
     {
         assertEquals(FileUtils.readFileToString(this.toSave, StandardCharsets.UTF_8), CONTENT_VERSION1);
 
@@ -104,7 +104,7 @@ public class FileSaveTransactionRunnableTest
     }
 
     @Test
-    public void rollbackAfterPreRunTest() throws Exception
+    void rollbackAfterPreRunTest() throws Exception
     {
         assertEquals(FileUtils.readFileToString(this.toSave, StandardCharsets.UTF_8), CONTENT_VERSION1);
 
@@ -130,7 +130,7 @@ public class FileSaveTransactionRunnableTest
     }
 
     @Test
-    public void rollbackAfterRunTest() throws Exception
+    void rollbackAfterRunTest() throws Exception
     {
         assertEquals(FileUtils.readFileToString(this.toSave, StandardCharsets.UTF_8), CONTENT_VERSION1);
 
@@ -153,7 +153,7 @@ public class FileSaveTransactionRunnableTest
     }
 
     @Test
-    public void rollbackAfterFailedCommit() throws Exception
+    void rollbackAfterFailedCommit() throws Exception
     {
         assertEquals(FileUtils.readFileToString(this.toSave, StandardCharsets.UTF_8), CONTENT_VERSION1);
 
@@ -174,7 +174,7 @@ public class FileSaveTransactionRunnableTest
     }
 
     @Test
-    public void saveWithNonexistantOriginalTest() throws Exception
+    void saveWithNonexistantOriginalTest() throws Exception
     {
         this.toSave.delete();
         assertFalse(this.toSave.exists());
@@ -189,7 +189,7 @@ public class FileSaveTransactionRunnableTest
     }
 
     @Test
-    public void rollbackWithNonexistantOriginalTest() throws Exception
+    void rollbackWithNonexistantOriginalTest() throws Exception
     {
         this.toSave.delete();
         assertFalse(this.toSave.exists());

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/src/test/java/org/xwiki/store/FileSystemStoreUtilsTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/src/test/java/org/xwiki/store/FileSystemStoreUtilsTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * 
  * @version $Id$
  */
-public class FileSystemStoreUtilsTest
+class FileSystemStoreUtilsTest
 {
     private void assertEncode(String encoded, String decoded, boolean caseInsensitive)
     {
@@ -40,7 +40,7 @@ public class FileSystemStoreUtilsTest
     // Tests
 
     @Test
-    public void encode()
+    void encode()
     {
         assertEncode("", "", true);
         assertEncode("", "", false);

--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-container/src/test/java/org/xwiki/url/internal/container/ContextAndActionURLNormalizerTest.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-container/src/test/java/org/xwiki/url/internal/container/ContextAndActionURLNormalizerTest.java
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.when;
  * @since 7.4M1
  */
 @ComponentTest
-public class ContextAndActionURLNormalizerTest
+class ContextAndActionURLNormalizerTest
 {
     @InjectMockComponents
     private ContextAndActionURLNormalizer normalizer;

--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-container/src/test/java/org/xwiki/url/internal/container/ContextExtendedURLURLNormalizerTest.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-container/src/test/java/org/xwiki/url/internal/container/ContextExtendedURLURLNormalizerTest.java
@@ -52,7 +52,7 @@ import static org.mockito.Mockito.when;
  * @since 6.1M2
  */
 @ComponentTest
-public class ContextExtendedURLURLNormalizerTest
+class ContextExtendedURLURLNormalizerTest
 {
     @InjectMockComponents
     private ContextExtendedURLURLNormalizer normalizer;

--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-container/src/test/java/org/xwiki/url/internal/container/URLURLNormalizerTest.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-container/src/test/java/org/xwiki/url/internal/container/URLURLNormalizerTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @version $Id$
  */
 @ComponentTest
-public class URLURLNormalizerTest
+class URLURLNormalizerTest
 {
     @InjectMockComponents
     private URLURLNormalizer normalizer;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-api/src/test/java/org/xwiki/user/CurrentUserReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-api/src/test/java/org/xwiki/user/CurrentUserReferenceTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  *
  * @version $Id$
  */
-public class CurrentUserReferenceTest
+class CurrentUserReferenceTest
 {
     @Test
     void isGlobal()

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-api/src/test/java/org/xwiki/user/EditorTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-api/src/test/java/org/xwiki/user/EditorTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * @version $Id$
  */
-public class EditorTest
+class EditorTest
 {
     @Test
     void fromString()

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-api/src/test/java/org/xwiki/user/GuestUserReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-api/src/test/java/org/xwiki/user/GuestUserReferenceTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * @version $Id$
  */
-public class GuestUserReferenceTest
+class GuestUserReferenceTest
 {
     @Test
     void isGlobal()

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-api/src/test/java/org/xwiki/user/SuperAdminUserReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-api/src/test/java/org/xwiki/user/SuperAdminUserReferenceTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * @version $Id$
  */
-public class SuperAdminUserReferenceTest
+class SuperAdminUserReferenceTest
 {
     @Test
     void isGlobal()

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-api/src/test/java/org/xwiki/user/UserTypeTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-api/src/test/java/org/xwiki/user/UserTypeTest.java
@@ -28,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * @version $Id$
  */
-public class UserTypeTest
+class UserTypeTest
 {
     @Test
     void fromString()


### PR DESCRIPTION
## Summary

Removes redundant `public` visibility modifiers from JUnit5 test classes and their test/lifecycle methods, as reported by SonarCloud rule [java:S5786](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS5786&ruleKey=java%3AS5786) ("JUnit5 test classes and methods should have default package visibility").

JUnit5 no longer requires test classes and methods to be `public`; the recommended visibility is package-private. This is a purely mechanical, behaviour-preserving change touching test code only (no production code).

## Details

- **31 test files** updated across 7 modules: `xwiki-platform-ratings-api`, `xwiki-platform-mail-general`, `xwiki-platform-user-api`, `xwiki-platform-like-api`, `xwiki-platform-url-container`, `xwiki-platform-observation-remote`, and `xwiki-platform-store-filesystem`.
- **60 redundant `public` modifiers** removed from test class declarations and their `@Test` / `@BeforeEach` / `@AfterEach` methods (and nested helper classes).
- No production code changed.

All 31 fixed issues belong to SonarCloud rule `java:S5786`. See the [open S5786 issues for this project](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&rules=java%3AS5786&issueStatuses=OPEN).

## Test plan

- `mvn clean install -Plegacy,snapshot -DskipTests` on the 7 affected modules in one reactor — BUILD SUCCESS (Checkstyle + test compilation pass).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CX6L9ucBVawVxyYztNfG5J)_