### PR TITLE
[Misc] Make JUnit5 test classes and methods package-private in oldcore (SonarCloud java:S5786)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/api/XWikiTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/api/XWikiTest.java
@@ -63,7 +63,7 @@ import static org.mockito.Mockito.when;
  */
 @OldcoreTest
 @ReferenceComponentList
-public class XWikiTest
+class XWikiTest
 {
     private static final DocumentReference DOCUMENT_REFERENCE = new DocumentReference("xwiki", "MilkyWay", "Fidis");
 
@@ -77,7 +77,7 @@ public class XWikiTest
     private XWiki apiXWiki;
 
     @BeforeEach
-    public void setup(MockitoOldcore mockitoOldcore) throws XWikiException
+    void setup(MockitoOldcore mockitoOldcore) throws XWikiException
     {
         XWikiContext xWikiContext = mockitoOldcore.getXWikiContext();
         this.apiXWiki = new XWiki(mockitoOldcore.getSpyXWiki(), xWikiContext);
@@ -98,7 +98,7 @@ public class XWikiTest
     }
 
     @Test
-    public void authorIsntChangedAfterDocumentCopy() throws XWikiException
+    void authorIsntChangedAfterDocumentCopy() throws XWikiException
     {
         String copyName = "Lyre";
         this.apiXWiki.copyDocument("MilkyWay.Fidis", copyName);
@@ -108,7 +108,7 @@ public class XWikiTest
     }
 
     @Test
-    public void creatorIsntChangedAfterDocumentCopy() throws XWikiException
+    void creatorIsntChangedAfterDocumentCopy() throws XWikiException
     {
         String copyName = "Sirius";
         this.apiXWiki.copyDocument("MilkyWay.Fidis", copyName);
@@ -118,7 +118,7 @@ public class XWikiTest
     }
 
     @Test
-    public void creationDateAfterDocumentCopy() throws XWikiException
+    void creationDateAfterDocumentCopy() throws XWikiException
     {
         String copyName = this.apiDocument.getDocumentReference().getName() + "Copy";
         long startTime = (Calendar.getInstance().getTimeInMillis() / 1000) * 1000;
@@ -130,7 +130,7 @@ public class XWikiTest
     }
 
     @Test
-    public void getAvailableRendererSyntax(MockitoComponentManager componentManager) throws Exception
+    void getAvailableRendererSyntax(MockitoComponentManager componentManager) throws Exception
     {
         PrintRendererFactory factory1 = componentManager.registerMockComponent(PrintRendererFactory.class,
             Syntax.PLAIN_1_0.toIdString());

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentMockitoTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentMockitoTest.java
@@ -111,7 +111,7 @@ import static org.mockito.Mockito.when;
 @OldcoreTest
 @ReferenceComponentList
 @XWikiDocumentFilterUtilsComponentList
-public class XWikiDocumentMockitoTest
+class XWikiDocumentMockitoTest
 {
     private static final String DOCWIKI = "wiki";
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/DefaultXWikiStubContextProviderTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/DefaultXWikiStubContextProviderTest.java
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @OldcoreTest
-public class DefaultXWikiStubContextProviderTest
+class DefaultXWikiStubContextProviderTest
 {
     @MockComponent
     private Execution execution;
@@ -67,7 +67,7 @@ public class DefaultXWikiStubContextProviderTest
     private XWikiURLFactoryService urlFactoryService = mock(XWikiURLFactoryService.class);
 
     @BeforeEach
-    public void beforeEach()
+    void beforeEach()
     {
         this.oldcore.getXWikiContext().setRequest(new XWikiServletRequestStub());
         this.oldcore.getXWikiContext().setResponse(new XWikiServletResponseStub());
@@ -80,7 +80,7 @@ public class DefaultXWikiStubContextProviderTest
     }
 
     @Test
-    public void createStubContext()
+    void createStubContext()
     {
         XWikiContext xcontext1 = this.provider.createStubContext();
         XWikiContext xcontext2 = this.provider.createStubContext();
@@ -92,7 +92,7 @@ public class DefaultXWikiStubContextProviderTest
     }
 
     @Test
-    public void createStubContextWithLoopProtection()
+    void createStubContextWithLoopProtection()
     {
         XWikiContext[] subContext = new XWikiContext[1];
 
@@ -115,7 +115,7 @@ public class DefaultXWikiStubContextProviderTest
     }
 
     @Test
-    public void createStubContextWithNoExecutionContext()
+    void createStubContextWithNoExecutionContext()
     {
         when(this.execution.getContext()).thenReturn(null);
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/XWikiStubContextInitializerTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/XWikiStubContextInitializerTest.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @OldcoreTest
-public class XWikiStubContextInitializerTest
+class XWikiStubContextInitializerTest
 {
     @MockComponent
     private XWikiStubContextProvider stubContextProvider;
@@ -46,7 +46,7 @@ public class XWikiStubContextInitializerTest
     private XWikiStubContextInitializer initializer;
 
     @Test
-    public void testWithAndWithoutXWikiContext() throws Exception
+    void testWithAndWithoutXWikiContext() throws Exception
     {
         XWikiContext stubContext = new XWikiContext();
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/context/XWikiContextContextStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/context/XWikiContextContextStoreTest.java
@@ -102,7 +102,7 @@ class XWikiContextContextStoreTest
     private URL requestwikiURL;
 
     @BeforeEach
-    public void beforeEach() throws WikiManagerException, ComponentLookupException, MalformedURLException
+    void beforeEach() throws WikiManagerException, ComponentLookupException, MalformedURLException
     {
         this.descriptor = new WikiDescriptor(WIKI, WIKI);
         this.descriptor.setMainPageReference(new DocumentReference(this.descriptor.getId(), "Space", "MainPage"));

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/doc/BaseObjectsTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/doc/BaseObjectsTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * 
  * @version $Id$
  */
-public class BaseObjectsTest
+class BaseObjectsTest
 {
     private static final class TestBaseObject extends BaseObject
     {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/filter/output/DocumentInstanceOutputFilterStreamTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/filter/output/DocumentInstanceOutputFilterStreamTest.java
@@ -454,7 +454,7 @@ class DocumentInstanceOutputFilterStreamTest extends AbstractInstanceFilterStrea
     }
 
     @Test
-    public void documentwithunknownClassproperty() throws FilterException, XWikiException
+    void documentwithunknownClassproperty() throws FilterException, XWikiException
     {
         DocumentInstanceOutputProperties outputProperties = new DocumentInstanceOutputProperties();
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/model/reference/CurrentEntityReferenceProviderTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/model/reference/CurrentEntityReferenceProviderTest.java
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.when;
  */
 @OldcoreTest
 @ComponentList(DefaultEntityReferenceProvider.class)
-public class CurrentEntityReferenceProviderTest
+class CurrentEntityReferenceProviderTest
 {
     private static final String CONTEXT_WIKI = "contextwiki";
 
@@ -120,7 +120,7 @@ public class CurrentEntityReferenceProviderTest
     private CurrentEntityReferenceProvider provider;
 
     @BeforeEach
-    public void beforeEach()
+    void beforeEach()
     {
         this.mockitoOldcore.getXWikiContext().setWikiId(null);
 
@@ -143,7 +143,7 @@ public class CurrentEntityReferenceProviderTest
     }
 
     @Test
-    public void getDefaultReferenceWithoutContextDocument()
+    void getDefaultReferenceWithoutContextDocument()
     {
         assertEquals(DEFAULT_WIKI_REFERENCE, this.provider.getDefaultReference(EntityType.WIKI));
 
@@ -163,7 +163,7 @@ public class CurrentEntityReferenceProviderTest
     }
 
     @Test
-    public void getDefaultReferenceWithContextDocument() throws IllegalAccessException
+    void getDefaultReferenceWithContextDocument() throws IllegalAccessException
     {
         this.mockitoOldcore.getXWikiContext().setWikiId(CONTEXT_WIKI);
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/model/reference/CurrentReferenceEntityReferenceResolverTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/model/reference/CurrentReferenceEntityReferenceResolverTest.java
@@ -48,7 +48,7 @@ import static org.mockito.Mockito.when;
  */
 @ComponentTest
 @ComponentList(DefaultEntityReferenceProvider.class)
-public class CurrentReferenceEntityReferenceResolverTest
+class CurrentReferenceEntityReferenceResolverTest
 {
     private static final String CURRENT_WIKI = "currentwiki";
 
@@ -102,7 +102,7 @@ public class CurrentReferenceEntityReferenceResolverTest
     private CurrentReferenceEntityReferenceResolver resolver;
 
     @BeforeEach
-    public void beforeEach() throws Exception
+    void beforeEach() throws Exception
     {
         when(this.currentProvider.getDefaultReference(EntityType.WIKI)).thenReturn(CURRENT_WIKI_REFERENCE);
         when(this.currentProvider.getDefaultReference(EntityType.SPACE)).thenReturn(CURRENT_SPACE_REFERENCE);
@@ -128,7 +128,7 @@ public class CurrentReferenceEntityReferenceResolverTest
     }
 
     @Test
-    public void testResolveAttachmentReferenceWhenMissingParents()
+    void testResolveAttachmentReferenceWhenMissingParents()
     {
         EntityReference reference =
             resolver.resolve(new EntityReference("filename", EntityType.ATTACHMENT), EntityType.ATTACHMENT);
@@ -142,7 +142,7 @@ public class CurrentReferenceEntityReferenceResolverTest
     }
 
     @Test
-    public void resolvePageReferenceWhenTypeIsDocument()
+    void resolvePageReferenceWhenTypeIsDocument()
     {
         EntityReference reference =
             this.resolver.resolve(new EntityReference("document", EntityType.DOCUMENT), EntityType.PAGE);
@@ -155,7 +155,7 @@ public class CurrentReferenceEntityReferenceResolverTest
     }
 
     @Test
-    public void resolvePageReferenceWhenTypeIsSpace()
+    void resolvePageReferenceWhenTypeIsSpace()
     {
         EntityReference reference =
             this.resolver.resolve(new EntityReference("space", EntityType.SPACE), EntityType.PAGE);
@@ -164,7 +164,7 @@ public class CurrentReferenceEntityReferenceResolverTest
     }
 
     @Test
-    public void resolveDocumentReferenceWhenTypeIsPage()
+    void resolveDocumentReferenceWhenTypeIsPage()
     {
         EntityReference reference =
             this.resolver.resolve(new EntityReference("page", EntityType.PAGE), EntityType.DOCUMENT);
@@ -179,7 +179,7 @@ public class CurrentReferenceEntityReferenceResolverTest
     }
 
     @Test
-    public void resolveSpaceReferenceWhenTypeIsPage()
+    void resolveSpaceReferenceWhenTypeIsPage()
     {
         EntityReference reference =
             this.resolver.resolve(new EntityReference("page", EntityType.PAGE), EntityType.SPACE);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/model/reference/CurrentStringEntityReferenceResolverTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/model/reference/CurrentStringEntityReferenceResolverTest.java
@@ -50,7 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @ComponentList(value = { CurrentEntityReferenceProvider.class, CurrentStringEntityReferenceResolver.class,
 DefaultModelConfiguration.class, DefaultSymbolScheme.class, ExplicitReferencePageReferenceResolver.class,
 ExplicitReferenceEntityReferenceResolver.class })
-public class CurrentStringEntityReferenceResolverTest
+class CurrentStringEntityReferenceResolverTest
 {
     @InjectMockitoOldcore
     private MockitoOldcore oldcore;
@@ -71,13 +71,13 @@ public class CurrentStringEntityReferenceResolverTest
     private CurrentStringEntityReferenceResolver resolver;
 
     @BeforeEach
-    public void beforeEach() throws Exception
+    void beforeEach() throws Exception
     {
         this.oldcore.getXWikiContext().setWikiId(CURRENT_WIKI);
     }
 
     @Test
-    public void testResolveDocumentReferenceWhenNoContextWiki() throws Exception
+    void testResolveDocumentReferenceWhenNoContextWiki() throws Exception
     {
         this.oldcore.getXWikiContext().setWikiId(null);
 
@@ -89,7 +89,7 @@ public class CurrentStringEntityReferenceResolverTest
     }
 
     @Test
-    public void testResolveDocumentReferenceWhenNoContextDocument() throws Exception
+    void testResolveDocumentReferenceWhenNoContextDocument() throws Exception
     {
         this.oldcore.getXWikiContext().setWikiId(null);
         this.oldcore.getXWikiContext().setDoc(null);
@@ -102,7 +102,7 @@ public class CurrentStringEntityReferenceResolverTest
     }
 
     @Test
-    public void testResolveDocumentReferenceWhenContextDocument() throws Exception
+    void testResolveDocumentReferenceWhenContextDocument() throws Exception
     {
         this.oldcore.getXWikiContext()
             .setDoc(new XWikiDocument(new DocumentReference(CURRENT_WIKI, CURRENTDOC_SPACE, CURRENTDOC_DOCUMENT)));
@@ -115,7 +115,7 @@ public class CurrentStringEntityReferenceResolverTest
     }
 
     @Test
-    public void testResolveAttachmentReference() throws Exception
+    void testResolveAttachmentReference() throws Exception
     {
         this.oldcore.getXWikiContext()
             .setDoc(new XWikiDocument(new DocumentReference(CURRENT_WIKI, CURRENTDOC_SPACE, CURRENTDOC_DOCUMENT)));
@@ -129,7 +129,7 @@ public class CurrentStringEntityReferenceResolverTest
     }
 
     @Test
-    public void testResolveAttachmentReferenceWhenMissingParentsAndNoContextDocument()
+    void testResolveAttachmentReferenceWhenMissingParentsAndNoContextDocument()
     {
         EntityReference reference = resolver.resolve("filename", EntityType.ATTACHMENT);
 
@@ -142,7 +142,7 @@ public class CurrentStringEntityReferenceResolverTest
     }
 
     @Test
-    public void testResolveAttachmentReferenceWhenMissingParentsAndContextDocument()
+    void testResolveAttachmentReferenceWhenMissingParentsAndContextDocument()
     {
         this.oldcore.getXWikiContext()
             .setDoc(new XWikiDocument(new DocumentReference("docwiki", CURRENT_SPACE, CURRENT_DOCUMENT)));
@@ -158,7 +158,7 @@ public class CurrentStringEntityReferenceResolverTest
     }
 
     @Test
-    public void testResolvePageReferenceKeywords() throws Exception
+    void testResolvePageReferenceKeywords() throws Exception
     {
         XWikiDocument document = new XWikiDocument(new DocumentReference("docwiki", CURRENT_SPACE, CURRENT_PAGE));
         FieldUtils.writeDeclaredField(document, "pageReferenceCache",

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/model/reference/SpaceReferenceConverterTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/model/reference/SpaceReferenceConverterTest.java
@@ -53,7 +53,7 @@ import static org.mockito.Mockito.when;
 @ComponentTest
 @ComponentList({DefaultConverterManager.class, ContextComponentManagerProvider.class, EnumConverter.class,
     ConvertUtilsConverter.class})
-public class SpaceReferenceConverterTest
+class SpaceReferenceConverterTest
 {
     @InjectMockComponents
     private SpaceReferenceConverter spaceReferenceConverter;
@@ -72,13 +72,13 @@ public class SpaceReferenceConverterTest
     private EntityReferenceSerializer<String> mockSerialier;
 
     @BeforeEach
-    public void setup(MockitoComponentManager componentManager) throws ComponentLookupException
+    void setup(MockitoComponentManager componentManager) throws ComponentLookupException
     {
         this.converterManager = componentManager.getInstance(ConverterManager.class);
     }
 
     @Test
-    public void testConvertFromString()
+    void testConvertFromString()
     {
         when(this.mockStringResolver.resolve("wiki:space", EntityType.SPACE))
             .thenReturn(new EntityReference("space", EntityType.SPACE, new WikiReference("wiki")));
@@ -87,7 +87,7 @@ public class SpaceReferenceConverterTest
     }
 
     @Test
-    public void testConvertFromReference()
+    void testConvertFromReference()
     {
         EntityReference reference;
 
@@ -100,13 +100,13 @@ public class SpaceReferenceConverterTest
     }
 
     @Test
-    public void testConvertFromNull()
+    void testConvertFromNull()
     {
         assertNull(this.converterManager.convert(SpaceReference.class, null));
     }
 
     @Test
-    public void testConvertToString()
+    void testConvertToString()
     {
         when(this.mockSerialier.serialize(new SpaceReference("wiki", "space"))).thenReturn("wiki:space");
         assertEquals("wiki:space", this.converterManager.convert(String.class, new SpaceReference("wiki", "space")));

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/objects/classes/DefaultPageQueryBuilderTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/objects/classes/DefaultPageQueryBuilderTest.java
@@ -42,7 +42,7 @@ import static org.mockito.Mockito.when;
  * @since 10.6
  */
 @ComponentTest
-public class DefaultPageQueryBuilderTest
+class DefaultPageQueryBuilderTest
 {
     @InjectMockComponents
     private DefaultPageQueryBuilder queryBuilder;
@@ -56,7 +56,7 @@ public class DefaultPageQueryBuilderTest
     private QueryBuilder<PageClass> implicitlyAllowedValuesQueryBuilder;
 
     @Test
-    public void build() throws Exception
+    void build() throws Exception
     {
         PageClass pageClass = new PageClass();
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/objects/classes/ExplicitlyAllowedValuesDBListQueryBuilderTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/objects/classes/ExplicitlyAllowedValuesDBListQueryBuilderTest.java
@@ -62,7 +62,7 @@ import static org.mockito.Mockito.when;
  * @since 9.8RC1
  */
 @ComponentTest
-public class ExplicitlyAllowedValuesDBListQueryBuilderTest
+class ExplicitlyAllowedValuesDBListQueryBuilderTest
 {
     private static final DocumentReference DOCUMENT_REFERENCE = new DocumentReference("math", "Some", "Page");
 
@@ -96,7 +96,7 @@ public class ExplicitlyAllowedValuesDBListQueryBuilderTest
     private DBListClass dbListClass = new DBListClass();
 
     @BeforeEach
-    public void configure() throws Exception
+    void configure() throws Exception
     {
         XWikiDocument ownerDocument = mock(XWikiDocument.class);
         when(ownerDocument.getDocumentReference()).thenReturn(DOCUMENT_REFERENCE);
@@ -113,7 +113,7 @@ public class ExplicitlyAllowedValuesDBListQueryBuilderTest
     }
 
     @Test
-    public void buildWithScriptRight() throws Exception
+    void buildWithScriptRight() throws Exception
     {
         when(this.authorizationManager.hasAccess(Right.SCRIPT, EntityType.DOCUMENT, AUTHOR_REFERENCE,
             DOCUMENT_REFERENCE)).thenReturn(true);
@@ -148,7 +148,7 @@ public class ExplicitlyAllowedValuesDBListQueryBuilderTest
     }
 
     @Test
-    public void buildWithoutScriptRight() throws Exception
+    void buildWithoutScriptRight() throws Exception
     {
         Query query = mock(Query.class);
         when(this.secureQueryManager.createQuery(this.dbListClass.getSql(), Query.HQL)).thenReturn(query);
@@ -161,7 +161,7 @@ public class ExplicitlyAllowedValuesDBListQueryBuilderTest
     }
 
     @Test
-    public void buildWithDocFullNameAppliesViewableFilter() throws Exception
+    void buildWithDocFullNameAppliesViewableFilter() throws Exception
     {
         String sqlWithFullName = "select distinct doc.fullName as unfilterableRightCheck, doc.web from XWikiDocument "
             + "doc where doc.name = 'WebHome' order by doc.web";

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/objects/classes/ImplicitlyAllowedValuesPageQueryBuilderTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/objects/classes/ImplicitlyAllowedValuesPageQueryBuilderTest.java
@@ -37,13 +37,13 @@ import static org.mockito.Mockito.when;
  * @since 10.6
  */
 @ComponentTest
-public class ImplicitlyAllowedValuesPageQueryBuilderTest
+class ImplicitlyAllowedValuesPageQueryBuilderTest
 {
     @InjectMockComponents
     private ImplicitlyAllowedValuesPageQueryBuilder queryBuilder;
 
     @Test
-    public void build() throws Exception
+    void build() throws Exception
     {
         PageClass pageClass = mock(PageClass.class);
         DBListClass dbListClass = mock(DBListClass.class);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/objects/classes/XClassMigratorListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/objects/classes/XClassMigratorListenerTest.java
@@ -57,7 +57,7 @@ import static org.mockito.Mockito.when;
 @OldcoreTest
 @ComponentList({ DefaultObservationManager.class, PropertyConverter.class, XClassPropertyEventGeneratorListener.class })
 @ReferenceComponentList
-public class XClassMigratorListenerTest
+class XClassMigratorListenerTest
 {
     @MockComponent
     private QueryManager mockQueryManager;
@@ -73,7 +73,7 @@ public class XClassMigratorListenerTest
     private XWikiDocument xclassDocument;
 
     @BeforeEach
-    public void beforeEach() throws Exception
+    void beforeEach() throws Exception
     {
         this.xclassDocument = new XWikiDocument(new DocumentReference("wiki", "Space", "Class"));
         this.xclassDocument.setSyntax(Syntax.PLAIN_1_0);
@@ -105,7 +105,7 @@ public class XClassMigratorListenerTest
     // Tests
 
     @Test
-    public void migrateProperty() throws Exception
+    void migrateProperty() throws Exception
     {
         this.xclassDocument.getXClass().addTextField("property", "property", 30);
         this.xclassDocument.getXClass().addNumberField("property2", "property2", 30, "integer");
@@ -135,7 +135,7 @@ public class XClassMigratorListenerTest
     }
 
     @Test
-    public void addNewProperty() throws Exception
+    void addNewProperty() throws Exception
     {
         this.oldcore.getSpyXWiki().saveDocument(this.xobjectDocument, this.oldcore.getXWikiContext());
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/render/ScriptXWikiServletRequestTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/render/ScriptXWikiServletRequestTest.java
@@ -58,7 +58,7 @@ import static org.mockito.Mockito.when;
  * 
  * @version $Id$
  */
-public class ScriptXWikiServletRequestTest
+class ScriptXWikiServletRequestTest
 {
     private final ContextualAuthorizationManager authorization = mock(ContextualAuthorizationManager.class);
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/resource/DefaultEntityResourceActionListerTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/resource/DefaultEntityResourceActionListerTest.java
@@ -60,7 +60,7 @@ class DefaultEntityResourceActionListerTest
     private MockitoComponentManager componentManager;
 
     @BeforeEach
-    public void beforeEach() throws Exception
+    void beforeEach() throws Exception
     {
         when(this.componentManagerProvider.get()).thenReturn(this.componentManager);
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/store/PropertyConverterTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/store/PropertyConverterTest.java
@@ -56,7 +56,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class PropertyConverterTest
+class PropertyConverterTest
 {
     @InjectMockComponents
     private PropertyConverter converter;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/store/hibernate/query/HqlQueryUtilsTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/internal/store/hibernate/query/HqlQueryUtilsTest.java
@@ -28,10 +28,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * 
  * @version $Id$
  */
-public class HqlQueryUtilsTest
+class HqlQueryUtilsTest
 {
     @Test
-    public void replaceLegacyQueryParameters()
+    void replaceLegacyQueryParameters()
     {
         assertEquals("select column from table where table.column = ?1",
             HqlQueryUtils.replaceLegacyQueryParameters("select column from table where table.column = ?"));
@@ -54,7 +54,7 @@ public class HqlQueryUtilsTest
     }
 
     @Test
-    public void toCompleteStatement()
+    void toCompleteStatement()
     {
         assertEquals("from table", HqlQueryUtils.toCompleteStatement("from table"));
         assertEquals("select * from table", HqlQueryUtils.toCompleteStatement("select * from table"));
@@ -68,7 +68,7 @@ public class HqlQueryUtilsTest
     }
 
     @Test
-    public void getValidQueryOrder()
+    void getValidQueryOrder()
     {
         assertEquals("asc", HqlQueryUtils.getValidQueryOrder("asc", "desc"));
         assertEquals("desc", HqlQueryUtils.getValidQueryOrder("desc", "asc"));

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/BaseStringPropertyTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/BaseStringPropertyTest.java
@@ -37,13 +37,13 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @OldcoreTest
-public class BaseStringPropertyTest
+class BaseStringPropertyTest
 {
     @InjectMockitoOldcore
     private MockitoOldcore oldcore;
 
     @Test
-    public void testHashCode()
+    void testHashCode()
     {
         String value = "test value";
 
@@ -57,7 +57,7 @@ public class BaseStringPropertyTest
     }
 
     @Test
-    public void setValueWhenTypeIsNotString() throws Exception
+    void setValueWhenTypeIsNotString() throws Exception
     {
         BaseStringProperty p = new BaseStringProperty();
         Integer value = new Integer(42);
@@ -73,7 +73,7 @@ public class BaseStringPropertyTest
     }
 
     @Test
-    public void setValueWhenTypeIsNotStringAndSameValue() throws Exception
+    void setValueWhenTypeIsNotStringAndSameValue() throws Exception
     {
         BaseStringProperty p = new BaseStringProperty();
         Integer value = new Integer(42);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/GroupsClassTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/GroupsClassTest.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.verify;
  * @version $Id$
  * @since 14.2RC1
  */
-public class GroupsClassTest
+class GroupsClassTest
 {
     @Test
     void fromList()

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/LevelsClassTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/classes/LevelsClassTest.java
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.when;
  * @since 13.3RC1
  * @since 12.10.7
  */
-public class LevelsClassTest
+class LevelsClassTest
 {
     private final static List<String> DEFAULT_LIST = Arrays.asList(
         "admin",

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/pdf/impl/FileSystemURLFactoryTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/pdf/impl/FileSystemURLFactoryTest.java
@@ -60,7 +60,7 @@ import static org.mockito.Mockito.when;
 @OldcoreTest
 @ReferenceComponentList
 @ComponentList({DefaultLegacySpaceResolver.class})
-public class FileSystemURLFactoryTest
+class FileSystemURLFactoryTest
 {
     private static final DocumentReference USER_REFERENCE = new DocumentReference("xwiki", "XWiki", "Alice");
 
@@ -83,7 +83,7 @@ public class FileSystemURLFactoryTest
     private XWikiRequest mockXWikiRequest;
 
     @BeforeEach
-    public void beforeEach() throws XWikiException, IOException
+    void beforeEach() throws XWikiException, IOException
     {
         this.oldcore.getXWikiContext().setUserReference(USER_REFERENCE);
 
@@ -100,7 +100,7 @@ public class FileSystemURLFactoryTest
     }
 
     @Test
-    public void createAttachmentURLWhenAttachmentDoesntExist() throws Exception
+    void createAttachmentURLWhenAttachmentDoesntExist() throws Exception
     {
         Map<String, File> usedFiles = new HashMap<>();
         this.oldcore.getXWikiContext().put("pdfexport-file-mapping", usedFiles);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/plugin/packaging/ImportTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/plugin/packaging/ImportTest.java
@@ -54,7 +54,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ImportTest extends AbstractPackageTest
+class ImportTest extends AbstractPackageTest
 {
     LocalizationContext localizationContext;
 
@@ -90,7 +90,7 @@ public class ImportTest extends AbstractPackageTest
      * @throws Exception
      */
     @Test
-    public void testImportDocument() throws Exception
+    void testImportDocument() throws Exception
     {
         XWikiDocument doc1 =
             new XWikiDocument(new DocumentReference(this.oldcore.getXWikiContext().getWikiId(), "Test", "DocImport"));
@@ -132,7 +132,7 @@ public class ImportTest extends AbstractPackageTest
      * @throws Exception
      */
     @Test
-    public void testImportExtension() throws Exception
+    void testImportExtension() throws Exception
     {
         ExtensionId extensionId = new ExtensionId("test", "1.0");
 
@@ -201,7 +201,7 @@ public class ImportTest extends AbstractPackageTest
      * @throws Exception
      */
     @Test
-    public void testImportDocumentNonAsciiTitle() throws Exception
+    void testImportDocumentNonAsciiTitle() throws Exception
     {
         XWikiDocument doc1 = new XWikiDocument(
             new DocumentReference(this.oldcore.getXWikiContext().getWikiId(), "Test", "\u60A8\u597D\u4E16\u754C"));
@@ -243,7 +243,7 @@ public class ImportTest extends AbstractPackageTest
      * @throws Exception
      */
     @Test
-    public void testImportDocumentNonAsciiTitleNonUtf8PlatformEncoding() throws Exception
+    void testImportDocumentNonAsciiTitleNonUtf8PlatformEncoding() throws Exception
     {
         String oldEncoding = System.getProperty("file.encoding");
         System.setProperty("file.encoding", "ISO-8859-1");
@@ -292,7 +292,7 @@ public class ImportTest extends AbstractPackageTest
      * @throws Exception
      */
     @Test
-    public void testImportDocumentXarCreatedByCommonsCompress() throws Exception
+    void testImportDocumentXarCreatedByCommonsCompress() throws Exception
     {
         XWikiDocument doc1 =
             new XWikiDocument(new DocumentReference(this.oldcore.getXWikiContext().getWikiId(), "Test", "DocImport"));
@@ -335,7 +335,7 @@ public class ImportTest extends AbstractPackageTest
      * @throws Exception
      */
     @Test
-    public void testImportOverwriteDocument() throws Exception
+    void testImportOverwriteDocument() throws Exception
     {
         XWikiDocument doc1 = new XWikiDocument(
             new DocumentReference(this.oldcore.getXWikiContext().getWikiId(), "Test", "DocImportOverwrite"));
@@ -382,7 +382,7 @@ public class ImportTest extends AbstractPackageTest
      * @throws Exception
      */
     @Test
-    public void testImportTranslationsOverwrite() throws Exception
+    void testImportTranslationsOverwrite() throws Exception
     {
         XWikiDocument original = new XWikiDocument(
             new DocumentReference(this.oldcore.getXWikiContext().getWikiId(), "Test", "DocTranslation"));

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/plugin/packaging/PackageTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/plugin/packaging/PackageTest.java
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.doReturn;
  * 
  * @version $Id$
  */
-public class PackageTest extends AbstractPackageTest
+class PackageTest extends AbstractPackageTest
 {
     private Package pack;
 
@@ -47,7 +47,7 @@ public class PackageTest extends AbstractPackageTest
     }
 
     @Test
-    public void testImportWithHeterogeneousEncodingInFiles() throws Exception
+    void testImportWithHeterogeneousEncodingInFiles() throws Exception
     {
         String docTitle = "Un \u00e9t\u00e9 36";
         String docContent = "\u00e0\u00e7\u00e9\u00e8\u00c0\u00c7\u00c9\u00c8\u00ef\u00f6\u00eb\u00fc";
@@ -73,7 +73,7 @@ public class PackageTest extends AbstractPackageTest
     }
 
     @Test
-    public void testImportWithHeterogeneousEncodingInFilesUsingCommonsCompress() throws Exception
+    void testImportWithHeterogeneousEncodingInFilesUsingCommonsCompress() throws Exception
     {
         String docTitle = "Un \u00e9t\u00e9 36";
         String docContent = "\u00e0\u00e7\u00e9\u00e8\u00c0\u00c7\u00c9\u00c8\u00ef\u00f6\u00eb\u00fc";

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/hibernate/query/HqlQueryExecutorTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/hibernate/query/HqlQueryExecutorTest.java
@@ -128,7 +128,7 @@ class HqlQueryExecutorTest
     }
 
     @BeforeEach
-    public void beforeEach() throws Exception
+    void beforeEach() throws Exception
     {
         when(this.authorization.hasAccess(Right.PROGRAM)).then(new Answer<Boolean>()
         {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/hibernate/query/VersioningStoreQueryFactoryTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/hibernate/query/VersioningStoreQueryFactoryTest.java
@@ -71,7 +71,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class VersioningStoreQueryFactoryTest
+class VersioningStoreQueryFactoryTest
 {
     @Mock
     private Session session;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/internal/script/XWikiScriptContextInitializerTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/internal/script/XWikiScriptContextInitializerTest.java
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @OldcoreTest
-public class XWikiScriptContextInitializerTest
+class XWikiScriptContextInitializerTest
 {
     @InjectMockitoOldcore
     MockitoOldcore oldcore;
@@ -63,7 +63,7 @@ public class XWikiScriptContextInitializerTest
     ScriptContext scriptContext = new SimpleScriptContext();
 
     @Test
-    public void getServletContext()
+    void getServletContext()
     {
         this.oldcore.getXWikiContext().setRequest(new XWikiServletRequestStub()
         {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/internal/template/ActionTemplateRequirementTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/internal/template/ActionTemplateRequirementTest.java
@@ -35,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * @version $Id$
  */
 @OldcoreTest
-public class ActionTemplateRequirementTest
+class ActionTemplateRequirementTest
 {
     @InjectMockComponents
     private ActionTemplateRequirement requirement;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/internal/velocity/XWikiVelocityManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/internal/velocity/XWikiVelocityManagerTest.java
@@ -71,7 +71,7 @@ import static org.mockito.Mockito.when;
     DefaultLoggerConfiguration.class
 })
 @OldcoreTest
-public class XWikiVelocityManagerTest
+class XWikiVelocityManagerTest
 {
     private static final DocumentReference TEMPLATE_DOCUMENT = new DocumentReference("xwiki", "XWiki", "TestMacros");
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/query/hql/internal/DefaultHQLStatementValidatorTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/query/hql/internal/DefaultHQLStatementValidatorTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * @version $Id$
  */
 @ComponentTest
-public class DefaultHQLStatementValidatorTest
+class DefaultHQLStatementValidatorTest
 {
     @InjectMockComponents
     private DefaultHQLStatementValidator validator;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/security/authservice/internal/AuthServiceConfigurationTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/org/xwiki/security/authservice/internal/AuthServiceConfigurationTest.java
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.when;
  */
 @OldcoreTest
 @ReferenceComponentList
-public class AuthServiceConfigurationTest
+class AuthServiceConfigurationTest
 {
     @InjectMockComponents
     private AuthServiceConfiguration configuration;


### PR DESCRIPTION
## Summary

Removes redundant `public` visibility modifiers from JUnit5 test classes and their test/lifecycle methods in `xwiki-platform-oldcore`, as reported by SonarCloud rule [java:S5786](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS5786&ruleKey=java%3AS5786) ("JUnit5 test classes and methods should have default package visibility").

JUnit5 no longer requires test classes and methods to be `public`; the recommended visibility is package-private. This is a purely mechanical, behaviour-preserving change touching test code only (no production code).

## Details

- **32 test files** updated in the `xwiki-platform-oldcore` module.
- **91 redundant `public` modifiers** removed from test class declarations and their `@Test` / `@BeforeEach` / `@AfterEach` lifecycle methods.
- No production code changed. Verified no test class is extended from another module (no cross-module compile impact).

All 32 fixed issues belong to SonarCloud rule `java:S5786`. See the [open S5786 issues for this project](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&rules=java%3AS5786&issueStatuses=OPEN).

## Test plan

- `mvn clean install -Plegacy,snapshot -DskipTests` on `xwiki-platform-core/xwiki-platform-oldcore` — BUILD SUCCESS (Checkstyle + test compilation pass).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019R3zj9FuwN3H8jWVm3PZox)_