### PR TITLE
[Misc] Merge collapsible nested if statements and remove unused code (SonarCloud)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
@@ -8004,11 +8004,9 @@ public class XWiki implements EventListener
             String fullName = entry.getKey();
 
             XWikiDocument doc = getDocument(fullName, context);
-            if (checkRight) {
-                if (!context.getWiki().getRightService().hasAccessLevel("view", context.getUser(), doc.getFullName(),
-                    context)) {
-                    continue;
-                }
+            if (checkRight && !context.getWiki().getRightService().hasAccessLevel("view", context.getUser(),
+                doc.getFullName(), context)) {
+                continue;
             }
             List<String> returnedAttachmentNames = entry.getValue();
             for (XWikiAttachment attach : doc.getAttachmentList()) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/doc/XWikiDocument.java
@@ -4304,11 +4304,10 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
         }
 
         String creator = eform.getCreator();
-        if ((creator != null) && (!creator.equals(getCreator()))) {
-            if ((getCreatorReference().equals(context.getUserReference()))
-                || (context.getWiki().getRightService().hasAdminRights(context))) {
-                setCreator(creator);
-            }
+        if ((creator != null) && (!creator.equals(getCreator()))
+            && ((getCreatorReference().equals(context.getUserReference()))
+                || (context.getWiki().getRightService().hasAdminRights(context)))) {
+            setCreator(creator);
         }
 
         String parent = eform.getParent();
@@ -7868,6 +7867,7 @@ public class XWikiDocument implements DocumentModelBridge, Cloneable, Disposable
      * use more rights than defined in the object, {@code false} otherwise
      * @since 16.10.0RC1
      */
+    @Override
     public boolean isEnforceRequiredRights()
     {
         return this.enforceRequiredRights;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/plugin/rightsmanager/UserIterator.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/plugin/rightsmanager/UserIterator.java
@@ -295,17 +295,15 @@ public class UserIterator<T> implements Iterator<T>
         boolean isGroupReference = members != null && !members.isEmpty();
 
         // If we have a group reference then stack the group members
-        if (isGroupReference) {
-            // Ensure groups are visited only once to prevent potential infinite loops
-            if (!processedGroups.contains(currentReference)) {
-                processedGroups.add(currentReference);
+        // Ensure groups are visited only once to prevent potential infinite loops
+        if (isGroupReference && !processedGroups.contains(currentReference)) {
+            processedGroups.add(currentReference);
 
-                // Extract the references and push them on the stack as an iterator
-                Collection<DocumentReference> groupMemberReferences =
-                    convertToDocumentReferences(members, currentReference);
-                if (!groupMemberReferences.isEmpty()) {
-                    this.userAndGroupIteratorStack.push(groupMemberReferences.iterator());
-                }
+            // Extract the references and push them on the stack as an iterator
+            Collection<DocumentReference> groupMemberReferences =
+                convertToDocumentReferences(members, currentReference);
+            if (!groupMemberReferences.isEmpty()) {
+                this.userAndGroupIteratorStack.push(groupMemberReferences.iterator());
             }
         }
         // If we have a user reference then we'll just return it

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/velocity/DefaultVelocityEvaluator.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/velocity/DefaultVelocityEvaluator.java
@@ -65,15 +65,14 @@ public class DefaultVelocityEvaluator implements VelocityEvaluator
         try {
             // Switch current namespace if needed
             String currentNamespace = renderingContext.getTransformationId();
-            if (namespace != null && !Strings.CS.equals(namespace, currentNamespace)) {
-                if (renderingContext instanceof MutableRenderingContext) {
-                    // Make the current velocity template id available
-                    ((MutableRenderingContext) renderingContext).push(renderingContext.getTransformation(),
-                        renderingContext.getXDOM(), renderingContext.getDefaultSyntax(), namespace,
-                        renderingContext.isRestricted(), renderingContext.getTargetSyntax());
+            if (namespace != null && !Strings.CS.equals(namespace, currentNamespace)
+                && renderingContext instanceof MutableRenderingContext) {
+                // Make the current velocity template id available
+                ((MutableRenderingContext) renderingContext).push(renderingContext.getTransformation(),
+                    renderingContext.getXDOM(), renderingContext.getDefaultSyntax(), namespace,
+                    renderingContext.isRestricted(), renderingContext.getTargetSyntax());
 
-                    renderingContextPushed = true;
-                }
+                renderingContextPushed = true;
             }
 
             velocityManager.getVelocityEngine().evaluate(vcontext, writer, namespace, content);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseCollection.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseCollection.java
@@ -749,22 +749,20 @@ public abstract class BaseCollection<R extends EntityReference> extends BaseElem
             if (!isSensitive && oldProperty != null) {
                 isSensitive = oldProperty.isSensitive(context);
             }
-            if (newProperty == null) {
-                // The property exists in the old object, but not in the new one
-                if ((oldProperty != null) && (!"".equals(oldProperty.toText()))) {
-                    if (pclass != null) {
-                        // Put the values as they would be displayed in the interface
-                        String oldPropertyValue = (oldProperty.getValue() instanceof String) ? oldProperty.toText()
-                            : pclass.displayView(propertyName, oldCollection, context);
-                        difflist.add(new ObjectDiff(oldCollection.getXClassReference(), oldCollection.getNumber(), "",
-                            ObjectDiff.ACTION_PROPERTYREMOVED, propertyName, propertyType, oldPropertyValue, "",
-                            isSensitive));
-                    } else {
-                        // Cannot get property definition, so use the plain value
-                        difflist.add(new ObjectDiff(oldCollection.getXClassReference(), oldCollection.getNumber(), "",
-                            ObjectDiff.ACTION_PROPERTYREMOVED, propertyName, propertyType, oldProperty.toText(), "",
-                            isSensitive));
-                    }
+            // The property exists in the old object, but not in the new one
+            if (newProperty == null && (oldProperty != null) && (!"".equals(oldProperty.toText()))) {
+                if (pclass != null) {
+                    // Put the values as they would be displayed in the interface
+                    String oldPropertyValue = (oldProperty.getValue() instanceof String) ? oldProperty.toText()
+                        : pclass.displayView(propertyName, oldCollection, context);
+                    difflist.add(new ObjectDiff(oldCollection.getXClassReference(), oldCollection.getNumber(), "",
+                        ObjectDiff.ACTION_PROPERTYREMOVED, propertyName, propertyType, oldPropertyValue, "",
+                        isSensitive));
+                } else {
+                    // Cannot get property definition, so use the plain value
+                    difflist.add(new ObjectDiff(oldCollection.getXClassReference(), oldCollection.getNumber(), "",
+                        ObjectDiff.ACTION_PROPERTYREMOVED, propertyName, propertyType, oldProperty.toText(), "",
+                        isSensitive));
                 }
             }
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseObject.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/BaseObject.java
@@ -407,17 +407,15 @@ public class BaseObject extends BaseCollection<BaseObjectReference> implements O
         if (!isSensitive && oldProperty != null) {
             isSensitive = oldProperty.isSensitive(context);
         }
-        if (newProperty == null) {
-            // The property exists in the old object, but not in the new one
-            if ((oldProperty != null) && (!oldProperty.toText().isEmpty())) {
-                String oldPropertyValue = getDiffPropertyValue(context, oldProperty, oldpclass, propertyName,
-                    oldObject);
-                String pClassType = (oldpclass != null) ? oldpclass.getClassType() : "";
-                difflist.add(
-                    new ObjectDiff(oldObject.getXClassReference(), oldObject.getNumber(), oldObject.getGuid(),
-                        ObjectDiff.ACTION_PROPERTYREMOVED, propertyName, pClassType, oldPropertyValue, "",
-                        isSensitive));
-            }
+        // The property exists in the old object, but not in the new one
+        if (newProperty == null && (oldProperty != null) && (!oldProperty.toText().isEmpty())) {
+            String oldPropertyValue = getDiffPropertyValue(context, oldProperty, oldpclass, propertyName,
+                oldObject);
+            String pClassType = (oldpclass != null) ? oldpclass.getClassType() : "";
+            difflist.add(
+                new ObjectDiff(oldObject.getXClassReference(), oldObject.getNumber(), oldObject.getGuid(),
+                    ObjectDiff.ACTION_PROPERTYREMOVED, propertyName, pClassType, oldPropertyValue, "",
+                    isSensitive));
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
@@ -1063,14 +1063,13 @@ public abstract class ListClass extends PropertyClass
         XWikiContext context, MergeResult mergeResult)
     {
         // If it's not a multiselect then we don't have any special merge to do. We keep default StringProperty behavior
-        if (isMultiSelect()) {
-            // If not a free input assume it's not an ordered list
-            if (!DISPLAYTYPE_INPUT.equals(getDisplayType()) && currentProperty instanceof ListProperty) {
-                mergeNotOrderedListProperty(currentProperty, previousProperty, newProperty, configuration, context,
-                    mergeResult);
+        // If not a free input assume it's not an ordered list
+        if (isMultiSelect() && !DISPLAYTYPE_INPUT.equals(getDisplayType())
+            && currentProperty instanceof ListProperty) {
+            mergeNotOrderedListProperty(currentProperty, previousProperty, newProperty, configuration, context,
+                mergeResult);
 
-                return;
-            }
+            return;
         }
 
         // Fallback on default ListProperty merging

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/pdf/impl/FileSystemURLFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/pdf/impl/FileSystemURLFactory.java
@@ -118,11 +118,10 @@ public class FileSystemURLFactory extends XWikiServletURLFactory
         try {
             Map<String, File> usedFiles = getFileMapping(context);
             String key = getSkinfileKey(filename, skin);
-            if (!usedFiles.containsKey(key)) {
-                if (!copyResource("/skins/" + skin + '/' + filename, key, usedFiles, context)) {
-                    // The resource does not exist, just return a http:// URL
-                    return super.createSkinURL(filename, skin, context);
-                }
+            if (!usedFiles.containsKey(key)
+                && !copyResource("/skins/" + skin + '/' + filename, key, usedFiles, context)) {
+                // The resource does not exist, just return a http:// URL
+                return super.createSkinURL(filename, skin, context);
             }
             return usedFiles.get(key).toURI().toURL();
         } catch (Exception ex) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/Package.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/Package.java
@@ -713,10 +713,9 @@ public class Package
 
             // Install the remaining documents (without class definitions).
             for (DocumentInfo docInfo : this.files) {
-                if (!this.classFiles.contains(docInfo)) {
-                    if (installDocument(docInfo, isAdmin, backup, context) == DocumentInfo.INSTALL_ERROR) {
-                        status = DocumentInfo.INSTALL_ERROR;
-                    }
+                if (!this.classFiles.contains(docInfo)
+                    && installDocument(docInfo, isAdmin, backup, context) == DocumentInfo.INSTALL_ERROR) {
+                    status = DocumentInfo.INSTALL_ERROR;
                 }
             }
             setStatus(status, context);
@@ -924,12 +923,11 @@ public class Package
                 context.getWiki().saveDocument(doc.getDoc(), saveMessage, context);
                 addToInstalled(doc.getFullName() + ":" + doc.getLanguage(), context);
 
-                if ((this.withVersions && packageHasHistory) || conserveExistingHistory) {
-                    // we need to force the saving the document archive.
-                    if (doc.getDoc().getDocumentArchive() != null) {
-                        context.getWiki().getVersioningStore()
-                            .saveXWikiDocArchive(doc.getDoc().getDocumentArchive(context), true, context);
-                    }
+                // we need to force the saving the document archive.
+                if (((this.withVersions && packageHasHistory) || conserveExistingHistory)
+                    && doc.getDoc().getDocumentArchive() != null) {
+                    context.getWiki().getVersioningStore()
+                        .saveXWikiDocArchive(doc.getDoc().getDocumentArchive(context), true, context);
                 }
 
                 if (shouldResetToInitialVersion) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/security/XWikiSecurityManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/security/XWikiSecurityManager.java
@@ -34,22 +34,18 @@ public class XWikiSecurityManager extends SecurityManager
     @Override
     public void checkPermission(Permission perm)
     {
-        if (this.enabled) {
-            // Under this security manager we refuse reflect code
-            if (perm instanceof ReflectPermission) {
-                throw new SecurityException();
-            }
+        // Under this security manager we refuse reflect code
+        if (this.enabled && perm instanceof ReflectPermission) {
+            throw new SecurityException();
         }
     }
 
     @Override
     public void checkPermission(Permission perm, Object context)
     {
-        if (this.enabled) {
-            // Under this security manager we refuse reflect code
-            if (perm instanceof ReflectPermission) {
-                throw new SecurityException();
-            }
+        // Under this security manager we refuse reflect code
+        if (this.enabled && perm instanceof ReflectPermission) {
+            throw new SecurityException();
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
@@ -826,17 +826,15 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
             // It's possible the space does not yet exist yet
             maybeCreateSpace(document.getDocumentReference().getLastSpaceReference(), document.isHidden(), session);
 
-            if (!document.isNew()) {
-                // If the hidden state of an existing document did not changed there is nothing to do
-                if (document.isHidden() != document.getOriginalDocument().isHidden()) {
-                    if (document.isHidden()) {
-                        // If the document became hidden it's possible the space did too
-                        maybeMakeSpaceHidden(document.getDocumentReference().getLastSpaceReference(),
-                            document.getFullName(), session);
-                    } else {
-                        // If the document became visible then all its parents should be visible as well
-                        makeSpaceVisible(document.getDocumentReference().getLastSpaceReference(), session);
-                    }
+            // If the hidden state of an existing document did not changed there is nothing to do
+            if (!document.isNew() && document.isHidden() != document.getOriginalDocument().isHidden()) {
+                if (document.isHidden()) {
+                    // If the document became hidden it's possible the space did too
+                    maybeMakeSpaceHidden(document.getDocumentReference().getLastSpaceReference(),
+                        document.getFullName(), session);
+                } else {
+                    // If the document became visible then all its parents should be visible as well
+                    makeSpaceVisible(document.getDocumentReference().getLastSpaceReference(), session);
                 }
             }
         }
@@ -2894,11 +2892,9 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
 
             XWikiDocument doc =
                 new XWikiDocument(this.defaultDocumentReferenceResolver.resolve(fullName, currentWikiReference));
-            if (checkRight) {
-                if (!context.getWiki().getRightService().hasAccessLevel("view", context.getUser(), doc.getFullName(),
-                    context)) {
-                    continue;
-                }
+            if (checkRight && !context.getWiki().getRightService().hasAccessLevel("view", context.getUser(),
+                doc.getFullName(), context)) {
+                continue;
             }
 
             DocumentReference documentReference = doc.getDocumentReference();

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiRightServiceImpl.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/XWikiRightServiceImpl.java
@@ -221,10 +221,9 @@ public class XWikiRightServiceImpl implements XWikiRightService
 
                 if ((user == null) && (needsAuth)) {
                     logDeny("unauthentified", doc.getFullName(), action, "Authentication needed");
-                    if (context.getRequest() != null) {
-                        if (!"true".equalsIgnoreCase(context.getWiki().Param("xwiki.hidelogin", "false"))) {
-                            context.getWiki().getAuthService().showLogin(context);
-                        }
+                    if (context.getRequest() != null
+                        && !"true".equalsIgnoreCase(context.getWiki().Param("xwiki.hidelogin", "false"))) {
+                        context.getWiki().getAuthService().showLogin(context);
                     }
 
                     return false;
@@ -539,24 +538,20 @@ public class XWikiRightServiceImpl implements XWikiRightService
         boolean deny = false;
         boolean allow = false;
         boolean allow_found = false;
-        boolean deny_found = false;
         boolean isReadOnly = context.getWiki().isReadOnly();
         String database = context.getWikiId();
         XWikiDocument currentdoc = null;
 
-        if (isReadOnly) {
-            if ("edit".equals(accessLevel) || DELETE.equals(accessLevel) || UNDELETE.equals(accessLevel)
-                || COMMENT.equals(accessLevel) || REGISTER.equals(accessLevel)) {
-                logDeny(userOrGroupName, entityReference, accessLevel, "server in read-only mode");
+        if (isReadOnly && ("edit".equals(accessLevel) || DELETE.equals(accessLevel) || UNDELETE.equals(accessLevel)
+            || COMMENT.equals(accessLevel) || REGISTER.equals(accessLevel))) {
+            logDeny(userOrGroupName, entityReference, accessLevel, "server in read-only mode");
 
-                return false;
-            }
+            return false;
         }
 
-        if (userOrGroupNameReference.getName().equals(XWikiRightService.GUEST_USER)) {
-            if (needsAuth(accessLevel, context)) {
-                return false;
-            }
+        if (userOrGroupNameReference.getName().equals(XWikiRightService.GUEST_USER)
+            && needsAuth(accessLevel, context)) {
+            return false;
         }
 
         // Fast return for delete right: allow the creator to delete the document
@@ -649,7 +644,6 @@ public class XWikiRightServiceImpl implements XWikiRightService
                     currentdoc =
                         currentdoc == null ? context.getWiki().getDocument(entityReference, context) : currentdoc;
                     deny = checkRight(userOrGroupName, currentdoc, accessLevel, user, false, false, context);
-                    deny_found = true;
                     if (deny) {
                         logDeny(userOrGroupName, entityReference, accessLevel, "document level");
                         return false;
@@ -686,7 +680,6 @@ public class XWikiRightServiceImpl implements XWikiRightService
                     if (hasDenyRights()) {
                         try {
                             deny = checkRight(userOrGroupName, webdoc, accessLevel, user, false, true, context);
-                            deny_found = true;
                             if (deny) {
                                 logDeny(userOrGroupName, entityReference, accessLevel, "web level");
 
@@ -729,7 +722,6 @@ public class XWikiRightServiceImpl implements XWikiRightService
             if (hasDenyRights()) {
                 try {
                     deny = checkRight(userOrGroupName, entityWikiPreferences, accessLevel, user, false, true, context);
-                    deny_found = true;
                     if (deny) {
                         logDeny(userOrGroupName, entityReference, accessLevel, "xwiki level");
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/ActionFilter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/ActionFilter.java
@@ -163,14 +163,12 @@ public class ActionFilter implements Filter
         // We need to also get rid of the wiki name in case of a XWiki instance in path-based mode.
         ConfigurationSource configuration =
             Utils.getComponent(ConfigurationSource.class, XWikiCfgConfigurationSource.ROLEHINT);
-        if ("1".equals(configuration.getProperty("xwiki.virtual.usepath", "1"))) {
-            if ((PATH_SEPARATOR + configuration.getProperty("xwiki.virtual.usepath.servletpath", "wiki")).equals(
-                servletPath))
-            {
-                // Move the wiki name together with the servlet path
-                servletPath += path.substring(0, index);
-                index = path.indexOf(PATH_SEPARATOR, index + 1);
-            }
+        if ("1".equals(configuration.getProperty("xwiki.virtual.usepath", "1"))
+            && (PATH_SEPARATOR + configuration.getProperty("xwiki.virtual.usepath.servletpath", "wiki")).equals(
+                servletPath)) {
+            // Move the wiki name together with the servlet path
+            servletPath += path.substring(0, index);
+            index = path.indexOf(PATH_SEPARATOR, index + 1);
         }
 
         String document = path.substring(index);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SkinAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/SkinAction.java
@@ -164,11 +164,10 @@ public class SkinAction extends XWikiAction
                 }
 
                 // Try on the base skin document, if it is not the same as above.
-                if (StringUtils.isNotEmpty(baseskin) && !doc.getName().equals(baseskin)) {
-                    if (renderSkin(filename, baseskindoc, context)) {
-                        found = true;
-                        break;
-                    }
+                if (StringUtils.isNotEmpty(baseskin) && !doc.getName().equals(baseskin)
+                    && renderSkin(filename, baseskindoc, context)) {
+                    found = true;
+                    break;
                 }
 
                 // Try on the default base skin, if it wasn't already tested above.

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/UploadAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/UploadAction.java
@@ -266,12 +266,11 @@ public class UploadAction extends XWikiAction
 
         // Try to use the name provided by the user
         filename = fileupload.getFileItemAsString(filenameField, context);
-        if (!StringUtils.isBlank(filename)) {
-            // TODO These should be supported, the URL should just contain escapes.
-            if (filename.indexOf("/") != -1 || filename.indexOf("\\") != -1 || filename.indexOf(";") != -1) {
-                throw new XWikiException(XWikiException.MODULE_XWIKI_APP, XWikiException.ERROR_XWIKI_APP_INVALID_CHARS,
-                    "Invalid filename: " + filename);
-            }
+        // TODO These should be supported, the URL should just contain escapes.
+        if (!StringUtils.isBlank(filename) && (filename.indexOf("/") != -1 || filename.indexOf("\\") != -1
+            || filename.indexOf(";") != -1)) {
+            throw new XWikiException(XWikiException.MODULE_XWIKI_APP, XWikiException.ERROR_XWIKI_APP_INVALID_CHARS,
+                "Invalid filename: " + filename);
         }
 
         if (StringUtils.isBlank(filename)) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/Utils.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/Utils.java
@@ -131,42 +131,38 @@ public class Utils
         if (cacheSetting == -1) {
             cacheSetting = 1;
         }
-        if ((!"download".equals(action)) && (!"skin".equals(action))) {
-            if (context.getResponse() instanceof XWikiServletResponse) {
-                // Add a last modified to tell when the page was last updated
-                if (context.getWiki().getXWikiPreferenceAsLong("headers_lastmodified", 0, context) != 0) {
-                    if (context.getDoc() != null) {
-                        response.setDateHeader("Last-Modified", context.getDoc().getDate().getTime());
-                    }
-                }
-                // Set a nocache to make sure the page is reloaded after an edit
-                if (cacheSetting == 1) {
-                    response.setHeader("Pragma", NO_CACHE);
-                    response.setHeader(CACHE_CONTROL_HEADER, NO_CACHE);
-                } else if (cacheSetting == 2) {
-                    response.setHeader("Pragma", NO_CACHE);
-                    response.setHeader(CACHE_CONTROL_HEADER, "max-age=0, no-cache, no-store");
-                } else if (cacheSetting == 3) {
-                    response.setHeader(CACHE_CONTROL_HEADER, "private");
-                } else if (cacheSetting == 4) {
-                    response.setHeader(CACHE_CONTROL_HEADER, "public");
-                }
+        if ((!"download".equals(action)) && (!"skin".equals(action))
+            && context.getResponse() instanceof XWikiServletResponse) {
+            // Add a last modified to tell when the page was last updated
+            if (context.getWiki().getXWikiPreferenceAsLong("headers_lastmodified", 0, context) != 0
+                && context.getDoc() != null) {
+                response.setDateHeader("Last-Modified", context.getDoc().getDate().getTime());
+            }
+            // Set a nocache to make sure the page is reloaded after an edit
+            if (cacheSetting == 1) {
+                response.setHeader("Pragma", NO_CACHE);
+                response.setHeader(CACHE_CONTROL_HEADER, NO_CACHE);
+            } else if (cacheSetting == 2) {
+                response.setHeader("Pragma", NO_CACHE);
+                response.setHeader(CACHE_CONTROL_HEADER, "max-age=0, no-cache, no-store");
+            } else if (cacheSetting == 3) {
+                response.setHeader(CACHE_CONTROL_HEADER, "private");
+            } else if (cacheSetting == 4) {
+                response.setHeader(CACHE_CONTROL_HEADER, "public");
+            }
 
-                // Set an expires in one month
-                long expires = context.getWiki().getXWikiPreferenceAsLong("headers_expires", -1, context);
-                if (expires == -1) {
-                    response.setDateHeader("Expires", -1);
-                } else if (expires != 0) {
-                    response.setDateHeader("Expires", (new Date()).getTime() + 30 * 24 * 3600 * 1000L);
-                }
+            // Set an expires in one month
+            long expires = context.getWiki().getXWikiPreferenceAsLong("headers_expires", -1, context);
+            if (expires == -1) {
+                response.setDateHeader("Expires", -1);
+            } else if (expires != 0) {
+                response.setDateHeader("Expires", (new Date()).getTime() + 30 * 24 * 3600 * 1000L);
             }
         }
 
-        if (("download".equals(action)) || ("skin".equals(action))) {
-            // Set a nocache to make sure these files are not cached by proxies
-            if (cacheSetting == 1 || cacheSetting == 2) {
-                response.setHeader(CACHE_CONTROL_HEADER, NO_CACHE);
-            }
+        // Set a nocache to make sure these files are not cached by proxies
+        if ((("download".equals(action)) || ("skin".equals(action))) && (cacheSetting == 1 || cacheSetting == 2)) {
+            response.setHeader(CACHE_CONTROL_HEADER, NO_CACHE);
         }
 
         context.getWiki().getPluginManager().beginParsing(context);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiAction.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiAction.java
@@ -355,18 +355,17 @@ public abstract class XWikiAction implements LegacyAction
     protected boolean isEntityReferenceNameValid(EntityReference entityReference)
     {
         if (this.getEntityNameValidationManager().getEntityReferenceNameStrategy() != null
-            && this.getEntityNameValidationConfiguration().useValidation()) {
-            if (!this.getEntityNameValidationManager().getEntityReferenceNameStrategy().isValid(entityReference)) {
-                Object[] args = {getLocalSerializer().serialize(entityReference)};
-                XWikiException invalidNameException = new XWikiException(XWikiException.MODULE_XWIKI_STORE,
-                    XWikiException.ERROR_XWIKI_APP_DOCUMENT_NAME_INVALID,
-                    "Cannot create document {0} because its name does not respect the name strategy of the wiki.", null,
-                    args);
-                ScriptContext scontext = getCurrentScriptContext();
-                scontext.setAttribute("invalidNameReference", entityReference, ScriptContext.ENGINE_SCOPE);
-                scontext.setAttribute("createException", invalidNameException, ScriptContext.ENGINE_SCOPE);
-                return false;
-            }
+            && this.getEntityNameValidationConfiguration().useValidation()
+            && !this.getEntityNameValidationManager().getEntityReferenceNameStrategy().isValid(entityReference)) {
+            Object[] args = {getLocalSerializer().serialize(entityReference)};
+            XWikiException invalidNameException = new XWikiException(XWikiException.MODULE_XWIKI_STORE,
+                XWikiException.ERROR_XWIKI_APP_DOCUMENT_NAME_INVALID,
+                "Cannot create document {0} because its name does not respect the name strategy of the wiki.", null,
+                args);
+            ScriptContext scontext = getCurrentScriptContext();
+            scontext.setAttribute("invalidNameReference", entityReference, ScriptContext.ENGINE_SCOPE);
+            scontext.setAttribute("createException", invalidNameException, ScriptContext.ENGINE_SCOPE);
+            return false;
         }
         return true;
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/plugin/packaging/AbstractPackageTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/plugin/packaging/AbstractPackageTest.java
@@ -150,10 +150,10 @@ public abstract class AbstractPackageTest
         OutputStreamWriter os = new OutputStreamWriter(ostr, charset);
 
         // Voluntarily ignore the first line... as it's the xml declaration
-        String line = bfr.readLine();
+        bfr.readLine();
         os.append("<?xml version=\"1.0\" encoding=\"" + charset + "\"?>\n");
 
-        line = bfr.readLine();
+        String line = bfr.readLine();
         while (null != line) {
             os.append(line);
             os.append("\n");

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/test/MockitoOldcore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/test/MockitoOldcore.java
@@ -1474,11 +1474,9 @@ public class MockitoOldcore
      */
     public WikiDescriptorManager getWikiDescriptorManager() throws ComponentLookupException
     {
-        if (this.wikiDescriptorManager == null) {
-            // Avoid initializing it if not needed
-            if (this.componentManager.hasComponent(WikiDescriptorManager.class)) {
-                this.wikiDescriptorManager = this.componentManager.getInstance(WikiDescriptorManager.class);
-            }
+        // Avoid initializing it if not needed
+        if (this.wikiDescriptorManager == null && this.componentManager.hasComponent(WikiDescriptorManager.class)) {
+            this.wikiDescriptorManager = this.componentManager.getInstance(WikiDescriptorManager.class);
         }
 
         return this.wikiDescriptorManager;


### PR DESCRIPTION
## Summary

Mechanical, behaviour-preserving cleanup of several SonarCloud issues in the `xwiki-platform-oldcore` module. **28 issues fixed** across 19 files, all in one module.

## Details

- **java:S1066 — Merge collapsible `if` statements (25 issues):** merged an inner `if` into its enclosing `if` with `&&`, dedenting the body and wrapping operands containing `||` in parentheses. Where a comment sat between the two `if`s it was moved directly above the merged condition. Conditions that would exceed the 120-char limit were two-line-wrapped with a continuation indent.
- **java:S1161 — Missing `@Override` (1 issue):** added the annotation on `XWikiDocument#isEnforceRequiredRights()`.
- **java:S1481 — Unused local variable (1 issue):** removed `deny_found` in `XWikiRightServiceImpl` along with its now-dead assignments.
- **java:S1854 — Dead store (1 issue):** removed a useless assignment to a local in `AbstractPackageTest` while preserving the side-effecting `readLine()` call.

No production behaviour changes; only test-compilation-relevant test files and production simplifications.

The following SonarCloud issues that were flagged in these files were intentionally **not** changed because the mechanical fix was unsafe (a multi-line explanatory comment between the two `if`s, an inner `if` that was not the sole statement of the outer, an `else if` outer, a field/variable whose removal would require touching a public setter or several assignments, or a `try` whose `finally` does not close an `AutoCloseable`).

See the [open S1066 issues for this project](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&rules=java%3AS1066&issueStatuses=OPEN).

## Test plan

- `mvn clean install -Plegacy,snapshot -DskipTests` on `xwiki-platform-core/xwiki-platform-oldcore` — BUILD SUCCESS (Checkstyle + test compilation pass).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XCGwqcVerNu4R45HfQKy4a)_