### PR TITLE
[Misc] Use assertEquals/assertNotEquals/assertNull instead of boolean assertions in chart-macro tests (SonarCloud java:S5785)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/test/java/org/xwiki/rendering/internal/macro/chart/ImageIdTest.java
+++ b/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/test/java/org/xwiki/rendering/internal/macro/chart/ImageIdTest.java
@@ -22,7 +22,7 @@ package org.xwiki.rendering.internal.macro.chart;
 import org.junit.jupiter.api.Test;
 import org.xwiki.rendering.macro.chart.ChartMacroParameters;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * Unit tests for {@link ImageId}.
@@ -41,6 +41,6 @@ class ImageIdTest
         ChartMacroParameters parameters1 = new ChartMacroParameters();
         ChartMacroParameters parameters2 = new ChartMacroParameters();
 
-        assertFalse(new ImageId(parameters1).getId().equals(new ImageId(parameters2).getId()));
+        assertNotEquals(new ImageId(parameters2).getId(), new ImageId(parameters1).getId());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/test/java/org/xwiki/rendering/internal/macro/chart/source/table/RangeParserTest.java
+++ b/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/test/java/org/xwiki/rendering/internal/macro/chart/source/table/RangeParserTest.java
@@ -21,7 +21,8 @@ package org.xwiki.rendering.internal.macro.chart.source.table;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Tests the range parser from {@link AbstractTableBlockDataSource}.
@@ -33,14 +34,14 @@ class RangeParserTest
     @Test
     void getColumnNumberFromIdentifier()
     {
-        assertTrue(0 == AbstractTableBlockDataSource.getColumnNumberFromIdentifier("A4"));
-        assertTrue(1 == AbstractTableBlockDataSource.getColumnNumberFromIdentifier("B4"));
-        assertTrue(25 == AbstractTableBlockDataSource.getColumnNumberFromIdentifier("Z4"));
-        assertTrue(26 == AbstractTableBlockDataSource.getColumnNumberFromIdentifier("AA4"));
-        assertTrue(27 == AbstractTableBlockDataSource.getColumnNumberFromIdentifier("AB4"));
-        assertTrue(52 == AbstractTableBlockDataSource.getColumnNumberFromIdentifier("BA4"));
-        assertTrue(53 == AbstractTableBlockDataSource.getColumnNumberFromIdentifier("BB4"));
-        assertTrue(701 == AbstractTableBlockDataSource.getColumnNumberFromIdentifier("ZZ4"));
-        assertTrue(null == AbstractTableBlockDataSource.getColumnNumberFromIdentifier("."));
+        assertEquals(0, AbstractTableBlockDataSource.getColumnNumberFromIdentifier("A4"));
+        assertEquals(1, AbstractTableBlockDataSource.getColumnNumberFromIdentifier("B4"));
+        assertEquals(25, AbstractTableBlockDataSource.getColumnNumberFromIdentifier("Z4"));
+        assertEquals(26, AbstractTableBlockDataSource.getColumnNumberFromIdentifier("AA4"));
+        assertEquals(27, AbstractTableBlockDataSource.getColumnNumberFromIdentifier("AB4"));
+        assertEquals(52, AbstractTableBlockDataSource.getColumnNumberFromIdentifier("BA4"));
+        assertEquals(53, AbstractTableBlockDataSource.getColumnNumberFromIdentifier("BB4"));
+        assertEquals(701, AbstractTableBlockDataSource.getColumnNumberFromIdentifier("ZZ4"));
+        assertNull(AbstractTableBlockDataSource.getColumnNumberFromIdentifier("."));
     }
 }

--- a/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/test/java/org/xwiki/rendering/internal/macro/chart/source/table/TableCategoryDatasetBuilderTest.java
+++ b/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/test/java/org/xwiki/rendering/internal/macro/chart/source/table/TableCategoryDatasetBuilderTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.xwiki.chart.model.ChartModel;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -59,19 +60,19 @@ class TableCategoryDatasetBuilderTest extends AbstractMacroContentTableBlockData
 
         CategoryDataset categoryDataset = (CategoryDataset) dataset;
 
-        assertTrue(categoryDataset.getRowKey(0).equals(" row 1 "));
-        assertTrue(categoryDataset.getRowKey(1).equals(" row 2 "));
+        assertEquals(" row 1 ", categoryDataset.getRowKey(0));
+        assertEquals(" row 2 ", categoryDataset.getRowKey(1));
 
-        assertTrue(categoryDataset.getColumnKey(0).equals(" column 2 "));
-        assertTrue(categoryDataset.getColumnKey(1).equals(" column 3 "));
-        assertTrue(categoryDataset.getColumnKey(2).equals(" column 4"));
+        assertEquals(" column 2 ", categoryDataset.getColumnKey(0));
+        assertEquals(" column 3 ", categoryDataset.getColumnKey(1));
+        assertEquals(" column 4", categoryDataset.getColumnKey(2));
 
-        assertTrue(categoryDataset.getValue(0, 0).intValue() == 12);
-        assertTrue(categoryDataset.getValue(0, 1).intValue() == 13);
-        assertTrue(categoryDataset.getValue(0, 2).intValue() == 14);
-        assertTrue(categoryDataset.getValue(1, 0).intValue() == 22);
-        assertTrue(categoryDataset.getValue(1, 1).intValue() == 23);
-        assertTrue(categoryDataset.getValue(1, 2).intValue() == 24);
+        assertEquals(12, categoryDataset.getValue(0, 0).intValue());
+        assertEquals(13, categoryDataset.getValue(0, 1).intValue());
+        assertEquals(14, categoryDataset.getValue(0, 2).intValue());
+        assertEquals(22, categoryDataset.getValue(1, 0).intValue());
+        assertEquals(23, categoryDataset.getValue(1, 1).intValue());
+        assertEquals(24, categoryDataset.getValue(1, 2).intValue());
     }
 
     @Test
@@ -95,18 +96,18 @@ class TableCategoryDatasetBuilderTest extends AbstractMacroContentTableBlockData
 
         CategoryDataset categoryDataset = (CategoryDataset) dataset;
 
-        assertTrue(categoryDataset.getColumnKey(0).equals(" row 1 "));
-        assertTrue(categoryDataset.getColumnKey(1).equals(" row 2 "));
+        assertEquals(" row 1 ", categoryDataset.getColumnKey(0));
+        assertEquals(" row 2 ", categoryDataset.getColumnKey(1));
 
-        assertTrue(categoryDataset.getRowKey(0).equals(" column 2 "));
-        assertTrue(categoryDataset.getRowKey(1).equals(" column 3 "));
-        assertTrue(categoryDataset.getRowKey(2).equals(" column 4"));
+        assertEquals(" column 2 ", categoryDataset.getRowKey(0));
+        assertEquals(" column 3 ", categoryDataset.getRowKey(1));
+        assertEquals(" column 4", categoryDataset.getRowKey(2));
 
-        assertTrue(categoryDataset.getValue(0, 0).intValue() == 12);
-        assertTrue(categoryDataset.getValue(1, 0).intValue() == 13);
-        assertTrue(categoryDataset.getValue(2, 0).intValue() == 14);
-        assertTrue(categoryDataset.getValue(0, 1).intValue() == 22);
-        assertTrue(categoryDataset.getValue(1, 1).intValue() == 23);
-        assertTrue(categoryDataset.getValue(2, 1).intValue() == 24);
+        assertEquals(12, categoryDataset.getValue(0, 0).intValue());
+        assertEquals(13, categoryDataset.getValue(1, 0).intValue());
+        assertEquals(14, categoryDataset.getValue(2, 0).intValue());
+        assertEquals(22, categoryDataset.getValue(0, 1).intValue());
+        assertEquals(23, categoryDataset.getValue(1, 1).intValue());
+        assertEquals(24, categoryDataset.getValue(2, 1).intValue());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/test/java/org/xwiki/rendering/internal/macro/chart/source/table/TablePieDatasetBuilderTest.java
+++ b/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/test/java/org/xwiki/rendering/internal/macro/chart/source/table/TablePieDatasetBuilderTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.xwiki.chart.model.ChartModel;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -55,11 +56,11 @@ class TablePieDatasetBuilderTest extends AbstractMacroContentTableBlockDataSourc
 
         PieDataset pieDataset = (PieDataset) dataset;
 
-        assertTrue(pieDataset.getKey(0).equals(" row 1 "));
-        assertTrue(pieDataset.getKey(1).equals(" row 2 "));
+        assertEquals(" row 1 ", pieDataset.getKey(0));
+        assertEquals(" row 2 ", pieDataset.getKey(1));
 
-        assertTrue(pieDataset.getValue(0).intValue() == 12);
-        assertTrue(pieDataset.getValue(1).intValue() == 22);
+        assertEquals(12, pieDataset.getValue(0).intValue());
+        assertEquals(22, pieDataset.getValue(1).intValue());
     }
 
     @Test
@@ -81,12 +82,12 @@ class TablePieDatasetBuilderTest extends AbstractMacroContentTableBlockDataSourc
 
         PieDataset pieDataset = (PieDataset) dataset;
 
-        assertTrue(pieDataset.getKey(0).equals(" column 2 "));
-        assertTrue(pieDataset.getKey(1).equals(" column 3 "));
-        assertTrue(pieDataset.getKey(2).equals(" column 4"));
+        assertEquals(" column 2 ", pieDataset.getKey(0));
+        assertEquals(" column 3 ", pieDataset.getKey(1));
+        assertEquals(" column 4", pieDataset.getKey(2));
 
-        assertTrue(pieDataset.getValue(0).intValue() == 12);
-        assertTrue(pieDataset.getValue(1).intValue() == 13);
-        assertTrue(pieDataset.getValue(2).intValue() == 14);
+        assertEquals(12, pieDataset.getValue(0).intValue());
+        assertEquals(13, pieDataset.getValue(1).intValue());
+        assertEquals(14, pieDataset.getValue(2).intValue());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/test/java/org/xwiki/rendering/internal/macro/chart/source/table/TableTimeTableXYBuilderTest.java
+++ b/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/test/java/org/xwiki/rendering/internal/macro/chart/source/table/TableTimeTableXYBuilderTest.java
@@ -31,6 +31,7 @@ import java.util.Locale;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -70,17 +71,17 @@ class TableTimeTableXYBuilderTest extends AbstractMacroContentTableBlockDataSour
 
         TimeTableXYDataset dataset = (TimeTableXYDataset) chartModel.getDataset();
 
-        assertTrue(dataset.getSeriesCount() == 3);
+        assertEquals(3, dataset.getSeriesCount());
 
-        assertTrue(dataset.getSeriesKey(0).equals(" column 2 "));
-        assertTrue(dataset.getSeriesKey(1).equals(" column 3 "));
-        assertTrue(dataset.getSeriesKey(2).equals(" column 4"));
+        assertEquals(" column 2 ", dataset.getSeriesKey(0));
+        assertEquals(" column 3 ", dataset.getSeriesKey(1));
+        assertEquals(" column 4", dataset.getSeriesKey(2));
 
-        assertTrue(dataset.getTimePeriod(0).getStart().equals(new Date(0)));
-        assertTrue(dataset.getTimePeriod(0).getEnd().equals(dateFormat.parse("2012-01-01 10:30:10")));
+        assertEquals(new Date(0), dataset.getTimePeriod(0).getStart());
+        assertEquals(dateFormat.parse("2012-01-01 10:30:10"), dataset.getTimePeriod(0).getEnd());
 
-        assertTrue(dataset.getTimePeriod(1).getStart().equals(dateFormat.parse("2012-01-01 10:30:10")));
-        assertTrue(dataset.getTimePeriod(1).getEnd().equals(dateFormat.parse("2012-01-01 10:30:20")));
+        assertEquals(dateFormat.parse("2012-01-01 10:30:10"), dataset.getTimePeriod(1).getStart());
+        assertEquals(dateFormat.parse("2012-01-01 10:30:20"), dataset.getTimePeriod(1).getEnd());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Mechanical, behaviour-preserving cleanup of SonarCloud rule [java:S5785](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS5785&ruleKey=java%3AS5785) ("Fix this assertion to correctly compare these two values") in the `xwiki-platform-chart-macro` module. **50 issues fixed** across 5 test files, all in one module.

Using a dedicated equality assertion instead of a boolean one makes a test failure report the actual and expected values instead of just `expected: <true> but was: <false>`.

## Details

- **50 assertions** rewritten in 5 test files:
  - `assertTrue(a.equals(b))` → `assertEquals(b, a)`
  - `assertFalse(a.equals(b))` → `assertNotEquals(b, a)`
  - `assertTrue(n == x)` / `assertTrue(x == n)` → `assertEquals(n, x)`
  - `assertTrue(x == null)` → `assertNull(x)`
- Static imports adjusted accordingly (`assertTrue`/`assertFalse` removed where no longer used).
- No production code changed; only test assertions.

Files: `ImageIdTest`, `RangeParserTest`, `TableCategoryDatasetBuilderTest`, `TablePieDatasetBuilderTest`, `TableTimeTableXYBuilderTest`.

All fixed issues belong to SonarCloud rule `java:S5785`. See the [open S5785 issues for this project](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&rules=java%3AS5785&issueStatuses=OPEN).

## Test plan

- `mvn clean install -Plegacy,snapshot` on `xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro` — BUILD SUCCESS (22 tests pass, Checkstyle passes).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PHd6eGZSrZApi6yRLmyHjN)_