### PR TITLE
[Misc] Use assertEquals/assertNotEquals instead of boolean assertions in model-api tests (SonarCloud java:S5785)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/EntityReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/EntityReferenceTest.java
@@ -36,6 +36,7 @@ import org.xwiki.model.EntityType;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -179,19 +180,19 @@ class EntityReferenceTest
         EntityReference reference10 = new EntityReference(PAGE_NAME, EntityType.DOCUMENT,
             new EntityReference(SPACE_NAME, EntityType.SPACE, new EntityReference(WIKI_NAME, EntityType.WIKI, null, map)));
 
-        assertTrue(reference1.equals(reference1));
-        assertTrue(reference1.equals(reference2));
-        assertFalse(reference1.equals(reference3));
-        assertFalse(reference1.equals(reference4));
-        assertFalse(reference1.equals(reference5));
-        assertFalse(reference1.equals(reference6));
+        assertEquals(reference1, reference1);
+        assertEquals(reference2, reference1);
+        assertNotEquals(reference3, reference1);
+        assertNotEquals(reference4, reference1);
+        assertNotEquals(reference5, reference1);
+        assertNotEquals(reference6, reference1);
         assertEquals(reference6, new EntityReference(PAGE_NAME, EntityType.DOCUMENT));
-        assertFalse(reference1.equals(reference7));
-        assertTrue(reference7.equals(reference8));
-        assertFalse(reference1.equals(reference9));
-        assertFalse(reference7.equals(reference9));
-        assertFalse(reference1.equals(reference10));
-        assertFalse(reference7.equals(reference10));
+        assertNotEquals(reference7, reference1);
+        assertEquals(reference8, reference7);
+        assertNotEquals(reference9, reference1);
+        assertNotEquals(reference9, reference7);
+        assertNotEquals(reference10, reference1);
+        assertNotEquals(reference10, reference7);
     }
 
     @Test
@@ -276,17 +277,17 @@ class EntityReferenceTest
 
         assertEquals(reference1.hashCode(), reference1.hashCode());
         assertEquals(reference1.hashCode(), reference2.hashCode());
-        assertFalse(reference1.hashCode() == reference3.hashCode());
-        assertFalse(reference1.hashCode() == reference4.hashCode());
-        assertFalse(reference1.hashCode() == reference5.hashCode());
-        assertFalse(reference1.hashCode() == reference6.hashCode());
+        assertNotEquals(reference1.hashCode(), reference3.hashCode());
+        assertNotEquals(reference1.hashCode(), reference4.hashCode());
+        assertNotEquals(reference1.hashCode(), reference5.hashCode());
+        assertNotEquals(reference1.hashCode(), reference6.hashCode());
         assertEquals(reference6.hashCode(), new EntityReference(PAGE_NAME, EntityType.DOCUMENT).hashCode());
-        assertFalse(reference1.hashCode() == reference7.hashCode());
+        assertNotEquals(reference1.hashCode(), reference7.hashCode());
         assertEquals(reference7.hashCode(), reference8.hashCode());
-        assertFalse(reference1.hashCode() == reference9.hashCode());
-        assertFalse(reference7.hashCode() == reference9.hashCode());
-        assertFalse(reference1.hashCode() == reference10.hashCode());
-        assertFalse(reference7.hashCode() == reference10.hashCode());
+        assertNotEquals(reference1.hashCode(), reference9.hashCode());
+        assertNotEquals(reference7.hashCode(), reference9.hashCode());
+        assertNotEquals(reference1.hashCode(), reference10.hashCode());
+        assertNotEquals(reference7.hashCode(), reference10.hashCode());
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/RegexEntityReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/test/java/org/xwiki/model/reference/RegexEntityReferenceTest.java
@@ -24,8 +24,8 @@ import java.util.regex.Pattern;
 import org.junit.jupiter.api.Test;
 import org.xwiki.model.EntityType;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * Validate {@link RegexEntityReference} class.
@@ -49,7 +49,7 @@ class RegexEntityReferenceTest
             new RegexEntityReference(Pattern.compile(REFERENCETOMATCH.getName(), Pattern.LITERAL), EntityType.DOCUMENT,
                 spaceReference);
 
-        assertTrue(reference.equals(REFERENCETOMATCH));
+        assertEquals(reference, REFERENCETOMATCH);
     }
 
     @Test
@@ -58,7 +58,7 @@ class RegexEntityReferenceTest
         EntityReference reference =
             new RegexEntityReference(Pattern.compile(REFERENCETOMATCH.getName(), Pattern.LITERAL), EntityType.DOCUMENT);
 
-        assertTrue(reference.equals(REFERENCETOMATCH));
+        assertEquals(reference, REFERENCETOMATCH);
     }
 
     @Test
@@ -68,7 +68,7 @@ class RegexEntityReferenceTest
             new RegexEntityReference(Pattern.compile(REFERENCETOMATCH.getWikiReference().getName(), Pattern.LITERAL),
                 EntityType.WIKI);
 
-        assertTrue(reference.equals(REFERENCETOMATCH));
+        assertEquals(reference, REFERENCETOMATCH);
     }
 
     @Test
@@ -76,7 +76,7 @@ class RegexEntityReferenceTest
     {
         EntityReference reference = new RegexEntityReference(Pattern.compile("p.*"), EntityType.DOCUMENT);
 
-        assertTrue(reference.equals(REFERENCETOMATCH));
+        assertEquals(reference, REFERENCETOMATCH);
     }
 
     @Test
@@ -84,7 +84,7 @@ class RegexEntityReferenceTest
     {
         EntityReference reference = new RegexEntityReference(Pattern.compile("space"), EntityType.DOCUMENT);
 
-        assertFalse(reference.equals(REFERENCETOMATCH));
+        assertNotEquals(reference, REFERENCETOMATCH);
     }
 
     @Test
@@ -94,6 +94,6 @@ class RegexEntityReferenceTest
             new RegexEntityReference(Pattern.compile("space"), EntityType.SPACE, new EntityReference("wiki",
                 EntityType.WIKI));
 
-        assertTrue(reference.equals(REFERENCETOMATCH));
+        assertEquals(reference, REFERENCETOMATCH);
     }
 }


### PR DESCRIPTION
## Summary

Mechanical, behaviour-preserving cleanup of SonarCloud rule [java:S5785](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS5785&ruleKey=java%3AS5785) ("Fix this assertion to correctly compare these two values") in the `xwiki-platform-model-api` module. **27 issues fixed** across 2 test files, all in one module.

Using a dedicated equality assertion instead of a boolean one makes a test failure report the actual and expected values instead of just `expected: <true> but was: <false>`.

## Details

- **27 assertions** rewritten in 2 test files:
  - `assertTrue(a.equals(b))` → `assertEquals(b, a)`
  - `assertFalse(a.equals(b))` → `assertNotEquals(b, a)`
  - `assertFalse(x == y)` → `assertNotEquals(x, y)` (hashCode comparisons)
- **`RegexEntityReferenceTest`**: `RegexEntityReference#equals()` is deliberately **asymmetric** (a regex reference matches a concrete reference, but not the reverse), so the original receiver is kept as the *first* argument (`assertEquals(reference, REFERENCETOMATCH)`) to preserve the tested direction.
- Static imports adjusted accordingly (`assertEquals`/`assertNotEquals` added; `assertTrue`/`assertFalse` removed from `RegexEntityReferenceTest` where no longer used, kept in `EntityReferenceTest` which still uses them elsewhere).
- No production code changed; only test assertions.

Files: `EntityReferenceTest` (21), `RegexEntityReferenceTest` (6).

All fixed issues belong to SonarCloud rule `java:S5785`. See the [open S5785 issues for this project](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&rules=java%3AS5785&issueStatuses=OPEN).

## Test plan

- `mvn clean install -Plegacy,snapshot` on `xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api` — BUILD SUCCESS (all tests pass, Checkstyle passes). The build with tests confirmed the asymmetric-equals operand ordering in `RegexEntityReferenceTest`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7qLEdPBcqRixTEjhurkCK)_