### PR TITLE
[Misc] Use assertEquals/assertNotEquals instead of boolean assertions in bridge and eventstream-api tests (SonarCloud java:S5785)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-bridge/src/test/java/org/xwiki/bridge/ActionExecutingEventTest.java
+++ b/xwiki-platform-core/xwiki-platform-bridge/src/test/java/org/xwiki/bridge/ActionExecutingEventTest.java
@@ -25,6 +25,7 @@ import org.xwiki.bridge.event.ActionExecutingEvent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -153,42 +154,42 @@ class ActionExecutingEventTest
     void equalsSameObject()
     {
         ActionExecutingEvent event = new ActionExecutingEvent("something");
-        assertTrue(event.equals(event), "Same object wasn't equal!");
+        assertEquals(event, event, "Same object wasn't equal!");
     }
 
     @Test
     void equalsSameAction()
     {
         ActionExecutingEvent event = new ActionExecutingEvent("something");
-        assertTrue(event.equals(new ActionExecutingEvent("something")), "Same action wasn't equal!");
+        assertEquals(event, new ActionExecutingEvent("something"), "Same action wasn't equal!");
     }
 
     @Test
     void equalsWithNull()
     {
         ActionExecutingEvent event = new ActionExecutingEvent("something");
-        assertFalse(event.equals(null), "null was equal!");
+        assertNotEquals(event, null, "null was equal!");
     }
 
     @Test
     void doesntEqualWildcardAction()
     {
         ActionExecutingEvent event = new ActionExecutingEvent("something");
-        assertFalse(event.equals(new ActionExecutingEvent()), "Wildcard action was equal!");
+        assertNotEquals(event, new ActionExecutingEvent(), "Wildcard action was equal!");
     }
 
     @Test
     void doesntEqualDifferentAction()
     {
         ActionExecutingEvent event = new ActionExecutingEvent("something");
-        assertFalse(event.equals(new ActionExecutingEvent("else")), "A different action was equal!");
+        assertNotEquals(event, new ActionExecutingEvent("else"), "A different action was equal!");
     }
 
     @Test
     void doesntEqualDifferentCaseAction()
     {
         ActionExecutingEvent event = new ActionExecutingEvent("something");
-        assertFalse(event.equals(new ActionExecutingEvent("SomeThing")),
+        assertNotEquals(event, new ActionExecutingEvent("SomeThing"),
             "Action equals comparison was case insensitive!");
     }
 
@@ -196,34 +197,34 @@ class ActionExecutingEventTest
     void doesntEqualDifferentTypeOfAction()
     {
         ActionExecutingEvent event = new ActionExecutingEvent("something");
-        assertFalse(event.equals(new ActionExecutedEvent("something")), "Same object isn't matched!");
+        assertNotEquals(event, new ActionExecutedEvent("something"), "Same object isn't matched!");
     }
 
     @Test
     void wildcardActionDoesntEqualOtherActions()
     {
         ActionExecutingEvent event = new ActionExecutingEvent("something");
-        assertFalse(new ActionExecutingEvent().equals(event), "Wildcard action equals another action!");
+        assertNotEquals(new ActionExecutingEvent(), event, "Wildcard action equals another action!");
     }
 
     @Test
     void wildcardActionDoesntEqualEmptyAction()
     {
         ActionExecutingEvent event = new ActionExecutingEvent("");
-        assertFalse(new ActionExecutingEvent().equals(event), "Wildcard action equals another action!");
+        assertNotEquals(new ActionExecutingEvent(), event, "Wildcard action equals another action!");
     }
 
     @Test
     void wildcardActionEqualsWildcardAction()
     {
-        assertTrue(new ActionExecutingEvent().equals(new ActionExecutingEvent()),
+        assertEquals(new ActionExecutingEvent(), new ActionExecutingEvent(),
             "Wildcard action isn't equal to another wildcard action");
     }
 
     @Test
     void wildcardActionDoesntEqualNull()
     {
-        assertFalse(new ActionExecutingEvent().equals(null), "Wildcard action equals null!");
+        assertNotEquals(new ActionExecutingEvent(), null, "Wildcard action equals null!");
     }
 
     // Tests for hashCode()
@@ -232,20 +233,20 @@ class ActionExecutingEventTest
     void verifyHashCode()
     {
         ActionExecutingEvent event = new ActionExecutingEvent("something");
-        assertTrue(event.hashCode() != 0, "Hashcode was zero!");
+        assertNotEquals(0, event.hashCode(), "Hashcode was zero!");
     }
 
     @Test
     void hashCodeWithEmptyAction()
     {
         ActionExecutingEvent event = new ActionExecutingEvent("");
-        assertTrue(event.hashCode() == 0, "Hashcode for empty string action wasn't zero!");
+        assertEquals(0, event.hashCode(), "Hashcode for empty string action wasn't zero!");
     }
 
     @Test
     void hashCodeForWildcardAction()
     {
         ActionExecutingEvent event = new ActionExecutingEvent();
-        assertTrue(event.hashCode() == 0, "Hashcode for wildcard action wasn't zero!");
+        assertEquals(0, event.hashCode(), "Hashcode for wildcard action wasn't zero!");
     }
 }

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/AbstractRecordableEventDescriptorTest.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/AbstractRecordableEventDescriptorTest.java
@@ -36,9 +36,7 @@ import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
@@ -197,11 +195,11 @@ class AbstractRecordableEventDescriptorTest
                 "app1", "type2");
 
 
-        assertTrue(descriptor1.equals(descriptor1));
-        assertTrue(descriptor1.equals(descriptor2));
-        assertFalse(descriptor1.equals(descriptor3));
-        assertFalse(descriptor1.equals(descriptor4));
-        assertFalse(descriptor1.equals(new Object()));
+        assertEquals(descriptor1, descriptor1);
+        assertEquals(descriptor1, descriptor2);
+        assertNotEquals(descriptor1, descriptor3);
+        assertNotEquals(descriptor1, descriptor4);
+        assertNotEquals(descriptor1, new Object());
 
         assertEquals(descriptor1.hashCode(), descriptor1.hashCode());
         assertEquals(descriptor1.hashCode(), descriptor2.hashCode());

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/SimpleEventQueryTest.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/test/java/org/xwiki/eventstream/SimpleEventQueryTest.java
@@ -506,22 +506,22 @@ class SimpleEventQueryTest
         SimpleEventQuery query4bis = new SimpleEventQuery();
         query4bis.eq("prop", "value");
 
-        assertTrue(query1.equals(query1));
-        assertTrue(query1bis.equals(query1bis));
+        assertEquals(query1, query1);
+        assertEquals(query1bis, query1bis);
 
-        assertTrue(query2.equals(query2));
-        assertTrue(query2bis.equals(query2bis));
+        assertEquals(query2, query2);
+        assertEquals(query2bis, query2bis);
 
-        assertTrue(query3.equals(query3));
-        assertTrue(query3bis.equals(query3bis));
+        assertEquals(query3, query3);
+        assertEquals(query3bis, query3bis);
 
-        assertTrue(query4.equals(query4));
-        assertTrue(query4bis.equals(query4bis));
+        assertEquals(query4, query4);
+        assertEquals(query4bis, query4bis);
 
-        assertFalse(query1.equals(query2));
-        assertFalse(query1.equals(query3));
-        assertFalse(query1.equals(query4));
-        assertFalse(query1.equals(null));
+        assertNotEquals(query1, query2);
+        assertNotEquals(query1, query3);
+        assertNotEquals(query1, query4);
+        assertNotEquals(query1, null);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Mechanical, behaviour-preserving cleanup of SonarCloud rule [java:S5785](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS5785&ruleKey=java%3AS5785) ("Fix this assertion to correctly compare these two values") across two modules. **31 issues fixed** in 3 test files.

Using a dedicated equality assertion instead of a boolean one makes a test failure report the actual and expected values instead of just `expected: <true> but was: <false>`.

## Details

- `assertTrue(a.equals(b))` → `assertEquals(a, b)`
- `assertFalse(a.equals(b))` → `assertNotEquals(a, b)`
- `assertTrue(x == 0)` → `assertEquals(0, x)` and `assertTrue(x != 0)` → `assertNotEquals(0, x)` (hashCode checks)

The **receiver is kept as the first argument** (`assertEquals(receiver, arg)` calls `receiver.equals(arg)`) so the exact `equals()` direction of each original assertion is preserved. This matters in `ActionExecutingEventTest.doesntEqualDifferentTypeOfAction`, which compares an `ActionExecutingEvent` against an `ActionExecutedEvent` (a different type).

Static imports adjusted accordingly: `assertNotEquals` added to `ActionExecutingEventTest`; the now-unused `assertTrue`/`assertFalse` removed from `AbstractRecordableEventDescriptorTest`; `SimpleEventQueryTest` keeps both (still used elsewhere).

No production code changed; only test assertions.

Files:
- `xwiki-platform-bridge` — `ActionExecutingEventTest` (14)
- `xwiki-platform-eventstream-api` — `SimpleEventQueryTest` (12), `AbstractRecordableEventDescriptorTest` (5)

All fixed issues belong to SonarCloud rule `java:S5785`. See the [open S5785 issues for this project](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&rules=java%3AS5785&issueStatuses=OPEN).

## Test plan

- `mvn clean install -Plegacy,snapshot` on `xwiki-platform-bridge` and `xwiki-platform-eventstream-api` **with tests** — BUILD SUCCESS (all tests pass, Checkstyle passes). Building with tests confirms the receiver-first operand ordering preserves each assertion's semantics.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sw3nsUNcYojCPnn72igq87)_