### PR TITLE
[Misc] Make JUnit5 test classes and methods package-private (SonarCloud java:S5786)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-captcha/xwiki-platform-captcha-jcaptcha/xwiki-platform-captcha-jcaptcha-api/src/test/java/org/xwiki/captcha/internal/JCaptchaResourceReferenceHandlerTest.java
+++ b/xwiki-platform-core/xwiki-platform-captcha/xwiki-platform-captcha-jcaptcha/xwiki-platform-captcha-jcaptcha-api/src/test/java/org/xwiki/captcha/internal/JCaptchaResourceReferenceHandlerTest.java
@@ -87,7 +87,7 @@ class JCaptchaResourceReferenceHandlerTest
     private ResourceReferenceHandlerChain resourceReferenceHandlerChain;
 
     @BeforeEach
-    public void setup(MockitoComponentManager mockitoComponentManager) throws Exception
+    void setup(MockitoComponentManager mockitoComponentManager) throws Exception
     {
         Container container = mockitoComponentManager.getInstance(Container.class);
         ServletRequest request = mock(ServletRequest.class);

--- a/xwiki-platform-core/xwiki-platform-captcha/xwiki-platform-captcha-jcaptcha/xwiki-platform-captcha-jcaptcha-api/src/test/java/org/xwiki/captcha/internal/JCaptchaResourceReferenceResolverTest.java
+++ b/xwiki-platform-core/xwiki-platform-captcha/xwiki-platform-captcha-jcaptcha/xwiki-platform-captcha-jcaptcha-api/src/test/java/org/xwiki/captcha/internal/JCaptchaResourceReferenceResolverTest.java
@@ -39,13 +39,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * @since 11.10
  */
 @ComponentTest
-public class JCaptchaResourceReferenceResolverTest
+class JCaptchaResourceReferenceResolverTest
 {
     @InjectMockComponents
     private JCaptchaResourceReferenceResolver jCaptchaResourceReferenceResolver;
 
     @Test
-    public void resolve() throws CreateResourceReferenceException, UnsupportedResourceReferenceException
+    void resolve() throws CreateResourceReferenceException, UnsupportedResourceReferenceException
     {
         ExtendedURL extendedURL =
             new ExtendedURL(Arrays.asList("foo", "bar"), Collections.singletonMap("customValue", Arrays.asList("baz")));
@@ -58,7 +58,7 @@ public class JCaptchaResourceReferenceResolverTest
     }
 
     @Test
-    public void resolveWrongUrl()
+    void resolveWrongUrl()
     {
         ExtendedURL extendedURL = new ExtendedURL(Arrays.asList("foo"), Collections.emptyMap());
 

--- a/xwiki-platform-core/xwiki-platform-captcha/xwiki-platform-captcha-jcaptcha/xwiki-platform-captcha-jcaptcha-api/src/test/java/org/xwiki/captcha/internal/script/JCaptchaInternalScriptServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-captcha/xwiki-platform-captcha-jcaptcha/xwiki-platform-captcha-jcaptcha-api/src/test/java/org/xwiki/captcha/internal/script/JCaptchaInternalScriptServiceTest.java
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class JCaptchaInternalScriptServiceTest
+class JCaptchaInternalScriptServiceTest
 {
     @InjectMockComponents
     private JCaptchaInternalScriptService scriptService;
@@ -61,7 +61,7 @@ public class JCaptchaInternalScriptServiceTest
     private LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.WARN);
 
     @Test
-    public void getURL() throws UnsupportedResourceReferenceException, SerializeResourceReferenceException
+    void getURL() throws UnsupportedResourceReferenceException, SerializeResourceReferenceException
     {
         ExtendedURL extendedURL = mock(ExtendedURL.class);
         when(serializer.serialize(any())).thenReturn(extendedURL);
@@ -75,7 +75,7 @@ public class JCaptchaInternalScriptServiceTest
     }
 
     @Test
-    public void getURLSerializerError() throws UnsupportedResourceReferenceException, SerializeResourceReferenceException
+    void getURLSerializerError() throws UnsupportedResourceReferenceException, SerializeResourceReferenceException
     {
         when(serializer.serialize(any())).thenThrow(new UnsupportedResourceReferenceException("customMessage"));
         assertNull(this.scriptService.getURL("myType", "myEngine", null));
@@ -89,7 +89,7 @@ public class JCaptchaInternalScriptServiceTest
     }
 
     @Test
-    public void getURLNullParams()
+    void getURLNullParams()
     {
         assertNull(this.scriptService.getURL(null, "foo", null));
         assertNull(this.scriptService.getURL("foo", null, null));

--- a/xwiki-platform-core/xwiki-platform-diff/xwiki-platform-diff-xml/src/test/java/org/xwiki/diff/xml/internal/DefaultDataURIConverterTest.java
+++ b/xwiki-platform-core/xwiki-platform-diff/xwiki-platform-diff-xml/src/test/java/org/xwiki/diff/xml/internal/DefaultDataURIConverterTest.java
@@ -116,7 +116,7 @@ class DefaultDataURIConverterTest
     }
 
     @BeforeEach
-    public void setUp()
+    void setUp()
     {
         when(this.userReferenceSerializer.serialize(CurrentUserReference.INSTANCE)).thenReturn(CURRENT_USER);
 

--- a/xwiki-platform-core/xwiki-platform-diff/xwiki-platform-diff-xml/src/test/java/org/xwiki/diff/xml/internal/ImageDownloaderTest.java
+++ b/xwiki-platform-core/xwiki-platform-diff/xwiki-platform-diff-xml/src/test/java/org/xwiki/diff/xml/internal/ImageDownloaderTest.java
@@ -103,7 +103,7 @@ class ImageDownloaderTest
     private HttpEntity httpEntity;
 
     @BeforeEach
-    public void setupMocks() throws IOException
+    void setupMocks() throws IOException
     {
         when(this.httpClientBuilderFactory.create()).thenReturn(this.httpClientBuilder);
         when(this.httpClientBuilder.build()).thenReturn(this.httpClient);

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/test/java/org/xwiki/index/tree/internal/nestedpages/ChildDocumentsTreeNodeGroupTest.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/test/java/org/xwiki/index/tree/internal/nestedpages/ChildDocumentsTreeNodeGroupTest.java
@@ -136,7 +136,7 @@ class ChildDocumentsTreeNodeGroupTest
     private DocumentReference terminalDocumentReference = new DocumentReference("wiki", "Some", "Page");
 
     @BeforeEach
-    public void before(MockitoComponentManager componentManager) throws Exception
+    void before(MockitoComponentManager componentManager) throws Exception
     {
         when(this.defaultEntityReferenceProvider.getDefaultReference(EntityType.DOCUMENT))
             .thenReturn(new EntityReference("WebHome", EntityType.DOCUMENT));

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/test/java/org/xwiki/index/tree/internal/nestedpages/DocumentTreeNodeTest.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/test/java/org/xwiki/index/tree/internal/nestedpages/DocumentTreeNodeTest.java
@@ -108,7 +108,7 @@ class DocumentTreeNodeTest
     private DocumentReference terminalDocumentReference = new DocumentReference("wiki", "Some", "Page");
 
     @BeforeEach
-    public void before() throws Exception
+    void before() throws Exception
     {
         when(this.translationsTreeNode.getType()).thenReturn("translations");
         when(this.attachmentsTreeNode.getType()).thenReturn("attachments");

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/test/java/org/xwiki/index/tree/internal/nestedpages/query/ExcludedDocumentFilterTest.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/test/java/org/xwiki/index/tree/internal/nestedpages/query/ExcludedDocumentFilterTest.java
@@ -34,13 +34,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @since 10.4
  */
 @ComponentTest
-public class ExcludedDocumentFilterTest
+class ExcludedDocumentFilterTest
 {
     @InjectMockComponents
     private ExcludedDocumentFilter excludedDocumentFilter;
 
     @Test
-    public void filterStatement()
+    void filterStatement()
     {
         String inputStatement = StringUtils.join("select xwikiPage.reference reference, xwikiPage.terminal terminal",
             "from (",

--- a/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/test/java/org/xwiki/index/tree/internal/nestedpages/query/ExcludedSpaceFilterTest.java
+++ b/xwiki-platform-core/xwiki-platform-index/xwiki-platform-index-tree/xwiki-platform-index-tree-api/src/test/java/org/xwiki/index/tree/internal/nestedpages/query/ExcludedSpaceFilterTest.java
@@ -34,13 +34,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @since 10.4
  */
 @ComponentTest
-public class ExcludedSpaceFilterTest
+class ExcludedSpaceFilterTest
 {
     @InjectMockComponents
     private ExcludedSpaceFilter excludedSpaceFilter;
 
     @Test
-    public void filterStatement()
+    void filterStatement()
     {
         assertEquals("select reference from XWikiSpace space  where reference not in (:excludedSpaces) order by name",
             this.excludedSpaceFilter.filterStatement("select reference from XWikiSpace space order by name",

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-model-api/src/test/java/org/xwiki/model/internal/reference/DeprecatedLocalReferenceEntityReferenceSerializerTest.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-model-api/src/test/java/org/xwiki/model/internal/reference/DeprecatedLocalReferenceEntityReferenceSerializerTest.java
@@ -37,7 +37,7 @@ import org.xwiki.model.reference.WikiReference;
  * 
  * @version $Id$
  */
-public class DeprecatedLocalReferenceEntityReferenceSerializerTest
+class DeprecatedLocalReferenceEntityReferenceSerializerTest
 {
     private EntityReferenceSerializer<EntityReference> serializer;
 

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-model-api/src/test/java/org/xwiki/model/internal/reference/ReferencesTest.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-model-api/src/test/java/org/xwiki/model/internal/reference/ReferencesTest.java
@@ -32,7 +32,7 @@ import org.xwiki.test.mockito.MockitoComponentManager;
 
 @ComponentTest
 @AllComponents
-public class ReferencesTest
+class ReferencesTest
 {
     @InjectComponentManager
     private MockitoComponentManager componentManager;

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-model-api/src/test/java/org/xwiki/model/internal/reference/StringsTest.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-model-api/src/test/java/org/xwiki/model/internal/reference/StringsTest.java
@@ -35,7 +35,7 @@ import org.xwiki.test.mockito.MockitoComponentManager;
 
 @ComponentTest
 @AllComponents
-public class StringsTest
+class StringsTest
 {
     @InjectComponentManager
     private MockitoComponentManager componentManager;

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-api/src/test/java/org/xwiki/model/validation/AbstractEntityNameValidationTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-api/src/test/java/org/xwiki/model/validation/AbstractEntityNameValidationTest.java
@@ -34,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class AbstractEntityNameValidationTest
+class AbstractEntityNameValidationTest
 {
     private class OnlyNameEntityNameValidationTestClass extends AbstractEntityNameValidation
     {
@@ -64,7 +64,7 @@ public class AbstractEntityNameValidationTest
         onlyNameValidatorTestClass = new OnlyNameEntityNameValidationTestClass("foo", "bar");
 
     @Test
-    public void transformation()
+    void transformation()
     {
         WikiReference wikiReference = new WikiReference("wiki");
         assertEquals(wikiReference, onlyNameValidatorTestClass.transform(wikiReference));
@@ -144,7 +144,7 @@ public class AbstractEntityNameValidationTest
     }
 
     @Test
-    public void isValid()
+    void isValid()
     {
         WikiReference wikiReference = new WikiReference("wiki");
         assertTrue(onlyNameValidatorTestClass.isValid(wikiReference));

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-api/src/test/java/org/xwiki/model/validation/script/ModelValidationScriptServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-validation/xwiki-platform-model-validation-api/src/test/java/org/xwiki/model/validation/script/ModelValidationScriptServiceTest.java
@@ -86,7 +86,7 @@ class ModelValidationScriptServiceTest
     private EntityReference entityReferenceTarget;
 
     @BeforeEach
-    public void setup()
+    void setup()
     {
         when(this.nameStrategy.transform(TEST_NAME)).thenReturn(TRANSFORMED_NAME);
         when(this.nameStrategy.transform(this.entityReferenceSource)).thenReturn(this.entityReferenceTarget);

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-async/xwiki-platform-rendering-async-default/src/test/java/org/xwiki/rendering/async/internal/AsyncRendererCacheTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-async/xwiki-platform-rendering-async-default/src/test/java/org/xwiki/rendering/async/internal/AsyncRendererCacheTest.java
@@ -80,7 +80,7 @@ class AsyncRendererCacheTest
     }
 
     @BeforeEach
-    public void beforeEach()
+    void beforeEach()
     {
         this.renderer = mock(AsyncRenderer.class);
 

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-async/xwiki-platform-rendering-async-default/src/test/java/org/xwiki/rendering/async/internal/service/AsyncRendererResourceReferenceResolverTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-async/xwiki-platform-rendering-async-default/src/test/java/org/xwiki/rendering/async/internal/service/AsyncRendererResourceReferenceResolverTest.java
@@ -38,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @version $Id$
  */
 @ComponentTest
-public class AsyncRendererResourceReferenceResolverTest
+class AsyncRendererResourceReferenceResolverTest
 {
     @InjectMockComponents
     private AsyncRendererResourceReferenceResolver resolver;

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-async/xwiki-platform-rendering-async-default/src/test/java/org/xwiki/rendering/async/internal/service/AsyncRendererResourceReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-async/xwiki-platform-rendering-async-default/src/test/java/org/xwiki/rendering/async/internal/service/AsyncRendererResourceReferenceTest.java
@@ -31,10 +31,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * 
  * @version $Id$
  */
-public class AsyncRendererResourceReferenceTest
+class AsyncRendererResourceReferenceTest
 {
     @Test
-    public void get()
+    void get()
     {
         AsyncRendererResourceReference reference = new AsyncRendererResourceReference(new ResourceType(""),
             Arrays.asList("id1", "id2"), "clientId", 42, "wiki");

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-api/src/test/java/org/xwiki/store/merge/MergeDocumentResultTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-api/src/test/java/org/xwiki/store/merge/MergeDocumentResultTest.java
@@ -44,10 +44,10 @@ import static org.mockito.Mockito.when;
  * @since 11.8RC1
  * @version $Id$
  */
-public class MergeDocumentResultTest
+class MergeDocumentResultTest
 {
     @Test
-    public void putMergeResult()
+    void putMergeResult()
     {
         MergeDocumentResult mergeDocumentResult = new MergeDocumentResult(null, null, null);
         assertFalse(mergeDocumentResult.isModified());
@@ -122,7 +122,7 @@ public class MergeDocumentResultTest
     }
 
     @Test
-    public void putMergeResultTwice()
+    void putMergeResultTwice()
     {
         MergeDocumentResult mergeDocumentResult = new MergeDocumentResult(null, null, null);
         assertNull(mergeDocumentResult.getMergeResult(MergeDocumentResult.DocumentPart.CONTENT));

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-api/src/test/java/org/xwiki/store/merge/MergeManagerResultTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-api/src/test/java/org/xwiki/store/merge/MergeManagerResultTest.java
@@ -40,10 +40,10 @@ import static org.mockito.Mockito.mock;
  * @since 11.8RC1
  * @version $Id$
  */
-public class MergeManagerResultTest
+class MergeManagerResultTest
 {
     @Test
-    public void hasConflict()
+    void hasConflict()
     {
         MergeManagerResult mergeManagerResult = new MergeManagerResult();
         assertFalse(mergeManagerResult.isModified());

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-default/src/test/java/org/xwiki/store/merge/MergeDocumentResultScriptTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-default/src/test/java/org/xwiki/store/merge/MergeDocumentResultScriptTest.java
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.when;
  * 
  * @version $Id$
  */
-public class MergeDocumentResultScriptTest
+class MergeDocumentResultScriptTest
 {
     private XWikiDocument mockDocument(XWikiContext xcontext)
     {
@@ -52,7 +52,7 @@ public class MergeDocumentResultScriptTest
     }
 
     @Test
-    public void misc()
+    void misc()
     {
         XWikiContext xcontext = mock(XWikiContext.class);
 

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-default/src/test/java/org/xwiki/store/merge/internal/DefaultMergeConflictDecisionManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-default/src/test/java/org/xwiki/store/merge/internal/DefaultMergeConflictDecisionManagerTest.java
@@ -65,7 +65,7 @@ import static org.mockito.Mockito.when;
     DefaultCacheManagerConfiguration.class,
     InfinispanCacheFactory.class })
 @ComponentTest
-public class DefaultMergeConflictDecisionManagerTest
+class DefaultMergeConflictDecisionManagerTest
 {
     @InjectMockComponents
     private DefaultMergeConflictDecisionsManager mergeConflictDecisionsManager;
@@ -77,13 +77,13 @@ public class DefaultMergeConflictDecisionManagerTest
     private LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.ERROR);
 
     @BeforeEach
-    public void setup()
+    void setup()
     {
         doAnswer(AdditionalAnswers.returnsArgAt(1)).when(configurationSource).getProperty(anyString(), anyString());
     }
 
     @Test
-    public void recordDecisions()
+    void recordDecisions()
     {
         DocumentReference documentReference = new DocumentReference("xwiki", "Space", "Page");
         EntityReference userReference = new DocumentReference("xwiki", "XWiki", "User");

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-default/src/test/java/org/xwiki/store/merge/internal/DefaultMergeManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-merge/xwiki-platform-store-merge-default/src/test/java/org/xwiki/store/merge/internal/DefaultMergeManagerTest.java
@@ -67,7 +67,7 @@ import static org.mockito.Mockito.when;
 
 @ComponentList({ DefaultDiffManager.class })
 @ComponentTest
-public class DefaultMergeManagerTest
+class DefaultMergeManagerTest
 {
     @InjectMockComponents
     private DefaultMergeManager mergeManager;
@@ -80,7 +80,7 @@ public class DefaultMergeManagerTest
     private List<ConflictDecision> conflictDecisionList;
 
     @BeforeEach
-    public void setup()
+    void setup()
     {
         this.documentReference = new DocumentReference("xwiki", "Space", "Page");
         this.userReference = new DocumentReference("xwiki", "XWiki", "User");
@@ -91,7 +91,7 @@ public class DefaultMergeManagerTest
     }
 
     @Test
-    public void mergeWhenDifferences()
+    void mergeWhenDifferences()
     {
         MergeManagerResult<String, String> result =
             mergeManager.mergeLines("content", "content\n", "content", new MergeConfiguration());
@@ -112,7 +112,7 @@ public class DefaultMergeManagerTest
     }
 
     @Test
-    public void mergeWhenCurrentStringDoesntEndWithNewLine()
+    void mergeWhenCurrentStringDoesntEndWithNewLine()
     {
         MergeManagerResult<String, String> result = mergeManager.mergeLines("content", "content", "content",
             new MergeConfiguration());
@@ -122,7 +122,7 @@ public class DefaultMergeManagerTest
     }
 
     @Test
-    public void mergeWhenCurrentStringEndsWithNewLine()
+    void mergeWhenCurrentStringEndsWithNewLine()
     {
         MergeManagerResult<String, String> result = mergeManager.mergeLines("content\n", "content\n", "content\n",
             new MergeConfiguration());
@@ -132,7 +132,7 @@ public class DefaultMergeManagerTest
     }
 
     @Test
-    public void mergeObjectSimple()
+    void mergeObjectSimple()
     {
         MergeManagerResult<String, String> result = mergeManager.mergeObject("old", "new", "old",
             new MergeConfiguration());
@@ -142,7 +142,7 @@ public class DefaultMergeManagerTest
     }
 
     @Test
-    public void mergeObjectAlreadyDone()
+    void mergeObjectAlreadyDone()
     {
         MergeManagerResult<String, String> result = mergeManager.mergeObject("old", "new", "new",
             new MergeConfiguration());
@@ -152,7 +152,7 @@ public class DefaultMergeManagerTest
     }
 
     @Test
-    public void mergeObjectWhileModified()
+    void mergeObjectWhileModified()
     {
         MergeManagerResult<String, String> result = mergeManager.mergeObject("old", "new", "old modified",
             new MergeConfiguration());
@@ -165,7 +165,7 @@ public class DefaultMergeManagerTest
     }
 
     @Test
-    public void mergeListSimple()
+    void mergeListSimple()
     {
         List<String> current = new ArrayList<String>(Arrays.asList("old1", "old2"));
         MergeManagerResult<List<String>, String> result = mergeManager.mergeList(Arrays.asList("old1", "old2"),
@@ -176,7 +176,7 @@ public class DefaultMergeManagerTest
     }
 
     @Test
-    public void mergeListAlreadyDone()
+    void mergeListAlreadyDone()
     {
         List<String> current = new ArrayList<String>(Arrays.asList("new1", "new2"));
         MergeManagerResult<List<String>, String> result = mergeManager.mergeList(Arrays.asList("old1", "old2"),
@@ -188,7 +188,7 @@ public class DefaultMergeManagerTest
     }
 
     @Test
-    public void mergeListWhileModified()
+    void mergeListWhileModified()
     {
         List<String> current = new ArrayList<String>(Arrays.asList("new1", "old modified2"));
         MergeManagerResult<List<String>, String> result = mergeManager.mergeList(Arrays.asList("new1", "old2"),
@@ -218,7 +218,7 @@ public class DefaultMergeManagerTest
     }
 
     @Test
-    public void mergeCharactersSimple()
+    void mergeCharactersSimple()
     {
         MergeManagerResult<String, Character> result =
             mergeManager.mergeCharacters("ab", "aib", "abc", new MergeConfiguration());
@@ -228,7 +228,7 @@ public class DefaultMergeManagerTest
     }
 
     @Test
-    public void mergeCharactersNull()
+    void mergeCharactersNull()
     {
         MergeManagerResult<String, Character> result =
             mergeManager.mergeCharacters(null, null, null, new MergeConfiguration());
@@ -238,7 +238,7 @@ public class DefaultMergeManagerTest
     }
 
     @Test
-    public void mergeCharactersEmpty()
+    void mergeCharactersEmpty()
     {
         MergeManagerResult<String, Character> result =
             mergeManager.mergeCharacters("", "", "", new MergeConfiguration());
@@ -248,7 +248,7 @@ public class DefaultMergeManagerTest
     }
 
     @Test
-    public void mergeCharactersWhileModified()
+    void mergeCharactersWhileModified()
     {
         MergeManagerResult<String, Character> result =
             mergeManager.mergeCharacters("ab", "aib", "ajb", new MergeConfiguration());
@@ -258,7 +258,7 @@ public class DefaultMergeManagerTest
     }
 
     @Test
-    public void mergeCharactersNoChanges()
+    void mergeCharactersNoChanges()
     {
         MergeManagerResult<String, Character> result =
             mergeManager.mergeCharacters("ab", "ab", "ab", new MergeConfiguration());
@@ -275,7 +275,7 @@ public class DefaultMergeManagerTest
     })
     @ReferenceComponentList
     @OldcoreTest
-    public class MergeManagerDocumentsTest
+    class MergeManagerDocumentsTest
     {
         @InjectMockitoOldcore
         private MockitoOldcore oldcore;
@@ -299,7 +299,7 @@ public class DefaultMergeManagerTest
         private MergeConfiguration configuration;
 
         @BeforeEach
-        public void before() throws Exception
+        void before() throws Exception
         {
             this.currentDocument = new XWikiDocument(new DocumentReference("wiki", "space", "page"));
             this.previousDocument = this.currentDocument.clone();
@@ -347,7 +347,7 @@ public class DefaultMergeManagerTest
         // #merge
 
         @Test
-        public void testMergeContent() throws Exception
+        void testMergeContent() throws Exception
         {
             this.previousDocument.setContent("some content");
             this.nextDocument.setContent("some new content");
@@ -359,7 +359,7 @@ public class DefaultMergeManagerTest
         }
 
         @Test
-        public void testMergeDefaultLocale() throws Exception
+        void testMergeDefaultLocale() throws Exception
         {
             this.previousDocument.setDefaultLocale(Locale.ENGLISH);
             this.nextDocument.setDefaultLocale(Locale.FRENCH);
@@ -371,7 +371,7 @@ public class DefaultMergeManagerTest
         }
 
         @Test
-        public void testMergeContentModified() throws Exception
+        void testMergeContentModified() throws Exception
         {
             this.previousDocument.setContent("some content");
             this.nextDocument.setContent("some content\nafter");
@@ -391,7 +391,7 @@ public class DefaultMergeManagerTest
         }
 
         @Test
-        public void testMergeNewObjectAdded() throws Exception
+        void testMergeNewObjectAdded() throws Exception
         {
             this.nextDocument.addXObject(this.xobject);
 
@@ -401,7 +401,7 @@ public class DefaultMergeManagerTest
         }
 
         @Test
-        public void testMergeNewObjectRemoved() throws Exception
+        void testMergeNewObjectRemoved() throws Exception
         {
             this.previousDocument.addXObject(this.xobject);
             this.currentDocument.addXObject(this.xobject.clone());
@@ -412,7 +412,7 @@ public class DefaultMergeManagerTest
         }
 
         @Test
-        public void testMergeObjectModified() throws Exception
+        void testMergeObjectModified() throws Exception
         {
             BaseObject previousobj = this.xobject;
             previousobj.setStringValue("test", "test1");
@@ -435,7 +435,7 @@ public class DefaultMergeManagerTest
         }
 
         @Test
-        public void testMergeCurrentObjectRemoved() throws Exception
+        void testMergeCurrentObjectRemoved() throws Exception
         {
             this.xobject.setStringValue("test", "");
             this.xobject.setStringValue("previoustest", "previoustest");
@@ -461,7 +461,7 @@ public class DefaultMergeManagerTest
         }
 
         @Test
-        public void testMergeCurrentObjectRemovedFallbackNext() throws Exception
+        void testMergeCurrentObjectRemovedFallbackNext() throws Exception
         {
             this.configuration.setConflictFallbackVersion(MergeConfiguration.ConflictFallbackVersion.NEXT);
             this.xobject.setStringValue("test", "");
@@ -485,7 +485,7 @@ public class DefaultMergeManagerTest
         }
 
         @Test
-        public void testMergeAttachmentEquals() throws Exception
+        void testMergeAttachmentEquals() throws Exception
         {
             XWikiAttachment attachment = new XWikiAttachment();
 
@@ -503,7 +503,7 @@ public class DefaultMergeManagerTest
         }
 
         @Test
-        public void testMergeAttachmentEqualsDeletedCurrent() throws Exception
+        void testMergeAttachmentEqualsDeletedCurrent() throws Exception
         {
             XWikiAttachment attachment = new XWikiAttachment();
 
@@ -520,7 +520,7 @@ public class DefaultMergeManagerTest
         }
 
         @Test
-        public void testMergeAttachmentEqualsAddedCurrent() throws Exception
+        void testMergeAttachmentEqualsAddedCurrent() throws Exception
         {
             XWikiAttachment attachment = new XWikiAttachment();
 
@@ -536,7 +536,7 @@ public class DefaultMergeManagerTest
         }
 
         @Test
-        public void testMergeAttachmentEqualsModifiedCurrent() throws Exception
+        void testMergeAttachmentEqualsModifiedCurrent() throws Exception
         {
             XWikiAttachment attachment = new XWikiAttachment();
 
@@ -559,7 +559,7 @@ public class DefaultMergeManagerTest
         }
 
         @Test
-        public void testMergeAttachmentNew() throws Exception
+        void testMergeAttachmentNew() throws Exception
         {
             XWikiAttachment attachment = new XWikiAttachment();
 
@@ -581,7 +581,7 @@ public class DefaultMergeManagerTest
         }
 
         @Test
-        public void mergeAttachmentNewButAddedInCurrent() throws Exception
+        void mergeAttachmentNewButAddedInCurrent() throws Exception
         {
             XWikiAttachment attachment = new XWikiAttachment();
 
@@ -605,7 +605,7 @@ public class DefaultMergeManagerTest
         }
 
         @Test
-        public void testMergeAttachmentDeleted() throws Exception
+        void testMergeAttachmentDeleted() throws Exception
         {
             XWikiAttachment attachment = new XWikiAttachment();
 
@@ -626,7 +626,7 @@ public class DefaultMergeManagerTest
         }
 
         @Test
-        public void testMergeAttachmentModified() throws Exception
+        void testMergeAttachmentModified() throws Exception
         {
             XWikiAttachment attachment = new XWikiAttachment();
 
@@ -655,7 +655,7 @@ public class DefaultMergeManagerTest
         }
 
         @Test
-        public void testMergeAttachmentModifiedDeletedInCurrent() throws Exception
+        void testMergeAttachmentModifiedDeletedInCurrent() throws Exception
         {
             XWikiAttachment attachment = new XWikiAttachment();
 
@@ -685,7 +685,7 @@ public class DefaultMergeManagerTest
         }
 
         @Test
-        public void testMergeAttachmentModifiedDeletedInCurrentFallbackOnNext() throws Exception
+        void testMergeAttachmentModifiedDeletedInCurrentFallbackOnNext() throws Exception
         {
             this.configuration.setConflictFallbackVersion(MergeConfiguration.ConflictFallbackVersion.NEXT);
             XWikiAttachment attachment = new XWikiAttachment();
@@ -720,7 +720,7 @@ public class DefaultMergeManagerTest
         // #apply
 
         @Test
-        public void testApplyWithUnmodifiedObject()
+        void testApplyWithUnmodifiedObject()
         {
             this.previousDocument.addXObject(this.xobject);
             this.currentDocument.addXObject(this.xobject.clone());
@@ -729,7 +729,7 @@ public class DefaultMergeManagerTest
         }
 
         @Test
-        public void testApplyWithModifiedObjectAndClean()
+        void testApplyWithModifiedObjectAndClean()
         {
             this.previousDocument.addXObject(this.xobject);
             BaseObject modifiedObject = this.xobject.clone();
@@ -741,7 +741,7 @@ public class DefaultMergeManagerTest
         }
 
         @Test
-        public void testMergeWithAddedSameObject() throws Exception
+        void testMergeWithAddedSameObject() throws Exception
         {
             this.currentDocument.addXObject(this.xobject);
             this.nextDocument.addXObject(this.xobject.clone());
@@ -752,7 +752,7 @@ public class DefaultMergeManagerTest
         }
 
         @Test
-        public void testMergeWithAddedSameProperty() throws Exception
+        void testMergeWithAddedSameProperty() throws Exception
         {
             this.previousDocument.addXObject(xobject);
             BaseObject xobj = this.xobject.clone();

--- a/xwiki-platform-core/xwiki-platform-uiextension/xwiki-platform-uiextension-default/src/test/java/org/xwiki/uiextension/WikiUIExtensionParametersTest.java
+++ b/xwiki-platform-core/xwiki-platform-uiextension/xwiki-platform-uiextension-default/src/test/java/org/xwiki/uiextension/WikiUIExtensionParametersTest.java
@@ -105,7 +105,7 @@ class WikiUIExtensionParametersTest
     private MockitoComponentManager componentManager;
 
     @BeforeEach
-    public void setUp() throws Exception
+    void setUp() throws Exception
     {
         VelocityContext velocityContext = new VelocityContext();
         ExecutionContext executionContext = mock(ExecutionContext.class);

--- a/xwiki-platform-core/xwiki-platform-uiextension/xwiki-platform-uiextension-default/src/test/java/org/xwiki/uiextension/WikiUIExtensionTest.java
+++ b/xwiki-platform-core/xwiki-platform-uiextension/xwiki-platform-uiextension-default/src/test/java/org/xwiki/uiextension/WikiUIExtensionTest.java
@@ -112,7 +112,7 @@ class WikiUIExtensionTest
     private BaseObject baseObject;
 
     @BeforeEach
-    public void setUp()
+    void setUp()
     {
         XWikiDocument ownerDocument = new XWikiDocument(DOC_REF);
         ownerDocument.setAuthorReference(AUTHOR_REFERENCE);

--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-schemes/xwiki-platform-url-scheme-standard/src/test/java/org/xwiki/url/internal/standard/ContextAndActionURLNormalizerTest.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-schemes/xwiki-platform-url-scheme-standard/src/test/java/org/xwiki/url/internal/standard/ContextAndActionURLNormalizerTest.java
@@ -133,7 +133,7 @@ class ContextAndActionURLNormalizerTest
     }
 
     @Test
-    public void normalizeWithSlashRootConfiguration()
+    void normalizeWithSlashRootConfiguration()
     {
         when(this.xwikiCfg.getProperty("xwiki.webapppath")).thenReturn("/");
         when(this.servletContext.getContextPath()).thenReturn("/bad");

--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-schemes/xwiki-platform-url-scheme-standard/src/test/java/org/xwiki/url/internal/standard/StandardURLStringEntityReferenceResolverTest.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-schemes/xwiki-platform-url-scheme-standard/src/test/java/org/xwiki/url/internal/standard/StandardURLStringEntityReferenceResolverTest.java
@@ -90,7 +90,7 @@ class StandardURLStringEntityReferenceResolverTest
     private LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.WARN);
 
     @BeforeEach
-    public void configure(MockitoComponentManager componentManager) throws Exception
+    void configure(MockitoComponentManager componentManager) throws Exception
     {
         XWikiRequest request = mock(XWikiRequest.class);
         when(request.getContextPath()).thenReturn("/xwiki");


### PR DESCRIPTION
## Summary

Mechanical, behaviour-preserving cleanup of SonarCloud rule [java:S5786](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS5786&ruleKey=java%3AS5786) ("JUnit5 test classes and methods should have default package visibility") across **10 modules**. **27 issues fixed** in 26 test files.

JUnit5 no longer requires test classes or test methods to be `public`; package-private is the recommended visibility.

## Details

For every flagged test file the `public` modifier was removed from:
- the test class declaration (and any nested `@Nested` / helper class declarations), and
- every method whose contiguous preceding annotation block contains a JUnit annotation (`@Test`, `@BeforeEach`, `@AfterEach`, `@BeforeAll`, `@AfterAll`, `@ParameterizedTest`, etc.).

Other modifiers (e.g. `static` on `@BeforeAll` methods) and non-test members were left untouched. No production code changed; only test visibility modifiers.

`AbstractEntityNameValidationTest` (despite its name, a non-abstract public class) has no subclasses inside or outside its module, so making it package-private is safe.

Modules touched: `xwiki-platform-index-tree-api`, `xwiki-platform-store-merge-default`, `xwiki-platform-store-merge-api`, `xwiki-platform-legacy-model-api`, `xwiki-platform-captcha-jcaptcha-api`, `xwiki-platform-rendering-async-default`, `xwiki-platform-model-validation-api`, `xwiki-platform-url-scheme-standard`, `xwiki-platform-uiextension-default`, `xwiki-platform-diff-xml`.

All fixed issues belong to SonarCloud rule `java:S5786`. See the [open S5786 issues for this project](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&rules=java%3AS5786&issueStatuses=OPEN).

## Test plan

- `mvn clean install -Plegacy,snapshot -DskipTests` across all 10 modules in one reactor — BUILD SUCCESS. Test sources still compile and Checkstyle passes; visibility-only changes are behaviour-preserving.

---
_Generated by [Claude Code](https://claude.ai/code/session_011b1iHLRMXhaGvEGyWmkTit)_