### PR TITLE
[Misc] Make JUnit5 test classes and methods package-private (SonarCloud java:S5786)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/test/java/org/xwiki/annotation/content/SpaceNormalizerContentAltererTest.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/test/java/org/xwiki/annotation/content/SpaceNormalizerContentAltererTest.java
@@ -86,7 +86,7 @@ class SpaceNormalizerContentAltererTest
      */
     @ParameterizedTest
     @MethodSource("filteringSource")
-    public void filtering(String initial, String altered)
+    void filtering(String initial, String altered)
     {
         AlteredContent alteredContent = this.alterer.alter(initial);
         assertEquals(altered, alteredContent.getContent().toString());

--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/test/java/org/xwiki/annotation/content/WhiteSpaceContentAltererTest.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-core/src/test/java/org/xwiki/annotation/content/WhiteSpaceContentAltererTest.java
@@ -39,7 +39,7 @@ import static org.junit.jupiter.params.provider.Arguments.of;
  */
 @ComponentTest
 @ComponentList({ WhiteSpaceFilter.class })
-public class WhiteSpaceContentAltererTest
+class WhiteSpaceContentAltererTest
 {
     /**
      * The content alterer to test.
@@ -71,7 +71,7 @@ public class WhiteSpaceContentAltererTest
      */
     @ParameterizedTest
     @MethodSource("filteringSource")
-    public void filtering(String initial, String altered)
+    void filtering(String initial, String altered)
     {
         AlteredContent alteredContent = this.alterer.alter(initial);
         assertEquals(altered, alteredContent.getContent().toString());

--- a/xwiki-platform-core/xwiki-platform-csrf/src/test/java/org/xwiki/csrf/CSRFTokenInvalidatorTest.java
+++ b/xwiki-platform-core/xwiki-platform-csrf/src/test/java/org/xwiki/csrf/CSRFTokenInvalidatorTest.java
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.verify;
  * @since 4.0M1
  */
 @ComponentTest
-public class CSRFTokenInvalidatorTest
+class CSRFTokenInvalidatorTest
 {
     /** Tested component. */
     @InjectMockComponents
@@ -53,7 +53,7 @@ public class CSRFTokenInvalidatorTest
      * Test that the list of monitored events contains an ActionExecutingEvent for the /logout/ action.
      */
     @Test
-    public void testEvents()
+    void testEvents()
     {
         List<Event> events = this.invalidator.getEvents();
         assertTrue(events.contains(new ActionExecutingEvent("logout")),
@@ -66,7 +66,7 @@ public class CSRFTokenInvalidatorTest
      * @throws Exception
      */
     @Test
-    public void testInvalidationOnLogout()
+    void testInvalidationOnLogout()
     {
         this.invalidator.onEvent(new ActionExecutingEvent("logout"), null, null);
         verify(mockCSRFTokenManager, atLeastOnce()).clearToken();

--- a/xwiki-platform-core/xwiki-platform-csrf/src/test/java/org/xwiki/csrf/DefaultCSRFTokenConfigurationTest.java
+++ b/xwiki-platform-core/xwiki-platform-csrf/src/test/java/org/xwiki/csrf/DefaultCSRFTokenConfigurationTest.java
@@ -40,7 +40,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class DefaultCSRFTokenConfigurationTest
+class DefaultCSRFTokenConfigurationTest
 {
     @InjectMockComponents
     private DefaultCSRFTokenConfiguration defaultCSRFTokenConfiguration;

--- a/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-html/src/test/java/org/xwiki/rendering/display/html/internal/DefaultTemplateHTMLDisplayerTest.java
+++ b/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-html/src/test/java/org/xwiki/rendering/display/html/internal/DefaultTemplateHTMLDisplayerTest.java
@@ -54,7 +54,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class DefaultTemplateHTMLDisplayerTest
+class DefaultTemplateHTMLDisplayerTest
 {
     @MockComponent
     private TemplateManager templateManager;
@@ -68,7 +68,7 @@ public class DefaultTemplateHTMLDisplayerTest
     private DocumentReference documentReference;
 
     @BeforeEach
-    public void setup()
+    void setup()
     {
         ScriptContext scriptContext = mock(ScriptContext.class);
         this.documentReference = new DocumentReference("wiki", "space", "page");
@@ -77,7 +77,7 @@ public class DefaultTemplateHTMLDisplayerTest
     }
 
     @Test
-    public void getTemplateTest() throws Exception
+    void getTemplateTest() throws Exception
     {
         this.defaultTemplateHTMLDisplayer.display(DocumentReference.class, documentReference);
         verify(this.templateManager).getTemplate("html_displayer/documentreference/view.vm");
@@ -87,7 +87,7 @@ public class DefaultTemplateHTMLDisplayerTest
     }
     
     @Test
-    public void getTemplateForEnum() throws Exception
+    void getTemplateForEnum() throws Exception
     {
         this.defaultTemplateHTMLDisplayer.display(EntityType.class, EntityType.DOCUMENT);
         verify(this.templateManager).getTemplate("html_displayer/entitytype/view.vm");
@@ -99,7 +99,7 @@ public class DefaultTemplateHTMLDisplayerTest
     }
 
     @Test
-    public void getTemplateWithNullTypeTest() throws Exception
+    void getTemplateWithNullTypeTest() throws Exception
     {
         this.defaultTemplateHTMLDisplayer.display(null, "test");
         verify(this.templateManager).getTemplate("html_displayer/string/view.vm");
@@ -109,7 +109,7 @@ public class DefaultTemplateHTMLDisplayerTest
     }
 
     @Test
-    public void getTemplateWithNullValueTest() throws Exception
+    void getTemplateWithNullValueTest() throws Exception
     {
         this.defaultTemplateHTMLDisplayer.display((new ArrayList<String>()).getClass(), null);
         verify(this.templateManager).getTemplate("html_displayer/arraylist/view.vm");
@@ -119,7 +119,7 @@ public class DefaultTemplateHTMLDisplayerTest
     }
 
     @Test
-    public void getTemplateWithNullValueAndSpecialTypeTest() throws Exception
+    void getTemplateWithNullValueAndSpecialTypeTest() throws Exception
     {
         this.defaultTemplateHTMLDisplayer.display(new DefaultParameterizedType(null, List.class, Block.class), null);
         verify(this.templateManager)
@@ -130,7 +130,7 @@ public class DefaultTemplateHTMLDisplayerTest
     }
 
     @Test
-    public void getTemplateWithNullTypeAndNullValueTest() throws Exception
+    void getTemplateWithNullTypeAndNullValueTest() throws Exception
     {
         this.defaultTemplateHTMLDisplayer.display(null, null);
         verify(this.templateManager).getTemplate("html_displayer/view.vm");
@@ -138,7 +138,7 @@ public class DefaultTemplateHTMLDisplayerTest
     }
 
     @Test
-    public void displayTest() throws Exception
+    void displayTest() throws Exception
     {
         Template template = mock(Template.class);
 
@@ -151,7 +151,7 @@ public class DefaultTemplateHTMLDisplayerTest
     }
 
     @Test
-    public void displayWithExceptionTest() throws Exception
+    void displayWithExceptionTest() throws Exception
     {
         Template template = mock(Template.class);
 

--- a/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-html/src/test/java/org/xwiki/rendering/display/html/script/HTMLDisplayerScriptServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-html/src/test/java/org/xwiki/rendering/display/html/script/HTMLDisplayerScriptServiceTest.java
@@ -42,7 +42,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class HTMLDisplayerScriptServiceTest
+class HTMLDisplayerScriptServiceTest
 {
     @MockComponent
     private HTMLDisplayerManager htmlDisplayerManager;
@@ -51,7 +51,7 @@ public class HTMLDisplayerScriptServiceTest
     private HTMLDisplayerScriptService htmlDisplayerScriptService;
 
     @Test
-    public void HTMLDisplayerScriptServiceTest() throws Exception
+    void HTMLDisplayerScriptServiceTest() throws Exception
     {
         Answer answer = i -> {
             String attributes = "";

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataSourceTest.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataSourceTest.java
@@ -37,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
  * @since 12.10
  */
 @ComponentTest
-public class LiveTableLiveDataSourceTest
+class LiveTableLiveDataSourceTest
 {
     @InjectMockComponents
     private LiveTableLiveDataSource liveTableSource;

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/PropertyTypeSupplierTest.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/PropertyTypeSupplierTest.java
@@ -54,7 +54,7 @@ import static org.mockito.Mockito.when;
  * @since 12.10
  */
 @ComponentTest
-public class PropertyTypeSupplierTest
+class PropertyTypeSupplierTest
 {
     @InjectMockComponents
     private PropertyTypeSupplier propertyTypeSupplier;

--- a/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-sources/xwiki-platform-localization-source-jar/src/test/java/org/xwiki/localization/jar/internal/JARTranslationBundleFactoryTest.java
+++ b/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-sources/xwiki-platform-localization-source-jar/src/test/java/org/xwiki/localization/jar/internal/JARTranslationBundleFactoryTest.java
@@ -93,7 +93,7 @@ class JARTranslationBundleFactoryTest
     private ExtensionPackager extensionPackager;
 
     @BeforeEach
-    public void beforeEach() throws Exception
+    void beforeEach() throws Exception
     {
         this.extensionPackager = new ExtensionPackager(null, new File("target/test-" + new Date().getTime()));
         this.extensionPackager.generateExtensions();

--- a/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-sources/xwiki-platform-localization-source-jar/src/test/java/org/xwiki/localization/jar/internal/RootClassLoaderTranslationBundleTest.java
+++ b/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-sources/xwiki-platform-localization-source-jar/src/test/java/org/xwiki/localization/jar/internal/RootClassLoaderTranslationBundleTest.java
@@ -49,7 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
     ContextComponentManagerProvider.class, DefaultLocalizationManager.class, DefaultTranslationBundleContext.class,
     DefaultExecution.class, DefaultModelContext.class, RootClassLoaderTranslationBundle.class})
 @ComponentTest
-public class RootClassLoaderTranslationBundleTest
+class RootClassLoaderTranslationBundleTest
 {
     @InjectComponentManager
     private MockitoComponentManager componentManager;
@@ -61,7 +61,7 @@ public class RootClassLoaderTranslationBundleTest
     private LocalizationManager localizationManager;
 
     @BeforeEach
-    public void beforeEach() throws Exception
+    void beforeEach() throws Exception
     {
         // Components
 

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-notifications/src/test/java/org/xwiki/mentions/internal/MentionsNotificationDisplayerTest.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-notifications/src/test/java/org/xwiki/mentions/internal/MentionsNotificationDisplayerTest.java
@@ -67,7 +67,7 @@ import static org.mockito.Mockito.when;
  * @since 12.5RC1
  */
 @ComponentTest
-public class MentionsNotificationDisplayerTest
+class MentionsNotificationDisplayerTest
 {
     @InjectMockComponents
     private MentionsNotificationDisplayer displayer;

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-notifications/src/test/java/org/xwiki/mentions/internal/MentionsRecordableEventConverterTest.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-notifications/src/test/java/org/xwiki/mentions/internal/MentionsRecordableEventConverterTest.java
@@ -48,7 +48,7 @@ import static org.mockito.Mockito.when;
  * @since 12.5RC1
  */
 @ComponentTest
-public class MentionsRecordableEventConverterTest
+class MentionsRecordableEventConverterTest
 {
     @InjectMockComponents
     private MentionsRecordableEventConverter converter;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/src/test/java/org/xwiki/notifications/internal/DefaultCompositeEventStatusManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/src/test/java/org/xwiki/notifications/internal/DefaultCompositeEventStatusManagerTest.java
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class DefaultCompositeEventStatusManagerTest
+class DefaultCompositeEventStatusManagerTest
 {
     @InjectMockComponents
     private DefaultCompositeEventStatusManager eventStatusManager;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/src/test/java/org/xwiki/notifications/internal/SimilarityCalculatorTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/src/test/java/org/xwiki/notifications/internal/SimilarityCalculatorTest.java
@@ -33,12 +33,12 @@ import static org.mockito.Mockito.when;
  *
  * @version $Id$
  */
-public class SimilarityCalculatorTest
+class SimilarityCalculatorTest
 {
     private SimilarityCalculator sq;
 
     @BeforeEach
-    public void setUp() throws Exception
+    void setUp() throws Exception
     {
         this.sq = new SimilarityCalculator();
     }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/DocumentMovedListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/DocumentMovedListenerTest.java
@@ -105,7 +105,7 @@ class DocumentMovedListenerTest
     }
 
     @BeforeEach
-    public void beforeEach() throws Exception
+    void beforeEach() throws Exception
     {
         when(this.contextProvider.get()).thenReturn(this.xwikicontext);
         when(this.xwikicontext.getWiki()).thenReturn(this.xwiki);

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/UserAddedEventListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/test/java/org/xwiki/notifications/filters/internal/UserAddedEventListenerTest.java
@@ -55,7 +55,7 @@ import static org.mockito.Mockito.when;
  * @since 13.3RC1
  */
 @ComponentTest
-public class UserAddedEventListenerTest
+class UserAddedEventListenerTest
 {
     @InjectMockComponents
     private UserAddedEventListener userAddedEventListener;

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/job/ReplaceUserJobTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/job/ReplaceUserJobTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.when;
  * @since 11.8RC1
  */
 @ComponentTest
-public class ReplaceUserJobTest
+class ReplaceUserJobTest
 {
     @InjectMockComponents
     private ReplaceUserJob replaceUserJob;
@@ -68,7 +68,7 @@ public class ReplaceUserJobTest
     private ReplaceUserRequest request = new ReplaceUserRequest();
 
     @BeforeEach
-    public void configure() throws Exception
+    void configure() throws Exception
     {
         when(this.xcontextProvider.get()).thenReturn(this.xcontext);
         when(this.xcontext.getWiki()).thenReturn(this.xwiki);
@@ -83,7 +83,7 @@ public class ReplaceUserJobTest
     }
 
     @Test
-    public void updateCreator() throws Exception
+    void updateCreator() throws Exception
     {
         this.request.setReplaceDocumentCreator(true);
         // Verify this doesn't have any effect if the document author doesn't match the request author.
@@ -100,7 +100,7 @@ public class ReplaceUserJobTest
     }
 
     @Test
-    public void updateAuthor() throws Exception
+    void updateAuthor() throws Exception
     {
         this.request.setReplaceDocumentAuthor(true);
         this.request.setReplaceDocumentContentAuthor(true);

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/listener/UpdateObjectsOnClassRenameListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/listener/UpdateObjectsOnClassRenameListenerTest.java
@@ -93,7 +93,7 @@ class UpdateObjectsOnClassRenameListenerTest
     private DocumentReference newClassReference = new DocumentReference("foo", "Code", "NewClass");
 
     @BeforeEach
-    public void configure()
+    void configure()
     {
         when(this.xcontextProvider.get()).thenReturn(this.xcontext);
         when(this.xcontext.getWiki()).thenReturn(this.wiki);

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-embedded/src/test/java/org/xwiki/search/solr/internal/DefaultSolrTest.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-embedded/src/test/java/org/xwiki/search/solr/internal/DefaultSolrTest.java
@@ -103,7 +103,7 @@ class DefaultSolrTest
     }
 
     @BeforeEach
-    public void beforeEach() throws Exception
+    void beforeEach() throws Exception
     {
         when(this.mockEnvironment.getPermanentDirectory()).thenReturn(this.permanentDirectory);
 

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-embedded/src/test/java/org/xwiki/search/solr/internal/EmbeddedSolrInitializationTest.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-embedded/src/test/java/org/xwiki/search/solr/internal/EmbeddedSolrInitializationTest.java
@@ -95,7 +95,7 @@ class EmbeddedSolrInitializationTest
     }
 
     @BeforeEach
-    public void beforeEach() throws Exception
+    void beforeEach() throws Exception
     {
         when(this.mockEnvironment.getPermanentDirectory()).thenReturn(this.permanentDirectory);
 

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultAuthenticationFailureManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultAuthenticationFailureManagerTest.java
@@ -138,7 +138,7 @@ class DefaultAuthenticationFailureManagerTest
     }
 
     @BeforeEach
-    public void setup() throws Exception
+    void setup() throws Exception
     {
         when(configuration.getFailureStrategies()).thenReturn(new String[] { "strategy1", "strategy2" });
         when(configuration.getMaxAuthorizedAttempts()).thenReturn(3);

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DisableAccountFailureStrategyTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DisableAccountFailureStrategyTest.java
@@ -60,7 +60,7 @@ class DisableAccountFailureStrategyTest
     private XWikiDocument updatedDocument;
 
     @BeforeEach
-    public void configure()
+    void configure()
     {
         DocumentReference documentReference = new DocumentReference("test", "Some", "Page");
 

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/SecurityReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/SecurityReferenceTest.java
@@ -54,7 +54,7 @@ import static org.mockito.Mockito.when;
  */
 @ComponentTest
 @ComponentList({EntityReferenceFactory.class})
-public class SecurityReferenceTest
+class SecurityReferenceTest
 {
     private EntityReference xwiki = new EntityReference("xwiki", EntityType.WIKI);
 
@@ -89,7 +89,7 @@ public class SecurityReferenceTest
     private DefaultSecurityReferenceFactory factory;
 
     @BeforeEach
-    public void beforeEach() throws Exception
+    void beforeEach() throws Exception
     {
         when(xwikiBridge.getMainWikiReference()).thenReturn(new WikiReference("xwiki"));
         when(xwikiBridge.toCompatibleEntityReference(any(EntityReference.class)))
@@ -104,7 +104,7 @@ public class SecurityReferenceTest
     }
 
     @Test
-    public void testEquality() throws Exception
+    void testEquality() throws Exception
     {
         assertThat(factory.newEntityReference(mainEntity), equalTo(factory.newEntityReference(mainEntity)));
         assertThat(factory.newEntityReference(subEntity), equalTo(factory.newEntityReference(subEntity)));
@@ -113,7 +113,7 @@ public class SecurityReferenceTest
     }
 
     @Test
-    public void testGetReversedSecurityReferenceChain() throws Exception
+    void testGetReversedSecurityReferenceChain() throws Exception
     {
         List<SecurityReference> subList =
             (List<SecurityReference>) factory.newEntityReference(subEntity).getReversedSecurityReferenceChain();
@@ -137,7 +137,7 @@ public class SecurityReferenceTest
     }
 
     @Test
-    public void testSecurityReferenceForNullReference() throws Exception
+    void testSecurityReferenceForNullReference() throws Exception
     {
         assertThat(factory.newEntityReference(null), equalTo(factory.newEntityReference(xwiki)));
         assertThat(factory.newUserReference(null), equalTo(factory.newEntityReference(xwiki)));
@@ -151,7 +151,7 @@ public class SecurityReferenceTest
     }
 
     @Test
-    public void testGetSecurityType() throws Exception
+    void testGetSecurityType() throws Exception
     {
         assertThat(factory.newEntityReference(null).getSecurityType(), equalTo(SecurityReference.FARM));
         assertThat(factory.newEntityReference(xwiki).getSecurityType(), equalTo(SecurityReference.FARM));
@@ -163,7 +163,7 @@ public class SecurityReferenceTest
     }
 
     @Test
-    public void testGetOriginalWikiReference() throws Exception
+    void testGetOriginalWikiReference() throws Exception
     {
         assertThat(factory.newEntityReference(null).getOriginalWikiReference(), equalTo(xwiki));
         assertThat(factory.newEntityReference(xwiki).getOriginalWikiReference(), equalTo(xwiki));
@@ -175,7 +175,7 @@ public class SecurityReferenceTest
     }
 
     @Test
-    public void testGetOriginalSpaceReference() throws Exception
+    void testGetOriginalSpaceReference() throws Exception
     {
         assertThat(factory.newEntityReference(null).getOriginalSpaceReference(), nullValue());
         assertThat(factory.newEntityReference(xwiki).getOriginalSpaceReference(), nullValue());
@@ -187,7 +187,7 @@ public class SecurityReferenceTest
     }
 
     @Test
-    public void testGetOriginalDocumentReference() throws Exception
+    void testGetOriginalDocumentReference() throws Exception
     {
         assertThat(factory.newEntityReference(null).getOriginalDocumentReference(), nullValue());
         assertThat(factory.newEntityReference(xwiki).getOriginalDocumentReference(), nullValue());
@@ -199,7 +199,7 @@ public class SecurityReferenceTest
     }
 
     @Test
-    public void testIsGlobal() throws Exception
+    void testIsGlobal() throws Exception
     {
         assertThat(factory.newUserReference(userRef).isGlobal(), is(true));
         assertThat(factory.newUserReference(anotherWikiUserRef).isGlobal(), is(false));
@@ -208,7 +208,7 @@ public class SecurityReferenceTest
     }
 
     @Test
-    public void testGetWikiReference() throws Exception
+    void testGetWikiReference() throws Exception
     {
         assertThat(factory.newUserReference(userRef).getWikiReference(), equalTo(xwiki));
         assertThat(factory.newUserReference(anotherWikiUserRef).getWikiReference(), equalTo(wiki));

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/cache/internal/DefaultSecurityCacheTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/cache/internal/DefaultSecurityCacheTest.java
@@ -730,7 +730,7 @@ class DefaultSecurityCacheTest extends AbstractSecurityTestCase
     }
 
     @Test
-    public void testAddSecurityAccessEntry() throws Exception
+    void testAddSecurityAccessEntry() throws Exception
     {
         InsertUsers();
         InsertEntities();

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/internal/DefaultAuthorizationSettlerTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/internal/DefaultAuthorizationSettlerTest.java
@@ -75,7 +75,7 @@ class DefaultAuthorizationSettlerTest extends AbstractAdditionalRightsTestCase
     private XWikiSecurityAccess denyAllAccess;
 
     @BeforeEach
-    public void configure() throws Exception
+    void configure() throws Exception
     {
         defaultAccess = XWikiSecurityAccess.getDefaultAccess();
         denyAllAccess = new XWikiSecurityAccess();

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-resource/src/test/java/org/xwiki/user/resource/internal/document/DocumentUserResourceReferenceSerializerTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-resource/src/test/java/org/xwiki/user/resource/internal/document/DocumentUserResourceReferenceSerializerTest.java
@@ -48,7 +48,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class DocumentUserResourceReferenceSerializerTest
+class DocumentUserResourceReferenceSerializerTest
 {
     @InjectMockComponents
     private DocumentUserResourceReferenceSerializer serializer;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-resource/src/test/java/org/xwiki/user/resource/internal/document/UserResourceReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-resource/src/test/java/org/xwiki/user/resource/internal/document/UserResourceReferenceTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
  *
  * @version $Id$
  */
-public class UserResourceReferenceTest
+class UserResourceReferenceTest
 {
     @Test
     void equalsAndHashcode()


### PR DESCRIPTION
## Summary

Mechanical, behaviour-preserving cleanup of SonarCloud rule [java:S5786](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS5786&ruleKey=java%3AS5786) ("JUnit5 test classes and methods should have default package visibility") across **13 modules**. **27 issues fixed** in 27 test files (55 `public` modifiers removed).

JUnit5 no longer requires test classes or test methods to be `public`; package-private is the recommended visibility.

## Details

For every flagged test file the `public` modifier was removed from:
- the test class declaration (and any nested `@Nested` / helper class declarations), and
- every method whose contiguous preceding annotation block contains a JUnit annotation (`@Test`, `@BeforeEach`, `@AfterEach`, `@BeforeAll`, `@AfterAll`, `@ParameterizedTest`, etc.).

Other modifiers (e.g. `static` on `@BeforeAll` methods) and non-JUnit members were left untouched — in particular XWiki-specific lifecycle methods such as `@BeforeComponent public void configure(...)` keep their visibility (they are not flagged by S5786). No production code changed; only test visibility modifiers.

Modules touched: `xwiki-platform-annotation-core`, `xwiki-platform-csrf`, `xwiki-platform-display-html`, `xwiki-platform-livedata-livetable`, `xwiki-platform-localization-source-jar`, `xwiki-platform-mentions-notifications`, `xwiki-platform-notifications-api`, `xwiki-platform-notifications-filters-default`, `xwiki-platform-refactoring-default`, `xwiki-platform-search-solr-embedded`, `xwiki-platform-security-authentication-default`, `xwiki-platform-security-authorization-api`, `xwiki-platform-user-resource`.

All fixed issues belong to SonarCloud rule `java:S5786`. See the [open S5786 issues for this project](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&rules=java%3AS5786&issueStatuses=OPEN).

## Test plan

- `mvn clean install -Plegacy,snapshot -DskipTests` across all 13 modules in one reactor — BUILD SUCCESS. Test sources still compile and Checkstyle passes; visibility-only changes are behaviour-preserving.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFe84d3BQFRLe4cVjAMQxE)_