### PR TITLE
[Misc] Remove unused code and add missing @Override annotations (SonarCloud)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/test/java/org/xwiki/administration/ConfigurableClassPageTest.java
+++ b/xwiki-platform-core/xwiki-platform-administration/xwiki-platform-administration-ui/src/test/java/org/xwiki/administration/ConfigurableClassPageTest.java
@@ -211,7 +211,7 @@ class ConfigurableClassPageTest extends PageTest
         this.xwiki.saveDocument(configClassDoc, this.context);
 
         XWikiDocument mySectionDoc = new XWikiDocument(MY_SECTION);
-        BaseObject configObject = mySectionDoc.newXObject(configClassRef, this.context);
+        mySectionDoc.newXObject(configClassRef, this.context);
         BaseObject object = mySectionDoc.newXObject(CONFIGURABLE_CLASS, this.context);
         object.setStringValue("displayInCategory", "other");
         object.setStringValue("displayInSection", "other");

--- a/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/main/java/org/xwiki/rendering/internal/macro/chart/source/table/AbstractTableBlockDataSource.java
+++ b/xwiki-platform-core/xwiki-platform-chart/xwiki-platform-chart-macro/src/main/java/org/xwiki/rendering/internal/macro/chart/source/table/AbstractTableBlockDataSource.java
@@ -92,11 +92,6 @@ public abstract class AbstractTableBlockDataSource extends AbstractDataSource
         Pattern.compile("^([A-Z]+|\\.)([0-9]+|\\.)-([A-Z]+|\\.)([0-9]+|\\.)$");
 
     /**
-     * The name of the category dataset.
-     */
-    private static final String CATEGORY_DATASET = "category";
-
-    /**
      * The range parameter.
      */
     private String range;

--- a/xwiki-platform-core/xwiki-platform-container/xwiki-platform-container-api/src/main/java/org/xwiki/container/RedirectResponse.java
+++ b/xwiki-platform-core/xwiki-platform-container/xwiki-platform-container-api/src/main/java/org/xwiki/container/RedirectResponse.java
@@ -38,5 +38,6 @@ public interface RedirectResponse extends Response
      * @param location the redirect URL
      * @throws IOException if an error happens
      */
+    @Override
     void sendRedirect(String location) throws IOException;
 }

--- a/xwiki-platform-core/xwiki-platform-csrf/src/main/java/org/xwiki/csrf/script/CSRFTokenScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-csrf/src/main/java/org/xwiki/csrf/script/CSRFTokenScriptService.java
@@ -75,6 +75,7 @@ public class CSRFTokenScriptService implements CSRFToken, ScriptService
      * @since 17.10.10
      */
     @Unstable
+    @Override
     public boolean isResubmitAllowedForRequestId(String srid)
     {
         return this.csrf.isResubmitAllowedForRequestId(srid);

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-events-hibernate/xwiki-platform-legacy-events-hibernate-api/src/main/java/org/xwiki/eventstream/store/internal/EventStreamCleanerJobDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-events-hibernate/xwiki-platform-legacy-events-hibernate-api/src/main/java/org/xwiki/eventstream/store/internal/EventStreamCleanerJobDocumentInitializer.java
@@ -30,7 +30,6 @@ import org.xwiki.bridge.event.ApplicationReadyEvent;
 import org.xwiki.bridge.event.WikiReadyEvent;
 import org.xwiki.component.annotation.Component;
 import org.xwiki.model.internal.document.DefaultDocumentAuthors;
-import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.LocalDocumentReference;
 import org.xwiki.observation.AbstractEventListener;
 import org.xwiki.observation.event.Event;
@@ -79,10 +78,6 @@ public class EventStreamCleanerJobDocumentInitializer extends AbstractEventListe
      */
     private static final String XWIKI = "XWiki";
 
-    /**
-     * XWiki Default Admin account.
-     */
-    private static final DocumentReference SUPER_ADMIN = new DocumentReference(MAIN_WIKI, XWIKI, "superadmin");
 
     /**
      * XWiki Rights class name.

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-events-hibernate/xwiki-platform-legacy-events-hibernate-api/src/test/java/org/xwiki/notifications/sources/internal/QueryGeneratorTest.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-events-hibernate/xwiki-platform-legacy-events-hibernate-api/src/test/java/org/xwiki/notifications/sources/internal/QueryGeneratorTest.java
@@ -75,6 +75,7 @@ class QueryGeneratorTest extends AbstractQueryGeneratorTest
     private String pref1StartDateParamName;
 
     @BeforeEach
+    @Override
     void beforeEach() throws Exception
     {
         super.beforeEach();

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-notifications/xwiki-platform-legacy-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/LegacyDefaultNotificationParametersFactory.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-notifications/xwiki-platform-legacy-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/LegacyDefaultNotificationParametersFactory.java
@@ -52,6 +52,7 @@ public class LegacyDefaultNotificationParametersFactory extends DefaultNotificat
      * @throws NotificationException if error happens
      * @since 12.6
      */
+    @Override
     public void useUserPreferences(NotificationParameters parameters) throws NotificationException
     {
         if (parameters.user != null) {

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/notify/DocObjectChangedRule.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/notify/DocObjectChangedRule.java
@@ -127,6 +127,7 @@ public class DocObjectChangedRule extends DocChangeRule
             return hasEqualsObjectsFromClass(newdoc, olddoc, className);
     }
 
+    @Override
     public void verify(XWikiDocument newdoc, XWikiDocument olddoc, XWikiContext context)
     {
         if (!hasEqualObjects(newdoc, olddoc, className))

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/notify/PropertyChangedRule.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/main/java/com/xpn/xwiki/notify/PropertyChangedRule.java
@@ -115,6 +115,7 @@ public class PropertyChangedRule extends DocChangeRule {
         return true;
     }
 
+    @Override
     public void verify(XWikiDocument newdoc, XWikiDocument olddoc, XWikiContext context) {
         if (this.className == null || "".equals(this.className)
                 || this.propertyName == null || "".equals(this.propertyName)) {

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/notify/PropertyChangedRuleTest.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/notify/PropertyChangedRuleTest.java
@@ -61,15 +61,11 @@ class PropertyChangedRuleTest implements XWikiDocChangeNotificationInterface
 
     private String testClassName = "Test.TestClass";
 
-    private DocumentReference testClassReference = new DocumentReference("Test", "Test", "TestClass");
-
     private BaseClass testClass;
 
     private BaseClass otherClass;
 
     private String otherClassName = "Test.OtherClass";
-
-    private DocumentReference testOtherClassReference = new DocumentReference("Test", "Test", "OtherClass");
 
     private String testPropertyName = "field";
 

--- a/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-sources/xwiki-platform-localization-source-wiki/src/test/java/org/xwiki/localization/wiki/internal/ComponentDocumentTranslationBundleTest.java
+++ b/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-sources/xwiki-platform-localization-source-wiki/src/test/java/org/xwiki/localization/wiki/internal/ComponentDocumentTranslationBundleTest.java
@@ -122,8 +122,6 @@ class ComponentDocumentTranslationBundleTest
 
     private XWikiDocument translationFrDocument;
 
-    private DocumentReference adminUserReference;
-
     /**
      * Capture logs.
      */

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-notifications/src/test/java/org/xwiki/mentions/templates/MentionPageTest.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-notifications/src/test/java/org/xwiki/mentions/templates/MentionPageTest.java
@@ -178,7 +178,6 @@ class MentionPageTest extends PageTest
 
         DocumentReference page1 = new DocumentReference("design", "XWiki", "Page1");
         DocumentReference userPage1 = new DocumentReference("xwiki", "XWiki", "U1");
-        DocumentReference userPage2 = new DocumentReference("xwiki", "YWiki", "U2");
         Date eventDate = new Date();
 
         // Create and save page 1 with a title.

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/src/test/java/org/xwiki/notifications/internal/DefaultGroupingEventStrategyTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/src/test/java/org/xwiki/notifications/internal/DefaultGroupingEventStrategyTest.java
@@ -472,8 +472,6 @@ class DefaultGroupingEventStrategyTest
         DocumentReference userA = new DocumentReference("xwiki", "XWiki", "UserA");
 
         // Example taken from a real case
-        Event event0 =
-            createMockedEvent("update", userA, userA, new Date(1510567729000L), "1997830249-1510567729000-Puhs4MSa");
         Event event1 =
             createMockedEvent("update", userA, userA, new Date(1510567724000L), "1997830249-1510567724000-aCjmsmSh");
         Event event2 =

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/QueryExpressionGenerator.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/QueryExpressionGenerator.java
@@ -318,7 +318,6 @@ public class QueryExpressionGenerator
             return excludeHiddenEvents(topNode);
         }
 
-        final DocumentReference userClass = new DocumentReference(USER_CLASS, parameters.user.getWikiReference());
         // Don't show hidden events unless the user want to display hidden pages
         boolean displayHiddenDocuments = this.userPropertiesResolver
             .resolve(this.userReferenceResolver.resolve(parameters.user)).displayHiddenDocuments();

--- a/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/internal/converter/DefaultOfficeConverter.java
+++ b/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/internal/converter/DefaultOfficeConverter.java
@@ -28,8 +28,6 @@ import org.apache.commons.io.IOUtils;
 import org.jodconverter.core.DocumentConverter;
 import org.jodconverter.core.document.DocumentFamily;
 import org.jodconverter.core.document.DocumentFormat;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.xwiki.officeimporter.converter.OfficeConverter;
 import org.xwiki.officeimporter.converter.OfficeConverterException;
 import org.xwiki.officeimporter.converter.OfficeDocumentFormat;
@@ -43,11 +41,6 @@ import org.xwiki.officeimporter.converter.OfficeDocumentFormat;
 public class DefaultOfficeConverter implements OfficeConverter
 {
     private static final String CONVERSION_ERROR_MESSAGE = "Error while performing conversion.";
-
-    /**
-     * The logger to log.
-     */
-    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultOfficeConverter.class);
 
     /**
      * Converter provided by JODConverter library.

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/job/MoveJobTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/internal/job/MoveJobTest.java
@@ -812,7 +812,6 @@ class MoveJobTest extends AbstractMoveJobTest
                 when(mock.isOverwrite()).thenReturn(false);
             })) {
             this.moveJob.initialize(request);
-            EntityJobStatus<MoveRequest> status = this.moveJob.getStatus();
 
             run(request);
         }

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultModelBridgeTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/test/java/org/xwiki/refactoring/internal/DefaultModelBridgeTest.java
@@ -793,7 +793,6 @@ class DefaultModelBridgeTest
     @Test
     void canRestoreDeletedDocument() throws Exception
     {
-        long deletedDocumentId = 42;
         String deletedDocumentFullName = "Space.DeletedDocument";
 
         DocumentReference userReferenceToCheck = new DocumentReference("wiki", "Space", "User");

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-api/src/main/java/org/xwiki/rendering/macro/wikibridge/binding/WikiMacroBinding.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-api/src/main/java/org/xwiki/rendering/macro/wikibridge/binding/WikiMacroBinding.java
@@ -45,8 +45,6 @@ public class WikiMacroBinding extends HashMap<String, Object> implements Binding
 
     private static final String RESULT = "result";
 
-    private static final String DOCUMENT = "doc";
-
     private static final String CONTEXT = "context";
 
     /**

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-default/src/test/java/org/xwiki/security/authentication/internal/DefaultResetPasswordManagerTest.java
@@ -347,8 +347,6 @@ class DefaultResetPasswordManagerTest
         when(xObject.getDateValue(ResetPasswordRequestClassDocumentInitializer.REQUEST_DATE_FIELD))
             .thenReturn(Date.from(Instant.now().minus(17, ChronoUnit.MINUTES)));
 
-        DefaultResetPasswordRequestResponse expected =
-            new DefaultResetPasswordRequestResponse(this.userReference);
 
         String saveComment = "Removed expired token";
         when(this.localizationManager

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-script/src/test/java/org/xwiki/security/authentication/script/AuthenticationScriptServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authentication/xwiki-platform-security-authentication-script/src/test/java/org/xwiki/security/authentication/script/AuthenticationScriptServiceTest.java
@@ -28,7 +28,6 @@ import java.util.Set;
 
 import javax.inject.Named;
 import javax.inject.Provider;
-import javax.mail.internet.InternetAddress;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -203,7 +202,6 @@ class AuthenticationScriptServiceTest
         UserReference userReference = mock(UserReference.class);
         ResetPasswordRequestResponse requestResponse = mock(ResetPasswordRequestResponse.class);
         when(this.resetPasswordManager.requestResetPassword(userReference)).thenReturn(requestResponse);
-        InternetAddress userEmail = new InternetAddress("acme@xwiki.org");
 
         this.scriptService.requestResetPassword(userReference);
         verify(this.resetPasswordManager).sendResetPasswordEmailRequest(requestResponse);

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/internal/DefaultAuthorizationSettlerTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/internal/DefaultAuthorizationSettlerTest.java
@@ -630,8 +630,6 @@ class DefaultAuthorizationSettlerTest extends AbstractAdditionalRightsTestCase
                 getMockedSecurityRuleEntries("denyAccessDAF", docRef,
                     Arrays.asList(Arrays.asList(denyImpliedDAF)))));
 
-        SecurityRule allowAllTestRightsUserAndAnotherGroup = getMockedSecurityRule("allowAllTestRightsUserAndAnotherGroup",
-            Arrays.asList(userRef), Arrays.asList(anotherGroupRef), allTestRights, ALLOW);
         SecurityRule denyAllTestRightsUserAndAnotherGroup = getMockedSecurityRule("denyAllTestRightsUserAndAnotherGroup",
             Arrays.asList(userRef), Arrays.asList(anotherGroupRef), allTestRights, DENY);
         SecurityRule denyAllTestRightsAnotherUserAndGroup = getMockedSecurityRule("denyAllTestRightsAnotherUserAndGroup",

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-bridge/src/main/java/org/xwiki/security/authorization/internal/XWikiCachingRightService.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-bridge/src/main/java/org/xwiki/security/authorization/internal/XWikiCachingRightService.java
@@ -28,7 +28,6 @@ import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.model.reference.DocumentReferenceResolver;
 import org.xwiki.model.reference.EntityReference;
 import org.xwiki.model.reference.WikiReference;
-import org.xwiki.rendering.transformation.RenderingContext;
 import org.xwiki.security.authorization.AuthorizationManager;
 import org.xwiki.security.authorization.ContextualAuthorizationManager;
 import org.xwiki.security.authorization.Right;
@@ -131,10 +130,6 @@ public class XWikiCachingRightService implements XWikiRightService
     @SuppressWarnings("unchecked")
     private DocumentReferenceResolver<String> userAndGroupReferenceResolver
         = Utils.getComponent(DocumentReferenceResolver.TYPE_STRING, "user");
-
-    /** The rendering context to check PR for signed macro. */
-    private final RenderingContext renderingContext
-        = Utils.getComponent(RenderingContext.class);
 
     /** The authorization manager used to really do the job. */
     private final AuthorizationManager authorizationManager

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/test/java/org/xwiki/store/filesystem/internal/TemporaryAttachmentSessionTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/test/java/org/xwiki/store/filesystem/internal/TemporaryAttachmentSessionTest.java
@@ -99,8 +99,6 @@ class TemporaryAttachmentSessionTest
     @Test
     void dispose()
     {
-        Map<DocumentReference, Map<String, XWikiAttachment>> editionsMap =
-            this.temporaryAttachmentSession.getEditionsMap();
 
         XWikiAttachmentContent contentFoo1 = mock(XWikiAttachmentContent.class);
         XWikiAttachmentContent contentBar1 = mock(XWikiAttachmentContent.class);

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/src/test/java/org/xwiki/store/FileSaveTransactionRunnableTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem/src/test/java/org/xwiki/store/FileSaveTransactionRunnableTest.java
@@ -209,7 +209,7 @@ class FileSaveTransactionRunnableTest
         final StartableTransactionRunnable str = new StartableTransactionRunnable();
         runnable.runIn(str);
         failRunnable.runIn(str);
-        Exception exception = assertThrows(Exception.class, str::start);
+        assertThrows(Exception.class, str::start);
 
         assertFalse(this.toSave.exists());
         assertFalse(this.temp.exists());

--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-default/src/main/java/org/xwiki/url/internal/DefaultURLSecurityManager.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-default/src/main/java/org/xwiki/url/internal/DefaultURLSecurityManager.java
@@ -74,11 +74,6 @@ public class DefaultURLSecurityManager implements URLSecurityManager
     private static final Pattern URI_PATTERN =
         Pattern.compile("^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?");
 
-    private static final String ERROR_TRANSFORMING_URI_LOG =
-        "Error while transforming redirect to [{}] to proper URI: [{}]";
-
-    private static final String FULL_STACK_TRACE = "Full stack trace:";
-
     @Inject
     private URLConfiguration urlConfiguration;
 

--- a/xwiki-platform-tools/xwiki-platform-tool-packager-plugin/src/main/java/com/xpn/xwiki/tool/backup/AbstractImportMojo.java
+++ b/xwiki-platform-tools/xwiki-platform-tool-packager-plugin/src/main/java/com/xpn/xwiki/tool/backup/AbstractImportMojo.java
@@ -75,12 +75,6 @@ public abstract class AbstractImportMojo extends AbstractOldCoreMojo
      */
     protected void importDependencies(Importer importer, String databaseName, File hibernateConfig) throws Exception
     {
-        // We need to distinguish between extensions installed explicitly and their transitive dependencies.
-        // We have to create our own Set because Maven changes the fields from the dependency Artifacts (e.g. resolves
-        // their version) after they are added to the Set of dependencies and this causes the hash code to change. As a
-        // result the #contains(Artifact) method doesn't work as expected because it uses the new hash code.
-        Set<Artifact> directDependencies = new HashSet<>(this.project.getDependencyArtifacts());
-
         // Reverse artifact order to have dependencies first (despite the fact that it's a Set it's actually an ordered
         // LinkedHashSet behind the scene)
         List<Artifact> dependenciesFirstArtifacts = new ArrayList<>(this.project.getArtifacts());

--- a/xwiki-platform-tools/xwiki-platform-tool-standards-validator/src/main/java/org/xwiki/validator/HTML5DutchWebGuidelinesValidator.java
+++ b/xwiki-platform-tools/xwiki-platform-tool-standards-validator/src/main/java/org/xwiki/validator/HTML5DutchWebGuidelinesValidator.java
@@ -62,8 +62,6 @@ public class HTML5DutchWebGuidelinesValidator extends AbstractHTML5Validator
     private static final String SUBMIT_BUTTONS = StringUtils.join(Arrays.asList("button[type='submit']",
         "button:not([type])", "input[type='submit']", "input[type='image'][alt]:not([alt=''])"), ", ");
 
-    private static final String DOCTYPE_ATT_NAME = "name";
-
     /**
      * Message resources.
      */


### PR DESCRIPTION
## Summary

Mechanical, behaviour-preserving cleanup of several SonarCloud rules across **24 modules** (**40 issues fixed** in 27 files):

- [java:S1068](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS1068&ruleKey=java%3AS1068) — remove unused private fields
- [java:S1481](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS1481&ruleKey=java%3AS1481) / [java:S1854](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS1854&ruleKey=java%3AS1854) — remove unused local variables and their dead-store assignments (these fire as a pair on the same line)
- [java:S1161](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS1161&ruleKey=java%3AS1161) — add missing `@Override` annotations

## Details

- **Unused private fields** (S1068): the field declaration (and its javadoc, if any) was removed. Where removal orphaned an import, that import was removed too (`DocumentReference`, `RenderingContext`, `Logger`/`LoggerFactory`, `InternetAddress`).
- **Unused locals / dead stores** (S1481 + S1854): when the right-hand side was a pure expression the whole declaration was removed; when it had a side effect that must be kept (e.g. `newXObject(...)`, `assertThrows(..., ...)`), only the `Type name =` prefix was stripped so the call remains a bare statement.
- **Missing `@Override`** (S1161): the annotation was added above the flagged method signatures. Purely additive.

No functional/behavioural change: unused code removal and annotation additions only.

A handful of remaining S1068 issues were intentionally left out because they are write-only fields assigned in multiple places (removing the declaration alone would not compile) — those need a non-mechanical change and are out of scope here.

## Test plan

- `mvn clean install -Plegacy,snapshot -DskipTests` across all 24 affected modules in one reactor — **BUILD SUCCESS**. Test sources still compile and Checkstyle passes; the changes are behaviour-preserving.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RCfKdWreSd1JekKvE2W79Q)_