### PR TITLE
[Misc] Use dedicated assertions instead of boolean assertions in oldcore tests (SonarCloud java:S5785)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentMockitoTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentMockitoTest.java
@@ -749,13 +749,13 @@ class XWikiDocumentMockitoTest
         assertNotNull(objects);
         assertNotNull(objectsFromXML);
 
-        assertTrue(objects.size() == objectsFromXML.size());
+        assertEquals(objects.size(), objectsFromXML.size());
 
         for (int i = 0; i < objects.size(); i++) {
             if (objects.get(i) == null) {
                 assertNull(objectsFromXML.get(i));
             } else {
-                assertTrue(objects.get(i).getNumber() == objectsFromXML.get(i).getNumber());
+                assertEquals(objects.get(i).getNumber(), objectsFromXML.get(i).getNumber());
             }
         }
     }
@@ -1127,7 +1127,7 @@ class XWikiDocumentMockitoTest
         XWikiDocument document = new XWikiDocument(new DocumentReference("wiki", "space", "page"));
         XWikiDocument otherDocument = document.clone();
 
-        assertTrue(document.equals(otherDocument));
+        assertEquals(document, otherDocument);
         assertTrue(document.equalsData(otherDocument));
 
         otherDocument.setAuthorReference(new DocumentReference("wiki", "space", "otherauthor"));
@@ -1139,7 +1139,7 @@ class XWikiDocumentMockitoTest
 
         document.setMinorEdit(false);
 
-        assertFalse(document.equals(otherDocument));
+        assertNotEquals(document, otherDocument);
         assertTrue(document.equalsData(otherDocument));
     }
 
@@ -1153,12 +1153,12 @@ class XWikiDocumentMockitoTest
         XWikiAttachment otherAttachment =
             otherDocument.addAttachment("file", new byte[] {1, 2}, this.oldcore.getXWikiContext());
 
-        assertTrue(document.equals(otherDocument));
+        assertEquals(document, otherDocument);
         assertTrue(document.equalsData(otherDocument));
 
         otherAttachment.setContent(new byte[] {1, 2, 3});
 
-        assertFalse(document.equals(otherDocument));
+        assertNotEquals(document, otherDocument);
         assertFalse(document.equalsData(otherDocument));
     }
 
@@ -1627,7 +1627,7 @@ class XWikiDocumentMockitoTest
         BaseObject newO = newDoc.getXObject(CLASS_REFERENCE);
 
         assertNotSame(o, newDoc.getXObject(CLASS_REFERENCE));
-        assertFalse(newO.getGuid().equals(o.getGuid()));
+        assertNotEquals(newO.getGuid(), o.getGuid());
         // Verify that the title is copied
         assertEquals("Some title", newDoc.getTitle());
         assertEquals(Locale.ENGLISH, newDoc.getLocale());
@@ -1735,17 +1735,17 @@ class XWikiDocumentMockitoTest
         XWikiAttachment attachment = new XWikiAttachment(this.document, "testAttachment");
         attachmentList.add(attachment);
         assertTrue(this.document.getAttachmentList().contains(attachment));
-        assertTrue(this.document.getAttachment("testAttachment") == attachment);
-        assertTrue(((XWikiAttachmentList) (attachmentList)).getByFilename("testAttachment") == attachment);
+        assertSame(this.document.getAttachment("testAttachment"), attachment);
+        assertSame(((XWikiAttachmentList) (attachmentList)).getByFilename("testAttachment"), attachment);
         assertFalse(attachmentList.add(attachment));
-        assertTrue(attachmentList.size() == 1);
+        assertEquals(1, attachmentList.size());
 
         // add using index
         XWikiAttachment attachment2 = new XWikiAttachment(this.document, "testAttachment2");
         attachmentList.add(0, attachment2);
         assertTrue(this.document.getAttachmentList().contains(attachment2));
-        assertTrue(this.document.getAttachment("testAttachment2") == attachment2);
-        assertTrue(((XWikiAttachmentList) (attachmentList)).getByFilename("testAttachment2") == attachment2);
+        assertSame(this.document.getAttachment("testAttachment2"), attachment2);
+        assertSame(((XWikiAttachmentList) (attachmentList)).getByFilename("testAttachment2"), attachment2);
     }
 
     @Test
@@ -1797,13 +1797,13 @@ class XWikiDocumentMockitoTest
         XWikiAttachment attachment = new XWikiAttachment(this.document, "testAttachment");
         attachmentList.set(0, attachment);
         assertTrue(this.document.getAttachmentList().contains(attachment));
-        assertTrue(this.document.getAttachment("testAttachment") == attachment);
+        assertSame(this.document.getAttachment("testAttachment"), attachment);
         XWikiAttachment attachment2 = new XWikiAttachment(this.document, "testAttachment");
         attachmentList.set(0, attachment2);
         assertTrue(this.document.getAttachmentList().contains(attachment2));
         assertFalse(this.document.getAttachmentList().contains(attachment));
-        assertFalse(this.document.getAttachment("testAttachment") == attachment);
-        assertTrue(this.document.getAttachment("testAttachment") == attachment2);
+        assertNotSame(this.document.getAttachment("testAttachment"), attachment);
+        assertSame(this.document.getAttachment("testAttachment"), attachment2);
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiLinkTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiLinkTest.java
@@ -22,7 +22,7 @@ package com.xpn.xwiki.doc;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * Unit tests for the {@link XWikiLink} class.
@@ -55,7 +55,7 @@ class XWikiLinkTest
         assertEquals(l1, l3);
 
         // equals null == false
-        assertFalse(l1.equals(null));
+        assertNotEquals(l1, null);
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/NumberPropertyTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/objects/NumberPropertyTest.java
@@ -22,11 +22,10 @@ package com.xpn.xwiki.objects;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for {@link NumberProperty}.
@@ -51,7 +50,7 @@ class NumberPropertyTest
         assertNotNull(notNullValueProperty.getValue());
 
         // Should not throw a NPE.
-        assertFalse(nullValueProperty.equals(notNullValueProperty));
+        assertNotEquals(nullValueProperty, notNullValueProperty);
     }
 
     /**
@@ -70,7 +69,7 @@ class NumberPropertyTest
         assertNull(notNullValueProperty.getValue());
 
         // Should not throw a NPE.
-        assertFalse(nullValueProperty.equals(notNullValueProperty));
+        assertNotEquals(nullValueProperty, notNullValueProperty);
     }
 
     /**
@@ -89,7 +88,7 @@ class NumberPropertyTest
         assertNull(nullValueProperty2.getValue());
 
         // Should not throw a NPE.
-        assertTrue(nullValueProperty1.equals(nullValueProperty2));
+        assertEquals(nullValueProperty1, nullValueProperty2);
     }
 
     /**
@@ -104,7 +103,7 @@ class NumberPropertyTest
         IntegerProperty notNullValueProperty = new IntegerProperty();
         notNullValueProperty.setValue(1);
 
-        assertTrue(nullValueProperty.equals(notNullValueProperty));
+        assertEquals(nullValueProperty, notNullValueProperty);
     }
 
     /**
@@ -119,7 +118,7 @@ class NumberPropertyTest
         IntegerProperty notNullValueProperty = new IntegerProperty();
         notNullValueProperty.setValue(1);
 
-        assertFalse(nullValueProperty.equals(notNullValueProperty));
+        assertNotEquals(nullValueProperty, notNullValueProperty);
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/DatabaseProductTest.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/test/java/com/xpn/xwiki/store/DatabaseProductTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for {@link DatabaseProduct}.
@@ -96,7 +95,6 @@ class DatabaseProductTest
     void toProductDifference()
     {
         DatabaseProduct product = DatabaseProduct.toProduct("Oracle");
-        assertTrue(product != DatabaseProduct.DERBY);
         assertNotSame(DatabaseProduct.DERBY, product);
     }
 


### PR DESCRIPTION
## Summary

Mechanical, behaviour-preserving cleanup of SonarCloud rule [java:S5785](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS5785&ruleKey=java%3AS5785) ("Fix this assertion to correctly compare these two values") in the `xwiki-platform-oldcore` module. **22 issues fixed** across 4 test files.

Using a dedicated equality/identity assertion instead of a boolean one makes a test failure report the actual and expected values instead of just `expected: <true> but was: <false>`.

## Details

- `assertTrue(a.equals(b))` → `assertEquals(a, b)`, `assertFalse(a.equals(b))` → `assertNotEquals(a, b)`
- `assertTrue(a == b)` → `assertSame(a, b)`, `assertFalse(a == b)` → `assertNotSame(a, b)` (reference comparisons on attachments / enum constants)
- `assertTrue(a == b)` / `assertTrue(a != b)` on numeric values (`size()`, `getNumber()`, `size() == 1`) → `assertEquals` / `assertNotEquals`

The **receiver is kept as the first argument** (`assertEquals(receiver, arg)` calls `receiver.equals(arg)`) so the exact `equals()`/identity direction of each original assertion is preserved. Reference-identity assertions (`assertSame`/`assertNotSame`) are symmetric, so the original operand order is kept for readability.

Static imports adjusted per file: `assertNotEquals` added to `NumberPropertyTest` and `XWikiLinkTest`; the now-unused `assertTrue`/`assertFalse` removed where the file no longer uses them (`NumberPropertyTest`, `XWikiLinkTest`, `DatabaseProductTest`). In `DatabaseProductTest.toProductDifference` the flagged `assertTrue(product != DatabaseProduct.DERBY)` was simply removed because the following line already asserts the same thing with `assertNotSame`.

No production code changed; only test assertions.

Files:
- `XWikiDocumentMockitoTest` (15)
- `NumberPropertyTest` (5)
- `XWikiLinkTest` (1)
- `DatabaseProductTest` (1)

All fixed issues belong to SonarCloud rule `java:S5785`. See the [open S5785 issues for this project](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&rules=java%3AS5785&issueStatuses=OPEN).

## Test plan

- `mvn clean install -Plegacy,snapshot` on `xwiki-platform-oldcore` running the 4 affected test classes **with tests** — BUILD SUCCESS (83 tests, 0 failures; Checkstyle passes). Building with tests confirms the receiver-first operand ordering preserves each assertion's semantics.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GYkSzfTXMfTJoSVnnrjMh2)_