### PR TITLE
[Misc] Merge collapsible nested if statements (SonarCloud java:S1066)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-dashboard/xwiki-platform-dashboard-macro/src/main/java/org/xwiki/rendering/internal/macro/dashboard/DashboardMacro.java
+++ b/xwiki-platform-core/xwiki-platform-dashboard/xwiki-platform-dashboard-macro/src/main/java/org/xwiki/rendering/internal/macro/dashboard/DashboardMacro.java
@@ -256,10 +256,8 @@ public class DashboardMacro extends AbstractMacro<DashboardMacroParameters> impl
         ExecutionContext ec = this.execution.getContext();
         if (ec != null) {
             Integer dashboardCalls = (Integer) ec.getProperty(DASHBOARD_MACRO_CALLS);
-            if (dashboardCalls != null) {
-                if (dashboardCalls > 0) {
-                    ec.setProperty(DASHBOARD_MACRO_CALLS, dashboardCalls - 1);
-                }
+            if (dashboardCalls != null && dashboardCalls > 0) {
+                ec.setProperty(DASHBOARD_MACRO_CALLS, dashboardCalls - 1);
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-cluster/src/main/java/org/xwiki/extension/cluster/internal/ExtensionJobEventConverter.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-cluster/src/main/java/org/xwiki/extension/cluster/internal/ExtensionJobEventConverter.java
@@ -61,13 +61,11 @@ public class ExtensionJobEventConverter extends AbstractEventConverter
             JobStartedEvent jobEvent = (JobStartedEvent) localEvent.getEvent();
 
             // Share only specific jobs
-            if (JOBS.contains(jobEvent.getJobType())) {
-                // Don't send back remote jobs
-                if (!jobEvent.getRequest().isRemote()) {
-                    remoteEvent.setEvent(jobEvent);
+            // Don't send back remote jobs
+            if (JOBS.contains(jobEvent.getJobType()) && !jobEvent.getRequest().isRemote()) {
+                remoteEvent.setEvent(jobEvent);
 
-                    return true;
-                }
+                return true;
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/repository/XarInstalledExtensionRepository.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/repository/XarInstalledExtensionRepository.java
@@ -231,12 +231,9 @@ public class XarInstalledExtensionRepository extends AbstractInstalledExtensionR
      */
     public Collection<XarInstalledExtension> getXarInstalledExtensions(DocumentReference reference)
     {
-        if (reference instanceof DocumentVersionReference versionReference) {
-            if (versionReference.getVersion() instanceof ExtensionId extensionId) {
-                if (extensionId != null) {
-                    return Arrays.asList((XarInstalledExtension) getInstalledExtension(extensionId));
-                }
-            }
+        if (reference instanceof DocumentVersionReference versionReference
+            && versionReference.getVersion() instanceof ExtensionId extensionId && extensionId != null) {
+            return Arrays.asList((XarInstalledExtension) getInstalledExtension(extensionId));
         }
 
         Collection<XarInstalledExtension> wikiExtensions = this.documents

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-script/src/main/java/org/xwiki/extension/script/ExtensionManagerScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-script/src/main/java/org/xwiki/extension/script/ExtensionManagerScriptService.java
@@ -1006,11 +1006,10 @@ public class ExtensionManagerScriptService extends AbstractExtensionScriptServic
      */
     public boolean isAllowed(Extension extension, String namespace)
     {
-        if (extension instanceof IndexedExtension) {
-            if (Boolean.FALSE.equals(((IndexedExtension) extension).isCompatible(namespace))) {
-                // If the extension has explicitly been marked as incompatible, return false
-                return false;
-            }
+        if (extension instanceof IndexedExtension
+            && Boolean.FALSE.equals(((IndexedExtension) extension).isCompatible(namespace))) {
+            // If the extension has explicitly been marked as incompatible, return false
+            return false;
         }
 
         return this.namespaceResolver.isAllowed(extension.getAllowedNamespaces(), namespace);

--- a/xwiki-platform-core/xwiki-platform-javascript/xwiki-platform-javascript-importmap/src/main/java/org/xwiki/javascript/importmap/internal/JavascriptImportmapEventListener.java
+++ b/xwiki-platform-core/xwiki-platform-javascript/xwiki-platform-javascript-importmap/src/main/java/org/xwiki/javascript/importmap/internal/JavascriptImportmapEventListener.java
@@ -74,14 +74,13 @@ public class JavascriptImportmapEventListener implements EventListener
     @Override
     public void onEvent(Event event, Object source, Object data)
     {
-        if (event instanceof AbstractExtensionEvent extensionInstalledEvent) {
-            if (!extensionInstalledEvent.hasNamespace() || Objects.equals(extensionInstalledEvent.getNamespace(),
-                new WikiNamespace(this.wikiDescriptorManager.getCurrentWikiId()).serialize()))
-            {
-                // Only clear the cache for events related to the current wiki (i.e., local to the wiki or global to
-                // the whole farm).
-                this.javascriptImportmapResolver.clearCache();
-            }
+        if (event instanceof AbstractExtensionEvent extensionInstalledEvent
+            && (!extensionInstalledEvent.hasNamespace() || Objects.equals(extensionInstalledEvent.getNamespace(),
+                new WikiNamespace(this.wikiDescriptorManager.getCurrentWikiId()).serialize())))
+        {
+            // Only clear the cache for events related to the current wiki (i.e., local to the wiki or global to
+            // the whole farm).
+            this.javascriptImportmapResolver.clearCache();
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-sources/xwiki-platform-localization-source-wiki/src/main/java/org/xwiki/localization/wiki/internal/OnDemandDocumentTranslationBundle.java
+++ b/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-sources/xwiki-platform-localization-source-wiki/src/main/java/org/xwiki/localization/wiki/internal/OnDemandDocumentTranslationBundle.java
@@ -63,12 +63,10 @@ class OnDemandDocumentTranslationBundle extends AbstractDocumentTranslationBundl
     {
         super.onEvent(event, source, data);
 
-        if (this.factory != null) {
-            if (event instanceof WikiDeletedEvent) {
-                // Clean on demand bundles cache here because DocumentTranslationBundleFactory won't (it does not
-                // receive document deleted event when a wiki is deleted)
-                this.factory.clear(this.uid);
-            }
+        if (this.factory != null && event instanceof WikiDeletedEvent) {
+            // Clean on demand bundles cache here because DocumentTranslationBundleFactory won't (it does not
+            // receive document deleted event when a wiki is deleted)
+            this.factory.clear(this.uid);
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/internal/reference/LocalUidStringEntityReferenceSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/internal/reference/LocalUidStringEntityReferenceSerializer.java
@@ -103,12 +103,11 @@ public class LocalUidStringEntityReferenceSerializer implements EntityReferenceS
 
         // FIXME: Not really nice to parse here the serialized XClass reference to remove its wiki name when local.
         // This also why this is not a simple derived class of UidStringEntityReferenceSerializer.
-        if (wikiReference != null && currentReference.getType() == EntityType.OBJECT) {
-            if (name.startsWith(wikiReference.getName()
+        if (wikiReference != null && currentReference.getType() == EntityType.OBJECT
+            && name.startsWith(wikiReference.getName()
                 + this.symbolScheme.getSeparatorSymbols().get(EntityType.SPACE).get(EntityType.WIKI)))
-            {
-                name = name.substring(wikiReference.getName().length() + 1);
-            }
+        {
+            name = name.substring(wikiReference.getName().length() + 1);
         }
         representation.append(name.length()).append(':').append(name);
 

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/reference/EntityReferenceSet.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/reference/EntityReferenceSet.java
@@ -151,12 +151,11 @@ public class EntityReferenceSet
             for (Map.Entry<EntityType, EntityReferenceEntryChildren> entry : this.children.entrySet()) {
                 EntityReferenceEntryChildren typedChilrendEntry = entry.getValue();
 
-                if (typedChilrendEntry.childrenType.isAllowedAncestor(entityType)) {
-                    // Only return a potential child of the passed type
-                    if (typedChildren == null
-                        || typedChildren.childrenType.isAllowedAncestor(typedChilrendEntry.childrenType)) {
-                        typedChildren = typedChilrendEntry;
-                    }
+                // Only return a potential child of the passed type
+                if (typedChilrendEntry.childrenType.isAllowedAncestor(entityType)
+                    && (typedChildren == null
+                        || typedChildren.childrenType.isAllowedAncestor(typedChilrendEntry.childrenType))) {
+                    typedChildren = typedChilrendEntry;
                 }
             }
 
@@ -205,10 +204,9 @@ public class EntityReferenceSet
         private boolean matches(Map<String, Serializable> referenceParameters, Map<String, Serializable> map)
         {
             for (Map.Entry<String, Serializable> entry : map.entrySet()) {
-                if (referenceParameters.containsKey(entry.getKey())) {
-                    if (!Objects.equals(entry.getValue(), referenceParameters.get(entry.getKey()))) {
-                        return false;
-                    }
+                if (referenceParameters.containsKey(entry.getKey())
+                    && !Objects.equals(entry.getValue(), referenceParameters.get(entry.getKey()))) {
+                    return false;
                 }
             }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/query/HqlQueryExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/hibernate/query/HqlQueryExecutor.java
@@ -175,16 +175,14 @@ public class HqlQueryExecutor extends AbstractQueryExecutor implements Initializ
 
     private void checkAllowed(SecureQuery secureQuery) throws QueryException
     {
-        if (secureQuery.isCurrentAuthorChecked()) {
-            // Not need to check the details if current author has programming right
-            if (!this.authorization.hasAccess(Right.PROGRAM)) {
-                if (secureQuery.isNamed() && !getSafeNamedQueries().contains(secureQuery.getStatement())) {
-                    throw new QueryException("Named queries requires programming right", secureQuery, null);
-                }
+        // Not need to check the details if current author has programming right
+        if (secureQuery.isCurrentAuthorChecked() && !this.authorization.hasAccess(Right.PROGRAM)) {
+            if (secureQuery.isNamed() && !getSafeNamedQueries().contains(secureQuery.getStatement())) {
+                throw new QueryException("Named queries requires programming right", secureQuery, null);
+            }
 
-                if (!this.queryValidator.isSafe(secureQuery.getStatement())) {
-                    throw new QueryException("The query requires programming right", secureQuery, null);
-                }
+            if (!this.queryValidator.isSafe(secureQuery.getStatement())) {
+                throw new QueryException("The query requires programming right", secureQuery, null);
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/main/java/org/xwiki/rendering/internal/macro/code/CodeMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/main/java/org/xwiki/rendering/internal/macro/code/CodeMacro.java
@@ -217,14 +217,12 @@ public class CodeMacro extends AbstractBoxMacro<CodeMacroParameters>
 
         ComponentManager componentManager = this.componentManagerProvider.get();
 
-        if (language != null) {
-            if (componentManager.hasComponent(HighlightParser.class, language)) {
-                try {
-                    parser = componentManager.getInstance(HighlightParser.class, language);
-                    return parser.highlight(language, new StringReader(source.getContent()));
-                } catch (ComponentLookupException e) {
-                    this.logger.error("Faild to load highlighting parser for language [{}]", language, e);
-                }
+        if (language != null && componentManager.hasComponent(HighlightParser.class, language)) {
+            try {
+                parser = componentManager.getInstance(HighlightParser.class, language);
+                return parser.highlight(language, new StringReader(source.getContent()));
+            } catch (ComponentLookupException e) {
+                this.logger.error("Faild to load highlighting parser for language [{}]", language, e);
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/main/java/org/xwiki/rendering/internal/parser/pygments/BlocksGeneratorPygmentsListener.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code/src/main/java/org/xwiki/rendering/internal/parser/pygments/BlocksGeneratorPygmentsListener.java
@@ -198,10 +198,8 @@ public class BlocksGeneratorPygmentsListener implements PygmentsListener
     {
         Object obj = styles.get(pyName);
 
-        if (obj != null && !(obj instanceof PyNone)) {
-            if (((Boolean) obj)) {
-                styleOut.append(cssValue);
-            }
+        if (obj != null && !(obj instanceof PyNone) && ((Boolean) obj)) {
+            styleOut.append(cssValue);
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-api/src/main/java/org/xwiki/rendering/internal/macro/wikibridge/WikiMacroEventListener.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-api/src/main/java/org/xwiki/rendering/internal/macro/wikibridge/WikiMacroEventListener.java
@@ -116,26 +116,24 @@ public class WikiMacroEventListener implements EventListener
         DocumentReference documentReference = document.getDocumentReference();
 
         // Unregister any existing macro registered under this document.
-        if (unregisterMacro(documentReference)) {
-            // Check whether the given document has a wiki macro defined in it.
-            if (this.macroFactory.containsWikiMacro(document)) {
-                // Attempt to create a wiki macro.
-                WikiMacro wikiMacro;
-                try {
-                    wikiMacro = this.macroFactory.createWikiMacro(documentReference);
-                } catch (WikiMacroException e) {
-                    this.logger.error(String.format("Failed to create wiki macro [%s]", documentReference), e);
-                    return;
-                }
-                if (wikiMacro != null) {
+        // Check whether the given document has a wiki macro defined in it.
+        if (unregisterMacro(documentReference) && this.macroFactory.containsWikiMacro(document)) {
+            // Attempt to create a wiki macro.
+            WikiMacro wikiMacro;
+            try {
+                wikiMacro = this.macroFactory.createWikiMacro(documentReference);
+            } catch (WikiMacroException e) {
+                this.logger.error(String.format("Failed to create wiki macro [%s]", documentReference), e);
+                return;
+            }
+            if (wikiMacro != null) {
 
-                    // Register the macro.
-                    registerMacro(documentReference, wikiMacro);
-                } else {
-                    // This should only occur when creating a new WikiMacro object from object editor.
-                    this.logger.debug("Macro from document [{}] cannot be registered because its id is null.",
-                        documentReference);
-                }
+                // Register the macro.
+                registerMacro(documentReference, wikiMacro);
+            } else {
+                // This should only occur when creating a new WikiMacro object from object editor.
+                this.logger.debug("Macro from document [{}] cannot be registered because its id is null.",
+                    documentReference);
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacro.java
@@ -230,10 +230,9 @@ public class DefaultWikiMacro extends AbstractAsyncContentBaseObjectWikiComponen
         }
 
         // Verify the a macro content is not empty if it was declared mandatory.
-        if (getDescriptor().getContentDescriptor() != null && getDescriptor().getContentDescriptor().isMandatory()) {
-            if (macroContent == null || macroContent.length() == 0) {
-                throw new MacroExecutionException("Missing macro content: this macro requires content (a body)");
-            }
+        if (getDescriptor().getContentDescriptor() != null && getDescriptor().getContentDescriptor().isMandatory()
+            && (macroContent == null || macroContent.length() == 0)) {
+            throw new MacroExecutionException("Missing macro content: this macro requires content (a body)");
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/AbstractExtensionRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-repository/xwiki-platform-repository-server-api/src/main/java/org/xwiki/repository/internal/resources/AbstractExtensionRESTResource.java
@@ -437,25 +437,23 @@ public abstract class AbstractExtensionRESTResource extends XWikiResource implem
                 versionDocument.getXObjects(XWikiRepositoryModel.EXTENSIONDEPENDENCY_CLASSREFERENCE);
             if (dependencies != null) {
                 for (BaseObject dependencyObject : dependencies) {
-                    if (dependencyObject != null) {
-                        if (Strings.CS.equals(this.extensionStore.getValue(dependencyObject,
-                            XWikiRepositoryModel.PROP_DEPENDENCY_EXTENSIONVERSION, null), version)) {
-                            ExtensionDependency dependency = extensionObjectFactory.createExtensionDependency();
-                            dependency.setId(this.extensionStore.getValue(dependencyObject,
-                                XWikiRepositoryModel.PROP_DEPENDENCY_ID));
-                            dependency.setConstraint(this.extensionStore.getValue(dependencyObject,
-                                XWikiRepositoryModel.PROP_DEPENDENCY_CONSTRAINT));
-                            List<String> dependencyExclusions = this.extensionStore.getValue(dependencyObject,
-                                XWikiRepositoryModel.PROP_DEPENDENCY_EXCLUSIONS);
-                            dependency.withExclusions(dependencyExclusions);
-                            dependency.setOptional(this.extensionStore.getBooleanValue(dependencyObject,
-                                XWikiRepositoryModel.PROP_DEPENDENCY_OPTIONAL, false));
-                            List<String> dependencyRepositories = this.extensionStore.getValue(dependencyObject,
-                                XWikiRepositoryModel.PROP_DEPENDENCY_REPOSITORIES);
-                            dependency.withRepositories(toExtensionRepositories(dependencyRepositories));
+                    if (dependencyObject != null && Strings.CS.equals(this.extensionStore.getValue(dependencyObject,
+                        XWikiRepositoryModel.PROP_DEPENDENCY_EXTENSIONVERSION, null), version)) {
+                        ExtensionDependency dependency = extensionObjectFactory.createExtensionDependency();
+                        dependency.setId(this.extensionStore.getValue(dependencyObject,
+                            XWikiRepositoryModel.PROP_DEPENDENCY_ID));
+                        dependency.setConstraint(this.extensionStore.getValue(dependencyObject,
+                            XWikiRepositoryModel.PROP_DEPENDENCY_CONSTRAINT));
+                        List<String> dependencyExclusions = this.extensionStore.getValue(dependencyObject,
+                            XWikiRepositoryModel.PROP_DEPENDENCY_EXCLUSIONS);
+                        dependency.withExclusions(dependencyExclusions);
+                        dependency.setOptional(this.extensionStore.getBooleanValue(dependencyObject,
+                            XWikiRepositoryModel.PROP_DEPENDENCY_OPTIONAL, false));
+                        List<String> dependencyRepositories = this.extensionStore.getValue(dependencyObject,
+                            XWikiRepositoryModel.PROP_DEPENDENCY_REPOSITORIES);
+                        dependency.withRepositories(toExtensionRepositories(dependencyRepositories));
 
-                            extensionVersion.getDependencies().add(dependency);
-                        }
+                        extensionVersion.getDependencies().add(dependency);
                     }
                 }
             }

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/ModelFactory.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/ModelFactory.java
@@ -717,15 +717,13 @@ public class ModelFactory
         }
 
         com.xpn.xwiki.api.Object tagsObject = doc.getObject("XWiki.TagClass", 0);
-        if (tagsObject != null) {
-            if (tagsObject.getProperty("tags") != null) {
-                String tagsUri = Utils.createURI(baseUri, PageTagsResource.class, doc.getWiki(), restSpacesValue,
-                    doc.getDocumentReference().getName()).toString();
-                Link tagsLink = this.objectFactory.createLink();
-                tagsLink.setHref(tagsUri);
-                tagsLink.setRel(Relations.TAGS);
-                pageSummary.getLinks().add(tagsLink);
-            }
+        if (tagsObject != null && tagsObject.getProperty("tags") != null) {
+            String tagsUri = Utils.createURI(baseUri, PageTagsResource.class, doc.getWiki(), restSpacesValue,
+                doc.getDocumentReference().getName()).toString();
+            Link tagsLink = this.objectFactory.createLink();
+            tagsLink.setHref(tagsUri);
+            tagsLink.setRel(Relations.TAGS);
+            pageSummary.getLinks().add(tagsLink);
         }
 
         String syntaxesUri = Utils.createURI(baseUri, SyntaxesResource.class).toString();

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/RangeIterable.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/RangeIterable.java
@@ -100,10 +100,8 @@ public class RangeIterable<T> implements Iterable<T>
             @Override
             public boolean hasNext()
             {
-                if (i < number) {
-                    if (i + start < list.size()) {
-                        return true;
-                    }
+                if (i < number && i + start < list.size()) {
+                    return true;
                 }
 
                 return false;

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/cache/internal/DefaultSecurityCacheTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/cache/internal/DefaultSecurityCacheTest.java
@@ -191,11 +191,10 @@ class DefaultSecurityCacheTest extends AbstractSecurityTestCase
         if (groupUserRefs.contains(entry.getReference())) {
             final List<GroupSecurityReference> groups = new ArrayList<>();
             for (GroupSecurityReference group : groupRefs.keySet()) {
-                if (groupRefs.get(group).contains(entry.getReference())) {
-                    if (group.getOriginalReference().getWikiReference()
+                if (groupRefs.get(group).contains(entry.getReference())
+                    && group.getOriginalReference().getWikiReference()
                         .equals(entry.getReference().getOriginalDocumentReference().getWikiReference())) {
-                        groups.add(group);
-                    }
+                    groups.add(group);
                 }
             }
             AddUserEntry(entry, groups);
@@ -213,13 +212,11 @@ class DefaultSecurityCacheTest extends AbstractSecurityTestCase
         if (groupUserRefs.contains(user.getReference())) {
             final List<GroupSecurityReference> groups = new ArrayList<>();
             for (GroupSecurityReference group : groupRefs.keySet()) {
-                if (groupRefs.get(group).contains(user.getReference())) {
-                    if (group.getOriginalReference().getWikiReference()
+                if (groupRefs.get(group).contains(user.getReference())
+                    && (group.getOriginalReference().getWikiReference()
                         .equals(user.getWikiReference().getOriginalWikiReference())
-                        || group.isGlobal())
-                    {
-                        groups.add(group);
-                    }
+                        || group.isGlobal())) {
+                    groups.add(group);
                 }
             }
             securityCache.add(user, groups, securityCache.getInvalidationCounter());

--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-schemes/xwiki-platform-url-scheme-standard/src/main/java/org/xwiki/url/internal/standard/AbstractWikiReferenceExtractor.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-schemes/xwiki-platform-url-scheme-standard/src/main/java/org/xwiki/url/internal/standard/AbstractWikiReferenceExtractor.java
@@ -57,12 +57,10 @@ public abstract class AbstractWikiReferenceExtractor implements WikiReferenceExt
         String normalizedWikiId = alias;
         String mainWiki = getMainWikiId();
         if (!mainWiki.equals(normalizedWikiId)
-            && this.configuration.getWikiNotFoundBehavior() == WikiNotFoundBehavior.REDIRECT_TO_MAIN_WIKI)
-        {
-            if (getWikiDescriptorById(normalizedWikiId) == null) {
-                // Fallback on main wiki
-                normalizedWikiId = mainWiki;
-            }
+            && this.configuration.getWikiNotFoundBehavior() == WikiNotFoundBehavior.REDIRECT_TO_MAIN_WIKI
+            && getWikiDescriptorById(normalizedWikiId) == null) {
+            // Fallback on main wiki
+            normalizedWikiId = mainWiki;
         }
         return normalizedWikiId;
     }

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-creationjob/src/main/java/org/xwiki/platform/wiki/creationjob/script/WikiCreationJobScriptServices.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-creationjob/src/main/java/org/xwiki/platform/wiki/creationjob/script/WikiCreationJobScriptServices.java
@@ -96,11 +96,9 @@ public class WikiCreationJobScriptServices implements ScriptService
             authorizationManager.checkAccess(Right.CREATE_WIKI, xcontext.getUserReference(), mainWikiReference);
             
             // Verify that if an extension id is provided, this extension is authorized.
-            if (request.getExtensionId() != null) {
-                if (!isAuthorizedExtension(request.getExtensionId())) {
-                    throw new WikiCreationException(String.format("The extension [%s] is not authorized.",
-                            request.getExtensionId()));
-                }
+            if (request.getExtensionId() != null && !isAuthorizedExtension(request.getExtensionId())) {
+                throw new WikiCreationException(String.format("The extension [%s] is not authorized.",
+                        request.getExtensionId()));
             }
             return wikiCreator.createWiki(request);
             

--- a/xwiki-platform-tools/xwiki-platform-tool-packager-plugin/src/main/java/com/xpn/xwiki/tool/backup/AbstractImportMojo.java
+++ b/xwiki-platform-tools/xwiki-platform-tool-packager-plugin/src/main/java/com/xpn/xwiki/tool/backup/AbstractImportMojo.java
@@ -87,10 +87,8 @@ public abstract class AbstractImportMojo extends AbstractOldCoreMojo
         Collections.reverse(dependenciesFirstArtifacts);
 
         for (Artifact artifact : dependenciesFirstArtifacts) {
-            if (!artifact.isOptional()) {
-                if ("xar".equals(artifact.getType())) {
-                    installXAR(artifact, importer, this.oldCoreHelper.getXWikiContext());
-                }
+            if (!artifact.isOptional() && "xar".equals(artifact.getType())) {
+                installXAR(artifact, importer, this.oldCoreHelper.getXWikiContext());
             }
         }
     }


### PR DESCRIPTION
## Summary

Mechanical, behaviour-preserving cleanup of SonarCloud rule [java:S1066](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS1066&ruleKey=java%3AS1066) ("Merge this if statement with the enclosing one") across **17 modules**. **23 issues fixed** in 20 files.

Merging a collapsible nested `if` into its enclosing one with `&&` reduces nesting and makes the combined condition explicit, without changing behaviour (`&&` short-circuits exactly as the nested `if`s did).

## Details

For each flagged inner `if`, the outer and inner conditions were merged with `&&`, the inner `if` line removed, the body dedented, and the redundant brace removed:

- `if (A) { if (B) { BODY } }` → `if (A && B) { BODY }`
- Operands containing a top-level `||` were wrapped in parentheses to preserve precedence.
- Where a single-line `//` comment between the two `if`s described the inner condition, it was moved directly above the merged `if`.
- A few merged conditions were wrapped onto two lines with a +4 continuation indent to stay within the 120-character line limit.

A number of flagged sites were intentionally **left out** because merging them would not be behaviour-preserving or clean: the enclosing statement is an `else if`, the inner `if` is not the sole statement of the outer body, or a multi-line comment (or a comment documenting the *outer* condition) sits between the two `if`s.

No production behaviour changed; only control-flow structure.

All fixed issues belong to SonarCloud rule `java:S1066`. See the [open S1066 issues for this project](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&rules=java%3AS1066&issueStatuses=OPEN).

## Test plan

- `mvn clean install -Plegacy,snapshot -DskipTests` across all 17 affected modules in one reactor — **BUILD SUCCESS**. Test sources still compile and Checkstyle passes; the merges are behaviour-preserving.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)