### PR TITLE
[Misc] Simplify code flagged by SonarCloud (inline returns, factor duplicated literals)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-captcha/xwiki-platform-captcha-default/src/main/java/org/xwiki/captcha/AbstractCaptcha.java
+++ b/xwiki-platform-core/xwiki-platform-captcha/xwiki-platform-captcha-default/src/main/java/org/xwiki/captcha/AbstractCaptcha.java
@@ -203,7 +203,6 @@ public abstract class AbstractCaptcha implements Captcha
      */
     protected XWikiContext getContext()
     {
-        XWikiContext context = contextProvider.get();
-        return context;
+        return contextProvider.get();
     }
 }

--- a/xwiki-platform-core/xwiki-platform-captcha/xwiki-platform-captcha-jcaptcha/xwiki-platform-captcha-jcaptcha-api/src/main/java/org/xwiki/captcha/internal/JCaptchaCaptcha.java
+++ b/xwiki-platform-core/xwiki-platform-captcha/xwiki-platform-captcha-jcaptcha/xwiki-platform-captcha-jcaptcha-api/src/main/java/org/xwiki/captcha/internal/JCaptchaCaptcha.java
@@ -140,7 +140,6 @@ public class JCaptchaCaptcha extends AbstractCaptcha
 
         String answer = request.getParameter("captchaAnswer");
 
-        boolean result = captchaService.validateResponseForID(id, answer);
-        return result;
+        return captchaService.validateResponseForID(id, answer);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/FeedPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/FeedPlugin.java
@@ -300,12 +300,10 @@ public class FeedPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfa
             XWikiFeedFetcher feedFetcher = new XWikiFeedFetcher();
             feedFetcher.setUserAgent(context.getWiki().Param("xwiki.plugins.feed.useragent",
                 context.getWiki().getHttpUserAgent(context)));
-            SyndFeed feed =
-                feedFetcher.retrieveFeed(
-                    feedURL,
-                    (int) context.getWiki().ParamAsLong("xwiki.plugins.feed.timeout",
-                        context.getWiki().getHttpTimeout(context)));
-            return feed;
+            return feedFetcher.retrieveFeed(
+                feedURL,
+                (int) context.getWiki().ParamAsLong("xwiki.plugins.feed.timeout",
+                    context.getWiki().getHttpTimeout(context)));
         } catch (Exception ex) {
             if (ignoreInvalidFeeds) {
                 @SuppressWarnings("unchecked")

--- a/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/SyndEntryDocumentSource.java
+++ b/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/SyndEntryDocumentSource.java
@@ -140,6 +140,11 @@ public class SyndEntryDocumentSource implements SyndEntrySource
 
     public static final String CONTENT_LENGTH = "ContentLength";
 
+    /**
+     * The JTidy configuration property name holding the input encoding.
+     */
+    private static final String INPUT_ENCODING = "input-encoding";
+
     public static final Properties TIDY_FEED_CONFIG;
 
     public static final Properties TIDY_XML_CONFIG;
@@ -180,7 +185,7 @@ public class SyndEntryDocumentSource implements SyndEntrySource
         TIDY_XML_CONFIG.setProperty("input-xml", "yes");
         TIDY_XML_CONFIG.setProperty("output-xml", "yes");
         TIDY_XML_CONFIG.setProperty("add-xml-pi", "no");
-        TIDY_XML_CONFIG.setProperty("input-encoding", "UTF8");
+        TIDY_XML_CONFIG.setProperty(INPUT_ENCODING, "UTF8");
 
         // HTML specific configuration
         TIDY_HTML_CONFIG = new Properties(TIDY_FEED_CONFIG);
@@ -189,7 +194,7 @@ public class SyndEntryDocumentSource implements SyndEntrySource
         TIDY_HTML_CONFIG.setProperty("drop-empty-paras", "yes");
         TIDY_HTML_CONFIG.setProperty("enclose-text", "yes");
         TIDY_HTML_CONFIG.setProperty("logical-emphasis", "yes");
-        TIDY_HTML_CONFIG.setProperty("input-encoding", "UTF8");
+        TIDY_HTML_CONFIG.setProperty(INPUT_ENCODING, "UTF8");
 
         // default parameters for all instances of this class
         DEFAULT_PARAMS = new HashMap<>();
@@ -636,7 +641,7 @@ public class SyndEntryDocumentSource implements SyndEntrySource
         // Even if we add a message listener we still have to redirect the output. Otherwise all the messages will be
         // written to the standard output (besides being logged by TIDY_LOGGER).
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        ByteArrayInputStream in = new ByteArrayInputStream(xmlFragment.getBytes(Charset.forName(config.getProperty("input-encoding"))));
+        ByteArrayInputStream in = new ByteArrayInputStream(xmlFragment.getBytes(Charset.forName(config.getProperty(INPUT_ENCODING))));
         return tidy.parseDOM(in, out);
     }
 

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-mail/xwiki-platform-legacy-mail-send/xwiki-platform-legacy-mail-send-default/src/main/java/org/xwiki/mail/internal/factory/users/UsersMimeMessageFactory.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-mail/xwiki-platform-legacy-mail-send/xwiki-platform-legacy-mail-send-default/src/main/java/org/xwiki/mail/internal/factory/users/UsersMimeMessageFactory.java
@@ -65,9 +65,8 @@ public class UsersMimeMessageFactory extends AbstractIteratorMimeMessageFactory
 
         MimeMessageFactory factory = getInternalMimeMessageFactory(factoryHint);
 
-        UsersMimeMessageIterator iterator = new UsersMimeMessageIterator(userReferences, factory, parameters,
+        return new UsersMimeMessageIterator(userReferences, factory, parameters,
             this.componentManagerProvider.get());
-        return iterator;
     }
 
 }

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-mail/xwiki-platform-legacy-mail-send/xwiki-platform-legacy-mail-send-storage/src/main/java/org/xwiki/mail/script/DeprecatedMailStorageScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-mail/xwiki-platform-legacy-mail-send/xwiki-platform-legacy-mail-send-storage/src/main/java/org/xwiki/mail/script/DeprecatedMailStorageScriptService.java
@@ -117,8 +117,7 @@ public class DeprecatedMailStorageScriptService extends AbstractMailScriptServic
     {
         try {
             MailStatusResult statusResult = this.mailResender.resendAsynchronously(batchId, uniqueMessageId);
-            ScriptMailResult scriptMailResult = new ScriptMailResult(new DefaultMailResult(batchId), statusResult);
-            return scriptMailResult;
+            return new ScriptMailResult(new DefaultMailResult(batchId), statusResult);
         } catch (MailStoreException e) {
             // Save the exception for reporting through the script services's getLastError() API
             setError(e);
@@ -311,8 +310,7 @@ public class DeprecatedMailStorageScriptService extends AbstractMailScriptServic
 
     private MimeMessage loadMessage(Session session, String batchId, String mailId) throws MailStoreException
     {
-        MimeMessage message = this.mailContentStore.load(session, batchId, mailId);
-        return message;
+        return this.mailContentStore.load(session, batchId, mailId);
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-mailsender/src/main/java/com/xpn/xwiki/plugin/mailsender/MailSenderPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-mailsender/src/main/java/com/xpn/xwiki/plugin/mailsender/MailSenderPlugin.java
@@ -101,6 +101,11 @@ public class MailSenderPlugin extends XWikiDefaultPlugin
     private static final String EMAIL_ENCODING = "UTF-8";
 
     /**
+     * Error message logged when a {@link MessagingException} occurs while sending emails.
+     */
+    private static final String MESSAGING_EXCEPTION_ERROR = "MessagingException has occured.";
+
+    /**
      * Error code signaling that the mail template requested for
      * {@link #sendMailFromTemplate(String, String, String, String, String, String, VelocityContext, XWikiContext)} was
      * not found.
@@ -673,7 +678,7 @@ public class MailSenderPlugin extends XWikiDefaultPlugin
                                 transport.close();
                             }
                         } catch (MessagingException ex) {
-                            LOGGER.error("MessagingException has occured.", ex);
+                            LOGGER.error(MESSAGING_EXCEPTION_ERROR, ex);
                         }
                         transport = null;
                         session = null;
@@ -689,7 +694,7 @@ public class MailSenderPlugin extends XWikiDefaultPlugin
                         throw ex;
                     }
                 } catch (MessagingException mex) {
-                    LOGGER.error("MessagingException has occured.", mex);
+                    LOGGER.error(MESSAGING_EXCEPTION_ERROR, mex);
                     LOGGER.error("Detailed email information" + mail.toString());
                     if (emailCount == 1) {
                         throw mex;
@@ -706,7 +711,7 @@ public class MailSenderPlugin extends XWikiDefaultPlugin
                     transport.close();
                 }
             } catch (MessagingException ex) {
-                LOGGER.error("MessagingException has occured.", ex);
+                LOGGER.error(MESSAGING_EXCEPTION_ERROR, ex);
             }
 
             LOGGER.info("sendEmails: Email count = " + emailCount + " sent count = " + count);

--- a/xwiki-platform-core/xwiki-platform-mailsender/src/main/java/com/xpn/xwiki/plugin/mailsender/MailSenderPluginApi.java
+++ b/xwiki-platform-core/xwiki-platform-mailsender/src/main/java/com/xpn/xwiki/plugin/mailsender/MailSenderPluginApi.java
@@ -45,6 +45,11 @@ public class MailSenderPluginApi extends PluginApi<MailSenderPlugin> implements 
     private static final Logger LOGGER = LoggerFactory.getLogger(MailSenderPluginApi.class);
 
     /**
+     * The key under which the error message is stored in the XWiki context.
+     */
+    private static final String ERROR_KEY = "error";
+
+    /**
      * API constructor.
      * 
      * @param plugin The wrapped plugin object.
@@ -119,7 +124,7 @@ public class MailSenderPluginApi extends PluginApi<MailSenderPlugin> implements 
         } catch (Exception e) {
             // If the exception is a null pointer exception there is no message and e.getMessage() is null.
             if (e.getMessage() != null) {
-                this.context.put("error", e.getMessage());
+                this.context.put(ERROR_KEY, e.getMessage());
             }
             LOGGER.error("sendMessageFromTemplate", e);
             return -1;
@@ -150,7 +155,7 @@ public class MailSenderPluginApi extends PluginApi<MailSenderPlugin> implements 
         } catch (Exception e) {
             // If the exception is a null pointer exception there is no message and e.getMessage() is null.
             if (e.getMessage() != null) {
-                this.context.put("error", e.getMessage());
+                this.context.put(ERROR_KEY, e.getMessage());
             }
             LOGGER.error("sendMessageFromTemplate", e);
             return -1;
@@ -172,7 +177,7 @@ public class MailSenderPluginApi extends PluginApi<MailSenderPlugin> implements 
         } catch (Exception e) {
             // If the exception is a null pointer exception there is no message and e.getMessage() is null.
             if (e.getMessage() != null) {
-                this.context.put("error", e.getMessage());
+                this.context.put(ERROR_KEY, e.getMessage());
             }
             LOGGER.error("Failed to send email [" + mail.toString() + "]", e);
             result = -1;
@@ -196,7 +201,7 @@ public class MailSenderPluginApi extends PluginApi<MailSenderPlugin> implements 
         } catch (Exception e) {
             // If the exception is a null pointer exception there is no message and e.getMessage() is null.
             if (e.getMessage() != null) {
-                this.context.put("error", e.getMessage());
+                this.context.put(ERROR_KEY, e.getMessage());
             }
             LOGGER.error("Failed to send email [" + mail.toString() + "] using mail configuration ["
                 + mailConfiguration.toString() + "]", e);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/XWiki.java
@@ -4227,7 +4227,8 @@ public class XWiki implements EventListener
 
         try {
             // TODO: Verify existing user
-            XWikiDocument doc = getDocument(new DocumentReference(context.getWikiId(), "XWiki", userName), context);
+            XWikiDocument doc =
+                getDocument(new DocumentReference(context.getWikiId(), SYSTEM_SPACE, userName), context);
 
             if (!doc.isNew()) {
                 // TODO: throws Exception

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/XWiki.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/api/XWiki.java
@@ -71,6 +71,9 @@ public class XWiki extends Api
     /** Logging helper object. */
     protected static final Logger LOGGER = LoggerFactory.getLogger(XWiki.class);
 
+    /** Value returned when Groovy parsing is denied because of missing programming rights. */
+    private static final String GROOVY_MISSINGRIGHTS = "groovy_missingrights";
+
     /** The internal object wrapped by this API. */
     private com.xpn.xwiki.XWiki xwiki;
 
@@ -2686,7 +2689,7 @@ public class XWiki extends Api
         if (hasProgrammingRights()) {
             return this.xwiki.parseGroovyFromString(script, getXWikiContext());
         }
-        return "groovy_missingrights";
+        return GROOVY_MISSINGRIGHTS;
     }
 
     /**
@@ -2703,7 +2706,7 @@ public class XWiki extends Api
         if (this.xwiki.getRightService().hasProgrammingRights(doc, getXWikiContext())) {
             return this.xwiki.parseGroovyFromString(doc.getContent(), jarWikiPage, getXWikiContext());
         }
-        return "groovy_missingrights";
+        return GROOVY_MISSINGRIGHTS;
     }
 
     /**
@@ -2720,7 +2723,7 @@ public class XWiki extends Api
         if (this.xwiki.getRightService().hasProgrammingRights(doc, getXWikiContext())) {
             return this.xwiki.parseGroovyFromString(doc.getContent(), getXWikiContext());
         }
-        return "groovy_missingrights";
+        return GROOVY_MISSINGRIGHTS;
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-xwql/src/main/java/org/xwiki/query/xwql/internal/hql/ObjectPrinter.java
+++ b/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-xwql/src/main/java/org/xwiki/query/xwql/internal/hql/ObjectPrinter.java
@@ -23,6 +23,8 @@ import org.xwiki.query.xwql.internal.QueryContext.ObjectInfo;
 
 public class ObjectPrinter
 {
+    private static final String AND = " and ";
+
     void print(ObjectInfo obj, Printer printer) throws Exception
     {
         if (obj.alias == null) {
@@ -31,18 +33,18 @@ public class ObjectPrinter
             printer.from.append(", BaseObject as ").append(obj.alias);
         }
         // join with the document
-        printer.where.append(" and ")
+        printer.where.append(AND)
             .append(obj.docAlias).append(".fullName=").append(obj.alias).append(".name");
         // className constraint
         if (obj.isCustomMapped()) {
             obj.customMappingAlias = printer.getContext().getAliasGenerator().generate(obj.alias + "CM");
             printer.from.append(", ")
                 .append(obj.className).append(" as ").append(obj.customMappingAlias);
-            printer.where.append(" and ")
+            printer.where.append(AND)
                 .append(obj.alias).append(".id=").append(obj.customMappingAlias).append(".id");
         } else {
             // main case
-            printer.where.append(" and ")
+            printer.where.append(AND)
                 .append(obj.alias).append(".className=").append("'").append(obj.className).append("'");
         }
     }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroRenderer.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroRenderer.java
@@ -115,6 +115,11 @@ public class DefaultWikiMacroRenderer extends AbstractBlockAsyncRenderer
     private static final String MACRO_BINDING = "wikimacro";
 
     /**
+     * The name of the metadata flagging a block as containing wiki macro content.
+     */
+    private static final String WIKIMACROCONTENT = "wikimacrocontent";
+
+    /**
      * The key under which macro body will be available inside macro context.
      * 
      * @deprecated since 11.6RC1, 11.3.2, 10.11.8. {@link WikiMacroBinding} should now be used.
@@ -196,7 +201,7 @@ public class DefaultWikiMacroRenderer extends AbstractBlockAsyncRenderer
      */
     private static final BlockMatcher MACROCONTENT_METADATA_MATCHER =
         testedBlock -> (testedBlock instanceof MetaDataBlock)
-            && "true".equals(((MetaDataBlock) testedBlock).getMetaData().getMetaData("wikimacrocontent"));
+            && "true".equals(((MetaDataBlock) testedBlock).getMetaData().getMetaData(WIKIMACROCONTENT));
 
     /**
      * Match all the metadata blocks that contains a non-generated-content metadata.
@@ -712,7 +717,7 @@ public class DefaultWikiMacroRenderer extends AbstractBlockAsyncRenderer
     {
         if (this.wikimacro.getDescriptor().getContentDescriptor() != null && this.macroContent != null) {
             MetaData nonGeneratedContentMetaData = getNonGeneratedContentMetaData();
-            nonGeneratedContentMetaData.addMetaData("wikimacrocontent", "true");
+            nonGeneratedContentMetaData.addMetaData(WIKIMACROCONTENT, "true");
 
             List<Block> blocks;
             try {
@@ -762,7 +767,7 @@ public class DefaultWikiMacroRenderer extends AbstractBlockAsyncRenderer
 
         if (parameterValue instanceof String) {
             MetaData nonGeneratedContentMetaData = getNonGeneratedParameterMetaData(parameterName);
-            nonGeneratedContentMetaData.addMetaData("wikimacrocontent", "true");
+            nonGeneratedContentMetaData.addMetaData(WIKIMACROCONTENT, "true");
 
             List<Block> blocks;
             try {

--- a/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/DatabaseKeywordSearchSource.java
+++ b/xwiki-platform-core/xwiki-platform-rest/xwiki-platform-rest-server/src/main/java/org/xwiki/rest/internal/resources/DatabaseKeywordSearchSource.java
@@ -93,6 +93,11 @@ public class DatabaseKeywordSearchSource implements KeywordSearchSource
      */
     private static final String KEYWORDS = "keywords";
 
+    /**
+     * The format used to surround the keywords with SQL {@code LIKE} wildcards.
+     */
+    private static final String KEYWORD_LIKE_FORMAT = "%%%s%%";
+
     @Inject
     protected ContextualAuthorizationManager authorizationManager;
 
@@ -272,7 +277,7 @@ public class DatabaseKeywordSearchSource implements KeywordSearchSource
             String queryString = f.toString();
 
             Query query = finalQueryManager.createQuery(queryString, Query.HQL)
-                .bindValue(KEYWORDS, String.format("%%%s%%", keywords.toUpperCase()))
+                .bindValue(KEYWORDS, String.format(KEYWORD_LIKE_FORMAT, keywords.toUpperCase()))
                 .addFilter(this.hiddenDocumentFilterProvider.get()).setOffset(options.start())
                 // Worst case scenario when making the locale aware query:
                 // e.g.: Search matches a document translated in fr_CA and fr
@@ -414,7 +419,7 @@ public class DatabaseKeywordSearchSource implements KeywordSearchSource
             + " order by lower(space.reference), space.reference";
 
         List<Object> queryResult = this.queryManager.createQuery(query, Query.HQL)
-            .bindValue(KEYWORDS, String.format("%%%s%%", escapedKeywords))
+            .bindValue(KEYWORDS, String.format(KEYWORD_LIKE_FORMAT, escapedKeywords))
             .bindValue("prefix", String.format("%s%%", escapedKeywords))
             .setWiki(wikiName).setLimit(number).setOffset(start)
             .addFilter(this.hiddenSpaceFilterProvider.get()).execute();
@@ -538,12 +543,12 @@ public class DatabaseKeywordSearchSource implements KeywordSearchSource
             if (options.space() != null) {
                 queryResult =
                     finalQueryManager.createQuery(query, Query.XWQL)
-                        .bindValue(KEYWORDS, String.format("%%%s%%", keywords.toUpperCase()))
+                        .bindValue(KEYWORDS, String.format(KEYWORD_LIKE_FORMAT, keywords.toUpperCase()))
                         .bindValue(SPACE, options.space()).setLimit(options.number()).execute();
             } else {
                 queryResult =
                     finalQueryManager.createQuery(query, Query.XWQL)
-                        .bindValue(KEYWORDS, String.format("%%%s%%", keywords.toUpperCase()))
+                        .bindValue(KEYWORDS, String.format(KEYWORD_LIKE_FORMAT, keywords.toUpperCase()))
                         .setLimit(options.number())
                         .execute();
             }

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-embedded/src/main/java/org/xwiki/search/solr/internal/EmbeddedSolr.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-embedded/src/main/java/org/xwiki/search/solr/internal/EmbeddedSolr.java
@@ -518,8 +518,7 @@ public class EmbeddedSolr extends AbstractSolr implements Disposable, Initializa
 
     private File getCacheCorePropertiesFile(Path corePath)
     {
-        File corePropertiesFile = corePath.resolve(CORE_PROPERTIES_FILENAME).toFile();
-        return corePropertiesFile;
+        return corePath.resolve(CORE_PROPERTIES_FILENAME).toFile();
     }
 
     private void createCacheCore(Path corePath, String solrCoreName) throws IOException

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-bridge/src/test/java/org/xwiki/security/authorization/testwikibuilding/LegacyTestWiki.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-bridge/src/test/java/org/xwiki/security/authorization/testwikibuilding/LegacyTestWiki.java
@@ -462,8 +462,7 @@ public class LegacyTestWiki extends AbstractTestWiki
         TestSpace getTestSpace(String spaceName)
         {
             if (this.spaces.containsKey(spaceName)) {
-                TestSpace space = mockSpace(spaceName);
-                return space;
+                return mockSpace(spaceName);
             }
 
             return null;

--- a/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/AbstractSkinExtensionPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-skin/xwiki-platform-skin-skinx/src/main/java/com/xpn/xwiki/plugin/skinx/AbstractSkinExtensionPlugin.java
@@ -443,8 +443,7 @@ public abstract class AbstractSkinExtensionPlugin extends XWikiDefaultPlugin imp
         // Using an XML comment is pretty safe, as extensions probably wouldn't work in other type
         // of documents, like RTF, CSV or JSON.
         String hook = "<!-- " + this.getClass().getCanonicalName() + " -->";
-        String result = content.replaceFirst(hook, getImportString(context));
-        return result;
+        return content.replaceFirst(hook, getImportString(context));
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-integration/src/main/java/org/xwiki/test/integration/XWikiExecutorTestMethodFilter.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-integration/src/main/java/org/xwiki/test/integration/XWikiExecutorTestMethodFilter.java
@@ -87,9 +87,7 @@ public class XWikiExecutorTestMethodFilter extends Filter
     public boolean shouldRun(Description description)
     {
         String testMethodName = String.format("%s#%s", description.getClassName(), description.getMethodName());
-        boolean result = testMethodName.matches(this.pattern);
-
-        return result;
+        return testMethodName.matches(this.pattern);
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-integration/src/main/java/org/xwiki/test/integration/junit/LogCapture.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-integration/src/main/java/org/xwiki/test/integration/junit/LogCapture.java
@@ -67,7 +67,6 @@ public class LogCapture
         // Put back stderr
         System.setOut(this.savedErr);
 
-        String outputContent = this.collectingContentStream.toString();
-        return outputContent;
+        return this.collectingContentStream.toString();
     }
 }

--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-schemes/xwiki-platform-url-scheme-standard/src/main/java/org/xwiki/url/internal/standard/StandardURLStringEntityReferenceResolver.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-schemes/xwiki-platform-url-scheme-standard/src/main/java/org/xwiki/url/internal/standard/StandardURLStringEntityReferenceResolver.java
@@ -87,8 +87,7 @@ public class StandardURLStringEntityReferenceResolver extends DefaultStringEntit
             ResourceReference reference =
                 this.resourceResolver.resolve(extendedURL, resourceType, Collections.emptyMap());
             if (reference instanceof EntityResourceReference) {
-                EntityReference entityReference = ((EntityResourceReference) reference).getEntityReference();
-                return entityReference;
+                return ((EntityResourceReference) reference).getEntityReference();
             }
         } catch (CreateResourceReferenceException | UnsupportedResourceReferenceException | CreateResourceTypeException
             | MalformedURLException e) {


### PR DESCRIPTION
## Summary

Mechanical, behaviour-preserving cleanup of two SonarCloud rules across 15 modules (**20 issues fixed** in 19 files):

- [**java:S1488**](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS1488&ruleKey=java%3AS1488) — "Immediately return this expression instead of assigning it to the temporary variable" (**12 issues**). Each `Type tmp = <expr>; return tmp;` was collapsed to `return <expr>;`.
- [**java:S1192**](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS1192&ruleKey=java%3AS1192) — "Define a constant instead of duplicating this literal" / "Use already-defined constant" (**8 issues**). A `private static final` constant was introduced (or an existing one reused) and the duplicated string literal replaced.

No production behaviour changed.

## Notes on skipped S1192 sites

A few flagged S1192 sites were intentionally **left out** because the fix would not be safe/clean:
- Coincidental value matches where the two literals mean different things (e.g. a plugin-name constant `"package"` vs. the `package.xml` XML root-element name; a script-context binding key vs. an id-namespace segment).
- Illegal forward references — the suggested existing constant is declared textually *after* the flagged static-field initializer.

## SonarCloud issues

S1488: `AZST1DhIZAC_a1NHeUDr`, `AX8RXBaZAp4U05lfTbt6`, `AZBvgR98cj_-G2g1uBsF`, `AXnpAhD5DDFOvAKXAQuj`, `AXnpAhD5DDFOvAKXAQuk`, `AW5-S-iw1Yj5qvzeRo32`, `AW5-S-hi1Yj5qvzeRo3x`, `AW5-S5Nq1Yj5qvzeRmzt`, `AW5-S-ET1Yj5qvzeRouh`, `AW5-S-XD1Yj5qvzeRo17`, `AW5-S-Ve1Yj5qvzeRo1M`, `AW5-S9_q1Yj5qvzeRorI`

S1192: `AZ9CRJnEiM_eM0I2UHyr`, `AZ8slQrNRFoArOAacNPX`, `AXnpAdZCDDFOvAKXAQEa`, `AW5-S-MH1Yj5qvzeRox6`, `AW5-S-L-1Yj5qvzeRoxy`, `AW5-S-AD1Yj5qvzeRos5`, `AW5-S7pB1Yj5qvzeRn8i`, `AW5-S51K1Yj5qvzeRm5_`

See the [open SonarCloud issues for this project](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&resolved=false).

The modified Maven modules build cleanly (`mvn clean install -DskipTests`, which runs Checkstyle + Spoon).


---
_Generated by [Claude Code](https://claude.ai/code/session_01WG2LjPoLEP6K7qrpQJ7vw3)_