### PR TITLE
XWIKI-24563: The URL input in the link edition picker is not keyboard focusable

### DIFF
--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/xwiki.selectize.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/xwiki.selectize.js
@@ -317,6 +317,19 @@ define('xwiki-selectize', [
 
     const tomSelect = new TomSelect(input, getSettings($(input), settings));
 
+    // Tom Select sets input.tabIndex (see above) AFTER firing its own 'destroy' event, so a 'destroy' listener runs
+    // too early to fix this up (it would get overwritten right after). Wrap destroy() itself so our fix runs
+    // strictly after Tom Select's own tabIndex restoration.
+    const originalDestroy = tomSelect.destroy.bind(tomSelect);
+    tomSelect.destroy = function() {
+      originalDestroy();
+      if (hadTabIndex) {
+        input.setAttribute('tabindex', originalTabIndex);
+      } else {
+        input.removeAttribute('tabindex');
+      }
+    };
+
     // We expose the TomSelect instance through the 'selectize' property / data on the target input / select that is
     // being enhanced, in order to preserve backwards compatibility. We can do this because TomSelect is a fork of
     // Selectize, preserving its JavaScript API. On the long term we need to hide the underlying implementation and
@@ -340,13 +353,6 @@ define('xwiki-selectize', [
     tomSelect.on('destroy', () => {
       // Remove the custom region we added for accessibility.
       tomSelect.liveRegion.remove();
-
-      // Restore the tabindex attribute as it was before Tom Select took over (see comment above).
-      if (hadTabIndex) {
-        input.setAttribute('tabindex', originalTabIndex);
-      } else {
-        input.removeAttribute('tabindex');
-      }
 
       // Delete the references to the TomSelect instance.
       delete input.selectize;

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/xwiki.selectize.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/xwiki.selectize.js
@@ -310,6 +310,11 @@ define('xwiki-selectize', [
     // Save the width before the input is hidden.
     $(input).data('initialWidth', $(input).width());
 
+    // Remember the original tabindex attribute. Tom Select restores the tabIndex DOM property on destroy(), which
+    // defaults to 0 and gets reflected back as a tabindex="0" attribute even when the input never had one.
+    const hadTabIndex = input.hasAttribute('tabindex');
+    const originalTabIndex = input.getAttribute('tabindex');
+
     const tomSelect = new TomSelect(input, getSettings($(input), settings));
 
     // We expose the TomSelect instance through the 'selectize' property / data on the target input / select that is
@@ -335,6 +340,13 @@ define('xwiki-selectize', [
     tomSelect.on('destroy', () => {
       // Remove the custom region we added for accessibility.
       tomSelect.liveRegion.remove();
+
+      // Restore the tabindex attribute as it was before Tom Select took over (see comment above).
+      if (hadTabIndex) {
+        input.setAttribute('tabindex', originalTabIndex);
+      } else {
+        input.removeAttribute('tabindex');
+      }
 
       // Delete the references to the TomSelect instance.
       delete input.selectize;

--- a/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/xwiki.selectize.js
+++ b/xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war/src/main/webapp/resources/uicomponents/suggest/xwiki.selectize.js
@@ -320,14 +320,15 @@ define('xwiki-selectize', [
     // Tom Select sets input.tabIndex (see above) AFTER firing its own 'destroy' event, so a 'destroy' listener runs
     // too early to fix this up (it would get overwritten right after). Wrap destroy() itself so our fix runs
     // strictly after Tom Select's own tabIndex restoration.
-    const originalDestroy = tomSelect.destroy.bind(tomSelect);
-    tomSelect.destroy = function() {
-      originalDestroy();
+    const originalDestroy = tomSelect.destroy;
+    tomSelect.destroy = function(...args) {
+      const result = originalDestroy.apply(tomSelect, args);
       if (hadTabIndex) {
         input.setAttribute('tabindex', originalTabIndex);
       } else {
         input.removeAttribute('tabindex');
       }
+      return result;
     };
 
     // We expose the TomSelect instance through the 'selectize' property / data on the target input / select that is


### PR DESCRIPTION




# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/XWIKI-24563
# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Added the logic to handle the tabindex like it used to be done when we used selectize in the back.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* See ticket for explanation of the issue. The fix is straightforward once we understand why this issue appeared.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
<img width="2120" height="2475" alt="comparison-trimmed" src="https://github.com/user-attachments/assets/f81a8636-9e3c-4b6d-aef0-954183f19502" />
# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Semi manual tests with Claude code (see comparison above made from the local instance).

Built the changes with `mvn -q clean install -pl xwiki-platform-core/xwiki-platform-web/xwiki-platform-web-war
  -Plegacy,snapshot -DskipTests
  -Dxwiki.checkstyle.skip=true -Dxwiki.revapi.skip=true -Dxwiki.surefire.captureconsole.skip=true`.

Ran the docker tests: `mvn clean verify
  -pl xwiki-platform-core/xwiki-platform-appwithinminutes/xwiki-platform-appwithinminutes-test/xwiki-platform-appwithinminutes-test-docker
  -Pintegration-tests,docker,legacy,snapshot
  -Dtest=UserClassFieldIT -DfailIfNoTests=false
  -Dxwiki.checkstyle.skip=true -Dxwiki.revapi.skip=true -Dxwiki.surefire.captureconsole.skip=true`

After building some modules back properly (leftover from other branch works), these tests passed successfully!

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * None. The cause was merged back in 18.2.0-rc1 so we definitely don't want to backport any further than that.