### PR TITLE
[Misc] Simplify code flagged by SonarCloud (method references, boolean literals, entrySet iteration)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-common/src/main/java/org/xwiki/eventstream/store/internal/DocumentEventListener.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-common/src/main/java/org/xwiki/eventstream/store/internal/DocumentEventListener.java
@@ -78,7 +78,7 @@ public class DocumentEventListener extends AbstractEventListener
         new AnnotationUpdatedEvent()
     );
 
-    private static final BeginFoldEvent IGNORED_EVENTS = otherEvent -> otherEvent instanceof BeginFoldEvent;
+    private static final BeginFoldEvent IGNORED_EVENTS = BeginFoldEvent.class::isInstance;
 
     @Inject
     private RemoteObservationManagerContext remoteObservationManagerContext;

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-common/src/main/java/org/xwiki/eventstream/store/internal/RecordableEventListener.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-common/src/main/java/org/xwiki/eventstream/store/internal/RecordableEventListener.java
@@ -49,7 +49,7 @@ import org.xwiki.observation.remote.RemoteObservationManagerContext;
 public class RecordableEventListener extends AbstractEventListener
 {
     // Event only contains a single method so the whole class can be replaced by a lambda.
-    private static final BeginFoldEvent IGNORED_EVENTS = otherEvent -> otherEvent instanceof BeginFoldEvent;
+    private static final BeginFoldEvent IGNORED_EVENTS = BeginFoldEvent.class::isInstance;
 
     @Inject
     private EventStore eventStore;

--- a/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/FeedPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/FeedPlugin.java
@@ -794,7 +794,7 @@ public class FeedPlugin extends XWikiDefaultPlugin implements XWikiPluginInterfa
             }
 
             List<com.xpn.xwiki.api.Object> apiObjs = new ArrayList<>();
-            for (Object obj[] : res) {
+            for (Object[] obj : res) {
                 try {
                     XWikiDocument doc = context.getWiki().getDocument((String) obj[1], context);
                     if (context.getWiki().getRightService().checkAccess("view", doc, context)) {

--- a/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/UpdateThread.java
+++ b/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/main/java/com/xpn/xwiki/plugin/feed/UpdateThread.java
@@ -80,7 +80,7 @@ public class UpdateThread extends AbstractXWikiRunnable
     public void update()
     {
         if (!stopUpdate) {
-            if (updateInProgress == false) {
+            if (!updateInProgress) {
                 updateInProgress = true;
                 nbLoadedFeeds = 0;
                 nbLoadedFeedsErrors = 0;
@@ -103,7 +103,7 @@ public class UpdateThread extends AbstractXWikiRunnable
                     context.getWiki().getStore().cleanUp(context);
                 }
                 // an update has been schedule..
-                if ((forceUpdate == true) && (stopUpdate == false)) {
+                if (forceUpdate && !stopUpdate) {
                     forceUpdate = false;
                     update();
                 }

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-notifications/xwiki-platform-legacy-notifications-notifiers/xwiki-platform-legacy-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/live/DefaultLiveMimeMessageIterator.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-notifications/xwiki-platform-legacy-notifications-notifiers/xwiki-platform-legacy-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/live/DefaultLiveMimeMessageIterator.java
@@ -97,7 +97,7 @@ public class DefaultLiveMimeMessageIterator extends AbstractMimeMessageIterator
                     it.remove();
                 }
             }
-            if (resultCompositeEvent.getEvents().size() == 0) {
+            if (resultCompositeEvent.getEvents().isEmpty()) {
                 return Collections.emptyList();
             }
 

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/XWikiNotificationTest.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/XWikiNotificationTest.java
@@ -30,7 +30,6 @@ import com.xpn.xwiki.api.Document;
 import com.xpn.xwiki.doc.XWikiDocument;
 import com.xpn.xwiki.notify.DocChangeRule;
 import com.xpn.xwiki.notify.XWikiDocChangeNotificationInterface;
-import com.xpn.xwiki.notify.XWikiNotificationManager;
 import com.xpn.xwiki.notify.XWikiNotificationRule;
 import com.xpn.xwiki.test.MockitoOldcore;
 import com.xpn.xwiki.test.junit5.mockito.OldcoreTest;

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/internal/DefaultLiveDataSourceManager.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-api/src/main/java/org/xwiki/livedata/internal/DefaultLiveDataSourceManager.java
@@ -31,6 +31,7 @@ import javax.inject.Singleton;
 
 import org.slf4j.Logger;
 import org.xwiki.component.annotation.Component;
+import org.xwiki.component.descriptor.ComponentDescriptor;
 import org.xwiki.component.internal.multi.ComponentManagerManager;
 import org.xwiki.component.manager.ComponentLookupException;
 import org.xwiki.component.manager.ComponentManager;
@@ -92,7 +93,7 @@ public class DefaultLiveDataSourceManager implements LiveDataSourceManager
             return Optional.empty();
         } else {
             return Optional.of(cm.getComponentDescriptorList((Type) LiveDataSource.class).stream()
-                .map(descriptor -> descriptor.getRoleHint()).collect(Collectors.toSet()));
+                .map(ComponentDescriptor::getRoleHint).collect(Collectors.toSet()));
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataEntryStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/test/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataEntryStoreTest.java
@@ -22,7 +22,6 @@ package org.xwiki.livedata.internal.livetable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 import javax.inject.Named;

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/internal/rest/DefaultLiveDataEntriesResource.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-rest/src/main/java/org/xwiki/livedata/internal/rest/DefaultLiveDataEntriesResource.java
@@ -129,7 +129,7 @@ public class DefaultLiveDataEntriesResource extends AbstractLiveDataResource imp
         List<SortEntry> sortEntries = new ArrayList<>();
         for (int i = 0; i < sortList.size(); i++) {
             String property = sortList.get(i);
-            boolean descending = i < descendingList.size() ? descendingList.get(i) : false;
+            boolean descending = i < descendingList.size() && descendingList.get(i);
             sortEntries.add(new SortEntry(property, descending));
         }
         return sortEntries;

--- a/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/analyzer/UpdatedDocumentMentionsAnalyzer.java
+++ b/xwiki-platform-core/xwiki-platform-mentions/xwiki-platform-mentions-default/src/main/java/org/xwiki/mentions/internal/analyzer/UpdatedDocumentMentionsAnalyzer.java
@@ -251,7 +251,7 @@ public class UpdatedDocumentMentionsAnalyzer extends AbstractDocumentMentionsAna
         String version, MentionLocation location, String authorReference, Syntax syntax)
     {
         Optional<XDOM> oldDom = oldBaseObject.flatMap(it -> ofNullable(it.getField(largeStringProperty.getName())))
-            .filter(it -> it instanceof LargeStringProperty)
+            .filter(LargeStringProperty.class::isInstance)
             .flatMap(it -> this.xdomService.parse(((LargeStringProperty) it).getValue(), syntax));
         return this.xdomService.parse(largeStringProperty.getValue(), syntax).flatMap(xdom -> {
             EntityReference entityReference = largeStringProperty.getReference();

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/reference/PartialEntityReference.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/reference/PartialEntityReference.java
@@ -90,7 +90,7 @@ public class PartialEntityReference extends EntityReference
                 if (!isNameEqual(entity.getName())) {
                     return false;
                 } else {
-                    return getParent() != null ? getParent().equals(entity.getParent()) : true;
+                    return getParent() == null || getParent().equals(entity.getParent());
                 }
             }
         }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-watch/src/main/java/org/xwiki/notifications/filters/watch/internal/AutomaticWatchModeListener.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-watch/src/main/java/org/xwiki/notifications/filters/watch/internal/AutomaticWatchModeListener.java
@@ -64,7 +64,7 @@ public class AutomaticWatchModeListener extends AbstractEventListener
     /**
      * The skipped events group matcher.
      */
-    private static final BeginEvent SKIPPED_EVENTS = event -> event instanceof BeginFoldEvent;
+    private static final BeginEvent SKIPPED_EVENTS = BeginFoldEvent.class::isInstance;
 
     /**
      * The events to match.

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/MailTemplateImageAttachmentsExtractor.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/MailTemplateImageAttachmentsExtractor.java
@@ -57,6 +57,6 @@ public class MailTemplateImageAttachmentsExtractor
         XWikiContext context = contextProvider.get();
         XWiki xwiki = context.getWiki();
         Document document = new Document(xwiki.getDocument(documentReference, context), context);
-        return document.getAttachmentList().stream().filter(att -> att.isImage()).collect(Collectors.toList());
+        return document.getAttachmentList().stream().filter(Attachment::isImage).collect(Collectors.toList());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/src/main/java/org/xwiki/notifications/preferences/internal/DefaultNotificationPreferenceManager.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/src/main/java/org/xwiki/notifications/preferences/internal/DefaultNotificationPreferenceManager.java
@@ -166,12 +166,13 @@ public class DefaultNotificationPreferenceManager implements NotificationPrefere
         }
 
         // Once we have created the mapping, save all the preferences using their correct providers
-        for (String providerHint : preferencesMapping.keySet()) {
+        for (Map.Entry<String, List<NotificationPreference>> entry : preferencesMapping.entrySet()) {
+            String providerHint = entry.getKey();
             try {
                 NotificationPreferenceProvider provider =
                         componentManager.getInstance(NotificationPreferenceProvider.class, providerHint);
 
-                provider.savePreferences(preferencesMapping.get(providerHint));
+                provider.savePreferences(entry.getValue());
 
             } catch (ComponentLookupException e) {
                 logger.error("Unable to retrieve the notification preference provide for hint {}: {}",

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-default/src/main/java/org/xwiki/notifications/preferences/internal/NotificationEmailPreferenceDocumentInitializer.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-default/src/main/java/org/xwiki/notifications/preferences/internal/NotificationEmailPreferenceDocumentInitializer.java
@@ -97,7 +97,7 @@ public class NotificationEmailPreferenceDocumentInitializer extends AbstractMand
         xclass.addStaticListField(FIELD_INTERVAL, "Notification interval", 1, false,
             "hourly=Hourly|daily=Daily|weekly=Weekly|live=Live", SELECT, SEPARATORS);
 
-        String values = Arrays.stream(NotificationEmailDiffType.values()).map(v -> v.name())
+        String values = Arrays.stream(NotificationEmailDiffType.values()).map(Enum::name)
             .reduce((v1, v2) -> String.format("%s|%s", v1, v2)).get();
 
         xclass.addStaticListField(FIELD_DIFF_TYPE, "Diff Type", 1, false, values, SELECT, SEPARATORS);

--- a/xwiki-platform-core/xwiki-platform-observation/xwiki-platform-observation-remote/src/main/java/org/xwiki/observation/remote/internal/DefaultRemoteObservationManagerConfiguration.java
+++ b/xwiki-platform-core/xwiki-platform-observation/xwiki-platform-observation-remote/src/main/java/org/xwiki/observation/remote/internal/DefaultRemoteObservationManagerConfiguration.java
@@ -65,7 +65,7 @@ public class DefaultRemoteObservationManagerConfiguration
     {
         Boolean enabled = this.configurationSource.getProperty("observation.remote.enabled", Boolean.class);
 
-        return enabled != null ? enabled : false;
+        return enabled != null && enabled;
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/internal/filter/LineBreakFilter.java
+++ b/xwiki-platform-core/xwiki-platform-office/xwiki-platform-office-importer/src/main/java/org/xwiki/officeimporter/internal/filter/LineBreakFilter.java
@@ -121,7 +121,7 @@ public class LineBreakFilter extends AbstractHTMLFilter
         boolean isBlockElement = false;
         if (null != node) {
             for (String blockElement : BLOCK_ELEMENT_TAGS) {
-                isBlockElement = blockElement.equals(node.getNodeName()) ? true : isBlockElement;
+                isBlockElement = blockElement.equals(node.getNodeName()) || isBlockElement;
             }
         }
         return isBlockElement;

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/AbstractIncludeMacro.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/main/java/org/xwiki/rendering/internal/macro/include/AbstractIncludeMacro.java
@@ -116,7 +116,7 @@ public abstract class AbstractIncludeMacro<P> extends AbstractMacro<P>
             .ifPresent(sectionOrHeaderBlock -> {
                 if (sectionOrHeaderBlock instanceof SectionBlock) {
                     List<Block> sectionChildren = sectionOrHeaderBlock.getChildren();
-                    sectionChildren.stream().findFirst().filter(block -> block instanceof HeaderBlock)
+                    sectionChildren.stream().findFirst().filter(HeaderBlock.class::isInstance)
                         .ifPresent(headerBlock ->
                             xdom.replaceChild(sectionChildren.subList(1, sectionChildren.size()),
                                 sectionOrHeaderBlock));

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroRenderer.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-wikimacro/xwiki-platform-rendering-wikimacro-store/src/main/java/org/xwiki/rendering/wikimacro/internal/DefaultWikiMacroRenderer.java
@@ -182,7 +182,7 @@ public class DefaultWikiMacroRenderer extends AbstractBlockAsyncRenderer
     /**
      * Match all the macro marker blocks.
      */
-    private static final BlockMatcher MACRO_MARKER_MATCHER = testedBlock -> (testedBlock instanceof MacroMarkerBlock);
+    private static final BlockMatcher MACRO_MARKER_MATCHER = MacroMarkerBlock.class::isInstance;
 
     private static final BlockMatcher PLACEHOLDERS_BLOCKMATCHER = testedBlock -> ((testedBlock instanceof RawBlock
         && (((RawBlock) testedBlock).getSyntax().getType().equals(SyntaxType.XHTML)

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-api/src/test/java/org/xwiki/user/CurrentUserReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-api/src/test/java/org/xwiki/user/CurrentUserReferenceTest.java
@@ -35,7 +35,7 @@ class CurrentUserReferenceTest
     void isGlobal()
     {
         Throwable exception = assertThrows(RuntimeException.class,
-            () -> CurrentUserReference.INSTANCE.isGlobal());
+            CurrentUserReference.INSTANCE::isGlobal);
         assertEquals("You need to resolve the current user first to find if it's a global user or not.",
             exception.getMessage());
     }

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/XWikiUserUserReferenceResolverTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/test/java/org/xwiki/user/internal/document/XWikiUserUserReferenceResolverTest.java
@@ -26,7 +26,6 @@ import org.xwiki.model.reference.DocumentReference;
 import org.xwiki.test.junit5.mockito.ComponentTest;
 import org.xwiki.test.junit5.mockito.InjectMockComponents;
 import org.xwiki.test.junit5.mockito.MockComponent;
-import org.xwiki.user.UserReference;
 import org.xwiki.user.UserReferenceResolver;
 
 import com.xpn.xwiki.user.api.XWikiUser;

--- a/xwiki-platform-tools/xwiki-platform-tool-packager-plugin/src/main/java/org/xwiki/tool/packager/PackageMojo.java
+++ b/xwiki-platform-tools/xwiki-platform-tool-packager-plugin/src/main/java/org/xwiki/tool/packager/PackageMojo.java
@@ -777,8 +777,8 @@ public class PackageMojo extends AbstractOldCoreMojo
     {
         Map<String, Object> properties = new HashMap<>(getDefaultConfigurationProperties());
         final Properties projectProperties = this.project.getProperties();
-        for (Object key : projectProperties.keySet()) {
-            properties.put(key.toString(), projectProperties.get(key).toString());
+        for (Map.Entry<Object, Object> entry : projectProperties.entrySet()) {
+            properties.put(entry.getKey().toString(), entry.getValue().toString());
         }
 
         VelocityContext context = new VelocityContext(properties);


### PR DESCRIPTION
This is a mechanical, behaviour-preserving cleanup of several SonarCloud issue types across 22 files (24 issues), all pure simplifications with no dataflow changes:

* **java:S1612** — replace lambdas with method references (e.g. `x -> x instanceof Foo` → `Foo.class::isInstance`, `d -> d.getRoleHint()` → `ComponentDescriptor::getRoleHint`).
* **java:S1125** — remove unnecessary boolean literals (e.g. `x == false` → `!x`, `cond ? y : true` → `!cond || y`).
* **java:S2864** — iterate over `entrySet()` instead of `keySet()` + `get(key)`.
* **java:S1155** — use `isEmpty()` instead of `size() == 0`.
* **java:S1197** — move array designators `[]` to the type (`Object obj[]` → `Object[] obj`).
* **java:S1128** — remove unused imports.

All 20 affected Maven modules build cleanly (`install -DskipTests`, Checkstyle + Spoon pass).

SonarCloud issues:
``https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&issueStatuses=OPEN&rules=java%3AS1612%2Cjava%3AS1125%2Cjava%3AS2864%2Cjava%3AS1155%2Cjava%3AS1197%2Cjava%3AS1128``

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhYmoBJQT6rDyJLDPpKRF7)_