### PR TITLE
[Misc] Use dedicated assertions instead of boolean assertions in tests (SonarCloud java:S5785)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-container/xwiki-platform-container-servlet/src/test/java/org/xwiki/container/servlet/filters/SavedRequestManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-container/xwiki-platform-container-servlet/src/test/java/org/xwiki/container/servlet/filters/SavedRequestManagerTest.java
@@ -35,7 +35,7 @@ import org.mockito.quality.Strictness;
 import org.xwiki.container.servlet.filters.SavedRequestManager.SavedRequest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -88,7 +88,7 @@ class SavedRequestManagerTest
     {
         String srid = SavedRequestManager.saveRequest(this.request);
         assertNotNull(srid);
-        assertFalse("".equals(srid));
+        assertNotEquals("", srid);
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-default/src/test/java/org/xwiki/icon/internal/DefaultIconSetManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-default/src/test/java/org/xwiki/icon/internal/DefaultIconSetManagerTest.java
@@ -58,8 +58,8 @@ import com.xpn.xwiki.XWikiContext;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -425,7 +425,7 @@ class DefaultIconSetManagerTest
         when(query.<String>execute()).thenReturn(results);
 
         // Test
-        assertTrue(results == this.iconSetManager.getIconSetNames());
+        assertSame(results, this.iconSetManager.getIconSetNames());
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-observation/src/test/java/org/xwiki/observation/ActionExecutionEventTest.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-observation/src/test/java/org/xwiki/observation/ActionExecutionEventTest.java
@@ -23,8 +23,8 @@ import org.junit.jupiter.api.Test;
 import org.xwiki.observation.event.ActionExecutionEvent;
 import org.xwiki.observation.event.Event;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 @Deprecated
 class ActionExecutionEventTest
@@ -35,8 +35,8 @@ class ActionExecutionEventTest
         Event e1 = new ActionExecutionEvent("test");
         Event e2 = new ActionExecutionEvent("test");
         Event e3 = new ActionExecutionEvent("different");
-        assertTrue(e1.equals(e1));
-        assertTrue(e1.equals(e2));
-        assertFalse(e1.equals(e3));
+        assertEquals(e1, e1);
+        assertEquals(e1, e2);
+        assertNotEquals(e1, e3);
     }
 }

--- a/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/test/java/org/xwiki/mail/internal/thread/SendMailRunnableTest.java
+++ b/xwiki-platform-core/xwiki-platform-mail/xwiki-platform-mail-send/xwiki-platform-mail-send-default/src/test/java/org/xwiki/mail/internal/thread/SendMailRunnableTest.java
@@ -51,7 +51,7 @@ import org.xwiki.test.mockito.MockitoComponentManager;
 import com.xpn.xwiki.XWikiContext;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
 
 /**
@@ -149,7 +149,7 @@ class SendMailRunnableTest
             // "UnknownHostException: xwiki-unknown"
             // "ConnectException: Connection refused"
             // Thus for now I only assert that there's an error set, but not its content.
-            assertTrue(status.getErrorSummary() != null);
+            assertNotNull(status.getErrorSummary());
             errorCount++;
         }
         assertEquals(2, errorCount);

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/job/question/EntitySelectionTest.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-api/src/test/java/org/xwiki/refactoring/job/question/EntitySelectionTest.java
@@ -24,9 +24,8 @@ import org.xwiki.model.EntityType;
 import org.xwiki.model.reference.EntityReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Unit tests for {@link EntitySelection}.
@@ -44,11 +43,11 @@ class EntitySelectionTest
         EntitySelection unselected = new EntitySelection(entityReference);
         unselected.setSelected(false);
 
-        assertFalse(selected.equals(null));
-        assertTrue(selected.equals(selected));
-        assertFalse(selected.equals(entityReference));
-        assertFalse(selected.equals(unselected));
-        assertTrue(selected.equals(new EntitySelection(entityReference)));
+        assertNotEquals(selected, null);
+        assertEquals(selected, selected);
+        assertNotEquals(selected, entityReference);
+        assertNotEquals(selected, unselected);
+        assertEquals(selected, new EntitySelection(entityReference));
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/RightMapTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/RightMapTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -316,7 +317,7 @@ class RightMapTest
         for (Right key : POPULATED_KEYS) {
             other.put(key, newValue());
         }
-        assertFalse(populatedMap.equals(other));
+        assertNotEquals(populatedMap, other);
     }
 
     @Test
@@ -327,7 +328,7 @@ class RightMapTest
             largerMap.put(key, populatedMap.get(key));
         }
         largerMap.put(Right.PROGRAM, newValue());
-        assertFalse(populatedMap.equals(largerMap));
+        assertNotEquals(populatedMap, largerMap);
     }
 
     @Test
@@ -337,7 +338,7 @@ class RightMapTest
         for (int i = 0; i < POPULATED_KEYS.length - 1; i++) {
             smallerMap.put(POPULATED_KEYS[i], populatedMap.get(POPULATED_KEYS[i]));
         }
-        assertFalse(populatedMap.equals(smallerMap));
+        assertNotEquals(populatedMap, smallerMap);
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/RightSetTest.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/test/java/org/xwiki/security/authorization/RightSetTest.java
@@ -26,7 +26,7 @@ import org.apache.commons.collections4.set.AbstractSetTest;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * Test Set interface of RightSet.
@@ -94,7 +94,7 @@ class RightSetTest extends AbstractSetTest<Right>
         final Set<Right> set2 = makeConfirmedCollection();
         // CUSTOM: the standard #testSetEquals add a String here, which does not make any sense for RightSet
         set2.add(Right.VIEW);
-        assertFalse(getCollection().equals(set2), "Empty set shouldn't equal nonempty set");
+        assertNotEquals(getCollection(), set2, "Empty set shouldn't equal nonempty set");
 
         resetFull();
         assertEquals(getCollection(), getConfirmed(), "Full sets should be equal");
@@ -102,6 +102,6 @@ class RightSetTest extends AbstractSetTest<Right>
 
         set2.clear();
         set2.addAll(Arrays.asList(getOtherElements()));
-        assertFalse(getCollection().equals(set2), "Sets with different contents shouldn't be equal");
+        assertNotEquals(getCollection(), set2, "Sets with different contents shouldn't be equal");
     }
 }

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/test/java/org/xwiki/store/serialization/xml/internal/AttachmentListMetadataSerializerTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-filesystem-oldcore/src/test/java/org/xwiki/store/serialization/xml/internal/AttachmentListMetadataSerializerTest.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.Test;
 import com.xpn.xwiki.doc.XWikiAttachment;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for AttachmentListMetadataSerializer
@@ -83,7 +82,7 @@ class AttachmentListMetadataSerializerTest
         final ByteArrayInputStream bais = new ByteArrayInputStream(TEST_CONTENT.getBytes("US-ASCII"));
         final List<XWikiAttachment> attachList = this.serializer.parse(bais);
         bais.close();
-        assertTrue(3 == attachList.size(), "Attachment list was wrong size");
+        assertEquals(3, attachList.size(), "Attachment list was wrong size");
 
         assertEquals("file1", attachList.get(0).getFilename(), "Attachment1 had wrong name");
         assertEquals("file1", attachList.get(1).getFilename(), "Attachment2 had wrong name");

--- a/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-api/src/test/java/org/xwiki/url/ExtendedURLTest.java
+++ b/xwiki-platform-core/xwiki-platform-url/xwiki-platform-url-api/src/test/java/org/xwiki/url/ExtendedURLTest.java
@@ -36,7 +36,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -133,9 +132,9 @@ class ExtendedURLTest
         assertNotEquals(extendedURL1, extendedURL4);
         assertNotEquals(extendedURL3, extendedURL4);
 
-        assertFalse(extendedURL1.equals(null));
-        assertTrue(extendedURL1.equals(extendedURL1));
-        assertFalse(extendedURL1.equals(extendedURL1.getWrappedURL()));
+        assertNotEquals(extendedURL1, null);
+        assertEquals(extendedURL1, extendedURL1);
+        assertNotEquals(extendedURL1, extendedURL1.getWrappedURL());
     }
 
     @Test

--- a/xwiki-platform-core/xwiki-platform-webjars/xwiki-platform-webjars-api/src/test/java/org/xwiki/webjars/WebJarResourceReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-webjars/xwiki-platform-webjars-api/src/test/java/org/xwiki/webjars/WebJarResourceReferenceTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.xwiki.webjars.internal.WebJarsResourceReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * Unit tests for {@link org.xwiki.webjars.internal.WebJarsResourceReference}.
@@ -53,10 +53,10 @@ class WebJarResourceReferenceTest
         assertEquals(reference2, reference1);
         assertEquals(reference2.hashCode(), reference1.hashCode());
 
-        assertFalse(reference3.equals(reference1));
-        assertFalse(reference3.hashCode() == reference1.hashCode());
+        assertNotEquals(reference3, reference1);
+        assertNotEquals(reference3.hashCode(), reference1.hashCode());
 
-        assertFalse(reference4.equals(reference3));
-        assertFalse(reference4.hashCode() == reference3.hashCode());
+        assertNotEquals(reference4, reference3);
+        assertNotEquals(reference4.hashCode(), reference3.hashCode());
     }
 }

--- a/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/test/java/org/xwiki/wiki/internal/manager/DefaultWikiCreatorTest.java
+++ b/xwiki-platform-core/xwiki-platform-wiki/xwiki-platform-wiki-default/src/test/java/org/xwiki/wiki/internal/manager/DefaultWikiCreatorTest.java
@@ -107,7 +107,7 @@ class DefaultWikiCreatorTest
         // Verify that the descriptor document has been saved
         verify(this.wikiDescriptorBuilder).save(eq(descriptor));
         // Verify that the descriptor has been reloaded after being saved
-        assertTrue(descriptor == newWikiDescriptor);
+        assertSame(descriptor, newWikiDescriptor);
     }
 
     @Test


### PR DESCRIPTION
Fixes 25 SonarCloud [java:S5785](https://rules.sonarsource.com/java/RSPEC-5785/) issues ("Use the assertions dedicated to the comparison, not `assertTrue`/`assertFalse`") across 11 test classes.

The boolean assertions are replaced with the assertion Sonar recommends for each site:
* `assertTrue(a.equals(b))` / `assertFalse(a.equals(b))` → `assertEquals(a, b)` / `assertNotEquals(a, b)` (receiver kept first so the exact same `equals` call is reproduced)
* `assertTrue(x == y)` / `assertFalse(x == y)` reference identity → `assertSame` / (`assertNotSame`)
* `assertTrue(LIT == x)` → `assertEquals(LIT, x)`
* `assertTrue(x != null)` → `assertNotNull(x)`

Static imports are adjusted accordingly (unused `assertTrue`/`assertFalse` removed, new ones added).

Behaviour-preserving; the affected test classes were run and pass.

SonarCloud rule: https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS5785&rule_key=java%3AS5785


---
_Generated by [Claude Code](https://claude.ai/code/session_013JYTr6JUoq4iKb28Rq8Y77)_