### PR TITLE
[Misc] Make JUnit5 test classes and methods package-private (SonarCloud java:S5786)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-reference/src/test/java/org/xwiki/annotation/reference/IndexedObjectReferenceTest.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-reference/src/test/java/org/xwiki/annotation/reference/IndexedObjectReferenceTest.java
@@ -71,7 +71,7 @@ class IndexedObjectReferenceTest
     }
 
     @Test
-    public void testObjectNumber()
+    void testObjectNumber()
     {
         IndexedObjectReference reference =
             new IndexedObjectReference(new EntityReference("XWiki.Class[2]", EntityType.OBJECT, new EntityReference(

--- a/xwiki-platform-core/xwiki-platform-classloader/xwiki-platform-classloader-protocols/xwiki-platform-classloader-protocol-attachmentjar/src/test/java/org/xwiki/classloader/internal/protocol/attachmentjar/AttachmentURLStreamHandlerTest.java
+++ b/xwiki-platform-core/xwiki-platform-classloader/xwiki-platform-classloader-protocols/xwiki-platform-classloader-protocol-attachmentjar/src/test/java/org/xwiki/classloader/internal/protocol/attachmentjar/AttachmentURLStreamHandlerTest.java
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class AttachmentURLStreamHandlerTest
+class AttachmentURLStreamHandlerTest
 {
     @InjectMockComponents
     private AttachmentURLStreamHandler handler;

--- a/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/test/java/org/xwiki/component/wiki/DefaultWikiComponentBridgeTest.java
+++ b/xwiki-platform-core/xwiki-platform-component/xwiki-platform-component-wiki/src/test/java/org/xwiki/component/wiki/DefaultWikiComponentBridgeTest.java
@@ -121,7 +121,7 @@ class DefaultWikiComponentBridgeTest implements WikiComponentConstants
     private MockitoComponentManager mockitoComponentManager;
 
     @BeforeEach
-    public void configure() throws Exception
+    void configure() throws Exception
     {
         Utils.setComponentManager(this.mockitoComponentManager);
 

--- a/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-api/src/test/java/org/xwiki/display/internal/DocumentContentDisplayerTest.java
+++ b/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-api/src/test/java/org/xwiki/display/internal/DocumentContentDisplayerTest.java
@@ -61,7 +61,7 @@ import static org.mockito.Mockito.when;
     DefaultDocumentContentAsyncParser.class,
     DocumentReferenceDequeContext.class
 })
-public class DocumentContentDisplayerTest
+class DocumentContentDisplayerTest
 {
     @InjectMockComponents
     private DocumentContentAsyncExecutor documentExecutor;
@@ -91,7 +91,7 @@ public class DocumentContentDisplayerTest
     private TransformationManager transformationManager;
 
     @Test
-    public void baseMetaDataIsSetBeforeExecutingTransformations() throws Exception
+    void baseMetaDataIsSetBeforeExecutingTransformations() throws Exception
     {
         when(this.executor.execute(any(), any())).then(new Answer<Block>()
         {

--- a/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-macro/src/test/java/org/xwiki/rendering/internal/macro/DisplayMacroParametersTest.java
+++ b/xwiki-platform-core/xwiki-platform-display/xwiki-platform-display-macro/src/test/java/org/xwiki/rendering/internal/macro/DisplayMacroParametersTest.java
@@ -30,10 +30,10 @@ import static org.junit.jupiter.api.Assertions.assertSame;
  * 
  * @version $Id$
  */
-public class DisplayMacroParametersTest
+class DisplayMacroParametersTest
 {
     @Test
-    public void setPage()
+    void setPage()
     {
         DisplayMacroParameters parameters = new DisplayMacroParameters();
 

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/test/java/org/xwiki/eventstream/store/solr/internal/EventStoreTest.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/test/java/org/xwiki/eventstream/store/solr/internal/EventStoreTest.java
@@ -94,7 +94,7 @@ import static org.mockito.Mockito.when;
     SpaceReferenceConverter.class, DocumentReferenceConverter.class, EntityReferenceConverter.class})
 @ReferenceComponentList
 @EmbeddedSolrComponentList
-public class EventStoreTest
+class EventStoreTest
 {
     private static final DefaultEvent EVENT1 = event("id1");
 

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-api/src/test/java/org/xwiki/extension/internal/validator/XWikiExtensionValidatorTest.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-api/src/test/java/org/xwiki/extension/internal/validator/XWikiExtensionValidatorTest.java
@@ -52,7 +52,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class XWikiExtensionValidatorTest
+class XWikiExtensionValidatorTest
 {
     private static final DocumentReference USER_REFERENCE = new DocumentReference("wiki", "XWiki", "user");
 
@@ -99,7 +99,7 @@ public class XWikiExtensionValidatorTest
     }
 
     @BeforeEach
-    public void beforeEach() throws AccessDeniedException
+    void beforeEach() throws AccessDeniedException
     {
         when(this.resolver.resolve(USER_REFERENCE_STRING, EntityType.DOCUMENT)).thenReturn(USER_REFERENCE);
 
@@ -109,7 +109,7 @@ public class XWikiExtensionValidatorTest
     // Tests
 
     @Test
-    public void checkRightDisabled() throws InstallException
+    void checkRightDisabled() throws InstallException
     {
         assertCheckInstallPass();
 
@@ -129,7 +129,7 @@ public class XWikiExtensionValidatorTest
     }
 
     @Test
-    public void checkRight() throws AccessDeniedException, InstallException
+    void checkRight() throws AccessDeniedException, InstallException
     {
         this.request.setProperty(AbstractExtensionValidator.PROPERTY_CHECKRIGHTS, true);
         this.request.setProperty(AbstractExtensionValidator.PROPERTY_CHECKRIGHTS_USER, true);
@@ -152,7 +152,7 @@ public class XWikiExtensionValidatorTest
     }
 
     @Test
-    public void checkRightOnUserNamespace() throws InstallException, AccessDeniedException
+    void checkRightOnUserNamespace() throws InstallException, AccessDeniedException
     {
         this.request.setProperty(AbstractExtensionValidator.PROPERTY_CHECKRIGHTS, true);
         this.request.setProperty(AbstractExtensionValidator.PROPERTY_CHECKRIGHTS_USER, true);

--- a/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/test/java/com/xpn/xwiki/plugin/feed/SyndEntryDocumentSourceTest.java
+++ b/xwiki-platform-core/xwiki-platform-feed/xwiki-platform-feed-api/src/test/java/com/xpn/xwiki/plugin/feed/SyndEntryDocumentSourceTest.java
@@ -211,7 +211,7 @@ class SyndEntryDocumentSourceTest
      * Tests if two successive calls of the source method with the same argument have the same result.
      */
     @Test
-    public void testSourceConsistency()
+    void testSourceConsistency()
     {
         assertEquals(source(this.doc), source(this.doc), INCONSISTENCY);
     }
@@ -221,7 +221,7 @@ class SyndEntryDocumentSourceTest
      * document, irrespective of its type: {@link XWikiDocument}, {@link Document}, and {@link String}.
      */
     @Test
-    public void testSourcePolymorphism()
+    void testSourcePolymorphism()
     {
         SyndEntryImpl fromXDoc = source(this.doc);
         SyndEntryImpl fromDoc = source(this.doc.newDocument(this.oldcore.getXWikiContext()));
@@ -237,7 +237,7 @@ class SyndEntryDocumentSourceTest
      * @throws XWikiException
      */
     @Test
-    public void testSourceAccessRights() throws XWikiException
+    void testSourceAccessRights() throws XWikiException
     {
         // odd user name length implies no access rights
         this.oldcore.getXWikiContext().setUser("XWiki.Albatross");
@@ -258,7 +258,7 @@ class SyndEntryDocumentSourceTest
      * Tests if {@link SyndEntryDocumentSource#CONTENT_TYPE} parameter is used correctly.
      */
     @Test
-    public void testSourceContentType()
+    void testSourceContentType()
     {
         Map instanceParams = new HashMap();
         instanceParams.put(SyndEntryDocumentSource.CONTENT_TYPE, SVG_MIME_TYPE);
@@ -276,7 +276,7 @@ class SyndEntryDocumentSourceTest
      * {@link SyndEntryDocumentSource#CONTENT_TYPE} is <i>text/plain</i>.
      */
     @Test
-    public void testArticleSourcePlainContentLength()
+    void testArticleSourcePlainContentLength()
     {
         int maxLength = 15;
         Map params = new HashMap();
@@ -295,7 +295,7 @@ class SyndEntryDocumentSourceTest
      * {@link SyndEntryDocumentSource#CONTENT_TYPE} is <i>text/html</i>.
      */
     @Test
-    public void testArticleSourceHTMLContentLength()
+    void testArticleSourceHTMLContentLength()
     {
         int maxLength = 16;
         Map params = new HashMap();
@@ -311,7 +311,7 @@ class SyndEntryDocumentSourceTest
     }
 
     @Test
-    public void testArticleSourceXMLContentLength()
+    void testArticleSourceXMLContentLength()
     {
         int maxLength = 17;
         Map params = new HashMap();
@@ -327,7 +327,7 @@ class SyndEntryDocumentSourceTest
     }
 
     @Test
-    public void testPreviewContentEncoding()
+    void testPreviewContentEncoding()
     {
         String snippet = "<p>Test ê</p>";
         String transformedHTML = SyndEntryDocumentSource.getHTMLPreview(snippet, 10);

--- a/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-macro/src/test/java/org/xwiki/icon/macro/internal/DisplayIconMacroTest.java
+++ b/xwiki-platform-core/xwiki-platform-icon/xwiki-platform-icon-macro/src/test/java/org/xwiki/icon/macro/internal/DisplayIconMacroTest.java
@@ -116,7 +116,7 @@ class DisplayIconMacroTest
     private XWikiDocument iconDocument;
 
     @BeforeEach
-    public void before(MockitoOldcore oldcore) throws Exception
+    void before(MockitoOldcore oldcore) throws Exception
     {
         this.iconDocument = new XWikiDocument(ICON_DOCUMENT_REFERENCE);
         this.iconDocument.setContentAuthorReference(AUTHOR);

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-notifications/xwiki-platform-legacy-notifications-filters/xwiki-platform-legacy-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/LegacyDefaultNotificationFilterManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-notifications/xwiki-platform-legacy-notifications-filters/xwiki-platform-legacy-notifications-filters-api/src/test/java/org/xwiki/notifications/filters/internal/LegacyDefaultNotificationFilterManagerTest.java
@@ -56,7 +56,7 @@ import static org.mockito.Mockito.when;
  * @since 15.5RC1
  */
 @ComponentTest
-public class LegacyDefaultNotificationFilterManagerTest
+class LegacyDefaultNotificationFilterManagerTest
 {
     @InjectMockComponents
     private LegacyDefaultNotificationFilterManager filterManager;

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-notifications/xwiki-platform-legacy-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/LegacyDefaultNotificationParametersFactoryTest.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-notifications/xwiki-platform-legacy-notifications-sources/src/test/java/org/xwiki/notifications/sources/internal/LegacyDefaultNotificationParametersFactoryTest.java
@@ -137,7 +137,7 @@ class LegacyDefaultNotificationParametersFactoryTest
     private List<NotificationFilterPreference> filterPreferenceList;
 
     @BeforeEach
-    public void setup(MockitoComponentManager componentManager) throws Exception
+    void setup(MockitoComponentManager componentManager) throws Exception
     {
         when(this.stringDocumentReferenceResolver.resolve(USER_SERIALIZED_REFERENCE)).thenReturn(USER_REFERENCE);
 

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentTest.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/doc/XWikiDocumentTest.java
@@ -107,7 +107,7 @@ class XWikiDocumentTest
     private BaseObject baseObject;
 
     @BeforeEach
-    public void setUp() throws Exception
+    void setUp() throws Exception
     {
         XWikiVersioningStoreInterface mockXWikiVersioningStore =
             this.componentManager.registerMockComponent(XWikiVersioningStoreInterface.class);

--- a/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/web/TempResourceActionTest.java
+++ b/xwiki-platform-core/xwiki-platform-legacy/xwiki-platform-legacy-oldcore/src/test/java/com/xpn/xwiki/web/TempResourceActionTest.java
@@ -56,7 +56,7 @@ import static org.mockito.Mockito.when;
  */
 @OldcoreTest
 @ReferenceComponentList
-public class TempResourceActionTest
+class TempResourceActionTest
 {
     @InjectMockitoOldcore
     private MockitoOldcore oldcore;
@@ -75,7 +75,7 @@ public class TempResourceActionTest
     private TempResourceAction action;
 
     @BeforeEach
-    public void beforeEach() throws Exception
+    void beforeEach() throws Exception
     {
         this.action = new TempResourceAction();
         when(this.environment.getTemporaryDirectory()).thenReturn(this.temporaryDirectory);
@@ -114,7 +114,7 @@ public class TempResourceActionTest
      * doesn't match the known pattern.
      */
     @Test
-    public void testGetTemporaryFileForBadURI() throws Exception
+    void testGetTemporaryFileForBadURI() throws Exception
     {
         createEmptyFile("temp/secret.txt");
         assertNull(action.getTemporaryFile("/xwiki/bin/temp/secret.txt", oldcore.getXWikiContext()));
@@ -125,7 +125,7 @@ public class TempResourceActionTest
      * temporary directory by ignoring relative URIs (i.e. which use ".." to move to the parent folder).
      */
     @Test
-    public void testGetTemporaryFileForRelativeURI() throws Exception
+    void testGetTemporaryFileForRelativeURI() throws Exception
     {
         createEmptyFile("temp/secret.txt");
         assertNull(action.getTemporaryFile("/xwiki/bin/temp/../../module/secret.txt", oldcore.getXWikiContext()));
@@ -135,7 +135,7 @@ public class TempResourceActionTest
      * Tests {@link TempResourceAction#getTemporaryFile(String, XWikiContext)} when the file is missing.
      */
     @Test
-    public void testGetTemporaryFileMissing() throws Exception
+    void testGetTemporaryFileMissing() throws Exception
     {
         assertFalse(new File(this.temporaryDirectory, "temp/module/xwiki/Space/Page/file.txt").exists());
         assertNull(action.getTemporaryFile("/xwiki/bin/temp/Space/Page/module/file.txt", oldcore.getXWikiContext()));
@@ -145,7 +145,7 @@ public class TempResourceActionTest
      * Tests {@link TempResourceAction#getTemporaryFile(String, XWikiContext)} when the file is present.
      */
     @Test
-    public void testGetTemporaryFile() throws Exception
+    void testGetTemporaryFile() throws Exception
     {
         oldcore.getXWikiContext().setWikiId("wiki");
         createEmptyFile("temp/module/wiki/Space/Page/file.txt");
@@ -156,7 +156,7 @@ public class TempResourceActionTest
      * Tests {@link TempResourceAction#getTemporaryFile(String, XWikiContext)} when the URL is over encoded.
      */
     @Test
-    public void testGetTemporaryFileForOverEncodedURL() throws Exception
+    void testGetTemporaryFileForOverEncodedURL() throws Exception
     {
         createEmptyFile("temp/officeviewer/xwiki/Sp*ace/Pa-ge/presentation.odp/presentation-slide0.jpg");
         assertNotNull(action.getTemporaryFile(
@@ -169,7 +169,7 @@ public class TempResourceActionTest
      * can happen for instance when XWiki is behind Apache's {@code mode_proxy} with {@code nocanon} option disabled.
      */
     @Test
-    public void testGetTemporaryFileForPartiallyDecodedURL() throws Exception
+    void testGetTemporaryFileForPartiallyDecodedURL() throws Exception
     {
         createEmptyFile("temp/officeviewer/xwiki/Space/Page/"
             + "attach%3Axwiki%3ASpace.Page%40pres%2Fentation.odp/13/presentation-slide0.jpg");
@@ -178,7 +178,7 @@ public class TempResourceActionTest
     }
 
     @Test
-    public void renderNormalBehavior() throws Exception
+    void renderNormalBehavior() throws Exception
     {
         XWikiRequest request = mock(XWikiRequest.class);
         XWikiResponse response = mock(XWikiResponse.class);
@@ -195,7 +195,7 @@ public class TempResourceActionTest
     }
 
     @Test
-    public void renderWithForceDownload() throws Exception
+    void renderWithForceDownload() throws Exception
     {
         XWikiRequest request = mock(XWikiRequest.class);
         XWikiResponse response = mock(XWikiResponse.class);

--- a/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-notifications/src/test/java/org/xwiki/like/internal/LikeEventListenerTest.java
+++ b/xwiki-platform-core/xwiki-platform-like/xwiki-platform-like-notifications/src/test/java/org/xwiki/like/internal/LikeEventListenerTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class LikeEventListenerTest
+class LikeEventListenerTest
 {
     @InjectMockComponents
     private LikeEventListener likeEventListener;

--- a/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
+++ b/xwiki-platform-core/xwiki-platform-livetable/xwiki-platform-livetable-ui/src/test/java/org/xwiki/livetable/LiveTableResultsTest.java
@@ -117,7 +117,7 @@ class LiveTableResultsTest extends PageTest
 
     @BeforeEach
     @SuppressWarnings("deprecation")
-    public void setUp() throws Exception
+    void setUp() throws Exception
     {
         // The LiveTableResultsMacros page expects that the HTTP query is done with the "get" action and asking for
         // plain output.

--- a/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-sources/xwiki-platform-localization-source-legacy/src/test/java/com/xpn/xwiki/web/XWikiMessageToolBridgeTest.java
+++ b/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-sources/xwiki-platform-localization-source-legacy/src/test/java/com/xpn/xwiki/web/XWikiMessageToolBridgeTest.java
@@ -54,7 +54,7 @@ class XWikiMessageToolBridgeTest
     private DocumentReference defaultWikiTranslationReference;
 
     @BeforeEach
-    public void setUp() throws Exception
+    void setUp() throws Exception
     {
 
         this.oldcore.notifyDocumentCreatedEvent(true);

--- a/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-sources/xwiki-platform-localization-source-wiki/src/test/java/org/xwiki/localization/wiki/internal/DocumentTranslationBundleFactoryTest.java
+++ b/xwiki-platform-core/xwiki-platform-localization/xwiki-platform-localization-sources/xwiki-platform-localization-source-wiki/src/test/java/org/xwiki/localization/wiki/internal/DocumentTranslationBundleFactoryTest.java
@@ -129,7 +129,7 @@ class DocumentTranslationBundleFactoryTest
     private LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.WARN);
 
     @BeforeEach
-    public void before() throws Exception
+    void before() throws Exception
     {
         this.oldcore.notifyDocumentCreatedEvent(true);
         this.oldcore.notifyDocumentUpdatedEvent(true);

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-watch/src/test/java/org/xwiki/notifications/filters/watch/internal/DefaultWatchedEntitiesConfigurationTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-watch/src/test/java/org/xwiki/notifications/filters/watch/internal/DefaultWatchedEntitiesConfigurationTest.java
@@ -62,7 +62,7 @@ class DefaultWatchedEntitiesConfigurationTest
     private WikiDescriptorManager wikiDescriptorManager;
 
     @BeforeEach
-    public void setUp()
+    void setUp()
     {
         when(documentAccessBridge.getCurrentDocumentReference())
             .thenReturn(new DocumentReference("wikiA", "Main", "WebHome"));

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/test/java/org/xwiki/notifications/NotificationRSSServicePageTest.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-ui/src/test/java/org/xwiki/notifications/NotificationRSSServicePageTest.java
@@ -86,7 +86,7 @@ class NotificationRSSServicePageTest extends PageTest
     private HighlightParser highlightParser;
 
     @BeforeEach
-    public void setUp(MockitoComponentManager componentManager) throws Exception
+    void setUp(MockitoComponentManager componentManager) throws Exception
     {
         NotificationScriptService notificationScriptService =
             componentManager.registerMockComponent(ScriptService.class, "notification",

--- a/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-api/src/test/java/org/xwiki/panels/internal/AbstractPanelsUIExtensionManagerTest.java
+++ b/xwiki-platform-core/xwiki-platform-panels/xwiki-platform-panels-api/src/test/java/org/xwiki/panels/internal/AbstractPanelsUIExtensionManagerTest.java
@@ -52,7 +52,7 @@ import static org.mockito.Mockito.when;
  * @since 10.9
  */
 @ComponentTest
-public class AbstractPanelsUIExtensionManagerTest
+class AbstractPanelsUIExtensionManagerTest
 {
     @MockComponent
     @Named("currentmixed")
@@ -69,7 +69,7 @@ public class AbstractPanelsUIExtensionManagerTest
     private LogCaptureExtension logCapture = new LogCaptureExtension(LogLevel.ERROR);
 
     @Test
-    public void get() throws Exception
+    void get() throws Exception
     {
         // We create a mock of the component manager to control the order on which the extensions will be retreived.
         WikiUIExtension wikiUIExtensionMenu1 = mock(WikiUIExtension.class);
@@ -116,7 +116,7 @@ public class AbstractPanelsUIExtensionManagerTest
     }
 
     @Test
-    public void getWhenLookupError() throws Exception
+    void getWhenLookupError() throws Exception
     {
         ComponentManager failingCM = mock(ComponentManager.class);
         when(contextComponentManagerProvider.get()).thenReturn(failingCM);

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-async/xwiki-platform-rendering-async-macro/src/test/java/org/xwiki/rendering/async/AsyncMacroTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-async/xwiki-platform-rendering-async-macro/src/test/java/org/xwiki/rendering/async/AsyncMacroTest.java
@@ -73,7 +73,7 @@ class AsyncMacroTest
     private BlockAsyncRendererExecutor executor;
 
     @BeforeEach
-    public void beforeEach() throws Exception
+    void beforeEach() throws Exception
     {
         this.executor = this.componentManager.getInstance(BlockAsyncRendererExecutor.class);
     }

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code-oldcore/src/test/java/org/xwiki/rendering/internal/macro/code/source/EntityCodeMacroSourceFactoryTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-code-oldcore/src/test/java/org/xwiki/rendering/internal/macro/code/source/EntityCodeMacroSourceFactoryTest.java
@@ -110,7 +110,7 @@ class EntityCodeMacroSourceFactoryTest
     private MacroTransformationContext macroContext;
 
     @BeforeEach
-    public void beforeEach()
+    void beforeEach()
     {
         this.macroContext = new MacroTransformationContext();
 

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-context/src/test/java/org/xwiki/rendering/internal/macro/context/ContextMacroTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-context/src/test/java/org/xwiki/rendering/internal/macro/context/ContextMacroTest.java
@@ -117,7 +117,7 @@ class ContextMacroTest
     private BlockAsyncRendererExecutor executor;
 
     @BeforeEach
-    public void beforeEach() throws Exception
+    void beforeEach() throws Exception
     {
         // Macro Descriptor set up
         BeanDescriptor descriptor = mock(BeanDescriptor.class);

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/include/IncludeMacroTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-include/src/test/java/org/xwiki/rendering/internal/macro/include/IncludeMacroTest.java
@@ -143,7 +143,7 @@ class IncludeMacroTest
     private PrintRendererFactory rendererFactory;
 
     @BeforeEach
-    public void setUp() throws Exception
+    void setUp() throws Exception
     {
         MemoryConfigurationSource memoryConfigurationSource = new MemoryConfigurationSource();
         this.componentManager.registerComponent(ConfigurationSource.class, memoryConfigurationSource);

--- a/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-script/src/test/java/org/xwiki/rendering/internal/macro/script/DefaultAttachmentClassLoaderFactoryTest.java
+++ b/xwiki-platform-core/xwiki-platform-rendering/xwiki-platform-rendering-macros/xwiki-platform-rendering-macro-script/src/test/java/org/xwiki/rendering/internal/macro/script/DefaultAttachmentClassLoaderFactoryTest.java
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  */
 @ComponentTest
 @ComponentList({ AttachmentURLStreamHandler.class, ExtendedURLStreamHandlerFactory.class })
-public class DefaultAttachmentClassLoaderFactoryTest
+class DefaultAttachmentClassLoaderFactoryTest
 {
     @InjectMockComponents
     private DefaultAttachmentClassLoaderFactory factory;

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/test/java/org/xwiki/search/ui/SearchSuggestConfigSheetPageTest.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-ui/src/test/java/org/xwiki/search/ui/SearchSuggestConfigSheetPageTest.java
@@ -64,7 +64,7 @@ import static org.mockito.Mockito.when;
     SearchSuggestSourceObjectEvaluator.class,
     TestNoScriptMacro.class,
 })
-public class SearchSuggestConfigSheetPageTest extends PageTest
+class SearchSuggestConfigSheetPageTest extends PageTest
 {
     private static final String WIKI_NAME = "xwiki";
 

--- a/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-transaction/src/test/java/org/xwiki/store/RootTransactionRunnableTest.java
+++ b/xwiki-platform-core/xwiki-platform-store/xwiki-platform-store-transaction/src/test/java/org/xwiki/store/RootTransactionRunnableTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * @version $Id$
  * @since 3.0M2
  */
-public class RootTransactionRunnableTest
+class RootTransactionRunnableTest
 {
     @Test
     void runInTest()

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-integration/src/test/java/org/xwiki/test/integration/junit5/StackTraceLogParserTest.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-integration/src/test/java/org/xwiki/test/integration/junit5/StackTraceLogParserTest.java
@@ -33,10 +33,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @version $Id$
  * @since 11.4RC1
  */
-public class StackTraceLogParserTest
+class StackTraceLogParserTest
 {
     @Test
-    public void parseLogWithStackTrace() throws Exception
+    void parseLogWithStackTrace() throws Exception
     {
         String log = IOUtils.toString(this.getClass().getClassLoader().getResourceAsStream("stacktrace.txt"), "UTF-8");
         StackTraceLogParser parser = new StackTraceLogParser();
@@ -53,7 +53,7 @@ public class StackTraceLogParserTest
     }
 
     @Test
-    public void parseWithInvalidStacktrace()
+    void parseWithInvalidStacktrace()
     {
         // Verify that it works if the third line is shorter or equal to the searched patterns.
         String log = "date - line1\n"
@@ -74,7 +74,7 @@ public class StackTraceLogParserTest
     }
 
     @Test
-    public void parseWithLeadingStacktrace()
+    void parseWithLeadingStacktrace()
     {
         String log = "date - line1\n"
             + "date - line2\n"
@@ -90,7 +90,7 @@ public class StackTraceLogParserTest
     }
 
     @Test
-    public void parseWithCapturedLogs()
+    void parseWithCapturedLogs()
     {
         String log = ""
             + "date [x] INFO  Class - STDOUT: date [main] ERROR OtherClass"
@@ -107,7 +107,7 @@ public class StackTraceLogParserTest
     }
 
     @Test
-    public void parseWithNoPrefixedLogs()
+    void parseWithNoPrefixedLogs()
     {
         String log = ""
             + "WARN  - stacktrace\n"

--- a/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-integration/src/test/java/org/xwiki/test/integration/maven/ArtifactCoordinateTest.java
+++ b/xwiki-platform-core/xwiki-platform-test/xwiki-platform-test-integration/src/test/java/org/xwiki/test/integration/maven/ArtifactCoordinateTest.java
@@ -31,7 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  *
  * @version $Id$
  */
-public class ArtifactCoordinateTest
+class ArtifactCoordinateTest
 {
     @Test
     void parseArtifacts()

--- a/xwiki-platform-core/xwiki-platform-tika/xwiki-platform-tika-parsers/src/test/java/org/xwiki/tika/internal/TikaUtilsTest.java
+++ b/xwiki-platform-core/xwiki-platform-tika/xwiki-platform-tika-parsers/src/test/java/org/xwiki/tika/internal/TikaUtilsTest.java
@@ -32,16 +32,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * 
  * @version $Id$
  */
-public class TikaUtilsTest
+class TikaUtilsTest
 {
     @Test
-    public void parsePDF() throws IOException, TikaException
+    void parsePDF() throws IOException, TikaException
     {
         assertEquals("\nPDF content\n\n\n", TikaUtils.parseToString(getClass().getResource("/pdf.pdf")));
     }
 
     @Test
-    public void parseAutoclosable() throws IOException, TikaException
+    void parseAutoclosable() throws IOException, TikaException
     {
         assertEquals("\nPDF content\n\n\n",
             TikaUtils.parseToString(new AutoCloseInputStream(getClass().getResourceAsStream("/pdf.pdf"))));

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-script/src/test/java/org/xwiki/user/script/UserScriptServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-script/src/test/java/org/xwiki/user/script/UserScriptServiceTest.java
@@ -45,7 +45,7 @@ import static org.mockito.Mockito.when;
  * @version $Id$
  */
 @ComponentTest
-public class UserScriptServiceTest
+class UserScriptServiceTest
 {
     @InjectComponentManager
     private MockitoComponentManager componentManager;

--- a/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/test/java/org/xwiki/wysiwyg/internal/cleaner/HTMLCleanerTest.java
+++ b/xwiki-platform-core/xwiki-platform-wysiwyg/xwiki-platform-wysiwyg-api/src/test/java/org/xwiki/wysiwyg/internal/cleaner/HTMLCleanerTest.java
@@ -64,7 +64,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * @version $Id$
  * @since 18.0.0RC1
  */
-public class HTMLCleanerTest
+class HTMLCleanerTest
 {
     private static final String DEFAULT_PATTERN = ".*\\.test";
 

--- a/xwiki-platform-core/xwiki-platform-xml/xwiki-platform-xml-script/src/test/java/org/xwiki/xml/script/XMLScriptServiceTest.java
+++ b/xwiki-platform-core/xwiki-platform-xml/xwiki-platform-xml-script/src/test/java/org/xwiki/xml/script/XMLScriptServiceTest.java
@@ -44,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  * @since 2.7RC1
  */
 @ComponentTest
-public class XMLScriptServiceTest
+class XMLScriptServiceTest
 {
     @InjectMockComponents
     private XMLScriptService xml;

--- a/xwiki-platform-core/xwiki-platform-zipexplorer/src/test/java/com/xpn/xwiki/plugin/zipexplorer/ZipExplorerTest.java
+++ b/xwiki-platform-core/xwiki-platform-zipexplorer/src/test/java/com/xpn/xwiki/plugin/zipexplorer/ZipExplorerTest.java
@@ -66,7 +66,7 @@ class ZipExplorerTest
     private ZipExplorerPlugin plugin;
 
     @BeforeEach
-    public void setUp(MockitoComponentManager componentManager) throws Exception
+    void setUp(MockitoComponentManager componentManager) throws Exception
     {
         this.plugin = new ZipExplorerPlugin("zipexplorer", ZipExplorerPlugin.class.getName(), null);
 


### PR DESCRIPTION
Removes redundant `public` visibility modifiers from JUnit5 test classes and their test/lifecycle methods, as flagged by SonarCloud rule [java:S5786](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS5786&rule_key=java%3AS5786) ("JUnit5 test classes and methods should have default package visibility").

This batch clears 34 open issues across 32 modules (one issue per module, so no single module was dense enough on its own):

* The change is purely mechanical and behaviour-preserving: only the `public` keyword is stripped from test-class declarations and from methods annotated with a JUnit lifecycle annotation (`@Test`, `@BeforeEach`, `@AfterEach`, `@BeforeAll`, `@AfterAll`, `@ParameterizedTest`, `@Nested`, …). Fields, non-JUnit helper methods and XWiki-specific lifecycle methods (e.g. `@BeforeComponent`) are left untouched.
* 34 files changed, 65 modifiers removed.

All 32 modules were verified with `mvn clean install -DskipTests` (Checkstyle + test-compile) — `BUILD SUCCESS`.

SonarCloud issues: filter [rule java:S5786, status OPEN](https://sonarcloud.io/project/issues?organization=xwiki&id=org.xwiki.platform%3Axwiki-platform&rules=java%3AS5786&issueStatuses=OPEN).

---
_Generated by [Claude Code](https://claude.ai/code/session_015gNkAzqpvPZW6HnSifvdLZ)_