### PR TITLE
[Misc] Use pattern matching for instanceof in oldcore (SonarCloud java:S6201)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/XWikiDocumentFilterUtils.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/filter/XWikiDocumentFilterUtils.java
@@ -176,8 +176,8 @@ public class XWikiDocumentFilterUtils
             .getInstance(new DefaultParameterizedType(null, EntityOutputFilterStream.class, entityClass));
         filterStream.setProperties(documentProperties);
         filterStream.setEntity(entity);
-        if (filterStream instanceof XWikiDocumentOutputFilterStream) {
-            ((XWikiDocumentOutputFilterStream) filterStream).disableRenderingEvents();
+        if (filterStream instanceof XWikiDocumentOutputFilterStream documentFilterStream) {
+            documentFilterStream.disableRenderingEvents();
         }
 
         // Input
@@ -320,15 +320,15 @@ public class XWikiDocumentFilterUtils
             // Spaces and document events
             FilterEventParameters documentParameters = null;
             DocumentReference documentReference = null;
-            if (entity instanceof XWikiDocument) {
-                documentReference = ((XWikiDocument) entity).getDocumentReference();
+            if (entity instanceof XWikiDocument document) {
+                documentReference = document.getDocumentReference();
                 for (SpaceReference spaceReference : documentReference.getSpaceReferences()) {
                     filter.beginWikiSpace(spaceReference.getName(), FilterEventParameters.EMPTY);
                 }
 
                 documentParameters = new FilterEventParameters();
                 documentParameters.put(WikiDocumentFilter.PARAMETER_LOCALE,
-                    ((XWikiDocument) entity).getDefaultLocale());
+                    document.getDefaultLocale());
                 filter.beginWikiDocument(documentReference.getName(), documentParameters);
             }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/ViewableAllowedDBListValueFilter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/objects/classes/ViewableAllowedDBListValueFilter.java
@@ -64,15 +64,14 @@ public class ViewableAllowedDBListValueFilter implements QueryFilter
     {
         List<Object> filteredResults = new LinkedList<>();
         for (Object result : results) {
-            if (result instanceof String) {
-                DocumentReference documentReference = this.documentReferenceResolver.resolve((String) result);
+            if (result instanceof String stringResult) {
+                DocumentReference documentReference = this.documentReferenceResolver.resolve(stringResult);
                 if (this.authorization.hasAccess(Right.VIEW, documentReference)) {
                     filteredResults.add(result);
                 }
-            } else if (result instanceof Object[]) {
-                Object[] row = (Object[]) result;
-                if (row.length > 0 && row[0] instanceof String) {
-                    DocumentReference documentReference = this.documentReferenceResolver.resolve((String) row[0]);
+            } else if (result instanceof Object[] row) {
+                if (row.length > 0 && row[0] instanceof String documentFullName) {
+                    DocumentReference documentReference = this.documentReferenceResolver.resolve(documentFullName);
                     if (this.authorization.hasAccess(Right.VIEW, documentReference)) {
                         // The document full name column was added just to be able to check view right. We can discard
                         // it now and return only the relevant columns.

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/PropertyConverter.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/PropertyConverter.java
@@ -108,10 +108,10 @@ public class PropertyConverter
 
     private Object convertPropertyValue(Object storedValue, PropertyClass modifiedPropertyClass)
     {
-        if (modifiedPropertyClass instanceof ListClass) {
-            return convertPropertyValue(storedValue, (ListClass) modifiedPropertyClass);
-        } else if (modifiedPropertyClass instanceof NumberClass) {
-            return convertPropertyValue(storedValue, (NumberClass) modifiedPropertyClass);
+        if (modifiedPropertyClass instanceof ListClass listClass) {
+            return convertPropertyValue(storedValue, listClass);
+        } else if (modifiedPropertyClass instanceof NumberClass numberClass) {
+            return convertPropertyValue(storedValue, numberClass);
         } else {
             // Return the stored value if no specific converter has been found. We will attempt to convert the stored
             // value through string deserialization later.
@@ -137,9 +137,8 @@ public class PropertyConverter
     private Object convertPropertyValue(Object storedValue, NumberClass modifiedNumberClass)
     {
         Object newValue = storedValue;
-        if (storedValue instanceof Number) {
+        if (storedValue instanceof Number storedNumber) {
             // Convert the stored value to the new number type.
-            Number storedNumber = (Number) storedValue;
             String newNumberType = modifiedNumberClass.getNumberType();
             if ("integer".equals(newNumberType)) {
                 newValue = Integer.valueOf(storedNumber.intValue());

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/HibernateStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/store/hibernate/HibernateStore.java
@@ -785,8 +785,8 @@ public class HibernateStore implements Disposable, Initializable
         this.logger.debug("Taken session from pool [{}]", session);
 
         // Put back legacy feature to the Hibernate session
-        if (session instanceof SessionImplementor) {
-            session = new LegacySessionImplementor((SessionImplementor) session, this.loggerConfiguration);
+        if (session instanceof SessionImplementor sessionImplementor) {
+            session = new LegacySessionImplementor(sessionImplementor, this.loggerConfiguration);
         }
 
         setCurrentSession(session);
@@ -869,8 +869,7 @@ public class HibernateStore implements Disposable, Initializable
             if (next == current) {
                 next = null;
             }
-            if (current instanceof SQLException) {
-                SQLException sx = (SQLException) current;
+            if (current instanceof SQLException sx) {
                 while (sx.getNextException() != null) {
                     sx = sx.getNextException();
                     sb.append("\nSQL next exception = [" + sx + "]");
@@ -1099,8 +1098,8 @@ public class HibernateStore implements Disposable, Initializable
             // FIXME: remove when https://hibernate.atlassian.net/browse/HHH-14627
             // (org.hibernate.mapping.PersistentClass#getProperty does not support composite ids) is fixed
             KeyValue identifier = persistentClass.getIdentifier();
-            if (identifier instanceof org.hibernate.mapping.Component) {
-                Iterator<Property> it = ((org.hibernate.mapping.Component) identifier).getPropertyIterator();
+            if (identifier instanceof org.hibernate.mapping.Component component) {
+                Iterator<Property> it = component.getPropertyIterator();
 
                 while (it.hasNext()) {
                     Property property = it.next();

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/template/InternalTemplateManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/internal/template/InternalTemplateManager.java
@@ -253,13 +253,13 @@ public class InternalTemplateManager implements Initializable, Disposable
             try (InputSource source = this.resource.getInputSource()) {
                 if (source instanceof StringInputSource) {
                     strinContent = source.toString();
-                } else if (source instanceof ReaderInputSource) {
-                    strinContent = IOUtils.toString(((ReaderInputSource) source).getReader());
-                } else if (source instanceof InputStreamInputSource) {
+                } else if (source instanceof ReaderInputSource readerInputSource) {
+                    strinContent = IOUtils.toString(readerInputSource.getReader());
+                } else if (source instanceof InputStreamInputSource inputStreamInputSource) {
                     // It's impossible to know the real attachment encoding, but let's assume that they respect the
                     // standard and use UTF-8 (which is required for the files located on the filesystem)
                     strinContent =
-                        IOUtils.toString(((InputStreamInputSource) source).getInputStream(), StandardCharsets.UTF_8);
+                        IOUtils.toString(inputStreamInputSource.getInputStream(), StandardCharsets.UTF_8);
                 } else {
                     return null;
                 }
@@ -1016,8 +1016,8 @@ public class InternalTemplateManager implements Initializable, Disposable
         Template template = getCachedTemplate(resource.getId(), null, resource::getInstant);
 
         if (template == null) {
-            if (resource instanceof AbstractSkinResource) {
-                template = new EnvironmentTemplate((AbstractSkinResource) resource);
+            if (resource instanceof AbstractSkinResource skinResource) {
+                template = new EnvironmentTemplate(skinResource);
             } else {
                 template = new DefaultTemplate(resource);
             }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/ListProperty.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/ListProperty.java
@@ -146,11 +146,11 @@ public class ListProperty extends BaseProperty implements Cloneable
 
         // If the collection was not yet initialized by Hibernate
         // Let's use the super result..
-        if ((list1 instanceof PersistentCollection) && (!((PersistentCollection) list1).wasInitialized())) {
+        if (list1 instanceof PersistentCollection persistentCollection && !persistentCollection.wasInitialized()) {
             return true;
         }
 
-        if ((list2 instanceof PersistentCollection) && (!((PersistentCollection) list2).wasInitialized())) {
+        if (list2 instanceof PersistentCollection persistentCollection && !persistentCollection.wasInitialized()) {
             return true;
         }
 
@@ -252,7 +252,7 @@ public class ListProperty extends BaseProperty implements Cloneable
     @Override
     public String toString()
     {
-        if ((getList() instanceof PersistentCollection) && (!((PersistentCollection) getList()).wasInitialized())) {
+        if (getList() instanceof PersistentCollection persistentCollection && !persistentCollection.wasInitialized()) {
             return "";
         }
 

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/DBListClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/DBListClass.java
@@ -96,8 +96,8 @@ public class DBListClass extends ListClass
             // were empty strings). This means we need to check for NULL and ignore NULL entries
             // from the list.
             if (item != null) {
-                if (item instanceof String) {
-                    result.add(new ListItem((String) item));
+                if (item instanceof String string) {
+                    result.add(new ListItem(string));
                 } else {
                     Object[] res = (Object[]) item;
                     if (res.length == 1) {
@@ -621,8 +621,8 @@ public class DBListClass extends ListClass
             return;
         }
 
-        if (prop instanceof ListProperty) {
-            selectlist = ((ListProperty) prop).getList();
+        if (prop instanceof ListProperty listProperty) {
+            selectlist = listProperty.getList();
             List<String> newlist = new ArrayList<>();
             for (String entry : selectlist) {
                 newlist.add(getDisplayValue(entry, name, map, context));

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/DBTreeListClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/DBTreeListClass.java
@@ -195,8 +195,8 @@ public class DBTreeListClass extends DBListClass
         BaseProperty prop = (BaseProperty) object.safeget(name);
         if (prop == null) {
             selectlist = new ArrayList<>();
-        } else if (prop instanceof ListProperty) {
-            selectlist = ((ListProperty) prop).getList();
+        } else if (prop instanceof ListProperty listProperty) {
+            selectlist = listProperty.getList();
         } else {
             selectlist = new ArrayList<>();
             selectlist.add(String.valueOf(prop.getValue()));
@@ -358,8 +358,8 @@ public class DBTreeListClass extends DBListClass
         BaseProperty prop = (BaseProperty) object.safeget(name);
         if (prop == null) {
             selectlist = new ArrayList<>();
-        } else if (prop instanceof ListProperty) {
-            selectlist = ((ListProperty) prop).getList();
+        } else if (prop instanceof ListProperty listProperty) {
+            selectlist = listProperty.getList();
         } else {
             selectlist = new ArrayList<>();
             selectlist.add(String.valueOf(prop.getValue()));

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
@@ -470,7 +470,7 @@ public abstract class ListClass extends PropertyClass
      */
     public static String getStringFromList(List<String> list, String separators)
     {
-        if ((list instanceof PersistentCollection) && (!((PersistentCollection) list).wasInitialized())) {
+        if ((list instanceof PersistentCollection persistentCollection) && (!persistentCollection.wasInitialized())) {
             return "";
         }
 
@@ -560,8 +560,7 @@ public abstract class ListClass extends PropertyClass
     public String toFormString(BaseProperty property)
     {
         String result;
-        if (property instanceof ListProperty) {
-            ListProperty listProperty = (ListProperty) property;
+        if (property instanceof ListProperty listProperty) {
             result = ListClass.getStringFromList(listProperty.getList(), getSeparators());
         } else {
             result = property.toText();
@@ -651,8 +650,8 @@ public abstract class ListClass extends PropertyClass
         List<Element> elist = ppcel.elements(ListXarObjectPropertySerializer.ELEMENT_VALUE);
         BaseProperty lprop = newProperty();
 
-        if (lprop instanceof ListProperty) {
-            List<String> llist = ((ListProperty) lprop).getList();
+        if (lprop instanceof ListProperty listProperty) {
+            List<String> llist = listProperty.getList();
             for (int i = 0; i < elist.size(); i++) {
                 Element el = elist.get(i);
                 llist.add(el.getText());
@@ -735,8 +734,8 @@ public abstract class ListClass extends PropertyClass
         if (rawvalue == null) {
             return "";
         }
-        if (rawvalue instanceof Object[]) {
-            return ((Object[]) rawvalue)[1].toString();
+        if (rawvalue instanceof Object[] objectArray) {
+            return objectArray[1].toString();
         }
         return getDisplayValue(rawvalue.toString(), name, map, context);
     }
@@ -753,8 +752,8 @@ public abstract class ListClass extends PropertyClass
         if (rawvalue == null) {
             return "";
         }
-        if (rawvalue instanceof Object[]) {
-            return ((Object[]) rawvalue)[0].toString();
+        if (rawvalue instanceof Object[] objectArray) {
+            return objectArray[0].toString();
         }
         return rawvalue.toString();
     }
@@ -1006,8 +1005,8 @@ public abstract class ListClass extends PropertyClass
 
         if (property == null) {
             list = Collections.emptyList();
-        } else if (property instanceof ListProperty) {
-            list = ((ListProperty) property).getList();
+        } else if (property instanceof ListProperty listProperty) {
+            list = listProperty.getList();
         } else {
             list = Arrays.asList(String.valueOf(property.getValue()));
         }
@@ -1047,8 +1046,8 @@ public abstract class ListClass extends PropertyClass
                 actualList = list;
             }
 
-            if (property instanceof ListProperty) {
-                ((ListProperty) property).setList(actualList);
+            if (property instanceof ListProperty listProperty) {
+                listProperty.setList(actualList);
             } else if (isMultiSelect()) {
                 property.setValue(getStringFromList(actualList, getFirstSeparator()));
             } else {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/XWikiHibernateStore.java
@@ -849,8 +849,8 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
             session.save(space);
 
             // Update parent space
-            if (space.getSpaceReference().getParent() instanceof SpaceReference) {
-                maybeCreateSpace((SpaceReference) space.getSpaceReference().getParent(), space.isHidden(), session);
+            if (space.getSpaceReference().getParent() instanceof SpaceReference parentReference) {
+                maybeCreateSpace(parentReference, space.isHidden(), session);
             }
         } finally {
             lock.unlock();
@@ -872,8 +872,8 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
             session.update(space);
 
             // Update parent
-            if (space.getSpaceReference().getParent() instanceof SpaceReference) {
-                makeSpaceVisible((SpaceReference) space.getSpaceReference().getParent(), session);
+            if (space.getSpaceReference().getParent() instanceof SpaceReference parentReference) {
+                makeSpaceVisible(parentReference, session);
             }
         }
     }
@@ -902,8 +902,8 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
             session.update(space);
 
             // Update space parent
-            if (spaceReference.getParent() instanceof SpaceReference) {
-                maybeMakeSpaceHidden((SpaceReference) spaceReference.getParent(), modifiedDocument, session);
+            if (spaceReference.getParent() instanceof SpaceReference parentReference) {
+                maybeMakeSpaceHidden(parentReference, modifiedDocument, session);
             }
         }
     }
@@ -1380,8 +1380,8 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
             session.delete(space);
 
             // Update parent
-            if (spaceReference.getParent() instanceof SpaceReference) {
-                maybeDeleteXWikiSpace((SpaceReference) spaceReference.getParent(), deletedDocument, session);
+            if (spaceReference.getParent() instanceof SpaceReference parentReference) {
+                maybeDeleteXWikiSpace(parentReference, deletedDocument, session);
             }
         } else {
             // Update space hidden property if needed
@@ -1768,8 +1768,8 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
                     cobject.setDocumentReference(object.getDocumentReference());
                     cobject.setClassName(object.getClassName());
                     cobject.setNumber(object.getNumber());
-                    if (object instanceof BaseObject) {
-                        cobject.setGuid(((BaseObject) object).getGuid());
+                    if (object instanceof BaseObject baseObject) {
+                        cobject.setGuid(baseObject.getGuid());
                     }
                     cobject.setId(object.getId());
                     if (evict) {
@@ -1813,8 +1813,7 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
                     session.load(property, (Serializable) property);
                     // In Oracle, empty string are converted to NULL. Since an undefined property is not found at all,
                     // it is safe to assume that a retrieved NULL value should actually be an empty string.
-                    if (property instanceof BaseStringProperty) {
-                        BaseStringProperty stringProperty = (BaseStringProperty) property;
+                    if (property instanceof BaseStringProperty stringProperty) {
                         if (stringProperty.getValue() == null) {
                             stringProperty.setValue("");
                         }
@@ -1830,8 +1829,8 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
                 // Let's force reading lists if there is a list
                 // This seems to be an issue since Hibernate 3.0
                 // Without this test ViewEditTest.testUpdateAdvanceObjectProp fails
-                if (property instanceof ListProperty) {
-                    ((ListProperty) property).getList();
+                if (property instanceof ListProperty listProperty) {
+                    listProperty.getList();
                 }
             } catch (Exception e) {
                 BaseCollection obj = property.getObject();
@@ -2397,11 +2396,11 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
         if (documentReference instanceof PageAttachmentReference) {
             documentReference = documentReference.extractReference(EntityType.PAGE);
         }
-        if (documentReference instanceof PageReference) {
+        if (documentReference instanceof PageReference pageReference) {
             // If the reference is a PageReference then we can't know if it points to a terminal page or a
             // non-terminal one, and thus we need to resolve it.
             documentReference =
-                this.currentPageReferenceDocumentReferenceResolver.resolve((PageReference) documentReference);
+                this.currentPageReferenceDocumentReferenceResolver.resolve(pageReference);
         } else {
             documentReference = documentReference.extractReference(EntityType.DOCUMENT);
         }
@@ -2751,8 +2750,8 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
                 // and
                 // String
                 String referenceString;
-                if (result instanceof String) {
-                    referenceString = (String) result;
+                if (result instanceof String stringResult) {
+                    referenceString = stringResult;
                 } else {
                     referenceString = (String) ((Object[]) result)[0];
                 }
@@ -2881,8 +2880,8 @@ public class XWikiHibernateStore extends XWikiHibernateBaseStore implements XWik
         for (Object result : documentDatas) {
             String fullName;
             String locale = null;
-            if (result instanceof String) {
-                fullName = (String) result;
+            if (result instanceof String stringResult) {
+                fullName = stringResult;
             } else {
                 fullName = (String) ((Object[]) result)[0];
                 if (distinctbylanguage) {

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiServletURLFactory.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/web/XWikiServletURLFactory.java
@@ -130,8 +130,8 @@ public class XWikiServletURLFactory extends XWikiDefaultURLFactory
 
         // Check if the request is a deamon thread request
         XWikiRequest request = context.getRequest();
-        this.daemon = request.getHttpServletRequest() instanceof XWikiServletRequestStub
-            && ((XWikiServletRequestStub) request.getHttpServletRequest()).isDaemon();
+        this.daemon = request.getHttpServletRequest() instanceof XWikiServletRequestStub stub
+            && stub.isDaemon();
 
         // Remember initial request base URL for path for last resort
         if (homepageConfigration != null && context.isMainWiki()) {
@@ -527,10 +527,10 @@ public class XWikiServletURLFactory extends XWikiDefaultURLFactory
     private void appendQueryParameter(String key, Object paramValue, StringBuilder stringBuilder)
         throws UnsupportedEncodingException
     {
-        if (paramValue instanceof String) {
+        if (paramValue instanceof String stringValue) {
             stringBuilder.append(URLEncoder.encode(key, UTF8));
             stringBuilder.append('=');
-            stringBuilder.append(URLEncoder.encode((String) paramValue, UTF8));
+            stringBuilder.append(URLEncoder.encode(stringValue, UTF8));
         } else if (paramValue.getClass().isArray()) {
             Class ofArray = paramValue.getClass().getComponentType();
             if (ofArray.isPrimitive()) {
@@ -551,8 +551,7 @@ public class XWikiServletURLFactory extends XWikiDefaultURLFactory
                     }
                 }
             }
-        } else if (paramValue instanceof Collection) {
-            Collection zeCollection = (Collection) paramValue;
+        } else if (paramValue instanceof Collection zeCollection) {
             int index = 0;
             for (Object paramValueElement : zeCollection) {
                 appendQueryParameter(key, paramValueElement.toString(), stringBuilder);

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/query/hql/internal/StandardHQLCompleteStatementValidator.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/org/xwiki/query/hql/internal/StandardHQLCompleteStatementValidator.java
@@ -255,7 +255,7 @@ public class StandardHQLCompleteStatementValidator implements HQLCompleteStateme
             Statements statements = validation.getParsedStatements();
 
             Statement statement = statements.getStatements().get(0);
-            if (statement instanceof Select && isSelectSafe((Select) statement)) {
+            if (statement instanceof Select select && isSelectSafe(select)) {
                 return Optional.of(true);
             }
         }
@@ -267,8 +267,8 @@ public class StandardHQLCompleteStatementValidator implements HQLCompleteStateme
     {
         SelectBody selectBody = select.getSelectBody();
 
-        if (selectBody instanceof PlainSelect) {
-            return isNodeSafe(((PlainSelect) selectBody).getASTNode());
+        if (selectBody instanceof PlainSelect plainSelect) {
+            return isNodeSafe(plainSelect.getASTNode());
         }
 
         return false;
@@ -290,17 +290,17 @@ public class StandardHQLCompleteStatementValidator implements HQLCompleteStateme
 
     private boolean isNodeSafe(Node node)
     {
-        if (node instanceof SimpleNode) {
+        if (node instanceof SimpleNode simpleNode) {
             // Check if the node is a function
-            Object value = ((SimpleNode) node).jjtGetValue();
-            if (value instanceof Function) {
+            Object value = simpleNode.jjtGetValue();
+            if (value instanceof Function function) {
                 // Check if the function is allowed
-                if (!isFunctionSafe((Function) value)) {
+                if (!isFunctionSafe(function)) {
                     return false;
                 }
-            } else if (value instanceof PlainSelect) {
+            } else if (value instanceof PlainSelect plainSelect) {
                 // Check if the select is safe
-                if (!isPlainSelectSafe((PlainSelect) value)) {
+                if (!isPlainSelectSafe(plainSelect)) {
                     return false;
                 }
             }
@@ -341,8 +341,8 @@ public class StandardHQLCompleteStatementValidator implements HQLCompleteStateme
 
     private void addFromItem(FromItem item, Map<String, String> tables)
     {
-        if (item instanceof Table) {
-            String tableName = ((Table) item).getName();
+        if (item instanceof Table table) {
+            String tableName = table.getName();
             tables.put(item.getAlias() != null ? item.getAlias().getName() : tableName, tableName);
         }
     }
@@ -353,8 +353,8 @@ public class StandardHQLCompleteStatementValidator implements HQLCompleteStateme
      */
     private boolean isSelectItemAllowed(SelectItem selectItem, Map<String, String> tables)
     {
-        if (selectItem instanceof SelectExpressionItem) {
-            return isSelectExpressionAllowed(((SelectExpressionItem) selectItem).getExpression(), tables);
+        if (selectItem instanceof SelectExpressionItem selectExpressionItem) {
+            return isSelectExpressionAllowed(selectExpressionItem.getExpression(), tables);
         }
 
         // TODO: we could support more select items
@@ -365,8 +365,8 @@ public class StandardHQLCompleteStatementValidator implements HQLCompleteStateme
     private boolean isAllowedAllTableColumns(ExpressionList parameters, Map<String, String> tables)
     {
         Expression expression = parameters.getExpressions().get(0);
-        return expression instanceof AllTableColumns
-            && isTableAllowed(getTableName(((AllTableColumns) expression).getTable(), tables));
+        return expression instanceof AllTableColumns allTableColumns
+            && isTableAllowed(getTableName(allTableColumns.getTable(), tables));
     }
 
     private boolean isAllowedAllColumns(ExpressionList parameters, Map<String, String> tables)
@@ -385,12 +385,12 @@ public class StandardHQLCompleteStatementValidator implements HQLCompleteStateme
     {
         boolean safe = false;
 
-        if (expression instanceof Column) {
-            if (isColumnAllowed(((Column) expression), tables)) {
+        if (expression instanceof Column column) {
+            if (isColumnAllowed(column, tables)) {
                 safe = true;
             }
-        } else if (expression instanceof Function) {
-            safe = isSelectFunctionSafe(((Function) expression), tables);
+        } else if (expression instanceof Function function) {
+            safe = isSelectFunctionSafe(function, tables);
         } else if (ALLOWED_VALUE_CLASSES.contains(expression.getClass())) {
             safe = true;
         }


### PR DESCRIPTION
## Description

Replaces `instanceof`-check-then-cast constructs with Java pattern matching for `instanceof`, removing the redundant explicit casts. This resolves **52 SonarCloud `java:S6201` issues** ("Replace this instanceof check and cast with pattern matching for instanceof") across 12 `xwiki-platform-oldcore` files.

The changes are purely mechanical and behaviour-preserving:

```java
if (obj instanceof Foo) {
    ((Foo) obj).doStuff();
}
```
becomes
```java
if (obj instanceof Foo foo) {
    foo.doStuff();
}
```

Files touched (all in `xwiki-platform-oldcore`):
- `StandardHQLCompleteStatementValidator`, `XWikiHibernateStore`, `HibernateStore`, `PropertyConverter`, `XWikiDocumentFilterUtils`, `InternalTemplateManager`, `ViewableAllowedDBListValueFilter`, `ListClass`, `DBListClass`, `DBTreeListClass`, `ListProperty`, `XWikiServletURLFactory`

## SonarCloud

Issues fixed under rule [`java:S6201`](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&issueStatuses=OPEN&rules=java%3AS6201).

## Testing

`mvn clean install -pl xwiki-platform-core/xwiki-platform-oldcore -Plegacy,snapshot -DskipTests` builds successfully (Checkstyle + Spoon + compilation pass).


---
_Generated by [Claude Code](https://claude.ai/code/session_018ZBSn3aAxeKqz6ZKrNZ2WC)_