### PR TITLE
[Misc] Use pattern matching for instanceof in notifications (SonarCloud java:S6201)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/src/main/java/org/xwiki/notifications/CompositeEvent.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-api/src/main/java/org/xwiki/notifications/CompositeEvent.java
@@ -227,9 +227,7 @@ public class CompositeEvent
             return true;
         }
 
-        if (obj instanceof CompositeEvent) {
-            CompositeEvent compositeEvent = (CompositeEvent) obj;
-
+        if (obj instanceof CompositeEvent compositeEvent) {
             EqualsBuilder builder = new EqualsBuilder();
             builder.append(getSimilarityBetweenEvents(), compositeEvent.getSimilarityBetweenEvents());
             builder.append(getEvents(), compositeEvent.getEvents());

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/NotificationFilter.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/NotificationFilter.java
@@ -207,8 +207,7 @@ public interface NotificationFilter extends Comparable
     @Override
     default int compareTo(Object o)
     {
-        if (o instanceof NotificationFilter) {
-            NotificationFilter other = (NotificationFilter) o;
+        if (o instanceof NotificationFilter other) {
             return other.getPriority() - this.getPriority();
         }
         return 0;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/expression/GreaterThanNode.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/expression/GreaterThanNode.java
@@ -77,8 +77,8 @@ public final class GreaterThanNode extends AbstractBinaryOperatorNode
             return true;
         }
 
-        if (o instanceof GreaterThanNode) {
-            return super.equals(o) && isOrEquals() == ((GreaterThanNode) o).isOrEquals();
+        if (o instanceof GreaterThanNode greaterThanNode) {
+            return super.equals(o) && isOrEquals() == greaterThanNode.isOrEquals();
         }
 
         return false;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/expression/LesserThanNode.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/expression/LesserThanNode.java
@@ -77,8 +77,8 @@ public final class LesserThanNode extends AbstractBinaryOperatorNode
             return true;
         }
 
-        if (o instanceof LesserThanNode) {
-            return super.equals(o) && isOrEquals() == ((LesserThanNode) o).isOrEquals();
+        if (o instanceof LesserThanNode lesserThanNode) {
+            return super.equals(o) && isOrEquals() == lesserThanNode.isOrEquals();
         }
 
         return false;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/expression/generics/AbstractBinaryOperatorNode.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/expression/generics/AbstractBinaryOperatorNode.java
@@ -68,9 +68,9 @@ public abstract class AbstractBinaryOperatorNode extends AbstractOperatorNode
     @Override
     public boolean equals(Object o)
     {
-        return (o instanceof AbstractBinaryOperatorNode
-                && leftOperand.equals(((AbstractBinaryOperatorNode) o).leftOperand)
-                && rightOperand.equals(((AbstractBinaryOperatorNode) o).rightOperand));
+        return (o instanceof AbstractBinaryOperatorNode abstractBinaryOperatorNode
+                && leftOperand.equals(abstractBinaryOperatorNode.leftOperand)
+                && rightOperand.equals(abstractBinaryOperatorNode.rightOperand));
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/expression/generics/AbstractUnaryOperatorNode.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/expression/generics/AbstractUnaryOperatorNode.java
@@ -55,8 +55,8 @@ public abstract class AbstractUnaryOperatorNode extends AbstractOperatorNode
     @Override
     public boolean equals(Object o)
     {
-        return (o instanceof AbstractUnaryOperatorNode
-                && operand.equals(((AbstractUnaryOperatorNode) o).operand));
+        return (o instanceof AbstractUnaryOperatorNode abstractUnaryOperatorNode
+                && operand.equals(abstractUnaryOperatorNode.operand));
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/expression/generics/AbstractValueNode.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/expression/generics/AbstractValueNode.java
@@ -216,8 +216,8 @@ public abstract class AbstractValueNode<T> extends AbstractNode
     @Override
     public boolean equals(Object o)
     {
-        return (o instanceof AbstractValueNode
-                && content.equals(((AbstractValueNode) o).content));
+        return (o instanceof AbstractValueNode abstractValueNode
+                && content.equals(abstractValueNode.content));
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilter.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/internal/scope/ScopeNotificationFilter.java
@@ -178,8 +178,8 @@ public class ScopeNotificationFilter implements NotificationFilter
 
         for (NotificationPreference preference : preferences) {
             Object eventType = preference.getProperties().get(NotificationPreferenceProperty.EVENT_TYPE);
-            if (preference.isNotificationEnabled() && eventType != null && eventType instanceof String) {
-                AbstractOperatorNode node = value(EventProperty.TYPE).eq(value((String) eventType))
+            if (preference.isNotificationEnabled() && eventType instanceof String eventTypeString) {
+                AbstractOperatorNode node = value(EventProperty.TYPE).eq(value(eventTypeString))
                         .and(value(EventProperty.DATE).greaterThan(value(preference.getStartDate())));
                 if (topNode == null) {
                     topNode = node;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/script/NotificationFiltersScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-api/src/main/java/org/xwiki/notifications/filters/script/NotificationFiltersScriptService.java
@@ -91,8 +91,8 @@ public class NotificationFiltersScriptService implements ScriptService
         DocumentReference result;
         if (userReference == null || userReference == CurrentUserReference.INSTANCE) {
             result = documentAccessBridge.getCurrentUserReference();
-        } else if (userReference instanceof DocumentUserReference) {
-            result = ((DocumentUserReference) userReference).getReference();
+        } else if (userReference instanceof DocumentUserReference documentUserReference) {
+            result = documentUserReference.getReference();
         } else {
             throw new NotificationException(
                 String.format("This should only be used with DocumentUserReference, "

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/CachedModelBridgeInvalidatorListener.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/CachedModelBridgeInvalidatorListener.java
@@ -70,9 +70,7 @@ public class CachedModelBridgeInvalidatorListener extends AbstractEventListener
     @Override
     public void onEvent(Event event, Object source, Object data)
     {
-        if (source instanceof DefaultNotificationFilterPreference) {
-            DefaultNotificationFilterPreference preferences = (DefaultNotificationFilterPreference) source;
-
+        if (source instanceof DefaultNotificationFilterPreference preferences) {
             String owner = preferences.getOwner();
 
             if (owner != null) {
@@ -86,10 +84,10 @@ public class CachedModelBridgeInvalidatorListener extends AbstractEventListener
                         .invalidatePreferencefilter(new WikiReference(owner));
                 }
             }
-        } else if (source instanceof DocumentReference) {
-            ((CachedFilterPreferencesModelBridge) this.bridge).invalidatePreferencefilter((DocumentReference) source);
-        } else if (source instanceof WikiReference) {
-            ((CachedFilterPreferencesModelBridge) this.bridge).invalidatePreferencefilter((WikiReference) source);
+        } else if (source instanceof DocumentReference documentReference) {
+            ((CachedFilterPreferencesModelBridge) this.bridge).invalidatePreferencefilter(documentReference);
+        } else if (source instanceof WikiReference wikiReference) {
+            ((CachedFilterPreferencesModelBridge) this.bridge).invalidatePreferencefilter(wikiReference);
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/DefaultFilterPreferencesModelBridge.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/DefaultFilterPreferencesModelBridge.java
@@ -216,8 +216,8 @@ public class DefaultFilterPreferencesModelBridge implements FilterPreferencesMod
         }
 
         for (NotificationFilterPreference preference : preferences) {
-            if (preference instanceof DefaultNotificationFilterPreference) {
-                ((DefaultNotificationFilterPreference) preference).setStartingDate(startDate);
+            if (preference instanceof DefaultNotificationFilterPreference defaultPreference) {
+                defaultPreference.setStartingDate(startDate);
             }
         }
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/DefaultNotificationFilterPreference.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/DefaultNotificationFilterPreference.java
@@ -94,9 +94,9 @@ public class DefaultNotificationFilterPreference implements NotificationFilterPr
     public DefaultNotificationFilterPreference(NotificationFilterPreference notificationFilterPreference,
         boolean keepId)
     {
-        if (keepId && notificationFilterPreference instanceof DefaultNotificationFilterPreference) {
-            this.internalId = ((DefaultNotificationFilterPreference) notificationFilterPreference).internalId;
-            this.owner = ((DefaultNotificationFilterPreference) notificationFilterPreference).owner;
+        if (keepId && notificationFilterPreference instanceof DefaultNotificationFilterPreference defaultPreference) {
+            this.internalId = defaultPreference.internalId;
+            this.owner = defaultPreference.owner;
         }
 
         this.id = notificationFilterPreference.getId();

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/event/NotificationFilterPreferenceEventConverter.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/internal/event/NotificationFilterPreferenceEventConverter.java
@@ -69,10 +69,10 @@ public class NotificationFilterPreferenceEventConverter extends AbstractEventCon
     {
         Serializable remote = null;
 
-        if (local instanceof DefaultNotificationFilterPreference) {
+        if (local instanceof DefaultNotificationFilterPreference preference) {
             Map<String, Object> map = new HashMap<>();
 
-            map.put(PROP_OWNER, ((DefaultNotificationFilterPreference) local).getOwner());
+            map.put(PROP_OWNER, preference.getOwner());
 
             remote = (Serializable) map;
         }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/migration/R160300000XWIKI17243DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-default/src/main/java/org/xwiki/notifications/filters/migration/R160300000XWIKI17243DataMigration.java
@@ -223,10 +223,10 @@ public class R160300000XWIKI17243DataMigration extends AbstractHibernateDataMigr
         List<String> values;
         PropertyInterface objProperty = obj.safeget(fieldName);
         // Support both pre and post 7.0 type of watchlist objects
-        if (objProperty instanceof ListProperty) {
-            values = ((ListProperty) objProperty).getList();
-        } else if (objProperty instanceof LargeStringProperty) {
-            values = ListClass.getListFromString(((LargeStringProperty) objProperty).getValue(), ",", false);
+        if (objProperty instanceof ListProperty listProperty) {
+            values = listProperty.getList();
+        } else if (objProperty instanceof LargeStringProperty largeStringProperty) {
+            values = ListClass.getListFromString(largeStringProperty.getValue(), ",", false);
         } else {
             values = Collections.emptyList();
         }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-watch/src/main/java/org/xwiki/notifications/filters/watch/script/NotificationWatchScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-filters/xwiki-platform-notifications-filters-watch/src/main/java/org/xwiki/notifications/filters/watch/script/NotificationWatchScriptService.java
@@ -226,8 +226,8 @@ public class NotificationWatchScriptService implements ScriptService
         DocumentReference result;
         if (userReference == null || userReference == CurrentUserReference.INSTANCE) {
             result = documentAccessBridge.getCurrentUserReference();
-        } else if (userReference instanceof DocumentUserReference) {
-            result = ((DocumentUserReference) userReference).getReference();
+        } else if (userReference instanceof DocumentUserReference documentUserReference) {
+            result = documentUserReference.getReference();
         } else {
             throw new NotificationException(
                 String.format("This should only be used with DocumentUserReference, "

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/IntervalUsersManagerInvalidator.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/IntervalUsersManagerInvalidator.java
@@ -89,8 +89,8 @@ public class IntervalUsersManagerInvalidator extends AbstractEventListener
     @Override
     public void onEvent(Event event, Object source, Object data)
     {
-        if (event instanceof WikiDeletedEvent) {
-            this.users.invalidateWiki(((WikiDeletedEvent) event).getWikiId());
+        if (event instanceof WikiDeletedEvent wikiDeletedEvent) {
+            this.users.invalidateWiki(wikiDeletedEvent.getWikiId());
         } else {
             XWikiDocument document = (XWikiDocument) source;
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/live/PrefilteringLiveNotificationEmailListener.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-api/src/main/java/org/xwiki/notifications/notifiers/internal/email/live/PrefilteringLiveNotificationEmailListener.java
@@ -85,10 +85,10 @@ public class PrefilteringLiveNotificationEmailListener extends AbstractEventList
                 // Load all the events for which live mail was processing was not finished and send them
                 // Don't block the event thread
                 this.manager.addEvents(this.wikis.getMainWikiId());
-            } else if (event instanceof WikiReadyEvent) {
+            } else if (event instanceof WikiReadyEvent wikiReadyEvent) {
                 // Load all the events for which live mail was processing was not finished and send them
                 // Don't block the event thread
-                this.manager.addEvents(((WikiReadyEvent) event).getWikiId());
+                this.manager.addEvents(wikiReadyEvent.getWikiId());
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/DefaultEmailTemplateRenderer.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/DefaultEmailTemplateRenderer.java
@@ -145,8 +145,8 @@ public class DefaultEmailTemplateRenderer implements EmailTemplateRenderer
             // Use the external URL factory to generate full URLs
             context.setURLFactory(new ExternalServletURLFactory(context));
             // Set the given syntax in the rendering context
-            if (renderingContext instanceof MutableRenderingContext) {
-                ((MutableRenderingContext) renderingContext).push(null, null, syntax, null, false, syntax);
+            if (renderingContext instanceof MutableRenderingContext mutableRenderingContext) {
+                mutableRenderingContext.push(null, null, syntax, null, false, syntax);
             }
             // Render the template or fallback to the default one
             return templateManager.execute(template);
@@ -154,8 +154,8 @@ public class DefaultEmailTemplateRenderer implements EmailTemplateRenderer
             throw new NotificationException("Failed to render the notification.", e);
         } finally {
             // Cleaning the rendering context
-            if (renderingContext instanceof MutableRenderingContext) {
-                ((MutableRenderingContext) renderingContext).pop();
+            if (renderingContext instanceof MutableRenderingContext mutableRenderingContext) {
+                mutableRenderingContext.pop();
             }
             // Cleaning the URL factory
             context.setURLFactory(originalURLFactory);

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/LogoAttachmentExtractor.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-notifiers/xwiki-platform-notifications-notifiers-default/src/main/java/org/xwiki/notifications/notifiers/internal/email/LogoAttachmentExtractor.java
@@ -137,8 +137,8 @@ public class LogoAttachmentExtractor
     {
         InputSource inputSource = sourceImageIS.getInputSource();
 
-        if (inputSource instanceof InputStreamInputSource) {
-            try (InputStreamInputSource inputStreamSource = (InputStreamInputSource) inputSource) {
+        if (inputSource instanceof InputStreamInputSource inputStreamSource) {
+            try (inputStreamSource) {
                 XWikiAttachmentContent content = new XWikiAttachmentContent();
                 content.setContent(inputStreamSource.getInputStream());
 

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/src/main/java/org/xwiki/notifications/preferences/internal/AbstractDocumentNotificationPreferenceProvider.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/src/main/java/org/xwiki/notifications/preferences/internal/AbstractDocumentNotificationPreferenceProvider.java
@@ -59,9 +59,7 @@ public abstract class AbstractDocumentNotificationPreferenceProvider implements 
         Map<EntityReference, List<NotificationPreference>> preferencesPerTarget = new HashMap<>();
 
         for (NotificationPreference preference : preferences) {
-            if (preference instanceof TargetableNotificationPreference) {
-                TargetableNotificationPreference targetablePreference = (TargetableNotificationPreference) preference;
-
+            if (preference instanceof TargetableNotificationPreference targetablePreference) {
                 List<NotificationPreference> list = preferencesPerTarget.get(targetablePreference.getTarget());
                 if (list == null) {
                     list = new ArrayList<>();
@@ -83,9 +81,9 @@ public abstract class AbstractDocumentNotificationPreferenceProvider implements 
     protected void savePreferences(List<NotificationPreference> preferences, EntityReference target)
             throws NotificationException
     {
-        if (target instanceof DocumentReference) {
+        if (target instanceof DocumentReference documentReference) {
             cachedNotificationPreferenceModelBridge
-                .saveNotificationsPreferences((DocumentReference) target, preferences);
+                .saveNotificationsPreferences(documentReference, preferences);
         } else {
             logger.warn("Preference's target [{}] is not a document reference. The corresponding preference will not"
                     + " be saved.");

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/src/main/java/org/xwiki/notifications/preferences/internal/WikiNotificationPreferenceProvider.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/src/main/java/org/xwiki/notifications/preferences/internal/WikiNotificationPreferenceProvider.java
@@ -79,9 +79,9 @@ public class WikiNotificationPreferenceProvider extends AbstractDocumentNotifica
     protected void savePreferences(List<NotificationPreference> preferences, EntityReference target)
             throws NotificationException
     {
-        if (target instanceof WikiReference) {
+        if (target instanceof WikiReference wikiReference) {
             cachedNotificationPreferenceModelBridge
-                .saveNotificationsPreferences(new DocumentReference(GLOBAL_PREFERENCES, (WikiReference) target),
+                .saveNotificationsPreferences(new DocumentReference(GLOBAL_PREFERENCES, wikiReference),
                     preferences);
         } else {
             logger.warn("Preference's target [{}] is not a wiki reference. The corresponding preference will not be"

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/src/main/java/org/xwiki/notifications/preferences/internal/cache/UnboundedEntityCacheInvalidatorListener.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/src/main/java/org/xwiki/notifications/preferences/internal/cache/UnboundedEntityCacheInvalidatorListener.java
@@ -78,9 +78,9 @@ public class UnboundedEntityCacheInvalidatorListener extends AbstractEventListen
     @Override
     public void onEvent(Event event, Object source, Object data)
     {
-        if (event instanceof WikiDeletedEvent) {
+        if (event instanceof WikiDeletedEvent wikiDeletedEvent) {
             // It's hard to find which cache entry is coming from wiki wiki so we remove them all
-            this.caches.remove(((WikiDeletedEvent) event).getWikiId());
+            this.caches.remove(wikiDeletedEvent.getWikiId());
         } else if (event instanceof DocumentDeletedEvent) {
             this.caches.remove(((XWikiDocument) source).getDocumentReference());
         } else {

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/src/main/java/org/xwiki/notifications/preferences/script/NotificationPreferenceScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-preferences/xwiki-platform-notifications-preferences-api/src/main/java/org/xwiki/notifications/preferences/script/NotificationPreferenceScriptService.java
@@ -127,10 +127,10 @@ public class NotificationPreferenceScriptService implements ScriptService
         */
 
         List<NotificationPreference> existingPreferences = Collections.emptyList();
-        if (target instanceof DocumentReference) {
-            existingPreferences = notificationPreferenceManager.getAllPreferences((DocumentReference) target);
-        } else if (target instanceof WikiReference) {
-            existingPreferences = notificationPreferenceManager.getAllPreferences((WikiReference) target);
+        if (target instanceof DocumentReference documentReference) {
+            existingPreferences = notificationPreferenceManager.getAllPreferences(documentReference);
+        } else if (target instanceof WikiReference wikiReference) {
+            existingPreferences = notificationPreferenceManager.getAllPreferences(wikiReference);
         }
 
         // Instantiate a new copy of TargetableNotificationPreferenceBuilder because this component is not thread-safe.
@@ -374,8 +374,8 @@ public class NotificationPreferenceScriptService implements ScriptService
         DocumentReference userDocumentReference;
         if (userReference == CurrentUserReference.INSTANCE) {
             userDocumentReference = documentAccessBridge.getCurrentUserReference();
-        } else if (userReference instanceof DocumentUserReference) {
-            userDocumentReference = ((DocumentUserReference) userReference).getReference();
+        } else if (userReference instanceof DocumentUserReference documentUserReference) {
+            userDocumentReference = documentUserReference.getReference();
         } else {
             throw new NotificationException(
                 String.format("The method isEventTypeEnabledForUser should only be used with DocumentUserReference, "

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/main/java/org/xwiki/notifications/rest/internal/NotificationEventExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-rest/src/main/java/org/xwiki/notifications/rest/internal/NotificationEventExecutor.java
@@ -371,8 +371,8 @@ public class NotificationEventExecutor implements Initializable, Disposable
             this.shortCache.remove(asyncId);
         }
 
-        if (result instanceof Throwable) {
-            throw new NotificationException("Asynchronous notifications gathering failed", (Throwable) result);
+        if (result instanceof Throwable throwable) {
+            throw new NotificationException("Asynchronous notifications gathering failed", throwable);
         }
 
         return result;

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/ExpressionNodeToEventQueryConverter.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/ExpressionNodeToEventQueryConverter.java
@@ -111,12 +111,12 @@ public class ExpressionNodeToEventQueryConverter
 
     private void parseBlock(ExpressionNode node, SimpleEventQuery result, boolean ingroup) throws EventStreamException
     {
-        if (node instanceof AbstractUnaryOperatorNode) {
-            parseUnaryOperator((AbstractUnaryOperatorNode) node, result, ingroup);
-        } else if (node instanceof AbstractBinaryOperatorNode) {
-            parseBinaryOperator((AbstractBinaryOperatorNode) node, result, ingroup);
-        } else if (node instanceof AbstractOperatorNode) {
-            parseOtherOperation((AbstractOperatorNode) node, result, ingroup);
+        if (node instanceof AbstractUnaryOperatorNode unaryOperatorNode) {
+            parseUnaryOperator(unaryOperatorNode, result, ingroup);
+        } else if (node instanceof AbstractBinaryOperatorNode binaryOperatorNode) {
+            parseBinaryOperator(binaryOperatorNode, result, ingroup);
+        } else if (node instanceof AbstractOperatorNode operatorNode) {
+            parseOtherOperation(operatorNode, result, ingroup);
         } else {
             // Unsupported
             throw new EventStreamException(String.format("Unsupported block node [%s]", node));
@@ -125,10 +125,10 @@ public class ExpressionNodeToEventQueryConverter
 
     private String getProperty(AbstractBinaryOperatorNode operator) throws EventStreamException
     {
-        if (operator.getLeftOperand() instanceof PropertyValueNode) {
-            return getProperty((PropertyValueNode) operator.getLeftOperand());
-        } else if (operator.getRightOperand() instanceof PropertyValueNode) {
-            return getProperty((PropertyValueNode) operator.getRightOperand());
+        if (operator.getLeftOperand() instanceof PropertyValueNode propertyValueNode) {
+            return getProperty(propertyValueNode);
+        } else if (operator.getRightOperand() instanceof PropertyValueNode propertyValueNode) {
+            return getProperty(propertyValueNode);
         } else {
             // TODO: Unsupported
             throw new EventStreamException(String.format(FORMAT_UNSUPPORTED_OPERATOR, operator));
@@ -184,11 +184,11 @@ public class ExpressionNodeToEventQueryConverter
     private void parseEqualsNode(AbstractBinaryOperatorNode operator, SimpleEventQuery result)
         throws EventStreamException
     {
-        if (operator.getLeftOperand() instanceof PropertyValueNode) {
-            result.eq(getProperty((PropertyValueNode) operator.getLeftOperand()),
+        if (operator.getLeftOperand() instanceof PropertyValueNode propertyValueNode) {
+            result.eq(getProperty(propertyValueNode),
                 getValue((AbstractValueNode) operator.getRightOperand()));
-        } else if (operator.getRightOperand() instanceof PropertyValueNode) {
-            result.eq(getProperty((PropertyValueNode) operator.getRightOperand()),
+        } else if (operator.getRightOperand() instanceof PropertyValueNode propertyValueNode) {
+            result.eq(getProperty(propertyValueNode),
                 getValue((AbstractValueNode) operator.getLeftOperand()));
         } else if (!operator.getLeftOperand().equals(operator.getRightOperand())) {
             // TODO: Unsupported
@@ -228,17 +228,13 @@ public class ExpressionNodeToEventQueryConverter
             result.startsWith(getProperty(operator), getValue(operator));
         } else if (operator instanceof EndsWith) {
             result.endsWith(getProperty(operator), getValue(operator));
-        } else if (operator instanceof GreaterThanNode) {
-            GreaterThanNode greater = (GreaterThanNode) operator;
-
+        } else if (operator instanceof GreaterThanNode greater) {
             if (greater.isOrEquals()) {
                 result.greaterOrEq(getProperty(operator), getValue(operator));
             } else {
                 result.greater(getProperty(operator), getValue(operator));
             }
-        } else if (operator instanceof LesserThanNode) {
-            LesserThanNode lesser = (LesserThanNode) operator;
-
+        } else if (operator instanceof LesserThanNode lesser) {
             if (lesser.isOrEquals()) {
                 result.lessOrEq(getProperty(operator), getValue(operator));
             } else {
@@ -253,15 +249,14 @@ public class ExpressionNodeToEventQueryConverter
     private void parseOtherOperation(AbstractOperatorNode operator, SimpleEventQuery result, boolean ingroup)
         throws EventStreamException
     {
-        if (operator instanceof InNode) {
-            InNode inNode = (InNode) operator;
-            if (inNode.getLeftOperand() instanceof PropertyValueNode) {
+        if (operator instanceof InNode inNode) {
+            if (inNode.getLeftOperand() instanceof PropertyValueNode propertyValueNode) {
                 List<Object> values = new ArrayList<>(inNode.getValues().size());
                 for (AbstractValueNode valueNode : inNode.getValues()) {
                     values.add(getValue(valueNode));
                 }
 
-                result.in(getProperty((PropertyValueNode) inNode.getLeftOperand()), values);
+                result.in(getProperty(propertyValueNode), values);
             } else {
                 // TODO: Unsupported
                 throw new EventStreamException(String.format(FORMAT_UNSUPPORTED_OPERATOR, operator));
@@ -269,17 +264,13 @@ public class ExpressionNodeToEventQueryConverter
         } else if (operator instanceof InSubQueryNode) {
             // TODO: Unsupported
             throw new EventStreamException(String.format(FORMAT_UNSUPPORTED_OPERATOR, operator));
-        } else if (operator instanceof OrderByNode) {
-            OrderByNode order = (OrderByNode) operator;
-
+        } else if (operator instanceof OrderByNode order) {
             parseBlock(order.getQuery(), result, ingroup);
 
             result.addSort(getProperty(order.getProperty()),
                 order.getOrder() == Order.ASC ? org.xwiki.eventstream.query.SortableEventQuery.SortClause.Order.ASC
                     : org.xwiki.eventstream.query.SortableEventQuery.SortClause.Order.DESC);
-        } else if (operator instanceof ForUserNode) {
-            ForUserNode forUser = (ForUserNode) operator;
-
+        } else if (operator instanceof ForUserNode forUser) {
             if (forUser.getFormat() == NotificationFormat.ALERT) {
                 if (forUser.getUser() != null && forUser.isRead() != null) {
                     result.withStatus(this.serializer.serialize(forUser.getUser()), forUser.isRead());

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/QueryExpressionGenerator.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/QueryExpressionGenerator.java
@@ -195,8 +195,8 @@ public class QueryExpressionGenerator
                 NotificationFilter filter = filterIterator.next();
                 ExpressionNode node =
                     filter.filterExpression(parameters.user, parameters.filterPreferences, preference);
-                if (node != null && node instanceof AbstractOperatorNode) {
-                    preferenceTypeNode = preferenceTypeNode.and((AbstractOperatorNode) node);
+                if (node != null && node instanceof AbstractOperatorNode operatorNode) {
+                    preferenceTypeNode = preferenceTypeNode.and(operatorNode);
                 }
             }
 
@@ -225,11 +225,11 @@ public class QueryExpressionGenerator
         for (NotificationFilter filter : parameters.filters) {
             ExpressionNode node = filter.filterExpression(parameters.user, parameters.filterPreferences,
                 NotificationFilterType.EXCLUSIVE, parameters.format);
-            if (node instanceof AbstractOperatorNode) {
+            if (node instanceof AbstractOperatorNode operatorNode) {
                 if (globalFiltersNode == null) {
-                    globalFiltersNode = (AbstractOperatorNode) node;
+                    globalFiltersNode = operatorNode;
                 } else {
-                    globalFiltersNode = globalFiltersNode.and((AbstractOperatorNode) node);
+                    globalFiltersNode = globalFiltersNode.and(operatorNode);
                 }
             }
         }
@@ -244,11 +244,11 @@ public class QueryExpressionGenerator
         for (NotificationFilter filter : parameters.filters) {
             ExpressionNode node = filter.filterExpression(parameters.user, parameters.filterPreferences,
                 NotificationFilterType.INCLUSIVE, parameters.format, parameters.preferences);
-            if (node != null && node instanceof AbstractOperatorNode) {
+            if (node != null && node instanceof AbstractOperatorNode operatorNode) {
                 if (globalFiltersNode == null) {
-                    globalFiltersNode = (AbstractOperatorNode) node;
+                    globalFiltersNode = operatorNode;
                 } else {
-                    globalFiltersNode = globalFiltersNode.or((AbstractOperatorNode) node);
+                    globalFiltersNode = globalFiltersNode.or(operatorNode);
                 }
             }
         }

--- a/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/TagNotificationFilter.java
+++ b/xwiki-platform-core/xwiki-platform-notifications/xwiki-platform-notifications-sources/src/main/java/org/xwiki/notifications/sources/internal/TagNotificationFilter.java
@@ -128,8 +128,7 @@ public class TagNotificationFilter implements NotificationFilter
     private String findCurrentWiki(Collection<NotificationFilterPreference> filterPreferences)
     {
         for (NotificationFilterPreference nfp : filterPreferences) {
-            if (nfp.isEnabled() && nfp instanceof TagNotificationFilterPreference) {
-                TagNotificationFilterPreference pref = (TagNotificationFilterPreference) nfp;
+            if (nfp.isEnabled() && nfp instanceof TagNotificationFilterPreference pref) {
                 return pref.getCurrentWiki();
             }
         }


### PR DESCRIPTION
Replaces the `instanceof` check + explicit cast idiom with `instanceof` pattern binding (Java 16+ pattern matching for `instanceof`) across the `xwiki-platform-notifications` modules, as flagged by SonarCloud rule [java:S6201](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS6201&rule_key=java%3AS6201).

This is a mechanical, behaviour-preserving cleanup covering 52 issues across 27 files in the following modules: notifications-api, notifications-filters-api, notifications-filters-default, notifications-filters-watch, notifications-notifiers-api, notifications-notifiers-default, notifications-preferences-api, notifications-sources and notifications-rest.

Each fix binds a pattern variable and removes the redundant cast(s) within its scope; where a redundant local declaration or a now-implied `!= null` guard existed, it was removed too. No behaviour changes.

SonarCloud issues (rule java:S6201, project `org.xwiki.platform:xwiki-platform`, notifications component):
https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&issueStatuses=OPEN&rules=java%3AS6201

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014TTUotoPpijVJ4YYjRZrwK)_