### PR TITLE
[Misc] Use pattern matching for instanceof in eventstream (SonarCloud java:S6201)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/AbstractRecordableEventDescriptor.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/AbstractRecordableEventDescriptor.java
@@ -83,8 +83,7 @@ public abstract class AbstractRecordableEventDescriptor implements RecordableEve
      */
     protected String getLocalizedMessage(String key)
     {
-        if (componentManager instanceof NamespacedComponentManager) {
-            NamespacedComponentManager namespacedComponentManager = (NamespacedComponentManager) componentManager;
+        if (componentManager instanceof NamespacedComponentManager namespacedComponentManager) {
             String namespaceOfTheDescriptor = namespacedComponentManager.getNamespace();
 
             if (namespaceOfTheDescriptor != null) {
@@ -126,8 +125,7 @@ public abstract class AbstractRecordableEventDescriptor implements RecordableEve
             return true;
         }
 
-        if (o instanceof RecordableEventDescriptor) {
-            RecordableEventDescriptor other = (RecordableEventDescriptor) o;
+        if (o instanceof RecordableEventDescriptor other) {
             EqualsBuilder equalsBuilder = new EqualsBuilder();
             equalsBuilder.append(other.getApplicationId(), this.getApplicationId());
             equalsBuilder.append(other.getEventType(), this.getEventType());

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/internal/AbstractAsynchronousEventStore.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/internal/AbstractAsynchronousEventStore.java
@@ -443,8 +443,7 @@ public abstract class AbstractAsynchronousEventStore implements EventStore, Init
         // Notify event listeners
         Object notificationOuput = task.output;
         boolean skipNotify = false;
-        if (task.output instanceof Optional<?>) {
-            Optional<?> optionalOutput = (Optional<?>) task.output;
+        if (task.output instanceof Optional<?> optionalOutput) {
             if (optionalOutput.isPresent()) {
                 notificationOuput = optionalOutput.get();
             } else {

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/internal/DefaultEntityEvent.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/internal/DefaultEntityEvent.java
@@ -90,9 +90,7 @@ public class DefaultEntityEvent implements EntityEvent
             return true;
         }
 
-        if (obj instanceof EntityEvent) {
-            EntityEvent otherEvent = (EntityEvent) obj;
-
+        if (obj instanceof EntityEvent otherEvent) {
             EqualsBuilder builder = new EqualsBuilder();
 
             builder.append(getEvent(), otherEvent.getEvent());

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/internal/DefaultEvent.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/internal/DefaultEvent.java
@@ -454,9 +454,7 @@ public class DefaultEvent implements Event
             return true;
         }
 
-        if (obj instanceof Event) {
-            Event otherEvent = (Event) obj;
-
+        if (obj instanceof Event otherEvent) {
             EqualsBuilder builder = new EqualsBuilder();
 
             builder.append(getApplication(), otherEvent.getApplication());

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/internal/DefaultEventStatus.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/internal/DefaultEventStatus.java
@@ -76,9 +76,7 @@ public class DefaultEventStatus extends DefaultEntityEvent implements EventStatu
             return true;
         }
 
-        if (obj instanceof EventStatus) {
-            EventStatus otherEvent = (EventStatus) obj;
-
+        if (obj instanceof EventStatus otherEvent) {
             EqualsBuilder builder = new EqualsBuilder();
 
             builder.appendSuper(super.equals(obj));

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/query/AbstractEntityQueryCondition.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/query/AbstractEntityQueryCondition.java
@@ -71,9 +71,7 @@ public abstract class AbstractEntityQueryCondition extends QueryCondition
             return true;
         }
 
-        if (obj instanceof AbstractEntityQueryCondition) {
-            AbstractEntityQueryCondition status = (AbstractEntityQueryCondition) obj;
-
+        if (obj instanceof AbstractEntityQueryCondition status) {
             EqualsBuilder builder = new EqualsBuilder();
 
             builder.appendSuper(super.equals(obj));

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/query/AbstractPropertyQueryCondition.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/query/AbstractPropertyQueryCondition.java
@@ -134,9 +134,7 @@ public abstract class AbstractPropertyQueryCondition extends QueryCondition
             return true;
         }
 
-        if (super.equals(obj) && obj instanceof AbstractPropertyQueryCondition) {
-            AbstractPropertyQueryCondition otherContition = (AbstractPropertyQueryCondition) obj;
-
+        if (super.equals(obj) && obj instanceof AbstractPropertyQueryCondition otherContition) {
             EqualsBuilder builder = new EqualsBuilder();
 
             builder.append(getProperty(), otherContition.getProperty());

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/query/CompareQueryCondition.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/query/CompareQueryCondition.java
@@ -185,9 +185,7 @@ public class CompareQueryCondition extends AbstractPropertyQueryCondition
             return true;
         }
 
-        if (obj instanceof CompareQueryCondition) {
-            CompareQueryCondition compare = (CompareQueryCondition) obj;
-
+        if (obj instanceof CompareQueryCondition compare) {
             EqualsBuilder builder = new EqualsBuilder();
 
             builder.appendSuper(super.equals(obj));

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/query/GroupQueryCondition.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/query/GroupQueryCondition.java
@@ -105,9 +105,7 @@ public class GroupQueryCondition extends QueryCondition
             return true;
         }
 
-        if (obj instanceof GroupQueryCondition) {
-            GroupQueryCondition group = (GroupQueryCondition) obj;
-
+        if (obj instanceof GroupQueryCondition group) {
             EqualsBuilder builder = new EqualsBuilder();
 
             builder.appendSuper(super.equals(obj));

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/query/InQueryCondition.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/query/InQueryCondition.java
@@ -104,9 +104,7 @@ public class InQueryCondition extends AbstractPropertyQueryCondition
             return true;
         }
 
-        if (obj instanceof InQueryCondition) {
-            InQueryCondition condition = (InQueryCondition) obj;
-
+        if (obj instanceof InQueryCondition condition) {
             EqualsBuilder builder = new EqualsBuilder();
 
             builder.appendSuper(super.equals(obj));

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/query/QueryCondition.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/query/QueryCondition.java
@@ -61,9 +61,7 @@ public class QueryCondition
             return true;
         }
 
-        if (obj instanceof QueryCondition) {
-            QueryCondition condition = (QueryCondition) obj;
-
+        if (obj instanceof QueryCondition condition) {
             return isReversed() == condition.isReversed();
         }
 

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/query/SimpleEventQuery.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/query/SimpleEventQuery.java
@@ -569,9 +569,7 @@ public class SimpleEventQuery extends GroupQueryCondition implements PageableEve
             return true;
         }
 
-        if (obj instanceof SimpleEventQuery) {
-            SimpleEventQuery query = (SimpleEventQuery) obj;
-
+        if (obj instanceof SimpleEventQuery query) {
             EqualsBuilder builder = new EqualsBuilder();
 
             builder.appendSuper(super.equals(obj));

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/query/SortableEventQuery.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/query/SortableEventQuery.java
@@ -169,9 +169,7 @@ public interface SortableEventQuery extends EventQuery
                 return true;
             }
 
-            if (obj instanceof SortClause) {
-                SortClause otherSortClause = (SortClause) obj;
-
+            if (obj instanceof SortClause otherSortClause) {
                 EqualsBuilder builder = new EqualsBuilder();
 
                 builder.append(getProperty(), otherSortClause.getProperty());

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/query/StatusQueryCondition.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-api/src/main/java/org/xwiki/eventstream/query/StatusQueryCondition.java
@@ -72,9 +72,7 @@ public class StatusQueryCondition extends AbstractEntityQueryCondition
             return true;
         }
 
-        if (obj instanceof StatusQueryCondition) {
-            StatusQueryCondition status = (StatusQueryCondition) obj;
-
+        if (obj instanceof StatusQueryCondition status) {
             EqualsBuilder builder = new EqualsBuilder();
 
             builder.appendSuper(super.equals(obj));

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-default/src/main/java/org/xwiki/eventstream/internal/DefaultModelBridge.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-default/src/main/java/org/xwiki/eventstream/internal/DefaultModelBridge.java
@@ -66,8 +66,7 @@ public class DefaultModelBridge implements ModelBridge
     {
         if (xObjectTypes.isEmpty()) {
             return true;
-        } else if (source instanceof XWikiDocument) {
-            XWikiDocument document = (XWikiDocument) source;
+        } else if (source instanceof XWikiDocument document) {
             Map<DocumentReference, List<BaseObject>> documentXObjects = document.getXObjects();
 
             for (String objectType : xObjectTypes) {

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-default/src/main/java/org/xwiki/eventstream/internal/DefaultRecordableEventConverter.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-default/src/main/java/org/xwiki/eventstream/internal/DefaultRecordableEventConverter.java
@@ -72,14 +72,13 @@ public class DefaultRecordableEventConverter implements RecordableEventConverter
         convertedEvent.setDate(new Date());
         convertedEvent.setUser(context.getUserReference());
         convertedEvent.setWiki(context.getWikiReference());
-        if (recordableEvent instanceof TargetableEvent) {
-            convertedEvent.setTarget(((TargetableEvent) recordableEvent).getTarget());
+        if (recordableEvent instanceof TargetableEvent targetableEvent) {
+            convertedEvent.setTarget(targetableEvent.getTarget());
         }
 
-        if (data instanceof String) {
-            convertedEvent.setBody((String) data);
-        } else if (data instanceof XWikiDocument) {
-            XWikiDocument document = (XWikiDocument) data;
+        if (data instanceof String stringData) {
+            convertedEvent.setBody(stringData);
+        } else if (data instanceof XWikiDocument document) {
             convertedEvent.setDocument(document.getDocumentReference());
             convertedEvent.setDocumentVersion(document.getVersion());
             convertedEvent.setDocumentTitle(document.getRenderedTitle(context));

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-default/src/main/java/org/xwiki/eventstream/internal/UntypedEventListener.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-default/src/main/java/org/xwiki/eventstream/internal/UntypedEventListener.java
@@ -189,8 +189,8 @@ public class UntypedEventListener extends AbstractEventListener
 
             // First check if the "xreturn" attribute has been set
             Object xreturn = this.scriptContextManager.getCurrentScriptContext().getAttribute(XRETURN_BINDING);
-            if (xreturn instanceof Boolean) {
-                return (Boolean) xreturn;
+            if (xreturn instanceof Boolean booleanValue) {
+                return booleanValue;
             }
 
             // Otherwise, for backward-compatibility, render the template to a string, and compare this
@@ -219,11 +219,11 @@ public class UntypedEventListener extends AbstractEventListener
             // Evaluate the template and look for the "xreturn" binding
             evaluateVelocity(event, source, expression, descriptor);
             Object xreturn = this.scriptContextManager.getCurrentScriptContext().getAttribute(XRETURN_BINDING);
-            if (xreturn instanceof Iterable) {
+            if (xreturn instanceof Iterable iterable) {
                 Set<String> target = new HashSet<>();
-                for (Object o : (Iterable) xreturn) {
-                    if (o instanceof String) {
-                        target.add((String) o);
+                for (Object o : iterable) {
+                    if (o instanceof String string) {
+                        target.add(string);
                     }
                 }
                 return target;

--- a/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/main/java/org/xwiki/eventstream/store/solr/internal/SolrEventStore.java
+++ b/xwiki-platform-core/xwiki-platform-eventstream/xwiki-platform-eventstream-stores/xwiki-platform-eventstream-store-solr/src/main/java/org/xwiki/eventstream/store/solr/internal/SolrEventStore.java
@@ -519,19 +519,17 @@ public class SolrEventStore extends AbstractAsynchronousEventStore
             fields.forEach(solrQuery::setFields);
         }
 
-        if (query instanceof PageableEventQuery) {
-            applyPageable(solrQuery, (PageableEventQuery) query);
+        if (query instanceof PageableEventQuery pageableQuery) {
+            applyPageable(solrQuery, pageableQuery);
         }
 
-        if (query instanceof SortableEventQuery) {
-            for (SortClause sort : ((SortableEventQuery) query).getSorts()) {
+        if (query instanceof SortableEventQuery sortableQuery) {
+            for (SortClause sort : sortableQuery.getSorts()) {
                 solrQuery.addSort(toSolrFieldName(sort), sort.getOrder() == Order.ASC ? ORDER.asc : ORDER.desc);
             }
         }
 
-        if (query instanceof SimpleEventQuery) {
-            SimpleEventQuery simpleQuery = (SimpleEventQuery) query;
-
+        if (query instanceof SimpleEventQuery simpleQuery) {
             addConditions(simpleQuery.isOr() && simpleQuery.getConditions().size() > 1
                 ? Collections.singletonList(simpleQuery) : simpleQuery.getConditions(), solrQuery);
         }
@@ -572,16 +570,16 @@ public class SolrEventStore extends AbstractAsynchronousEventStore
     {
         String conditionString;
 
-        if (condition instanceof CompareQueryCondition) {
-            conditionString = serializeCompareCondition((CompareQueryCondition) condition);
-        } else if (condition instanceof StatusQueryCondition) {
-            conditionString = serializeStatusCondition((StatusQueryCondition) condition);
-        } else if (condition instanceof MailEntityQueryCondition) {
-            conditionString = serializeMailCondition((MailEntityQueryCondition) condition);
-        } else if (condition instanceof InQueryCondition) {
-            conditionString = serializeInCondition((InQueryCondition) condition);
-        } else if (condition instanceof GroupQueryCondition) {
-            conditionString = serializeGroupCondition((GroupQueryCondition) condition);
+        if (condition instanceof CompareQueryCondition compareCondition) {
+            conditionString = serializeCompareCondition(compareCondition);
+        } else if (condition instanceof StatusQueryCondition statusCondition) {
+            conditionString = serializeStatusCondition(statusCondition);
+        } else if (condition instanceof MailEntityQueryCondition mailCondition) {
+            conditionString = serializeMailCondition(mailCondition);
+        } else if (condition instanceof InQueryCondition inCondition) {
+            conditionString = serializeInCondition(inCondition);
+        } else if (condition instanceof GroupQueryCondition groupCondition) {
+            conditionString = serializeGroupCondition(groupCondition);
         } else {
             conditionString = null;
         }
@@ -731,10 +729,10 @@ public class SolrEventStore extends AbstractAsynchronousEventStore
     private Type resolveCustomType(AbstractPropertyQueryCondition condition)
     {
         Object value = null;
-        if (condition instanceof CompareQueryCondition) {
-            value = ((CompareQueryCondition) condition).getValue();
-        } else if (condition instanceof InQueryCondition) {
-            List<Object> values = ((InQueryCondition) condition).getValues();
+        if (condition instanceof CompareQueryCondition compareCondition) {
+            value = compareCondition.getValue();
+        } else if (condition instanceof InQueryCondition inCondition) {
+            List<Object> values = inCondition.getValues();
             if (values != null && !values.isEmpty()) {
                 value = values.getFirst();
             }


### PR DESCRIPTION
Fixes 32 open [SonarCloud java:S6201](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS6201&rule_key=java%3AS6201) issues ("Replace this instanceof check and cast with 'instanceof ... '") across the `xwiki-platform-eventstream` module.

Each `instanceof` check followed by a redundant cast is rewritten to use an `instanceof` pattern variable (Java 16+), removing the explicit cast (and, where present, the redundant local variable declaration).

Modules touched:
* `xwiki-platform-eventstream-api` (14 sites, 14 files)
* `xwiki-platform-eventstream-default` (8 sites, 3 files)
* `xwiki-platform-eventstream-store-solr` (10 sites, 1 file)

All 32 flagged sites were converted (0 dropped). Behaviour-preserving; the three modules build cleanly (`mvn clean install -DskipTests`, which runs Checkstyle + Spoon).

SonarCloud query: https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&rules=java%3AS6201&issueStatuses=OPEN

---
_Generated by [Claude Code](https://claude.ai/code/session_016Bd48ZY3x2JRBwrjhg4QFr)_