### PR TITLE
[Misc] Use pattern matching for instanceof in search-solr (SonarCloud java:S6201)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/DefaultSolrUtils.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/DefaultSolrUtils.java
@@ -194,8 +194,8 @@ public class DefaultSolrUtils implements SolrUtils
             return typeName;
         }
 
-        if (value instanceof Collection) {
-            typeName = getTypeName((Collection) value);
+        if (value instanceof Collection collection) {
+            typeName = getTypeName(collection);
         } else if (value.getClass().isArray()) {
             typeName = getTypeName(value.getClass().getComponentType());
             if (typeName != null) {
@@ -270,12 +270,12 @@ public class DefaultSolrUtils implements SolrUtils
     private static String getTypeName(Type type)
     {
         if (type != null) {
-            if (type instanceof Class) {
-                return getTypeName((Class) type);
-            } else if (type instanceof ParameterizedType) {
-                Type rawType = ((ParameterizedType) type).getRawType();
+            if (type instanceof Class clazz) {
+                return getTypeName(clazz);
+            } else if (type instanceof ParameterizedType parameterizedType) {
+                Type rawType = parameterizedType.getRawType();
 
-                if (rawType instanceof Class && Iterable.class.isAssignableFrom((Class) rawType)) {
+                if (rawType instanceof Class rawClass && Iterable.class.isAssignableFrom(rawClass)) {
                     Map<TypeVariable<?>, Type> variables = TypeUtils.getTypeArguments(type, Iterable.class);
 
                     return getIterableTypeName(variables.get(ITERABLE_PARAMETER));
@@ -365,11 +365,11 @@ public class DefaultSolrUtils implements SolrUtils
 
                 if (typeName != null) {
                     document.setField(getMapFieldName(key, mapFieldName, typeName), value);
-                } else if (value instanceof Iterable) {
-                    typeName = getTypeName((Iterable) value);
+                } else if (value instanceof Iterable iterable) {
+                    typeName = getTypeName(iterable);
 
                     if (typeName != null) {
-                        for (Object element : (Iterable) value) {
+                        for (Object element : iterable) {
                             document.addField(getMapFieldName(key, mapFieldName, typeName), element);
                         }
                     }
@@ -488,8 +488,8 @@ public class DefaultSolrUtils implements SolrUtils
         }
 
         String str;
-        if (value instanceof String) {
-            str = (String) value;
+        if (value instanceof String string) {
+            str = string;
         } else if (CLASS_SUFFIX_MAPPING.containsKey(fieldValue.getClass())) {
             str = value.toString();
         } else {
@@ -506,8 +506,8 @@ public class DefaultSolrUtils implements SolrUtils
         }
 
         String str;
-        if (fieldValue instanceof String) {
-            str = (String) fieldValue;
+        if (fieldValue instanceof String string) {
+            str = string;
         } else if (CLASS_SUFFIX_MAPPING.containsKey(fieldValue.getClass())) {
             str = fieldValue.toString();
         } else {
@@ -535,8 +535,8 @@ public class DefaultSolrUtils implements SolrUtils
         }
 
         String str;
-        if (fieldValue instanceof Date) {
-            str = ((Date) fieldValue).toInstant().toString();
+        if (fieldValue instanceof Date date) {
+            str = date.toInstant().toString();
         } else {
             str = toFilterQueryString(toString(fieldValue));
         }
@@ -557,8 +557,8 @@ public class DefaultSolrUtils implements SolrUtils
         }
 
         String str;
-        if (value instanceof Date) {
-            str = ((Date) value).toInstant().toString();
+        if (value instanceof Date date) {
+            str = date.toInstant().toString();
         } else {
             str = toFilterQueryString(toString(value, valueType));
         }
@@ -598,7 +598,7 @@ public class DefaultSolrUtils implements SolrUtils
 
     private <T> T toValue(Object storedValue, Type targetType)
     {
-        if (storedValue == null && (!(targetType instanceof Class) || !((Class) targetType).isPrimitive())) {
+        if (storedValue == null && (!(targetType instanceof Class clazz) || !clazz.isPrimitive())) {
             return null;
         }
 

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/SolrIndexEventListener.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/SolrIndexEventListener.java
@@ -169,8 +169,8 @@ public class SolrIndexEventListener implements EventListener
             } else if (event instanceof GeneralMailConfigurationUpdatedEvent) {
                 // Refresh the index when the mail configuration is changed because the mail configuration is used to
                 // decide if emails shall be indexed or not.
-                if (source instanceof String) {
-                    this.solrIndexer.get().index(new WikiReference((String) source), true);
+                if (source instanceof String sourceString) {
+                    this.solrIndexer.get().index(new WikiReference(sourceString), true);
                 } else {
                     this.solrIndexer.get().index(null, true);
                 }

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/SolrIndexInitializeListener.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/SolrIndexInitializeListener.java
@@ -119,8 +119,7 @@ public class SolrIndexInitializeListener implements EventListener
                         request.setId(requestId);
                     }
                 } else if (startupMode == SolrConfiguration.SynchronizeAtStartupMode.WIKI
-                    && event instanceof WikiReadyEvent) {
-                    WikiReadyEvent wikiReadyEvent = (WikiReadyEvent) event;
+                    && event instanceof WikiReadyEvent wikiReadyEvent) {
                     WikiReference wikiReference = new WikiReference(wikiReadyEvent.getWikiId());
                     request = new IndexerRequest();
                     request.setRootReference(wikiReference);

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/AbstractSolrMetadataExtractor.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/AbstractSolrMetadataExtractor.java
@@ -393,8 +393,8 @@ public abstract class AbstractSolrMetadataExtractor implements SolrMetadataExtra
         PropertyClass propertyClass, Locale locale)
     {
         Object propertyValue = property.getValue();
-        if (propertyClass instanceof StaticListClass) {
-            setStaticListPropertyValue(solrDocument, property, (StaticListClass) propertyClass, locale);
+        if (propertyClass instanceof StaticListClass staticListClass) {
+            setStaticListPropertyValue(solrDocument, property, staticListClass, locale);
         } else if (propertyClass instanceof TextAreaClass
             || (propertyClass != null && "String".equals(propertyClass.getClassType()))
             || (propertyValue instanceof CharSequence
@@ -429,9 +429,9 @@ public abstract class AbstractSolrMetadataExtractor implements SolrMetadataExtra
                     setPropertyValue(solrDocument, property, new TypedValue(value), locale);
                 }
             }
-        } else if (propertyValue instanceof Integer && propertyClass instanceof BooleanClass) {
+        } else if (propertyValue instanceof Integer integerValue && propertyClass instanceof BooleanClass) {
             // Boolean properties are stored as integers (0 is false and 1 is true).
-            Boolean booleanValue = ((Integer) propertyValue) != 0;
+            Boolean booleanValue = integerValue != 0;
             setPropertyValue(solrDocument, property, new TypedValue(booleanValue), locale);
         } else if (!property.isSensitive(xcontextProvider.get())) {
             // Avoid indexing passwords and, when obfuscation is enabled, emails.

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/DefaultLinkStore.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/internal/metadata/DefaultLinkStore.java
@@ -126,8 +126,8 @@ public class DefaultLinkStore implements LinkStore
         Collection<Object> links = solrDocument.getFieldValues(FieldUtils.LINKS);
         Set<EntityReference> entities = new HashSet<>(links.size());
         for (Object link : links) {
-            if (link instanceof String) {
-                EntityReference entityLink = this.linkSerializer.unserialize((String) link);
+            if (link instanceof String linkString) {
+                EntityReference entityLink = this.linkSerializer.unserialize(linkString);
 
                 if (entityLink != null) {
                     // Make sure to resolve the reference as a DOCUMENT based references and not a PAGE one
@@ -213,8 +213,8 @@ public class DefaultLinkStore implements LinkStore
         }
 
         if (entityReference.getType() == EntityType.PAGE) {
-            return this.currentDocumentResolver.resolve(pageReference instanceof PageReference
-                ? (PageReference) pageReference : new PageReference(pageReference));
+            return this.currentDocumentResolver.resolve(pageReference instanceof PageReference pageRef
+                ? pageRef : new PageReference(pageReference));
         }
 
         EntityType documentBasedType =
@@ -225,7 +225,7 @@ public class DefaultLinkStore implements LinkStore
 
         // Find the right DOCUMENT reference
         DocumentReference documentReference = this.currentDocumentResolver.resolve(
-            pageReference instanceof PageReference ? (PageReference) pageReference : new PageReference(pageReference));
+            pageReference instanceof PageReference pageRef ? pageRef : new PageReference(pageReference));
 
         // Switch the parent
         return documentBasedReference.replaceParent(documentBasedReference.extractReference(EntityType.DOCUMENT),

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-query/src/main/java/org/xwiki/query/solr/internal/SolrQueryExecutor.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-query/src/main/java/org/xwiki/query/solr/internal/SolrQueryExecutor.java
@@ -129,11 +129,11 @@ public class SolrQueryExecutor extends AbstractQueryExecutor
             // A better way would be using a PostFilter as described in this article:
             // http://java.dzone.com/articles/custom-security-filtering-solr
             List<DocumentReference> usersToCheck = new ArrayList<>(2);
-            if (query instanceof SecureQuery) {
-                if (((SecureQuery) query).isCurrentUserChecked()) {
+            if (query instanceof SecureQuery secureQuery) {
+                if (secureQuery.isCurrentUserChecked()) {
                     usersToCheck.add(xcontextProvider.get().getUserReference());
                 }
-                if (((SecureQuery) query).isCurrentAuthorChecked()) {
+                if (secureQuery.isCurrentAuthorChecked()) {
                     usersToCheck.add(xcontextProvider.get().getAuthorReference());
                 }
             } else {
@@ -171,8 +171,8 @@ public class SolrQueryExecutor extends AbstractQueryExecutor
         for (Entry<String, Object> entry : query.getNamedParameters().entrySet()) {
             Object value = entry.getValue();
 
-            if (value instanceof Iterable) {
-                solrQuery.set(entry.getKey(), toStringArray((Iterable) value));
+            if (value instanceof Iterable iterable) {
+                solrQuery.set(entry.getKey(), toStringArray(iterable));
             } else if (value != null && value.getClass().isArray()) {
                 solrQuery.set(entry.getKey(), toStringArray(value));
             } else {


### PR DESCRIPTION
Replaces `instanceof`-check-and-cast patterns with Java 16+ `instanceof` pattern matching in the `xwiki-platform-search-solr` module, as flagged by SonarCloud rule [java:S6201](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS6201&rule_key=java%3AS6201).

This fixes all 21 open `java:S6201` issues in the module across 6 files:

- `DefaultSolrUtils.java` (11)
- `SolrQueryExecutor.java` (3)
- `DefaultLinkStore.java` (3)
- `AbstractSolrMetadataExtractor.java` (2)
- `SolrIndexEventListener.java` (1)
- `SolrIndexInitializeListener.java` (1)

All changes are behaviour-preserving (bind a pattern variable and drop the redundant cast). Verified with `mvn clean install -DskipTests` (Checkstyle + Spoon) on `xwiki-platform-search-solr-api` and `xwiki-platform-search-solr-query`.

SonarCloud issues: ``https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&issueStatuses=OPEN&rules=java%3AS6201&files=xwiki-platform-core%2Fxwiki-platform-search%2Fxwiki-platform-search-solr``

---
_Generated by [Claude Code](https://claude.ai/code/session_013ZRDz7sdQtFK2WZBxrRuTQ)_