### PR TITLE
[Misc] Use pattern matching for instanceof in security modules (SonarCloud java:S6201)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/SecurityReference.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/SecurityReference.java
@@ -143,8 +143,8 @@ public class SecurityReference extends EntityReference
     public WikiReference getOriginalWikiReference()
     {
         return (this.getType() == EntityType.WIKI)
-            ? (this.originalReference instanceof WikiReference)
-                ? (WikiReference) this.originalReference
+            ? (this.originalReference instanceof WikiReference wikiReference)
+                ? wikiReference
                 : new WikiReference(this.originalReference)
             : null;
     }
@@ -156,8 +156,8 @@ public class SecurityReference extends EntityReference
     public SpaceReference getOriginalSpaceReference()
     {
         return (this.getType() == EntityType.SPACE)
-            ? (this.originalReference instanceof SpaceReference)
-                ? (SpaceReference) this.originalReference
+            ? (this.originalReference instanceof SpaceReference spaceReference)
+                ? spaceReference
                 : new SpaceReference(this.originalReference)
             : null;
     }
@@ -169,8 +169,8 @@ public class SecurityReference extends EntityReference
     public DocumentReference getOriginalDocumentReference()
     {
         return (this.getType() == EntityType.DOCUMENT)
-            ? (this.originalReference instanceof DocumentReference)
-                ? (DocumentReference) this.originalReference
+            ? (this.originalReference instanceof DocumentReference documentReference)
+                ? documentReference
                 : new DocumentReference(this.originalReference)
             : null;
     }

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/DefaultAuthorizationManager.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/DefaultAuthorizationManager.java
@@ -101,8 +101,8 @@ public class DefaultAuthorizationManager implements AuthorizationManager
                 throw new AccessDeniedException(right, userReference, entityReference);
             }
         } catch (Exception e) {
-            if (e instanceof AccessDeniedException) {
-                throw (AccessDeniedException) e;
+            if (e instanceof AccessDeniedException accessDeniedException) {
+                throw accessDeniedException;
             } else {
                 throw new AccessDeniedException(right, userReference, entityReference, e);
             }

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/RightMap.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/RightMap.java
@@ -111,7 +111,7 @@ public class RightMap<V> extends AbstractMap<Right, V> implements Serializable, 
     @Override
     public boolean containsKey(Object o)
     {
-        return o instanceof Right && getValue(((Right) o).ordinal()) != null;
+        return o instanceof Right right && getValue(right.ordinal()) != null;
     }
 
     @Override
@@ -143,7 +143,7 @@ public class RightMap<V> extends AbstractMap<Right, V> implements Serializable, 
     @Override
     public V get(Object o)
     {
-        return (o instanceof Right ? unmaskNull(getValue(((Right) o).ordinal())) : null);
+        return (o instanceof Right right ? unmaskNull(getValue(right.ordinal())) : null);
     }
 
     @Override
@@ -224,8 +224,8 @@ public class RightMap<V> extends AbstractMap<Right, V> implements Serializable, 
     @Override
     public V remove(Object o)
     {
-        if (o instanceof Right) {
-            return updateValue(((Right) o).ordinal(), null);
+        if (o instanceof Right right) {
+            return updateValue(right.ordinal(), null);
         }
         return null;
     }
@@ -377,8 +377,8 @@ public class RightMap<V> extends AbstractMap<Right, V> implements Serializable, 
             }
 
             Map.Entry entry = (Map.Entry) o;
-            return entry.getKey() instanceof Right
-                && maskNull(entry.getValue()).equals(getValue(((Right) entry.getKey()).ordinal()));
+            return entry.getKey() instanceof Right right
+                && maskNull(entry.getValue()).equals(getValue(right.ordinal()));
         }
 
         @Override

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/RightSet.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/RightSet.java
@@ -181,7 +181,7 @@ public class RightSet extends AbstractSet<Right> implements Cloneable, java.io.S
     @Override
     public boolean contains(Object o)
     {
-        return o != null && o instanceof Right && (rights & (1L << ((Right) o).ordinal())) != 0;
+        return o != null && o instanceof Right right && (rights & (1L << right.ordinal())) != 0;
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/cache/internal/DefaultSecurityCache.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-authorization/xwiki-platform-security-authorization-api/src/main/java/org/xwiki/security/authorization/cache/internal/DefaultSecurityCache.java
@@ -359,8 +359,8 @@ public class DefaultSecurityCache implements SecurityCache, Initializable
         {
             Collection<SecurityCacheEntry> result = new ArrayList<>(groups.size());
             for (GroupSecurityReference group : groups) {
-                SecurityCacheEntry parent = (entry instanceof SecurityShadowEntry && group.isGlobal())
-                    ? DefaultSecurityCache.this.getShadowEntry(group, ((SecurityShadowEntry) entry).getWikiReference())
+                SecurityCacheEntry parent = entry instanceof SecurityShadowEntry securityShadowEntry && group.isGlobal()
+                    ? DefaultSecurityCache.this.getShadowEntry(group, securityShadowEntry.getWikiReference())
                     : DefaultSecurityCache.this.getEntry(group);
                 if (parent == null) {
                     throw new ParentEntryEvictedException(String
@@ -608,10 +608,10 @@ public class DefaultSecurityCache implements SecurityCache, Initializable
      */
     private String getEntryKey(SecurityEntry entry)
     {
-        if (entry instanceof SecurityAccessEntry) {
-            return getEntryKey((SecurityAccessEntry) entry);
-        } else if (entry instanceof SecurityRuleEntry) {
-            return getEntryKey((SecurityRuleEntry) entry);
+        if (entry instanceof SecurityAccessEntry securityAccessEntry) {
+            return getEntryKey(securityAccessEntry);
+        } else if (entry instanceof SecurityRuleEntry securityRuleEntry) {
+            return getEntryKey(securityRuleEntry);
         } else {
             return getEntryKey((SecurityShadowEntry) entry);
         }
@@ -883,9 +883,9 @@ public class DefaultSecurityCache implements SecurityCache, Initializable
     private SecurityCacheEntry newSecurityCacheEntry(SecurityEntry entry, Collection<GroupSecurityReference> groups)
         throws ParentEntryEvictedException
     {
-        if (entry instanceof SecurityRuleEntry) {
-            return (groups == null) ? new SecurityCacheEntry((SecurityRuleEntry) entry)
-                : new SecurityCacheEntry((SecurityRuleEntry) entry, groups);
+        if (entry instanceof SecurityRuleEntry securityRuleEntry) {
+            return (groups == null) ? new SecurityCacheEntry(securityRuleEntry)
+                : new SecurityCacheEntry(securityRuleEntry, groups);
         } else {
             return (groups == null) ? new SecurityCacheEntry((SecurityShadowEntry) entry)
                 : new SecurityCacheEntry((SecurityShadowEntry) entry, groups);
@@ -1047,8 +1047,8 @@ public class DefaultSecurityCache implements SecurityCache, Initializable
             for (SecurityCacheEntry parent : userEntry.parents) {
                 // Add the parent group (if we have not already seen it)
                 SecurityReference parentRef = parent.getEntry().getReference();
-                if (parentRef instanceof GroupSecurityReference) {
-                    groups.add((GroupSecurityReference) parentRef);
+                if (parentRef instanceof GroupSecurityReference groupSecurityReference) {
+                    groups.add(groupSecurityReference);
                 }
             }
         }

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/main/java/org/xwiki/platform/security/requiredrights/internal/RequiredRightsChangedResult.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/main/java/org/xwiki/platform/security/requiredrights/internal/RequiredRightsChangedResult.java
@@ -202,11 +202,11 @@ public class RequiredRightsChangedResult
         for (RequiredRightAnalysisResult requiredRightAnalysisResult : list) {
             EntityReference entityReference = requiredRightAnalysisResult.getEntityReference();
             EntityReference extractedDocument = entityReference.extractReference(EntityType.DOCUMENT);
-            if (extractedDocument instanceof DocumentReference && !extractedDocument.equals(entityReference)) {
+            if (extractedDocument instanceof DocumentReference docRef && !extractedDocument.equals(entityReference)) {
                 entityReference = entityReference.replaceParent(extractedDocument,
-                    cleanupLocale((DocumentReference) extractedDocument));
-            } else if (entityReference instanceof DocumentReference) {
-                entityReference = cleanupLocale((DocumentReference) entityReference);
+                    cleanupLocale(docRef));
+            } else if (entityReference instanceof DocumentReference documentReference) {
+                entityReference = cleanupLocale(documentReference);
             }
             if (map.containsKey(entityReference)) {
                 map.get(entityReference).add(requiredRightAnalysisResult);

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/main/java/org/xwiki/platform/security/requiredrights/internal/analyzer/AbstractMacroBlockRequiredRightAnalyzer.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/main/java/org/xwiki/platform/security/requiredrights/internal/analyzer/AbstractMacroBlockRequiredRightAnalyzer.java
@@ -153,8 +153,8 @@ public abstract class AbstractMacroBlockRequiredRightAnalyzer
     {
         // Keep whatever metadata was present on the XDOM.
         MetaData metaData = null;
-        if (macroBlock.getRoot() instanceof XDOM) {
-            metaData = new MetaData(((XDOM) macroBlock.getRoot()).getMetaData().getMetaData());
+        if (macroBlock.getRoot() instanceof XDOM xdom) {
+            metaData = new MetaData(xdom.getMetaData().getMetaData());
         }
         MacroTransformationContext transformationContext = getTransformationContext(macroBlock);
         try {
@@ -185,9 +185,8 @@ public abstract class AbstractMacroBlockRequiredRightAnalyzer
                 Block.Axes.ANCESTOR);
 
         if (metaDataBlock != null && metaDataBlock.getMetaData()
-            .getMetaData(XDOMRequiredRightAnalyzer.ENTITY_REFERENCE_METADATA) instanceof EntityReference) {
-            result = (EntityReference) metaDataBlock.getMetaData()
-                .getMetaData(XDOMRequiredRightAnalyzer.ENTITY_REFERENCE_METADATA);
+            .getMetaData(XDOMRequiredRightAnalyzer.ENTITY_REFERENCE_METADATA) instanceof EntityReference entityRef) {
+            result = entityRef;
         } else {
             metaDataBlock = source.getFirstBlock(new MetadataBlockMatcher(MetaData.SOURCE), Block.Axes.ANCESTOR);
             if (metaDataBlock != null) {

--- a/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/main/java/org/xwiki/platform/security/requiredrights/internal/analyzer/ScriptMacroAnalyzer.java
+++ b/xwiki-platform-core/xwiki-platform-security/xwiki-platform-security-requiredrights/xwiki-platform-security-requiredrights-default/src/main/java/org/xwiki/platform/security/requiredrights/internal/analyzer/ScriptMacroAnalyzer.java
@@ -87,10 +87,10 @@ public class ScriptMacroAnalyzer extends AbstractMacroBlockRequiredRightAnalyzer
                 macro.getDescriptor().getParametersBeanClass().getDeclaredConstructor().newInstance();
             this.beanManager.populate(macroParameters, macroBlock.getParameters());
 
-            if (macroParameters instanceof ScriptMacroParameters) {
+            if (macroParameters instanceof ScriptMacroParameters scriptMacroParameters) {
                 MacroPermissionPolicy mpp =
                     this.componentManagerProvider.get().getInstance(MacroPermissionPolicy.class, macroBlock.getId());
-                requiredRight = mpp.getRequiredRight((ScriptMacroParameters) macroParameters);
+                requiredRight = mpp.getRequiredRight(scriptMacroParameters);
             }
         } catch (Exception ex) {
             if (!(macro instanceof PrivilegedScriptMacro)) {


### PR DESCRIPTION
Replaces `instanceof` checks followed by explicit casts with pattern matching for `instanceof`, as flagged by SonarCloud rule [java:S6201](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS6201&rule_key=java%3AS6201).

Fixes 20 issues across two leaf modules:
* `xwiki-platform-security-authorization-api` (`SecurityReference`, `DefaultAuthorizationManager`, `RightMap`, `RightSet`, `DefaultSecurityCache`)
* `xwiki-platform-security-requiredrights-default` (`RequiredRightsChangedResult`, `AbstractMacroBlockRequiredRightAnalyzer`, `ScriptMacroAnalyzer`)

All changes are behaviour-preserving mechanical refactorings; both modules build cleanly (`install`, Checkstyle + Spoon included).

SonarCloud issues: https://sonarcloud.io/project/issues?resolved=false&rules=java%3AS6201&id=org.xwiki.platform%3Axwiki-platform&tags=&issueStatuses=OPEN


---
_Generated by [Claude Code](https://claude.ai/code/session_01GBK7ixeNjk9siarB9kmHJh)_