### PR TITLE
[Misc] Fix various SonarCloud issues (combine catch blocks, remove redundant jumps)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/SingleAnnotationRESTResource.java
+++ b/xwiki-platform-core/xwiki-platform-annotation/xwiki-platform-annotation-rest/src/main/java/org/xwiki/annotation/rest/internal/SingleAnnotationRESTResource.java
@@ -88,10 +88,7 @@ public class SingleAnnotationRESTResource extends AbstractAnnotationRESTResource
             annotationService.removeAnnotation(documentName, id);
             // and then return the annotated content, as specified by the annotation request
             return getSuccessResponseWithAnnotatedContent(documentName, request);
-        } catch (XWikiException e) {
-            getLogger().error(e.getMessage(), e);
-            return getErrorResponse(e);
-        } catch (AnnotationServiceException e) {
+        } catch (XWikiException | AnnotationServiceException e) {
             getLogger().error(e.getMessage(), e);
             return getErrorResponse(e);
         }
@@ -160,10 +157,7 @@ public class SingleAnnotationRESTResource extends AbstractAnnotationRESTResource
             this.cleanTemporaryUploadedFiles(documentReference);
             // and then return the annotated content, as specified by the annotation request
             return getSuccessResponseWithAnnotatedContent(documentName, updateRequest);
-        } catch (XWikiException e) {
-            getLogger().error(e.getMessage(), e);
-            return getErrorResponse(e);
-        } catch (AnnotationServiceException e) {
+        } catch (XWikiException | AnnotationServiceException e) {
             getLogger().error(e.getMessage(), e);
             return getErrorResponse(e);
         }

--- a/xwiki-platform-core/xwiki-platform-dashboard/xwiki-platform-dashboard-macro/src/main/java/org/xwiki/rendering/internal/macro/dashboard/ColumnGadget.java
+++ b/xwiki-platform-core/xwiki-platform-dashboard/xwiki-platform-dashboard-macro/src/main/java/org/xwiki/rendering/internal/macro/dashboard/ColumnGadget.java
@@ -79,10 +79,8 @@ class ColumnGadget extends Gadget
         try {
             this.column = Integer.valueOf(split[0].trim());
             this.index = Integer.valueOf(split[1].trim());
-        } catch (ArrayIndexOutOfBoundsException e) {
+        } catch (ArrayIndexOutOfBoundsException | NumberFormatException e) {
             // nothing, just leave column and index null. Not layoutable in columns
-        } catch (NumberFormatException e) {
-            // same, nothing, just leave column and index null. Not layoutable in columns
         }
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/objects/classes/ListClass.java
@@ -409,7 +409,6 @@ public abstract class ListClass extends PropertyClass
                     previousWasSeparator = false;
                 }
                 previousSeparator = currentChar;
-                continue;
             // if we are finding a separator and we are not in escape mode, then we finished to parse one value
             // we are adding the value to the result, and start a new value to parse
             } else if (StringUtils.containsAny(separators, currentChar) && !inEscape) {
@@ -1105,7 +1104,5 @@ public abstract class ListClass extends PropertyClass
         }
 
         fromList(currentProperty, currentList);
-
-        return;
     }
 }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/PackageAPI.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/plugin/packaging/PackageAPI.java
@@ -240,10 +240,7 @@ public class PackageAPI extends Api
         try {
             this.pack.Import(data, getXWikiContext());
             return true;
-        } catch (XWikiException e) {
-            getXWikiContext().put("import_error", e.getMessage());
-            return false;
-        } catch (IOException e) {
+        } catch (XWikiException | IOException e) {
             getXWikiContext().put("import_error", e.getMessage());
             return false;
         }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R35100XWIKI7564DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R35100XWIKI7564DataMigration.java
@@ -128,7 +128,7 @@ public class R35100XWIKI7564DataMigration extends AbstractHibernateDataMigration
                 }
                 throw ex;
             } catch (IOException ex) {
-                // Shouldn't happen, the script is supposed to be there
+                // Shouldn't happen: UTF-8 is always available and the script is supposed to be there
             }
         }
     }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R35100XWIKI7564DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R35100XWIKI7564DataMigration.java
@@ -23,7 +23,6 @@ package com.xpn.xwiki.store.migration.hibernate;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.sql.BatchUpdateException;
 import java.sql.Connection;
@@ -78,9 +77,7 @@ public class R35100XWIKI7564DataMigration extends AbstractHibernateDataMigration
             shouldExecute = (startupVersion.getVersion() > 0
                 && getStore().getDatabaseProductName() == DatabaseProduct.POSTGRESQL);
             getStore().endTransaction(getXWikiContext(), false);
-        } catch (XWikiException ex) {
-            // Shouldn't happen, ignore
-        } catch (DataMigrationException ex) {
+        } catch (XWikiException | DataMigrationException ex) {
             // Shouldn't happen, ignore
         }
         return shouldExecute;
@@ -130,8 +127,6 @@ public class R35100XWIKI7564DataMigration extends AbstractHibernateDataMigration
                     return;
                 }
                 throw ex;
-            } catch (UnsupportedEncodingException ex) {
-                // Should never happen, UTF-8 is always available
             } catch (IOException ex) {
                 // Shouldn't happen, the script is supposed to be there
             }

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R35101XWIKI7645DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R35101XWIKI7645DataMigration.java
@@ -80,9 +80,7 @@ public class R35101XWIKI7645DataMigration extends AbstractHibernateDataMigration
             // Run this migration if the database isn't new
             shouldExecute = getStore().getDatabaseProductName() == DatabaseProduct.ORACLE;
             getStore().endTransaction(getXWikiContext(), false);
-        } catch (XWikiException ex) {
-            // Shouldn't happen, ignore
-        } catch (DataMigrationException ex) {
+        } catch (XWikiException | DataMigrationException ex) {
             // Shouldn't happen, ignore
         }
         return shouldExecute;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R35102XWIKI7771DataMigration.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/store/migration/hibernate/R35102XWIKI7771DataMigration.java
@@ -80,9 +80,7 @@ public class R35102XWIKI7771DataMigration extends AbstractHibernateDataMigration
             shouldExecute = (startupVersion.getVersion() > 0
                 && getStore().getDatabaseProductName() == DatabaseProduct.POSTGRESQL);
             getStore().endTransaction(getXWikiContext(), false);
-        } catch (XWikiException ex) {
-            // Shouldn't happen, ignore
-        } catch (DataMigrationException ex) {
+        } catch (XWikiException | DataMigrationException ex) {
             // Shouldn't happen, ignore
         }
         return shouldExecute;

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyFormAuthenticator.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyFormAuthenticator.java
@@ -100,8 +100,6 @@ public class MyFormAuthenticator extends FormAuthenticator implements XWikiAuthe
         }
         response.sendRedirect(response.encodeRedirectURL(request.getContextPath() + this.loginPage + "?"
             + sridParameter + "&xredirect=" + URLEncoder.encode(redirectBack.toString(), "UTF-8")));
-
-        return;
     }
 
     @Override

--- a/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyPersistentLoginManager.java
+++ b/xwiki-platform-core/xwiki-platform-oldcore/src/main/java/com/xpn/xwiki/user/impl/xwiki/MyPersistentLoginManager.java
@@ -227,7 +227,6 @@ public class MyPersistentLoginManager extends DefaultPersistentLoginManager
                 }
             }
         }
-        return;
     }
 
     /**
@@ -393,7 +392,6 @@ public class MyPersistentLoginManager extends DefaultPersistentLoginManager
         removeCookie(request, response, getCookiePrefix() + COOKIE_PASSWORD);
         removeCookie(request, response, getCookiePrefix() + COOKIE_REMEMBERME);
         removeCookie(request, response, getCookiePrefix() + COOKIE_VALIDATION);
-        return;
     }
 
     /**

--- a/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/script/SolrIndexScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-search/xwiki-platform-search-solr/xwiki-platform-search-solr-api/src/main/java/org/xwiki/search/solr/script/SolrIndexScriptService.java
@@ -226,9 +226,7 @@ public class SolrIndexScriptService implements ScriptService
         EntityType type;
         try {
             type = EntityType.valueOf((String) document.get(FieldUtils.TYPE));
-        } catch (IllegalArgumentException e) {
-            return null;
-        } catch (NullPointerException e) {
+        } catch (IllegalArgumentException | NullPointerException e) {
             return null;
         }
 

--- a/xwiki-platform-core/xwiki-platform-zipexplorer/src/main/java/com/xpn/xwiki/plugin/zipexplorer/ZipExplorerPlugin.java
+++ b/xwiki-platform-core/xwiki-platform-zipexplorer/src/main/java/com/xpn/xwiki/plugin/zipexplorer/ZipExplorerPlugin.java
@@ -155,9 +155,7 @@ public class ZipExplorerPlugin extends XWikiDefaultPlugin
                     break;
                 }
             }
-        } catch (XWikiException e) {
-            e.printStackTrace();
-        } catch (IOException e) {
+        } catch (XWikiException | IOException e) {
             e.printStackTrace();
         }
         return newAttachment;
@@ -187,9 +185,7 @@ public class ZipExplorerPlugin extends XWikiDefaultPlugin
                     zipList.add(entry.getName());
                 }
             }
-        } catch (XWikiException e) {
-            e.printStackTrace();
-        } catch (IOException e) {
+        } catch (XWikiException | IOException e) {
             e.printStackTrace();
         }
         return zipList;


### PR DESCRIPTION
Fixes a batch of mechanical SonarCloud issues across several modules.

## `java:S2147` — Combine `catch` clauses with identical bodies (multi-catch)

- `ColumnGadget` — [issue](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&open=AZ0l7a1QhkAMMveQw35B)
- `SingleAnnotationRESTResource` (x2) — [issue](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&open=AW5-S5HZ1Yj5qvzeRmyp), [issue](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&open=AW5-S5HZ1Yj5qvzeRmyq)
- `PackageAPI` — [issue](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&open=AW5-S6tf1Yj5qvzeRnpJ)
- `R35100XWIKI7564DataMigration` (x2) — [issue](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&open=AW5-S6mw1Yj5qvzeRngs), [issue](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&open=AW5-S6mw1Yj5qvzeRngu)
- `R35101XWIKI7645DataMigration` — [issue](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&open=AW5-S6kp1Yj5qvzeRnf2)
- `R35102XWIKI7771DataMigration` — [issue](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&open=AW5-S6kQ1Yj5qvzeRnfn)
- `SolrIndexScriptService` — [issue](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&open=AW5-S79j1Yj5qvzeRoC-)
- `ZipExplorerPlugin` (x2) — [issue](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&open=AW5-S-oQ1Yj5qvzeRo48), [issue](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&open=AW5-S-oQ1Yj5qvzeRo4_)

Note: in `R35100XWIKI7564DataMigration`, `UnsupportedEncodingException` (a subclass of `IOException`) is caught with an identical empty body, so the redundant subclass `catch` was removed rather than merged (multi-catch of a type and its subtype is illegal); the now-unused import was removed too.

## `java:S3626` — Remove redundant jump statements

- `MyFormAuthenticator` — trailing `return;` — [issue](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&open=AW5-S6NJ1Yj5qvzeRnFR)
- `MyPersistentLoginManager` (x2) — trailing `return;` — [issue](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&open=AW5-S6MQ1Yj5qvzeRnEY), [issue](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&open=AW5-S6MQ1Yj5qvzeRnEp)
- `ListClass` — trailing `return;` and a redundant `continue;` — [issue](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&open=AW5-S6QN1Yj5qvzeRnIo), [issue](https://sonarcloud.io/project/issues?id=org.xwiki.platform:xwiki-platform&open=AW_XW_tlnBrFejmlUdEB)

All changes are behavior-preserving. Verified with `mvn clean install` (checkstyle + Spoon) on the affected modules.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mi8aeaQW8bToq6AT377bA4)_