### PR TITLE
[Misc] Use pattern matching for instanceof in query-manager and refactoring (SonarCloud java:S6201)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/DocumentQueryFilter.java
+++ b/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/DocumentQueryFilter.java
@@ -58,12 +58,11 @@ public class DocumentQueryFilter implements QueryFilter
     {
         for (int i = 0; i < results.size(); i++) {
             Object result = results.get(i);
-            if (result instanceof String) {
-                results.set(i, this.documentReferenceResolver.resolve((String) result));
-            } else if (result instanceof Object[]) {
-                Object[] row = (Object[]) result;
-                if (row.length > 0 && row[0] instanceof String) {
-                    row[0] = this.documentReferenceResolver.resolve((String) row[0]);
+            if (result instanceof String resultString) {
+                results.set(i, this.documentReferenceResolver.resolve(resultString));
+            } else if (result instanceof Object[] row) {
+                if (row.length > 0 && row[0] instanceof String rowString) {
+                    row[0] = this.documentReferenceResolver.resolve(rowString);
                 }
             }
         }

--- a/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/EscapeLikeParametersQuery.java
+++ b/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/EscapeLikeParametersQuery.java
@@ -142,11 +142,9 @@ public class EscapeLikeParametersQuery extends WrappingQuery
     private String modifyStatement(String statementString) throws JSQLParserException
     {
         Statement statement = CCJSqlParserUtil.parse(statementString);
-        if (statement instanceof Select) {
-            Select select = (Select) statement;
+        if (statement instanceof Select select) {
             SelectBody selectBody = select.getSelectBody();
-            if (selectBody instanceof PlainSelect) {
-                PlainSelect plainSelect = (PlainSelect) selectBody;
+            if (selectBody instanceof PlainSelect plainSelect) {
                 Expression where = plainSelect.getWhere();
                 where.accept(new XWikiExpressionVisitor());
             }

--- a/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/ScriptQuery.java
+++ b/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/ScriptQuery.java
@@ -282,7 +282,7 @@ public class ScriptQuery implements SecureQuery
     @Override
     public boolean isCurrentAuthorChecked()
     {
-        return !(this.query instanceof SecureQuery) || ((SecureQuery) this.query).isCurrentAuthorChecked();
+        return !(this.query instanceof SecureQuery secureQuery) || secureQuery.isCurrentAuthorChecked();
     }
 
     /**
@@ -329,14 +329,14 @@ public class ScriptQuery implements SecureQuery
     @Override
     public boolean isCurrentUserChecked()
     {
-        return this.query instanceof SecureQuery && ((SecureQuery) this.query).isCurrentAuthorChecked();
+        return this.query instanceof SecureQuery secureQuery && secureQuery.isCurrentAuthorChecked();
     }
 
     @Override
     public SecureQuery checkCurrentUser(boolean checkCurrentUser)
     {
-        if (this.query instanceof SecureQuery) {
-            ((SecureQuery) this.query).isCurrentAuthorChecked();
+        if (this.query instanceof SecureQuery secureQuery) {
+            secureQuery.isCurrentAuthorChecked();
         }
 
         return this;

--- a/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/SecureQueryExecutorManager.java
+++ b/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/SecureQueryExecutorManager.java
@@ -56,8 +56,7 @@ public class SecureQueryExecutorManager implements QueryExecutorManager
     @Override
     public <T> List<T> execute(Query query) throws QueryException
     {
-        if (query instanceof SecureQuery) {
-            SecureQuery secureQuery = (SecureQuery) query;
+        if (query instanceof SecureQuery secureQuery) {
             // Force checking current author rights
             secureQuery.checkCurrentAuthor(true);
         } else if (!this.authorization.hasAccess(Right.PROGRAM)) {

--- a/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/ViewableQueryFilter.java
+++ b/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/internal/ViewableQueryFilter.java
@@ -61,10 +61,10 @@ public class ViewableQueryFilter implements QueryFilter
         List<Object> filteredResults = new LinkedList<>();
         for (Object result : results) {
             EntityReference entityReference = null;
-            if (result instanceof EntityReference) {
-                entityReference = (EntityReference) result;
-            } else if (result instanceof Object[] && ((Object[]) result)[0] instanceof EntityReference) {
-                entityReference = (EntityReference) ((Object[]) result)[0];
+            if (result instanceof EntityReference reference) {
+                entityReference = reference;
+            } else if (result instanceof Object[] array && array[0] instanceof EntityReference reference) {
+                entityReference = reference;
             }
             if (entityReference != null && this.authorization.hasAccess(Right.VIEW, entityReference)) {
                 filteredResults.add(result);

--- a/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/script/QueryManagerScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-query/xwiki-platform-query-manager/src/main/java/org/xwiki/query/script/QueryManagerScriptService.java
@@ -137,9 +137,9 @@ public class QueryManagerScriptService implements ScriptService
     private Query createQuery(String statement, String language, boolean checkCurrentUser) throws QueryException
     {
         Query query = this.secureQueryManager.createQuery(statement, language);
-        if (query instanceof SecureQuery) {
-            ((SecureQuery) query).checkCurrentAuthor(true);
-            ((SecureQuery) query).checkCurrentUser(checkCurrentUser);
+        if (query instanceof SecureQuery secureQuery) {
+            secureQuery.checkCurrentAuthor(true);
+            secureQuery.checkCurrentUser(checkCurrentUser);
         }
 
         return new ScriptQuery(query, this.componentManager);

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultReferenceRenamer.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultReferenceRenamer.java
@@ -165,8 +165,7 @@ public class DefaultReferenceRenamer implements ReferenceRenamer
         boolean modified = false;
 
         for (Block matchingBlock : blocks) {
-            if (matchingBlock instanceof MacroBlock) {
-                MacroBlock macroBlock = (MacroBlock) matchingBlock;
+            if (matchingBlock instanceof MacroBlock macroBlock) {
                 Optional<MacroBlock> optionalMacroBlock = handleMacroBlock(macroBlock, currentDocumentReference,
                     oldTarget, newTarget, macroRefactoringLambda);
                 if (optionalMacroBlock.isPresent()) {
@@ -175,11 +174,9 @@ public class DefaultReferenceRenamer implements ReferenceRenamer
                 }
             } else {
                 ResourceReference reference;
-                if (matchingBlock instanceof LinkBlock) {
-                    LinkBlock linkBlock = (LinkBlock) matchingBlock;
+                if (matchingBlock instanceof LinkBlock linkBlock) {
                     reference = linkBlock.getReference();
-                } else if (matchingBlock instanceof ImageBlock) {
-                    ImageBlock imageBlock = (ImageBlock) matchingBlock;
+                } else if (matchingBlock instanceof ImageBlock imageBlock) {
                     reference = imageBlock.getReference();
                 } else {
                     throw new IllegalArgumentException(String.format(
@@ -218,9 +215,9 @@ public class DefaultReferenceRenamer implements ReferenceRenamer
             // last fallback in the unlikely case of there's no document syntax
             syntax = this.extendedRenderingConfiguration.getDefaultContentSyntax();
         }
-        if (this.renderingContext instanceof MutableRenderingContext) {
+        if (this.renderingContext instanceof MutableRenderingContext mutableRenderingContext) {
             // Set the default syntax
-            ((MutableRenderingContext) this.renderingContext).push(this.renderingContext.getTransformation(),
+            mutableRenderingContext.push(this.renderingContext.getTransformation(),
                 this.renderingContext.getXDOM(), syntax, this.renderingContext.getTransformationId(),
                 this.renderingContext.isRestricted(), this.renderingContext.getTargetSyntax());
         }
@@ -231,8 +228,8 @@ public class DefaultReferenceRenamer implements ReferenceRenamer
                 + "document [{}]", oldTarget, newTarget, macroBlock.getId(), currentDocumentReference);
         } finally {
             // don't forget to pop the rendering context.
-            if (this.renderingContext instanceof MutableRenderingContext) {
-                ((MutableRenderingContext) this.renderingContext).pop();
+            if (this.renderingContext instanceof MutableRenderingContext mutableRenderingContext) {
+                mutableRenderingContext.pop();
             }
         }
         return Optional.empty();

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultReferenceUpdater.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/DefaultReferenceUpdater.java
@@ -177,14 +177,11 @@ public class DefaultReferenceUpdater implements ReferenceUpdater
 
         for (Object fieldClass : xclass.getProperties()) {
             // Wiki content stored in xobjects
-            if (fieldClass instanceof TextAreaClass && ((TextAreaClass) fieldClass).isWikiContent()) {
-                TextAreaClass textAreaClass = (TextAreaClass) fieldClass;
+            if (fieldClass instanceof TextAreaClass textAreaClass && textAreaClass.isWikiContent()) {
                 PropertyInterface field = xobject.getField(textAreaClass.getName());
 
                 // Make sure the field is the right type (might happen while a document is being migrated)
-                if (field instanceof LargeStringProperty) {
-                    LargeStringProperty largeField = (LargeStringProperty) field;
-
+                if (field instanceof LargeStringProperty largeField) {
                     try {
                         // Parse property content
                         XDOM xdom = this.contentParser.parse(largeField.getValue(), document.getSyntax(),
@@ -352,13 +349,13 @@ public class DefaultReferenceUpdater implements ReferenceUpdater
 
     private DocumentReference toDocumentReference(EntityReference entityReference)
     {
-        return entityReference instanceof DocumentReference ? (DocumentReference) entityReference
+        return entityReference instanceof DocumentReference documentReference ? documentReference
             : new DocumentReference(entityReference);
     }
 
     private AttachmentReference toAttachmentReference(EntityReference entityReference)
     {
-        return entityReference instanceof AttachmentReference ? (AttachmentReference) entityReference
+        return entityReference instanceof AttachmentReference attachmentReference ? attachmentReference
             : new AttachmentReference(entityReference);
     }
 

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/listener/UpdateObjectsOnClassRenameListener.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/internal/listener/UpdateObjectsOnClassRenameListener.java
@@ -99,8 +99,8 @@ public class UpdateObjectsOnClassRenameListener extends AbstractLocalEventListen
     public void processLocalEvent(Event event, Object source, Object data)
     {
         boolean updateLinks = true;
-        if (data instanceof MoveRequest) {
-            updateLinks = ((MoveRequest) data).isUpdateLinks();
+        if (data instanceof MoveRequest moveRequest) {
+            updateLinks = moveRequest.isUpdateLinks();
         }
         if (updateLinks) {
             DocumentRenamedEvent documentRenamedEvent = (DocumentRenamedEvent) event;

--- a/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/job/XClassDeletingListener.java
+++ b/xwiki-platform-core/xwiki-platform-refactoring/xwiki-platform-refactoring-default/src/main/java/org/xwiki/refactoring/job/XClassDeletingListener.java
@@ -158,8 +158,7 @@ public class XClassDeletingListener extends AbstractEventListener
                 cancelableEvent.cancel("Question has been interrupted.");
             }
             // we always want the event and the CancelableJobStatus to be consistent
-            if (jobStatus instanceof CancelableJobStatus) {
-                CancelableJobStatus cancelableJobStatus = (CancelableJobStatus) jobStatus;
+            if (jobStatus instanceof CancelableJobStatus cancelableJobStatus) {
                 if (cancelableJobStatus.isCanceled()) {
                     cancelableEvent.cancel();
                 }


### PR DESCRIPTION
Replaces `instanceof` checks followed by explicit casts with pattern matching for `instanceof`, as flagged by SonarCloud rule [java:S6201](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS6201&rule_key=java%3AS6201).

This is a mechanical, behaviour-preserving cleanup across two modules:
- `xwiki-platform-query-manager` (13 issues fixed)
- `xwiki-platform-refactoring-default` (12 issues fixed)

**25 SonarCloud issues fixed.** One flagged site in `EscapeLikeParametersQuery` (L86) was left as-is because introducing a pattern variable would push the line past the 120-character checkstyle limit.

SonarCloud issues:
https://sonarcloud.io/project/issues?resolved=false&rules=java%3AS6201&id=org.xwiki.platform%3Axwiki-platform

---
_Generated by [Claude Code](https://claude.ai/code/session_015QsNgeXDGLxac1miMad1Mw)_