### PR TITLE
[Misc] Use pattern matching for instanceof in extension modules (SonarCloud java:S6201)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-api/src/main/java/org/xwiki/extension/internal/validator/AbstractExtensionValidator.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-api/src/main/java/org/xwiki/extension/internal/validator/AbstractExtensionValidator.java
@@ -98,8 +98,8 @@ public abstract class AbstractExtensionValidator implements ExtensionValidator
     {
         Object obj = request.getProperty(property);
 
-        if (obj instanceof DocumentReference) {
-            return (DocumentReference) obj;
+        if (obj instanceof DocumentReference documentReference) {
+            return documentReference;
         }
 
         return null;

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-cluster/src/main/java/org/xwiki/extension/cluster/internal/ExtensionJobEventConverter.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-cluster/src/main/java/org/xwiki/extension/cluster/internal/ExtensionJobEventConverter.java
@@ -57,13 +57,11 @@ public class ExtensionJobEventConverter extends AbstractEventConverter
     @Override
     public boolean toRemote(LocalEventData localEvent, RemoteEventData remoteEvent)
     {
-        if (localEvent.getEvent() instanceof JobStartedEvent) {
-            JobStartedEvent jobEvent = (JobStartedEvent) localEvent.getEvent();
-
+        if (localEvent.getEvent() instanceof JobStartedEvent jobStartedEvent) {
             // Share only specific jobs
             // Don't send back remote jobs
-            if (JOBS.contains(jobEvent.getJobType()) && !jobEvent.getRequest().isRemote()) {
-                remoteEvent.setEvent(jobEvent);
+            if (JOBS.contains(jobStartedEvent.getJobType()) && !jobStartedEvent.getRequest().isRemote()) {
+                remoteEvent.setEvent(jobStartedEvent);
 
                 return true;
             }
@@ -75,11 +73,9 @@ public class ExtensionJobEventConverter extends AbstractEventConverter
     @Override
     public boolean fromRemote(RemoteEventData remoteEvent, LocalEventData localEvent)
     {
-        if (remoteEvent.getEvent() instanceof JobStartedEvent) {
-            JobStartedEvent jobEvent = (JobStartedEvent) remoteEvent.getEvent();
-
-            if (JOBS.contains(jobEvent.getJobType())) {
-                Request request = jobEvent.getRequest();
+        if (remoteEvent.getEvent() instanceof JobStartedEvent jobStartedEvent) {
+            if (JOBS.contains(jobStartedEvent.getJobType())) {
+                Request request = jobStartedEvent.getRequest();
 
                 // Indicate the job has been triggered by a remote event
                 if (!(request instanceof AbstractRequest)) {
@@ -89,7 +85,7 @@ public class ExtensionJobEventConverter extends AbstractEventConverter
 
                 // We don't want to directly simulate a new JobStartedEvent event but we want to start a new job
                 // which will generate a new JobStartedEvent
-                localEvent.setEvent(new RemoteExtensionJobStartedEvent(jobEvent.getJobType(), request));
+                localEvent.setEvent(new RemoteExtensionJobStartedEvent(jobStartedEvent.getJobType(), request));
 
                 return true;
             }

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-distribution/src/main/java/org/xwiki/extension/distribution/internal/DefaultDistributionManager.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-distribution/src/main/java/org/xwiki/extension/distribution/internal/DefaultDistributionManager.java
@@ -357,8 +357,8 @@ public class DefaultDistributionManager implements DistributionManager, Initiali
 
         DistributionJobStatus farmJobStatus;
         if (jobStatus != null) {
-            if (jobStatus instanceof DistributionJobStatus) {
-                farmJobStatus = (DistributionJobStatus) jobStatus;
+            if (jobStatus instanceof DistributionJobStatus distributionJobStatus) {
+                farmJobStatus = distributionJobStatus;
             } else {
                 // RETRO-COMPATIBILITY: the status used to be a DistributionJobStatus
                 farmJobStatus = new DistributionJobStatus(jobStatus, this.observationManagerProvider.get(),

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-distribution/src/main/java/org/xwiki/extension/distribution/internal/WikiDistributionWikiEventListener.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-distribution/src/main/java/org/xwiki/extension/distribution/internal/WikiDistributionWikiEventListener.java
@@ -57,10 +57,10 @@ public class WikiDistributionWikiEventListener extends AbstractEventListener
     @Override
     public void onEvent(Event event, Object o, Object context)
     {
-        if (event instanceof WikiCopiedEvent) {
-            onWikiCopied((WikiCopiedEvent) event);
-        } else if (event instanceof WikiDeletedEvent) {
-            onWikiDeleted((WikiDeletedEvent) event);
+        if (event instanceof WikiCopiedEvent wikiCopiedEvent) {
+            onWikiCopied(wikiCopiedEvent);
+        } else if (event instanceof WikiDeletedEvent wikiDeletedEvent) {
+            onWikiDeleted(wikiDeletedEvent);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-distribution/src/main/java/org/xwiki/extension/distribution/internal/job/DistributionJobStatus.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-distribution/src/main/java/org/xwiki/extension/distribution/internal/job/DistributionJobStatus.java
@@ -77,9 +77,7 @@ public class DistributionJobStatus extends DefaultJobStatus<DistributionRequest>
         super(status.getJobType(), ObjectUtils.cloneIfPossible((DistributionRequest) status.getRequest()), null,
             observationManager, loggerManager);
 
-        if (status instanceof DistributionJobStatus) {
-            DistributionJobStatus distributionJobStatus = (DistributionJobStatus) status;
-
+        if (status instanceof DistributionJobStatus distributionJobStatus) {
             this.previousDistributionExtension = distributionJobStatus.previousDistributionExtension;
             this.previousDistributionExtensionUi = distributionJobStatus.previousDistributionExtensionUi;
             this.distributionExtension = distributionJobStatus.distributionExtension;

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/delete/DocumentsDeletingListener.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/delete/DocumentsDeletingListener.java
@@ -140,8 +140,7 @@ public class DocumentsDeletingListener extends AbstractEventListener
                 cancelableEvent.cancel("Question has been interrupted.");
             }
             // we always want the event and the CancelableJobStatus to be consistent
-            if (jobStatus instanceof CancelableJobStatus) {
-                CancelableJobStatus cancelableJobStatus = (CancelableJobStatus) jobStatus;
+            if (jobStatus instanceof CancelableJobStatus cancelableJobStatus) {
                 if (cancelableJobStatus.isCanceled()) {
                     cancelableEvent.cancel();
                 }

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/doc/InstalledExtensionDocumentListener.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/doc/InstalledExtensionDocumentListener.java
@@ -161,8 +161,8 @@ public class InstalledExtensionDocumentListener extends AbstractEventListener
     private void forEachExtensionDocument(ExtensionEvent extensionEvent, InstalledExtension installedExtension,
         Consumer<DocumentReference> action)
     {
-        if (extensionEvent.hasNamespace() && installedExtension instanceof XarInstalledExtension) {
-            getExtensionDocuments((XarInstalledExtension) installedExtension, extensionEvent.getNamespace()).stream()
+        if (extensionEvent.hasNamespace() && installedExtension instanceof XarInstalledExtension xarExtension) {
+            getExtensionDocuments(xarExtension, extensionEvent.getNamespace()).stream()
                 .forEach(action);
         }
     }

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/handler/WikiEventListener.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/handler/WikiEventListener.java
@@ -91,12 +91,12 @@ public class WikiEventListener extends AbstractEventListener
     @Override
     public void onEvent(Event event, Object o, Object context)
     {
-        if (event instanceof WikiCopiedEvent) {
-            onWikiCopied((WikiCopiedEvent) event);
-        } else if (event instanceof WikiCreatedEvent) {
-            onWikiCreated((WikiCreatedEvent) event, (XWikiContext) context);
-        } else if (event instanceof WikiDeletedEvent) {
-            onWikiDeleted((WikiDeletedEvent) event);
+        if (event instanceof WikiCopiedEvent wikiCopiedEvent) {
+            onWikiCopied(wikiCopiedEvent);
+        } else if (event instanceof WikiCreatedEvent wikiCreatedEvent) {
+            onWikiCreated(wikiCreatedEvent, (XWikiContext) context);
+        } else if (event instanceof WikiDeletedEvent wikiDeletedEvent) {
+            onWikiDeleted(wikiDeletedEvent);
         }
     }
 

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/handler/XarExtensionHandler.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/handler/XarExtensionHandler.java
@@ -116,8 +116,8 @@ public class XarExtensionHandler extends AbstractExtensionHandler
     {
         Object obj = request.getProperty(property);
 
-        if (obj instanceof DocumentReference) {
-            return (DocumentReference) obj;
+        if (obj instanceof DocumentReference documentReference) {
+            return documentReference;
         }
 
         return null;

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/handler/packager/Packager.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar/src/main/java/org/xwiki/extension/xar/internal/handler/packager/Packager.java
@@ -323,8 +323,8 @@ public class Packager
     {
         // Remove the version if any since it does not make sense in a XAR
         DocumentReference documentReference = reference;
-        if (reference instanceof DocumentVersionReference) {
-            documentReference = ((DocumentVersionReference) reference).removeVersion();
+        if (reference instanceof DocumentVersionReference documentVersionReference) {
+            documentReference = documentVersionReference.removeVersion();
         }
 
         return documentReference;

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-script/src/main/java/org/xwiki/extension/script/ExtensionManagerScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-script/src/main/java/org/xwiki/extension/script/ExtensionManagerScriptService.java
@@ -1006,8 +1006,8 @@ public class ExtensionManagerScriptService extends AbstractExtensionScriptServic
      */
     public boolean isAllowed(Extension extension, String namespace)
     {
-        if (extension instanceof IndexedExtension
-            && Boolean.FALSE.equals(((IndexedExtension) extension).isCompatible(namespace))) {
+        if (extension instanceof IndexedExtension indexedExtension
+            && Boolean.FALSE.equals(indexedExtension.isCompatible(namespace))) {
             // If the extension has explicitly been marked as incompatible, return false
             return false;
         }

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-script/src/main/java/org/xwiki/extension/script/ExtensionRatingScriptService.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-script/src/main/java/org/xwiki/extension/script/ExtensionRatingScriptService.java
@@ -110,10 +110,10 @@ public class ExtensionRatingScriptService extends AbstractExtensionScriptService
 
         Collection<ExtensionRepository> repositories = getRepositories();
         for (ExtensionRepository repository : repositories) {
-            if (repository instanceof Ratable) {
+            if (repository instanceof Ratable ratable) {
                 try {
                     setError(null);
-                    return ((Ratable) repository).getRating(extensionId, extensionVersion);
+                    return ratable.getRating(extensionId, extensionVersion);
                 } catch (ResolveException e) {
                     setError(e);
                     // Keep looking. Maybe there's another repository with the same extension.

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-script/src/main/java/org/xwiki/extension/script/internal/safe/ExtensionRepositoryScriptSafeProvider.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-script/src/main/java/org/xwiki/extension/script/internal/safe/ExtensionRepositoryScriptSafeProvider.java
@@ -64,22 +64,22 @@ public class ExtensionRepositoryScriptSafeProvider extends AbstractScriptSafePro
         ExtensionRepository safe;
 
         // TODO: convert all that to a proxy with "plugins"
-        if (unsafe instanceof CoreExtensionRepository) {
+        if (unsafe instanceof CoreExtensionRepository coreExtensionRepository) {
             safe =
-                new SafeCoreExtensionRepository<CoreExtensionRepository>((CoreExtensionRepository) unsafe,
+                new SafeCoreExtensionRepository<CoreExtensionRepository>(coreExtensionRepository,
                     this.defaultSafeProvider, this.execution, hasProgrammingRights());
-        } else if (unsafe instanceof InstalledExtensionRepository) {
+        } else if (unsafe instanceof InstalledExtensionRepository installedExtensionRepository) {
             safe =
                 new SafeInstalledExtensionRepository<InstalledExtensionRepository>(
-                    (InstalledExtensionRepository) unsafe, this.defaultSafeProvider, this.execution,
+                    installedExtensionRepository, this.defaultSafeProvider, this.execution,
                     hasProgrammingRights());
-        } else if (unsafe instanceof LocalExtensionRepository) {
+        } else if (unsafe instanceof LocalExtensionRepository localExtensionRepository) {
             safe =
-                new SafeLocalExtensionRepository<LocalExtensionRepository>((LocalExtensionRepository) unsafe,
+                new SafeLocalExtensionRepository<LocalExtensionRepository>(localExtensionRepository,
                     this.defaultSafeProvider, this.execution, hasProgrammingRights());
-        } else if (unsafe instanceof ExtensionIndex) {            
+        } else if (unsafe instanceof ExtensionIndex extensionIndex) {
             safe =
-                new SafeExtensionIndex<ExtensionIndex>((ExtensionIndex) unsafe,
+                new SafeExtensionIndex<ExtensionIndex>(extensionIndex,
                     this.defaultSafeProvider, this.execution, hasProgrammingRights());
         } else if (unsafe instanceof AdvancedSearchable) {
             if (unsafe instanceof Ratable) {

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-script/src/main/java/org/xwiki/extension/script/internal/safe/ExtensionScriptSafeProvider.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-script/src/main/java/org/xwiki/extension/script/internal/safe/ExtensionScriptSafeProvider.java
@@ -61,19 +61,19 @@ public class ExtensionScriptSafeProvider implements ScriptSafeProvider<Extension
     {
         Extension safe;
 
-        if (unsafe instanceof CoreExtension) {
-            safe = new SafeCoreExtension<CoreExtension>((CoreExtension) unsafe, this.defaultSafeProvider);
-        } else if (unsafe instanceof InstalledExtension) {
-            safe = new SafeInstalledExtension<InstalledExtension>((InstalledExtension) unsafe, this.defaultSafeProvider,
+        if (unsafe instanceof CoreExtension coreExtension) {
+            safe = new SafeCoreExtension<CoreExtension>(coreExtension, this.defaultSafeProvider);
+        } else if (unsafe instanceof InstalledExtension installedExtension) {
+            safe = new SafeInstalledExtension<InstalledExtension>(installedExtension, this.defaultSafeProvider,
                 this.documentReferenceResolver);
-        } else if (unsafe instanceof LocalExtension) {
-            safe = new SafeLocalExtension<LocalExtension>((LocalExtension) unsafe, this.defaultSafeProvider);
-        } else if (unsafe instanceof IndexedExtension) {
-            safe = new SafeIndexedExtension<IndexedExtension>((IndexedExtension) unsafe, this.defaultSafeProvider);
-        } else if (unsafe instanceof RatingExtension) {
-            safe = new SafeRatingExtension<RatingExtension>((RatingExtension) unsafe, this.defaultSafeProvider);
-        } else if (unsafe instanceof RemoteExtension) {
-            safe = new SafeRemoteExtension<RemoteExtension>((RemoteExtension) unsafe, this.defaultSafeProvider);
+        } else if (unsafe instanceof LocalExtension localExtension) {
+            safe = new SafeLocalExtension<LocalExtension>(localExtension, this.defaultSafeProvider);
+        } else if (unsafe instanceof IndexedExtension indexedExtension) {
+            safe = new SafeIndexedExtension<IndexedExtension>(indexedExtension, this.defaultSafeProvider);
+        } else if (unsafe instanceof RatingExtension ratingExtension) {
+            safe = new SafeRatingExtension<RatingExtension>(ratingExtension, this.defaultSafeProvider);
+        } else if (unsafe instanceof RemoteExtension remoteExtension) {
+            safe = new SafeRemoteExtension<RemoteExtension>(remoteExtension, this.defaultSafeProvider);
         } else {
             safe = new SafeExtension<Extension>(unsafe, this.defaultSafeProvider);
         }

--- a/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-script/src/main/java/org/xwiki/extension/script/internal/safe/SafeInstalledExtension.java
+++ b/xwiki-platform-core/xwiki-platform-extension/xwiki-platform-extension-script/src/main/java/org/xwiki/extension/script/internal/safe/SafeInstalledExtension.java
@@ -121,11 +121,11 @@ public class SafeInstalledExtension<T extends InstalledExtension> extends SafeLo
     {
         DocumentReference userReference = null;
         Object value = getNamespaceProperty("user.reference", namespace);
-        if (value instanceof DocumentReference) {
-            userReference = (DocumentReference) value;
-        } else if (value instanceof String) {
+        if (value instanceof DocumentReference documentReference) {
+            userReference = documentReference;
+        } else if (value instanceof String string) {
             // The extension store doesn't know how to serialize a DocumentReference and so it saves the string value.
-            userReference = this.documentReferenceResolver.resolve((String) value);
+            userReference = this.documentReferenceResolver.resolve(string);
         }
         return userReference;
     }


### PR DESCRIPTION
## Description

Fixes 28 [SonarCloud `java:S6201`](https://sonarcloud.io/project/issues?id=org.xwiki.platform%3Axwiki-platform&issueStatuses=OPEN&rules=java%3AS6201) issues ("Replace this instanceof check and cast with pattern matching for instanceof") across the `xwiki-platform-extension` modules.

Each `instanceof` check immediately followed by an explicit cast to the same type is replaced by an `instanceof` pattern-matching binding (Java 16+), reusing the bound variable in place of the cast. The changes are behaviour-preserving.

Modules touched (5 submodules, 15 files):
* `xwiki-platform-extension-api`
* `xwiki-platform-extension-cluster`
* `xwiki-platform-extension-distribution`
* `xwiki-platform-extension-handlers/xwiki-platform-extension-handler-xar`
* `xwiki-platform-extension-script`

## Verification

`mvn clean install` (with Checkstyle/Spoon) passes for all five modules.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HHmLd1XyGCn5pgtQ238Yy8)_