### PR TITLE
[Misc] Use pattern matching for instanceof in model, user, livedata and lesscss modules (SonarCloud java:S6201)

### DIFF
--- a/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/cache/CacheKeyFactory.java
+++ b/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/cache/CacheKeyFactory.java
@@ -82,8 +82,8 @@ public class CacheKeyFactory
             Request request = container.getRequest();
             List<String> excludes = Arrays.asList("skin", "colorTheme", "colorThemeVersion", "language", "docVersion",
                 XWiki.CACHE_VERSION);
-            if (request instanceof ServletRequest) {
-                Map<String, String[]> parameters = ((ServletRequest) request).getHttpServletRequest().getParameterMap();
+            if (request instanceof ServletRequest servletRequest) {
+                Map<String, String[]> parameters = servletRequest.getHttpServletRequest().getParameterMap();
                 for (Map.Entry<String, String[]> entry : parameters.entrySet()) {
                     if (!excludes.contains(entry.getKey())) {
                         String[] values = entry.getValue();

--- a/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/colortheme/DocumentColorThemeReference.java
+++ b/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/colortheme/DocumentColorThemeReference.java
@@ -50,8 +50,7 @@ public class DocumentColorThemeReference implements ColorThemeReference
     @Override
     public boolean equals(Object o)
     {
-        if (o instanceof DocumentColorThemeReference) {
-            DocumentColorThemeReference documentSkinReference = (DocumentColorThemeReference) o;
+        if (o instanceof DocumentColorThemeReference documentSkinReference) {
             return colorThemeDocument.equals(documentSkinReference.colorThemeDocument);
         }
         return false;

--- a/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/colortheme/NamedColorThemeReference.java
+++ b/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/colortheme/NamedColorThemeReference.java
@@ -42,8 +42,7 @@ public class NamedColorThemeReference implements ColorThemeReference
     @Override
     public boolean equals(Object o)
     {
-        if (o instanceof NamedColorThemeReference) {
-            NamedColorThemeReference namedColorThemeReference = (NamedColorThemeReference) o;
+        if (o instanceof NamedColorThemeReference namedColorThemeReference) {
             return colorThemeName.equals(namedColorThemeReference.colorThemeName);
         }
         return false;

--- a/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/compiler/CachedLESSCompiler.java
+++ b/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/compiler/CachedLESSCompiler.java
@@ -109,9 +109,9 @@ public class CachedLESSCompiler implements CachedCompilerInterface<String>, Init
             if (useVelocity) {
                 DocumentReference authorReference;
                 DocumentReference documentReference;
-                if (lessResourceReference instanceof WikiLESSResourceReference) {
-                    authorReference = ((WikiLESSResourceReference) lessResourceReference).getAuthorReference();
-                    documentReference = ((WikiLESSResourceReference) lessResourceReference).getDocumentReference();
+                if (lessResourceReference instanceof WikiLESSResourceReference wikiLESSResourceReference) {
+                    authorReference = wikiLESSResourceReference.getAuthorReference();
+                    documentReference = wikiLESSResourceReference.getDocumentReference();
                 } else {
                     authorReference = InternalTemplateManager.SUPERADMIN_REFERENCE;
                     documentReference = null;

--- a/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/resources/LESSObjectPropertyResourceReference.java
+++ b/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/resources/LESSObjectPropertyResourceReference.java
@@ -64,9 +64,7 @@ public class LESSObjectPropertyResourceReference implements WikiLESSResourceRefe
     @Override
     public boolean equals(Object o)
     {
-        if (o instanceof LESSObjectPropertyResourceReference) {
-            LESSObjectPropertyResourceReference lessObjectPropertyResourceReference =
-                (LESSObjectPropertyResourceReference) o;
+        if (o instanceof LESSObjectPropertyResourceReference lessObjectPropertyResourceReference) {
             return objectPropertyReference.equals(lessObjectPropertyResourceReference.objectPropertyReference);
         }
 

--- a/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/resources/LESSSkinFileResourceReference.java
+++ b/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/resources/LESSSkinFileResourceReference.java
@@ -55,8 +55,8 @@ public class LESSSkinFileResourceReference implements LESSResourceReference
     @Override
     public boolean equals(Object o)
     {
-        if (o instanceof LESSSkinFileResourceReference) {
-            return fileName.equals(((LESSSkinFileResourceReference) o).fileName);
+        if (o instanceof LESSSkinFileResourceReference lessSkinFileResourceReference) {
+            return fileName.equals(lessSkinFileResourceReference.fileName);
         }
 
         return false;

--- a/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/skin/DocumentSkinReference.java
+++ b/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/skin/DocumentSkinReference.java
@@ -57,8 +57,7 @@ public class DocumentSkinReference implements SkinReference
     @Override
     public boolean equals(Object o)
     {
-        if (o instanceof DocumentSkinReference) {
-            DocumentSkinReference documentSkinReference = (DocumentSkinReference) o;
+        if (o instanceof DocumentSkinReference documentSkinReference) {
             return skinDocument.equals(documentSkinReference.skinDocument);
         }
         return false;

--- a/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/skin/FSSkinReference.java
+++ b/xwiki-platform-core/xwiki-platform-lesscss/xwiki-platform-lesscss-default/src/main/java/org/xwiki/lesscss/internal/skin/FSSkinReference.java
@@ -49,8 +49,7 @@ public class FSSkinReference implements SkinReference
     @Override
     public boolean equals(Object o)
     {
-        if (o instanceof FSSkinReference) {
-            FSSkinReference fsSkinReference = (FSSkinReference) o;
+        if (o instanceof FSSkinReference fsSkinReference) {
             return skinName.equals(fsSkinReference.skinName);
         }
         return false;

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/DefaultLiveDataConfigurationResolver.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/DefaultLiveDataConfigurationResolver.java
@@ -114,8 +114,8 @@ public class DefaultLiveDataConfigurationResolver extends AbstractLiveDataConfig
     private LiveDataPropertyDescriptorStore getPropertyStore(Source sourceConfig)
     {
         LiveDataPropertyDescriptorStore propertyStore = this.propertyStoreProvider.get();
-        if (propertyStore instanceof WithParameters && sourceConfig != null) {
-            ((WithParameters) propertyStore).getParameters().putAll(sourceConfig.getParameters());
+        if (propertyStore instanceof WithParameters withParameters && sourceConfig != null) {
+            withParameters.getParameters().putAll(sourceConfig.getParameters());
         }
         return propertyStore;
     }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataEntryStore.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataEntryStore.java
@@ -135,10 +135,10 @@ public class LiveTableLiveDataEntryStore extends WithParameters implements LiveD
             Object template = query.getSource().getParameters().get(LiveTableRequestHandler.TEMPLATE);
             Object resultPage = query.getSource().getParameters().get(LiveTableRequestHandler.RESULT_PAGE);
             String liveTableResultsJSON;
-            if (template instanceof String) {
-                liveTableResultsJSON = this.resultsRenderer.getLiveTableResultsFromTemplate((String) template, query);
-            } else if (resultPage instanceof String) {
-                liveTableResultsJSON = this.resultsRenderer.getLiveTableResultsFromPage((String) resultPage, query);
+            if (template instanceof String templateString) {
+                liveTableResultsJSON = this.resultsRenderer.getLiveTableResultsFromTemplate(templateString, query);
+            } else if (resultPage instanceof String resultPageString) {
+                liveTableResultsJSON = this.resultsRenderer.getLiveTableResultsFromPage(resultPageString, query);
             } else {
                 liveTableResultsJSON =
                     this.resultsRenderer.getLiveTableResultsFromPage("XWiki.LiveTableResults", query);

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataPropertyStore.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataPropertyStore.java
@@ -191,16 +191,16 @@ public class LiveTableLiveDataPropertyStore extends WithParameters implements Li
         descriptor.setDescription(xproperty.getHint());
         descriptor.setType(xproperty.getClassType());
         // List properties are sortable by default, but only if they have single selection.
-        if (xproperty instanceof ListClass && ((ListClass) xproperty).isMultiSelect()) {
+        if (xproperty instanceof ListClass listClass && listClass.isMultiSelect()) {
             descriptor.setSortable(false);
         }
         // The returned property value is the displayer output.
         descriptor.setDisplayer(new DisplayerDescriptor("xObjectProperty"));
         if (xproperty instanceof ListClass) {
             FilterDescriptor filterList = new FilterDescriptor("list");
-            if (xproperty instanceof LevelsClass) {
+            if (xproperty instanceof LevelsClass levelsClass) {
                 // We need to provide a list of maps of value / labels so that selectize can interpret them.
-                filterList.setParameter("options", ((LevelsClass) xproperty).getList(xcontext)
+                filterList.setParameter("options", levelsClass.getList(xcontext)
                     .stream()
                     .map(item -> Map.of(
                         "value", item,
@@ -219,8 +219,8 @@ public class LiveTableLiveDataPropertyStore extends WithParameters implements Li
                 filterList.setDefaultOperator(EQUALS_OPERATOR);
             }
             descriptor.setFilter(filterList);
-        } else if (xproperty instanceof DateClass) {
-            String dateFormat = ((DateClass) xproperty).getDateFormat();
+        } else if (xproperty instanceof DateClass dateClass) {
+            String dateFormat = dateClass.getDateFormat();
             if (!StringUtils.isEmpty(dateFormat)) {
                 descriptor.setFilter(new FilterDescriptor("date"));
                 descriptor.getFilter().setParameter("dateFormat", dateFormat);

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataSource.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableLiveDataSource.java
@@ -52,8 +52,8 @@ public class LiveTableLiveDataSource extends WithParameters implements LiveDataS
     @Override
     public LiveDataEntryStore getEntries()
     {
-        if (this.entryStore instanceof WithParameters) {
-            ((WithParameters) this.entryStore).getParameters().putAll(this.getParameters());
+        if (this.entryStore instanceof WithParameters withParameters) {
+            withParameters.getParameters().putAll(this.getParameters());
         }
         return this.entryStore;
     }
@@ -61,8 +61,8 @@ public class LiveTableLiveDataSource extends WithParameters implements LiveDataS
     @Override
     public LiveDataPropertyDescriptorStore getProperties()
     {
-        if (this.propertyStore instanceof WithParameters) {
-            ((WithParameters) this.propertyStore).getParameters().putAll(this.getParameters());
+        if (this.propertyStore instanceof WithParameters withParameters) {
+            withParameters.getParameters().putAll(this.getParameters());
         }
         return this.propertyStore;
     }

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableResultsURLDocumentReferenceResolver.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/LiveTableResultsURLDocumentReferenceResolver.java
@@ -85,8 +85,8 @@ public class LiveTableResultsURLDocumentReferenceResolver
             ExtendedURL extendedURL = new ExtendedURL(url, xcontext.getRequest().getContextPath());
             ResourceType type = this.typeResolver.resolve(extendedURL, Collections.emptyMap());
             ResourceReference reference = this.resourceResolver.resolve(extendedURL, type, Collections.emptyMap());
-            if (reference instanceof EntityResourceReference) {
-                EntityReference entityReference = ((EntityResourceReference) reference).getEntityReference();
+            if (reference instanceof EntityResourceReference entityResourceReference) {
+                EntityReference entityReference = entityResourceReference.getEntityReference();
                 DocumentReference documentReference =
                     this.currentEntityDocumentReferenceResolver.resolve(entityReference);
                 return this.defaultEntityReferenceSerializer.serialize(documentReference);

--- a/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/PropertyTypeSupplier.java
+++ b/xwiki-platform-core/xwiki-platform-livedata/xwiki-platform-livedata-livetable/src/main/java/org/xwiki/livedata/internal/livetable/PropertyTypeSupplier.java
@@ -69,8 +69,8 @@ public class PropertyTypeSupplier
         try {
             XWikiDocument classDocument = xcontext.getWiki().getDocument(classReference, xcontext);
             PropertyInterface property = classDocument.getXClass().get(propertyName);
-            if (property instanceof PropertyClass) {
-                return ((PropertyClass) property).getClassType();
+            if (property instanceof PropertyClass propertyClass) {
+                return propertyClass.getClassType();
             }
         } catch (XWikiException e) {
             this.logger.warn("Failed to read the type of property [{}] from [{}]. Root cause is [{}].", propertyName,

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/internal/reference/AbstractEntityReferenceResolver.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/internal/reference/AbstractEntityReferenceResolver.java
@@ -91,13 +91,11 @@ public abstract class AbstractEntityReferenceResolver
     {
         EntityReference resolvedDefaultValue = null;
 
-        if (parameters != null && parameters.length > 0 && parameters[0] instanceof EntityReference) {
-            // Try to extract the required type from the passed parameter.
-            EntityReference referenceParameter = (EntityReference) parameters[0];
+        if (parameters != null && parameters.length > 0 && parameters[0] instanceof EntityReference reference) {
             // Make sure to use a compatible reference
-            referenceParameter = toCompatibleEntityReference(referenceParameter, type);
+            reference = toCompatibleEntityReference(reference, type);
 
-            EntityReference extractedReference = referenceParameter.extractReference(type);
+            EntityReference extractedReference = reference.extractReference(type);
             if (extractedReference != null) {
                 resolvedDefaultValue = extractedReference;
 

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/internal/reference/DefaultReferenceAttachmentReferenceResolver.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/internal/reference/DefaultReferenceAttachmentReferenceResolver.java
@@ -52,8 +52,8 @@ public class DefaultReferenceAttachmentReferenceResolver implements AttachmentRe
     @Override
     public AttachmentReference resolve(EntityReference attachmentReferenceRepresentation, Object... parameters)
     {
-        if (attachmentReferenceRepresentation instanceof AttachmentReference) {
-            return (AttachmentReference) attachmentReferenceRepresentation;
+        if (attachmentReferenceRepresentation instanceof AttachmentReference attachmentReference) {
+            return attachmentReference;
         }
 
         return new AttachmentReference(this.entityReferenceResolver.resolve(attachmentReferenceRepresentation,

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/internal/reference/DefaultReferenceDocumentReferenceResolver.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/internal/reference/DefaultReferenceDocumentReferenceResolver.java
@@ -52,8 +52,8 @@ public class DefaultReferenceDocumentReferenceResolver implements DocumentRefere
     @Override
     public DocumentReference resolve(EntityReference documentReferenceRepresentation, Object... parameters)
     {
-        if (documentReferenceRepresentation instanceof DocumentReference) {
-            return (DocumentReference) documentReferenceRepresentation;
+        if (documentReferenceRepresentation instanceof DocumentReference documentReference) {
+            return documentReference;
         }
 
         return new DocumentReference(this.entityReferenceResolver.resolve(documentReferenceRepresentation,

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/internal/reference/DefaultReferencePageAttachmentReferenceResolver.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/internal/reference/DefaultReferencePageAttachmentReferenceResolver.java
@@ -52,8 +52,8 @@ public class DefaultReferencePageAttachmentReferenceResolver implements PageAtta
     @Override
     public PageAttachmentReference resolve(EntityReference attachmentReferenceRepresentation, Object... parameters)
     {
-        if (attachmentReferenceRepresentation instanceof PageAttachmentReference) {
-            return (PageAttachmentReference) attachmentReferenceRepresentation;
+        if (attachmentReferenceRepresentation instanceof PageAttachmentReference pageAttachmentReference) {
+            return pageAttachmentReference;
         }
 
         return new PageAttachmentReference(this.entityReferenceResolver.resolve(attachmentReferenceRepresentation,

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/internal/reference/DefaultReferencePageReferenceResolver.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/internal/reference/DefaultReferencePageReferenceResolver.java
@@ -52,8 +52,8 @@ public class DefaultReferencePageReferenceResolver implements PageReferenceResol
     @Override
     public PageReference resolve(EntityReference pageReferenceRepresentation, Object... parameters)
     {
-        if (pageReferenceRepresentation instanceof PageReference) {
-            return (PageReference) pageReferenceRepresentation;
+        if (pageReferenceRepresentation instanceof PageReference pageReference) {
+            return pageReference;
         }
 
         return new PageReference(

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/internal/reference/DefaultReferenceSpaceReferenceResolver.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/internal/reference/DefaultReferenceSpaceReferenceResolver.java
@@ -51,8 +51,8 @@ public class DefaultReferenceSpaceReferenceResolver implements SpaceReferenceRes
     @Override
     public SpaceReference resolve(EntityReference spaceReferenceRepresentation, Object... parameters)
     {
-        if (spaceReferenceRepresentation instanceof SpaceReference) {
-            return (SpaceReference) spaceReferenceRepresentation;
+        if (spaceReferenceRepresentation instanceof SpaceReference spaceReference) {
+            return spaceReference;
         }
 
         return new SpaceReference(this.entityReferenceResolver.resolve(spaceReferenceRepresentation, EntityType.SPACE,

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/internal/reference/DefaultWikiReferenceProvider.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/internal/reference/DefaultWikiReferenceProvider.java
@@ -58,7 +58,7 @@ public class DefaultWikiReferenceProvider implements Provider<WikiReference>
             EntityReference reference = this.provider.getDefaultReference(EntityType.WIKI);
 
             this.cachedReference = this.factory.getReference(
-                reference instanceof WikiReference ? (WikiReference) reference : new WikiReference(reference));
+                reference instanceof WikiReference wikiReference ? wikiReference : new WikiReference(reference));
         }
 
         return this.cachedReference;

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/internal/reference/LocalUidStringEntityReferenceSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/internal/reference/LocalUidStringEntityReferenceSerializer.java
@@ -113,8 +113,8 @@ public class LocalUidStringEntityReferenceSerializer implements EntityReferenceS
         representation.append(name.length()).append(':').append(name);
 
         // Append Locale
-        if (currentReference instanceof DocumentReference) {
-            Locale locale = ((DocumentReference) currentReference).getLocale();
+        if (currentReference instanceof DocumentReference documentReference) {
+            Locale locale = documentReference.getLocale();
             if (locale != null) {
                 String localeString = locale.toString();
                 if (!localeString.isEmpty()) {

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/internal/reference/LocalizedStringEntityReferenceSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/internal/reference/LocalizedStringEntityReferenceSerializer.java
@@ -55,13 +55,11 @@ public class LocalizedStringEntityReferenceSerializer extends DefaultStringEntit
         super.serializeEntityReference(currentReference, representation, isLastReference, parameters);
 
         // Append parameters for DocumentReference (if any)
-        if (currentReference instanceof DocumentReference) {
-            DocumentReference documentReference = (DocumentReference) currentReference;
+        if (currentReference instanceof DocumentReference documentReference) {
             if (documentReference.getLocale() != null) {
                 representation.append('(').append(documentReference.getLocale()).append(')');
             }
-        } else if (currentReference instanceof LocalDocumentReference) {
-            LocalDocumentReference documentReference = (LocalDocumentReference) currentReference;
+        } else if (currentReference instanceof LocalDocumentReference documentReference) {
             if (documentReference.getLocale() != null) {
                 representation.append('(').append(documentReference.getLocale()).append(')');
             }

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/internal/reference/UidStringEntityReferenceSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/internal/reference/UidStringEntityReferenceSerializer.java
@@ -57,8 +57,8 @@ public class UidStringEntityReferenceSerializer extends AbstractStringEntityRefe
         representation.append(name.length()).append(':').append(name);
 
         // Append Locale
-        if (currentReference instanceof AbstractLocalizedEntityReference) {
-            Locale locale = ((AbstractLocalizedEntityReference) currentReference).getLocale();
+        if (currentReference instanceof AbstractLocalizedEntityReference reference) {
+            Locale locale = reference.getLocale();
             if (locale != null) {
                 String localeString = locale.toString();
                 representation.append(localeString.length()).append(":").append(localeString);

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/reference/AttachmentReferenceConverter.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/reference/AttachmentReferenceConverter.java
@@ -62,8 +62,8 @@ public class AttachmentReferenceConverter extends AbstractConverter<AttachmentRe
 
         AttachmentReference reference;
 
-        if (value instanceof EntityReference) {
-            reference = this.referenceResolver.resolve((EntityReference) value);
+        if (value instanceof EntityReference entityReference) {
+            reference = this.referenceResolver.resolve(entityReference);
         } else {
             reference = this.stringResolver.resolve(value.toString());
         }

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/reference/DocumentReference.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/reference/DocumentReference.java
@@ -394,12 +394,12 @@ public class DocumentReference extends AbstractLocalizedEntityReference
     {
         Optional<DocumentReference> result = Optional.empty();
         if (entityReference != null) {
-            if (entityReference instanceof DocumentReference) {
-                result = Optional.of((DocumentReference) entityReference);
+            if (entityReference instanceof DocumentReference documentReference) {
+                result = Optional.of(documentReference);
             } else {
                 EntityReference extractedRef = entityReference.extractReference(EntityType.DOCUMENT);
-                if (extractedRef instanceof DocumentReference) {
-                    result = Optional.of((DocumentReference) extractedRef);
+                if (extractedRef instanceof DocumentReference documentReference) {
+                    result = Optional.of(documentReference);
                 } else if (extractedRef != null) {
                     result = Optional.of(new DocumentReference(extractedRef));
                 }

--- a/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/reference/EntityReference.java
+++ b/xwiki-platform-core/xwiki-platform-model/xwiki-platform-model-api/src/main/java/org/xwiki/model/reference/EntityReference.java
@@ -809,8 +809,8 @@ public class EntityReference implements Serializable, Cloneable, Comparable<Enti
                 return 1;
             }
 
-            if (value.getClass() == otherValue.getClass() && value instanceof Comparable) {
-                return ((Comparable) value).compareTo(otherValue);
+            if (value.getClass() == otherValue.getClass() && value instanceof Comparable comparable) {
+                return comparable.compareTo(otherValue);
             }
 
             if (!value.equals(otherValue)) {

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/document/AbstractDocumentStringUserReferenceResolver.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/document/AbstractDocumentStringUserReferenceResolver.java
@@ -52,8 +52,8 @@ public abstract class AbstractDocumentStringUserReferenceResolver extends Abstra
             reference = CurrentUserReference.INSTANCE;
         } else {
             EntityReference baseEntityReference;
-            if (parameters.length == 1 && parameters[0] instanceof WikiReference) {
-                baseEntityReference = new EntityReference(USER_SPACE_REFERENCE, (WikiReference) parameters[0]);
+            if (parameters.length == 1 && parameters[0] instanceof WikiReference wikiReference) {
+                baseEntityReference = new EntityReference(USER_SPACE_REFERENCE, wikiReference);
             } else {
                 baseEntityReference = USER_SPACE_REFERENCE;
             }

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/document/DocumentStringUserReferenceSerializer.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/document/DocumentStringUserReferenceSerializer.java
@@ -87,10 +87,9 @@ public class DocumentStringUserReferenceSerializer implements UserReferenceSeria
     private String serializeInternal(UserReference userReference, Object... parameters)
     {
         String result;
-        if (!(userReference instanceof DocumentUserReference)) {
+        if (!(userReference instanceof DocumentUserReference documentUserReference)) {
             throw new IllegalArgumentException("Only DocumentUserReference are handled");
         } else {
-            DocumentUserReference documentUserReference = (DocumentUserReference) userReference;
             result = getEntityReferenceSerializer().serialize(documentUserReference.getReference(), parameters);
         }
         return result;

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/group/DefaultGroupManager.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/group/DefaultGroupManager.java
@@ -122,10 +122,10 @@ public class DefaultGroupManager implements GroupManager
         Collection<String> searchWikis = new TreeSet<>();
 
         for (Object wiki : wikiTarget) {
-            if (wiki instanceof String) {
-                searchWikis.add((String) wiki);
-            } else if (wiki instanceof WikiReference) {
-                searchWikis.add(((WikiReference) wiki).getName());
+            if (wiki instanceof String string) {
+                searchWikis.add(string);
+            } else if (wiki instanceof WikiReference wikiReference) {
+                searchWikis.add(wikiReference.getName());
             } else if (wiki instanceof WikiTarget) {
                 searchWikis.addAll(getSearchWikis(reference, wikiTarget, resolve));
             }
@@ -139,14 +139,14 @@ public class DefaultGroupManager implements GroupManager
     {
         Collection<String> cacheWikis;
 
-        if (wikiTarget instanceof WikiTarget) {
-            cacheWikis = getSearchWikis(reference, (WikiTarget) wikiTarget, resolve);
-        } else if (wikiTarget instanceof String) {
-            cacheWikis = Collections.singleton((String) wikiTarget);
-        } else if (wikiTarget instanceof WikiReference) {
-            cacheWikis = Collections.singleton(((WikiReference) wikiTarget).getName());
-        } else if (wikiTarget instanceof Collection && !((Collection) wikiTarget).isEmpty()) {
-            cacheWikis = getSearchWikis(reference, (Collection) wikiTarget, resolve);
+        if (wikiTarget instanceof WikiTarget wikiTargetValue) {
+            cacheWikis = getSearchWikis(reference, wikiTargetValue, resolve);
+        } else if (wikiTarget instanceof String string) {
+            cacheWikis = Collections.singleton(string);
+        } else if (wikiTarget instanceof WikiReference wikiReference) {
+            cacheWikis = Collections.singleton(wikiReference.getName());
+        } else if (wikiTarget instanceof Collection collection && !collection.isEmpty()) {
+            cacheWikis = getSearchWikis(reference, collection, resolve);
         } else if (wikiTarget == null) {
             cacheWikis = getSearchWikis(reference, WikiTarget.ALL, resolve);
         } else {

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/group/GroupCacheInvalidationListener.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/group/GroupCacheInvalidationListener.java
@@ -85,8 +85,8 @@ public class GroupCacheInvalidationListener extends AbstractEventListener
     @Override
     public void onEvent(Event event, Object source, Object data)
     {
-        if (event instanceof WikiDeletedEvent) {
-            WikiReference wikiReference = new WikiReference(((WikiDeletedEvent) event).getWikiId());
+        if (event instanceof WikiDeletedEvent wikiDeletedEvent) {
+            WikiReference wikiReference = new WikiReference(wikiDeletedEvent.getWikiId());
             this.groupsCache.cleanCache(wikiReference.getName());
             this.membersCache.cleanCache(wikiReference.getName());
             this.wikiGroupCache.invalidate(wikiReference.getName());

--- a/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/group/UsersCacheInvalidationListener.java
+++ b/xwiki-platform-core/xwiki-platform-user/xwiki-platform-user-default/src/main/java/org/xwiki/user/internal/group/UsersCacheInvalidationListener.java
@@ -74,8 +74,8 @@ public class UsersCacheInvalidationListener extends AbstractEventListener
     @Override
     public void onEvent(Event event, Object source, Object data)
     {
-        if (event instanceof WikiDeletedEvent) {
-            WikiReference wikiReference = new WikiReference(((WikiDeletedEvent) event).getWikiId());
+        if (event instanceof WikiDeletedEvent wikiDeletedEvent) {
+            WikiReference wikiReference = new WikiReference(wikiDeletedEvent.getWikiId());
             this.userCache.cleanCache(wikiReference.getName());
         } else {
             XWikiDocument document = (XWikiDocument) source;


### PR DESCRIPTION
Replaces `instanceof` checks followed by an explicit cast with `instanceof` pattern variables (Java 16+ pattern matching), as flagged by SonarCloud rule [java:S6201](https://sonarcloud.io/organizations/xwiki/rules?open=java%3AS6201&rule_key=java%3AS6201).

This is a mechanical, behaviour-preserving cleanup covering 45 issues across four modules:

* `xwiki-platform-model-api` — 15 issues
* `xwiki-platform-user-default` — 11 issues
* `xwiki-platform-livedata-livetable` — 10 issues
* `xwiki-platform-lesscss-default` — 9 issues

Each site binds a pattern variable and drops the now-redundant cast (including the negated-guard / early-exit and `&&` short-circuit shapes, and reusing existing explicit-cast locals where present). No public API changes.

Verified with `mvn clean install` (Checkstyle + Spoon) on the four affected modules.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XCE4q1qutgzD44o44cnRCP)_